### PR TITLE
Documentation: Add pkg-config to homebrew deps

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -56,7 +56,7 @@ Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake cmake ninja ccache
+brew install autoconf autoconf-archive automake cmake ninja ccache pkg-config
 ```
 
 If you also plan to use the Qt chrome on macOS:


### PR DESCRIPTION
When building on macOS (Apple Silicon; homebrew), I got this error:

```
CMake Error at scripts/cmake/vcpkg_find_acquire_program.cmake:166 (message):
  Could not find pkg-config.  Please install it via your package manager:

      brew install pkg-config
Call Stack (most recent call first):
  scripts/cmake/vcpkg_fixup_pkgconfig.cmake:193 (vcpkg_find_acquire_program)
  buildtrees/versioning_/versions/libpng/1b0781214ef5a3497d0e7db2c0ed7f7fae74248b/portfile.cmake:94 (vcpkg_fixup_pkgconfig)
  scripts/ports.cmake:175 (include)
  ```
  
  after installing `pkg-config` I was able to successfully build Ladybird.