### PR TITLE
LibWasm: Improve element validation and instantiation

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -224,6 +224,9 @@ ErrorOr<void, ValidationError> Validator::validate(ElementSection const& section
             [](ElementSection::Passive const&) -> ErrorOr<void, ValidationError> { return {}; },
             [&](ElementSection::Active const& active) -> ErrorOr<void, ValidationError> {
                 TRY(validate(active.index));
+                auto table = m_context.tables[active.index.value()];
+                if (table.element_type() != segment.type)
+                    return Errors::invalid("active element reference type"sv);
                 auto expression_result = TRY(validate(active.expression, { ValueType(ValueType::I32) }));
                 if (!expression_result.is_constant)
                     return Errors::invalid("active element initializer"sv);

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -1281,10 +1281,10 @@ ParseResult<ElementSection::Element> ElementSection::Element::parse(Stream& stre
     Vector<Expression> items;
     if (!has_exprs) {
         auto indices = TRY(parse_vector<GenericIndexParser<FunctionIndex>>(stream));
-        Vector<Instruction> instructions;
-        for (auto& index : indices)
-            instructions.empend(Instructions::ref_func, index);
-        items = { Expression { move(instructions) } };
+        for (auto& index : indices) {
+            Vector<Instruction> instructions { Instruction(Instructions::ref_func, index) };
+            items.empend(move(instructions));
+        }
     } else {
         items = TRY(parse_vector<Expression>(stream));
     }


### PR DESCRIPTION
This gets `elem.wast` to almost fully pass (2 tests left)! The remaining tests are pretty hard to fix with our current representation of constant expressions. They're simple enough in the spec that we don't need a full-fledged `Expression` to handle them, which might be relevant in a future PR.