### PR TITLE
LibJS: Support non-Gregorian calendars for Intl.DateTimeFormat

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -21,25 +21,28 @@
 
 namespace JS::Intl {
 
+using LocaleKey = Variant<Empty, String>;
+Optional<LocaleKey> locale_key_from_value(Value);
+
 struct LocaleOptions {
     Value locale_matcher;
-    Optional<String> ca; // [[Calendar]]
-    Optional<String> co; // [[Collation]]
-    Optional<String> hc; // [[HourCycle]]
-    Optional<String> kf; // [[CaseFirst]]
-    Optional<String> kn; // [[Numeric]]
-    Optional<String> nu; // [[NumberingSystem]]
+    Optional<LocaleKey> ca; // [[Calendar]]
+    Optional<LocaleKey> co; // [[Collation]]
+    Optional<LocaleKey> hc; // [[HourCycle]]
+    Optional<LocaleKey> kf; // [[CaseFirst]]
+    Optional<LocaleKey> kn; // [[Numeric]]
+    Optional<LocaleKey> nu; // [[NumberingSystem]]
 };
 
 struct LocaleResult {
     String locale;
     String data_locale;
-    Optional<String> ca; // [[Calendar]]
-    Optional<String> co; // [[Collation]]
-    Optional<String> hc; // [[HourCycle]]
-    Optional<String> kf; // [[CaseFirst]]
-    Optional<String> kn; // [[Numeric]]
-    Optional<String> nu; // [[NumberingSystem]]
+    LocaleKey ca; // [[Calendar]]
+    LocaleKey co; // [[Collation]]
+    LocaleKey hc; // [[HourCycle]]
+    LocaleKey kf; // [[CaseFirst]]
+    LocaleKey kn; // [[Numeric]]
+    LocaleKey nu; // [[NumberingSystem]]
 };
 
 struct PatternPartition {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -343,7 +343,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
         // d. Let styles be dataLocaleData.[[styles]].[[<resolvedCalendar>]].
         // e. Let bestFormat be DateTimeStyleFormat(dateStyle, timeStyle, styles).
         auto formatter = ::Locale::DateTimeFormat::create_for_date_and_time_style(
-            date_time_format->data_locale(),
+            date_time_format->locale(),
             time_zone,
             format_options.hour_cycle,
             format_options.hour12,
@@ -421,7 +421,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
         // h. Else,
         //     i. Let bestFormat be BestFitFormatMatcher(formatOptions, formats).
         auto formatter = ::Locale::DateTimeFormat::create_for_pattern_options(
-            date_time_format->data_locale(),
+            date_time_format->locale(),
             time_zone,
             format_options);
         date_time_format->set_formatter(move(formatter));

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -77,8 +77,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     // 8. Let opt be the Record { [[localeMatcher]]: matcher, [[nu]]: numberingSystem }.
     LocaleOptions opt {};
     opt.locale_matcher = matcher;
-    if (!numbering_system.is_undefined())
-        opt.nu = numbering_system.as_string().utf8_string();
+    opt.nu = locale_key_from_value(numbering_system);
 
     // 9. Let r be ResolveLocale(%DurationFormat%.[[AvailableLocales]], requestedLocales, opt, %DurationFormat%.[[RelevantExtensionKeys]], %DurationFormat%.[[LocaleData]]).
     auto result = resolve_locale(requested_locales, opt, DurationFormat::relevant_extension_keys());
@@ -110,8 +109,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     duration_format->set_minutes_seconds_separator(move(digital_format.minutes_seconds_separator));
 
     // 22. Set durationFormat.[[NumberingSystem]] to r.[[nu]].
-    if (result.nu.has_value())
-        duration_format->set_numbering_system(result.nu.release_value());
+    if (auto* resolved_numbering_system = result.nu.get_pointer<String>())
+        duration_format->set_numbering_system(move(*resolved_numbering_system));
 
     // 23. Let style be ? GetOption(options, "style", string, « "long", "short", "narrow", "digital" », "short").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv, "digital"sv }, "short"sv));

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -106,10 +106,10 @@ ThrowCompletionOr<NonnullGCPtr<NumberFormat>> initialize_number_format(VM& vm, N
         // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
         if (!::Locale::is_type_identifier(numbering_system.as_string().utf8_string_view()))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
-
-        // 8. Set opt.[[nu]] to numberingSystem.
-        opt.nu = numbering_system.as_string().utf8_string();
     }
+
+    // 8. Set opt.[[nu]] to numberingSystem.
+    opt.nu = locale_key_from_value(numbering_system);
 
     // 9. Let localeData be %NumberFormat%.[[LocaleData]].
     // 10. Let r be ResolveLocale(%NumberFormat%.[[AvailableLocales]], requestedLocales, opt, %NumberFormat%.[[RelevantExtensionKeys]], localeData).
@@ -122,8 +122,8 @@ ThrowCompletionOr<NonnullGCPtr<NumberFormat>> initialize_number_format(VM& vm, N
     number_format.set_data_locale(move(result.data_locale));
 
     // 13. Set numberFormat.[[NumberingSystem]] to r.[[nu]].
-    if (result.nu.has_value())
-        number_format.set_numbering_system(result.nu.release_value());
+    if (auto* resolved_numbering_system = result.nu.get_pointer<String>())
+        number_format.set_numbering_system(move(*resolved_numbering_system));
 
     // 14. Perform ? SetNumberFormatUnitOptions(numberFormat, options).
     TRY(set_number_format_unit_options(vm, number_format, *options));

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -77,10 +77,10 @@ ThrowCompletionOr<NonnullGCPtr<Object>> RelativeTimeFormatConstructor::construct
         // a. If numberingSystem cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
         if (!::Locale::is_type_identifier(numbering_system.as_string().utf8_string_view()))
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
-
-        // 10. Set opt.[[nu]] to numberingSystem.
-        opt.nu = numbering_system.as_string().utf8_string();
     }
+
+    // 10. Set opt.[[nu]] to numberingSystem.
+    opt.nu = locale_key_from_value(numbering_system);
 
     // 11. Let r be ResolveLocale(%Intl.RelativeTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %Intl.RelativeTimeFormat%.[[RelevantExtensionKeys]], %Intl.RelativeTimeFormat%.[[LocaleData]]).
     auto result = resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys());
@@ -95,8 +95,8 @@ ThrowCompletionOr<NonnullGCPtr<Object>> RelativeTimeFormatConstructor::construct
     relative_time_format->set_data_locale(move(result.data_locale));
 
     // 15. Set relativeTimeFormat.[[NumberingSystem]] to r.[[nu]].
-    if (result.nu.has_value())
-        relative_time_format->set_numbering_system(result.nu.release_value());
+    if (auto* resolved_numbering_system = result.nu.get_pointer<String>())
+        relative_time_format->set_numbering_system(move(*resolved_numbering_system));
 
     // 16. Let style be ? GetOption(options, "style", string, « "long", "short", "narrow" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -537,3 +537,41 @@ describe("timeZoneName", () => {
         });
     });
 });
+
+describe("non-Gregorian calendars", () => {
+    test("Hebrew", () => {
+        const en = new Intl.DateTimeFormat("en-u-ca-hebrew", {
+            dateStyle: "long",
+            timeStyle: "long",
+            timeZone: "UTC",
+        });
+        expect(en.format(d0)).toBe("3 Tevet 5782 at 5:40:50\u202fPM UTC");
+        expect(en.format(d1)).toBe("17 Shevat 5749 at 7:08:09\u202fAM UTC");
+
+        const ar = new Intl.DateTimeFormat("ar-u-ca-hebrew", {
+            dateStyle: "long",
+            timeStyle: "long",
+            timeZone: "UTC",
+        });
+        expect(ar.format(d0)).toBe("٣ طيفت ٥٧٨٢ ص في ٥:٤٠:٥٠ م UTC");
+        expect(ar.format(d1)).toBe("١٧ شباط ٥٧٤٩ ص في ٧:٠٨:٠٩ ص UTC");
+    });
+
+    test("Chinese", () => {
+        const en = new Intl.DateTimeFormat("en-u-ca-chinese", {
+            dateStyle: "long",
+            timeStyle: "long",
+            timeZone: "UTC",
+        });
+        expect(en.format(d0)).toBe("Eleventh Month 4, 2021(xin-chou) at 5:40:50\u202fPM UTC");
+        expect(en.format(d1)).toBe("Twelfth Month 16, 1988(wu-chen) at 7:08:09\u202fAM UTC");
+
+        const zh = new Intl.DateTimeFormat("zh-u-ca-chinese", {
+            dateStyle: "long",
+            timeStyle: "long",
+            timeZone: "UTC",
+        });
+        expect(zh.format(d0)).toBe("2021辛丑年十一月初四 UTC 17:40:50");
+        expect(zh.format(d1)).toBe("1988戊辰年腊月十六 UTC 07:08:09");
+    });
+});


### PR DESCRIPTION
This almost worked out of the box, but we need to be sure we pass the full locale (e.g. `en-u-ca-hebrew`) and not just the data locale (`en`) to ICU. This PR also includes a bug fix for handling null vs undefined locale keys, as passing the full locale to ICU otherwise regressed some tests.

test262 diff:
```
Summary:
    Diff Tests:
        +6 ✅    -6 ❌

Diff Tests:
    test/intl402/DateTimeFormat/prototype/format/related-year-zh.js                          ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatRangeToParts/pattern-on-calendar.js          ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatToParts/pattern-on-calendar.js               ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatToParts/related-year-zh.js                   ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/formatToParts/related-year.js                      ❌ -> ✅
    test/intl402/DateTimeFormat/prototype/resolvedOptions/resolved-locale-with-hc-unicode.js ❌ -> ✅
```

We now pass all `Intl.DateTimeFormat` tests (except the few that are specifically for temporal) :^)