### PR TITLE
LibJS: Don't overwrite cached `this` value on async/generator reentry

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -717,7 +717,13 @@ Interpreter::ResultAndReturnRegister Interpreter::run_executable(Executable& exe
 
     reg(Register::accumulator()) = initial_accumulator_value;
     reg(Register::return_value()) = {};
-    reg(Register::this_value()) = running_execution_context.this_value;
+
+    // NOTE: We only copy the `this` value from ExecutionContext if it's not already set.
+    //       If we are re-entering an async/generator context, the `this` value
+    //       may have already been cached by a ResolveThisBinding instruction,
+    //       and subsequent instructions expect this value to be set.
+    if (reg(Register::this_value()).is_empty())
+        reg(Register::this_value()) = running_execution_context.this_value;
 
     running_execution_context.executable = &executable;
 

--- a/Userland/Libraries/LibJS/Tests/async-this-value.js
+++ b/Userland/Libraries/LibJS/Tests/async-this-value.js
@@ -1,0 +1,8 @@
+test("this value in async function", () => {
+    function X() {
+        this.boog = async () => {
+            this.f = await null;
+        };
+    }
+    new X().boog();
+});


### PR DESCRIPTION
When resuming execution of a suspended function, we must not overwrite any cached `this` value with something from the ExecutionContext.

This was causing an empty JS::Value to leak into the VM when resuming an async arrow function, since the "this mode" for such functions is lexical and thus ExecutionContext will have an empty `this`.

It became a problem due to the bytecode optimization where we allow ourselves to assume that `this` remains cached after we've executed a ResolveThisBinding in this (or the first) basic block of the executable.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/138