### PR TITLE
LibWeb: Implement dialog element's close watcher

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/CloseWatcher.h
+++ b/Userland/Libraries/LibWeb/HTML/CloseWatcher.h
@@ -23,6 +23,7 @@ class CloseWatcher final : public DOM::EventTarget {
 
 public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseWatcher>> construct_impl(JS::Realm&, CloseWatcherOptions const& = {});
+    [[nodiscard]] static JS::NonnullGCPtr<CloseWatcher> establish(HTML::Window&);
 
     bool request_close();
     void close();
@@ -38,7 +39,6 @@ public:
 
 private:
     CloseWatcher(JS::Realm&);
-    [[nodiscard]] static JS::NonnullGCPtr<CloseWatcher> establish(HTML::Window&);
 
     virtual void initialize(JS::Realm&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -34,6 +34,7 @@ private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
 
     void close_the_dialog(Optional<String> result);
 
@@ -41,6 +42,7 @@ private:
 
     String m_return_value;
     bool m_is_modal { false };
+    JS::GCPtr<CloseWatcher> m_close_watcher;
 };
 
 }


### PR DESCRIPTION
Dialog elements now correctly establish a close watcher when shown modally.

This means modal dialogs now correctly close with an escape key press.


https://github.com/LadybirdBrowser/ladybird/assets/32498324/a063fe92-2f61-4933-ba31-4dd7edb75dbe

