### PR TITLE
 LibWeb: Respect selected painter in SVGDecodedImageData

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1188,7 +1188,8 @@ void TraversableNavigable::paint(Web::DevicePixelRect const& content_rect, Gfx::
     paint_config.has_focus = paint_options.has_focus;
     record_painting_commands(recording_painter, paint_config);
 
-    if (paint_options.use_gpu_painter) {
+    auto painting_command_executor_type = page().client().painting_command_executor_type();
+    if (painting_command_executor_type == PaintingCommandExecutorType::GPU) {
 #ifdef HAS_ACCELERATED_GRAPHICS
         Web::Painting::CommandExecutorGPU painting_command_executor(*paint_options.accelerated_graphics_context, target);
         painting_commands.execute(painting_command_executor);
@@ -1200,11 +1201,11 @@ void TraversableNavigable::paint(Web::DevicePixelRect const& content_rect, Gfx::
             has_warned_about_configuration = true;
         }
 #endif
-    } else if (paint_options.use_skia_painter) {
+    } else if (painting_command_executor_type == PaintingCommandExecutorType::Skia) {
         Painting::CommandExecutorSkia painting_command_executor(target);
         painting_commands.execute(painting_command_executor);
     } else {
-        Web::Painting::CommandExecutorCPU painting_command_executor(target, paint_options.use_experimental_cpu_transform_support);
+        Web::Painting::CommandExecutorCPU painting_command_executor(target, painting_command_executor_type == PaintingCommandExecutorType::CPUWithExperimentalTransformSupport);
         painting_commands.execute(painting_command_executor);
     }
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -269,13 +269,16 @@ struct PaintOptions {
     bool should_show_line_box_borders { false };
     bool has_focus { false };
 
-    bool use_gpu_painter { false };
-    bool use_skia_painter { false };
-    bool use_experimental_cpu_transform_support { false };
-
 #ifdef HAS_ACCELERATED_GRAPHICS
     AccelGfx::Context* accelerated_graphics_context { nullptr };
 #endif
+};
+
+enum class PaintingCommandExecutorType {
+    CPU,
+    CPUWithExperimentalTransformSupport,
+    GPU,
+    Skia
 };
 
 class PageClient : public JS::Cell {
@@ -370,6 +373,8 @@ public:
 
     virtual void schedule_repaint() = 0;
     virtual bool is_ready_to_paint() const = 0;
+
+    virtual PaintingCommandExecutorType painting_command_executor_type() const = 0;
 
 protected:
     virtual ~PageClient() = default;

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -80,6 +80,8 @@ public:
     virtual void schedule_repaint() override { }
     virtual bool is_ready_to_paint() const override { return true; }
 
+    virtual PaintingCommandExecutorType painting_command_executor_type() const override { return m_host_page->client().painting_command_executor_type(); }
+
 private:
     explicit SVGPageClient(Page& host_page)
         : m_host_page(host_page)

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -225,9 +225,6 @@ void PageClient::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& ta
 #ifdef HAS_ACCELERATED_GRAPHICS
     paint_options.accelerated_graphics_context = m_accelerated_graphics_context.ptr();
 #endif
-    paint_options.use_gpu_painter = s_use_gpu_painter;
-    paint_options.use_skia_painter = s_use_skia_painter;
-    paint_options.use_experimental_cpu_transform_support = s_use_experimental_cpu_transform_support;
     page().top_level_traversable()->paint(content_rect, target, paint_options);
 }
 
@@ -729,6 +726,17 @@ void PageClient::console_peer_did_misbehave(char const* reason)
 void PageClient::did_get_js_console_messages(i32 start_index, Vector<ByteString> message_types, Vector<ByteString> messages)
 {
     client().async_did_get_js_console_messages(m_id, start_index, move(message_types), move(messages));
+}
+
+Web::PaintingCommandExecutorType PageClient::painting_command_executor_type() const
+{
+    if (s_use_gpu_painter)
+        return Web::PaintingCommandExecutorType::GPU;
+    if (s_use_skia_painter)
+        return Web::PaintingCommandExecutorType::Skia;
+    if (s_use_experimental_cpu_transform_support)
+        return Web::PaintingCommandExecutorType::CPUWithExperimentalTransformSupport;
+    return Web::PaintingCommandExecutorType::CPU;
 }
 
 }

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -89,6 +89,8 @@ public:
 
     virtual double device_pixels_per_css_pixel() const override { return m_device_pixels_per_css_pixel; }
 
+    virtual Web::PaintingCommandExecutorType painting_command_executor_type() const override;
+
 private:
     PageClient(PageHost&, u64 id);
 

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -36,6 +36,7 @@ public:
     virtual void request_file(Web::FileRequest) override;
     virtual void schedule_repaint() override {};
     virtual bool is_ready_to_paint() const override { return true; }
+    virtual Web::PaintingCommandExecutorType painting_command_executor_type() const override { VERIFY_NOT_REACHED(); }
 
 private:
     explicit PageHost(ConnectionFromClient&);


### PR DESCRIPTION
Now SVGDecodedImageData uses Skia painter, if it's selected.