### PR TITLE
LibWeb: Disallow pasting into non-editable text nodes

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -900,6 +900,8 @@ void EventHandler::handle_paste(String const& text)
         return;
 
     if (auto cursor_position = m_navigable->cursor_position()) {
+        if (!cursor_position->node()->is_editable())
+            return;
         active_document->update_layout();
         m_edit_event_handler->handle_insert(*cursor_position, text);
         cursor_position->set_offset(cursor_position->offset() + text.code_points().length());


### PR DESCRIPTION
With this change it is no longer possible for the paste action to change the text of non-editable text nodes.

Ideally, we would hide the paste button in the context menu completely. I already have some code to do this, but it doesn't behave exactly as other browsers do, due to how we focus the text cursor. I plan to look at this in a separate PR.

Before:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/3bcbacb8-9c27-408b-ade9-21b4a4d5ffab

After:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/83984b46-bb5a-43b9-98c5-de0982bd76ad


