### PR TITLE
UI/Qt: Add standard shortcuts for find in page actions

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -157,6 +157,20 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     m_find_in_page_action->setIcon(load_icon_from_uri("resource://icons/16x16/find.png"sv));
     m_find_in_page_action->setShortcuts(QKeySequence::keyBindings(QKeySequence::StandardKey::Find));
 
+    auto find_previous_shortcuts = QKeySequence::keyBindings(QKeySequence::StandardKey::FindPrevious);
+    for (auto const& shortcut : find_previous_shortcuts)
+        new QShortcut(shortcut, this, [this] {
+            if (m_current_tab)
+                m_current_tab->find_previous();
+        });
+
+    auto find_next_shortcuts = QKeySequence::keyBindings(QKeySequence::StandardKey::FindNext);
+    for (auto const& shortcut : find_next_shortcuts)
+        new QShortcut(shortcut, this, [this] {
+            if (m_current_tab)
+                m_current_tab->find_next();
+        });
+
     edit_menu->addAction(m_find_in_page_action);
     QObject::connect(m_find_in_page_action, &QAction::triggered, this, &BrowserWindow::show_find_in_page);
 

--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -142,4 +142,14 @@ void FindInPageWidget::update_result_label(size_t current_match_index, Optional<
     }
 }
 
+void FindInPageWidget::find_previous()
+{
+    m_previous_button->click();
+}
+
+void FindInPageWidget::find_next()
+{
+    m_next_button->click();
+}
+
 }

--- a/Ladybird/Qt/FindInPageWidget.h
+++ b/Ladybird/Qt/FindInPageWidget.h
@@ -26,6 +26,9 @@ public:
 
     void update_result_label(size_t current_match_index, Optional<size_t> const& total_match_count);
 
+    void find_previous();
+    void find_next();
+
     virtual ~FindInPageWidget() override;
 
 public slots:

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -950,6 +950,16 @@ void Tab::show_find_in_page()
     m_find_in_page->setFocus();
 }
 
+void Tab::find_previous()
+{
+    m_find_in_page->find_previous();
+}
+
+void Tab::find_next()
+{
+    m_find_in_page->find_next();
+}
+
 void Tab::close_sub_widgets()
 {
     auto close_widget_window = [](auto* widget) {

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -53,6 +53,8 @@ public:
     void show_inspector_window(InspectorTarget = InspectorTarget::Document);
 
     void show_find_in_page();
+    void find_previous();
+    void find_next();
 
     QIcon const& favicon() const { return m_favicon; }
     QString const& title() const { return m_title; }


### PR DESCRIPTION
This commit adds the standard shortcuts for the Find Next and Find Previous buttons on the find in page panel. These shortcuts are usually F3 and Shift+F3 respectively, although Qt standard shortcuts may vary across platforms.

Video:


https://github.com/LadybirdBrowser/ladybird/assets/2817754/af9fcd2b-3eec-45a6-8de0-e68bf0a2f4d6

