### PR TITLE
AK+CMake: Use the find module to find the correct backtrace(3) header

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -5,14 +5,11 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/Backtrace.h>
 #include <AK/Format.h>
 #include <AK/Platform.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
-
-#if (defined(AK_OS_LINUX) && !defined(AK_OS_ANDROID)) || defined(AK_LIBC_GLIBC) || defined(AK_OS_BSD_GENERIC) || defined(AK_OS_SOLARIS) || defined(AK_OS_HAIKU)
-#    define EXECINFO_BACKTRACE
-#endif
 
 #if defined(AK_OS_ANDROID) && (__ANDROID_API__ >= 33)
 #    include <android/log.h>
@@ -22,9 +19,8 @@
 #    define PRINT_ERROR(s) (void)fputs((s), stderr)
 #endif
 
-#if defined(EXECINFO_BACKTRACE)
+#if defined(AK_HAS_BACKTRACE_HEADER)
 #    include <cxxabi.h>
-#    include <execinfo.h>
 #endif
 
 #if defined(AK_OS_SERENITY)
@@ -33,7 +29,7 @@
 #    define ERRORLN warnln
 #endif
 
-#if defined(EXECINFO_BACKTRACE)
+#if defined(AK_HAS_BACKTRACE_HEADER)
 namespace {
 ALWAYS_INLINE void dump_backtrace()
 {
@@ -100,7 +96,7 @@ void ak_verification_failed(char const* message)
     else
         ERRORLN("VERIFICATION FAILED: {}", message);
 
-#if defined(EXECINFO_BACKTRACE)
+#if defined(AK_HAS_BACKTRACE_HEADER)
     dump_backtrace();
 #endif
     __builtin_trap();

--- a/AK/Backtrace.h.in
+++ b/AK/Backtrace.h.in
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#cmakedefine Backtrace_FOUND
+#if defined(Backtrace_FOUND)
+#    define AK_HAS_BACKTRACE_HEADER
+#    undef Backtrace_FOUND
+#endif
+
+#if defined(AK_HAS_BACKTRACE_HEADER)
+#    include <@Backtrace_HEADER@>
+#endif

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -329,9 +329,16 @@ install(TARGETS LibC LibCrypt NoCoverage EXPORT LagomTargets)
 add_serenity_subdirectory(AK)
 lagom_lib(AK ak SOURCES ${AK_SOURCES})
 find_package(Backtrace)
-if (Backtrace_FOUND AND NOT "${Backtrace_LIBRARIES}" STREQUAL "")
-    target_link_libraries(AK PRIVATE ${Backtrace_LIBRARIES})
-    target_include_directories(AK PRIVATE ${Backtrace_INCLUDE_DIRS})
+configure_file(../../AK/Backtrace.h.in AK/Backtrace.h @ONLY)
+if (Backtrace_FOUND)
+    if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.30)
+        target_link_libraries(AK PRIVATE Backtrace::Backtrace)
+    else()
+        target_include_directories(AK PRIVATE ${Backtrace_INCLUDE_DIRS})
+        target_link_libraries(AK PRIVATE ${Backtrace_LIBRARIES})
+    endif()
+else()
+    message(WARNING "Backtrace not found, stack traces will be unavailable")
 endif()
 
 # LibCoreMinimal
@@ -361,6 +368,7 @@ install(
 )
 install(FILES
     ${Lagom_BINARY_DIR}/AK/Debug.h
+    ${Lagom_BINARY_DIR}/AK/Backtrace.h
     COMPONENT Lagom_Development
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/AK"
 )


### PR DESCRIPTION
As recommended by the CMake docs, let's tolerate systems or setups that don't have backtrace(3) in the `<execinfo.h>` header file, such as those using libbacktrace directly.

@sideeffect42 does this fix your issue in the same way that #274 does?