### PR TITLE
LibWeb: Fire `auxclick` event on middle click

### DIFF
--- a/Tests/LibWeb/Text/expected/UIEvents/auxevent.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/auxevent.txt
@@ -1,0 +1,1 @@
+auxclick event fired

--- a/Tests/LibWeb/Text/input/UIEvents/auxevent.html
+++ b/Tests/LibWeb/Text/input/UIEvents/auxevent.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0px;
+        padding: 5px;
+        width: 200px;
+        height: 200px;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        document.body.onauxclick = () => {
+            println("auxclick event fired");
+            done();
+        };
+
+        window.onload = () => {
+            internals.middleClick(10, 10);
+        };
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -78,9 +78,19 @@ void Internals::commit_text()
 
 void Internals::click(double x, double y)
 {
+    click(x, y, UIEvents::MouseButton::Primary);
+}
+
+void Internals::middle_click(double x, double y)
+{
+    click(x, y, UIEvents::MouseButton::Middle);
+}
+
+void Internals::click(double x, double y, UIEvents::MouseButton button)
+{
     auto& page = global_object().browsing_context()->page();
-    page.handle_mousedown({ x, y }, { x, y }, 1, 0, 0);
-    page.handle_mouseup({ x, y }, { x, y }, 1, 0, 0);
+    page.handle_mousedown({ x, y }, { x, y }, button, 0, 0);
+    page.handle_mouseup({ x, y }, { x, y }, button, 0, 0);
 }
 
 void Internals::move_pointer_to(double x, double y)

--- a/Userland/Libraries/LibWeb/Internals/Internals.h
+++ b/Userland/Libraries/LibWeb/Internals/Internals.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Internals/InternalAnimationTimeline.h>
+#include <LibWeb/UIEvents/MouseButton.h>
 
 namespace Web::Internals {
 
@@ -27,6 +28,7 @@ public:
     void commit_text();
 
     void click(double x, double y);
+    void middle_click(double x, double y);
     void move_pointer_to(double x, double y);
     void wheel(double x, double y, double delta_x, double delta_y);
 
@@ -37,6 +39,8 @@ public:
 private:
     explicit Internals(JS::Realm&);
     virtual void initialize(JS::Realm&) override;
+
+    void click(double x, double y, UIEvents::MouseButton);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Internals/Internals.idl
+++ b/Userland/Libraries/LibWeb/Internals/Internals.idl
@@ -13,6 +13,7 @@ interface Internals {
     undefined commitText();
 
     undefined click(double x, double y);
+    undefined middleClick(double x, double y);
     undefined movePointerTo(double x, double y);
     undefined wheel(double x, double y, double deltaX, double deltaY);
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -278,6 +278,8 @@ bool EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPixelPoint
             if (node.ptr() == m_mousedown_target) {
                 if (button == UIEvents::MouseButton::Primary) {
                     run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::click, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
+                } else if (button == UIEvents::MouseButton::Middle) {
+                    run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(node->realm(), UIEvents::EventNames::auxclick, screen_position, page_offset, client_offset, offset, {}, 1, button, modifiers).release_value_but_fixme_should_propagate_errors());
                 } else if (button == UIEvents::MouseButton::Secondary) {
                     // Allow the user to bypass custom context menus by holding shift, like Firefox.
                     if ((modifiers & UIEvents::Mod_Shift) == 0)


### PR DESCRIPTION
Previously, no event was fired on middle click. This change also allows the UI to open a link in a new tab on middle click.

https://github.com/LadybirdBrowser/ladybird/assets/2817754/6e116fa3-83d6-42d1-b4e6-4ec38304ea54

Fixes #175