### PR TITLE
LibWeb: Block file: and resource: URLs on websites (and make resource: work on file: pages)

### DIFF
--- a/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -548,7 +548,8 @@ HTML::Origin url_origin(URL::URL const& url)
     }
 
     // -> "file"
-    if (url.scheme() == "file"sv) {
+    // AD-HOC: Our resource:// is basically an alias to file://
+    if (url.scheme() == "file"sv || url.scheme() == "resource"sv) {
         // Unfortunate as it is, this is left as an exercise to the reader. When in doubt, return a new opaque origin.
         // Note: We must return an origin with the `file://' protocol for `file://' iframes to work from `file://' pages.
         return HTML::Origin(url.scheme().to_byte_string(), String {}, 0);

--- a/Userland/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
@@ -54,7 +54,8 @@ Trustworthiness is_origin_potentially_trustworthy(HTML::Origin const& origin)
     }
 
     // 6. If origin’s scheme is "file", return "Potentially Trustworthy".
-    if (origin.scheme() == "file"sv)
+    // AD-HOC: Our resource:// is basically an alias to file://
+    if (origin.scheme() == "file"sv || origin.scheme() == "resource"sv)
         return Trustworthiness::PotentiallyTrustworthy;
 
     // 7. If origin’s scheme component is one which the user agent considers to be authenticated, return "Potentially Trustworthy".


### PR DESCRIPTION
This makes icons once again load in the directory listings
![Screenshot at 2024-06-10 12-35-28](https://github.com/LadybirdBrowser/ladybird/assets/39885272/4af6645f-bae1-42eb-b9e8-e3a716f216b9)
