### PR TITLE
LibWeb: Initial support for dashed lines in Canvas

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.h
@@ -31,6 +31,29 @@ public:
         return my_drawing_state().line_width;
     }
 
+    // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-setlinedash
+    void set_line_dash(Vector<double> segments)
+    {
+        // 1. If any value in segments is not finite (e.g. an Infinity or a NaN value), or if any value is negative (less than zero), then return (without throwing an exception; user agents could show a message on a developer console, though, as that would be helpful for debugging).
+        for (auto const& segment : segments) {
+            if (!isfinite(segment) || segment < 0)
+                return;
+        }
+
+        // 2. If the number of elements in segments is odd, then let segments be the concatenation of two copies of segments.
+        if (segments.size() % 2 == 1)
+            segments.extend(segments);
+
+        // 3. Let the object's dash list be segments.
+        my_drawing_state().dash_list = segments;
+    }
+
+    // https://html.spec.whatwg.org/multipage/canvas.html#dom-context-2d-getlinedash
+    Vector<double> get_line_dash()
+    {
+        return my_drawing_state().dash_list;
+    }
+
 protected:
     CanvasPathDrawingStyles() = default;
 

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasPathDrawingStyles.idl
@@ -9,7 +9,7 @@ interface mixin CanvasPathDrawingStyles {
     [FIXME] attribute CanvasLineJoin lineJoin;
     [FIXME] attribute unrestricted double miterLimit;
 
-    [FIXME] undefined setLineDash(sequence<unrestricted double> segments);
-    [FIXME] sequence<unrestricted double> getLineDash();
+    undefined setLineDash(sequence<unrestricted double> segments);
+    sequence<unrestricted double> getLineDash();
     [FIXME] attribute unrestricted double lineDashOffset;
 };

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasState.h
@@ -77,6 +77,7 @@ public:
         FillOrStrokeStyle fill_style { Gfx::Color::Black };
         FillOrStrokeStyle stroke_style { Gfx::Color::Black };
         float line_width { 1 };
+        Vector<double> dash_list;
         bool image_smoothing_enabled { true };
         Bindings::ImageSmoothingQuality image_smoothing_quality { Bindings::ImageSmoothingQuality::Low };
         float global_alpha = { 1 };


### PR DESCRIPTION
Implement setLineDash() and getLineDash() in CanvasPathDrawingStyles,
which write/read from the CanvasState object.
This doesn't implement the actual drawing of a dashed line, but at least
sites using the Chart.js library no longer fail with an exception.
Unfortunately the Painter classes don't support dashed/dotted lines
based on segments yet.