### PR TITLE
 Everywhere: Use IOSurface as backing store on macOS

### DIFF
--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -18,6 +18,8 @@
 #include <LibWebView/Database.h>
 #include <LibWebView/ProcessManager.h>
 #include <LibWebView/URL.h>
+#include <LibWebView/ViewImplementation.h>
+#include <LibWebView/WebContentClient.h>
 
 #import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
@@ -120,6 +122,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     set_mach_server_name(mach_port_server->server_port_name());
     mach_port_server->on_receive_child_mach_port = [](auto pid, auto port) {
         WebView::ProcessManager::the().add_process(pid, move(port));
+    };
+    mach_port_server->on_receive_backing_stores = [](Ladybird::MachPortServer::BackingStoresMessage message) {
+        auto view = WebView::WebContentClient::view_for_pid_and_page_id(message.pid, message.page_id);
+        view->did_allocate_iosurface_backing_stores(message.front_backing_store_id, move(message.front_backing_store_port), message.back_backing_store_id, move(message.back_backing_store_port));
     };
 
     auto database = TRY(WebView::Database::create());

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -48,6 +48,9 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
         if (!result.is_error()) {
             auto process = result.release_value();
 
+            if constexpr (requires { process.client->set_pid(pid_t {}); })
+                process.client->set_pid(process.process.pid());
+
             if (register_with_process_manager == RegisterWithProcessManager::Yes)
                 WebView::ProcessManager::the().add_process(WebView::process_type_from_name(server_name), process.process.pid());
 

--- a/Ladybird/MachPortServer.h
+++ b/Ladybird/MachPortServer.h
@@ -31,6 +31,15 @@ public:
     bool is_initialized();
 
     Function<void(pid_t, Core::MachPort)> on_receive_child_mach_port;
+    struct BackingStoresMessage {
+        pid_t pid { -1 };
+        u64 page_id { 0 };
+        i32 front_backing_store_id { 0 };
+        i32 back_backing_store_id { 0 };
+        Core::MachPort front_backing_store_port;
+        Core::MachPort back_backing_store_port;
+    };
+    Function<void(BackingStoresMessage)> on_receive_backing_stores;
 
     ByteString const& server_port_name() const { return m_server_port_name; }
 

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -148,6 +148,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     mach_port_server->on_receive_child_mach_port = [](auto pid, auto port) {
         WebView::ProcessManager::the().add_process(pid, move(port));
     };
+    mach_port_server->on_receive_backing_stores = [](Ladybird::MachPortServer::BackingStoresMessage message) {
+        auto view = WebView::WebContentClient::view_for_pid_and_page_id(message.pid, message.page_id);
+        view->did_allocate_iosurface_backing_stores(message.front_backing_store_id, move(message.front_backing_store_port), message.back_backing_store_id, move(message.back_backing_store_port));
+    };
 #endif
 
     RefPtr<WebView::Database> database;

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -6,6 +6,7 @@ set(WEBCONTENT_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebContent/)
 set(WEBCONTENT_SOURCES
     ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.cpp
     ${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalEnvironmentExtensions.cpp
+    ${WEBCONTENT_SOURCE_DIR}/BackingStoreManager.cpp
     ${WEBCONTENT_SOURCE_DIR}/PageClient.cpp
     ${WEBCONTENT_SOURCE_DIR}/PageHost.cpp
     ${WEBCONTENT_SOURCE_DIR}/WebContentConsoleClient.cpp

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -138,7 +138,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 #if defined(AK_OS_MACOS)
     if (!mach_server_name.is_empty()) {
-        Core::Platform::register_with_mach_server(mach_server_name);
+        auto server_port = Core::Platform::register_with_mach_server(mach_server_name);
+        WebContent::BackingStoreManager::set_browser_mach_port(move(server_port));
     }
 #endif
 

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -79,6 +79,10 @@ if (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
     list(APPEND SOURCES MachPort.cpp)
 endif()
 
+if (APPLE)
+    list(APPEND SOURCES IOSurface.cpp)
+endif()
+
 serenity_lib(LibCore core)
 target_link_libraries(LibCore PRIVATE LibCrypt LibTimeZone LibURL)
 target_link_libraries(LibCore PUBLIC LibCoreMinimal)
@@ -87,6 +91,7 @@ if (APPLE)
     target_link_libraries(LibCore PUBLIC "-framework CoreFoundation")
     target_link_libraries(LibCore PUBLIC "-framework CoreServices")
     target_link_libraries(LibCore PUBLIC "-framework Foundation")
+    target_link_libraries(LibCore PUBLIC "-framework IOSurface")
 endif()
 
 if (ANDROID)

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -49,4 +49,8 @@ class UDPSocket;
 
 enum class TimerShouldFireWhenNotVisible;
 
+#ifdef AK_OS_MACH
+class MachPort;
+#endif
+
 }

--- a/Userland/Libraries/LibCore/IOSurface.cpp
+++ b/Userland/Libraries/LibCore/IOSurface.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/OwnPtr.h>
+#include <LibCore/IOSurface.h>
+
+#if !defined(AK_OS_MACOS)
+static_assert(false, "This file must only be used for macOS");
+#endif
+
+#define FixedPoint FixedPointMacOS
+#define Duration DurationMacOS
+#include <IOSurface/IOSurface.h>
+#undef FixedPoint
+#undef Duration
+
+namespace Core {
+
+template<typename T>
+class RefAutoRelease {
+    AK_MAKE_NONCOPYABLE(RefAutoRelease);
+
+public:
+    RefAutoRelease(T ref)
+        : m_ref(ref)
+    {
+    }
+
+    ~RefAutoRelease()
+    {
+        if (m_ref)
+            CFRelease(m_ref);
+        m_ref = nullptr;
+    }
+
+    T ref() const { return m_ref; }
+
+private:
+    T m_ref { nullptr };
+};
+
+struct IOSurfaceHandle::IOSurfaceRefWrapper {
+    IOSurfaceRef ref;
+};
+
+IOSurfaceHandle::IOSurfaceHandle(OwnPtr<IOSurfaceRefWrapper>&& ref_wrapper)
+    : m_ref_wrapper(move(ref_wrapper))
+{
+}
+
+IOSurfaceHandle::IOSurfaceHandle(IOSurfaceHandle&& other) = default;
+IOSurfaceHandle& IOSurfaceHandle::operator=(IOSurfaceHandle&& other) = default;
+
+IOSurfaceHandle::~IOSurfaceHandle()
+{
+    if (m_ref_wrapper)
+        CFRelease(m_ref_wrapper->ref);
+}
+
+IOSurfaceHandle IOSurfaceHandle::create(int width, int height)
+{
+    size_t bytes_per_element = 4;
+    uint32_t pixel_format = 'BGRA';
+
+    RefAutoRelease<CFNumberRef> width_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &width);
+    RefAutoRelease<CFNumberRef> height_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &height);
+    RefAutoRelease<CFNumberRef> bytes_per_element_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &bytes_per_element);
+    RefAutoRelease<CFNumberRef> pixel_format_number = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &pixel_format);
+
+    CFMutableDictionaryRef props = CFDictionaryCreateMutable(kCFAllocatorDefault,
+        0,
+        &kCFTypeDictionaryKeyCallBacks,
+        &kCFTypeDictionaryValueCallBacks);
+
+    CFDictionarySetValue(props, kIOSurfaceWidth, width_number.ref());
+    CFDictionarySetValue(props, kIOSurfaceHeight, height_number.ref());
+    CFDictionarySetValue(props, kIOSurfaceBytesPerElement, bytes_per_element_number.ref());
+    CFDictionarySetValue(props, kIOSurfacePixelFormat, pixel_format_number.ref());
+
+    auto* ref = IOSurfaceCreate(props);
+    VERIFY(ref);
+    return IOSurfaceHandle(make<IOSurfaceRefWrapper>(ref));
+}
+
+MachPort IOSurfaceHandle::create_mach_port() const
+{
+    auto port = IOSurfaceCreateMachPort(m_ref_wrapper->ref);
+    return MachPort::adopt_right(port, MachPort::PortRight::Send);
+}
+
+IOSurfaceHandle IOSurfaceHandle::from_mach_port(MachPort const& port)
+{
+    // NOTE: This call does not destroy the port
+    auto* ref = IOSurfaceLookupFromMachPort(port.port());
+    VERIFY(ref);
+    return IOSurfaceHandle(make<IOSurfaceRefWrapper>(ref));
+}
+
+size_t IOSurfaceHandle::width() const
+{
+    return IOSurfaceGetWidth(m_ref_wrapper->ref);
+}
+
+size_t IOSurfaceHandle::height() const
+{
+    return IOSurfaceGetHeight(m_ref_wrapper->ref);
+}
+
+size_t IOSurfaceHandle::bytes_per_element() const
+{
+    return IOSurfaceGetBytesPerElement(m_ref_wrapper->ref);
+}
+
+void* IOSurfaceHandle::data() const
+{
+    return IOSurfaceGetBaseAddress(m_ref_wrapper->ref);
+}
+
+}

--- a/Userland/Libraries/LibCore/IOSurface.h
+++ b/Userland/Libraries/LibCore/IOSurface.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/Noncopyable.h>
+#include <LibCore/MachPort.h>
+
+namespace Core {
+
+class IOSurfaceHandle {
+    AK_MAKE_NONCOPYABLE(IOSurfaceHandle);
+
+public:
+    IOSurfaceHandle(IOSurfaceHandle&& other);
+    IOSurfaceHandle& operator=(IOSurfaceHandle&& other);
+
+    static IOSurfaceHandle create(int width, int height);
+    static IOSurfaceHandle from_mach_port(MachPort const& port);
+
+    MachPort create_mach_port() const;
+
+    size_t width() const;
+    size_t height() const;
+    size_t bytes_per_element() const;
+    void* data() const;
+
+    ~IOSurfaceHandle();
+
+private:
+    struct IOSurfaceRefWrapper;
+
+    IOSurfaceHandle(OwnPtr<IOSurfaceRefWrapper>&&);
+
+    OwnPtr<IOSurfaceRefWrapper> m_ref_wrapper;
+};
+
+}

--- a/Userland/Libraries/LibCore/MachPort.h
+++ b/Userland/Libraries/LibCore/MachPort.h
@@ -69,7 +69,7 @@ public:
 #endif
 
     // FIXME: mach_msg wrapper? For now just let the owner poke into the internals
-    mach_port_t port() { return m_port; }
+    mach_port_t port() const { return m_port; }
 
 private:
     MachPort(PortRight, mach_port_t);

--- a/Userland/Libraries/LibCore/Platform/MachMessageTypes.h
+++ b/Userland/Libraries/LibCore/Platform/MachMessageTypes.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if !defined(AK_OS_MACH)
+#    error "This file is only available on Mach platforms"
+#endif
+
+#include <mach/mach.h>
+
+namespace Core::Platform {
+
+struct MessageBodyWithSelfTaskPort {
+    mach_msg_body_t body;
+    mach_msg_port_descriptor_t port_descriptor;
+    mach_msg_audit_trailer_t trailer;
+};
+
+struct MessageWithSelfTaskPort {
+    mach_msg_header_t header;
+    mach_msg_body_t body;
+    mach_msg_port_descriptor_t port_descriptor;
+};
+
+struct BackingStoreMetadata {
+    u64 page_id { 0 };
+    i32 back_backing_store_id { 0 };
+    i32 front_backing_store_id { 0 };
+};
+
+struct MessageBodyWithBackingStores {
+    mach_msg_body_t body;
+    mach_msg_port_descriptor_t front_descriptor;
+    mach_msg_port_descriptor_t back_descriptor;
+    BackingStoreMetadata metadata;
+    mach_msg_audit_trailer_t trailer;
+};
+
+struct MessageWithBackingStores {
+    mach_msg_header_t header;
+    mach_msg_body_t body;
+    mach_msg_port_descriptor_t front_descriptor;
+    mach_msg_port_descriptor_t back_descriptor;
+    BackingStoreMetadata metadata;
+};
+
+struct ReceivedMachMessage {
+    mach_msg_header_t header;
+    union {
+        MessageBodyWithSelfTaskPort parent;
+        MessageBodyWithBackingStores parent_iosurface;
+    } body;
+};
+
+static constexpr mach_msg_id_t SELF_TASK_PORT_MESSAGE_ID = 0x1234CAFE;
+static constexpr mach_msg_id_t BACKING_STORE_IOSURFACES_MESSAGE_ID = 0x1234CAFF;
+
+}

--- a/Userland/Libraries/LibCore/Platform/ProcessStatisticsMach.h
+++ b/Userland/Libraries/LibCore/Platform/ProcessStatisticsMach.h
@@ -17,21 +17,6 @@
 
 namespace Core::Platform {
 
-struct ChildPortMessage {
-    mach_msg_header_t header;
-    mach_msg_body_t body;
-    mach_msg_port_descriptor_t port_descriptor;
-};
-
-struct ParentPortMessage {
-    mach_msg_header_t header;
-    mach_msg_body_t body;
-    mach_msg_port_descriptor_t port_descriptor;
-    mach_msg_audit_trailer_t trailer; // for the child's pid
-};
-
-static constexpr mach_msg_id_t SELF_TASK_PORT_MESSAGE_ID = 0x1234CAFE;
-
-void register_with_mach_server(ByteString const& server_name);
+MachPort register_with_mach_server(ByteString const& server_name);
 
 }

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -63,7 +63,7 @@ class Bitmap : public RefCounted<Bitmap> {
 public:
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create(BitmapFormat, IntSize);
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_shareable(BitmapFormat, IntSize);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, IntSize, size_t pitch, void*);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, IntSize, size_t pitch, void*, Function<void()>&& destruction_callback = {});
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_file(StringView path, Optional<IntSize> ideal_size = {});
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_file(NonnullOwnPtr<Core::File>, StringView path, Optional<IntSize> ideal_size = {});
     [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> load_from_bytes(ReadonlyBytes, Optional<IntSize> ideal_size = {}, Optional<ByteString> mine_type = {});
@@ -160,7 +160,7 @@ public:
 
 private:
     Bitmap(BitmapFormat, IntSize, BackingStore const&);
-    Bitmap(BitmapFormat, IntSize, size_t pitch, void*);
+    Bitmap(BitmapFormat, IntSize, size_t pitch, void*, Function<void()>&& destruction_callback);
     Bitmap(BitmapFormat, Core::AnonymousBuffer, IntSize);
 
     static ErrorOr<BackingStore> allocate_backing_store(BitmapFormat format, IntSize size);
@@ -169,8 +169,8 @@ private:
     void* m_data { nullptr };
     size_t m_pitch { 0 };
     BitmapFormat m_format { BitmapFormat::Invalid };
-    bool m_data_is_malloced { false };
     Core::AnonymousBuffer m_buffer;
+    Function<void()> m_destruction_callback;
 };
 
 ALWAYS_INLINE u8* Bitmap::scanline_u8(int y)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -18,6 +18,7 @@
 #include <LibGfx/Palette.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
+#include <LibGfx/ShareableBitmap.h>
 #include <LibGfx/Size.h>
 #include <LibGfx/StandardCursor.h>
 #include <LibIPC/Forward.h>
@@ -346,6 +347,7 @@ public:
     virtual void page_did_request_activate_tab() { }
     virtual void page_did_close_top_level_traversable() { }
     virtual void page_did_update_navigation_buttons_state([[maybe_unused]] bool back_enabled, [[maybe_unused]] bool forward_enabled) { }
+    virtual void page_did_allocate_backing_stores([[maybe_unused]] i32 front_bitmap_id, [[maybe_unused]] Gfx::ShareableBitmap front_bitmap, [[maybe_unused]] i32 back_bitmap_id, [[maybe_unused]] Gfx::ShareableBitmap back_bitmap) { }
 
     virtual void request_file(FileRequest) = 0;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -117,6 +117,8 @@ public:
 
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
 
+    void did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::ShareableBitmap const&, i32 back_bitmap_id, Gfx::ShareableBitmap const&);
+
     enum class ScreenshotType {
         Visible,
         Full,
@@ -222,12 +224,6 @@ protected:
     u64 page_id() const;
     virtual void update_zoom() = 0;
 
-    enum class WindowResizeInProgress {
-        No,
-        Yes,
-    };
-    void resize_backing_stores_if_needed(WindowResizeInProgress);
-
     void handle_resize();
 
     enum class CreateNewClient {
@@ -250,7 +246,6 @@ protected:
         SharedBitmap front_bitmap;
         SharedBitmap back_bitmap;
         u64 page_index { 0 };
-        i32 next_bitmap_id { 0 };
         bool has_usable_bitmap { false };
     } m_client_state;
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -12,6 +12,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/Queue.h>
 #include <AK/String.h>
+#include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/StandardCursor.h>
@@ -118,6 +119,9 @@ public:
     void did_update_navigation_buttons_state(Badge<WebContentClient>, bool back_enabled, bool forward_enabled) const;
 
     void did_allocate_backing_stores(Badge<WebContentClient>, i32 front_bitmap_id, Gfx::ShareableBitmap const&, i32 back_bitmap_id, Gfx::ShareableBitmap const&);
+#ifdef AK_OS_MACOS
+    void did_allocate_iosurface_backing_stores(i32 front_bitmap_id, Core::MachPort&&, i32 back_bitmap_id, Core::MachPort&&);
+#endif
 
     enum class ScreenshotType {
         Visible,

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -593,6 +593,12 @@ void WebContentClient::did_update_navigation_buttons_state(u64 page_id, bool bac
         view->did_update_navigation_buttons_state({}, back_enabled, forward_enabled);
 }
 
+void WebContentClient::did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->did_allocate_backing_stores({}, front_bitmap_id, front_bitmap, back_bitmap_id, back_bitmap);
+}
+
 void WebContentClient::inspector_did_load(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -34,13 +34,6 @@ void WebContentClient::unregister_view(u64 page_id)
     m_views.remove(page_id);
 }
 
-void WebContentClient::notify_process_information(WebView::ProcessHandle const& handle)
-{
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::NotifyProcessInformation! pid={}", handle.pid);
-    ProcessManager::the().add_process(ProcessType::WebContent, handle.pid);
-    m_process_handle = handle;
-}
-
 void WebContentClient::did_paint(u64 page_id, Gfx::IntRect const& rect, i32 bitmap_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -33,10 +33,11 @@ public:
 
     Function<void()> on_web_content_process_crash;
 
+    void set_pid(pid_t pid) { m_process_handle.pid = pid; }
+
 private:
     virtual void die() override;
 
-    virtual void notify_process_information(WebView::ProcessHandle const&) override;
     virtual void did_paint(u64 page_id, Gfx::IntRect const&, i32) override;
     virtual void did_finish_loading(u64 page_id, URL::URL const&) override;
     virtual void did_request_navigate_back(u64 page_id) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -100,6 +100,7 @@ private:
     virtual void did_insert_clipboard_entry(u64 page_id, String const& data, String const& presentation_style, String const& mime_type) override;
     virtual void did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState) override;
     virtual void did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) override;
+    virtual void did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap const&, i32 back_bitmap_id, Gfx::ShareableBitmap const&) override;
     virtual void inspector_did_load(u64 page_id) override;
     virtual void inspector_did_select_dom_node(u64 page_id, i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String const& text) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -26,7 +26,10 @@ class WebContentClient final
     IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/session/%sid/portal/webcontent"sv);
 
 public:
+    static Optional<ViewImplementation&> view_for_pid_and_page_id(pid_t pid, u64 page_id);
+
     WebContentClient(NonnullOwnPtr<Core::LocalSocket>, ViewImplementation&);
+    ~WebContentClient();
 
     void register_view(u64 page_id, ViewImplementation&);
     void unregister_view(u64 page_id);

--- a/Userland/Services/WebContent/BackingStoreManager.cpp
+++ b/Userland/Services/WebContent/BackingStoreManager.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Timer.h>
+#include <LibWeb/HTML/TraversableNavigable.h>
+#include <WebContent/BackingStoreManager.h>
+#include <WebContent/PageClient.h>
+
+namespace WebContent {
+
+BackingStoreManager::BackingStoreManager(PageClient& page_client)
+    : m_page_client(page_client)
+{
+    m_backing_store_shrink_timer = Core::Timer::create_single_shot(3000, [this] {
+        resize_backing_stores_if_needed(WindowResizingInProgress::No);
+    });
+}
+
+void BackingStoreManager::restart_resize_timer()
+{
+    m_backing_store_shrink_timer->restart();
+}
+
+void BackingStoreManager::resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress)
+{
+    auto css_pixels_viewport_rect = m_page_client.page().top_level_traversable()->viewport_rect();
+    auto viewport_size = m_page_client.page().css_to_device_rect(css_pixels_viewport_rect).size();
+
+    if (viewport_size.is_empty())
+        return;
+
+    Web::DevicePixelSize minimum_needed_size;
+    if (window_resize_in_progress == WindowResizingInProgress::Yes) {
+        // Pad the minimum needed size so that we don't have to keep reallocating backing stores while the window is being resized.
+        minimum_needed_size = { viewport_size.width() + 256, viewport_size.height() + 256 };
+    } else {
+        // If we're not in the middle of a resize, we can shrink the backing store size to match the viewport size.
+        minimum_needed_size = viewport_size;
+        m_front_bitmap.clear();
+        m_back_bitmap.clear();
+    }
+
+    auto old_front_bitmap_id = m_front_bitmap_id;
+    auto old_back_bitmap_id = m_back_bitmap_id;
+
+    auto reallocate_backing_store_if_needed = [&](RefPtr<Gfx::Bitmap>& bitmap, int& id) {
+        if (!bitmap || !bitmap->size().contains(minimum_needed_size.to_type<int>())) {
+            if (auto new_bitmap_or_error = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, minimum_needed_size.to_type<int>()); !new_bitmap_or_error.is_error()) {
+                bitmap = new_bitmap_or_error.release_value();
+                id = m_next_bitmap_id++;
+            }
+        }
+    };
+
+    reallocate_backing_store_if_needed(m_front_bitmap, m_front_bitmap_id);
+    reallocate_backing_store_if_needed(m_back_bitmap, m_back_bitmap_id);
+
+    auto& front_bitmap = m_front_bitmap;
+    auto& back_bitmap = m_back_bitmap;
+
+    if (m_front_bitmap_id != old_front_bitmap_id || m_back_bitmap_id != old_back_bitmap_id) {
+        m_page_client.page_did_allocate_backing_stores(m_front_bitmap_id, front_bitmap->to_shareable_bitmap(), m_back_bitmap_id, back_bitmap->to_shareable_bitmap());
+    }
+}
+
+void BackingStoreManager::swap_back_and_front()
+{
+    swap(m_front_bitmap, m_back_bitmap);
+    swap(m_front_bitmap_id, m_back_bitmap_id);
+}
+
+}

--- a/Userland/Services/WebContent/BackingStoreManager.cpp
+++ b/Userland/Services/WebContent/BackingStoreManager.cpp
@@ -9,7 +9,21 @@
 #include <WebContent/BackingStoreManager.h>
 #include <WebContent/PageClient.h>
 
+#ifdef AK_OS_MACOS
+#    include <LibCore/IOSurface.h>
+#    include <LibCore/MachPort.h>
+#    include <LibCore/Platform/MachMessageTypes.h>
+#endif
+
 namespace WebContent {
+
+#ifdef AK_OS_MACOS
+static Optional<Core::MachPort> s_browser_mach_port;
+void BackingStoreManager::set_browser_mach_port(Core::MachPort&& port)
+{
+    s_browser_mach_port = move(port);
+}
+#endif
 
 BackingStoreManager::BackingStoreManager(PageClient& page_client)
     : m_page_client(page_client)
@@ -24,10 +38,71 @@ void BackingStoreManager::restart_resize_timer()
     m_backing_store_shrink_timer->restart();
 }
 
+void BackingStoreManager::reallocate_backing_stores(Gfx::IntSize size)
+{
+#ifdef AK_OS_MACOS
+    if (s_browser_mach_port.has_value()) {
+        auto back_iosurface = Core::IOSurfaceHandle::create(size.width(), size.height());
+        auto back_iosurface_port = back_iosurface.create_mach_port();
+
+        auto front_iosurface = Core::IOSurfaceHandle::create(size.width(), size.height());
+        auto front_iosurface_port = front_iosurface.create_mach_port();
+
+        m_front_bitmap_id = m_next_bitmap_id++;
+        m_back_bitmap_id = m_next_bitmap_id++;
+
+        m_front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, size, size.width() * front_iosurface.bytes_per_element(), front_iosurface.data(), [handle = move(front_iosurface)] {}).release_value();
+        m_back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, size, size.width() * back_iosurface.bytes_per_element(), back_iosurface.data(), [handle = move(back_iosurface)] {}).release_value();
+
+        Core::Platform::BackingStoreMetadata metadata;
+        metadata.page_id = m_page_client.m_id;
+        metadata.front_backing_store_id = m_front_bitmap_id;
+        metadata.back_backing_store_id = m_back_bitmap_id;
+
+        Core::Platform::MessageWithBackingStores message;
+
+        message.header.msgh_remote_port = s_browser_mach_port->port();
+        message.header.msgh_local_port = MACH_PORT_NULL;
+        message.header.msgh_bits = MACH_MSGH_BITS(MACH_MSG_TYPE_COPY_SEND, 0) | MACH_MSGH_BITS_COMPLEX;
+        message.header.msgh_size = sizeof(message);
+        message.header.msgh_id = Core::Platform::BACKING_STORE_IOSURFACES_MESSAGE_ID;
+
+        message.body.msgh_descriptor_count = 2;
+
+        message.front_descriptor.name = front_iosurface_port.release();
+        message.front_descriptor.disposition = MACH_MSG_TYPE_MOVE_SEND;
+        message.front_descriptor.type = MACH_MSG_PORT_DESCRIPTOR;
+
+        message.back_descriptor.name = back_iosurface_port.release();
+        message.back_descriptor.disposition = MACH_MSG_TYPE_MOVE_SEND;
+        message.back_descriptor.type = MACH_MSG_PORT_DESCRIPTOR;
+
+        message.metadata = metadata;
+
+        mach_msg_timeout_t const timeout = 100; // milliseconds
+        auto const send_result = mach_msg(&message.header, MACH_SEND_MSG | MACH_SEND_TIMEOUT, message.header.msgh_size, 0, MACH_PORT_NULL, timeout, MACH_PORT_NULL);
+        if (send_result != KERN_SUCCESS) {
+            dbgln("Failed to send message to server: {}", mach_error_string(send_result));
+            VERIFY_NOT_REACHED();
+        }
+
+        return;
+    }
+#endif
+
+    m_front_bitmap_id = m_next_bitmap_id++;
+    m_back_bitmap_id = m_next_bitmap_id++;
+
+    m_front_bitmap = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, size).release_value();
+    m_back_bitmap = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, size).release_value();
+
+    m_page_client.page_did_allocate_backing_stores(m_front_bitmap_id, m_front_bitmap->to_shareable_bitmap(), m_back_bitmap_id, m_back_bitmap->to_shareable_bitmap());
+}
+
 void BackingStoreManager::resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress)
 {
-    auto css_pixels_viewport_rect = m_page_client.page().top_level_traversable()->viewport_rect();
-    auto viewport_size = m_page_client.page().css_to_device_rect(css_pixels_viewport_rect).size();
+    auto css_pixels_viewpor_rect = m_page_client.page().top_level_traversable()->viewport_rect();
+    auto viewport_size = m_page_client.page().css_to_device_rect(css_pixels_viewpor_rect).size();
 
     if (viewport_size.is_empty())
         return;
@@ -43,26 +118,8 @@ void BackingStoreManager::resize_backing_stores_if_needed(WindowResizingInProgre
         m_back_bitmap.clear();
     }
 
-    auto old_front_bitmap_id = m_front_bitmap_id;
-    auto old_back_bitmap_id = m_back_bitmap_id;
-
-    auto reallocate_backing_store_if_needed = [&](RefPtr<Gfx::Bitmap>& bitmap, int& id) {
-        if (!bitmap || !bitmap->size().contains(minimum_needed_size.to_type<int>())) {
-            if (auto new_bitmap_or_error = Gfx::Bitmap::create_shareable(Gfx::BitmapFormat::BGRA8888, minimum_needed_size.to_type<int>()); !new_bitmap_or_error.is_error()) {
-                bitmap = new_bitmap_or_error.release_value();
-                id = m_next_bitmap_id++;
-            }
-        }
-    };
-
-    reallocate_backing_store_if_needed(m_front_bitmap, m_front_bitmap_id);
-    reallocate_backing_store_if_needed(m_back_bitmap, m_back_bitmap_id);
-
-    auto& front_bitmap = m_front_bitmap;
-    auto& back_bitmap = m_back_bitmap;
-
-    if (m_front_bitmap_id != old_front_bitmap_id || m_back_bitmap_id != old_back_bitmap_id) {
-        m_page_client.page_did_allocate_backing_stores(m_front_bitmap_id, front_bitmap->to_shareable_bitmap(), m_back_bitmap_id, back_bitmap->to_shareable_bitmap());
+    if (!m_front_bitmap || !m_back_bitmap || !m_front_bitmap->size().contains(minimum_needed_size.to_type<int>())) {
+        reallocate_backing_stores(minimum_needed_size.to_type<int>());
     }
 }
 

--- a/Userland/Services/WebContent/BackingStoreManager.h
+++ b/Userland/Services/WebContent/BackingStoreManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibCore/Forward.h>
 #include <LibWeb/Page/Page.h>
 #include <WebContent/Forward.h>
 
@@ -13,11 +14,16 @@ namespace WebContent {
 
 class BackingStoreManager {
 public:
+#ifdef AK_OS_MACOS
+    static void set_browser_mach_port(Core::MachPort&&);
+#endif
+
     enum class WindowResizingInProgress {
         No,
         Yes
     };
     void resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress);
+    void reallocate_backing_stores(Gfx::IntSize);
     void restart_resize_timer();
 
     RefPtr<Gfx::Bitmap> back_bitmap() { return m_back_bitmap; }

--- a/Userland/Services/WebContent/BackingStoreManager.h
+++ b/Userland/Services/WebContent/BackingStoreManager.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/Page/Page.h>
+#include <WebContent/Forward.h>
+
+namespace WebContent {
+
+class BackingStoreManager {
+public:
+    enum class WindowResizingInProgress {
+        No,
+        Yes
+    };
+    void resize_backing_stores_if_needed(WindowResizingInProgress window_resize_in_progress);
+    void restart_resize_timer();
+
+    RefPtr<Gfx::Bitmap> back_bitmap() { return m_back_bitmap; }
+    i32 front_id() const { return m_front_bitmap_id; }
+
+    void swap_back_and_front();
+
+    BackingStoreManager(PageClient&);
+
+private:
+    PageClient& m_page_client;
+
+    i32 m_front_bitmap_id { -1 };
+    i32 m_back_bitmap_id { -1 };
+    RefPtr<Gfx::Bitmap> m_front_bitmap;
+    RefPtr<Gfx::Bitmap> m_back_bitmap;
+    int m_next_bitmap_id { 0 };
+
+    RefPtr<Core::Timer> m_backing_store_shrink_timer;
+};
+
+}

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -155,12 +155,6 @@ void ConnectionFromClient::set_viewport_size(u64 page_id, Web::DevicePixelSize c
         page->set_viewport_size(size);
 }
 
-void ConnectionFromClient::add_backing_store(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap)
-{
-    if (auto page = this->page(page_id); page.has_value())
-        page->add_backing_store(front_bitmap_id, front_bitmap, back_bitmap_id, back_bitmap);
-}
-
 void ConnectionFromClient::ready_to_paint(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value())

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -754,19 +754,7 @@ void ConnectionFromClient::take_document_screenshot(u64 page_id)
     if (!page.has_value())
         return;
 
-    auto* document = page->page().top_level_browsing_context().active_document();
-    if (!document || !document->document_element()) {
-        async_did_take_screenshot(page_id, {});
-        return;
-    }
-
-    auto const& content_size = page->content_size();
-    Web::DevicePixelRect rect { { 0, 0 }, content_size };
-
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
-    page->paint(rect, *bitmap);
-
-    async_did_take_screenshot(page_id, bitmap->to_shareable_bitmap());
+    page->queue_screenshot_task({});
 }
 
 void ConnectionFromClient::take_dom_node_screenshot(u64 page_id, i32 node_id)
@@ -775,18 +763,7 @@ void ConnectionFromClient::take_dom_node_screenshot(u64 page_id, i32 node_id)
     if (!page.has_value())
         return;
 
-    auto* dom_node = Web::DOM::Node::from_unique_id(node_id);
-    if (!dom_node || !dom_node->paintable_box()) {
-        async_did_take_screenshot(page_id, {});
-        return;
-    }
-
-    auto rect = page->page().enclosing_device_rect(dom_node->paintable_box()->absolute_border_box_rect());
-
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, rect.size().to_type<int>()).release_value_but_fixme_should_propagate_errors();
-    page->paint(rect, *bitmap, { .paint_overlay = Web::PaintOptions::PaintOverlay::No });
-
-    async_did_take_screenshot(page_id, bitmap->to_shareable_bitmap());
+    page->queue_screenshot_task(node_id);
 }
 
 Messages::WebContentServer::DumpGcGraphResponse ConnectionFromClient::dump_gc_graph(u64)

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -55,7 +55,6 @@ ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> sock
     , m_page_host(PageHost::create(*this))
 {
     m_input_event_queue_timer = Web::Platform::Timer::create_single_shot(0, [this] { process_next_input_event(); });
-    async_notify_process_information({ ::getpid() });
 }
 
 ConnectionFromClient::~ConnectionFromClient() = default;

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -63,7 +63,6 @@ private:
     virtual void set_viewport_size(u64 page_id, Web::DevicePixelSize const) override;
     virtual void key_event(u64 page_id, Web::KeyEvent const&) override;
     virtual void mouse_event(u64 page_id, Web::MouseEvent const&) override;
-    virtual void add_backing_store(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap) override;
     virtual void ready_to_paint(u64 page_id) override;
     virtual void debug_request(u64 page_id, ByteString const&, ByteString const&) override;
     virtual void get_source(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
+#include <WebContent/BackingStoreManager.h>
 #include <WebContent/Forward.h>
 
 #ifdef HAS_ACCELERATED_GRAPHICS
@@ -75,8 +76,6 @@ public:
 
     void ready_to_paint();
 
-    void add_backing_store(i32 front_bitmap_id, Gfx::ShareableBitmap const& front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap const& back_bitmap);
-
     void initialize_js_console(Web::DOM::Document& document);
     void destroy_js_console(Web::DOM::Document& document);
     void js_console_input(ByteString const& js_source);
@@ -91,6 +90,8 @@ public:
     virtual Web::PaintingCommandExecutorType painting_command_executor_type() const override;
 
     void queue_screenshot_task(Optional<i32> node_id);
+
+    friend class BackingStoreManager;
 
 private:
     PageClient(PageHost&, u64 id);
@@ -156,6 +157,7 @@ private:
     virtual void page_did_change_theme_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
+    virtual void page_did_allocate_backing_stores(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) override;
     virtual IPC::File request_worker_agent() override;
     virtual void inspector_did_load() override;
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
@@ -203,13 +205,7 @@ private:
     OwnPtr<AccelGfx::Context> m_accelerated_graphics_context;
 #endif
 
-    struct BackingStores {
-        i32 front_bitmap_id { -1 };
-        i32 back_bitmap_id { -1 };
-        RefPtr<Gfx::Bitmap> front_bitmap;
-        RefPtr<Gfx::Bitmap> back_bitmap;
-    };
-    BackingStores m_backing_stores;
+    BackingStoreManager m_backing_store_manager;
 
     // NOTE: These documents are not visited, but manually removed from the map on document finalization.
     HashMap<JS::RawGCPtr<Web::DOM::Document>, JS::NonnullGCPtr<WebContentConsoleClient>> m_console_clients;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -90,6 +90,8 @@ public:
 
     virtual Web::PaintingCommandExecutorType painting_command_executor_type() const override;
 
+    void queue_screenshot_task(Optional<i32> node_id);
+
 private:
     PageClient(PageHost&, u64 id);
 
@@ -185,6 +187,11 @@ private:
     };
 
     PaintState m_paint_state { PaintState::Ready };
+
+    struct ScreenshotTask {
+        Optional<i32> node_id;
+    };
+    Queue<ScreenshotTask> m_screenshot_tasks;
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
     Web::CSS::PreferredContrast m_preferred_contrast { Web::CSS::PreferredContrast::NoPreference };

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -80,6 +80,7 @@ endpoint WebContentClient
     did_change_theme_color(u64 page_id, Gfx::Color color) =|
     did_insert_clipboard_entry(u64 page_id, String data, String presentation_style, String mime_type) =|
     did_update_navigation_buttons_state(u64 page_id, bool back_enabled, bool forward_enabled) =|
+    did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
 
     did_change_audio_play_state(u64 page_id, Web::HTML::AudioPlayState play_state) =|
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -17,8 +17,6 @@
 
 endpoint WebContentClient
 {
-    notify_process_information(WebView::ProcessHandle handle) =|
-
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
     did_request_navigate_back(u64 page_id) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -1,8 +1,6 @@
 #include <LibURL/URL.h>
 #include <LibIPC/File.h>
-#include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Rect.h>
-#include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
@@ -28,7 +26,6 @@ endpoint WebContentServer
     reload(u64 page_id) =|
     traverse_the_history_by_delta(u64 page_id, i32 delta) =|
 
-    add_backing_store(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) =|
     ready_to_paint(u64 page_id) =|
 
     set_viewport_size(u64 page_id, Web::DevicePixelSize size) =|


### PR DESCRIPTION
Using mmap-allocated memory for backing stores does not allow us to
benefit from using GPU-accelerated painting, because all the performance
increase we get is mostly negated by reading the GPU-allocated texture
back into RAM, so it can be shared with the browser process.

With IOSurface, we get a framebuffer that is both shareable between
processes and can be used as underlying memory for an OpenGL/Metal
texture.

This change does not yet benefit from using IOSurface and merely wraps
them into Gfx::Bitmap to be used by the CPU painter.