### PR TITLE
LibTimeZone: Remove entirely unused time zone methods

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -348,12 +348,6 @@ add_serenity_subdirectory(Userland/Libraries/LibMain)
 # This is needed even if Lagom is not enabled because it is depended upon by code generators.
 add_serenity_subdirectory(Userland/Libraries/LibFileSystem)
 
-# LibTimeZone
-# This is needed even if Lagom is not enabled because it is depended upon by code generators.
-add_serenity_subdirectory(Userland/Libraries/LibTimeZone)
-# We need an install rule for LibTimeZone b/c it is a manual OBJECT library instead of serenity_lib
-install(TARGETS LibTimeZone EXPORT LagomTargets)
-
 # LibIDL
 # This is used by the BindingsGenerator so needs to always be built.
 add_serenity_subdirectory(Userland/Libraries/LibIDL)
@@ -401,6 +395,7 @@ set(lagom_standard_libraries
     Syntax
     TextCodec
     Threading
+    TimeZone
     TLS
     Unicode
     URL

--- a/Tests/LibTimeZone/TestTimeZone.cpp
+++ b/Tests/LibTimeZone/TestTimeZone.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -178,35 +178,6 @@ TEST_CASE(get_time_zone_offset_with_dst)
     test_offset("America/Asuncion"sv, 1642558528, offset(-1, 3, 00, 00), Yes); // Wednesday, January 19, 2022 2:15:28 AM
     test_offset("America/Asuncion"sv, 1663553728, offset(-1, 4, 00, 00), No);  // Monday, September 19, 2022 2:15:28 AM
     test_offset("America/Asuncion"sv, 1671453238, offset(-1, 3, 00, 00), Yes); // Monday, December 19, 2022 12:33:58 PM
-}
-
-TEST_CASE(get_named_time_zone_offsets)
-{
-    auto test_named_offsets = [](auto time_zone, i64 time, i64 expected_standard_offset, i64 expected_daylight_offset, auto expected_standard_name, auto expected_daylight_name) {
-        auto actual_offsets = TimeZone::get_named_time_zone_offsets(time_zone, AK::UnixDateTime::from_seconds_since_epoch(time));
-        VERIFY(actual_offsets.has_value());
-
-        EXPECT_EQ(actual_offsets->at(0).seconds, expected_standard_offset);
-        EXPECT_EQ(actual_offsets->at(1).seconds, expected_daylight_offset);
-        EXPECT_EQ(actual_offsets->at(0).name, expected_standard_name);
-        EXPECT_EQ(actual_offsets->at(1).name, expected_daylight_name);
-    };
-
-    test_named_offsets("America/New_York"sv, 1642558528, offset(-1, 5, 00, 00), offset(-1, 4, 00, 00), "EST"sv, "EDT"sv); // Wednesday, January 19, 2022 2:15:28 AM
-    test_named_offsets("UTC"sv, 1642558528, offset(+1, 0, 00, 00), offset(+1, 0, 00, 00), "UTC"sv, "UTC"sv);              // Wednesday, January 19, 2022 2:15:28 AM
-    test_named_offsets("GMT"sv, 1642558528, offset(+1, 0, 00, 00), offset(+1, 0, 00, 00), "GMT"sv, "GMT"sv);              // Wednesday, January 19, 2022 2:15:28 AM
-
-    // Phoenix does not observe DST.
-    test_named_offsets("America/Phoenix"sv, 1642558528, offset(-1, 7, 00, 00), offset(-1, 7, 00, 00), "MST"sv, "MST"sv); // Wednesday, January 19, 2022 2:15:28 AM
-
-    // Moscow's observed DST changed several times in 1919.
-    test_named_offsets("Europe/Moscow"sv, -1609459200, offset(+1, 2, 31, 19), offset(+1, 3, 31, 19), "MSK"sv, "MSD"sv);  // Wednesday, January 1, 1919 12:00:00 AM
-    test_named_offsets("Europe/Moscow"sv, -1596412800, offset(+1, 2, 31, 19), offset(+1, 4, 31, 19), "MSK"sv, "MDST"sv); // Sunday, June 1, 1919 12:00:00 AM
-    test_named_offsets("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00), offset(+1, 4, 00, 00), "MSK"sv, "MSD"sv);  // Monday, August 25, 1919 12:00:00 AM
-
-    // Shanghai's DST rules end in 1991.
-    test_named_offsets("Asia/Shanghai"sv, 694223999, offset(+1, 8, 00, 00), offset(+1, 9, 00, 00), "CST"sv, "CDT"sv); // Tuesday, December 31, 1991 11:59:59 PM
-    test_named_offsets("Asia/Shanghai"sv, 694224000, offset(+1, 8, 00, 00), offset(+1, 8, 00, 00), "CST"sv, "CST"sv); // Wednesday, January 1, 1992 12:00:00 AM
 }
 
 #else

--- a/Userland/Libraries/LibTimeZone/CMakeLists.txt
+++ b/Userland/Libraries/LibTimeZone/CMakeLists.txt
@@ -4,15 +4,8 @@ set(SOURCES
     ${TIME_ZONE_DATA_SOURCES}
     TimeZone.cpp
 )
+
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
 
-add_library(LibTimeZone OBJECT ${SOURCES})
-serenity_generated_sources(LibTimeZone)
+serenity_lib(LibTimeZone timezone)
 target_compile_definitions(LibTimeZone PRIVATE ENABLE_TIME_ZONE_DATA=$<BOOL:${ENABLE_TIME_ZONE_DATABASE_DOWNLOAD}>)
-
-# NOTE: These objects are used by the DynamicLoader, which is always built without coverage instrumentation.
-#       We could allow them to be instrumented for coverage if DynamicLoader built its own copy
-target_link_libraries(LibTimeZone PRIVATE NoCoverage)
-if (SERENITYOS)
-    add_dependencies(LibTimeZone install_libc_headers)
-endif()

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -1,13 +1,11 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Array.h>
-#include <AK/ByteString.h>
 #include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/Optional.h>
@@ -39,46 +37,15 @@ struct Offset {
     InDST in_dst { InDST::No };
 };
 
-struct NamedOffset : public Offset {
-    ByteString name;
-};
-
-struct Coordinate {
-    constexpr float decimal_coordinate() const
-    {
-        return static_cast<float>(degrees) + (static_cast<float>(minutes) / 60.0f) + (static_cast<float>(seconds) / 3'600.0f);
-    }
-
-    i16 degrees { 0 };
-    u8 minutes { 0 };
-    u8 seconds { 0 };
-};
-
-struct Location {
-    Coordinate latitude;
-    Coordinate longitude;
-};
-
-StringView system_time_zone();
 StringView current_time_zone();
-ErrorOr<void> change_time_zone(StringView time_zone);
 ReadonlySpan<TimeZoneIdentifier> all_time_zones();
 
 Optional<TimeZone> time_zone_from_string(StringView time_zone);
 StringView time_zone_to_string(TimeZone time_zone);
 Optional<StringView> canonicalize_time_zone(StringView time_zone);
 
-Optional<DaylightSavingsRule> daylight_savings_rule_from_string(StringView daylight_savings_rule);
-StringView daylight_savings_rule_to_string(DaylightSavingsRule daylight_savings_rule);
-
 Optional<Offset> get_time_zone_offset(TimeZone time_zone, AK::UnixDateTime time);
 Optional<Offset> get_time_zone_offset(StringView time_zone, AK::UnixDateTime time);
-
-Optional<Array<NamedOffset, 2>> get_named_time_zone_offsets(TimeZone time_zone, AK::UnixDateTime time);
-Optional<Array<NamedOffset, 2>> get_named_time_zone_offsets(StringView time_zone, AK::UnixDateTime time);
-
-Optional<Location> get_time_zone_location(TimeZone time_zone);
-Optional<Location> get_time_zone_location(StringView time_zone);
 
 Optional<Region> region_from_string(StringView region);
 StringView region_to_string(Region region);


### PR DESCRIPTION
Just some cleanup to make it simpler to find a TZDB replacement. This way we don't have to keep mental track of what functionality actually needs to be replaced. At quick glance, we may be able to use ICU for this.