### PR TITLE
LibWeb+WebContent+UI/Qt: Provide feedback on find in page requests

### DIFF
--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -66,10 +66,15 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
         find_text_changed();
     });
 
+    m_result_label = new QLabel(this);
+    m_result_label->setVisible(false);
+    m_result_label->setStyleSheet("font-weight: bold;");
+
     layout->addWidget(m_find_text, 1);
     layout->addWidget(m_previous_button);
     layout->addWidget(m_next_button);
     layout->addWidget(m_match_case);
+    layout->addWidget(m_result_label);
     layout->addStretch(1);
     layout->addWidget(m_exit_button);
 }
@@ -121,6 +126,20 @@ void FindInPageWidget::hideEvent(QHideEvent*)
 {
     if (m_tab && m_tab->isVisible())
         m_tab->update_hover_label();
+}
+
+void FindInPageWidget::update_result_label(size_t current_match_index, Optional<size_t> const& total_match_count)
+{
+    if (total_match_count.has_value()) {
+        auto label_text = "Phrase not found"_string;
+        if (total_match_count.value() > 0)
+            label_text = MUST(String::formatted("{} of {} matches", current_match_index + 1, total_match_count.value()));
+
+        m_result_label->setText(qstring_from_ak_string(label_text));
+        m_result_label->setVisible(true);
+    } else {
+        m_result_label->setVisible(false);
+    }
 }
 
 }

--- a/Ladybird/Qt/FindInPageWidget.h
+++ b/Ladybird/Qt/FindInPageWidget.h
@@ -9,6 +9,7 @@
 #include "WebContentView.h"
 #include <LibWebView/Forward.h>
 #include <QCheckBox>
+#include <QLabel>
 #include <QLineEdit>
 #include <QPushButton>
 #include <QWidget>
@@ -22,6 +23,8 @@ class FindInPageWidget final : public QWidget {
 
 public:
     FindInPageWidget(Tab* tab, WebContentView* content_view);
+
+    void update_result_label(size_t current_match_index, Optional<size_t> const& total_match_count);
 
     virtual ~FindInPageWidget() override;
 
@@ -43,6 +46,7 @@ private:
     QPushButton* m_next_button { nullptr };
     QPushButton* m_exit_button { nullptr };
     QCheckBox* m_match_case { nullptr };
+    QLabel* m_result_label { nullptr };
 };
 
 }

--- a/Ladybird/Qt/FindInPageWidget.h
+++ b/Ladybird/Qt/FindInPageWidget.h
@@ -43,7 +43,6 @@ private:
     QPushButton* m_next_button { nullptr };
     QPushButton* m_exit_button { nullptr };
     QCheckBox* m_match_case { nullptr };
-    QAction* m_copy_attribute_value_action { nullptr };
 };
 
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -315,6 +315,10 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         view().file_picker_closed(std::move(selected_files));
     };
 
+    view().on_find_in_page = [this](auto current_match_index, auto const& total_match_count) {
+        m_find_in_page->update_result_label(current_match_index, total_match_count);
+    };
+
     m_select_dropdown = new QMenu("Select Dropdown", this);
     QObject::connect(m_select_dropdown, &QMenu::aboutToHide, this, [this]() {
         if (!m_select_dropdown->activeAction())

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -548,14 +548,14 @@ void Page::clear_selection()
     }
 }
 
-void Page::find_in_page(String const& query, CaseSensitivity case_sensitivity)
+Page::FindInPageResult Page::find_in_page(String const& query, CaseSensitivity case_sensitivity)
 {
     m_find_in_page_match_index = 0;
 
     if (query.is_empty()) {
         m_find_in_page_matches = {};
         update_find_in_page_selection();
-        return;
+        return {};
     }
 
     auto documents = HTML::main_thread_event_loop().documents_in_this_event_loop();
@@ -573,12 +573,17 @@ void Page::find_in_page(String const& query, CaseSensitivity case_sensitivity)
         m_find_in_page_matches.append(*match);
 
     update_find_in_page_selection();
+
+    return Page::FindInPageResult {
+        .current_match_index = m_find_in_page_match_index,
+        .total_match_count = m_find_in_page_matches.size(),
+    };
 }
 
-void Page::find_in_page_next_match()
+Page::FindInPageResult Page::find_in_page_next_match()
 {
     if (m_find_in_page_matches.is_empty())
-        return;
+        return {};
 
     if (m_find_in_page_match_index == m_find_in_page_matches.size() - 1) {
         m_find_in_page_match_index = 0;
@@ -587,12 +592,17 @@ void Page::find_in_page_next_match()
     }
 
     update_find_in_page_selection();
+
+    return Page::FindInPageResult {
+        .current_match_index = m_find_in_page_match_index,
+        .total_match_count = m_find_in_page_matches.size(),
+    };
 }
 
-void Page::find_in_page_previous_match()
+Page::FindInPageResult Page::find_in_page_previous_match()
 {
     if (m_find_in_page_matches.is_empty())
-        return;
+        return {};
 
     if (m_find_in_page_match_index == 0) {
         m_find_in_page_match_index = m_find_in_page_matches.size() - 1;
@@ -601,6 +611,11 @@ void Page::find_in_page_previous_match()
     }
 
     update_find_in_page_selection();
+
+    return Page::FindInPageResult {
+        .current_match_index = m_find_in_page_match_index,
+        .total_match_count = m_find_in_page_matches.size(),
+    };
 }
 
 void Page::update_find_in_page_selection()

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -181,9 +181,13 @@ public:
 
     void clear_selection();
 
-    void find_in_page(String const& query, CaseSensitivity);
-    void find_in_page_next_match();
-    void find_in_page_previous_match();
+    struct FindInPageResult {
+        size_t current_match_index { 0 };
+        Optional<size_t> total_match_count {};
+    };
+    FindInPageResult find_in_page(String const& query, CaseSensitivity);
+    FindInPageResult find_in_page_next_match();
+    FindInPageResult find_in_page_previous_match();
 
 private:
     explicit Page(JS::NonnullGCPtr<PageClient>);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -189,6 +189,7 @@ public:
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;
     Function<void(Web::KeyEvent const&)> on_finish_handling_key_event;
     Function<void()> on_text_test_finish;
+    Function<void(size_t current_match_index, Optional<size_t> const& total_match_count)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;
     Function<void(Web::HTML::AudioPlayState)> on_audio_play_state_changed;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -78,6 +78,14 @@ void WebContentClient::did_finish_text_test(u64 page_id)
     }
 }
 
+void WebContentClient::did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> const& total_match_count)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_find_in_page)
+            view->on_find_in_page(current_match_index, total_match_count);
+    }
+}
+
 void WebContentClient::did_request_navigate_back(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -95,6 +95,7 @@ private:
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items) override;
     virtual void did_finish_handling_input_event(u64 page_id, bool event_was_accepted) override;
     virtual void did_finish_text_test(u64 page_id) override;
+    virtual void did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> const& total_match_count) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, String const& data, String const& presentation_style, String const& mime_type) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -826,7 +826,8 @@ void ConnectionFromClient::find_in_page(u64 page_id, String const& query, CaseSe
     if (!page.has_value())
         return;
 
-    page->page().find_in_page(query, case_sensitivity);
+    auto result = page->page().find_in_page(query, case_sensitivity);
+    async_did_find_in_page(page_id, result.current_match_index, result.total_match_count);
 }
 
 void ConnectionFromClient::find_in_page_next_match(u64 page_id)
@@ -835,7 +836,8 @@ void ConnectionFromClient::find_in_page_next_match(u64 page_id)
     if (!page.has_value())
         return;
 
-    page->page().find_in_page_next_match();
+    auto result = page->page().find_in_page_next_match();
+    async_did_find_in_page(page_id, result.current_match_index, result.total_match_count);
 }
 
 void ConnectionFromClient::find_in_page_previous_match(u64 page_id)
@@ -844,7 +846,8 @@ void ConnectionFromClient::find_in_page_previous_match(u64 page_id)
     if (!page.has_value())
         return;
 
-    page->page().find_in_page_previous_match();
+    auto result = page->page().find_in_page_previous_match();
+    async_did_find_in_page(page_id, result.current_match_index, result.total_match_count);
 }
 
 void ConnectionFromClient::paste(u64 page_id, String const& text)

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -88,6 +88,8 @@ endpoint WebContentClient
 
     did_finish_text_test(u64 page_id) =|
 
+    did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> total_match_count) =|
+
     request_worker_agent(u64 page_id) => (IPC::File socket) // FIXME: Add required attributes to select a SharedWorker Agent
 
     inspector_did_load(u64 page_id) =|


### PR DESCRIPTION
With this PR the results of a find in page query can now be reported back to the user interface. Currently, the number of results found and the current match index are reported.

I've updated the Qt chrome to show the results in the find in page panel. I haven't touched the MacOS chrome in this PR.

Demo:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/dae1da9c-83a9-48fa-9d4f-8ba9d89260e3

