### PR TITLE
LibJS+LibLocale: Some code removal / cleanup leftover from ICU porting

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -5,16 +5,16 @@
  */
 
 #include <AK/AllOf.h>
-#include <AK/AnyOf.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Find.h>
-#include <AK/Function.h>
 #include <AK/QuickSort.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/Locale.h>
+#include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/ValueInlines.h>
 #include <LibLocale/Locale.h>
 #include <LibLocale/UnicodeKeywords.h>
@@ -683,65 +683,6 @@ ThrowCompletionOr<Optional<int>> get_number_option(VM& vm, Object const& options
 
     // 3. Return ? DefaultNumberOption(value, minimum, maximum, fallback).
     return default_number_option(vm, value, minimum, maximum, move(fallback));
-}
-
-// 9.2.17 PartitionPattern ( pattern ), https://tc39.es/ecma402/#sec-partitionpattern
-Vector<PatternPartition> partition_pattern(StringView pattern)
-{
-    // 1. Let result be a new empty List.
-    Vector<PatternPartition> result;
-
-    // 2. Let beginIndex be StringIndexOf(pattern, "{", 0).
-    auto begin_index = pattern.find('{', 0);
-
-    // 3. Let endIndex be 0.
-    size_t end_index = 0;
-
-    // 4. Let nextIndex be 0.
-    size_t next_index = 0;
-
-    // 5. Let length be the number of code units in pattern.
-    // 6. Repeat, while beginIndex is an integer index into pattern,
-    while (begin_index.has_value()) {
-        // a. Set endIndex to StringIndexOf(pattern, "}", beginIndex).
-        end_index = pattern.find('}', *begin_index).value();
-
-        // b. Assert: endIndex is greater than beginIndex.
-        VERIFY(end_index > *begin_index);
-
-        // c. If beginIndex is greater than nextIndex, then
-        if (*begin_index > next_index) {
-            // i. Let literal be a substring of pattern from position nextIndex, inclusive, to position beginIndex, exclusive.
-            auto literal = pattern.substring_view(next_index, *begin_index - next_index);
-
-            // ii. Append a new Record { [[Type]]: "literal", [[Value]]: literal } as the last element of the list result.
-            result.append({ "literal"sv, MUST(String::from_utf8(literal)) });
-        }
-
-        // d. Let p be the substring of pattern from position beginIndex, exclusive, to position endIndex, exclusive.
-        auto partition = pattern.substring_view(*begin_index + 1, end_index - *begin_index - 1);
-
-        // e. Append a new Record { [[Type]]: p, [[Value]]: undefined } as the last element of the list result.
-        result.append({ partition, {} });
-
-        // f. Set nextIndex to endIndex + 1.
-        next_index = end_index + 1;
-
-        // g. Set beginIndex to StringIndexOf(pattern, "{", nextIndex).
-        begin_index = pattern.find('{', next_index);
-    }
-
-    // 7. If nextIndex is less than length, then
-    if (next_index < pattern.length()) {
-        // a. Let literal be the substring of pattern from position nextIndex, inclusive, to position length, exclusive.
-        auto literal = pattern.substring_view(next_index);
-
-        // b. Append a new Record { [[Type]]: "literal", [[Value]]: literal } as the last element of the list result.
-        result.append({ "literal"sv, MUST(String::from_utf8(literal)) });
-    }
-
-    // 8. Return result.
-    return result;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -12,10 +12,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Completion.h>
-#include <LibJS/Runtime/Intl/DisplayNames.h>
-#include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
-#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibLocale/Forward.h>
 
@@ -45,44 +42,6 @@ struct LocaleResult {
     LocaleKey nu; // [[NumberingSystem]]
 };
 
-struct PatternPartition {
-    PatternPartition() = default;
-
-    PatternPartition(StringView type_string, String value_string)
-        : type(type_string)
-        , value(move(value_string))
-    {
-    }
-
-    StringView type;
-    String value;
-};
-
-struct PatternPartitionWithSource : public PatternPartition {
-    template<typename ParentList>
-    static Vector<PatternPartitionWithSource> create_from_parent_list(ParentList partitions)
-    {
-        Vector<PatternPartitionWithSource> result;
-        result.ensure_capacity(partitions.size());
-
-        for (auto& partition : partitions) {
-            PatternPartitionWithSource partition_with_source {};
-            partition_with_source.type = partition.type;
-            partition_with_source.value = move(partition.value);
-            result.unchecked_append(move(partition_with_source));
-        }
-
-        return result;
-    }
-
-    bool operator==(PatternPartitionWithSource const& other) const
-    {
-        return (type == other.type) && (value == other.value) && (source == other.source);
-    }
-
-    StringView source;
-};
-
 using StringOrBoolean = Variant<StringView, bool>;
 
 bool is_structurally_valid_language_tag(StringView locale);
@@ -98,7 +57,6 @@ ThrowCompletionOr<Object*> coerce_options_to_object(VM&, Value options);
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback);
 ThrowCompletionOr<Optional<int>> default_number_option(VM&, Value value, int minimum, int maximum, Optional<int> fallback);
 ThrowCompletionOr<Optional<int>> get_number_option(VM&, Object const& options, PropertyKey const& property, int minimum, int maximum, Optional<int> fallback);
-Vector<PatternPartition> partition_pattern(StringView pattern);
 
 template<size_t Size>
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, StringView const (&string_values)[Size], StringOrBoolean fallback)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -12,6 +12,7 @@
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Temporal/Duration.h>
+#include <LibLocale/Locale.h>
 
 namespace JS::Intl {
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -19,11 +19,13 @@
 #include <LibJS/Runtime/Intl/PluralRulesConstructor.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
 #include <LibJS/Runtime/Intl/SegmenterConstructor.h>
+#include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
 #include <LibJS/Runtime/Temporal/TimeZone.h>
 #include <LibLocale/DateTimeFormat.h>
 #include <LibLocale/Locale.h>
 #include <LibLocale/NumberFormat.h>
 #include <LibLocale/UnicodeKeywords.h>
+#include <LibTimeZone/TimeZone.h>
 
 namespace JS::Intl {
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -22,24 +22,24 @@ ListFormat::ListFormat(Object& prototype)
 }
 
 // 13.5.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist
-Vector<::Locale::ListFormatPart> create_parts_from_list(ListFormat const& list_format, Vector<String> const& list)
+Vector<::Locale::ListFormat::Partition> create_parts_from_list(ListFormat const& list_format, ReadonlySpan<String> list)
 {
-    return ::Locale::format_list_to_parts(list_format.locale(), list_format.type(), list_format.style(), list);
+    return list_format.formatter().format_to_parts(list);
 }
 
 // 13.5.3 FormatList ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlist
-String format_list(ListFormat const& list_format, Vector<String> const& list)
+String format_list(ListFormat const& list_format, ReadonlySpan<String> list)
 {
     // 1. Let parts be ! CreatePartsFromList(listFormat, list).
     // 2. Let result be an empty String.
     // 3. For each Record { [[Type]], [[Value]] } part in parts, do
     //     a. Set result to the string-concatenation of result and part.[[Value]].
     // 4. Return result.
-    return ::Locale::format_list(list_format.locale(), list_format.type(), list_format.style(), list);
+    return list_format.formatter().format(list);
 }
 
 // 13.5.4 FormatListToParts ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlisttoparts
-NonnullGCPtr<Array> format_list_to_parts(VM& vm, ListFormat const& list_format, Vector<String> const& list)
+NonnullGCPtr<Array> format_list_to_parts(VM& vm, ListFormat const& list_format, ReadonlySpan<String> list)
 {
     auto& realm = *vm.current_realm();
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -41,17 +41,23 @@ public:
     void set_style(StringView style) { m_style = ::Locale::style_from_string(style); }
     StringView style_string() const { return ::Locale::style_to_string(m_style); }
 
+    ::Locale::ListFormat const& formatter() const { return *m_formatter; }
+    void set_formatter(NonnullOwnPtr<::Locale::ListFormat> formatter) { m_formatter = move(formatter); }
+
 private:
     explicit ListFormat(Object& prototype);
 
     String m_locale;                                                           // [[Locale]]
     ::Locale::ListFormatType m_type { ::Locale::ListFormatType::Conjunction }; // [[Type]]
     ::Locale::Style m_style { ::Locale::Style::Long };                         // [[Style]]
+
+    // Non-standard. Stores the ICU list formatter for the Intl object's formatting options.
+    OwnPtr<::Locale::ListFormat> m_formatter;
 };
 
-Vector<::Locale::ListFormatPart> create_parts_from_list(ListFormat const&, Vector<String> const& list);
-String format_list(ListFormat const&, Vector<String> const& list);
-NonnullGCPtr<Array> format_list_to_parts(VM&, ListFormat const&, Vector<String> const& list);
+Vector<::Locale::ListFormat::Partition> create_parts_from_list(ListFormat const&, ReadonlySpan<String> list);
+String format_list(ListFormat const&, ReadonlySpan<String> list);
+NonnullGCPtr<Array> format_list_to_parts(VM&, ListFormat const&, ReadonlySpan<String> list);
 ThrowCompletionOr<Vector<String>> string_list_from_iterable(VM&, Value iterable);
 
 }

--- a/Userland/Libraries/LibLocale/ListFormat.h
+++ b/Userland/Libraries/LibLocale/ListFormat.h
@@ -17,16 +17,24 @@ enum class ListFormatType {
     Disjunction,
     Unit,
 };
+ListFormatType list_format_type_from_string(StringView);
+StringView list_format_type_to_string(ListFormatType);
 
-ListFormatType list_format_type_from_string(StringView list_format_type);
-StringView list_format_type_to_string(ListFormatType list_format_type);
+class ListFormat {
+public:
+    static NonnullOwnPtr<ListFormat> create(StringView locale, ListFormatType, Style);
+    virtual ~ListFormat() = default;
 
-struct ListFormatPart {
-    StringView type;
-    String value;
+    struct Partition {
+        StringView type;
+        String value;
+    };
+
+    virtual String format(ReadonlySpan<String> list) const = 0;
+    virtual Vector<Partition> format_to_parts(ReadonlySpan<String> list) const = 0;
+
+protected:
+    ListFormat() = default;
 };
-
-String format_list(StringView locale, ListFormatType, Style, ReadonlySpan<String> list);
-Vector<ListFormatPart> format_list_to_parts(StringView locale, ListFormatType, Style, ReadonlySpan<String> list);
 
 }


### PR DESCRIPTION
Removing some dead code and changing ListFormat to match the caching style of other formats (number, datetime, etc).

No functional change, no test262 diff.