### PR TITLE
LibWeb: Add attribute list that must always be compared without casing

### DIFF
--- a/Tests/LibWeb/Ref/css-case-insensitive-html-attributes-selector.html
+++ b/Tests/LibWeb/Ref/css-case-insensitive-html-attributes-selector.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<link rel="match" href="reference/css-case-insensitive-html-attributes-selector-ref.html" />
+<style>
+    div[type=one] { /* 'type' is a case-insensitive html attribute */
+        background: red;
+    }
+    div[test=two] { /* 'test' is NOT a case-insensitive html attribute */
+        background: green;
+    }
+</style>
+<div type="ONE">I have a red background</div>
+<div type="TWO">I don't have a green background</div>

--- a/Tests/LibWeb/Ref/reference/css-case-insensitive-html-attributes-selector-ref.html
+++ b/Tests/LibWeb/Ref/reference/css-case-insensitive-html-attributes-selector-ref.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<style>
+    div[type=one] {
+        background: red;
+    }
+</style>
+<div type="one">I have a red background</div>
+<div type="two">I don't have a green background</div>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -75,6 +75,56 @@ public:
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();
 
+    // https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
+    static constexpr Array case_insensitive_html_attributes = {
+        "accept"sv,
+        "accept-charset"sv,
+        "align"sv,
+        "alink"sv,
+        "axis"sv,
+        "bgcolor"sv,
+        "charset"sv,
+        "checked"sv,
+        "clear"sv,
+        "codetype"sv,
+        "color"sv,
+        "compact"sv,
+        "declare"sv,
+        "defer"sv,
+        "dir"sv,
+        "direction"sv,
+        "disabled"sv,
+        "enctype"sv,
+        "face"sv,
+        "frame"sv,
+        "hreflang"sv,
+        "http-equiv"sv,
+        "lang"sv,
+        "language"sv,
+        "link"sv,
+        "media"sv,
+        "method"sv,
+        "multiple"sv,
+        "nohref"sv,
+        "noresize"sv,
+        "noshade"sv,
+        "nowrap"sv,
+        "readonly"sv,
+        "rel"sv,
+        "rev"sv,
+        "rules"sv,
+        "scope"sv,
+        "scrolling"sv,
+        "selected"sv,
+        "shape"sv,
+        "target"sv,
+        "text"sv,
+        "type"sv,
+        "valign"sv,
+        "valuetype"sv,
+        "vlink"sv,
+    };
+
 private:
     Parser(ParsingContext const&, Vector<Token>);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -226,6 +226,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
         dbgln_if(CSS_PARSER_DEBUG, "Expected qualified-name for attribute name, got: '{}'", attribute_tokens.peek_token().to_debug_string());
         return ParseError::SyntaxError;
     }
+    auto qualified_name = maybe_qualified_name.release_value();
 
     Selector::SimpleSelector simple_selector {
         .type = Selector::SimpleSelector::Type::Attribute,
@@ -236,8 +237,10 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
             // they are converted to lowercase, so we do that here too. If we want to be
             // correct with XML later, we'll need to keep the original case and then do
             // a case-insensitive compare later.
-            .qualified_name = maybe_qualified_name.release_value(),
-            .case_type = Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
+            .qualified_name = qualified_name,
+            .case_type = case_insensitive_html_attributes.contains_slow(qualified_name.name.lowercase_name)
+                ? Selector::SimpleSelector::Attribute::CaseType::CaseInsensitiveMatch
+                : Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
         }
     };
 


### PR DESCRIPTION
Before:
<img width="222" alt="Screenshot 2024-06-22 at 13 44 18" src="https://github.com/LadybirdBrowser/ladybird/assets/6866019/52fef381-02a3-47f9-8b11-915f84150467">

After:
<img width="225" alt="Screenshot 2024-06-22 at 13 42 07" src="https://github.com/LadybirdBrowser/ladybird/assets/6866019/93e02c0a-f0f5-452f-a151-712732b91a0e">

Firefox as reference:
<img width="251" alt="Screenshot 2024-06-22 at 13 44 40" src="https://github.com/LadybirdBrowser/ladybird/assets/6866019/4eff97fd-4de5-4ab0-8e24-c87c03c11a7e">

https://github.com/mozilla/gecko-dev/blob/a18d79db1695fc6019cac47874113fd3bb65a821/servo/components/selectors/build.rs#L30