### PR TITLE
LibWeb+WebContent: Move PageClient::paint() into TraversableNavigable

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2092,7 +2092,7 @@ void Navigable::inform_the_navigation_api_about_aborting_navigation()
     }));
 }
 
-void Navigable::paint(Painting::RecordingPainter& recording_painter, PaintConfig config)
+void Navigable::record_painting_commands(Painting::RecordingPainter& recording_painter, PaintConfig config)
 {
     auto document = active_document();
     if (!document)

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -183,7 +183,7 @@ public:
         bool should_show_line_box_borders { false };
         bool has_focus { false };
     };
-    void paint(Painting::RecordingPainter&, PaintConfig);
+    void record_painting_commands(Painting::RecordingPainter&, PaintConfig);
 
     Page& page() { return m_page; }
     Page const& page() const { return m_page; }

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/NavigationType.h>
 #include <LibWeb/HTML/SessionHistoryTraversalQueue.h>
 #include <LibWeb/HTML/VisibilityState.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::HTML {
 
@@ -83,6 +84,8 @@ public:
     void set_window_handle(String window_handle) { m_window_handle = move(window_handle); }
 
     [[nodiscard]] JS::GCPtr<DOM::Node> currently_focused_area();
+
+    void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions);
 
 private:
     TraversableNavigable(JS::NonnullGCPtr<Page>);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -39,6 +39,10 @@
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/UIEvents/KeyCode.h>
 
+#ifdef HAS_ACCELERATED_GRAPHICS
+#    include <LibAccelGfx/Context.h>
+#endif
+
 namespace Web {
 
 class PageClient;
@@ -245,6 +249,15 @@ struct PaintOptions {
     };
 
     PaintOverlay paint_overlay { PaintOverlay::Yes };
+    bool should_show_line_box_borders { false };
+    bool has_focus { false };
+
+    bool use_gpu_painter { false };
+    bool use_experimental_cpu_transform_support { false };
+
+#ifdef HAS_ACCELERATED_GRAPHICS
+    AccelGfx::Context* accelerated_graphics_context { nullptr };
+#endif
 };
 
 class PageClient : public JS::Cell {

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -60,7 +60,7 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
         paint_config.paint_overlay = context.should_paint_overlay();
         paint_config.should_show_line_box_borders = context.should_show_line_box_borders();
         paint_config.has_focus = context.has_focus();
-        const_cast<DOM::Document*>(hosted_document)->navigable()->paint(context.recording_painter(), paint_config);
+        const_cast<DOM::Document*>(hosted_document)->navigable()->record_painting_commands(context.recording_painter(), paint_config);
 
         context.recording_painter().restore();
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -96,7 +96,7 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
     Painting::RecordingPainter recording_painter(painting_commands);
     Painting::CommandExecutorCPU executor { *bitmap };
 
-    m_document->navigable()->paint(recording_painter, {});
+    m_document->navigable()->record_painting_commands(recording_painter, {});
     painting_commands.execute(executor);
 
     return bitmap;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -7,22 +7,17 @@
  */
 
 #include <LibGfx/ShareableBitmap.h>
-#include <LibGfx/SystemTheme.h>
 #include <LibJS/Console.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
-#include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
-#include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Layout/Viewport.h>
-#include <LibWeb/Painting/CommandExecutorCPU.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
-#include <LibWeb/Platform/Timer.h>
 #include <LibWebView/Attribute.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
@@ -203,34 +198,12 @@ void PageClient::paint_next_frame()
 
 void PageClient::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& target, Web::PaintOptions paint_options)
 {
-    Web::Painting::CommandList painting_commands;
-    Web::Painting::RecordingPainter recording_painter(painting_commands);
-
-    Gfx::IntRect bitmap_rect { {}, content_rect.size().to_type<int>() };
-    recording_painter.fill_rect(bitmap_rect, Web::CSS::SystemColor::canvas());
-
-    Web::HTML::Navigable::PaintConfig paint_config;
-    paint_config.paint_overlay = paint_options.paint_overlay == Web::PaintOptions::PaintOverlay::Yes;
-    paint_config.should_show_line_box_borders = m_should_show_line_box_borders;
-    paint_config.has_focus = m_has_focus;
-    page().top_level_traversable()->record_painting_commands(recording_painter, paint_config);
-
-    if (s_use_gpu_painter) {
-#ifdef HAS_ACCELERATED_GRAPHICS
-        Web::Painting::CommandExecutorGPU painting_command_executor(*m_accelerated_graphics_context, target);
-        painting_commands.execute(painting_command_executor);
-#else
-        static bool has_warned_about_configuration = false;
-
-        if (!has_warned_about_configuration) {
-            warnln("\033[31;1mConfigured to use GPU painter, but current platform does not have accelerated graphics\033[0m");
-            has_warned_about_configuration = true;
-        }
-#endif
-    } else {
-        Web::Painting::CommandExecutorCPU painting_command_executor(target, s_use_experimental_cpu_transform_support);
-        painting_commands.execute(painting_command_executor);
-    }
+    paint_options.should_show_line_box_borders = m_should_show_line_box_borders;
+    paint_options.has_focus = m_has_focus;
+    paint_options.accelerated_graphics_context = m_accelerated_graphics_context.ptr();
+    paint_options.use_gpu_painter = s_use_gpu_painter;
+    paint_options.use_experimental_cpu_transform_support = s_use_experimental_cpu_transform_support;
+    page().top_level_traversable()->paint(content_rect, target, paint_options);
 }
 
 void PageClient::set_viewport_size(Web::DevicePixelSize const& size)

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -213,7 +213,7 @@ void PageClient::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& ta
     paint_config.paint_overlay = paint_options.paint_overlay == Web::PaintOptions::PaintOverlay::Yes;
     paint_config.should_show_line_box_borders = m_should_show_line_box_borders;
     paint_config.has_focus = m_has_focus;
-    page().top_level_traversable()->paint(recording_painter, paint_config);
+    page().top_level_traversable()->record_painting_commands(recording_painter, paint_config);
 
     if (s_use_gpu_painter) {
 #ifdef HAS_ACCELERATED_GRAPHICS


### PR DESCRIPTION
This way we leak less LibWeb implementation details into WebContent.