### PR TITLE
LibLocale: Move definition of Range structure to dedicated header

### DIFF
--- a/Userland/Libraries/LibLocale/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/DateTimeFormat.cpp
@@ -15,6 +15,7 @@
 #include <LibLocale/ICU.h>
 #include <LibLocale/Locale.h>
 #include <LibLocale/NumberFormat.h>
+#include <LibLocale/PartitionRange.h>
 #include <stdlib.h>
 
 #include <unicode/calendar.h>
@@ -659,16 +660,6 @@ static bool is_formatted_range_actually_a_range(icu::FormattedDateInterval const
     return has_range;
 }
 
-struct Range {
-    constexpr bool contains(i32 position) const
-    {
-        return start <= position && position < end;
-    }
-
-    i32 start { 0 };
-    i32 end { 0 };
-};
-
 class DateTimeFormatImpl : public DateTimeFormat {
 public:
     DateTimeFormatImpl(icu::Locale& locale, icu::UnicodeString const& pattern, StringView time_zone_identifier, NonnullOwnPtr<icu::SimpleDateFormat> formatter)
@@ -765,8 +756,8 @@ public:
         i32 previous_end_index = 0;
 
         Vector<Partition> result;
-        Optional<Range> start_range;
-        Optional<Range> end_range;
+        Optional<PartitionRange> start_range;
+        Optional<PartitionRange> end_range;
 
         auto create_partition = [&](i32 field, i32 begin, i32 end) {
             Partition partition;
@@ -789,7 +780,7 @@ public:
 
             if (position.getCategory() == UFIELD_CATEGORY_DATE_INTERVAL_SPAN) {
                 auto& range = position.getField() == 0 ? start_range : end_range;
-                range = Range { position.getStart(), position.getLimit() };
+                range = PartitionRange { position.getField(), position.getStart(), position.getLimit() };
             } else if (position.getCategory() == UFIELD_CATEGORY_DATE) {
                 create_partition(position.getField(), position.getStart(), position.getLimit());
             }

--- a/Userland/Libraries/LibLocale/PartitionRange.h
+++ b/Userland/Libraries/LibLocale/PartitionRange.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Locale {
+
+struct PartitionRange {
+    // ICU does not contain a field enumeration for "literal" partitions. Define a custom field so that we may provide
+    // a type for those partitions.
+    static constexpr i32 LITERAL_FIELD = -1;
+
+    constexpr bool contains(i32 position) const
+    {
+        return start <= position && position < end;
+    }
+
+    constexpr bool operator<(PartitionRange const& other) const
+    {
+        if (start < other.start)
+            return true;
+        if (start == other.start)
+            return end > other.end;
+        return false;
+    }
+
+    i32 field { LITERAL_FIELD };
+    i32 start { 0 };
+    i32 end { 0 };
+};
+
+}

--- a/Userland/Libraries/LibLocale/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibLocale/RelativeTimeFormat.cpp
@@ -9,6 +9,7 @@
 #include <LibLocale/ICU.h>
 #include <LibLocale/Locale.h>
 #include <LibLocale/NumberFormat.h>
+#include <LibLocale/PartitionRange.h>
 #include <LibLocale/RelativeTimeFormat.h>
 
 #include <unicode/decimfmt.h>
@@ -117,14 +118,10 @@ static constexpr UDateRelativeDateTimeFormatterStyle icu_relative_date_time_styl
     VERIFY_NOT_REACHED();
 }
 
-// ICU does not contain a field enumeration for "literal" partitions. Define a custom field so that we may provide a
-// type for those partitions.
-static constexpr i32 LITERAL_FIELD = -1;
-
 static constexpr StringView icu_relative_time_format_field_to_string(i32 field)
 {
     switch (field) {
-    case LITERAL_FIELD:
+    case PartitionRange::LITERAL_FIELD:
         return "literal"sv;
     case UNUM_INTEGER_FIELD:
         return "integer"sv;
@@ -137,12 +134,6 @@ static constexpr StringView icu_relative_time_format_field_to_string(i32 field)
     }
     VERIFY_NOT_REACHED();
 }
-
-struct Range {
-    i32 field { 0 };
-    i32 start { 0 };
-    i32 end { 0 };
-};
 
 class RelativeTimeFormatImpl : public RelativeTimeFormat {
 public:
@@ -178,7 +169,7 @@ public:
             return {};
 
         Vector<Partition> result;
-        Vector<Range> separators;
+        Vector<PartitionRange> separators;
 
         auto create_partition = [&](i32 field, i32 begin, i32 end, bool is_unit) {
             Partition partition;
@@ -201,7 +192,7 @@ public:
             }
 
             if (previous_end_index < position.getStart())
-                create_partition(LITERAL_FIELD, previous_end_index, position.getStart(), false);
+                create_partition(PartitionRange::LITERAL_FIELD, previous_end_index, position.getStart(), false);
 
             auto start = position.getStart();
 
@@ -223,7 +214,7 @@ public:
         }
 
         if (previous_end_index < formatted_time.length())
-            create_partition(LITERAL_FIELD, previous_end_index, formatted_time.length(), false);
+            create_partition(PartitionRange::LITERAL_FIELD, previous_end_index, formatted_time.length(), false);
 
         return result;
     }


### PR DESCRIPTION
We were redefining a Range type in a few formatters. Move it to its own header to avoid ODR violations (and give it a more descriptive name).