### PR TITLE
LibWeb: Replace usage of Gfx::PaintStyle in fill{stoke}_path commands

### DIFF
--- a/Userland/Libraries/LibGfx/PaintStyle.h
+++ b/Userland/Libraries/LibGfx/PaintStyle.h
@@ -161,6 +161,8 @@ public:
     }
 
     ReadonlySpan<ColorStop> color_stops() const { return m_color_stops; }
+    void set_color_stops(Vector<ColorStop>&& color_stops) { m_color_stops = move(color_stops); }
+
     Optional<float> repeat_length() const { return m_repeat_length; }
 
 private:
@@ -314,6 +316,9 @@ public:
         m_spread_method = spread_method;
     }
 
+    void set_inverse_transform(AffineTransform transform) { m_inverse_transform = transform; }
+    void set_scale(float scale) { m_scale = scale; }
+
 protected:
     Optional<AffineTransform> const& scale_adjusted_inverse_gradient_transform() const { return m_inverse_transform; }
     float gradient_transform_scale() const { return m_scale; }
@@ -342,14 +347,14 @@ public:
         m_p1 = end_point;
     }
 
-private:
-    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
-
     SVGLinearGradientPaintStyle(FloatPoint p0, FloatPoint p1)
         : m_p0(p0)
         , m_p1(p1)
     {
     }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
 
     FloatPoint m_p0;
     FloatPoint m_p1;
@@ -382,9 +387,6 @@ public:
         m_end_radius = end_radius;
     }
 
-private:
-    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
-
     SVGRadialGradientPaintStyle(FloatPoint start_center, float start_radius, FloatPoint end_center, float end_radius)
         : m_start_center(start_center)
         , m_start_radius(start_radius)
@@ -392,6 +394,9 @@ private:
         , m_end_radius(end_radius)
     {
     }
+
+private:
+    virtual void paint(IntRect physical_bounding_box, PaintFunction paint) const override;
 
     FloatPoint m_start_center;
     float m_start_radius { 0.0f };

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -553,6 +553,7 @@ set(SOURCES
     Painting/MediaPaintable.cpp
     Painting/NestedBrowsingContextPaintable.cpp
     Painting/PaintContext.cpp
+    Painting/PaintStyle.cpp
     Painting/Paintable.cpp
     Painting/PaintableBox.cpp
     Painting/PaintableFragment.cpp

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Variant.h>
 #include <LibJS/Forward.h>
 
 namespace Web {
@@ -24,6 +25,8 @@ class XMLDocumentBuilder;
 
 namespace Web::Painting {
 class RecordingPainter;
+class SVGGradientPaintStyle;
+using PaintStyle = RefPtr<SVGGradientPaintStyle>;
 }
 
 namespace Web::Animations {

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -33,6 +33,7 @@
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/GradientData.h>
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
+#include <LibWeb/Painting/PaintStyle.h>
 
 namespace Web::Painting {
 
@@ -198,7 +199,7 @@ struct FillPathUsingColor {
 struct FillPathUsingPaintStyle {
     Gfx::IntRect path_bounding_rect;
     Gfx::Path path;
-    NonnullRefPtr<Gfx::PaintStyle> paint_style;
+    PaintStyle paint_style;
     Gfx::WindingRule winding_rule;
     float opacity;
     Gfx::FloatPoint aa_translation;
@@ -231,7 +232,7 @@ struct StrokePathUsingColor {
 struct StrokePathUsingPaintStyle {
     Gfx::IntRect path_bounding_rect;
     Gfx::Path path;
-    NonnullRefPtr<Gfx::PaintStyle> paint_style;
+    PaintStyle paint_style;
     float thickness;
     float opacity = 1.0f;
     Gfx::FloatPoint aa_translation;

--- a/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CommandExecutorCPU.cpp
@@ -333,8 +333,9 @@ CommandResult CommandExecutorCPU::fill_path_using_color(FillPathUsingColor const
 CommandResult CommandExecutorCPU::fill_path_using_paint_style(FillPathUsingPaintStyle const& command)
 {
     Gfx::AntiAliasingPainter aa_painter(painter());
+    auto gfx_paint_style = command.paint_style->create_gfx_paint_style();
     aa_painter.translate(command.aa_translation);
-    aa_painter.fill_path(command.path, command.paint_style, command.opacity, command.winding_rule);
+    aa_painter.fill_path(command.path, gfx_paint_style, command.opacity, command.winding_rule);
     return CommandResult::Continue;
 }
 
@@ -349,8 +350,9 @@ CommandResult CommandExecutorCPU::stroke_path_using_color(StrokePathUsingColor c
 CommandResult CommandExecutorCPU::stroke_path_using_paint_style(StrokePathUsingPaintStyle const& command)
 {
     Gfx::AntiAliasingPainter aa_painter(painter());
+    auto gfx_paint_style = command.paint_style->create_gfx_paint_style();
     aa_painter.translate(command.aa_translation);
-    aa_painter.stroke_path(command.path, command.paint_style, command.thickness, command.opacity);
+    aa_painter.stroke_path(command.path, gfx_paint_style, command.thickness, command.opacity);
     return CommandResult::Continue;
 }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintStyle.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintStyle.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Painting/PaintStyle.h>
+
+namespace Web::Painting {
+
+void SVGGradientPaintStyle::set_gradient_transform(Gfx::AffineTransform transform)
+{
+    // Note: The scaling is removed so enough points on the gradient line are generated.
+    // Otherwise, if you scale a tiny path the gradient looks pixelated.
+    m_scale = 1.0f;
+    if (auto inverse = transform.inverse(); inverse.has_value()) {
+        auto transform_scale = transform.scale();
+        m_scale = max(transform_scale.x(), transform_scale.y());
+        m_inverse_transform = Gfx::AffineTransform {}.scale(m_scale, m_scale).multiply(*inverse);
+    } else {
+        m_inverse_transform = OptionalNone {};
+    }
+}
+
+NonnullRefPtr<Gfx::SVGGradientPaintStyle> SVGLinearGradientPaintStyle::create_gfx_paint_style() const
+{
+    auto gfx_paint_style = adopt_ref(*new Gfx::SVGLinearGradientPaintStyle(m_start_point, m_end_point));
+
+    Vector<Gfx::ColorStop> color_stops;
+    for (auto const& color_stop : m_color_stops)
+        color_stops.append({ color_stop.color, color_stop.position, color_stop.transition_hint });
+    gfx_paint_style->set_color_stops(move(color_stops));
+
+    if (m_repeat_length.has_value())
+        gfx_paint_style->set_repeat_length(*m_repeat_length);
+
+    if (m_inverse_transform.has_value())
+        gfx_paint_style->set_inverse_transform(*m_inverse_transform);
+
+    gfx_paint_style->set_scale(m_scale);
+
+    auto spread_method = static_cast<Gfx::SVGGradientPaintStyle::SpreadMethod>(to_underlying(m_spread_method));
+    gfx_paint_style->set_spread_method(spread_method);
+
+    return gfx_paint_style;
+}
+
+NonnullRefPtr<Gfx::SVGGradientPaintStyle> SVGRadialGradientPaintStyle::create_gfx_paint_style() const
+{
+    auto gfx_paint_style = adopt_ref(*new Gfx::SVGRadialGradientPaintStyle(m_start_center, m_start_radius, m_end_center, m_end_radius));
+
+    Vector<Gfx::ColorStop> color_stops;
+    for (auto const& color_stop : m_color_stops)
+        color_stops.append({ color_stop.color, color_stop.position, color_stop.transition_hint });
+    gfx_paint_style->set_color_stops(move(color_stops));
+
+    if (m_repeat_length.has_value())
+        gfx_paint_style->set_repeat_length(*m_repeat_length);
+
+    if (m_inverse_transform.has_value())
+        gfx_paint_style->set_inverse_transform(*m_inverse_transform);
+
+    gfx_paint_style->set_scale(m_scale);
+
+    auto spread_method = static_cast<Gfx::SVGGradientPaintStyle::SpreadMethod>(to_underlying(m_spread_method));
+    gfx_paint_style->set_spread_method(spread_method);
+
+    return gfx_paint_style;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Painting/PaintStyle.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintStyle.h
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefCounted.h>
+#include <AK/Variant.h>
+#include <LibGfx/PaintStyle.h>
+
+namespace Web::Painting {
+
+struct ColorStop {
+    Color color;
+    float position = AK::NaN<float>;
+    Optional<float> transition_hint = {};
+};
+
+class SVGGradientPaintStyle : public RefCounted<SVGGradientPaintStyle> {
+public:
+    virtual NonnullRefPtr<Gfx::SVGGradientPaintStyle> create_gfx_paint_style() const { VERIFY_NOT_REACHED(); }
+
+    void set_gradient_transform(Gfx::AffineTransform transform);
+
+    enum class SpreadMethod {
+        Pad,
+        Repeat,
+        Reflect
+    };
+
+    void set_spread_method(SpreadMethod spread_method) { m_spread_method = spread_method; }
+
+    Optional<Gfx::AffineTransform> const& scale_adjusted_inverse_gradient_transform() const { return m_inverse_transform; }
+    float gradient_transform_scale() const { return m_scale; }
+    SpreadMethod spread_method() const { return m_spread_method; }
+
+    void add_color_stop(float position, Color color, Optional<float> transition_hint = {})
+    {
+        return add_color_stop(ColorStop { color, position, transition_hint });
+    }
+
+    void add_color_stop(ColorStop stop, bool sort = true)
+    {
+        m_color_stops.append(stop);
+        if (sort)
+            quick_sort(m_color_stops, [](auto& a, auto& b) { return a.position < b.position; });
+    }
+
+    ReadonlySpan<ColorStop> color_stops() const { return m_color_stops; }
+    Optional<float> repeat_length() const { return m_repeat_length; }
+
+    virtual ~SVGGradientPaintStyle() {};
+
+protected:
+    Vector<ColorStop, 4> m_color_stops;
+    Optional<float> m_repeat_length;
+
+    Optional<Gfx::AffineTransform> m_inverse_transform {};
+    float m_scale { 1.0f };
+    SpreadMethod m_spread_method { SpreadMethod::Pad };
+};
+
+class SVGLinearGradientPaintStyle final : public SVGGradientPaintStyle {
+public:
+    static NonnullRefPtr<SVGLinearGradientPaintStyle> create(Gfx::FloatPoint start_point, Gfx::FloatPoint end_point)
+    {
+        return adopt_ref(*new SVGLinearGradientPaintStyle(start_point, end_point));
+    }
+
+    NonnullRefPtr<Gfx::SVGGradientPaintStyle> create_gfx_paint_style() const override;
+
+    void set_start_point(Gfx::FloatPoint start_point) { m_start_point = start_point; }
+    void set_end_point(Gfx::FloatPoint end_point) { m_end_point = end_point; }
+
+private:
+    SVGLinearGradientPaintStyle(Gfx::FloatPoint start_point, Gfx::FloatPoint end_point)
+        : m_start_point(start_point)
+        , m_end_point(end_point)
+    {
+    }
+
+    Gfx::FloatPoint m_start_point;
+    Gfx::FloatPoint m_end_point;
+};
+
+class SVGRadialGradientPaintStyle final : public SVGGradientPaintStyle {
+public:
+    static NonnullRefPtr<SVGRadialGradientPaintStyle> create(Gfx::FloatPoint start_center, float start_radius, Gfx::FloatPoint end_center, float end_radius)
+    {
+        return adopt_ref(*new SVGRadialGradientPaintStyle(start_center, start_radius, end_center, end_radius));
+    }
+
+    NonnullRefPtr<Gfx::SVGGradientPaintStyle> create_gfx_paint_style() const override;
+
+    void set_start_center(Gfx::FloatPoint start_center) { m_start_center = start_center; }
+    void set_start_radius(float start_radius) { m_start_radius = start_radius; }
+    void set_end_center(Gfx::FloatPoint end_center) { m_end_center = end_center; }
+    void set_end_radius(float end_radius) { m_end_radius = end_radius; }
+
+private:
+    SVGRadialGradientPaintStyle(Gfx::FloatPoint start_center, float start_radius, Gfx::FloatPoint end_center, float end_radius)
+        : m_start_center(start_center)
+        , m_start_radius(start_radius)
+        , m_end_center(end_center)
+        , m_end_radius(end_radius)
+    {
+    }
+
+    Gfx::FloatPoint m_start_center;
+    float m_start_radius { 0.0f };
+    Gfx::FloatPoint m_end_center;
+    float m_end_radius { 0.0f };
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
+++ b/Userland/Libraries/LibWeb/Painting/RecordingPainter.h
@@ -35,6 +35,7 @@
 #include <LibWeb/Painting/CommandList.h>
 #include <LibWeb/Painting/GradientData.h>
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
+#include <LibWeb/Painting/PaintStyle.h>
 
 namespace Web::Painting {
 
@@ -55,7 +56,7 @@ public:
 
     struct FillPathUsingPaintStyleParams {
         Gfx::Path path;
-        NonnullRefPtr<Gfx::PaintStyle> paint_style;
+        PaintStyle paint_style;
         Gfx::WindingRule winding_rule = Gfx::WindingRule::EvenOdd;
         float opacity;
         Optional<Gfx::FloatPoint> translation = {};
@@ -72,7 +73,7 @@ public:
 
     struct StrokePathUsingPaintStyleParams {
         Gfx::Path path;
-        NonnullRefPtr<Gfx::PaintStyle> paint_style;
+        PaintStyle paint_style;
         float thickness;
         float opacity;
         Optional<Gfx::FloatPoint> translation = {};

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGGradientElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGGradientElement.h>
 #include <LibWeb/SVG/SVGGraphicsElement.h>
@@ -93,7 +94,7 @@ Gfx::AffineTransform SVGGradientElement::gradient_paint_transform(SVGPaintContex
     return Gfx::AffineTransform { paint_context.transform }.multiply(transform);
 }
 
-void SVGGradientElement::add_color_stops(Gfx::SVGGradientPaintStyle& paint_style) const
+void SVGGradientElement::add_color_stops(Painting::SVGGradientPaintStyle& paint_style) const
 {
     for_each_color_stop([&](auto& stop) {
         // https://svgwg.org/svg2-draft/pservers.html#StopNotes
@@ -104,7 +105,7 @@ void SVGGradientElement::add_color_stops(Gfx::SVGGradientPaintStyle& paint_style
         // stop's offset value. If a given gradient stop's offset value is not equal to or greater than all
         // previous offset values, then the offset value is adjusted to be equal to the largest of all previous
         // offset values.
-        paint_style.add_color_stop(stop_offset, stop.stop_color().with_opacity(stop.stop_opacity())).release_value_but_fixme_should_propagate_errors();
+        paint_style.add_color_stop(stop_offset, stop.stop_color().with_opacity(stop.stop_opacity()));
     });
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -8,6 +8,7 @@
 
 #include <AK/IterationDecision.h>
 #include <LibGfx/PaintStyle.h>
+#include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGStopElement.h>
@@ -20,15 +21,15 @@ struct SVGPaintContext {
     Gfx::AffineTransform transform;
 };
 
-inline Gfx::SVGGradientPaintStyle::SpreadMethod to_gfx_spread_method(SpreadMethod spread_method)
+inline Painting::SVGGradientPaintStyle::SpreadMethod to_painting_spread_method(SpreadMethod spread_method)
 {
     switch (spread_method) {
     case SpreadMethod::Pad:
-        return Gfx::SVGGradientPaintStyle::SpreadMethod::Pad;
+        return Painting::SVGGradientPaintStyle::SpreadMethod::Pad;
     case SpreadMethod::Reflect:
-        return Gfx::SVGGradientPaintStyle::SpreadMethod::Reflect;
+        return Painting::SVGGradientPaintStyle::SpreadMethod::Reflect;
     case SpreadMethod::Repeat:
-        return Gfx::SVGGradientPaintStyle::SpreadMethod::Repeat;
+        return Painting::SVGGradientPaintStyle::SpreadMethod::Repeat;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -42,7 +43,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const = 0;
+    virtual Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&) const = 0;
 
     GradientUnits gradient_units() const;
 
@@ -66,7 +67,7 @@ protected:
         return for_each_color_stop_impl(callback, seen_gradients);
     }
 
-    void add_color_stops(Gfx::SVGGradientPaintStyle&) const;
+    void add_color_stops(Painting::SVGGradientPaintStyle&) const;
 
 private:
     template<VoidFunction<SVGStopElement> Callback>

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/SVGGraphicsPaintable.h>
 #include <LibWeb/SVG/AttributeNames.h>
@@ -48,7 +49,7 @@ void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<Strin
     }
 }
 
-Optional<Gfx::PaintStyle const&> SVGGraphicsElement::svg_paint_computed_value_to_gfx_paint_style(SVGPaintContext const& paint_context, Optional<CSS::SVGPaint> const& paint_value) const
+Optional<Painting::PaintStyle> SVGGraphicsElement::svg_paint_computed_value_to_gfx_paint_style(SVGPaintContext const& paint_context, Optional<CSS::SVGPaint> const& paint_value) const
 {
     // FIXME: This entire function is an ad-hoc hack:
     if (!paint_value.has_value() || !paint_value->is_url())
@@ -58,14 +59,14 @@ Optional<Gfx::PaintStyle const&> SVGGraphicsElement::svg_paint_computed_value_to
     return {};
 }
 
-Optional<Gfx::PaintStyle const&> SVGGraphicsElement::fill_paint_style(SVGPaintContext const& paint_context) const
+Optional<Painting::PaintStyle> SVGGraphicsElement::fill_paint_style(SVGPaintContext const& paint_context) const
 {
     if (!layout_node())
         return {};
     return svg_paint_computed_value_to_gfx_paint_style(paint_context, layout_node()->computed_values().fill());
 }
 
-Optional<Gfx::PaintStyle const&> SVGGraphicsElement::stroke_paint_style(SVGPaintContext const& paint_context) const
+Optional<Painting::PaintStyle> SVGGraphicsElement::stroke_paint_style(SVGPaintContext const& paint_context) const
 {
     if (!layout_node())
         return {};

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -51,8 +51,8 @@ public:
 
     Gfx::AffineTransform get_transform() const;
 
-    Optional<Gfx::PaintStyle const&> fill_paint_style(SVGPaintContext const&) const;
-    Optional<Gfx::PaintStyle const&> stroke_paint_style(SVGPaintContext const&) const;
+    Optional<Painting::PaintStyle> fill_paint_style(SVGPaintContext const&) const;
+    Optional<Painting::PaintStyle> stroke_paint_style(SVGPaintContext const&) const;
 
     JS::GCPtr<SVG::SVGMaskElement const> mask() const;
     JS::GCPtr<SVG::SVGClipPathElement const> clip_path() const;
@@ -70,7 +70,7 @@ protected:
         return m_transform;
     }
 
-    Optional<Gfx::PaintStyle const&> svg_paint_computed_value_to_gfx_paint_style(SVGPaintContext const& paint_context, Optional<CSS::SVGPaint> const& paint_value) const;
+    Optional<Painting::PaintStyle> svg_paint_computed_value_to_gfx_paint_style(SVGPaintContext const& paint_context, Optional<CSS::SVGPaint> const& paint_value) const;
 
     Gfx::AffineTransform m_transform = {};
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGLinearGradientElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/AttributeParser.h>
 #include <LibWeb/SVG/SVGLinearGradientElement.h>
@@ -34,16 +35,12 @@ void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional
     // FIXME: Should allow for `<number-percentage> | <length>` for x1, x2, y1, y2
     if (name == SVG::AttributeNames::x1) {
         m_x1 = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::y1) {
         m_y1 = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::x2) {
         m_x2 = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
     } else if (name == SVG::AttributeNames::y2) {
         m_y2 = AttributeParser::parse_number_percentage(value.value_or(String {}));
-        m_paint_style = nullptr;
     }
 }
 
@@ -115,7 +112,7 @@ NumberPercentage SVGLinearGradientElement::end_y_impl(HashTable<SVGGradientEleme
     return NumberPercentage::create_percentage(0);
 }
 
-Optional<Gfx::PaintStyle const&> SVGLinearGradientElement::to_gfx_paint_style(SVGPaintContext const& paint_context) const
+Optional<Painting::PaintStyle> SVGLinearGradientElement::to_gfx_paint_style(SVGPaintContext const& paint_context) const
 {
     auto units = gradient_units();
     // FIXME: Resolve percentages properly
@@ -148,8 +145,7 @@ Optional<Gfx::PaintStyle const&> SVGLinearGradientElement::to_gfx_paint_style(SV
     }
 
     if (!m_paint_style) {
-        m_paint_style = Gfx::SVGLinearGradientPaintStyle::create(start_point, end_point)
-                            .release_value_but_fixme_should_propagate_errors();
+        m_paint_style = Painting::SVGLinearGradientPaintStyle::create(start_point, end_point);
         // FIXME: Update stops in DOM changes:
         add_color_stops(*m_paint_style);
     } else {
@@ -158,7 +154,7 @@ Optional<Gfx::PaintStyle const&> SVGLinearGradientElement::to_gfx_paint_style(SV
     }
 
     m_paint_style->set_gradient_transform(gradient_paint_transform(paint_context));
-    m_paint_style->set_spread_method(to_gfx_spread_method(spread_method()));
+    m_paint_style->set_spread_method(to_painting_spread_method(spread_method()));
     return *m_paint_style;
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -21,7 +21,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
+    virtual Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&) const override;
 
     JS::NonnullGCPtr<SVGAnimatedLength> x1() const;
     JS::NonnullGCPtr<SVGAnimatedLength> y1() const;
@@ -56,7 +56,7 @@ private:
     Optional<NumberPercentage> m_x2;
     Optional<NumberPercentage> m_y2;
 
-    mutable RefPtr<Gfx::SVGLinearGradientPaintStyle> m_paint_style;
+    mutable RefPtr<Painting::SVGLinearGradientPaintStyle> m_paint_style;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SVGRadialGradientElementPrototype.h>
+#include <LibWeb/Painting/PaintStyle.h>
 #include <LibWeb/SVG/AttributeNames.h>
 #include <LibWeb/SVG/SVGRadialGradientElement.h>
 
@@ -160,7 +161,7 @@ NumberPercentage SVGRadialGradientElement::end_circle_radius_impl(HashTable<SVGG
     return NumberPercentage::create_percentage(50);
 }
 
-Optional<Gfx::PaintStyle const&> SVGRadialGradientElement::to_gfx_paint_style(SVGPaintContext const& paint_context) const
+Optional<Painting::PaintStyle> SVGRadialGradientElement::to_gfx_paint_style(SVGPaintContext const& paint_context) const
 {
     auto units = gradient_units();
     Gfx::FloatPoint start_center;
@@ -200,8 +201,7 @@ Optional<Gfx::PaintStyle const&> SVGRadialGradientElement::to_gfx_paint_style(SV
     }
 
     if (!m_paint_style) {
-        m_paint_style = Gfx::SVGRadialGradientPaintStyle::create(start_center, start_radius, end_center, end_radius)
-                            .release_value_but_fixme_should_propagate_errors();
+        m_paint_style = Painting::SVGRadialGradientPaintStyle::create(start_center, start_radius, end_center, end_radius);
         // FIXME: Update stops in DOM changes:
         add_color_stops(*m_paint_style);
     } else {
@@ -211,7 +211,7 @@ Optional<Gfx::PaintStyle const&> SVGRadialGradientElement::to_gfx_paint_style(SV
         m_paint_style->set_end_radius(end_radius);
     }
     m_paint_style->set_gradient_transform(gradient_paint_transform(paint_context));
-    m_paint_style->set_spread_method(to_gfx_spread_method(spread_method()));
+    m_paint_style->set_spread_method(to_painting_spread_method(spread_method()));
     return *m_paint_style;
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -21,7 +21,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
-    virtual Optional<Gfx::PaintStyle const&> to_gfx_paint_style(SVGPaintContext const&) const override;
+    virtual Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&) const override;
 
     JS::NonnullGCPtr<SVGAnimatedLength> cx() const;
     JS::NonnullGCPtr<SVGAnimatedLength> cy() const;
@@ -64,7 +64,7 @@ private:
     Optional<NumberPercentage> m_fr;
     Optional<NumberPercentage> m_r;
 
-    mutable RefPtr<Gfx::SVGRadialGradientPaintStyle> m_paint_style;
+    mutable RefPtr<Painting::SVGRadialGradientPaintStyle> m_paint_style;
 };
 
 }


### PR DESCRIPTION
...with a struct defined in LibWeb. This is a step towards uncoupling LibWeb from LibGfx, so we can try third-party libraries for painting.