### PR TITLE
Fetch: Make sure we iterate over HeaderMap's headers()

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1877,7 +1877,7 @@ static void log_load_request(auto const& load_request)
 static void log_response(auto const& status_code, auto const& headers, auto const& data)
 {
     dbgln("< HTTP/1.1 {}", status_code.value_or(0));
-    for (auto const& [name, value] : headers)
+    for (auto const& [name, value] : headers.headers())
         dbgln("< {}: {}", name, value);
     dbgln("<");
     for (auto line : StringView { data }.split_view('\n', SplitBehavior::KeepEmpty))


### PR DESCRIPTION
This fixes a build failure when built with CMake option '-DENABLE_ALL_THE_DEBUG_MACROS=ON'.

Noticed this on pipeline SerenityOS (GNU, ubuntu-22.04, x86_64, ALL_DEBUG) / CI
https://github.com/SerenityOS/serenity/actions/runs/9437632127/job/25993714543#step:12:5623
