### PR TITLE
LibWeb: Add null checks to several navigation-related methods

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3049,9 +3049,14 @@ Vector<JS::Handle<HTML::Navigable>> const Document::descendant_navigables() cons
 // https://html.spec.whatwg.org/multipage/document-sequences.html#inclusive-descendant-navigables
 Vector<JS::Handle<HTML::Navigable>> Document::inclusive_descendant_navigables()
 {
+    // NOTE: This isn't in the spec, but if we don't have a navigable, we can't have descendants either.
+    auto document_node_navigable = navigable();
+    if (!document_node_navigable)
+        return {};
+
     // 1. Let navigables be « document's node navigable ».
     Vector<JS::Handle<HTML::Navigable>> navigables;
-    navigables.append(*navigable());
+    navigables.append(*document_node_navigable);
 
     // 2. Extend navigables with document's descendant navigables.
     navigables.extend(descendant_navigables());
@@ -3095,11 +3100,16 @@ Vector<JS::Handle<HTML::Navigable>> const Document::ancestor_navigables() const
 // https://html.spec.whatwg.org/multipage/document-sequences.html#inclusive-ancestor-navigables
 Vector<JS::Handle<HTML::Navigable>> Document::inclusive_ancestor_navigables()
 {
+    // NOTE: This isn't in the spec, but if we don't have a navigable, we can't have ancestors either.
+    auto document_node_navigable = navigable();
+    if (!document_node_navigable)
+        return {};
+
     // 1. Let navigables be document's ancestor navigables.
     auto navigables = ancestor_navigables();
 
     // 2. Append document's node navigable to navigables.
-    navigables.append(*navigable());
+    navigables.append(*document_node_navigable);
 
     // 3. Return navigables.
     return navigables;

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1243,7 +1243,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
     auto initiator_base_url_snapshot = source_document->base_url();
 
     // 5. If sourceDocument's node navigable is not allowed by sandboxing to navigate navigable given and sourceSnapshotParams, then:
-    if (!source_document->navigable()->allowed_by_sandboxing_to_navigate(*this, source_snapshot_params)) {
+    if (source_document->navigable() && !source_document->navigable()->allowed_by_sandboxing_to_navigate(*this, source_snapshot_params)) {
         // 1. If exceptionsEnabled is true, then throw a "SecurityError" DOMException.
         if (exceptions_enabled) {
             return WebIDL::SecurityError::create(realm, "Source document's node navigable is not allowed to navigate"_fly_string);


### PR DESCRIPTION
This PR adds checks to ensure the document's node navigable is not null in `Document::inclusive_ancestor_navigables()`, `Document::inclusive_descendant_navigables` and `Navigable::navigate()`. These null checks aren't explicitly mentioned by the spec, but the spec also doesn't prohibit these methods being called with a null navigable.

Each of these methods previously caused a crash when trying to navigate between pages on https://engadget.com.

Fixes #199