### PR TITLE
CI: Use Xcode's Clang in the macOS workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -49,6 +49,7 @@ runs:
       shell: bash
       run: |
         set -e
+        sudo xcode-select --switch /Applications/Xcode_15.4.app
         brew update
         brew install autoconf autoconf-archive automake coreutils bash ninja wabt ccache unzip qt llvm@18
 

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -72,8 +72,8 @@ jobs:
               echo "host_cxx=g++-13" >> "$GITHUB_OUTPUT"
             fi
           elif ${{ inputs.os_name == 'macOS' }} ; then
-            echo "host_cc=$(brew --prefix llvm@18)/bin/clang" >> "$GITHUB_OUTPUT"
-            echo "host_cxx=$(brew --prefix llvm@18)/bin/clang++" >> "$GITHUB_OUTPUT"
+            echo "host_cc=$(xcrun --find clang)" >> "$GITHUB_OUTPUT"
+            echo "host_cxx=$(xcrun --find clang++)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set dynamic environment variables

--- a/.github/workflows/nightly-android.yml
+++ b/.github/workflows/nightly-android.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Assign Build Parameters
         id: 'build-parameters'
         run: |
-          echo "host_cc=$(brew --prefix llvm@18)/bin/clang" >> "$GITHUB_OUTPUT"
-          echo "host_cxx=$(brew --prefix llvm@18)/bin/clang++" >> "$GITHUB_OUTPUT"
+          echo "host_cc=$(xcrun --find clang)" >> "$GITHUB_OUTPUT"
+          echo "host_cxx=$(xcrun --find clang++)" >> "$GITHUB_OUTPUT"
 
       - name: Install NDK
         run: |


### PR DESCRIPTION
Most users will be building with Xcode Clang on macOS anyway, as our
build scripts default to the system compiler if it's new enough. We
already have an upstream Clang-based workflow on Linux, so we won't lose
any compiler coverage by switching to Apple Clang on macOS.

This should help us avoid build breakages like https://github.com/LadybirdBrowser/ladybird/issues/186.