### PR TITLE
Everywhere: Remove all KERNEL `#define`s

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -33,9 +33,7 @@
 #    define ERRORLN warnln
 #endif
 
-#if !defined(KERNEL)
-
-#    if defined(EXECINFO_BACKTRACE)
+#if defined(EXECINFO_BACKTRACE)
 namespace {
 ALWAYS_INLINE void dump_backtrace()
 {
@@ -74,39 +72,37 @@ ALWAYS_INLINE void dump_backtrace()
         } else {
             error_builder.append(sym);
         }
-#        if !defined(AK_OS_ANDROID)
+#    if !defined(AK_OS_ANDROID)
         error_builder.append('\n');
-#        endif
+#    endif
         error_builder.append('\0');
         PRINT_ERROR(error_builder.string_view().characters_without_null_termination());
     }
     free(syms);
 }
 }
-#    endif
+#endif
 
 extern "C" {
 
 void ak_verification_failed(char const* message)
 {
-#    if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
+#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
     bool colorize_output = true;
-#    elif defined(AK_OS_WINDOWS)
+#elif defined(AK_OS_WINDOWS)
     bool colorize_output = false;
-#    else
+#else
     bool colorize_output = isatty(STDERR_FILENO) == 1;
-#    endif
+#endif
 
     if (colorize_output)
         ERRORLN("\033[31;1mVERIFICATION FAILED\033[0m: {}", message);
     else
         ERRORLN("VERIFICATION FAILED: {}", message);
 
-#    if defined(EXECINFO_BACKTRACE)
+#if defined(EXECINFO_BACKTRACE)
     dump_backtrace();
-#    endif
+#endif
     __builtin_trap();
 }
 }
-
-#endif

--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -6,19 +6,15 @@
 
 #pragma once
 
-#if defined(KERNEL)
-#    include <Kernel/Library/Assertions.h>
-#else
 extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
-#    define __stringify_helper(x) #x
-#    define __stringify(x) __stringify_helper(x)
-#    define VERIFY(expr)                                                                  \
-        (__builtin_expect(!(expr), 0)                                                     \
-                ? ak_verification_failed(#expr " at " __FILE__ ":" __stringify(__LINE__)) \
-                : (void)0)
-#    define VERIFY_NOT_REACHED() VERIFY(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define __stringify_helper(x) #x
+#define __stringify(x) __stringify_helper(x)
+#define VERIFY(expr)                                                                  \
+    (__builtin_expect(!(expr), 0)                                                     \
+            ? ak_verification_failed(#expr " at " __FILE__ ":" __stringify(__LINE__)) \
+            : (void)0)
+#define VERIFY_NOT_REACHED() VERIFY(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 static constexpr bool TODO = false;
-#    define TODO() VERIFY(TODO)                /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#    define TODO_AARCH64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#    define TODO_RISCV64() VERIFY(TODO)        /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#endif
+#define TODO() VERIFY(TODO)         /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO_AARCH64() VERIFY(TODO) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO_RISCV64() VERIFY(TODO) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */

--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -6,11 +6,9 @@
 
 #pragma once
 
-#ifndef KERNEL
-
-#    include <AK/ByteString.h>
-#    include <AK/StringView.h>
-#    include <cxxabi.h>
+#include <AK/ByteString.h>
+#include <AK/StringView.h>
+#include <cxxabi.h>
 
 namespace AK {
 
@@ -26,8 +24,6 @@ inline ByteString demangle(StringView name)
 
 }
 
-#    if USING_AK_GLOBALLY
+#if USING_AK_GLOBALLY
 using AK::demangle;
-#    endif
-
 #endif

--- a/AK/DoublyLinkedList.h
+++ b/AK/DoublyLinkedList.h
@@ -134,7 +134,6 @@ public:
         return {};
     }
 
-#ifndef KERNEL
     template<typename U>
     void append(U&& value)
     {
@@ -146,7 +145,6 @@ public:
     {
         MUST(try_prepend(forward<U>(value)));
     }
-#endif
 
     [[nodiscard]] bool contains_slow(T const& value) const
     {

--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -6,20 +6,11 @@
 
 #include <AK/Error.h>
 
-#ifdef KERNEL
-#    include <AK/Format.h>
-#endif
-
 namespace AK {
 
 Error Error::from_string_view_or_print_error_and_return_errno(StringView string_literal, [[maybe_unused]] int code)
 {
-#ifdef KERNEL
-    dmesgln("{}", string_literal);
-    return Error::from_errno(code);
-#else
     return Error::from_string_view(string_literal);
-#endif
 }
 
 }

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -9,13 +9,8 @@
 #include <AK/StringView.h>
 #include <AK/Try.h>
 #include <AK/Variant.h>
-
-#if defined(AK_OS_SERENITY) && defined(KERNEL)
-#    include <errno_codes.h>
-#else
-#    include <errno.h>
-#    include <string.h>
-#endif
+#include <errno.h>
+#include <string.h>
 
 namespace AK {
 
@@ -36,7 +31,6 @@ public:
     // the Error::from_string_view method!
     static Error from_string_view_or_print_error_and_return_errno(StringView string_literal, int code);
 
-#ifndef KERNEL
     static Error from_syscall(StringView syscall_name, int rc)
     {
         return Error(syscall_name, rc);
@@ -52,14 +46,11 @@ public:
         VERIFY_NOT_REACHED();
     }
 
-#endif
-
     static Error copy(Error const& error)
     {
         return Error(error);
     }
 
-#ifndef KERNEL
     // NOTE: Prefer `from_string_literal` when directly typing out an error message:
     //
     //     return Error::from_string_literal("Class: Some failure");
@@ -78,15 +69,10 @@ public:
     {
         return from_string_view(string);
     }
-#endif
 
     bool operator==(Error const& other) const
     {
-#ifdef KERNEL
-        return m_code == other.m_code;
-#else
         return m_code == other.m_code && m_string_literal == other.m_string_literal && m_syscall == other.m_syscall;
-#endif
     }
 
     int code() const { return m_code; }
@@ -94,7 +80,6 @@ public:
     {
         return m_code != 0;
     }
-#ifndef KERNEL
     bool is_syscall() const
     {
         return m_syscall;
@@ -103,7 +88,6 @@ public:
     {
         return m_string_literal;
     }
-#endif
 
 protected:
     Error(int code)
@@ -112,7 +96,6 @@ protected:
     }
 
 private:
-#ifndef KERNEL
     Error(StringView string_literal)
         : m_string_literal(string_literal)
     {
@@ -124,20 +107,15 @@ private:
         , m_syscall(true)
     {
     }
-#endif
 
     Error(Error const&) = default;
     Error& operator=(Error const&) = default;
 
-#ifndef KERNEL
     StringView m_string_literal;
-#endif
 
     int m_code { 0 };
 
-#ifndef KERNEL
     bool m_syscall { false };
-#endif
 };
 
 template<typename T, typename E>

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -9,12 +9,10 @@
 #include <AK/Concepts.h>
 #include <AK/Format.h>
 #include <AK/IntegralMath.h>
+#include <AK/Math.h>
 #include <AK/NumericLimits.h>
 #include <AK/Types.h>
 
-#ifndef KERNEL
-#    include <AK/Math.h>
-#endif
 #ifndef __SIZEOF_INT128__
 #    include <AK/UFixedBigInt.h>
 #    include <AK/UFixedBigIntDivision.h>
@@ -45,13 +43,11 @@ public:
     {
     }
 
-#ifndef KERNEL
     template<FloatingPoint F>
     FixedPoint(F value)
         : m_value(round_to<Underlying>(value * (static_cast<Underlying>(1) << precision)))
     {
     }
-#endif
 
     template<size_t P, typename U>
     explicit constexpr FixedPoint(FixedPoint<P, U> const& other)
@@ -59,13 +55,11 @@ public:
     {
     }
 
-#ifndef KERNEL
     template<FloatingPoint F>
     explicit ALWAYS_INLINE operator F() const
     {
         return (F)m_value * pow<F>(0.5, precision);
     }
-#endif
 
     template<Integral I>
     explicit constexpr operator I() const

--- a/AK/FloatingPointStringConversions.h
+++ b/AK/FloatingPointStringConversions.h
@@ -6,11 +6,6 @@
 
 #pragma once
 
-#ifdef KERNEL
-#    error This file should not be included in the KERNEL as it deals with doubles \
-           and there is no guraantee does not do any floating point computations.
-#endif
-
 #include <AK/StringView.h>
 
 namespace AK {

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -122,17 +122,6 @@ class NonnullOwnPtr;
 template<typename T>
 class Optional;
 
-#ifdef KERNEL
-template<typename T>
-class NonnullLockRefPtr;
-
-template<typename T>
-struct LockRefPtrTraits;
-
-template<typename T, typename PtrTraits = LockRefPtrTraits<T>>
-class LockRefPtr;
-#endif
-
 template<typename T>
 class RefPtr;
 
@@ -209,11 +198,5 @@ using AK::Utf32View;
 using AK::Utf8CodePointIterator;
 using AK::Utf8View;
 using AK::Vector;
-
-#    ifdef KERNEL
-using AK::LockRefPtr;
-using AK::LockRefPtrTraits;
-using AK::NonnullLockRefPtr;
-#    endif
 
 #endif

--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -5,15 +5,12 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/ByteString.h>
 #include <AK/CharacterTypes.h>
 #include <AK/GenericLexer.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#    include <AK/Utf16View.h>
-#endif
+#include <AK/Utf16View.h>
 
 namespace AK {
 // Consume a number of characters
@@ -210,7 +207,6 @@ template ErrorOr<i32> GenericLexer::consume_decimal_integer<i32>();
 template ErrorOr<u64> GenericLexer::consume_decimal_integer<u64>();
 template ErrorOr<i64> GenericLexer::consume_decimal_integer<i64>();
 
-#ifndef KERNEL
 Optional<ByteString> GenericLexer::consume_and_unescape_string(char escape_char)
 {
     auto view = consume_quoted_string(escape_char);
@@ -292,6 +288,5 @@ auto GenericLexer::decode_single_or_paired_surrogate(bool combine_surrogate_pair
     retreat(6);
     return *high_surrogate;
 }
-#endif
 
 }

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -92,14 +92,12 @@ public:
         return true;
     }
 
-#ifndef KERNEL
     bool consume_specific(ByteString next) = delete;
 
     bool consume_specific(String const& next)
     {
         return consume_specific(next.bytes_as_string_view());
     }
-#endif
 
     constexpr bool consume_specific(char const* next)
     {
@@ -128,9 +126,7 @@ public:
     StringView consume_until(char const*);
     StringView consume_until(StringView);
     StringView consume_quoted_string(char escape_char = 0);
-#ifndef KERNEL
     Optional<ByteString> consume_and_unescape_string(char escape_char = '\\');
-#endif
     template<Integral T>
     ErrorOr<T> consume_decimal_integer();
 
@@ -139,9 +135,7 @@ public:
         UnicodeEscapeOverflow,
     };
 
-#ifndef KERNEL
     Result<u32, UnicodeEscapeError> consume_escaped_code_point(bool combine_surrogate_pairs = true);
-#endif
 
     constexpr void ignore(size_t count = 1)
     {
@@ -228,10 +222,8 @@ protected:
     size_t m_index { 0 };
 
 private:
-#ifndef KERNEL
     Result<u32, UnicodeEscapeError> decode_code_point();
     Result<u32, UnicodeEscapeError> decode_single_or_paired_surrogate(bool combine_surrogate_pairs);
-#endif
 };
 
 class LineTrackingLexer : public GenericLexer {

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -34,17 +34,6 @@ ErrorOr<ByteBuffer> decode_hex(StringView input)
     return { move(output) };
 }
 
-#ifdef KERNEL
-ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(ReadonlyBytes const input)
-{
-    StringBuilder output(input.size() * 2);
-
-    for (auto ch : input)
-        TRY(output.try_appendff("{:02x}", ch));
-
-    return Kernel::KString::try_create(output.string_view());
-}
-#else
 ByteString encode_hex(ReadonlyBytes const input)
 {
     StringBuilder output(input.size() * 2);
@@ -54,6 +43,5 @@ ByteString encode_hex(ReadonlyBytes const input)
 
     return output.to_byte_string();
 }
-#endif
 
 }

--- a/AK/Hex.h
+++ b/AK/Hex.h
@@ -7,14 +7,9 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
 #include <AK/Error.h>
 #include <AK/StringView.h>
-
-#ifdef KERNEL
-#    include <Kernel/Library/KString.h>
-#else
-#    include <AK/ByteString.h>
-#endif
 
 namespace AK {
 
@@ -31,11 +26,7 @@ constexpr u8 decode_hex_digit(char digit)
 
 ErrorOr<ByteBuffer> decode_hex(StringView);
 
-#ifdef KERNEL
-ErrorOr<NonnullOwnPtr<Kernel::KString>> encode_hex(ReadonlyBytes);
-#else
 ByteString encode_hex(ReadonlyBytes);
-#endif
 
 }
 

--- a/AK/IPv4Address.h
+++ b/AK/IPv4Address.h
@@ -6,20 +6,14 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/Endian.h>
 #include <AK/Format.h>
 #include <AK/Optional.h>
 #include <AK/SipHash.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
-
-#ifdef KERNEL
-#    include <AK/Error.h>
-#    include <Kernel/Library/KString.h>
-#else
-#    include <AK/ByteString.h>
-#    include <AK/String.h>
-#endif
 
 namespace AK {
 
@@ -57,16 +51,6 @@ public:
         return octet(SubnetClass(i));
     }
 
-#ifdef KERNEL
-    ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const
-    {
-        return Kernel::KString::formatted("{}.{}.{}.{}",
-            octet(SubnetClass::A),
-            octet(SubnetClass::B),
-            octet(SubnetClass::C),
-            octet(SubnetClass::D));
-    }
-#else
     ByteString to_byte_string() const
     {
         return ByteString::formatted("{}.{}.{}.{}",
@@ -93,7 +77,6 @@ public:
             octet(SubnetClass::C),
             octet(SubnetClass::D));
     }
-#endif
 
     static Optional<IPv4Address> from_string(StringView string)
     {
@@ -166,15 +149,6 @@ struct Traits<IPv4Address> : public DefaultTraits<IPv4Address> {
     static unsigned hash(IPv4Address const& address) { return secure_sip_hash(static_cast<u64>(address.to_u32())); }
 };
 
-#ifdef KERNEL
-template<>
-struct Formatter<IPv4Address> : Formatter<StringView> {
-    ErrorOr<void> format(FormatBuilder& builder, IPv4Address value)
-    {
-        return Formatter<StringView>::format(builder, TRY(value.to_string())->view());
-    }
-};
-#else
 template<>
 struct Formatter<IPv4Address> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, IPv4Address value)
@@ -182,7 +156,6 @@ struct Formatter<IPv4Address> : Formatter<StringView> {
         return Formatter<StringView>::format(builder, value.to_byte_string());
     }
 };
-#endif
 
 }
 

--- a/AK/IntrusiveDetails.h
+++ b/AK/IntrusiveDetails.h
@@ -8,9 +8,6 @@
 
 #include <AK/NonnullRefPtr.h>
 
-#ifdef KERNEL
-#    include <Kernel/Library/LockRefPtr.h>
-#endif
 namespace AK::Detail {
 
 template<typename T, typename Container>
@@ -22,13 +19,6 @@ template<typename T>
 struct SubstituteIntrusiveContainerType<T, NonnullRefPtr<T>> {
     using Type = RefPtr<T>;
 };
-
-#ifdef KERNEL
-template<typename T>
-struct SubstituteIntrusiveContainerType<T, NonnullLockRefPtr<T>> {
-    using Type = LockRefPtr<T>;
-};
-#endif
 
 template<typename Container, bool _IsRaw>
 struct SelfReferenceIfNeeded {

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -13,10 +13,6 @@
 #include <AK/Noncopyable.h>
 #include <AK/StdLibExtras.h>
 
-#ifdef KERNEL
-#    include <Kernel/Library/LockRefPtr.h>
-#endif
-
 namespace AK::Detail {
 
 template<typename T, typename Container = RawPtr<T>>
@@ -435,22 +431,6 @@ public:
     [[nodiscard]] NonnullRefPtr<T> take_first() { return *IntrusiveList<T, RefPtr<T>, member>::take_first(); }
     [[nodiscard]] NonnullRefPtr<T> take_last() { return *IntrusiveList<T, RefPtr<T>, member>::take_last(); }
 };
-
-#ifdef KERNEL
-// Specialise IntrusiveList for NonnullLockRefPtr
-// By default, intrusive lists cannot contain null entries anyway, so switch to LockRefPtr
-// and just make the user-facing functions deref the pointers.
-
-template<class T, SubstitutedIntrusiveListNode<T, NonnullLockRefPtr<T>> T::*member>
-class IntrusiveList<T, NonnullLockRefPtr<T>, member> : public IntrusiveList<T, LockRefPtr<T>, member> {
-public:
-    [[nodiscard]] NonnullLockRefPtr<T> first() const { return *IntrusiveList<T, LockRefPtr<T>, member>::first(); }
-    [[nodiscard]] NonnullLockRefPtr<T> last() const { return *IntrusiveList<T, LockRefPtr<T>, member>::last(); }
-
-    [[nodiscard]] NonnullLockRefPtr<T> take_first() { return *IntrusiveList<T, LockRefPtr<T>, member>::take_first(); }
-    [[nodiscard]] NonnullLockRefPtr<T> take_last() { return *IntrusiveList<T, LockRefPtr<T>, member>::take_last(); }
-};
-#endif
 
 }
 

--- a/AK/JsonArraySerializer.h
+++ b/AK/JsonArraySerializer.h
@@ -8,11 +8,8 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/JsonValue.h>
 #include <AK/Try.h>
-
-#ifndef KERNEL
-#    include <AK/JsonValue.h>
-#endif
 
 namespace AK {
 
@@ -43,14 +40,12 @@ public:
 
     JsonArraySerializer(JsonArraySerializer const&) = delete;
 
-#ifndef KERNEL
     ErrorOr<void> add(JsonValue const& value)
     {
         TRY(begin_item());
         value.serialize(m_builder);
         return {};
     }
-#endif
 
     ErrorOr<void> add(StringView value)
     {
@@ -67,7 +62,6 @@ public:
         return {};
     }
 
-#ifndef KERNEL
     ErrorOr<void> add(ByteString const& value)
     {
         TRY(begin_item());
@@ -82,7 +76,6 @@ public:
         }
         return {};
     }
-#endif
 
     ErrorOr<void> add(char const* value)
     {

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -108,7 +108,6 @@ Optional<bool> JsonObject::get_bool(StringView key) const
     return {};
 }
 
-#if !defined(KERNEL)
 Optional<ByteString> JsonObject::get_byte_string(StringView key) const
 {
     auto maybe_value = get(key);
@@ -116,7 +115,6 @@ Optional<ByteString> JsonObject::get_byte_string(StringView key) const
         return maybe_value->as_string();
     return {};
 }
-#endif
 
 Optional<JsonObject const&> JsonObject::get_object(StringView key) const
 {
@@ -134,7 +132,6 @@ Optional<JsonArray const&> JsonObject::get_array(StringView key) const
     return {};
 }
 
-#if !defined(KERNEL)
 Optional<double> JsonObject::get_double_with_precision_loss(StringView key) const
 {
     auto maybe_value = get(key);
@@ -150,7 +147,6 @@ Optional<float> JsonObject::get_float_with_precision_loss(StringView key) const
         return maybe_value->get_float_with_precision_loss();
     return {};
 }
-#endif
 
 bool JsonObject::has(StringView key) const
 {

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -74,17 +74,13 @@ public:
     Optional<FlatPtr> get_addr(StringView key) const;
     Optional<bool> get_bool(StringView key) const;
 
-#if !defined(KERNEL)
     Optional<ByteString> get_byte_string(StringView key) const;
-#endif
 
     Optional<JsonObject const&> get_object(StringView key) const;
     Optional<JsonArray const&> get_array(StringView key) const;
 
-#if !defined(KERNEL)
     Optional<double> get_double_with_precision_loss(StringView key) const;
     Optional<float> get_float_with_precision_loss(StringView key) const;
-#endif
 
     void set(ByteString const& key, JsonValue value);
 

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -9,11 +9,8 @@
 
 #include <AK/Error.h>
 #include <AK/JsonArraySerializer.h>
+#include <AK/JsonValue.h>
 #include <AK/Try.h>
-
-#ifndef KERNEL
-#    include <AK/JsonValue.h>
-#endif
 
 namespace AK {
 
@@ -38,14 +35,12 @@ public:
 
     JsonObjectSerializer(JsonObjectSerializer const&) = delete;
 
-#ifndef KERNEL
     ErrorOr<void> add(StringView key, JsonValue const& value)
     {
         TRY(begin_item(key));
         value.serialize(m_builder);
         return {};
     }
-#endif
 
     ErrorOr<void> add(StringView key, StringView value)
     {
@@ -62,7 +57,6 @@ public:
         return {};
     }
 
-#ifndef KERNEL
     ErrorOr<void> add(StringView key, ByteString const& value)
     {
         TRY(begin_item(key));
@@ -77,7 +71,6 @@ public:
         }
         return {};
     }
-#endif
 
     ErrorOr<void> add(StringView key, char const* value)
     {
@@ -164,7 +157,6 @@ public:
         return {};
     }
 
-#ifndef KERNEL
     ErrorOr<void> add(StringView key, float value)
     {
         TRY(begin_item(key));
@@ -184,7 +176,6 @@ public:
             TRY(m_builder.appendff("{}", value));
         return {};
     }
-#endif
 
     ErrorOr<JsonArraySerializer<Builder>> add_array(StringView key)
     {

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -211,11 +211,6 @@ ErrorOr<JsonValue> JsonParser::parse_number()
     }
 
     auto fallback_to_double_parse = [&]() -> ErrorOr<JsonValue> {
-#ifdef KERNEL
-#    error JSONParser is currently not available for the Kernel because it disallows floating point. \
-       If you want to make this KERNEL compatible you can just make this fallback_to_double \
-       function fail with an error in KERNEL mode.
-#endif
         // FIXME: Since we know all the characters so far are ascii digits (and one . or e) we could
         //        use that in the floating point parser.
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -7,10 +7,6 @@
 
 #pragma once
 
-#ifdef KERNEL
-#    error "JsonValue does not propagate allocation failures, so it is not safe to use in the kernel."
-#endif
-
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -13,10 +13,6 @@
 #include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
-#ifdef KERNEL
-#    error "Including AK/Math.h from the Kernel is never correct! Floating point is disabled."
-#endif
-
 namespace AK {
 
 template<FloatingPoint T>

--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -8,12 +8,7 @@
 #pragma once
 
 #include <AK/Types.h>
-
-#if defined(KERNEL)
-#    include <Kernel/Library/StdLib.h>
-#else
-#    include <string.h>
-#endif
+#include <string.h>
 
 ALWAYS_INLINE void fast_u32_copy(u32* dest, u32 const* src, size_t count)
 {

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -9,10 +9,7 @@
 #include <AK/Forward.h>
 #include <AK/Noncopyable.h>
 
-#if defined(KERNEL)
-#    include <Kernel/Arch/Processor.h>
-#    include <Kernel/Heap/kmalloc.h>
-#elif defined(AK_OS_SERENITY)
+#if defined(AK_OS_SERENITY)
 #    include <mallocdefs.h>
 #endif
 
@@ -37,9 +34,7 @@ public:
 private:
     static bool get_thread_allocation_state()
     {
-#if defined(KERNEL)
-        return Processor::current_thread()->get_allocation_enabled();
-#elif defined(AK_OS_SERENITY)
+#if defined(AK_OS_SERENITY)
         // This extern thread-local lives in our LibC, which doesn't exist on other systems.
         return s_allocation_enabled;
 #else
@@ -49,9 +44,7 @@ private:
 
     static void set_thread_allocation_state(bool value)
     {
-#if defined(KERNEL)
-        Processor::current_thread()->set_allocation_enabled(value);
-#elif defined(AK_OS_SERENITY)
+#if defined(AK_OS_SERENITY)
         s_allocation_enabled = value;
 #else
         (void)value;

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -136,8 +136,6 @@ private:
     T* m_ptr = nullptr;
 };
 
-#if !defined(KERNEL)
-
 template<typename T>
 inline NonnullOwnPtr<T> adopt_own(T& object)
 {
@@ -150,15 +148,13 @@ requires(IsConstructible<T, Args...>) inline NonnullOwnPtr<T> make(Args&&... arg
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T(forward<Args>(args)...));
 }
 
-#    ifdef AK_COMPILER_APPLE_CLANG
+#ifdef AK_COMPILER_APPLE_CLANG
 // FIXME: Remove once P0960R3 is available in Apple Clang.
 template<class T, class... Args>
 inline NonnullOwnPtr<T> make(Args&&... args)
 {
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T { forward<Args>(args)... });
 }
-#    endif
-
 #endif
 
 // Use like `adopt_nonnull_own_or_enomem(new (nothrow) T(args...))`.
@@ -220,11 +216,9 @@ struct Formatter<NonnullOwnPtr<T>> : Formatter<T const*> {
 }
 
 #if USING_AK_GLOBALLY
-#    if !defined(KERNEL)
+using AK::adopt_nonnull_own_or_enomem;
 using AK::adopt_own;
 using AK::make;
-#    endif
-using AK::adopt_nonnull_own_or_enomem;
 using AK::NonnullOwnPtr;
 using AK::try_make;
 #endif

--- a/AK/NumericLimits.h
+++ b/AK/NumericLimits.h
@@ -110,7 +110,6 @@ struct NumericLimits<unsigned long long> {
     static constexpr size_t digits() { return __CHAR_BIT__ * sizeof(long long); }
 };
 
-#ifndef KERNEL
 template<>
 struct NumericLimits<float> {
     static constexpr float lowest() { return -__FLT_MAX__; }
@@ -143,7 +142,6 @@ struct NumericLimits<long double> {
     static constexpr bool is_signed() { return true; }
     static constexpr size_t digits() { return __LDBL_MANT_DIG__; }
 };
-#endif
 
 }
 

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -9,12 +9,9 @@
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Types.h>
+#include <math.h>
 #include <stdarg.h>
-
-#ifndef KERNEL
-#    include <math.h>
-#    include <wchar.h>
-#endif
+#include <wchar.h>
 
 #ifdef AK_OS_SERENITY
 extern "C" size_t strlen(char const*);
@@ -162,7 +159,6 @@ ALWAYS_INLINE int print_decimal(PutChFunc putch, CharType*& bufptr, u64 number, 
 
     return field_width;
 }
-#ifndef KERNEL
 template<typename PutChFunc, typename CharType>
 ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, u32 precision, bool trailing_zeros)
 {
@@ -220,7 +216,6 @@ ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number
 
     return length;
 }
-#endif
 template<typename PutChFunc, typename CharType>
 ALWAYS_INLINE int print_octal_number(PutChFunc putch, CharType*& bufptr, u64 number, bool alternate_form, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
 {
@@ -349,14 +344,12 @@ struct PrintfImpl {
         // FIXME: Narrow characters should be converted to wide characters on the fly and vice versa.
         // https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html
         // https://pubs.opengroup.org/onlinepubs/9699919799/functions/wprintf.html
-#ifndef KERNEL
         if (state.long_qualifiers) {
             wchar_t const* sp = NextArgument<wchar_t const*>()(ap);
             if (!sp)
                 sp = L"(null)";
             return print_string(m_putch, m_bufptr, sp, wcslen(sp), state.left_pad, state.field_width, state.dot, state.precision, state.has_precision);
         }
-#endif
         char const* sp = NextArgument<char const*>()(ap);
         if (!sp)
             sp = "(null)";
@@ -398,7 +391,6 @@ struct PrintfImpl {
     {
         return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, false, state.left_pad, state.zero_pad, 16, false, 1);
     }
-#ifndef KERNEL
     ALWAYS_INLINE int format_g(ModifierState const& state, ArgumentListRefT ap) const
     {
         // FIXME: Exponent notation
@@ -408,7 +400,6 @@ struct PrintfImpl {
     {
         return print_double(m_putch, m_bufptr, NextArgument<double>()(ap), state.always_sign, state.left_pad, state.zero_pad, state.field_width, state.precision, true);
     }
-#endif
     ALWAYS_INLINE int format_o(ModifierState const& state, ArgumentListRefT ap) const
     {
         return print_octal_number(m_putch, m_bufptr, NextArgument<u32>()(ap), state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
@@ -592,10 +583,8 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, IdentityType<CharType>* buffe
                 PRINTF_IMPL_DELEGATE_TO_IMPL(X);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(c);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(d);
-#ifndef KERNEL
                 PRINTF_IMPL_DELEGATE_TO_IMPL(f);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(g);
-#endif
                 PRINTF_IMPL_DELEGATE_TO_IMPL(i);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(n);
                 PRINTF_IMPL_DELEGATE_TO_IMPL(o);

--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -181,7 +181,6 @@ public:
         return {};
     }
 
-#ifndef KERNEL
     template<typename U = T>
     void append(U&& value)
     {
@@ -193,7 +192,6 @@ public:
     {
         MUST(try_prepend(forward<U>(value)));
     }
-#endif
 
     bool contains_slow(T const& value) const
     {
@@ -266,7 +264,6 @@ public:
         return {};
     }
 
-#ifndef KERNEL
     template<typename U = T>
     void insert_before(Iterator iterator, U&& value)
     {
@@ -278,7 +275,6 @@ public:
     {
         MUST(try_insert_after(iterator, forward<U>(value)));
     }
-#endif
 
     void remove(Iterator& iterator)
     {

--- a/AK/SipHash.cpp
+++ b/AK/SipHash.cpp
@@ -5,16 +5,11 @@
  */
 
 #include <AK/ByteReader.h>
+#include <AK/Random.h>
 #include <AK/Singleton.h>
 #include <AK/SipHash.h>
 #include <AK/Span.h>
 #include <AK/UFixedBigInt.h>
-
-#ifdef KERNEL
-#    include <Kernel/Security/Random.h>
-#else
-#    include <AK/Random.h>
-#endif
 
 namespace AK {
 
@@ -137,12 +132,8 @@ static void do_siphash(ReadonlyBytes input, u128 key, Bytes output)
 struct SipHashKey {
     SipHashKey()
     {
-#ifdef KERNEL
-        key = Kernel::get_good_random<u128>();
-#else
         // get_random is assumed to be secure, otherwise SipHash doesn't deliver on its promises!
         key = get_random<u128>();
-#endif
     }
     constexpr u128 operator*() const { return key; }
     u128 key;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -201,11 +201,9 @@ requires(!IsIntegral<T>)
 __DEFINE_GENERIC_ABS(int, 0, abs);
 __DEFINE_GENERIC_ABS(long, 0L, labs);
 __DEFINE_GENERIC_ABS(long long, 0LL, llabs);
-#ifndef KERNEL
 __DEFINE_GENERIC_ABS(float, 0.0F, fabsf);
 __DEFINE_GENERIC_ABS(double, 0.0, fabs);
 __DEFINE_GENERIC_ABS(long double, 0.0L, fabsl);
-#endif
 
 #undef __DEFINE_GENERIC_ABS
 

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -6,19 +6,16 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
 #include <AK/Checked.h>
+#include <AK/FlyString.h>
 #include <AK/PrintfImplementation.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/UnicodeUtils.h>
+#include <AK/Utf16View.h>
 #include <AK/Utf32View.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#    include <AK/FlyString.h>
-#    include <AK/Utf16View.h>
-#endif
 
 namespace AK {
 
@@ -143,7 +140,6 @@ ErrorOr<ByteBuffer> StringBuilder::to_byte_buffer() const
     return ByteBuffer::copy(data(), length());
 }
 
-#ifndef KERNEL
 ByteString StringBuilder::to_byte_string() const
 {
     if (is_empty())
@@ -170,7 +166,6 @@ ErrorOr<FlyString> StringBuilder::to_fly_string() const
 {
     return FlyString::from_utf8(string_view());
 }
-#endif
 
 u8* StringBuilder::data()
 {
@@ -230,7 +225,6 @@ void StringBuilder::append_code_point(u32 code_point)
     }
 }
 
-#ifndef KERNEL
 ErrorOr<void> StringBuilder::try_append(Utf16View const& utf16_view)
 {
     for (size_t i = 0; i < utf16_view.length_in_code_units();) {
@@ -246,7 +240,6 @@ void StringBuilder::append(Utf16View const& utf16_view)
 {
     MUST(try_append(utf16_view));
 }
-#endif
 
 ErrorOr<void> StringBuilder::try_append(Utf32View const& utf32_view)
 {

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -32,9 +32,7 @@ public:
     ~StringBuilder() = default;
 
     ErrorOr<void> try_append(StringView);
-#ifndef KERNEL
     ErrorOr<void> try_append(Utf16View const&);
-#endif
     ErrorOr<void> try_append(Utf32View const&);
     ErrorOr<void> try_append_code_point(u32);
     ErrorOr<void> try_append(char);
@@ -49,9 +47,7 @@ public:
     ErrorOr<void> try_append_escaped_for_json(StringView);
 
     void append(StringView);
-#ifndef KERNEL
     void append(Utf16View const&);
-#endif
     void append(Utf32View const&);
     void append(char);
     void append_code_point(u32);
@@ -69,9 +65,7 @@ public:
         MUST(vformat(*this, fmtstr.view(), variadic_format_params));
     }
 
-#ifndef KERNEL
     [[nodiscard]] ByteString to_byte_string() const;
-#endif
 
     [[nodiscard]] String to_string_without_validation() const;
     ErrorOr<String> to_string() const;

--- a/AK/StringFloatingPointConversions.h
+++ b/AK/StringFloatingPointConversions.h
@@ -6,12 +6,6 @@
 
 #pragma once
 
-#ifdef KERNEL
-#    error This file should not be included in the KERNEL, as doubles should not appear in the \
-           kernel code, although the conversion currently does not use any floating point \
-           computations.
-#endif
-
 #include <AK/Concepts.h>
 #include <AK/Types.h>
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -5,7 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteString.h>
 #include <AK/CharacterTypes.h>
+#include <AK/FloatingPointStringConversions.h>
 #include <AK/MemMem.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
@@ -13,14 +15,7 @@
 #include <AK/StringUtils.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
-
-#ifdef KERNEL
-#    include <Kernel/Library/StdLib.h>
-#else
-#    include <AK/ByteString.h>
-#    include <AK/FloatingPointStringConversions.h>
-#    include <string.h>
-#endif
+#include <string.h>
 
 namespace AK {
 
@@ -237,7 +232,6 @@ template Optional<u16> convert_to_uint_from_octal(StringView str, TrimWhitespace
 template Optional<u32> convert_to_uint_from_octal(StringView str, TrimWhitespace);
 template Optional<u64> convert_to_uint_from_octal(StringView str, TrimWhitespace);
 
-#ifndef KERNEL
 template<typename T>
 Optional<T> convert_to_floating_point(StringView str, TrimWhitespace trim_whitespace)
 {
@@ -252,7 +246,6 @@ Optional<T> convert_to_floating_point(StringView str, TrimWhitespace trim_whites
 
 template Optional<double> convert_to_floating_point(StringView str, TrimWhitespace);
 template Optional<float> convert_to_floating_point(StringView str, TrimWhitespace);
-#endif
 
 bool equals_ignoring_ascii_case(StringView a, StringView b)
 {
@@ -469,7 +462,6 @@ Optional<size_t> find_any_of(StringView haystack, StringView needles, SearchDire
     return {};
 }
 
-#ifndef KERNEL
 ByteString to_snakecase(StringView str)
 {
     auto should_insert_underscore = [&](auto i, auto current_char) {
@@ -589,7 +581,6 @@ ErrorOr<String> replace(String const& haystack, StringView needle, StringView re
     auto resulting_builder = replace_into_builder(source_bytes, needle, replacement, replace_mode, *maybe_first);
     return resulting_builder.to_string();
 }
-#endif
 
 // TODO: Benchmark against KMP (AK/MemMem.h) and switch over if it's faster for short strings too
 size_t count(StringView str, StringView needle)

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -82,10 +82,8 @@ template<typename T = unsigned>
 Optional<T> convert_to_uint_from_hex(StringView, TrimWhitespace = TrimWhitespace::Yes);
 template<typename T = unsigned>
 Optional<T> convert_to_uint_from_octal(StringView, TrimWhitespace = TrimWhitespace::Yes);
-#ifndef KERNEL
 template<typename T>
 Optional<T> convert_to_floating_point(StringView, TrimWhitespace = TrimWhitespace::Yes);
-#endif
 bool equals_ignoring_ascii_case(StringView, StringView);
 bool ends_with(StringView a, StringView b, CaseSensitivity);
 bool starts_with(StringView, StringView, CaseSensitivity);

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -6,22 +6,18 @@
 
 #include <AK/AnyOf.h>
 #include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
+#include <AK/DeprecatedFlyString.h>
 #include <AK/Find.h>
+#include <AK/FlyString.h>
 #include <AK/Function.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#    include <AK/DeprecatedFlyString.h>
-#    include <AK/FlyString.h>
-#    include <AK/String.h>
-#endif
-
 namespace AK {
 
-#ifndef KERNEL
 StringView::StringView(String const& string)
     : m_characters(reinterpret_cast<char const*>(string.bytes().data()))
     , m_length(string.bytes().size())
@@ -45,7 +41,6 @@ StringView::StringView(DeprecatedFlyString const& string)
     , m_length(string.length())
 {
 }
-#endif
 
 StringView::StringView(ByteBuffer const& buffer)
     : m_characters((char const*)buffer.data())
@@ -207,7 +202,6 @@ bool StringView::equals_ignoring_ascii_case(StringView other) const
     return StringUtils::equals_ignoring_ascii_case(*this, other);
 }
 
-#ifndef KERNEL
 ByteString StringView::to_lowercase_string() const
 {
     return StringImpl::create_lowercased(characters_without_null_termination(), length()).release_nonnull();
@@ -222,7 +216,6 @@ ByteString StringView::to_titlecase_string() const
 {
     return StringUtils::to_titlecase(*this);
 }
-#endif
 
 StringView StringView::substring_view_starting_from_substring(StringView substring) const
 {
@@ -254,8 +247,6 @@ bool StringView::copy_characters_to_buffer(char* buffer, size_t buffer_size) con
     return characters_to_copy == m_length;
 }
 
-#ifndef KERNEL
-
 bool StringView::operator==(ByteString const& string) const
 {
     return *this == string.view();
@@ -267,7 +258,6 @@ ByteString StringView::replace(StringView needle, StringView replacement, Replac
 {
     return StringUtils::replace(*this, needle, replacement, replace_mode);
 }
-#endif
 
 Vector<size_t> StringView::find_all(StringView needle) const
 {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -48,20 +48,16 @@ public:
     }
 
     StringView(ByteBuffer const&);
-#ifndef KERNEL
     StringView(String const&);
     StringView(FlyString const&);
     StringView(ByteString const&);
     StringView(DeprecatedFlyString const&);
-#endif
 
     explicit StringView(ByteBuffer&&) = delete;
-#ifndef KERNEL
     explicit StringView(String&&) = delete;
     explicit StringView(FlyString&&) = delete;
     explicit StringView(ByteString&&) = delete;
     explicit StringView(DeprecatedFlyString&&) = delete;
-#endif
 
     template<OneOf<String, FlyString, ByteString, DeprecatedFlyString, ByteBuffer> StringType>
     StringView& operator=(StringType&&) = delete;
@@ -110,11 +106,9 @@ public:
     [[nodiscard]] StringView trim(StringView characters, TrimMode mode = TrimMode::Both) const { return StringUtils::trim(*this, characters, mode); }
     [[nodiscard]] StringView trim_whitespace(TrimMode mode = TrimMode::Both) const { return StringUtils::trim_whitespace(*this, mode); }
 
-#ifndef KERNEL
     [[nodiscard]] ByteString to_lowercase_string() const;
     [[nodiscard]] ByteString to_uppercase_string() const;
     [[nodiscard]] ByteString to_titlecase_string() const;
-#endif
 
     [[nodiscard]] Optional<size_t> find(char needle, size_t start = 0) const
     {
@@ -285,9 +279,7 @@ public:
         return m_length == 1 && *m_characters == c;
     }
 
-#ifndef KERNEL
     bool operator==(ByteString const&) const;
-#endif
 
     [[nodiscard]] constexpr int compare(StringView other) const
     {
@@ -327,18 +319,14 @@ public:
 
     constexpr bool operator>=(StringView other) const { return compare(other) >= 0; }
 
-#ifndef KERNEL
     [[nodiscard]] ByteString to_byte_string() const;
-#endif
 
     [[nodiscard]] bool is_whitespace() const
     {
         return StringUtils::is_whitespace(*this);
     }
 
-#ifndef KERNEL
     [[nodiscard]] ByteString replace(StringView needle, StringView replacement, ReplaceMode) const;
-#endif
     [[nodiscard]] size_t count(StringView needle) const
     {
         return StringUtils::count(*this, needle);
@@ -370,10 +358,8 @@ public:
     template<Arithmetic T>
     Optional<T> to_number(TrimWhitespace trim_whitespace = TrimWhitespace::Yes) const
     {
-#ifndef KERNEL
         if constexpr (IsFloatingPoint<T>)
             return StringUtils::convert_to_floating_point<T>(*this, trim_whitespace);
-#endif
         if constexpr (IsSigned<T>)
             return StringUtils::convert_to_int<T>(*this, trim_whitespace);
         else

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -6,15 +6,8 @@
 
 #include <AK/Checked.h>
 #include <AK/Time.h>
-
-// Make a reasonable guess as to which timespec/timeval definition to use.
-// It doesn't really matter, since both are identical.
-#ifdef KERNEL
-#    include <Kernel/UnixTypes.h>
-#else
-#    include <sys/time.h>
-#    include <time.h>
-#endif
+#include <sys/time.h>
+#include <time.h>
 
 namespace AK {
 
@@ -207,7 +200,6 @@ Duration Duration::from_half_sanitized(i64 seconds, i32 extra_seconds, u32 nanos
     return Duration { seconds + extra_seconds, nanoseconds };
 }
 
-#ifndef KERNEL
 namespace {
 static Duration now_time_from_clock(clockid_t clock_id)
 {
@@ -236,7 +228,5 @@ UnixDateTime UnixDateTime::now_coarse()
 {
     return UnixDateTime { now_time_from_clock(CLOCK_REALTIME_COARSE) };
 }
-
-#endif
 
 }

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -47,7 +47,6 @@ struct Traits<T> : public DefaultTraits<T> {
     }
 };
 
-#ifndef KERNEL
 template<FloatingPoint T>
 struct Traits<T> : public DefaultTraits<T> {
     static constexpr bool is_trivial() { return true; }
@@ -60,7 +59,6 @@ struct Traits<T> : public DefaultTraits<T> {
             return u64_hash(bit_cast<u64>(value));
     }
 };
-#endif
 
 template<typename T>
 requires(IsPointer<T> && !Detail::IsPointerOfType<char, T>) struct Traits<T> : public DefaultTraits<T> {

--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -232,10 +232,8 @@ private:
 
         if constexpr (requires(MetadataType t) { { t.copy() } -> SpecializationOf<ErrorOr>; })
             return Optional<MetadataType> { TRY(metadata->copy()) };
-#ifndef KERNEL
         else
             return Optional<MetadataType> { MetadataType(metadata.value()) };
-#endif
     }
 
     static ErrorOr<void> skip_to_next_iterator(auto& state, auto& current_node)

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -17,20 +17,18 @@ using i32 = __INT32_TYPE__;
 using i16 = __INT16_TYPE__;
 using i8 = __INT8_TYPE__;
 
-#ifndef KERNEL
 using f32 = float;
 static_assert(__FLT_MANT_DIG__ == 24 && __FLT_MAX_EXP__ == 128);
 
 using f64 = double;
 static_assert(__DBL_MANT_DIG__ == 53 && __DBL_MAX_EXP__ == 1024);
 
-#    if __LDBL_MANT_DIG__ == 64 && __LDBL_MAX_EXP__ == 16384
-#        define AK_HAS_FLOAT_80 1
+#if __LDBL_MANT_DIG__ == 64 && __LDBL_MAX_EXP__ == 16384
+#    define AK_HAS_FLOAT_80 1
 using f80 = long double;
-#    elif __LDBL_MANT_DIG__ == 113 && __LDBL_MAX_EXP__ == 16384
-#        define AK_HAS_FLOAT_128 1
+#elif __LDBL_MANT_DIG__ == 113 && __LDBL_MAX_EXP__ == 16384
+#    define AK_HAS_FLOAT_128 1
 using f128 = long double;
-#    endif
 #endif
 
 namespace AK::Detail {

--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -76,27 +76,6 @@ UUID::UUID(StringView uuid_string_view, Endianness endianness)
     VERIFY_NOT_REACHED();
 }
 
-#ifdef KERNEL
-ErrorOr<NonnullOwnPtr<Kernel::KString>> UUID::to_string() const
-{
-    StringBuilder builder(36);
-    auto nibble0 = TRY(encode_hex(m_uuid_buffer.span().trim(4)));
-    TRY(builder.try_append(nibble0->view()));
-    TRY(builder.try_append('-'));
-    auto nibble1 = TRY(encode_hex(m_uuid_buffer.span().slice(4).trim(2)));
-    TRY(builder.try_append(nibble1->view()));
-    TRY(builder.try_append('-'));
-    auto nibble2 = TRY(encode_hex(m_uuid_buffer.span().slice(6).trim(2)));
-    TRY(builder.try_append(nibble2->view()));
-    TRY(builder.try_append('-'));
-    auto nibble3 = TRY(encode_hex(m_uuid_buffer.span().slice(8).trim(2)));
-    TRY(builder.try_append(nibble3->view()));
-    TRY(builder.try_append('-'));
-    auto nibble4 = TRY(encode_hex(m_uuid_buffer.span().slice(10).trim(6)));
-    TRY(builder.try_append(nibble4->view()));
-    return Kernel::KString::try_create(builder.string_view());
-}
-#else
 ErrorOr<String> UUID::to_string() const
 {
     auto buffer_span = m_uuid_buffer.span();
@@ -112,7 +91,6 @@ ErrorOr<String> UUID::to_string() const
     TRY(builder.try_append(encode_hex(buffer_span.slice(10, 6))));
     return builder.to_string();
 }
-#endif
 
 bool UUID::is_zero() const
 {

--- a/AK/UUID.h
+++ b/AK/UUID.h
@@ -8,14 +8,9 @@
 
 #include <AK/Array.h>
 #include <AK/ByteBuffer.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
-
-#ifdef KERNEL
-#    include <Kernel/Library/KString.h>
-#else
-#    include <AK/String.h>
-#endif
 
 namespace AK {
 
@@ -33,11 +28,7 @@ public:
 
     bool operator==(const UUID&) const = default;
 
-#ifdef KERNEL
-    ErrorOr<NonnullOwnPtr<Kernel::KString>> to_string() const;
-#else
     ErrorOr<String> to_string() const;
-#endif
     bool is_zero() const;
 
 private:

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -7,13 +7,10 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/Format.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace AK {
 
@@ -71,14 +68,12 @@ public:
     {
     }
 
-#ifndef KERNEL
     explicit Utf8View(ByteString& string)
         : m_string(string.view())
     {
     }
 
     explicit Utf8View(ByteString&&) = delete;
-#endif
 
     enum class AllowSurrogates {
         Yes,
@@ -238,7 +233,6 @@ private:
     mutable bool m_have_length { false };
 };
 
-#ifndef KERNEL
 class DeprecatedStringCodePointIterator {
 public:
     Optional<u32> next()
@@ -272,7 +266,6 @@ private:
     ByteString m_string;
     Utf8CodePointIterator m_it;
 };
-#endif
 
 template<>
 struct Formatter<Utf8View> : Formatter<StringView> {
@@ -282,9 +275,7 @@ struct Formatter<Utf8View> : Formatter<StringView> {
 }
 
 #if USING_AK_GLOBALLY
-#    ifndef KERNEL
 using AK::DeprecatedStringCodePointIterator;
-#    endif
 using AK::Utf8CodePointIterator;
 using AK::Utf8View;
 #endif

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -226,8 +226,6 @@ public:
         return false;
     }
 
-#ifndef KERNEL
-
     template<typename U = T>
     void insert(size_t index, U&& value)
     requires(CanBePlacedInsideVector<U>)
@@ -252,8 +250,6 @@ public:
         MUST(try_extend(other));
     }
 
-#endif
-
     ALWAYS_INLINE void append(T&& value)
     {
         if constexpr (contains_reference)
@@ -268,12 +264,10 @@ public:
         MUST(try_append(T(value)));
     }
 
-#ifndef KERNEL
     void append(StorageType const* values, size_t count)
     {
         MUST(try_append(values, count));
     }
-#endif
 
     template<typename U = T>
     ALWAYS_INLINE void unchecked_append(U&& value)
@@ -296,7 +290,6 @@ public:
         m_size += count;
     }
 
-#ifndef KERNEL
     template<class... Args>
     void empend(Args&&... args)
     requires(!contains_reference)
@@ -320,8 +313,6 @@ public:
     {
         MUST(try_prepend(values, count));
     }
-
-#endif
 
     // FIXME: What about assigning from a vector with lower inline capacity?
     Vector& operator=(Vector&& other)

--- a/AK/kmalloc.cpp
+++ b/AK/kmalloc.cpp
@@ -7,7 +7,7 @@
 
 #include <AK/kmalloc.h>
 
-#if defined(AK_OS_SERENITY) && !defined(KERNEL)
+#if defined(AK_OS_SERENITY)
 
 #    include <AK/Assertions.h>
 

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -9,22 +9,17 @@
 
 #include <AK/Checked.h>
 #include <AK/Platform.h>
+#include <new>
+#include <stdlib.h>
 
-#if defined(KERNEL)
-#    include <Kernel/Heap/kmalloc.h>
-#else
-#    include <new>
-#    include <stdlib.h>
-
-#    define kcalloc calloc
-#    define kmalloc malloc
-#    define kmalloc_good_size malloc_good_size
+#define kcalloc calloc
+#define kmalloc malloc
+#define kmalloc_good_size malloc_good_size
 
 inline void kfree_sized(void* ptr, size_t)
 {
     free(ptr);
 }
-#endif
 
 #ifndef AK_OS_SERENITY
 #    include <AK/Types.h>

--- a/AK/kstdio.h
+++ b/AK/kstdio.h
@@ -9,17 +9,13 @@
 #include <AK/Platform.h>
 
 #ifdef AK_OS_SERENITY
-#    ifdef KERNEL
-#        include <Kernel/kstdio.h>
-#    else
-#        include <AK/Types.h>
-#        include <stdarg.h>
+#    include <AK/Types.h>
+#    include <stdarg.h>
 extern "C" {
 void dbgputstr(char const*, size_t);
 int sprintf(char* buf, char const* fmt, ...) __attribute__((format(printf, 2, 3)));
 int snprintf(char* buffer, size_t, char const* fmt, ...) __attribute__((format(printf, 3, 4)));
 }
-#    endif
 #else
 #    include <stdio.h>
 inline void dbgputstr(char const* characters, size_t length)

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.h
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.h
@@ -7,13 +7,10 @@
 #pragma once
 
 #include <AK/ByteReader.h>
+#include <AK/ByteString.h>
 #include <AK/Endian.h>
 #include <AK/Types.h>
 #include <LibCrypto/Hash/HashFunction.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Authentication {
 
@@ -47,12 +44,10 @@ public:
 
     constexpr static size_t digest_size() { return TagType::Size; }
 
-#ifndef KERNEL
     ByteString class_name() const
     {
         return "GHash";
     }
-#endif
 
     TagType process(ReadonlyBytes aad, ReadonlyBytes cipher);
 

--- a/Userland/Libraries/LibCrypto/Authentication/HMAC.h
+++ b/Userland/Libraries/LibCrypto/Authentication/HMAC.h
@@ -7,14 +7,11 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 constexpr static auto IPAD = 0x36;
 constexpr static auto OPAD = 0x5c;
@@ -72,7 +69,6 @@ public:
         m_outer_hasher.update(m_key_data + m_inner_hasher.block_size(), m_outer_hasher.block_size());
     }
 
-#ifndef KERNEL
     ByteString class_name() const
     {
         StringBuilder builder;
@@ -80,7 +76,6 @@ public:
         builder.append(m_inner_hasher.class_name());
         return builder.to_byte_string();
     }
-#endif
 
 private:
     void derive_key(u8 const* key, size_t length)

--- a/Userland/Libraries/LibCrypto/Cipher/AES.cpp
+++ b/Userland/Libraries/LibCrypto/Cipher/AES.cpp
@@ -23,7 +23,6 @@ constexpr void swap_keys(u32* keys, size_t i, size_t j)
     keys[j] = temp;
 }
 
-#ifndef KERNEL
 ByteString AESCipherBlock::to_byte_string() const
 {
     StringBuilder builder;
@@ -39,7 +38,6 @@ ByteString AESCipherKey::to_byte_string() const
         builder.appendff("{:02x}", m_rd_keys[i]);
     return builder.to_byte_string();
 }
-#endif
 
 void AESCipherKey::expand_encrypt_key(ReadonlyBytes user_key, size_t bits)
 {

--- a/Userland/Libraries/LibCrypto/Cipher/AES.h
+++ b/Userland/Libraries/LibCrypto/Cipher/AES.h
@@ -7,15 +7,12 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/Vector.h>
 #include <LibCrypto/Cipher/Cipher.h>
 #include <LibCrypto/Cipher/Mode/CBC.h>
 #include <LibCrypto/Cipher/Mode/CTR.h>
 #include <LibCrypto/Cipher/Mode/GCM.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Cipher {
 
@@ -47,9 +44,7 @@ public:
             m_data[i] ^= ivec[i];
     }
 
-#ifndef KERNEL
     ByteString to_byte_string() const;
-#endif
 
 private:
     constexpr static size_t data_size() { return sizeof(m_data); }
@@ -63,9 +58,7 @@ struct AESCipherKey : public CipherKey {
     virtual void expand_decrypt_key(ReadonlyBytes user_key, size_t bits) override;
     static bool is_valid_key_size(size_t bits) { return bits == 128 || bits == 192 || bits == 256; }
 
-#ifndef KERNEL
     ByteString to_byte_string() const;
-#endif
 
     u32 const* round_keys() const
     {
@@ -119,12 +112,10 @@ public:
     virtual void encrypt_block(BlockType const& in, BlockType& out) override;
     virtual void decrypt_block(BlockType const& in, BlockType& out) override;
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return "AES";
     }
-#endif
 
 protected:
     AESCipherKey m_key;

--- a/Userland/Libraries/LibCrypto/Cipher/Cipher.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Cipher.h
@@ -111,9 +111,7 @@ public:
     virtual void encrypt_block(BlockType const& in, BlockType& out) = 0;
     virtual void decrypt_block(BlockType const& in, BlockType& out) = 0;
 
-#ifndef KERNEL
     virtual ByteString class_name() const = 0;
-#endif
 
 protected:
     virtual ~Cipher() = default;

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/CBC.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/CBC.h
@@ -6,13 +6,10 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <LibCrypto/Cipher/Mode/Mode.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Cipher {
 
@@ -28,7 +25,6 @@ public:
     {
     }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         StringBuilder builder;
@@ -36,7 +32,6 @@ public:
         builder.append("_CBC"sv);
         return builder.to_byte_string();
     }
-#endif
 
     virtual size_t IV_length() const override
     {

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/CTR.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/CTR.h
@@ -6,13 +6,10 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <LibCrypto/Cipher/Mode/Mode.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Cipher {
 
@@ -103,7 +100,6 @@ public:
     {
     }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         StringBuilder builder;
@@ -111,7 +107,6 @@ public:
         builder.append("_CTR"sv);
         return builder.to_byte_string();
     }
-#endif
 
     virtual size_t IV_length() const override
     {

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/Memory.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringBuilder.h>
@@ -13,10 +14,6 @@
 #include <LibCrypto/Authentication/GHash.h>
 #include <LibCrypto/Cipher/Mode/CTR.h>
 #include <LibCrypto/Verification.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Cipher {
 
@@ -43,7 +40,6 @@ public:
         m_ghash = Authentication::GHash(m_auth_key);
     }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         StringBuilder builder;
@@ -51,7 +47,6 @@ public:
         builder.append("_GCM"sv);
         return builder.to_byte_string();
     }
-#endif
 
     virtual size_t IV_length() const override
     {

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
@@ -33,9 +33,7 @@ public:
             return ByteBuffer::create_uninitialized(input_size + T::block_size() - remainder);
     }
 
-#ifndef KERNEL
     virtual ByteString class_name() const = 0;
-#endif
 
     T& cipher()
     {

--- a/Userland/Libraries/LibCrypto/Hash/BLAKE2b.h
+++ b/Userland/Libraries/LibCrypto/Hash/BLAKE2b.h
@@ -6,12 +6,9 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <LibCrypto/Hash/HashFunction.h>
 #include <LibCrypto/Hash/SHA2.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Hash {
 
@@ -43,12 +40,10 @@ public:
     static DigestType hash(ByteBuffer const& buffer) { return hash(buffer.data(), buffer.size()); }
     static DigestType hash(StringView buffer) { return hash((u8 const*)buffer.characters_without_null_termination(), buffer.length()); }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return "BLAKE2b";
     }
-#endif
 
     virtual void reset() override
     {

--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -54,9 +54,7 @@ public:
 
     virtual void reset() = 0;
 
-#ifndef KERNEL
     virtual ByteString class_name() const = 0;
-#endif
 
 protected:
     virtual ~HashFunction() = default;

--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -196,14 +196,12 @@ public:
             [&](auto& hash) { hash.reset(); });
     }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return m_algorithm.visit(
             [&](Empty const&) -> ByteString { return "UninitializedHashManager"; },
             [&](auto const& hash) { return hash.class_name(); });
     }
-#endif
 
     inline HashKind kind() const
     {

--- a/Userland/Libraries/LibCrypto/Hash/MD5.h
+++ b/Userland/Libraries/LibCrypto/Hash/MD5.h
@@ -6,12 +6,9 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/Types.h>
 #include <LibCrypto/Hash/HashFunction.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Hash {
 
@@ -55,12 +52,10 @@ public:
     virtual DigestType digest() override;
     virtual DigestType peek() override;
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return "MD5";
     }
-#endif
 
     static DigestType hash(u8 const* data, size_t length)
     {

--- a/Userland/Libraries/LibCrypto/Hash/SHA1.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA1.h
@@ -6,11 +6,8 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <LibCrypto/Hash/HashFunction.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Hash {
 
@@ -51,12 +48,10 @@ public:
     static DigestType hash(ByteBuffer const& buffer) { return hash(buffer.data(), buffer.size()); }
     static DigestType hash(StringView buffer) { return hash((u8 const*)buffer.characters_without_null_termination(), buffer.length()); }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return "SHA1";
     }
-#endif
 
     virtual void reset() override
     {

--- a/Userland/Libraries/LibCrypto/Hash/SHA2.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA2.h
@@ -6,12 +6,9 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
 #include <AK/StringBuilder.h>
 #include <LibCrypto/Hash/HashFunction.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::Hash {
 
@@ -99,12 +96,10 @@ public:
     static DigestType hash(ByteBuffer const& buffer) { return hash(buffer.data(), buffer.size()); }
     static DigestType hash(StringView buffer) { return hash((u8 const*)buffer.characters_without_null_termination(), buffer.length()); }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return ByteString::formatted("SHA{}", DigestSize * 8);
     }
-#endif
 
     virtual void reset() override
     {
@@ -151,12 +146,10 @@ public:
     static DigestType hash(ByteBuffer const& buffer) { return hash(buffer.data(), buffer.size()); }
     static DigestType hash(StringView buffer) { return hash((u8 const*)buffer.characters_without_null_termination(), buffer.length()); }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return ByteString::formatted("SHA{}", DigestSize * 8);
     }
-#endif
 
     virtual void reset() override
     {
@@ -203,12 +196,10 @@ public:
     static DigestType hash(ByteBuffer const& buffer) { return hash(buffer.data(), buffer.size()); }
     static DigestType hash(StringView buffer) { return hash((u8 const*)buffer.characters_without_null_termination(), buffer.length()); }
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return ByteString::formatted("SHA{}", DigestSize * 8);
     }
-#endif
 
     virtual void reset() override
     {

--- a/Userland/Libraries/LibCrypto/PK/PK.h
+++ b/Userland/Libraries/LibCrypto/PK/PK.h
@@ -7,11 +7,8 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/ByteString.h>
 #include <LibCrypto/ASN1/DER.h>
-
-#ifndef KERNEL
-#    include <AK/ByteString.h>
-#endif
 
 namespace Crypto::PK {
 
@@ -95,9 +92,7 @@ public:
     virtual void sign(ReadonlyBytes in, Bytes& out) = 0;
     virtual void verify(ReadonlyBytes in, Bytes& out) = 0;
 
-#ifndef KERNEL
     virtual ByteString class_name() const = 0;
-#endif
 
     virtual size_t output_size() const = 0;
 

--- a/Userland/Libraries/LibCrypto/PK/RSA.h
+++ b/Userland/Libraries/LibCrypto/PK/RSA.h
@@ -206,12 +206,10 @@ public:
     virtual void sign(ReadonlyBytes in, Bytes& out) override;
     virtual void verify(ReadonlyBytes in, Bytes& out) override;
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return "RSA";
     }
-#endif
 
     virtual size_t output_size() const override
     {
@@ -242,12 +240,11 @@ public:
     virtual void sign(ReadonlyBytes, Bytes&) override;
     virtual void verify(ReadonlyBytes, Bytes&) override;
 
-#ifndef KERNEL
     virtual ByteString class_name() const override
     {
         return "RSA_PKCS1-EME";
     }
-#endif
+
     virtual size_t output_size() const override
     {
         return m_public_key.length();

--- a/Userland/Libraries/LibTest/TestMain.cpp
+++ b/Userland/Libraries/LibTest/TestMain.cpp
@@ -9,11 +9,7 @@
 #include <AK/Vector.h>
 #include <LibTest/TestSuite.h>
 
-#ifdef KERNEL
-#    define TEST_MAIN test_main
-#else
-#    define TEST_MAIN main
-#endif
+#define TEST_MAIN main
 
 int TEST_MAIN(int argc, char** argv)
 {


### PR DESCRIPTION
This PR removes all Serenity kernel specific code from AK and other libraries that were included in the Serenity kernel.