### PR TITLE
UI/Qt: Show search engine name in location bar

### DIFF
--- a/Ladybird/Qt/LocationEdit.cpp
+++ b/Ladybird/Qt/LocationEdit.cpp
@@ -19,10 +19,10 @@ namespace Ladybird {
 LocationEdit::LocationEdit(QWidget* parent)
     : QLineEdit(parent)
 {
-    if (Settings::the()->enable_search())
-        setPlaceholderText("Search or enter web address");
-    else
-        setPlaceholderText("Enter web address");
+    update_placeholder();
+    QObject::connect(Settings::the(), &Settings::enable_search_changed, this, &LocationEdit::update_placeholder);
+    QObject::connect(Settings::the(), &Settings::search_engine_changed, this, &LocationEdit::update_placeholder);
+
     m_autocomplete = make<AutoComplete>(this);
     this->setCompleter(m_autocomplete);
 
@@ -74,6 +74,16 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
             setText(qstring_from_ak_string(m_url.serialize()));
     }
     highlight_location();
+}
+
+void LocationEdit::update_placeholder()
+{
+    if (Settings::the()->enable_search())
+        setPlaceholderText(qstring_from_ak_string(
+            MUST(String::formatted("Search with {} or enter web address",
+                Settings::the()->search_engine().name))));
+    else
+        setPlaceholderText("Enter web address");
 }
 
 void LocationEdit::highlight_location()

--- a/Ladybird/Qt/LocationEdit.h
+++ b/Ladybird/Qt/LocationEdit.h
@@ -27,6 +27,7 @@ private:
     virtual void focusInEvent(QFocusEvent* event) override;
     virtual void focusOutEvent(QFocusEvent* event) override;
 
+    void update_placeholder();
     void highlight_location();
     AK::OwnPtr<AutoComplete> m_autocomplete;
 

--- a/Ladybird/Qt/Settings.cpp
+++ b/Ladybird/Qt/Settings.cpp
@@ -64,6 +64,7 @@ void Settings::set_search_engine(WebView::SearchEngine search_engine)
 {
     m_qsettings->setValue("search_engine_name", qstring_from_ak_string(search_engine.name));
     m_search_engine = move(search_engine);
+    emit search_engine_changed(m_search_engine);
 }
 
 Settings::EngineProvider Settings::autocomplete_engine()
@@ -109,6 +110,7 @@ bool Settings::enable_search()
 void Settings::set_enable_search(bool enable)
 {
     m_qsettings->setValue("enable_search", enable);
+    emit enable_search_changed(enable);
 }
 
 bool Settings::show_menubar()

--- a/Ladybird/Qt/Settings.h
+++ b/Ladybird/Qt/Settings.h
@@ -63,6 +63,8 @@ public:
 
 signals:
     void show_menubar_changed(bool show_menubar);
+    void enable_search_changed(bool enable);
+    void search_engine_changed(WebView::SearchEngine engine);
 
 protected:
     Settings();


### PR DESCRIPTION
The placeholder text shows "Search or enter web address" which doesn't tell the user about *how* the search will be performed. Other popular open source browsers show the search engine that will be used. For example:

	Chromium: "Search **engine** or type a URL"
	Firefox: "Search with **engine** or enter address"

This change changes the placeholder text of the location bar to show "Search with **engine** or enter web address".