### PR TITLE
LibJS+LibIDL+LibWeb: Reduce [FIXME] attribute unintended side effects

### DIFF
--- a/Userland/Libraries/LibIDL/IDLParser.cpp
+++ b/Userland/Libraries/LibIDL/IDLParser.cpp
@@ -1158,6 +1158,8 @@ Interface& Parser::parse()
 
     // Create overload sets
     for (auto& function : interface.functions) {
+        if (function.extended_attributes.contains("FIXME"))
+            continue;
         auto& overload_set = interface.overload_sets.ensure(function.name);
         function.overload_index = overload_set.size();
         overload_set.append(function);
@@ -1169,6 +1171,8 @@ Interface& Parser::parse()
             overloaded_function.is_overloaded = true;
     }
     for (auto& function : interface.static_functions) {
+        if (function.extended_attributes.contains("FIXME"))
+            continue;
         auto& overload_set = interface.static_overload_sets.ensure(function.name);
         function.overload_index = overload_set.size();
         overload_set.append(function);
@@ -1180,6 +1184,8 @@ Interface& Parser::parse()
             overloaded_function.is_overloaded = true;
     }
     for (auto& constructor : interface.constructors) {
+        if (constructor.extended_attributes.contains("FIXME"))
+            continue;
         auto& overload_set = interface.constructor_overload_sets.ensure(constructor.name);
         constructor.overload_index = overload_set.size();
         overload_set.append(constructor);

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -808,6 +808,13 @@ ThrowCompletionOr<Optional<PropertyDescriptor>> Object::internal_get_own_propert
     // 3. Let X be O's own property whose key is P.
     auto [value, attributes, property_offset] = *maybe_storage_entry;
 
+    // AD-HOC: Properties with the [[Unimplemented]] attribute are used for reporting unimplemented IDL interfaces.
+    if (attributes.is_unimplemented()) {
+        if (vm().on_unimplemented_property_access)
+            vm().on_unimplemented_property_access(*this, property_key);
+        descriptor.unimplemented = true;
+    }
+
     // 4. If X is a data property, then
     if (!value.is_accessor()) {
         // a. Set D.[[Value]] to the value of X's [[Value]] attribute.

--- a/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyAttributes.h
@@ -19,6 +19,8 @@ struct Attribute {
         Writable = 1 << 0,
         Enumerable = 1 << 1,
         Configurable = 1 << 2,
+        // AD-HOC: This is used for reporting unimplemented IDL interfaces.
+        Unimplemented = 1 << 3,
     };
 };
 
@@ -33,6 +35,7 @@ public:
     [[nodiscard]] bool is_writable() const { return m_bits & Attribute::Writable; }
     [[nodiscard]] bool is_enumerable() const { return m_bits & Attribute::Enumerable; }
     [[nodiscard]] bool is_configurable() const { return m_bits & Attribute::Configurable; }
+    [[nodiscard]] bool is_unimplemented() const { return m_bits & Attribute::Unimplemented; }
 
     void set_writable(bool writable = true)
     {

--- a/Userland/Libraries/LibJS/Runtime/PropertyDescriptor.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyDescriptor.h
@@ -31,7 +31,7 @@ public:
     // Not a standard abstract operation, but "If every field in Desc is absent".
     [[nodiscard]] bool is_empty() const
     {
-        return !value.has_value() && !get.has_value() && !set.has_value() && !writable.has_value() && !enumerable.has_value() && !configurable.has_value();
+        return !value.has_value() && !get.has_value() && !set.has_value() && !writable.has_value() && !enumerable.has_value() && !configurable.has_value() && !unimplemented.has_value();
     }
 
     Optional<Value> value {};
@@ -40,6 +40,7 @@ public:
     Optional<bool> writable {};
     Optional<bool> enumerable {};
     Optional<bool> configurable {};
+    Optional<bool> unimplemented {};
 
     Optional<u32> property_offset {};
 };
@@ -65,6 +66,8 @@ struct Formatter<JS::PropertyDescriptor> : Formatter<StringView> {
             TRY(parts.try_append(TRY(String::formatted("[[Enumerable]]: {}", *property_descriptor.enumerable))));
         if (property_descriptor.configurable.has_value())
             TRY(parts.try_append(TRY(String::formatted("[[Configurable]]: {}", *property_descriptor.configurable))));
+        if (property_descriptor.unimplemented.has_value())
+            TRY(parts.try_append(TRY(String::formatted("[[Unimplemented]]: {}", *property_descriptor.unimplemented))));
         return Formatter<StringView>::format(builder, TRY(String::formatted("PropertyDescriptor {{ {} }}", TRY(String::join(", "sv, parts)))));
     }
 };

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -223,6 +223,7 @@ public:
     Function<void()> on_call_stack_emptied;
     Function<void(Promise&)> on_promise_unhandled_rejection;
     Function<void(Promise&)> on_promise_rejection_handled;
+    Function<void(Object const&, PropertyKey const&)> on_unimplemented_property_access;
 
     CustomData* custom_data() { return m_custom_data; }
 

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -81,6 +81,9 @@ ErrorOr<void> initialize_main_thread_vm()
     VERIFY(!s_main_thread_vm);
 
     s_main_thread_vm = TRY(JS::VM::create(make<WebEngineCustomData>()));
+    s_main_thread_vm->on_unimplemented_property_access = [](auto const& object, auto const& property_key) {
+        dbgln("FIXME: Unimplemented IDL interface: '{}.{}'", object.class_name(), property_key.to_string());
+    };
 
     // NOTE: We intentionally leak the main thread JavaScript VM.
     //       This avoids doing an exhaustive garbage collection on process exit.


### PR DESCRIPTION
This PR adds a new `JS::Attribute` - [[Unimplemented]]. Properties marked with the [[Unimplemented]] attribute behave as normal but invoke the `VM::on_unimplemented_property_access` callback whenever they are accessed.

This attribute is now used to implement IDL interfaces with the [FIXME] extended attribute. This fixes an issue where [FIXME] methods broke feature detection on some sites.