### PR TITLE
LibWasm: Make loops work

### DIFF
--- a/Meta/CMake/wasm_spec_tests.cmake
+++ b/Meta/CMake/wasm_spec_tests.cmake
@@ -28,11 +28,6 @@ if(INCLUDE_WASM_SPEC_TESTS)
         foreach(PATH ${WASM_TESTS})
             get_filename_component(NAME ${PATH} NAME_WLE)
             message(STATUS "Generating test cases for WebAssembly test ${NAME}...")
-            # FIXME: GH 8668. loop_0.wasm causes CI timeout
-            if (NAME STREQUAL "loop")
-                message(STATUS "Skipping generation of ${NAME} test due to timeouts")
-                continue()
-            endif()
             execute_process(
                 COMMAND env SKIP_PRETTIER=${SKIP_PRETTIER} bash ${SerenityOS_SOURCE_DIR}/Meta/generate-libwasm-spec-test.sh "${PATH}" "${CMAKE_CURRENT_BINARY_DIR}/Tests/Spec" "${NAME}" "${WASM_SPEC_TEST_PATH}")
         endforeach()

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -79,7 +79,7 @@ void BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelInd
         configuration.stack().pop();
     }
 
-    for (auto& result : results)
+    for (auto& result : results.in_reverse())
         configuration.stack().push(move(result));
 
     configuration.ip() = label->continuation();
@@ -555,7 +555,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
             break;
         case BlockType::Index: {
             auto& type = configuration.frame().module().types()[args.block_type.type_index().value()];
-            arity = type.results().size();
+            arity = type.parameters().size();
             parameter_count = type.parameters().size();
         }
         }


### PR DESCRIPTION
This also enables the compilation of `loop.wast` into a JavaScript test file, since it should no longer cause timeouts or segfault.