### PR TITLE
Meta: Change the default build type to RelWithDebInfo

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -13,6 +13,7 @@
       "generator": "Ninja",
       "binaryDir": "${sourceDir}/Build/ladybird",
       "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "SERENITY_CACHE_DIR": "${sourceDir}/Build/caches",
         "CMAKE_TOOLCHAIN_FILE": "${sourceDir}/Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_INSTALL_OPTIONS": "--no-print-usage"


### PR DESCRIPTION
By default, we were linking the debug version of all vcpkg dependencies, which was very noticeable in benchmarks. Let's default to a build type with reasonable performance.