### PR TITLE
CMake: Create a set of vcpkg overlay triplets for sanitizers

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -76,6 +76,13 @@ jobs:
             echo "host_cxx=$(brew --prefix llvm@18)/bin/clang++" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Set dynamic environment variables
+        id: 'set-env-vars'
+        run: |
+          # Note: Required for vcpkg to use this compiler for its own builds.
+          echo "CC=${{ steps.build-parameters.outputs.host_cc }} >> "$GITHUB_ENV"
+          echo "CXX=${{ steps.build-parameters.outputs.host_cxx }} >> "$GITHUB_ENV"
+
       # https://github.com/actions/runner-images/issues/9330
       - name: Enable Microphone Access (macOS 14)
         if: ${{ inputs.os == 'macos-14' }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -45,7 +45,8 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "ENABLE_UNDEFINED_SANITIZER": "ON",
-        "ENABLE_ADDRESS_SANITIZER": "ON"
+        "ENABLE_ADDRESS_SANITIZER": "ON",
+        "VCPKG_OVERLAY_TRIPLETS": "${sourceDir}/Meta/CMake/vcpkg/sanitizer-triplets"
       }
     },
     {

--- a/Meta/CMake/vcpkg/sanitizer-triplets/arm64-osx.cmake
+++ b/Meta/CMake/vcpkg/sanitizer-triplets/arm64-osx.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+
+set(VCPKG_C_FLAGS -fsanitize=address,undefined)
+set(VCPKG_CXX_FLAGS -fsanitize=address,undefined)

--- a/Meta/CMake/vcpkg/sanitizer-triplets/x64-linux.cmake
+++ b/Meta/CMake/vcpkg/sanitizer-triplets/x64-linux.cmake
@@ -1,0 +1,8 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+set(VCPKG_C_FLAGS -fsanitize=address,undefined)
+set(VCPKG_CXX_FLAGS -fsanitize=address,undefined)

--- a/Meta/CMake/vcpkg/sanitizer-triplets/x64-osx.cmake
+++ b/Meta/CMake/vcpkg/sanitizer-triplets/x64-osx.cmake
@@ -1,0 +1,9 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES x86_64)
+
+set(VCPKG_C_FLAGS -fsanitize=address,undefined)
+set(VCPKG_CXX_FLAGS -fsanitize=address,undefined)

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -77,6 +77,10 @@ cmd_with_target() {
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER=${CC}")
     CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=${CXX}")
 
+    # Export CC and CXX for the vcpkg toolchain, so it will pick up the same version as the ladybird build
+    export CC="$CC"
+    export CXX="$CXX"
+
     if [ ! -d "$LADYBIRD_SOURCE_DIR" ]; then
         LADYBIRD_SOURCE_DIR="$(get_top_dir)"
         export LADYBIRD_SOURCE_DIR


### PR DESCRIPTION
This changes the Sanitizer configs to build all the vcpkg dependencies with our specified CFLAGS and CXXFLAGS for ASAN and UBSAN.

This is kind of risky, because it might fail our CI due to problems in our dependencies. But hopefully we won't be pulling in dependencies with such problems :). Or we can just patch them locally and open PRs.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/162