### PR TITLE
UI/Qt: Update placeholder text if search disabled

### DIFF
--- a/Ladybird/Qt/LocationEdit.cpp
+++ b/Ladybird/Qt/LocationEdit.cpp
@@ -19,7 +19,10 @@ namespace Ladybird {
 LocationEdit::LocationEdit(QWidget* parent)
     : QLineEdit(parent)
 {
-    setPlaceholderText("Search or enter web address");
+    if (Settings::the()->enable_search())
+        setPlaceholderText("Search or enter web address");
+    else
+        setPlaceholderText("Enter web address");
     m_autocomplete = make<AutoComplete>(this);
     this->setCompleter(m_autocomplete);
 


### PR DESCRIPTION
The placeholder text is there to prompt the user as to what could be added in the address bar. The current text tells the user that they can "Search or enter web address" even when the search setting is disabled. When attempting to "Search" the user is instead sent to page ":", with an error in the console:
    WebContent(575249): (FIXME) Don't know how to navigate to :

This patch fixes this by checking whether the search feature is enabled and setting the placeholder appropriately. This provides a slightly better user experience.

Closes #132