### PR TITLE
AK: Expect execinfo.h only on glibc-based Linux

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -10,7 +10,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 
-#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
+#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID) && defined(AK_LIBC_GLIBC)) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
 #    define EXECINFO_BACKTRACE
 #endif
 


### PR DESCRIPTION
e.g. musl libc doesn't have it.