### PR TITLE
LibWebView: Allow data URLs in sanitize_url

### DIFF
--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -62,7 +62,7 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
     }
 
     ByteString url_with_scheme = url;
-    if (!(url_with_scheme.starts_with("about:"sv) || url_with_scheme.contains("://"sv)))
+    if (!(url_with_scheme.starts_with("about:"sv) || url_with_scheme.contains("://"sv) || url_with_scheme.starts_with("data:"sv)))
         url_with_scheme = ByteString::formatted("https://{}"sv, url_with_scheme);
 
     auto result = URL::create_with_url_or_path(url_with_scheme);


### PR DESCRIPTION
Allow navigation to data URLs from browser UI.

<img width="456" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/32498324/32c8dd69-ca95-4072-a5f0-9306a3d448e0">
