### PR TITLE
WebDriver: Launch Ladybird with `--force-new-process`

### DIFF
--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -46,6 +46,7 @@ static ErrorOr<pid_t> launch_browser(ByteString const& socket_path)
     }
 
     arguments.append("--allow-popups");
+    arguments.append("--force-new-process");
 
     arguments.append("about:blank");
 


### PR DESCRIPTION
This allows multiple WPT tests to be run in parallel with using the `--processes` option.