### PR TITLE
LibWeb: Prevent select.click() opening the dropdown

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -431,9 +431,10 @@ WebIDL::ExceptionOr<void> HTMLSelectElement::show_picker()
     return {};
 }
 
-void HTMLSelectElement::activation_behavior(DOM::Event const&)
+void HTMLSelectElement::activation_behavior(DOM::Event const& event)
 {
-    show_the_picker_if_applicable();
+    if (event.is_trusted())
+        show_the_picker_if_applicable();
 }
 
 void HTMLSelectElement::did_select_item(Optional<u32> const& id)


### PR DESCRIPTION
No other browser allows opening the select element dropdown with the select.click() function.
This change stops this happening in Ladybird.


You can test this with https://demo.lukewarlow.dev/showPicker/ - select.click() won't open the picker UI in any browser. focus will on iOS only, showPicker will in Chrome and Firefox (safari support isn't finished yet)

There's no explicit callout for this in the HTML spec as lots of the form control UI is UA defined, but https://html.spec.whatwg.org/multipage/input.html#the-input-element:activation-behaviour-2 shows that .click() should only show the picker for legacy cases of file and color inputs, no other input's picker should show, and this includes select elements.