### PR TITLE
LibWeb: Display error message on error page + error passing changes

### DIFF
--- a/Base/res/ladybird/templates/error.html
+++ b/Base/res/ladybird/templates/error.html
@@ -22,5 +22,6 @@
         <img src="resource://icons/32x32/msgbox-warning.png" alt="Warning" width="24" height="24">
         <h1>Failed to load @failed_url@</h1>
     </header>
+    <p>@error_message@</p>
 </body>
 </html>

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2222,7 +2222,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
             auto response = Infrastructure::Response::create(vm);
             // FIXME: This is ugly, ResourceLoader should tell us.
             if (status_code.value_or(0) == 0) {
-                response = Infrastructure::Response::network_error(vm, "HTTP request failed"_string);
+                response = Infrastructure::Response::network_error(vm, TRY_OR_IGNORE(String::from_byte_string(error)));
             } else {
                 response->set_type(Infrastructure::Response::Type::Error);
                 response->set_status(status_code.value_or(400));

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -52,6 +52,9 @@ class Navigable : public JS::Cell {
 public:
     virtual ~Navigable() override;
 
+    using NullWithError = StringView;
+    using NavigationParamsVariant = Variant<Empty, NullWithError, JS::NonnullGCPtr<NavigationParams>, JS::NonnullGCPtr<NonFetchSchemeNavigationParams>>;
+
     ErrorOr<void> initialize_navigable(JS::NonnullGCPtr<DocumentState> document_state, JS::GCPtr<Navigable> parent);
 
     Vector<JS::Handle<Navigable>> child_navigables() const;
@@ -123,7 +126,7 @@ public:
         SourceSnapshotParams const& source_snapshot_params,
         TargetSnapshotParams const& target_snapshot_params,
         Optional<String> navigation_id = {},
-        Variant<Empty, JS::NonnullGCPtr<NavigationParams>, JS::NonnullGCPtr<NonFetchSchemeNavigationParams>> navigation_params = Empty {},
+        NavigationParamsVariant navigation_params = Empty {},
         CSPNavigationType csp_navigation_type = CSPNavigationType::Other,
         bool allow_POST = false,
         JS::SafeFunction<void()> completion_steps = [] {});

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -26,7 +26,7 @@ void set_chrome_process_executable_path(StringView executable_path)
     s_chrome_process_executable_path = MUST(String::from_utf8(executable_path));
 }
 
-ErrorOr<String> load_error_page(URL::URL const& url)
+ErrorOr<String> load_error_page(URL::URL const& url, StringView error_message)
 {
     // Generate HTML error page from error template file
     // FIXME: Use an actual templating engine (our own one when it's built, preferably with a way to check these usages at compile time)
@@ -34,6 +34,7 @@ ErrorOr<String> load_error_page(URL::URL const& url)
     StringBuilder builder;
     SourceGenerator generator { builder };
     generator.set("failed_url", url.to_byte_string());
+    generator.set("error_message", escape_html_entities(error_message));
     generator.append(template_file->data());
     return TRY(String::from_utf8(generator.as_string_view()));
 }

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -17,7 +17,7 @@ static String s_chrome_process_executable_path {};
 void set_chrome_process_command_line(StringView command_line);
 void set_chrome_process_executable_path(StringView executable_path);
 
-ErrorOr<String> load_error_page(URL::URL const&);
+ErrorOr<String> load_error_page(URL::URL const&, StringView error_message);
 
 ErrorOr<String> load_file_directory_page(URL::URL const&);
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -301,6 +301,8 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
         auto resource = Core::Resource::load_from_uri(url.serialize());
         if (resource.is_error()) {
             log_failure(request, resource.error());
+            if (error_callback)
+                error_callback(ByteString::formatted("{}", resource.error()), {}, {}, {});
             return;
         }
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -337,10 +337,8 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
 
             if (file_or_error.is_error()) {
                 log_failure(request, file_or_error.error());
-                if (error_callback) {
-                    auto status = file_or_error.error().code() == ENOENT ? 404u : 500u;
-                    error_callback(ByteString::formatted("{}", file_or_error.error()), status, {}, {});
-                }
+                if (error_callback)
+                    error_callback(ByteString::formatted("{}", file_or_error.error()), {}, {}, {});
                 return;
             }
 
@@ -357,7 +355,7 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
             if (st_or_error.is_error()) {
                 log_failure(request, st_or_error.error());
                 if (error_callback)
-                    error_callback(ByteString::formatted("{}", st_or_error.error()), 500u, {}, {});
+                    error_callback(ByteString::formatted("{}", st_or_error.error()), {}, {}, {});
                 return;
             }
 
@@ -366,7 +364,7 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
             if (maybe_file.is_error()) {
                 log_failure(request, maybe_file.error());
                 if (error_callback)
-                    error_callback(ByteString::formatted("{}", maybe_file.error()), 500u, {}, {});
+                    error_callback(ByteString::formatted("{}", maybe_file.error()), {}, {}, {});
                 return;
             }
 
@@ -375,7 +373,7 @@ void ResourceLoader::load(LoadRequest& request, SuccessCallback success_callback
             if (maybe_data.is_error()) {
                 log_failure(request, maybe_data.error());
                 if (error_callback)
-                    error_callback(ByteString::formatted("{}", maybe_data.error()), 500u, {}, {});
+                    error_callback(ByteString::formatted("{}", maybe_data.error()), {}, {}, {});
                 return;
             }
 


### PR DESCRIPTION
## LibWeb: Pass network error message to generated error page
This adds a non-standard "null" state to the navigation params which can contain an additional error message, this is then passed to the `load_error_page` function
## LibWeb/Fetch: Pass error from ResourceLoader into network_error
This changes the generic "HTTP request failed" error into the one provided by ResourceLoader
## LibWeb/ResourceLoader: Call error callback if resource: load fails, LibWeb/ResourceLoader: Report file: errors as "network errors" 
This changes the errors from file: and resource: loads to "network errors", which trigger the error page instead of silently failing. Alternatively we could map `errno`s to status codes more intelligently, and have empty bodies trigger the error page. (From what I can tell this already mostly happens with HTTP requests [but it results in a network error as well](https://github.com/LadybirdBrowser/ladybird/blob/8c9d3b30cf62016ffb03e425f1e7e3f2461262bf/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp#L421))
## In a future PR
Hook up the error messages from RequestServer to ResourceLoader so you don't get a generic "Load failed" error if you enter the wrong domain name
# Screenshots
![Screenshot at 2024-06-19 14-49-49](https://github.com/LadybirdBrowser/ladybird/assets/39885272/3cc90071-ed0c-48e2-b55c-e23be3223c2b)
![Screenshot at 2024-06-19 14-50-32](https://github.com/LadybirdBrowser/ladybird/assets/39885272/a76da7fe-b461-4bb8-9bfe-f48646744d4e)
![Screenshot at 2024-06-18 21-02-20](https://github.com/LadybirdBrowser/ladybird/assets/39885272/50388bc9-4181-4dca-89dd-84845c5bf909)
^ in combination with #129