### PR TITLE
LibWeb: Implement type attribute validation for image loading

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -932,6 +932,33 @@ void HTMLImageElement::restart_the_animation()
     }
 }
 
+static bool is_supported_image_type(String const& type)
+{
+    if (type.is_empty())
+        return true;
+    if (!type.starts_with_bytes("image/"sv, CaseSensitivity::CaseInsensitive))
+        return false;
+    // FIXME: These should be derived from ImageDecoder
+    if (type.equals_ignoring_ascii_case("image/bmp"sv)
+        || type.equals_ignoring_ascii_case("image/gif"sv)
+        || type.equals_ignoring_ascii_case("image/vnd.microsoft.icon"sv)
+        || type.equals_ignoring_ascii_case("image/x-icon"sv)
+        || type.equals_ignoring_ascii_case("image/jpeg"sv)
+        || type.equals_ignoring_ascii_case("image/jpg"sv)
+        || type.equals_ignoring_ascii_case("image/pjpeg"sv)
+        || type.equals_ignoring_ascii_case("image/jxl"sv)
+        || type.equals_ignoring_ascii_case("image/png"sv)
+        || type.equals_ignoring_ascii_case("image/apng"sv)
+        || type.equals_ignoring_ascii_case("image/x-png"sv)
+        || type.equals_ignoring_ascii_case("image/tiff"sv)
+        || type.equals_ignoring_ascii_case("image/tinyvg"sv)
+        || type.equals_ignoring_ascii_case("image/webp"sv)
+        || type.equals_ignoring_ascii_case("image/svg+xml"sv))
+        return true;
+
+    return false;
+}
+
 // https://html.spec.whatwg.org/multipage/images.html#update-the-source-set
 static void update_the_source_set(DOM::Element& element)
 {
@@ -1041,8 +1068,15 @@ static void update_the_source_set(DOM::Element& element)
         // 7. Parse child's sizes attribute, and let source set's source size be the returned value.
         source_set.m_source_size = parse_a_sizes_attribute(element.document(), child->get_attribute_value(HTML::AttributeNames::sizes));
 
-        // FIXME: 8. If child has a type attribute, and its value is an unknown or unsupported MIME type, continue to the next child.
+        // 8. If child has a type attribute, and its value is an unknown or unsupported MIME type, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::type)) {
+            auto mime_type = child->get_attribute_value(HTML::AttributeNames::type);
+            if (is<HTMLImageElement>(element)) {
+                if (!is_supported_image_type(mime_type))
+                    continue;
+            }
+
+            // FIXME: Implement this step for link elements
         }
 
         // FIXME: 9. If child has width or height attributes, set el's dimension attribute source to child.


### PR DESCRIPTION
This change fixes image loading where unsupported image types are included in the list of source elements.

Relevant website source code:

```html
<picture>
    <source srcset="/assets/luke-0amITIOs.avif" type="image/avif">
    <img alt="Photo of Luke" class="rounded-full max-w-[100px] md:max-w-[150px] w-full h-auto" fetchpriority="high" height="460" width="460" src="/assets/luke-pH3SNxb2.jpeg">
</picture>
```

| Before | After |
| -------|------|
|  <img width="443" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/32498324/b9f4248b-5e58-4ffa-94fd-d501b9601be2">  | <img width="497" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/32498324/a24e8267-0352-4a62-b55f-7a75e31a6737"> |