### PR TITLE
CI: Restore the code linting job

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -29,7 +29,7 @@ runs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 
         sudo apt-get update
-        sudo apt-get install autoconf autoconf-archive automake ccache clang-18 clang++-18 clang-format-18 lld-18 gcc-13 g++-13 libstdc++-13-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
+        sudo apt-get install autoconf autoconf-archive automake ccache clang-18 clang++-18 lld-18 gcc-13 g++-13 libstdc++-13-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
@@ -41,17 +41,12 @@ runs:
         rm ./wabt-1.0.35-ubuntu-20.04.tar.gz
         echo "${{ github.workspace }}/wabt-1.0.35/bin" >> $GITHUB_PATH
 
-    - name: 'Install JS dependencies'
-      if: ${{ inputs.os == 'Linux' }}
-      shell: bash
-      run: sudo npm install -g prettier@2.7.1
-
     - name: 'Install Python dependencies'
       if: ${{ inputs.os == 'Linux' }}
       shell: bash
       run: |
         python3 -m pip install --upgrade pip
-        pip3 install flake8 requests six
+        pip3 install requests six
 
     - name: 'Install Dependencies'
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -1,0 +1,37 @@
+name: Lint Code
+
+on: [ push, pull_request ]
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    if: always() && github.repository == 'LadybirdBrowser/ladybird'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set Up Environment
+        shell: bash
+        run: |
+          set -e
+
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+
+          sudo apt-get update
+          sudo apt-get install clang-format-18 generate-ninja
+
+      - name: Install JS Dependencies
+        shell: bash
+        run: sudo npm install -g prettier@2.7.1
+
+      - name: Install Python Dependencies
+        shell: bash
+        run: |
+          python3 -m pip install --upgrade pip
+          pip3 install flake8
+
+      - name: Lint
+        run: ${{ github.workspace }}/Meta/lint-ci.sh

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,4 +1,4 @@
-name: Commit linter
+name: Lint Commit Messages
 
 on: [pull_request_target]
 
@@ -6,7 +6,7 @@ on: [pull_request_target]
 # (… but don't accept overlong 'fixup!' commit descriptions.)
 
 jobs:
-  lint_commits:
+  lint:
     runs-on: ubuntu-22.04
     if: always() && github.repository == 'LadybirdBrowser/ladybird'
 

--- a/Meta/CMake/all_the_debug_macros.cmake
+++ b/Meta/CMake/all_the_debug_macros.cmake
@@ -80,3 +80,8 @@ set(WEB_WORKER_DEBUG ON)
 set(WEBP_DEBUG ON)
 set(WORKER_THREAD_DEBUG ON)
 set(XML_PARSER_DEBUG ON)
+
+# False positive: ANDROID_LOG_DEBUG is a log level, not a debug flag
+# set(ANDROID_LOG_DEBUG ON)
+# Clogs up build: The BindingsGenerator stuff is run at compile time.
+# set(BINDINGS_GENERATOR_DEBUG ON)

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
@@ -40,12 +40,14 @@ EasingStyleValue::CubicBezier EasingStyleValue::CubicBezier::ease_in_out()
     return bezier;
 }
 
-EasingStyleValue::Steps EasingStyleValue::Steps::step_start() {
+EasingStyleValue::Steps EasingStyleValue::Steps::step_start()
+{
     static Steps steps { 1, Steps::Position::Start };
     return steps;
 }
 
-EasingStyleValue::Steps EasingStyleValue::Steps::step_end() {
+EasingStyleValue::Steps EasingStyleValue::Steps::step_end()
+{
     static Steps steps { 1, Steps::Position::End };
     return steps;
 }
@@ -57,8 +59,7 @@ bool EasingStyleValue::CubicBezier::operator==(Web::CSS::EasingStyleValue::Cubic
 
 double EasingStyleValue::Function::evaluate_at(double input_progress, bool before_flag) const
 {
-    constexpr static auto cubic_bezier_at = [](double x1, double x2, double t)
-    {
+    constexpr static auto cubic_bezier_at = [](double x1, double x2, double t) {
         auto a = 1.0 - 3.0 * x2 + 3.0 * x1;
         auto b = 3.0 * x2 - 6.0 * x1;
         auto c = 3.0 * x1;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -70,8 +70,7 @@ public:
         bool operator==(Steps const&) const = default;
     };
 
-    struct Function : public Variant<Linear, CubicBezier, Steps>
-    {
+    struct Function : public Variant<Linear, CubicBezier, Steps> {
         using Variant::Variant;
 
         double evaluate_at(double input_progress, bool before_flag) const;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -95,15 +95,16 @@ String HTMLLinkElement::as() const
 {
     String attribute_value = get_attribute_value(HTML::AttributeNames::as);
 
-    if (attribute_value.equals_ignoring_ascii_case("fetch"sv) ||
-        attribute_value.equals_ignoring_ascii_case("image"sv) ||
-        attribute_value.equals_ignoring_ascii_case("script"sv) ||
-        attribute_value.equals_ignoring_ascii_case("style"sv) ||
-        attribute_value.equals_ignoring_ascii_case("video"sv) ||
-        attribute_value.equals_ignoring_ascii_case("audio"sv) ||
-        attribute_value.equals_ignoring_ascii_case("track"sv) ||
-        attribute_value.equals_ignoring_ascii_case("font"sv))
+    if (attribute_value.equals_ignoring_ascii_case("fetch"sv)
+        || attribute_value.equals_ignoring_ascii_case("image"sv)
+        || attribute_value.equals_ignoring_ascii_case("script"sv)
+        || attribute_value.equals_ignoring_ascii_case("style"sv)
+        || attribute_value.equals_ignoring_ascii_case("video"sv)
+        || attribute_value.equals_ignoring_ascii_case("audio"sv)
+        || attribute_value.equals_ignoring_ascii_case("track"sv)
+        || attribute_value.equals_ignoring_ascii_case("font"sv)) {
         return attribute_value.to_lowercase().release_value();
+    }
 
     return String {};
 }

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.cpp
@@ -1,12 +1,12 @@
 /*
-* Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
-*
-* SPDX-License-Identifier: BSD-2-Clause
-*/
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 
 #include <LibWeb/Bindings/Intrinsics.h>
-#include <LibWeb/HTML/ValidityState.h>
 #include <LibWeb/Bindings/ValidityStatePrototype.h>
+#include <LibWeb/HTML/ValidityState.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.h
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.h
@@ -1,8 +1,8 @@
 /*
-* Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
-*
-* SPDX-License-Identifier: BSD-2-Clause
-*/
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 
 #pragma once
 
@@ -12,16 +12,16 @@ namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#validitystate
 class ValidityState final : public Bindings::PlatformObject {
-   WEB_PLATFORM_OBJECT(ValidityState, Bindings::PlatformObject);
-   JS_DECLARE_ALLOCATOR(ValidityState);
+    WEB_PLATFORM_OBJECT(ValidityState, Bindings::PlatformObject);
+    JS_DECLARE_ALLOCATOR(ValidityState);
 
 public:
-   virtual ~ValidityState() override = default;
+    virtual ~ValidityState() override = default;
 
 private:
     ValidityState(JS::Realm&);
 
-   virtual void initialize(JS::Realm&) override;
+    virtual void initialize(JS::Realm&) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -2889,7 +2889,6 @@ bool readable_byte_stream_controller_should_call_pull(ReadableByteStreamControll
     return false;
 }
 
-
 // NON-STANDARD: Can be used instead of CreateReadableStream in cases where we need to set up a newly allocated
 //               ReadableStream before initialization of said ReadableStream, i.e. ReadableStream is captured by lambdas in an uninitialized state.
 // Spec steps are taken from: https://streams.spec.whatwg.org/#create-readable-stream


### PR DESCRIPTION
We mistakenly did not add the clang-format linter to the new repo's CI,
and some unformatted code made its way into the repo.