### PR TITLE
LibJS: Link LibLocale publicly to ensure ICU data is available

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -271,7 +271,10 @@ set(SOURCES
 )
 
 serenity_lib(LibJS js)
-target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibLocale LibUnicode LibTimeZone)
+target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax LibUnicode LibTimeZone)
+
+# Link LibLocale publicly to ensure ICU data (which is in libicudata.a) is available in any process using LibJS.
+target_link_libraries(LibJS PUBLIC LibLocale)
 
 # TODO: This is probably also needed on RISC-V.
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "i.86.*")


### PR DESCRIPTION
Linking LibLocale publicly ensures that libicudata.a is also available in all embedders of LibJS. Otherwise, ICU crashes in hard-to-track-down ways at runtime when the data is not available.

Fixes #163

![Screenshot_20240614_072636](https://github.com/LadybirdBrowser/ladybird/assets/5600524/d3541f8f-6a03-423a-ad53-b1ae9227d874)
