### PR TITLE
UI/Qt+WebDriver: Add `--allow-popups` option and make WebDriver use it

### DIFF
--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -62,9 +62,9 @@ void Application::close_task_manager_window()
     }
 }
 
-BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab, Optional<u64> page_index)
 {
-    auto* window = new BrowserWindow(initial_urls, cookie_jar, web_content_options, webdriver_content_ipc_path, parent_tab, move(page_index));
+    auto* window = new BrowserWindow(initial_urls, cookie_jar, web_content_options, webdriver_content_ipc_path, allow_popups, parent_tab, move(page_index));
     set_active_window(*window);
     window->show();
     window->activateWindow();

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -27,7 +27,7 @@ public:
     Function<void(URL::URL)> on_open_file;
     RefPtr<Protocol::RequestClient> request_server_client;
 
-    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     void show_task_manager_window();
     void close_task_manager_window();

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -69,11 +69,12 @@ public:
     }
 };
 
-BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab, Optional<u64> page_index)
     : m_tabs_container(new TabWidget(this))
     , m_cookie_jar(cookie_jar)
     , m_web_content_options(web_content_options)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
+    , m_allow_popups(allow_popups)
 {
     setWindowIcon(app_icon());
 
@@ -480,7 +481,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
 
     m_block_pop_ups_action = new QAction("Block Pop-ups", this);
     m_block_pop_ups_action->setCheckable(true);
-    m_block_pop_ups_action->setChecked(true);
+    m_block_pop_ups_action->setChecked(!allow_popups);
     debug_menu->addAction(m_block_pop_ups_action);
     QObject::connect(m_block_pop_ups_action, &QAction::triggered, this, [this] {
         bool state = m_block_pop_ups_action->isChecked();
@@ -522,7 +523,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [this] {
         auto initial_urls = Vector<URL::URL> { ak_url_from_qstring(Settings::the()->new_tab_page()) };
-        (void)static_cast<Ladybird::Application*>(QApplication::instance())->new_window(initial_urls, m_cookie_jar, m_web_content_options, m_webdriver_content_ipc_path);
+        (void)static_cast<Ladybird::Application*>(QApplication::instance())->new_window(initial_urls, m_cookie_jar, m_web_content_options, m_webdriver_content_ipc_path, m_allow_popups);
     });
     QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
     QObject::connect(settings_action, &QAction::triggered, this, [this] {
@@ -686,7 +687,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
 
     tab->view().on_new_web_view = [this, tab](auto activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) {
         if (hints.popup) {
-            auto& window = static_cast<Ladybird::Application*>(QApplication::instance())->new_window({}, m_cookie_jar, m_web_content_options, m_webdriver_content_ipc_path, tab, AK::move(page_index));
+            auto& window = static_cast<Ladybird::Application*>(QApplication::instance())->new_window({}, m_cookie_jar, m_web_content_options, m_webdriver_content_ipc_path, m_allow_popups, tab, AK::move(page_index));
             window.set_window_rect(hints.screen_x, hints.screen_y, hints.width, hints.height);
             return window.current_tab()->view().handle();
         }

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -31,7 +31,7 @@ class BrowserWindow : public QMainWindow {
     Q_OBJECT
 
 public:
-    BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     WebContentView& view() const { return m_current_tab->view(); }
 
@@ -204,6 +204,8 @@ private:
 
     WebContentOptions m_web_content_options;
     StringView m_webdriver_content_ipc_path;
+
+    bool m_allow_popups { false };
 };
 
 }

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -102,6 +102,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool enable_idl_tracing = false;
     bool new_window = false;
     bool force_new_process = false;
+    bool allow_popups = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -119,6 +120,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
     args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
+    args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
     args_parser.parse(arguments);
 
     WebView::ChromeProcess chrome_process;
@@ -181,10 +183,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     chrome_process.on_new_window = [&](auto const& urls) {
-        app.new_window(sanitize_urls(urls), *cookie_jar, web_content_options, webdriver_content_ipc_path);
+        app.new_window(sanitize_urls(urls), *cookie_jar, web_content_options, webdriver_content_ipc_path, allow_popups);
     };
 
-    auto& window = app.new_window(sanitize_urls(raw_urls), *cookie_jar, web_content_options, webdriver_content_ipc_path);
+    auto& window = app.new_window(sanitize_urls(raw_urls), *cookie_jar, web_content_options, webdriver_content_ipc_path, allow_popups);
     window.setWindowTitle("Ladybird");
 
     if (Ladybird::Settings::the()->is_maximized()) {

--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -45,6 +45,8 @@ static ErrorOr<pid_t> launch_browser(ByteString const& socket_path)
         arguments.append(certificate_args.last().view().characters_without_null_termination());
     }
 
+    arguments.append("--allow-popups");
+
     arguments.append("about:blank");
 
     return launch_process("Ladybird"sv, arguments.span());


### PR DESCRIPTION
This PR adds the `--allow-popups` option to Qt Ladybird, which disables popup blocking by default. WebDriver now uses this option to ensure popups are enabled for testing. This prevents an "unable to find test window" error on tests that
attempt to open a new window.