### PR TITLE
LibWeb: Ensure a repaint occurs when the current selection is cleared

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -97,12 +97,13 @@ void Range::set_associated_selection(Badge<Selection::Selection>, JS::GCPtr<Sele
 
 void Range::update_associated_selection()
 {
-    if (!m_associated_selection)
-        return;
-    if (auto* viewport = m_associated_selection->document()->paintable()) {
+    if (auto* viewport = m_start_container->document().paintable()) {
         viewport->recompute_selection_states();
         viewport->set_needs_display();
     }
+
+    if (!m_associated_selection)
+        return;
 
     // https://w3c.github.io/selection-api/#selectionchange-event
     // When the selection is dissociated with its range, associated with a new range or the associated range's boundary


### PR DESCRIPTION
This fixes an issue where clearing the find in page query would not always visually clear the selection.

Before:


https://github.com/LadybirdBrowser/ladybird/assets/2817754/02431fff-5e54-4f20-928f-05721e14fa27



After:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/999cb547-2e5e-4278-b000-9dde40e5b85a

