### PR TITLE
UI/Qt: Don't show URL when a new tab is initially focused

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -599,8 +599,11 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab, Tab& par
     }
 
     m_tabs_container->addTab(tab, "New Tab");
-    if (activate_tab == Web::HTML::ActivateTab::Yes)
+    if (activate_tab == Web::HTML::ActivateTab::Yes) {
         m_tabs_container->setCurrentWidget(tab);
+        if (m_tabs_container->count() != 1)
+            tab->set_url_is_hidden(true);
+    }
     initialize_tab(tab);
     return *tab;
 }
@@ -614,8 +617,11 @@ Tab& BrowserWindow::create_new_tab(Web::HTML::ActivateTab activate_tab)
     }
 
     m_tabs_container->addTab(tab, "New Tab");
-    if (activate_tab == Web::HTML::ActivateTab::Yes)
+    if (activate_tab == Web::HTML::ActivateTab::Yes) {
         m_tabs_container->setCurrentWidget(tab);
+        if (m_tabs_container->count() != 1)
+            tab->set_url_is_hidden(true);
+    }
     initialize_tab(tab);
 
     return *tab;

--- a/Ladybird/Qt/LocationEdit.cpp
+++ b/Ladybird/Qt/LocationEdit.cpp
@@ -37,7 +37,7 @@ LocationEdit::LocationEdit(QWidget* parent)
         auto query = ak_string_from_qstring(text());
 
         if (auto url = WebView::sanitize_url(query, search_engine_url); url.has_value())
-            setText(qstring_from_ak_string(url->serialize()));
+            set_url(url.release_value());
     });
 
     connect(this, &QLineEdit::textEdited, [this] {
@@ -65,6 +65,11 @@ void LocationEdit::focusInEvent(QFocusEvent* event)
 void LocationEdit::focusOutEvent(QFocusEvent* event)
 {
     QLineEdit::focusOutEvent(event);
+    if (m_url_is_hidden) {
+        m_url_is_hidden = false;
+        if (text().isEmpty())
+            setText(qstring_from_ak_string(m_url.serialize()));
+    }
     highlight_location();
 }
 
@@ -107,6 +112,16 @@ void LocationEdit::highlight_location()
 
     QInputMethodEvent event(QString(), attributes);
     QCoreApplication::sendEvent(this, &event);
+}
+
+void LocationEdit::set_url(URL::URL const& url)
+{
+    m_url = url;
+    if (m_url_is_hidden) {
+        clear();
+    } else {
+        setText(qstring_from_ak_string(url.serialize()));
+    }
 }
 
 }

--- a/Ladybird/Qt/LocationEdit.h
+++ b/Ladybird/Qt/LocationEdit.h
@@ -17,12 +17,21 @@ class LocationEdit final : public QLineEdit {
 public:
     explicit LocationEdit(QWidget*);
 
+    URL::URL url() const { return m_url; }
+    void set_url(URL::URL const&);
+
+    bool url_is_hidden() const { return m_url_is_hidden; }
+    void set_url_is_hidden(bool url_is_hidden) { m_url_is_hidden = url_is_hidden; }
+
 private:
     virtual void focusInEvent(QFocusEvent* event) override;
     virtual void focusOutEvent(QFocusEvent* event) override;
 
     void highlight_location();
     AK::OwnPtr<AutoComplete> m_autocomplete;
+
+    URL::URL m_url;
+    bool m_url_is_hidden { false };
 };
 
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -145,7 +145,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
         m_favicon = default_favicon();
         emit favicon_changed(tab_index(), m_favicon);
 
-        m_location_edit->setText(url_serialized);
+        m_location_edit->set_url(url);
         m_location_edit->setCursorPosition(0);
     };
 
@@ -155,7 +155,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     };
 
     view().on_url_change = [this](auto const& url) {
-        m_location_edit->setText(qstring_from_ak_string(url.serialize()));
+        m_location_edit->set_url(url);
     };
 
     QObject::connect(m_location_edit, &QLineEdit::returnPressed, this, &Tab::location_edit_return_pressed);
@@ -863,7 +863,7 @@ void Tab::copy_link_url(URL::URL const& url)
 
 void Tab::location_edit_return_pressed()
 {
-    navigate(ak_url_from_qstring(m_location_edit->text()));
+    navigate(m_location_edit->url());
 }
 
 void Tab::open_file()

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -71,6 +71,9 @@ public:
     void set_scripting(bool);
     void set_user_agent_string(ByteString const&);
 
+    bool url_is_hidden() const { return m_location_edit->url_is_hidden(); }
+    void set_url_is_hidden(bool url_is_hidden) { m_location_edit->set_url_is_hidden(url_is_hidden); }
+
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();


### PR DESCRIPTION
Previously, I often found myself in this situation:

* Copy a URL from somewhere
* Open a new tab Ladybird
* Paste the new URL and hit Enter
* `about:newtabhttp://some-site-i-want-to-visit.com not found` :sob: 

This PR makes 2 separate but related changes that make it easier for the user to copy and paste URLs into a new tab.  

Firstly, the `about:newtab` URL is no longer displayed in the location bar when viewing the new tab page. This also has the effect of allowing the user to see the placeholder text when opening a new tab

~~Secondly, the "Page on New Tab" option has been replaced with a "Page on New Window" option. The `about:newtab` page is now shown when opening a new tab in an existing window. This matches the behavior of all other browsers that I have used - Firefox also allows the user to choose between `about:blank` and `about:newtab` for new tabs, I'd be happy to add that behavior if desired.~~
**EDIT:** I've removed this change for now, see the discussion below.

I haven't updated the AppKit chrome with this new behavior as part of this PR.

Demo with "Page on New Window" set to "http://example.com":

https://github.com/LadybirdBrowser/ladybird/assets/2817754/37bde33b-73a9-42be-b7e6-2a5c1bba3749

Fixes #137


