### PR TITLE
LibWasm: Make `memory.fill` fill with single bytes

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -62,7 +62,7 @@ protected:
     Optional<VectorType> pop_vector(Configuration&);
     template<typename M, template<typename> typename SetSign, typename VectorType = Native128ByteVectorOf<M, SetSign>>
     Optional<VectorType> peek_vector(Configuration&);
-    void store_to_memory(Configuration&, Instruction const&, ReadonlyBytes data, i32 base);
+    void store_to_memory(Configuration&, Instruction const&, ReadonlyBytes data, u32 base);
     void call_address(Configuration&, FunctionAddress);
 
     template<typename PopTypeLHS, typename PushType, typename Operator, typename PopTypeRHS = PopTypeLHS, typename... Args>


### PR DESCRIPTION
Previously, `memory.fill` filled memory with 4-byte values, even though `memory.fill` should fill with just one byte. Also fixes some other issues with some of the bulk memory instructions, like `memory.init`. This PR gets `memory_fill.wast` and `memory_copy.wast` to fully pass!