### PR TITLE
Meta/Windows: fix compilation flags for clang-cl

### DIFF
--- a/Meta/CMake/lagom_compile_options.cmake
+++ b/Meta/CMake/lagom_compile_options.cmake
@@ -2,8 +2,17 @@ include(${CMAKE_CURRENT_LIST_DIR}/common_compile_options.cmake)
 
 add_compile_options(-Wno-maybe-uninitialized)
 add_compile_options(-Wno-shorten-64-to-32)
-add_compile_options(-fsigned-char)
-add_compile_options(-ggnu-pubnames)
+
+if(NOT MSVC)
+    add_compile_options(-fsigned-char)
+    add_compile_options(-ggnu-pubnames)
+else()
+    # char is signed
+    add_compile_options(/J)
+    # full symbolic debugginng information
+    add_compile_options(/Z7)
+endif()
+
 if (NOT WIN32)
     add_compile_options(-fPIC)
 endif()
@@ -13,7 +22,9 @@ if (LINUX)
 endif()
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_compile_options(-ggdb3)
+    if (NOT MSVC)
+        add_compile_options(-ggdb3)
+    endif()
     add_compile_options(-Og)
 else()
     add_compile_options(-O2)


### PR DESCRIPTION
As part of https://github.com/LadybirdWebBrowser/ladybird/issues/38 - the first baby step, is to make sure that we do not use compile flags not supported by clang-cl.

If the clang-cl version I got installed from VisualStudio 2022 is not enough - we have another step.

```
C:\Program Files\Microsoft Visual Studio\2022\Community>clang-cl --version
clang version 17.0.3
Target: x86_64-pc-windows-msvc
Thread model: posix
InstalledDir: C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Tools\Llvm\x64\bin
```

After this patch - we got syntax errors and missing APIs to fix, and longer compile flags issues. 