### PR TITLE
LibWeb: Implement and wire up TransformStream's cancel callback

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStream-can-cancel.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStream-can-cancel.txt
@@ -1,0 +1,1 @@
+ReadableStream cancelled due to: Test cancellation

--- a/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-readable-side.txt
+++ b/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-readable-side.txt
@@ -1,0 +1,1 @@
+TransformStream cancelled due to: cancel called by the readable side.

--- a/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-writable-side.txt
+++ b/Tests/LibWeb/Text/expected/Streams/TransformStream-cancelled-by-writable-side.txt
@@ -1,0 +1,1 @@
+TransformStream cancelled due to: abort called by the writable side.

--- a/Tests/LibWeb/Text/input/Streams/ReadableStream-can-cancel.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStream-can-cancel.html
@@ -1,0 +1,17 @@
+<script src="../include.js"></script>
+<script>
+    function testReadableStreamCancellation() {
+        const readableStream = new ReadableStream({
+            cancel(reason) {
+                println(`ReadableStream cancelled due to: ${reason}`);
+                return Promise.resolve();
+            }
+        });
+
+        readableStream.cancel('Test cancellation');
+    }
+
+    test(() => {
+        testReadableStreamCancellation();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-readable-side.html
+++ b/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-readable-side.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    function testTransformStreamReadableStreamCancellation() {
+        const transformStream = new TransformStream({
+            cancel(reason) {
+                println(`TransformStream cancelled due to: ${reason}`);
+                return Promise.resolve();
+            }
+        });
+        transformStream.readable.cancel('cancel called by the readable side.');
+    }
+
+    test(() => {
+        testTransformStreamReadableStreamCancellation();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-writable-side.html
+++ b/Tests/LibWeb/Text/input/Streams/TransformStream-cancelled-by-writable-side.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    function testTransformStreamReadableStreamCancellation() {
+        const transformStream = new TransformStream({
+            cancel(reason) {
+                println(`TransformStream cancelled due to: ${reason}`);
+                return Promise.resolve();
+            }
+        });
+        transformStream.writable.abort('abort called by the writable side.');
+    }
+
+    test(() => {
+        testTransformStreamReadableStreamCancellation();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -4599,12 +4599,9 @@ void initialize_transform_stream(TransformStream& stream, JS::NonnullGCPtr<JS::P
     });
 
     // 7. Let cancelAlgorithm be the following steps, taking a reason argument:
-    auto cancel_algorithm = JS::create_heap_function(realm.heap(), [&stream, &realm](JS::Value reason) {
-        // 1. Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, reason).
-        transform_stream_error_writable_and_unblock_write(stream, reason);
-
-        // 2. Return a promise resolved with undefined.
-        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    auto cancel_algorithm = JS::create_heap_function(realm.heap(), [&stream](JS::Value reason) {
+        // 1. Return ! TransformStreamDefaultSourceCancelAlgorithm(stream, reason).
+        return transform_stream_default_source_cancel_algorithm(stream, reason);
     });
 
     // 8. Set stream.[[readable]] to ! CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, readableHighWaterMark, readableSizeAlgorithm).

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -4619,7 +4619,7 @@ void initialize_transform_stream(TransformStream& stream, JS::NonnullGCPtr<JS::P
 }
 
 // https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller
-void set_up_transform_stream_default_controller(TransformStream& stream, TransformStreamDefaultController& controller, JS::NonnullGCPtr<TransformAlgorithm> transform_algorithm, JS::NonnullGCPtr<FlushAlgorithm> flush_algorithm)
+void set_up_transform_stream_default_controller(TransformStream& stream, TransformStreamDefaultController& controller, JS::NonnullGCPtr<TransformAlgorithm> transform_algorithm, JS::NonnullGCPtr<FlushAlgorithm> flush_algorithm, JS::NonnullGCPtr<CancelAlgorithm> cancel_algorithm)
 {
     // 1. Assert: stream implements TransformStream.
     // 2. Assert: stream.[[controller]] is undefined.
@@ -4636,6 +4636,9 @@ void set_up_transform_stream_default_controller(TransformStream& stream, Transfo
 
     // 6. Set controller.[[flushAlgorithm]] to flushAlgorithm.
     controller.set_flush_algorithm(flush_algorithm);
+
+    // 7. Set controller.[[cancelAlgorithm]] to cancelAlgorithm.
+    controller.set_cancel_algorithm(cancel_algorithm);
 }
 
 // https://streams.spec.whatwg.org/#set-up-transform-stream-default-controller-from-transformer
@@ -4667,7 +4670,12 @@ void set_up_transform_stream_default_controller_from_transformer(TransformStream
         return WebIDL::create_resolved_promise(realm, JS::js_undefined());
     });
 
-    // 4. If transformerDict["transform"] exists, set transformAlgorithm to an algorithm which takes an argument chunk
+    // 4. Let cancelAlgorithm be an algorithm which returns a promise resolved with undefined.
+    auto cancel_algorithm = JS::create_heap_function(realm.heap(), [&realm](JS::Value) {
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    });
+
+    // 5. If transformerDict["transform"] exists, set transformAlgorithm to an algorithm which takes an argument chunk
     //    and returns the result of invoking transformerDict["transform"] with argument list « chunk, controller » and
     //    callback this value transformer.
     if (transformer_dict.transform) {
@@ -4678,7 +4686,7 @@ void set_up_transform_stream_default_controller_from_transformer(TransformStream
         });
     }
 
-    // 5. If transformerDict["flush"] exists, set flushAlgorithm to an algorithm which returns the result of invoking
+    // 6. If transformerDict["flush"] exists, set flushAlgorithm to an algorithm which returns the result of invoking
     //    transformerDict["flush"] with argument list « controller » and callback this value transformer.
     if (transformer_dict.flush) {
         flush_algorithm = JS::create_heap_function(realm.heap(), [&realm, transformer, callback = transformer_dict.flush, controller]() {
@@ -4688,8 +4696,18 @@ void set_up_transform_stream_default_controller_from_transformer(TransformStream
         });
     }
 
-    // 6. Perform ! SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm).
-    set_up_transform_stream_default_controller(stream, *controller, transform_algorithm, flush_algorithm);
+    // 7. If transformerDict["cancel"] exists, set cancelAlgorithm to an algorithm which takes an argument reason and returns
+    // the result of invoking transformerDict["cancel"] with argument list « reason » and callback this value transformer.
+    if (transformer_dict.cancel) {
+        cancel_algorithm = JS::create_heap_function(realm.heap(), [&realm, transformer, callback = transformer_dict.cancel](JS::Value reason) {
+            // Note: callback returns a promise, so invoke_callback will never return an abrupt completion
+            auto result = MUST(WebIDL::invoke_callback(*callback, transformer, reason)).release_value();
+            return WebIDL::create_resolved_promise(realm, result);
+        });
+    }
+
+    // 8. Perform ! SetUpTransformStreamDefaultController(stream, controller, transformAlgorithm, flushAlgorithm).
+    set_up_transform_stream_default_controller(stream, *controller, transform_algorithm, flush_algorithm, cancel_algorithm);
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-default-controller-clear-algorithms
@@ -4701,6 +4719,9 @@ void transform_stream_default_controller_clear_algorithms(TransformStreamDefault
 
     // 2. Set controller.[[flushAlgorithm]] to undefined.
     controller.set_flush_algorithm({});
+
+    // 3. Set controller.[[cancelAlgorithm]] to undefined.
+    controller.set_cancel_algorithm({});
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-default-controller-enqueue
@@ -5073,7 +5094,7 @@ void transform_stream_set_backpressure(TransformStream& stream, bool backpressur
 }
 
 // https://streams.spec.whatwg.org/#transformstream-set-up
-void transform_stream_set_up(TransformStream& stream, JS::NonnullGCPtr<TransformAlgorithm> transform_algorithm, JS::GCPtr<FlushAlgorithm> flush_algorithm, JS::GCPtr<CancelAlgorithm>)
+void transform_stream_set_up(TransformStream& stream, JS::NonnullGCPtr<TransformAlgorithm> transform_algorithm, JS::GCPtr<FlushAlgorithm> flush_algorithm, JS::GCPtr<CancelAlgorithm> cancel_algorithm)
 {
     auto& realm = stream.realm();
 
@@ -5122,7 +5143,20 @@ void transform_stream_set_up(TransformStream& stream, JS::NonnullGCPtr<Transform
         return WebIDL::create_resolved_promise(realm, JS::js_undefined());
     });
 
-    // FIXME 7. Let cancelAlgorithmWrapper be an algorithm that runs these steps given a value reason:
+    // 7. Let cancelAlgorithmWrapper be an algorithm that runs these steps given a value reason:
+    auto cancel_algorithm_wrapper = JS::create_heap_function(realm.heap(), [&realm, cancel_algorithm](JS::Value reason) -> JS::NonnullGCPtr<WebIDL::Promise> {
+        // 1. Let result be the result of running cancelAlgorithm given reason, if cancelAlgorithm was given, or null otherwise. If this throws an exception e, return a promise rejected with e.
+        JS::GCPtr<JS::PromiseCapability> result = nullptr;
+        if (cancel_algorithm)
+            result = cancel_algorithm->function()(reason);
+
+        // 2. If result is a Promise, then return result.
+        if (result)
+            return JS::NonnullGCPtr { *result };
+
+        // 3. Return a promise resolved with undefined.
+        return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    });
 
     // 8. Let startPromise be a promise resolved with undefined.
     auto start_promise = WebIDL::create_resolved_promise(realm, JS::js_undefined());
@@ -5134,7 +5168,7 @@ void transform_stream_set_up(TransformStream& stream, JS::NonnullGCPtr<Transform
     auto controller = realm.heap().allocate<TransformStreamDefaultController>(realm, realm);
 
     // 11. Perform ! SetUpTransformStreamDefaultController(stream, controller, transformAlgorithmWrapper, flushAlgorithmWrapper, cancelAlgorithmWrapper).
-    set_up_transform_stream_default_controller(stream, controller, transform_algorithm_wrapper, flush_algorithm_wrapper);
+    set_up_transform_stream_default_controller(stream, controller, transform_algorithm_wrapper, flush_algorithm_wrapper, cancel_algorithm_wrapper);
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-unblock-write

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -5032,6 +5032,14 @@ void transform_stream_set_up(TransformStream& stream, JS::NonnullGCPtr<Transform
     set_up_transform_stream_default_controller(stream, controller, transform_algorithm_wrapper, flush_algorithm_wrapper);
 }
 
+// https://streams.spec.whatwg.org/#transform-stream-unblock-write
+void transform_stream_unblock_write(TransformStream& stream)
+{
+    // 1. If stream.[[backpressure]] is true, perform ! TransformStreamSetBackpressure(stream, false).
+    if (stream.backpressure().has_value() && stream.backpressure().value())
+        transform_stream_set_backpressure(stream, false);
+}
+
 // https://streams.spec.whatwg.org/#is-non-negative-number
 bool is_non_negative_number(JS::Value value)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -4804,11 +4804,60 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_abort_algorithm(
 {
     auto& realm = stream.realm();
 
-    // 1. Perform ! TransformStreamError(stream, reason).
-    transform_stream_error(stream, reason);
+    // 1. Let controller be stream.[[controller]].
+    auto controller = stream.controller();
+    VERIFY(controller);
 
-    // 2. Return a promise resolved with undefined.
-    return WebIDL::create_resolved_promise(realm, JS::js_undefined());
+    // 2. If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
+    if (controller->finish_promise())
+        return JS::NonnullGCPtr { *controller->finish_promise() };
+
+    // 3. Let readable be stream.[[readable]].
+    auto readable = stream.readable();
+
+    // 4. Let controller.[[finishPromise]] be a new promise.
+    controller->set_finish_promise(WebIDL::create_promise(realm));
+
+    // 5. Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
+    auto cancel_promise = controller->cancel_algorithm()->function()(reason);
+
+    // 6. Perform ! TransformStreamDefaultControllerClearAlgorithms(controller).
+    transform_stream_default_controller_clear_algorithms(*controller);
+
+    // 7. React to cancelPromise:
+    WebIDL::react_to_promise(
+        *cancel_promise,
+        // 1. If cancelPromise was fulfilled, then:
+        JS::create_heap_function(realm.heap(), [&realm, readable, controller](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
+            // 1. If readable.[[state]] is "errored", reject controller.[[finishPromise]] with readable.[[storedError]].
+            if (readable->state() == ReadableStream::State::Errored) {
+                WebIDL::reject_promise(realm, *controller->finish_promise(), readable->stored_error());
+            }
+            // 2. Otherwise:
+            else {
+                VERIFY(readable->controller().has_value() && readable->controller()->has<JS::NonnullGCPtr<ReadableStreamDefaultController>>());
+                // 1. Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], reason).
+                readable_stream_default_controller_error(readable->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>(), reason);
+
+                // 2. Resolve controller.[[finishPromise]] with undefined.
+                WebIDL::resolve_promise(realm, *controller->finish_promise(), JS::js_undefined());
+            }
+            return JS::js_undefined();
+        }),
+        // 2. If cancelPromise was rejected with reason r, then:
+        JS::create_heap_function(realm.heap(), [&realm, readable, controller](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
+            VERIFY(readable->controller().has_value() && readable->controller()->has<JS::NonnullGCPtr<ReadableStreamDefaultController>>());
+            // 1. Perform ! ReadableStreamDefaultControllerError(readable.[[controller]], r).
+            readable_stream_default_controller_error(readable->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>(), reason);
+
+            // 2. Reject controller.[[finishPromise]] with r.
+            WebIDL::reject_promise(realm, *controller->finish_promise(), reason);
+
+            return JS::js_undefined();
+        }));
+
+    // 8. Return controller.[[finishPromise]].
+    return JS::NonnullGCPtr { *controller->finish_promise() };
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-default-sink-close-algorithm

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -4920,6 +4920,65 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_pull_algorithm
     return JS::NonnullGCPtr { *stream.backpressure_change_promise() };
 }
 
+// https://streams.spec.whatwg.org/#transform-stream-default-source-cancel
+JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_cancel_algorithm(TransformStream& stream, JS::Value reason)
+{
+    auto& realm = stream.realm();
+
+    // 1. Let controller be stream.[[controller]].
+    auto controller = stream.controller();
+
+    // 2. If controller.[[finishPromise]] is not undefined, return controller.[[finishPromise]].
+    if (controller->finish_promise())
+        return JS::NonnullGCPtr { *controller->finish_promise() };
+
+    // 3. Let writable be stream.[[writable]].
+    auto writable = stream.writable();
+
+    // 4. Let controller.[[finishPromise]] be a new promise.
+    controller->set_finish_promise(WebIDL::create_promise(realm));
+
+    // 5. Let cancelPromise be the result of performing controller.[[cancelAlgorithm]], passing reason.
+    auto cancel_promise = controller->cancel_algorithm()->function()(reason);
+
+    // 6. Perform ! TransformStreamDefaultControllerClearAlgorithms(controller).
+    transform_stream_default_controller_clear_algorithms(*controller);
+
+    // 7. React to cancelPromise:
+    WebIDL::react_to_promise(
+        *cancel_promise,
+        // 1. If cancelPromise was fulfilled, then:
+        JS::create_heap_function(realm.heap(), [&realm, writable, controller, &stream](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
+            // 1. If writable.[[state]] is "errored", reject controller.[[finishPromise]] with writable.[[storedError]].
+            if (writable->state() == WritableStream::State::Errored) {
+                WebIDL::reject_promise(realm, *controller->finish_promise(), writable->stored_error());
+            }
+            // 2. Otherwise:
+            else {
+                // 1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(writable.[[controller]], reason).
+                writable_stream_default_controller_error_if_needed(*writable->controller(), reason);
+                // 2. Perform ! TransformStreamUnblockWrite(stream).
+                transform_stream_unblock_write(stream);
+                // 3. Resolve controller.[[finishPromise]] with undefined.
+                WebIDL::resolve_promise(realm, *controller->finish_promise(), JS::js_undefined());
+            }
+            return JS::js_undefined();
+        }),
+        // 2. If cancelPromise was rejected with reason r, then:
+        JS::create_heap_function(realm.heap(), [&realm, writable, &stream, controller](JS::Value reason) -> WebIDL::ExceptionOr<JS::Value> {
+            // 1. Perform ! WritableStreamDefaultControllerErrorIfNeeded(writable.[[controller]], r).
+            writable_stream_default_controller_error_if_needed(*writable->controller(), reason);
+            // 2. Perform ! TransformStreamUnblockWrite(stream).
+            transform_stream_unblock_write(stream);
+            // 3. Reject controller.[[finishPromise]] with r.
+            WebIDL::reject_promise(realm, *controller->finish_promise(), reason);
+            return JS::js_undefined();
+        }));
+
+    // 8. Return controller.[[finishPromise]].
+    return JS::NonnullGCPtr { *controller->finish_promise() };
+}
+
 // https://streams.spec.whatwg.org/#transform-stream-error
 void transform_stream_error(TransformStream& stream, JS::Value error)
 {

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -166,7 +166,7 @@ void writable_stream_default_controller_process_write(WritableStreamDefaultContr
 void writable_stream_default_controller_write(WritableStreamDefaultController&, JS::Value chunk, JS::Value chunk_size);
 
 void initialize_transform_stream(TransformStream&, JS::NonnullGCPtr<JS::PromiseCapability> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm);
-void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, JS::NonnullGCPtr<TransformAlgorithm>, JS::NonnullGCPtr<FlushAlgorithm>);
+void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, JS::NonnullGCPtr<TransformAlgorithm>, JS::NonnullGCPtr<FlushAlgorithm>, JS::NonnullGCPtr<CancelAlgorithm>);
 void set_up_transform_stream_default_controller_from_transformer(TransformStream&, JS::Value transformer, Transformer&);
 void transform_stream_default_controller_clear_algorithms(TransformStreamDefaultController&);
 WebIDL::ExceptionOr<void> transform_stream_default_controller_enqueue(TransformStreamDefaultController&, JS::Value chunk);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -181,6 +181,7 @@ void transform_stream_error(TransformStream&, JS::Value error);
 void transform_stream_error_writable_and_unblock_write(TransformStream&, JS::Value error);
 void transform_stream_set_backpressure(TransformStream&, bool backpressure);
 void transform_stream_set_up(TransformStream&, JS::NonnullGCPtr<TransformAlgorithm>, JS::GCPtr<FlushAlgorithm> = {}, JS::GCPtr<CancelAlgorithm> = {});
+void transform_stream_unblock_write(TransformStream&);
 
 bool is_non_negative_number(JS::Value);
 bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer);

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -177,6 +177,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_abort_algorithm(
 JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_close_algorithm(TransformStream&);
 JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_write_algorithm(TransformStream&, JS::Value chunk);
 JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_pull_algorithm(TransformStream&);
+JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_cancel_algorithm(TransformStream&, JS::Value reason);
 void transform_stream_error(TransformStream&, JS::Value error);
 void transform_stream_error_writable_and_unblock_write(TransformStream&, JS::Value error);
 void transform_stream_set_backpressure(TransformStream&, bool backpressure);

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2023-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,6 +30,8 @@ void TransformStreamDefaultController::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_stream);
+    visitor.visit(m_cancel_algorithm);
+    visitor.visit(m_finish_promise);
     visitor.visit(m_flush_algorithm);
     visitor.visit(m_transform_algorithm);
 }

--- a/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.h
+++ b/Userland/Libraries/LibWeb/Streams/TransformStreamDefaultController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Kenneth Myhra <kennethmyhra@serenityos.org>
+ * Copyright (c) 2023-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +24,12 @@ public:
     void error(Optional<JS::Value> reason = {});
     void terminate();
 
+    JS::GCPtr<CancelAlgorithm> cancel_algorithm() { return m_cancel_algorithm; }
+    void set_cancel_algorithm(JS::GCPtr<CancelAlgorithm> value) { m_cancel_algorithm = value; }
+
+    JS::GCPtr<JS::PromiseCapability> finish_promise() { return m_finish_promise; }
+    void set_finish_promise(JS::GCPtr<JS::PromiseCapability> value) { m_finish_promise = value; }
+
     JS::GCPtr<FlushAlgorithm> flush_algorithm() { return m_flush_algorithm; }
     void set_flush_algorithm(JS::GCPtr<FlushAlgorithm>&& value) { m_flush_algorithm = move(value); }
 
@@ -37,6 +43,12 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     virtual void visit_edges(Cell::Visitor&) override;
+
+    // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-cancelalgorithm
+    JS::GCPtr<CancelAlgorithm> m_cancel_algorithm;
+
+    // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-finishpromise
+    JS::GCPtr<JS::PromiseCapability> m_finish_promise;
 
     // https://streams.spec.whatwg.org/#transformstreamdefaultcontroller-flushalgorithm
     JS::GCPtr<FlushAlgorithm> m_flush_algorithm;

--- a/Userland/Libraries/LibWeb/Streams/Transformer.cpp
+++ b/Userland/Libraries/LibWeb/Streams/Transformer.cpp
@@ -22,6 +22,7 @@ JS::ThrowCompletionOr<Transformer> Transformer::from_value(JS::VM& vm, JS::Value
         .start = TRY(property_to_callback(vm, value, "start", WebIDL::OperationReturnsPromise::No)),
         .transform = TRY(property_to_callback(vm, value, "transform", WebIDL::OperationReturnsPromise::Yes)),
         .flush = TRY(property_to_callback(vm, value, "flush", WebIDL::OperationReturnsPromise::Yes)),
+        .cancel = TRY(property_to_callback(vm, value, "cancel", WebIDL::OperationReturnsPromise::Yes)),
         .readable_type = {},
         .writable_type = {},
     };

--- a/Userland/Libraries/LibWeb/Streams/Transformer.h
+++ b/Userland/Libraries/LibWeb/Streams/Transformer.h
@@ -20,6 +20,8 @@ struct Transformer {
     JS::Handle<WebIDL::CallbackType> transform;
     // https://streams.spec.whatwg.org/#dom-transformer-flush
     JS::Handle<WebIDL::CallbackType> flush;
+    // https://streams.spec.whatwg.org/#dom-transformer-cancel
+    JS::Handle<WebIDL::CallbackType> cancel;
 
     // https://streams.spec.whatwg.org/#dom-transformer-readabletype
     Optional<JS::Value> readable_type;


### PR DESCRIPTION
This implements the `cancel` callback for TransformStream. The `cancel` callback is raised when the readable side of the TransformStream is cancelled, or the writable side is aborted.

Also added a test to prove a ReadableStream can be cancelled, noticed this behavior lacked a test.