### PR TITLE
LibWebView: Don't query public suffix list when sanitizing URLs

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -532,6 +532,7 @@ if (BUILD_TESTING)
         LibTTF
         LibTimeZone
         LibUnicode
+        LibURL
         LibVideo
         LibWeb
         LibWebView

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -489,3 +489,24 @@ TEST_CASE(username_and_password)
         EXPECT_EQ(MUST(url.password()), password);
     }
 }
+
+TEST_CASE(ascii_only_url)
+{
+    {
+        constexpr auto upper_case_url = "HTTP://EXAMPLE.COM:80/INDEX.HTML#FRAGMENT"sv;
+        URL::URL url(upper_case_url);
+        EXPECT(url.is_valid());
+        EXPECT_EQ(url.scheme(), "http");
+        EXPECT_EQ(MUST(url.serialized_host()), "example.com"sv);
+        EXPECT_EQ(url.to_byte_string(), "http://example.com/INDEX.HTML#FRAGMENT");
+    }
+
+    {
+        constexpr auto mixed_case_url = "hTtP://eXaMpLe.CoM:80/iNdEx.HtMl#fRaGmEnT"sv;
+        URL::URL url(mixed_case_url);
+        EXPECT(url.is_valid());
+        EXPECT_EQ(url.scheme(), "http");
+        EXPECT_EQ(MUST(url.serialized_host()), "example.com"sv);
+        EXPECT_EQ(url.to_byte_string(), "http://example.com/iNdEx.HtMl#fRaGmEnT");
+    }
+}

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -586,7 +586,9 @@ static ErrorOr<String> domain_to_ascii(StringView domain, bool be_strict)
         // 3. If result is the empty string, domain-to-ASCII validation error, return failure.
         if (domain.is_empty())
             return Error::from_string_literal("Empty domain");
-        return String::from_utf8_without_validation(domain.bytes());
+
+        auto lowercase_domain = domain.to_lowercase_string();
+        return String::from_utf8_without_validation(lowercase_domain.bytes());
     }
 
     Unicode::IDNA::ToAsciiOptions const options {


### PR DESCRIPTION
Previously, part of the procedure we used to sanitize URLs entered via the command line would check the host against the public suffix database. This led to some valid, but not publicly accessible URLs being treated as invalid.

This allows me to visit my favorite website (http://web-platform.test:8000) by entering it on the command line.

URLs are now also now converted to lowercase when they are sanitized, previously an uppercase string entered into the URL bar, such as EXAMPLE.COM, would fail to load as expected.