### PR TITLE
Meta: Detect vcpkg updates and update ICU

### DIFF
--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -127,7 +127,6 @@ build_cmake() {
 }
 
 build_vcpkg() {
-    echo "Building vcpkg"
     ( cd "$LADYBIRD_SOURCE_DIR/Toolchain" && ./BuildVcpkg.sh )
 }
 
@@ -136,10 +135,7 @@ ensure_toolchain() {
         build_cmake
     fi
 
-    # FIXME: Add a version check if needed.
-    if [ ! -x "${LADYBIRD_SOURCE_DIR}/Toolchain/Local/vcpkg/bin/vcpkg" ]; then
-        build_vcpkg
-    fi
+    build_vcpkg
 }
 
 run_gdb() {

--- a/Toolchain/BuildVcpkg.sh
+++ b/Toolchain/BuildVcpkg.sh
@@ -21,7 +21,7 @@ if [ "$ci" -eq 0 ]; then
 fi
 
 GIT_REPO="https://github.com/microsoft/vcpkg.git"
-GIT_REV="01f602195983451bc83e72f4214af2cbc495aa94" # 2024.05.24
+GIT_REV="f7423ee180c4b7f40d43402c2feb3859161ef625" # 2024.06.15
 PREFIX_DIR="$DIR/Local/vcpkg"
 
 mkdir -p "$DIR/Tarballs"

--- a/Toolchain/BuildVcpkg.sh
+++ b/Toolchain/BuildVcpkg.sh
@@ -26,7 +26,17 @@ PREFIX_DIR="$DIR/Local/vcpkg"
 
 mkdir -p "$DIR/Tarballs"
 pushd "$DIR/Tarballs"
-    [ ! -d vcpkg ] && git clone $GIT_REPO
+    if [[ ! -d vcpkg ]]; then
+        git clone "${GIT_REPO}"
+    else
+        bootstrapped_vcpkg_version=$(git -C vcpkg rev-parse HEAD)
+
+        if [[ "${bootstrapped_vcpkg_version}" == "${GIT_REV}" ]]; then
+            exit 0
+        fi
+    fi
+
+    echo "Building vcpkg"
 
     cd vcpkg
     git fetch origin

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "01f602195983451bc83e72f4214af2cbc495aa94",
+  "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
   "dependencies": [
     {
       "name": "fontconfig",
@@ -22,7 +22,7 @@
     },
     {
       "name": "icu",
-      "version": "74.2#1"
+      "version": "74.2#2"
     },
     {
       "name": "libjpeg-turbo",


### PR DESCRIPTION
In the ICU update, there is no functional change, but they added an error message to the install output to indicate what host tools need to be installed. This has tripped some people up, so it seems worth updating to.