### PR TITLE
LibJS+LibLocale: Update AOs involved in locale resolution to the latest ECMA-402

### DIFF
--- a/Userland/Libraries/LibJS/Print.cpp
+++ b/Userland/Libraries/LibJS/Print.cpp
@@ -666,8 +666,6 @@ ErrorOr<void> print_intl_number_format(JS::PrintContext& print_context, JS::Intl
     TRY(print_type(print_context, "Intl.NumberFormat"sv));
     TRY(js_out(print_context, "\n  locale: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(number_format.vm(), number_format.locale()), seen_objects));
-    TRY(js_out(print_context, "\n  dataLocale: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(number_format.vm(), number_format.data_locale()), seen_objects));
     TRY(js_out(print_context, "\n  numberingSystem: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(number_format.vm(), number_format.numbering_system()), seen_objects));
     TRY(js_out(print_context, "\n  style: "));
@@ -875,8 +873,6 @@ ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::In
     TRY(print_type(print_context, "Intl.DurationFormat"sv));
     out("\n  locale: ");
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.locale()), seen_objects));
-    out("\n  dataLocale: ");
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.data_locale()), seen_objects));
     out("\n  numberingSystem: ");
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.numbering_system()), seen_objects));
     out("\n  style: ");

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -499,7 +499,7 @@ LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptio
         if (auto* options_string = options_value.has_value() ? options_value->get_pointer<String>() : nullptr) {
             // 1. Let optionsValue be the string optionsValue after performing the algorithm steps to transform Unicode extension values to canonical syntax per Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers, treating key as ukey and optionsValue as uvalue productions.
             // 2. Let optionsValue be the string optionsValue after performing the algorithm steps to replace Unicode extension values with their canonical form per Unicode Technical Standard #35 LDML § 3.2.1 Canonical Unicode Locale Identifiers, treating key as ukey and optionsValue as uvalue productions.
-            ::Locale::canonicalize_unicode_extension_values(key, *options_string);
+            *options_string = ::Locale::canonicalize_unicode_extension_values(key, *options_string);
 
             // 3. If optionsValue is the empty String, then
             if (options_string->is_empty()) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -14,7 +14,7 @@
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
 #include <LibJS/Runtime/Value.h>
-#include <LibLocale/Forward.h>
+#include <LibLocale/Locale.h>
 
 namespace JS::Intl {
 
@@ -31,9 +31,13 @@ struct LocaleOptions {
     Optional<LocaleKey> nu; // [[NumberingSystem]]
 };
 
-struct LocaleResult {
+struct MatchedLocale {
     String locale;
-    String data_locale;
+    Optional<::Locale::Extension> extension;
+};
+
+struct ResolvedLocale {
+    String locale;
     LocaleKey ca; // [[Calendar]]
     LocaleKey co; // [[Collation]]
     LocaleKey hc; // [[HourCycle]]
@@ -49,10 +53,11 @@ String canonicalize_unicode_locale_id(StringView locale);
 bool is_well_formed_currency_code(StringView currency);
 bool is_well_formed_unit_identifier(StringView unit_identifier);
 ThrowCompletionOr<Vector<String>> canonicalize_locale_list(VM&, Value locales);
-Optional<StringView> best_available_locale(StringView locale);
-String insert_unicode_extension_and_canonicalize(::Locale::LocaleID locale_id, ::Locale::LocaleExtension extension);
-LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, ReadonlySpan<StringView> relevant_extension_keys);
-ThrowCompletionOr<Array*> supported_locales(VM&, Vector<String> const& requested_locales, Value options);
+Optional<MatchedLocale> lookup_matching_locale_by_prefix(ReadonlySpan<String> requested_locales);
+Optional<MatchedLocale> lookup_matching_locale_by_best_fit(ReadonlySpan<String> requested_locales);
+String insert_unicode_extension_and_canonicalize(::Locale::LocaleID locale_id, Vector<String> attributes, Vector<::Locale::Keyword> keywords);
+ResolvedLocale resolve_locale(ReadonlySpan<String> requested_locales, LocaleOptions const& options, ReadonlySpan<StringView> relevant_extension_keys);
+ThrowCompletionOr<Array*> filter_locales(VM& vm, ReadonlySpan<String> requested_locales, Value options);
 ThrowCompletionOr<Object*> coerce_options_to_object(VM&, Value options);
 ThrowCompletionOr<StringOrBoolean> get_boolean_or_string_number_format_option(VM& vm, Object const& options, PropertyKey const& property, ReadonlySpan<StringView> string_values, StringOrBoolean fallback);
 ThrowCompletionOr<Optional<int>> default_number_option(VM&, Value value, int minimum, int maximum, Optional<int> fallback);

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -199,8 +199,8 @@ JS_DEFINE_NATIVE_FUNCTION(CollatorConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -39,9 +39,6 @@ public:
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
-    String const& data_locale() const { return m_data_locale; }
-    void set_data_locale(String data_locale) { m_data_locale = move(data_locale); }
-
     String const& calendar() const { return m_calendar; }
     void set_calendar(String calendar) { m_calendar = move(calendar); }
 
@@ -79,8 +76,6 @@ private:
     Optional<::Locale::DateTimeStyle> m_date_style; // [[DateStyle]]
     Optional<::Locale::DateTimeStyle> m_time_style; // [[TimeStyle]]
     GCPtr<NativeFunction> m_bound_format;           // [[BoundFormat]]
-
-    String m_data_locale;
 
     // Non-standard. Stores the ICU date-time formatter for the Intl object's formatting options.
     OwnPtr<::Locale::DateTimeFormat> m_formatter;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -77,8 +77,8 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 // 11.1.2 CreateDateTimeFormat ( newTarget, locales, options, required, defaults ), https://tc39.es/ecma402/#sec-createdatetimeformat
@@ -160,10 +160,6 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
         date_time_format->set_numbering_system(move(*resolved_numbering_system));
 
     // 23. Let dataLocale be r.[[dataLocale]].
-    auto data_locale = move(result.data_locale);
-
-    // Non-standard, the data locale is needed for LibUnicode lookups while formatting.
-    date_time_format->set_data_locale(data_locale);
 
     // 24. Let dataLocaleData be localeData.[[<dataLocale>]].
     Optional<::Locale::HourCycle> hour_cycle_value;
@@ -188,7 +184,7 @@ ThrowCompletionOr<NonnullGCPtr<DateTimeFormat>> create_date_time_format(VM& vm, 
 
         // c. If hc is null, set hc to dataLocaleData.[[hourCycle]].
         if (!hour_cycle_value.has_value())
-            hour_cycle_value = ::Locale::default_hour_cycle(data_locale);
+            hour_cycle_value = ::Locale::default_hour_cycle(date_time_format->locale());
     }
 
     // 28. Set dateTimeFormat.[[HourCycle]] to hc.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -147,8 +147,8 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -57,9 +57,6 @@ public:
     void set_locale(String locale) { m_locale = move(locale); }
     String const& locale() const { return m_locale; }
 
-    void set_data_locale(String data_locale) { m_data_locale = move(data_locale); }
-    String const& data_locale() const { return m_data_locale; }
-
     void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }
     String const& numbering_system() const { return m_numbering_system; }
 
@@ -173,7 +170,6 @@ private:
     static StringView display_to_string(Display);
 
     String m_locale;                    // [[Locale]]
-    String m_data_locale;               // [[DataLocale]]
     String m_numbering_system;          // [[NumberingSystem]]
     String m_hours_minutes_separator;   // [[HourMinutesSeparator]]
     String m_minutes_seconds_separator; // [[MinutesSecondsSeparator]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -89,12 +89,12 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DurationFormatConstructor::construct(Fun
     duration_format->set_locale(move(locale));
 
     // 12. Set durationFormat.[[DataLocale]] to r.[[dataLocale]].
-    duration_format->set_data_locale(move(result.data_locale));
+    // NOTE: The [[dataLocale]] internal slot no longer exists.
 
     // 13. Let dataLocale be durationFormat.[[DataLocale]].
     // 14. Let dataLocaleData be durationFormat.[[LocaleData]].[[<dataLocale>]].
     // 15. Let digitalFormat be dataLocaleData.[[DigitalFormat]].
-    auto digital_format = ::Locale::digital_format(duration_format->data_locale());
+    auto digital_format = ::Locale::digital_format(duration_format->locale());
 
     // 16. Let twoDigitHours be digitalFormat.[[TwoDigitHours]].
     // 17. Set durationFormat.[[TwoDigitHours]] to twoDigitHours.
@@ -172,8 +172,8 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -112,8 +112,8 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -34,9 +34,6 @@ public:
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
-    String const& data_locale() const { return m_data_locale; }
-    void set_data_locale(String data_locale) { m_data_locale = move(data_locale); }
-
     int min_integer_digits() const { return m_min_integer_digits; }
     void set_min_integer_digits(int min_integer_digits) { m_min_integer_digits = min_integer_digits; }
 
@@ -85,7 +82,6 @@ protected:
 
 private:
     String m_locale;                                                                             // [[Locale]]
-    String m_data_locale;                                                                        // [[DataLocale]]
     int m_min_integer_digits { 0 };                                                              // [[MinimumIntegerDigits]]
     Optional<int> m_min_fraction_digits {};                                                      // [[MinimumFractionDigits]]
     Optional<int> m_max_fraction_digits {};                                                      // [[MaximumFractionDigits]]
@@ -173,7 +169,6 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     String m_locale;                                                 // [[Locale]]
-    String m_data_locale;                                            // [[DataLocale]]
     String m_numbering_system;                                       // [[NumberingSystem]]
     ::Locale::NumberFormatStyle m_style;                             // [[Style]]
     Optional<String> m_currency;                                     // [[Currency]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -76,8 +76,8 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 // 15.1.2 InitializeNumberFormat ( numberFormat, locales, options ), https://tc39.es/ecma402/#sec-initializenumberformat
@@ -118,8 +118,7 @@ ThrowCompletionOr<NonnullGCPtr<NumberFormat>> initialize_number_format(VM& vm, N
     // 11. Set numberFormat.[[Locale]] to r.[[locale]].
     number_format.set_locale(move(result.locale));
 
-    // 12. Set numberFormat.[[DataLocale]] to r.[[dataLocale]].
-    number_format.set_data_locale(move(result.data_locale));
+    // 12. Set numberFormat.[[LocaleData]] to r.[[LocaleData]].
 
     // 13. Set numberFormat.[[NumberingSystem]] to r.[[nu]].
     if (auto* resolved_numbering_system = result.nu.get_pointer<String>())

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -77,9 +77,6 @@ ThrowCompletionOr<NonnullGCPtr<Object>> PluralRulesConstructor::construct(Functi
     // 10. Set pluralRules.[[Locale]] to r.[[locale]].
     plural_rules->set_locale(move(result.locale));
 
-    // Non-standard, the data locale is used by our NumberFormat implementation.
-    plural_rules->set_data_locale(move(result.data_locale));
-
     // 11. Let t be ? GetOption(options, "type", string, « "cardinal", "ordinal" », "cardinal").
     auto type = TRY(get_option(vm, *options, vm.names.type, OptionType::String, AK::Array { "cardinal"sv, "ordinal"sv }, "cardinal"sv));
 
@@ -114,8 +111,8 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -35,9 +35,6 @@ public:
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
-    String const& data_locale() const { return m_data_locale; }
-    void set_data_locale(String data_locale) { m_data_locale = move(data_locale); }
-
     String const& numbering_system() const { return m_numbering_system; }
     void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }
 
@@ -56,7 +53,6 @@ private:
     explicit RelativeTimeFormat(Object& prototype);
 
     String m_locale;                                                         // [[Locale]]
-    String m_data_locale;                                                    // [[DataLocale]]
     String m_numbering_system;                                               // [[NumberingSystem]]
     ::Locale::Style m_style { ::Locale::Style::Long };                       // [[Style]]
     ::Locale::NumericDisplay m_numeric { ::Locale::NumericDisplay::Always }; // [[Numeric]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -92,7 +92,6 @@ ThrowCompletionOr<NonnullGCPtr<Object>> RelativeTimeFormatConstructor::construct
     relative_time_format->set_locale(locale);
 
     // 14. Set relativeTimeFormat.[[LocaleData]] to r.[[LocaleData]].
-    relative_time_format->set_data_locale(move(result.data_locale));
 
     // 15. Set relativeTimeFormat.[[NumberingSystem]] to r.[[nu]].
     if (auto* resolved_numbering_system = result.nu.get_pointer<String>())
@@ -132,8 +131,8 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/SegmenterConstructor.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -100,8 +100,8 @@ JS_DEFINE_NATIVE_FUNCTION(SegmenterConstructor::supported_locales_of)
     // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(vm, locales));
 
-    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
-    return TRY(supported_locales(vm, requested_locales, options));
+    // 3. Return ? FilterLocales(availableLocales, requestedLocales, options).
+    return TRY(filter_locales(vm, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1275,17 +1275,16 @@ static ThrowCompletionOr<String> transform_case(VM& vm, String const& string, Va
     }
     VERIFY(requested_locale.has_value());
 
-    // 4. Let noExtensionsLocale be the String value that is requestedLocale with any Unicode locale extension sequences (6.2.1) removed.
+    // 4. Let noExtensionsLocale be the String value that is requestedLocale with any Unicode locale extension sequences removed.
     requested_locale->remove_extension_type<Locale::LocaleExtension>();
     auto no_extensions_locale = requested_locale->to_string();
 
     // 5. Let availableLocales be a List with language tags that includes the languages for which the Unicode Character Database contains language sensitive case mappings. Implementations may add additional language tags if they support case mapping for additional locales.
-    // 6. Let locale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
-    auto locale = Intl::best_available_locale(no_extensions_locale);
+    // 6. Let match be LookupMatchingLocaleByPrefix(availableLocales, noExtensionsLocale).
+    auto match = Intl::lookup_matching_locale_by_prefix({ { no_extensions_locale } });
 
-    // 7. If locale is undefined, set locale to "und".
-    if (!locale.has_value())
-        locale = "und"sv;
+    // 7. If match is not undefined, let locale be match.[[locale]]; else let locale be "und".
+    StringView locale = match.has_value() ? match->locale : "und"sv;
 
     // 8. Let codePoints be StringToCodePoints(S).
 
@@ -1295,13 +1294,13 @@ static ThrowCompletionOr<String> transform_case(VM& vm, String const& string, Va
     // 9. If targetCase is lower, then
     case TargetCase::Lower:
         // a. Let newCodePoints be a List whose elements are the result of a lowercase transformation of codePoints according to an implementation-derived algorithm using locale or the Unicode Default Case Conversion algorithm.
-        new_code_points = MUST(string.to_lowercase(*locale));
+        new_code_points = MUST(string.to_lowercase(locale));
         break;
     // 10. Else,
     case TargetCase::Upper:
         // a. Assert: targetCase is upper.
         // b. Let newCodePoints be a List whose elements are the result of an uppercase transformation of codePoints according to an implementation-derived algorithm using locale or the Unicode Default Case Conversion algorithm.
-        new_code_points = MUST(string.to_uppercase(*locale));
+        new_code_points = MUST(string.to_uppercase(locale));
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.calendar.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.calendar.js
@@ -12,5 +12,11 @@ describe("normal behavior", () => {
         expect(new Intl.Locale("en-u-ca-abc").calendar).toBe("abc");
         expect(new Intl.Locale("en", { calendar: "abc" }).calendar).toBe("abc");
         expect(new Intl.Locale("en-u-ca-abc", { calendar: "def" }).calendar).toBe("def");
+
+        expect(new Intl.Locale("en", { calendar: "islamicc" }).calendar).toBe("islamic-civil");
+        expect(new Intl.Locale("en-u-ca-islamicc").calendar).toBe("islamic-civil");
+
+        expect(new Intl.Locale("en", { calendar: "ethiopic-amete-alem" }).calendar).toBe("ethioaa");
+        expect(new Intl.Locale("en-u-ca-ethiopic-amete-alem").calendar).toBe("ethioaa");
     });
 });

--- a/Userland/Libraries/LibLocale/Locale.cpp
+++ b/Userland/Libraries/LibLocale/Locale.cpp
@@ -491,7 +491,7 @@ String canonicalize_unicode_locale_id(StringView locale)
     return locale_data->to_string();
 }
 
-void canonicalize_unicode_extension_values(StringView key, String& value)
+String canonicalize_unicode_extension_values(StringView key, StringView value)
 {
     UErrorCode status = U_ZERO_ERROR;
 
@@ -507,7 +507,7 @@ void canonicalize_unicode_extension_values(StringView key, String& value)
     auto result = locale.getUnicodeKeywordValue<StringBuilder>(icu_string_piece(key), status);
     VERIFY(icu_success(status));
 
-    value = MUST(result.to_string());
+    return MUST(result.to_string());
 }
 
 StringView default_locale()

--- a/Userland/Libraries/LibLocale/Locale.h
+++ b/Userland/Libraries/LibLocale/Locale.h
@@ -128,7 +128,7 @@ Optional<LanguageID> parse_unicode_language_id(StringView);
 Optional<LocaleID> parse_unicode_locale_id(StringView);
 
 String canonicalize_unicode_locale_id(StringView);
-void canonicalize_unicode_extension_values(StringView key, String& value);
+String canonicalize_unicode_extension_values(StringView key, StringView value);
 
 StringView default_locale();
 bool is_locale_available(StringView locale);


### PR DESCRIPTION
There have been a number of changes to the locale resolution AOs that we've fallen behind on. Mostly editorial, but includes one normative change to canonicalize Unicode extension keywords in the Intl.Locale constructor.

The normative change is actually a fix for [a bug I reported ~2 years ago](https://github.com/tc39/ecma402/issues/707), so that's neat :^)

```
Diff Tests:
    test/intl402/Locale/constructor-options-canonicalized.js ❌ -> ✅
    test/intl402/Locale/prototype/calendar/canonicalize.js   ❌ -> ✅
```

We now pass all `Intl.Locale` tests:
```
test/intl402/Locale    147/147   (100.00%) [ ✅ 147   ]
```