### PR TITLE
LibWeb: Implement (most of) declarative shadow DOM

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -80,6 +80,7 @@ static bool is_platform_object(Type const& type)
         "Request"sv,
         "Selection"sv,
         "SVGTransform"sv,
+        "ShadowRoot"sv,
         "Table"sv,
         "Text"sv,
         "TextMetrics"sv,

--- a/Tests/LibWeb/Text/expected/ShadowDOM/declarative-basic.txt
+++ b/Tests/LibWeb/Text/expected/ShadowDOM/declarative-basic.txt
@@ -1,0 +1,25 @@
+open closed open open open   [object ShadowRoot]
+0
+null
+0
+[object ShadowRoot]
+1
+null
+0
+[object ShadowRoot]
+0
+
+
+
+<template shadowrootmode="open">open</template>
+
+
+<template shadowrootmode="open" shadowrootserializable="">open</template>
+
+
+
+
+
+<template shadowrootmode="open" shadowrootserializable="">open</template>
+
+

--- a/Tests/LibWeb/Text/input/ShadowDOM/declarative-basic.html
+++ b/Tests/LibWeb/Text/input/ShadowDOM/declarative-basic.html
@@ -1,0 +1,43 @@
+<div id="basicOpen">
+<template shadowrootmode="open">open</template>
+</div>
+<div id="basicClosed">
+<template shadowrootmode="closed">closed</template>
+</div>
+<div id="redundant">
+<template shadowrootmode="open">open</template>
+<template shadowrootmode="open">also open</template>
+</div>
+<div id="basicOpenClonable">
+<template shadowrootmode="open" shadowrootclonable>open</template>
+</div>
+<div id="basicOpenSerializable">
+<template shadowrootmode="open" shadowrootserializable>open</template>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(basicOpen.shadowRoot);
+        println(basicOpen.childElementCount);
+
+        println(basicClosed.shadowRoot);
+        println(basicClosed.childElementCount);
+
+        println(redundant.shadowRoot);
+        println(redundant.childElementCount);
+
+        let clonedUnclonable = basicOpen.cloneNode();
+        println(clonedUnclonable.shadowRoot);
+        println(clonedUnclonable.childElementCount);
+
+        let clonedClonable = basicOpenClonable.cloneNode();
+        println(clonedClonable.shadowRoot);
+        println(clonedClonable.childElementCount);
+
+        println(basicOpen.getHTML({ serializableShadowRoots: true}));
+        println(basicOpen.getHTML({ shadowRoots: [ basicOpen.shadowRoot ]}));
+        println(basicOpenSerializable.getHTML({ serializableShadowRoots: true}));
+        println(basicOpenSerializable.getHTML({ serializableShadowRoots: false}));
+        println(basicOpenSerializable.getHTML({ shadowRoots: [ basicOpenSerializable.shadowRoot ]}));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -288,7 +288,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
     //     URL: creationURL
     //     current document readiness: "loading"
     //     about base URL: navigationParams's about base URL
-    //     FIXME: allow declarative shadow roots: true
+    //     allow declarative shadow roots: true
     auto document = HTML::HTMLDocument::create(window->realm());
     document->m_type = type;
     document->m_content_type = move(content_type);
@@ -300,6 +300,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
     document->set_url(*creation_url);
     document->m_readiness = HTML::DocumentReadyState::Loading;
     document->m_about_base_url = navigation_params.about_base_url;
+    document->set_allow_declarative_shadow_roots(true);
 
     document->m_window = window;
 
@@ -5207,6 +5208,18 @@ Vector<JS::Handle<DOM::Range>> Document::find_matching_text(String const& query,
     }
 
     return matches;
+}
+
+// https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots
+bool Document::allow_declarative_shadow_roots() const
+{
+    return m_allow_declarative_shadow_roots;
+}
+
+// https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots
+void Document::set_allow_declarative_shadow_roots(bool allow)
+{
+    m_allow_declarative_shadow_roots = allow;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1175,7 +1175,7 @@ void Document::update_layout()
 
     if (needs_full_style_update || node.child_needs_style_update()) {
         if (node.is_element()) {
-            if (auto* shadow_root = static_cast<DOM::Element&>(node).shadow_root_internal()) {
+            if (auto shadow_root = static_cast<DOM::Element&>(node).shadow_root()) {
                 if (needs_full_style_update || shadow_root->needs_style_update() || shadow_root->child_needs_style_update()) {
                     auto subtree_invalidation = update_style_recursively(*shadow_root, style_computer);
                     if (!is_display_none)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -400,6 +400,9 @@ public:
     bool is_fully_active() const;
     bool is_active() const;
 
+    [[nodiscard]] bool allow_declarative_shadow_roots() const;
+    void set_allow_declarative_shadow_roots(bool);
+
     JS::NonnullGCPtr<HTML::History> history();
     JS::NonnullGCPtr<HTML::History> history() const;
 
@@ -929,6 +932,9 @@ private:
     // instead they generate boxes as if they were siblings of the root element.
     OrderedHashTable<JS::NonnullGCPtr<Element>> m_top_layer_elements;
     OrderedHashTable<JS::NonnullGCPtr<Element>> m_top_layer_pending_removals;
+
+    // https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots
+    bool m_allow_declarative_shadow_roots { false };
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2583,4 +2583,16 @@ CSS::StyleSheetList& Element::document_or_shadow_root_style_sheets()
     return document().style_sheets();
 }
 
+// https://html.spec.whatwg.org/#dom-element-gethtml
+WebIDL::ExceptionOr<String> Element::get_html(GetHTMLOptions const& options) const
+{
+    // Element's getHTML(options) method steps are to return the result
+    // of HTML fragment serialization algorithm with this,
+    // options["serializableShadowRoots"], and options["shadowRoots"].
+    return HTML::HTMLParser::serialize_html_fragment(
+        *this,
+        options.serializable_shadow_roots ? HTML::HTMLParser::SerializableShadowRoots::Yes : HTML::HTMLParser::SerializableShadowRoots::No,
+        options.shadow_roots);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -675,7 +675,6 @@ WebIDL::ExceptionOr<void> Element::attach_a_shadow_root(Bindings::ShadowRootMode
 
     // 12. Set element’s shadow root to shadow.
     set_shadow_root(shadow);
-
     return {};
 }
 
@@ -690,7 +689,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowR
 }
 
 // https://dom.spec.whatwg.org/#dom-element-shadowroot
-JS::GCPtr<ShadowRoot> Element::shadow_root() const
+JS::GCPtr<ShadowRoot> Element::shadow_root_for_bindings() const
 {
     // 1. Let shadow be this’s shadow root.
     auto shadow = m_shadow_root;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -593,25 +593,33 @@ DOMTokenList* Element::class_list()
     return m_class_list;
 }
 
-// https://dom.spec.whatwg.org/#dom-element-attachshadow
-WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowRootInit init)
+// https://dom.spec.whatwg.org/#valid-shadow-host-name
+bool is_valid_shadow_host_name(FlyString const& name)
 {
-    // 1. If this’s namespace is not the HTML namespace, then throw a "NotSupportedError" DOMException.
+    // A valid shadow host name is:
+    // - a valid custom element name
+    // - "article", "aside", "blockquote", "body", "div", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "main", "nav", "p", "section", or "span"
+    if (!HTML::is_valid_custom_element_name(name)
+        && !name.is_one_of("article", "aside", "blockquote", "body", "div", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "main", "nav", "p", "section", "span")) {
+        return false;
+    }
+    return true;
+}
+
+// https://dom.spec.whatwg.org/#concept-attach-a-shadow-root
+WebIDL::ExceptionOr<void> Element::attach_a_shadow_root(Bindings::ShadowRootMode mode, bool clonable, bool serializable, bool delegates_focus, Bindings::SlotAssignmentMode slot_assignment)
+{
+    // 1. If element’s namespace is not the HTML namespace, then throw a "NotSupportedError" DOMException.
     if (namespace_uri() != Namespace::HTML)
         return WebIDL::NotSupportedError::create(realm(), "Element's namespace is not the HTML namespace"_fly_string);
 
-    // 2. If this’s local name is not one of the following:
-    //    - a valid custom element name
-    //    - "article", "aside", "blockquote", "body", "div", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "main", "nav", "p", "section", or "span"
-    if (!HTML::is_valid_custom_element_name(local_name())
-        && !local_name().is_one_of("article", "aside", "blockquote", "body", "div", "footer", "h1", "h2", "h3", "h4", "h5", "h6", "header", "main", "nav", "p", "section", "span")) {
-        // then throw a "NotSupportedError" DOMException.
-        return WebIDL::NotSupportedError::create(realm(), MUST(String::formatted("Element '{}' cannot be a shadow host", local_name())));
-    }
+    // 2. If element’s local name is not a valid shadow host name, then throw a "NotSupportedError" DOMException.
+    if (!is_valid_shadow_host_name(local_name()))
+        return WebIDL::NotSupportedError::create(realm(), "Element's local name is not a valid shadow host name"_fly_string);
 
-    // 3. If this’s local name is a valid custom element name, or this’s is value is not null, then:
+    // 3. If element’s local name is a valid custom element name, or element’s is value is not null, then:
     if (HTML::is_valid_custom_element_name(local_name()) || m_is_value.has_value()) {
-        // 1. Let definition be the result of looking up a custom element definition given this’s node document, its namespace, its local name, and its is value.
+        // 1. Let definition be the result of looking up a custom element definition given element’s node document, its namespace, its local name, and its is value.
         auto definition = document().lookup_custom_element_definition(namespace_uri(), local_name(), m_is_value);
 
         // 2. If definition is not null and definition’s disable shadow is true, then throw a "NotSupportedError" DOMException.
@@ -619,28 +627,66 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowR
             return WebIDL::NotSupportedError::create(realm(), "Cannot attach a shadow root to a custom element that has disabled shadow roots"_fly_string);
     }
 
-    // 4. If this is a shadow host, then throw an "NotSupportedError" DOMException.
-    if (is_shadow_host())
-        return WebIDL::NotSupportedError::create(realm(), "Element already is a shadow host"_fly_string);
+    // 4. If element is a shadow host, then:
+    if (is_shadow_host()) {
+        // 1. Let currentShadowRoot be element’s shadow root.
+        auto current_shadow_root = shadow_root();
 
-    // 5. Let shadow be a new shadow root whose node document is this’s node document, host is this, and mode is init["mode"].
-    auto shadow = heap().allocate<ShadowRoot>(realm(), document(), *this, init.mode);
+        // 2. If any of the following are true:
+        // - currentShadowRoot’s declarative is false; or
+        // - currentShadowRoot’s mode is not mode,
+        // then throw a "NotSupportedError" DOMException.
+        if (!current_shadow_root->declarative() || current_shadow_root->mode() != mode) {
+            return WebIDL::NotSupportedError::create(realm(), "Element already is a shadow host"_fly_string);
+        }
 
-    // 6. Set shadow’s delegates focus to init["delegatesFocus"].
-    shadow->set_delegates_focus(init.delegates_focus);
+        // 3. Otherwise:
+        //    1. Remove all of currentShadowRoot’s children, in tree order.
+        current_shadow_root->remove_all_children();
 
-    // 7. If this’s custom element state is "precustomized" or "custom", then set shadow’s available to element internals to true.
+        //    2. Set currentShadowRoot’s declarative to false.
+        current_shadow_root->set_declarative(false);
+
+        //    3. Return.
+        return {};
+    }
+
+    // 5. Let shadow be a new shadow root whose node document is element’s node document, host is this, and mode is mode.
+    auto shadow = heap().allocate<ShadowRoot>(realm(), document(), *this, mode);
+
+    // 6. Set shadow’s delegates focus to delegatesFocus".
+    shadow->set_delegates_focus(delegates_focus);
+
+    // 7. If element’s custom element state is "precustomized" or "custom", then set shadow’s available to element internals to true.
     if (m_custom_element_state == CustomElementState::Precustomized || m_custom_element_state == CustomElementState::Custom)
         shadow->set_available_to_element_internals(true);
 
-    // 8. Set shadow’s slot assignment to init["slotAssignment"].
-    shadow->set_slot_assignment(init.slot_assignment);
+    // 8. Set shadow’s slot assignment to slotAssignment.
+    shadow->set_slot_assignment(slot_assignment);
 
-    // 9. Set this’s shadow root to shadow.
+    // 9. Set shadow’s declarative to false.
+    shadow->set_declarative(false);
+
+    // 10. Set shadow’s clonable to clonable.
+    shadow->set_clonable(clonable);
+
+    // 11. Set shadow’s serializable to serializable.
+    shadow->set_serializable(serializable);
+
+    // 12. Set element’s shadow root to shadow.
     set_shadow_root(shadow);
 
-    // 10. Return shadow.
-    return shadow;
+    return {};
+}
+
+// https://dom.spec.whatwg.org/#dom-element-attachshadow
+WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> Element::attach_shadow(ShadowRootInit init)
+{
+    // 1. Run attach a shadow root with this, init["mode"], init["clonable"], init["serializable"], init["delegatesFocus"], and init["slotAssignment"].
+    TRY(attach_a_shadow_root(init.mode, init.clonable, init.serializable, init.delegates_focus, init.slot_assignment));
+
+    // 2. Return this’s shadow root.
+    return JS::NonnullGCPtr { *shadow_root() };
 }
 
 // https://dom.spec.whatwg.org/#dom-element-shadowroot

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -187,6 +187,8 @@ public:
     WebIDL::ExceptionOr<String> inner_html() const;
     WebIDL::ExceptionOr<void> set_inner_html(StringView);
 
+    WebIDL::ExceptionOr<String> get_html(GetHTMLOptions const&) const;
+
     WebIDL::ExceptionOr<void> insert_adjacent_html(String const& position, String const&);
 
     WebIDL::ExceptionOr<String> outer_html() const;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -129,7 +129,7 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> attach_shadow(ShadowRootInit init);
     WebIDL::ExceptionOr<void> attach_a_shadow_root(Bindings::ShadowRootMode mode, bool clonable, bool serializable, bool delegates_focus, Bindings::SlotAssignmentMode slot_assignment);
-    JS::GCPtr<ShadowRoot> shadow_root() const;
+    JS::GCPtr<ShadowRoot> shadow_root_for_bindings() const;
 
     WebIDL::ExceptionOr<bool> matches(StringView selectors) const;
     WebIDL::ExceptionOr<DOM::Element const*> closest(StringView selectors) const;
@@ -195,8 +195,8 @@ public:
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(StringView);
 
     bool is_shadow_host() const;
-    ShadowRoot* shadow_root_internal() { return m_shadow_root.ptr(); }
-    ShadowRoot const* shadow_root_internal() const { return m_shadow_root.ptr(); }
+    JS::GCPtr<ShadowRoot> shadow_root() { return m_shadow_root; }
+    JS::GCPtr<ShadowRoot const> shadow_root() const { return m_shadow_root; }
     void set_shadow_root(JS::GCPtr<ShadowRoot>);
 
     void set_custom_properties(Optional<CSS::Selector::PseudoElement::Type>, HashMap<FlyString, CSS::StyleProperty> custom_properties);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -37,6 +37,11 @@ struct ShadowRootInit {
     bool serializable = false;
 };
 
+struct GetHTMLOptions {
+    bool serializable_shadow_roots { false };
+    Vector<JS::Handle<ShadowRoot>> shadow_roots {};
+};
+
 // https://w3c.github.io/csswg-drafts/cssom-view-1/#dictdef-scrollintoviewoptions
 struct ScrollIntoViewOptions : public HTML::ScrollOptions {
     Bindings::ScrollLogicalPosition block { Bindings::ScrollLogicalPosition::Start };

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -33,6 +33,8 @@ struct ShadowRootInit {
     Bindings::ShadowRootMode mode;
     bool delegates_focus = false;
     Bindings::SlotAssignmentMode slot_assignment { Bindings::SlotAssignmentMode::Named };
+    bool clonable = false;
+    bool serializable = false;
 };
 
 // https://w3c.github.io/csswg-drafts/cssom-view-1/#dictdef-scrollintoviewoptions
@@ -126,6 +128,7 @@ public:
     DOMTokenList* class_list();
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<ShadowRoot>> attach_shadow(ShadowRootInit init);
+    WebIDL::ExceptionOr<void> attach_a_shadow_root(Bindings::ShadowRootMode mode, bool clonable, bool serializable, bool delegates_focus, Bindings::SlotAssignmentMode slot_assignment);
     JS::GCPtr<ShadowRoot> shadow_root() const;
 
     WebIDL::ExceptionOr<bool> matches(StringView selectors) const;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -3,7 +3,6 @@
 #import <DOM/Attr.idl>
 #import <DOM/ChildNode.idl>
 #import <DOM/DOMTokenList.idl>
-#import <DOM/InnerHTML.idl>
 #import <DOM/NamedNodeMap.idl>
 #import <DOM/Node.idl>
 #import <DOM/NodeList.idl>
@@ -94,10 +93,24 @@ interface Element : Node {
     readonly attribute long clientHeight;
     readonly attribute double currentCSSZoom;
 
-    // https://w3c.github.io/DOM-Parsing/#extensions-to-the-element-interface
+    // https://html.spec.whatwg.org/#dom-parsing-and-serialization
+    [FIXME, CEReactions] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
+    [FIXME] DOMString getHTML(optional GetHTMLOptions options = {});
+
+    // FIXME: [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
+    [CEReactions, LegacyNullToEmptyString] attribute DOMString innerHTML;
+
+    // FIXME: [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) outerHTML;
     [CEReactions, LegacyNullToEmptyString] attribute DOMString outerHTML;
+
+    // FIXME: [CEReactions] undefined insertAdjacentHTML(DOMString position, (TrustedHTML or DOMString) string);
     [CEReactions] undefined insertAdjacentHTML(DOMString position, DOMString text);
 
+};
+
+dictionary GetHTMLOptions {
+    boolean serializableShadowRoots = false;
+    sequence<ShadowRoot> shadowRoots = [];
 };
 
 dictionary ShadowRootInit {
@@ -110,7 +123,6 @@ dictionary ShadowRootInit {
 
 Element includes ParentNode;
 Element includes ChildNode;
-Element includes InnerHTML;
 // https://www.w3.org/TR/wai-aria-1.2/#idl_element
 Element includes ARIAMixin;
 Element includes Slottable;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -104,6 +104,8 @@ dictionary ShadowRootInit {
     required ShadowRootMode mode;
     boolean delegatesFocus = false;
     SlotAssignmentMode slotAssignment = "named";
+    boolean clonable = false;
+    boolean serializable = false;
 };
 
 Element includes ParentNode;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -95,7 +95,7 @@ interface Element : Node {
 
     // https://html.spec.whatwg.org/#dom-parsing-and-serialization
     [FIXME, CEReactions] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
-    [FIXME] DOMString getHTML(optional GetHTMLOptions options = {});
+    DOMString getHTML(optional GetHTMLOptions options = {});
 
     // FIXME: [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
     [CEReactions, LegacyNullToEmptyString] attribute DOMString innerHTML;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -54,7 +54,7 @@ interface Element : Node {
     [CEReactions] Attr removeAttributeNode(Attr attr);
 
     ShadowRoot attachShadow(ShadowRootInit init);
-    readonly attribute ShadowRoot? shadowRoot;
+    [ImplementedAs=shadow_root_for_bindings] readonly attribute ShadowRoot? shadowRoot;
 
     boolean matches(DOMString selectors);
     Element? closest(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/InnerHTML.idl
+++ b/Userland/Libraries/LibWeb/DOM/InnerHTML.idl
@@ -1,4 +1,0 @@
-// https://w3c.github.io/DOM-Parsing/#the-innerhtml-mixin
-interface mixin InnerHTML {
-    [LegacyNullToEmptyString, CEReactions] attribute DOMString innerHTML;
-};

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1352,17 +1352,17 @@ void Node::string_replace_all(String const& string)
     replace_all(node);
 }
 
-// https://w3c.github.io/DOM-Parsing/#dfn-fragment-serializing-algorithm
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#fragment-serializing-algorithm-steps
 WebIDL::ExceptionOr<String> Node::serialize_fragment(DOMParsing::RequireWellFormed require_well_formed, FragmentSerializationMode fragment_serialization_mode) const
 {
     // 1. Let context document be the value of node's node document.
     auto const& context_document = document();
 
-    // 2. If context document is an HTML document, return an HTML serialization of node.
+    // 2. If context document is an HTML document, return the result of HTML fragment serialization algorithm with node, false, and « ».
     if (context_document.is_html_document())
-        return HTML::HTMLParser::serialize_html_fragment(*this, fragment_serialization_mode);
+        return HTML::HTMLParser::serialize_html_fragment(*this, HTML::HTMLParser::SerializableShadowRoots::No, {}, fragment_serialization_mode);
 
-    // 3. Otherwise, context document is an XML document; return an XML serialization of node passing the flag require well-formed.
+    // 3. Return the XML serialization of node given require well-formed.
     return DOMParsing::serialize_node_to_xml_string(*this, require_well_formed);
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -817,7 +817,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::replace_child(JS::NonnullGCPtr
 }
 
 // https://dom.spec.whatwg.org/#concept-node-clone
-JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::clone_node(Document* document, bool clone_children)
 {
     // 1. If document is not given, let document be node’s node document.
     if (!document)
@@ -898,18 +898,37 @@ JS::NonnullGCPtr<Node> Node::clone_node(Document* document, bool clone_children)
     // FIXME: 4. Set copy’s node document and document to copy, if copy is a document, and set copy’s node document to document otherwise.
 
     // 5. Run any cloning steps defined for node in other applicable specifications and pass copy, node, document and the clone children flag if set, as parameters.
-    cloned(*copy, clone_children);
+    TRY(cloned(*copy, clone_children));
 
     // 6. If the clone children flag is set, clone all the children of node and append them to copy, with document as specified and the clone children flag being set.
     if (clone_children) {
-        for_each_child([&](auto& child) {
-            MUST(copy->append_child(child.clone_node(document, true)));
-            return IterationDecision::Continue;
-        });
+        for (auto child = first_child(); child; child = child->next_sibling()) {
+            TRY(copy->append_child(TRY(child->clone_node(document, true))));
+        }
+    }
+
+    // 7. If node is a shadow host whose shadow root’s clonable is true:
+    if (is_element() && static_cast<Element const&>(*this).is_shadow_host() && static_cast<Element const&>(*this).shadow_root()->clonable()) {
+        // 1. Assert: copy is not a shadow host.
+        VERIFY(!copy->is_element() || !static_cast<Element const&>(*copy).is_shadow_host());
+
+        // 2. Run attach a shadow root with copy, node’s shadow root’s mode, true, node’s shadow root’s serializable,
+        //    node’s shadow root’s delegates focus, and node’s shadow root’s slot assignment.
+        auto& node_shadow_root = *static_cast<Element const&>(*this).shadow_root();
+        TRY(static_cast<Element&>(*copy).attach_a_shadow_root(node_shadow_root.mode(), true, node_shadow_root.serializable(), node_shadow_root.delegates_focus(), node_shadow_root.slot_assignment()));
+
+        // 3. Set copy’s shadow root’s declarative to node’s shadow root’s declarative.
+        static_cast<Element&>(*copy).shadow_root()->set_declarative(node_shadow_root.declarative());
+
+        // 4. For each child child of node’s shadow root, in tree order:
+        //    append the result of cloning child with document and the clone children flag set, to copy’s shadow root.
+        for (auto child = node_shadow_root.first_child(); child; child = child->next_sibling()) {
+            TRY(static_cast<Element&>(*copy).shadow_root()->append_child(TRY(child->clone_node(document, true))));
+        }
     }
 
     // 7. Return copy.
-    return *copy;
+    return JS::NonnullGCPtr { *copy };
 }
 
 // https://dom.spec.whatwg.org/#dom-node-clonenode

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -275,7 +275,7 @@ void Node::invalidate_style()
         node.m_needs_style_update = true;
         if (node.has_children())
             node.m_child_needs_style_update = true;
-        if (auto* shadow_root = node.is_element() ? static_cast<DOM::Element&>(node).shadow_root_internal() : nullptr) {
+        if (auto shadow_root = node.is_element() ? static_cast<DOM::Element&>(node).shadow_root() : nullptr) {
             node.m_child_needs_style_update = true;
             shadow_root->m_needs_style_update = true;
             if (shadow_root->has_children())
@@ -462,7 +462,7 @@ void Node::insert_before(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child, boo
             auto& element = static_cast<DOM::Element&>(*this);
 
             auto is_named_shadow_host = element.is_shadow_host()
-                && element.shadow_root_internal()->slot_assignment() == Bindings::SlotAssignmentMode::Named;
+                && element.shadow_root()->slot_assignment() == Bindings::SlotAssignmentMode::Named;
 
             if (is_named_shadow_host && node_to_insert->is_slottable())
                 assign_a_slot(node_to_insert->as_slottable());
@@ -914,7 +914,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::clone_node(Document* document,
 
         // 2. Run attach a shadow root with copy, node’s shadow root’s mode, true, node’s shadow root’s serializable,
         //    node’s shadow root’s delegates focus, and node’s shadow root’s slot assignment.
-        auto& node_shadow_root = *static_cast<Element const&>(*this).shadow_root();
+        auto& node_shadow_root = *static_cast<Element&>(*this).shadow_root();
         TRY(static_cast<Element&>(*copy).attach_a_shadow_root(node_shadow_root.mode(), true, node_shadow_root.serializable(), node_shadow_root.delegates_focus(), node_shadow_root.slot_assignment()));
 
         // 3. Set copy’s shadow root’s declarative to node’s shadow root’s declarative.
@@ -1260,7 +1260,7 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
             element->serialize_pseudo_elements_as_json(children);
 
             if (element->is_shadow_host())
-                add_child(*element->shadow_root_internal());
+                add_child(*element->shadow_root());
         }
 
         MUST(children.finish());

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -140,7 +140,7 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> replace_child(JS::NonnullGCPtr<Node> node, JS::NonnullGCPtr<Node> child);
 
-    JS::NonnullGCPtr<Node> clone_node(Document* document = nullptr, bool clone_children = false);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> clone_node(Document* document = nullptr, bool clone_children = false);
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> clone_node_binding(bool deep);
 
     // NOTE: This is intended for the JS bindings.
@@ -198,7 +198,7 @@ public:
     virtual void removed_from(Node*);
     virtual void children_changed() { }
     virtual void adopted_from(Document&) { }
-    virtual void cloned(Node&, bool) {};
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) { return {}; }
 
     Layout::Node const* layout_node() const { return m_layout_node; }
     Layout::Node* layout_node() { return m_layout_node; }

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -633,7 +633,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 4. If original start node is original end node and it is a CharacterData node, then:
     if (original_start_node.ptr() == original_end_node.ptr() && is<CharacterData>(*original_start_node)) {
         // 1. Let clone be a clone of original start node.
-        auto clone = original_start_node->clone_node();
+        auto clone = TRY(original_start_node->clone_node());
 
         // 2. Set the data of clone to the result of substringing data with node original start node,
         //    offset original start offset, and count original end offset minus original start offset.
@@ -723,7 +723,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 15. If first partially contained child is a CharacterData node, then:
     if (first_partially_contained_child && is<CharacterData>(*first_partially_contained_child)) {
         // 1. Let clone be a clone of original start node.
-        auto clone = original_start_node->clone_node();
+        auto clone = TRY(original_start_node->clone_node());
 
         // 2. Set the data of clone to the result of substringing data with node original start node, offset original start offset,
         //    and count original start node’s length minus original start offset.
@@ -739,7 +739,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 16. Otherwise, if first partially contained child is not null:
     else if (first_partially_contained_child) {
         // 1. Let clone be a clone of first partially contained child.
-        auto clone = first_partially_contained_child->clone_node();
+        auto clone = TRY(first_partially_contained_child->clone_node());
 
         // 2. Append clone to fragment.
         TRY(fragment->append_child(clone));
@@ -762,7 +762,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 18. If last partially contained child is a CharacterData node, then:
     if (last_partially_contained_child && is<CharacterData>(*last_partially_contained_child)) {
         // 1. Let clone be a clone of original end node.
-        auto clone = original_end_node->clone_node();
+        auto clone = TRY(original_end_node->clone_node());
 
         // 2. Set the data of clone to the result of substringing data with node original end node, offset 0, and count original end offset.
         auto result = TRY(static_cast<CharacterData const&>(*original_end_node).substring_data(0, original_end_offset));
@@ -777,7 +777,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 19. Otherwise, if last partially contained child is not null:
     else if (last_partially_contained_child) {
         // 1. Let clone be a clone of last partially contained child.
-        auto clone = last_partially_contained_child->clone_node();
+        auto clone = TRY(last_partially_contained_child->clone_node());
 
         // 2. Append clone to fragment.
         TRY(fragment->append_child(clone));
@@ -962,7 +962,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 4. If original start node is original end node and it is a CharacterData node, then:
     if (original_start_node.ptr() == original_end_node.ptr() && is<CharacterData>(*original_start_node)) {
         // 1. Let clone be a clone of original start node.
-        auto clone = original_start_node->clone_node();
+        auto clone = TRY(original_start_node->clone_node());
 
         // 2. Set the data of clone to the result of substringing data with node original start node,
         //    offset original start offset, and count original end offset minus original start offset.
@@ -1027,7 +1027,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 13. If first partially contained child is a CharacterData node, then:
     if (first_partially_contained_child && is<CharacterData>(*first_partially_contained_child)) {
         // 1. Let clone be a clone of original start node.
-        auto clone = original_start_node->clone_node();
+        auto clone = TRY(original_start_node->clone_node());
 
         // 2. Set the data of clone to the result of substringing data with node original start node, offset original start offset,
         //    and count original start node’s length minus original start offset.
@@ -1040,7 +1040,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 14. Otherwise, if first partially contained child is not null:
     else if (first_partially_contained_child) {
         // 1. Let clone be a clone of first partially contained child.
-        auto clone = first_partially_contained_child->clone_node();
+        auto clone = TRY(first_partially_contained_child->clone_node());
 
         // 2. Append clone to fragment.
         TRY(fragment->append_child(clone));
@@ -1058,7 +1058,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 15. For each contained child in contained children.
     for (auto& contained_child : contained_children) {
         // 1. Let clone be a clone of contained child with the clone children flag set.
-        auto clone = contained_child->clone_node(nullptr, true);
+        auto clone = TRY(contained_child->clone_node(nullptr, true));
 
         // 2. Append clone to fragment.
         TRY(fragment->append_child(move(clone)));
@@ -1067,7 +1067,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 16. If last partially contained child is a CharacterData node, then:
     if (last_partially_contained_child && is<CharacterData>(*last_partially_contained_child)) {
         // 1. Let clone be a clone of original end node.
-        auto clone = original_end_node->clone_node();
+        auto clone = TRY(original_end_node->clone_node());
 
         // 2. Set the data of clone to the result of substringing data with node original end node, offset 0, and count original end offset.
         auto result = TRY(static_cast<CharacterData const&>(*original_end_node).substring_data(0, original_end_offset));
@@ -1079,7 +1079,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 17. Otherwise, if last partially contained child is not null:
     else if (last_partially_contained_child) {
         // 1. Let clone be a clone of last partially contained child.
-        auto clone = last_partially_contained_child->clone_node();
+        auto clone = TRY(last_partially_contained_child->clone_node());
 
         // 2. Append clone to fragment.
         TRY(fragment->append_child(clone));

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOMParsing/InnerHTML.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/Layout/BlockContainer.h>
 
 namespace Web::DOM {
@@ -73,6 +74,18 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(StringView markup)
 
     set_needs_style_update(true);
     return {};
+}
+
+// https://html.spec.whatwg.org/#dom-element-gethtml
+WebIDL::ExceptionOr<String> ShadowRoot::get_html(GetHTMLOptions const& options) const
+{
+    // ShadowRoot's getHTML(options) method steps are to return the result
+    // of HTML fragment serialization algorithm with this,
+    // options["serializableShadowRoots"], and options["shadowRoots"].
+    return HTML::HTMLParser::serialize_html_fragment(
+        *this,
+        options.serializable_shadow_roots ? HTML::HTMLParser::SerializableShadowRoots::Yes : HTML::HTMLParser::SerializableShadowRoots::No,
+        options.shadow_roots);
 }
 
 CSS::StyleSheetList& ShadowRoot::style_sheets()

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -46,6 +46,8 @@ public:
     WebIDL::ExceptionOr<String> inner_html() const;
     WebIDL::ExceptionOr<void> set_inner_html(StringView);
 
+    WebIDL::ExceptionOr<String> get_html(GetHTMLOptions const&) const;
+
     CSS::StyleSheetList& style_sheets();
     CSS::StyleSheetList const& style_sheets() const;
 

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -25,6 +25,15 @@ public:
     bool delegates_focus() const { return m_delegates_focus; }
     void set_delegates_focus(bool delegates_focus) { m_delegates_focus = delegates_focus; }
 
+    [[nodiscard]] bool declarative() const { return m_declarative; }
+    void set_declarative(bool declarative) { m_declarative = declarative; }
+
+    [[nodiscard]] bool clonable() const { return m_clonable; }
+    void set_clonable(bool clonable) { m_clonable = clonable; }
+
+    [[nodiscard]] bool serializable() const { return m_serializable; }
+    void set_serializable(bool serializable) { m_serializable = serializable; }
+
     void set_onslotchange(WebIDL::CallbackType*);
     WebIDL::CallbackType* onslotchange();
 
@@ -67,6 +76,15 @@ private:
     Bindings::SlotAssignmentMode m_slot_assignment { Bindings::SlotAssignmentMode::Named };
     bool m_delegates_focus { false };
     bool m_available_to_element_internals { false };
+
+    // https://dom.spec.whatwg.org/#shadowroot-declarative
+    bool m_declarative { false };
+
+    // https://dom.spec.whatwg.org/#shadowroot-clonable
+    bool m_clonable { false };
+
+    // https://dom.spec.whatwg.org/#shadowroot-serializable
+    bool m_serializable { false };
 
     JS::GCPtr<CSS::StyleSheetList> m_style_sheets;
     mutable JS::GCPtr<WebIDL::ObservableArray> m_adopted_style_sheets;

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -100,7 +100,7 @@ inline TraversalDecision Node::for_each_shadow_including_inclusive_descendant(Ca
         return TraversalDecision::Break;
     for (auto* child = first_child(); child; child = child->next_sibling()) {
         if (child->is_element()) {
-            if (JS::GCPtr<ShadowRoot> shadow_root = static_cast<Element*>(child)->shadow_root_internal()) {
+            if (auto shadow_root = static_cast<Element*>(child)->shadow_root()) {
                 if (shadow_root->for_each_shadow_including_inclusive_descendant(callback) == TraversalDecision::Break)
                     return TraversalDecision::Break;
             }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -8,6 +8,8 @@ interface ShadowRoot : DocumentFragment {
     readonly attribute ShadowRootMode mode;
     readonly attribute boolean delegatesFocus;
     readonly attribute SlotAssignmentMode slotAssignment;
+    readonly attribute boolean clonable;
+    readonly attribute boolean serializable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;
 };

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -16,7 +16,7 @@ interface ShadowRoot : DocumentFragment {
     // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
 
     [FIXME, CEReactions] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
-    [FIXME] DOMString getHTML(optional GetHTMLOptions options = {});
+    DOMString getHTML(optional GetHTMLOptions options = {});
 
     // FIXME: [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
     [CEReactions, LegacyNullToEmptyString] attribute DOMString innerHTML;

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.idl
@@ -1,6 +1,6 @@
 #import <DOM/DocumentFragment.idl>
 #import <DOM/DocumentOrShadowRoot.idl>
-#import <DOM/InnerHTML.idl>
+#import <DOM/Element.idl>
 
 // https://dom.spec.whatwg.org/#shadowroot
 [Exposed=Window]
@@ -12,9 +12,16 @@ interface ShadowRoot : DocumentFragment {
     readonly attribute boolean serializable;
     readonly attribute Element host;
     attribute EventHandler onslotchange;
+
+    // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsing-and-serialization
+
+    [FIXME, CEReactions] undefined setHTMLUnsafe((TrustedHTML or DOMString) html);
+    [FIXME] DOMString getHTML(optional GetHTMLOptions options = {});
+
+    // FIXME: [CEReactions] attribute (TrustedHTML or [LegacyNullToEmptyString] DOMString) innerHTML;
+    [CEReactions, LegacyNullToEmptyString] attribute DOMString innerHTML;
 };
 
-ShadowRoot includes InnerHTML;
 ShadowRoot includes DocumentOrShadowRoot;
 
 enum ShadowRootMode { "open", "closed" };

--- a/Userland/Libraries/LibWeb/DOM/Slottable.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Slottable.cpp
@@ -61,7 +61,7 @@ JS::GCPtr<HTML::HTMLSlotElement> find_a_slot(Slottable const& slottable, OpenFla
         return nullptr;
 
     // 2. Let shadow be slottable’s parent’s shadow root.
-    auto* shadow = parent->shadow_root_internal();
+    auto shadow = parent->shadow_root();
 
     // 3. If shadow is null, then return null.
     if (shadow == nullptr)

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -97,7 +97,7 @@ void dump_tree(StringBuilder& builder, DOM::Node const& node)
     }
     ++indent;
     if (is<DOM::Element>(node)) {
-        if (auto* shadow_root = static_cast<DOM::Element const&>(node).shadow_root_internal()) {
+        if (auto shadow_root = static_cast<DOM::Element const&>(node).shadow_root()) {
             dump_tree(builder, *shadow_root);
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -224,6 +224,10 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(scheme)                     \
     __ENUMERATE_HTML_ATTRIBUTE(scrolling)                  \
     __ENUMERATE_HTML_ATTRIBUTE(selected)                   \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootclonable)         \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootdelegatesfocus)   \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootmode)             \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootserializable)     \
     __ENUMERATE_HTML_ATTRIBUTE(shape)                      \
     __ENUMERATE_HTML_ATTRIBUTE(size)                       \
     __ENUMERATE_HTML_ATTRIBUTE(sizes)                      \

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -246,6 +246,9 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     // about base URL: creatorBaseURL
     document->set_about_base_url(creator_base_url);
 
+    // allow declarative shadow roots: true
+    document->set_allow_declarative_shadow_roots(true);
+
     // 16. If creator is non-null, then:
     if (creator) {
         // 1. Set document's referrer to the serialization of creator's URL.

--- a/Userland/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Focus.cpp
@@ -241,7 +241,7 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
     //    context's DOM anchor, then set old focus target to that currently focused area of a top-level browsing
     //    context.
     if (is_shadow_host(old_focus_target)) {
-        auto* shadow_root = static_cast<DOM::Element*>(old_focus_target)->shadow_root_internal();
+        auto shadow_root = static_cast<DOM::Element*>(old_focus_target)->shadow_root();
         if (shadow_root->delegates_focus()) {
             auto top_level_traversable = old_focus_target->document().browsing_context()->top_level_traversable();
             if (auto currently_focused_area = top_level_traversable->currently_focused_area()) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -119,7 +119,7 @@ void HTMLDetailsElement::queue_a_details_toggle_event_task(String old_state, Str
 // https://html.spec.whatwg.org/#the-details-and-summary-elements
 WebIDL::ExceptionOr<void> HTMLDetailsElement::create_shadow_tree_if_needed()
 {
-    if (shadow_root_internal())
+    if (shadow_root())
         return {};
 
     auto& realm = this->realm();
@@ -145,7 +145,7 @@ WebIDL::ExceptionOr<void> HTMLDetailsElement::create_shadow_tree_if_needed()
 
 void HTMLDetailsElement::update_shadow_tree_slots()
 {
-    if (!shadow_root_internal())
+    if (!shadow_root())
         return;
 
     Vector<HTMLSlotElement::SlottableHandle> summary_assignment;
@@ -177,7 +177,7 @@ void HTMLDetailsElement::update_shadow_tree_slots()
 // https://html.spec.whatwg.org/#the-details-and-summary-elements:the-details-element-6
 void HTMLDetailsElement::update_shadow_tree_style()
 {
-    if (!shadow_root_internal())
+    if (!shadow_root())
         return;
 
     if (has_attribute(HTML::AttributeNames::open)) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -732,7 +732,7 @@ Optional<String> HTMLInputElement::placeholder_value() const
 
 void HTMLInputElement::create_shadow_tree_if_needed()
 {
-    if (shadow_root_internal())
+    if (shadow_root())
         return;
 
     switch (type_state()) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -179,7 +179,7 @@ void HTMLMeterElement::removed_from(DOM::Node*)
 
 void HTMLMeterElement::create_shadow_tree_if_needed()
 {
-    if (shadow_root_internal())
+    if (shadow_root())
         return;
 
     auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -97,7 +97,7 @@ void HTMLProgressElement::removed_from(DOM::Node*)
 
 void HTMLProgressElement::create_shadow_tree_if_needed()
 {
-    if (shadow_root_internal())
+    if (shadow_root())
         return;
 
     auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -503,7 +503,7 @@ void HTMLSelectElement::computed_css_values_changed()
 
 void HTMLSelectElement::create_shadow_tree_if_needed()
 {
-    if (shadow_root_internal())
+    if (shadow_root())
         return;
 
     auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -63,4 +63,9 @@ void HTMLTemplateElement::cloned(Node& copy, bool clone_children)
     });
 }
 
+void HTMLTemplateElement::set_template_contents(JS::NonnullGCPtr<DOM::DocumentFragment> contents)
+{
+    m_content = contents;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.h
@@ -21,6 +21,8 @@ public:
     JS::NonnullGCPtr<DOM::DocumentFragment> content() { return *m_content; }
     JS::NonnullGCPtr<DOM::DocumentFragment> const content() const { return *m_content; }
 
+    void set_template_contents(JS::NonnullGCPtr<DOM::DocumentFragment>);
+
     virtual void adopted_from(DOM::Document&) override;
     virtual void cloned(Node& copy, bool clone_children) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.h
@@ -24,7 +24,7 @@ public:
     void set_template_contents(JS::NonnullGCPtr<DOM::DocumentFragment>);
 
     virtual void adopted_from(DOM::Document&) override;
-    virtual void cloned(Node& copy, bool clone_children) override;
+    virtual WebIDL::ExceptionOr<void> cloned(Node& copy, bool clone_children) override;
 
 private:
     HTMLTemplateElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTemplateElement.idl
@@ -8,5 +8,8 @@ interface HTMLTemplateElement : HTMLElement {
     [HTMLConstructor] constructor();
 
     readonly attribute DocumentFragment content;
-
+    [Reflect=shadowrootmode, Enumerated=ShadowRootMode, CEReactions] attribute DOMString shadowRootMode;
+    [Reflect=shadowrootdelegatesfocus, CEReactions] attribute boolean shadowRootDelegatesFocus;
+    [Reflect=shadowrootclonable, CEReactions] attribute boolean shadowRootClonable;
+    [Reflect=shadowrootserializable, CEReactions] attribute boolean shadowRootSerializable;
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -334,7 +334,7 @@ WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_rows(unsigned rows)
 
 void HTMLTextAreaElement::create_shadow_tree_if_needed()
 {
-    if (shadow_root_internal())
+    if (shadow_root())
         return;
 
     auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -130,9 +130,15 @@ private:
 
     AdjustedInsertionLocation find_appropriate_place_for_inserting_node(JS::GCPtr<DOM::Element> override_target = nullptr);
 
+    void insert_an_element_at_the_adjusted_insertion_location(JS::NonnullGCPtr<DOM::Element>);
+
     DOM::Text* find_character_insertion_node();
     void flush_character_insertions();
-    JS::NonnullGCPtr<DOM::Element> insert_foreign_element(HTMLToken const&, Optional<FlyString> const& namespace_);
+    enum class OnlyAddToElementStack {
+        No,
+        Yes,
+    };
+    JS::NonnullGCPtr<DOM::Element> insert_foreign_element(HTMLToken const&, Optional<FlyString> const& namespace_, OnlyAddToElementStack);
     JS::NonnullGCPtr<DOM::Element> insert_html_element(HTMLToken const&);
     DOM::Element& current_node();
     DOM::Element& adjusted_current_node();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -61,7 +61,11 @@ public:
     DOM::Document& document();
 
     static Vector<JS::Handle<DOM::Node>> parse_html_fragment(DOM::Element& context_element, StringView);
-    static String serialize_html_fragment(DOM::Node const& node, DOM::FragmentSerializationMode = DOM::FragmentSerializationMode::Inner);
+    enum class SerializableShadowRoots {
+        No,
+        Yes,
+    };
+    static String serialize_html_fragment(DOM::Node const&, SerializableShadowRoots, Vector<JS::Handle<DOM::ShadowRoot>> const&, DOM::FragmentSerializationMode = DOM::FragmentSerializationMode::Inner);
 
     enum class InsertionMode {
 #define __ENUMERATE_INSERTION_MODE(mode) mode,

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -372,7 +372,7 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
     }
 
-    auto* shadow_root = is<DOM::Element>(dom_node) ? verify_cast<DOM::Element>(dom_node).shadow_root_internal() : nullptr;
+    auto shadow_root = is<DOM::Element>(dom_node) ? verify_cast<DOM::Element>(dom_node).shadow_root() : nullptr;
 
     // Add node for the ::before pseudo-element.
     if (is<DOM::Element>(dom_node) && layout_node->can_have_children()) {

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -130,7 +130,7 @@ void SVGUseElement::clone_element_tree_as_our_shadow_tree(Element* to_clone) con
 
     if (to_clone && is_valid_reference_element(to_clone)) {
         // The ‘use’ element references another element, a copy of which is rendered in place of the ‘use’ in the document.
-        auto cloned_reference_node = to_clone->clone_node(nullptr, true);
+        auto cloned_reference_node = MUST(to_clone->clone_node(nullptr, true));
         shadow_root()->append_child(cloned_reference_node).release_value_but_fixme_should_propagate_errors();
     }
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -126,12 +126,12 @@ JS::GCPtr<DOM::Element> SVGUseElement::referenced_element()
 // https://svgwg.org/svg2-draft/struct.html#UseShadowTree
 void SVGUseElement::clone_element_tree_as_our_shadow_tree(Element* to_clone) const
 {
-    shadow_root()->remove_all_children();
+    const_cast<DOM::ShadowRoot&>(*shadow_root()).remove_all_children();
 
     if (to_clone && is_valid_reference_element(to_clone)) {
         // The ‘use’ element references another element, a copy of which is rendered in place of the ‘use’ in the document.
         auto cloned_reference_node = MUST(to_clone->clone_node(nullptr, true));
-        shadow_root()->append_child(cloned_reference_node).release_value_but_fixme_should_propagate_errors();
+        const_cast<DOM::ShadowRoot&>(*shadow_root()).append_child(cloned_reference_node).release_value_but_fixme_should_propagate_errors();
     }
 }
 
@@ -177,7 +177,7 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGUseElement::height() const
 // https://svgwg.org/svg2-draft/struct.html#TermInstanceRoot
 JS::GCPtr<SVGElement> SVGUseElement::instance_root() const
 {
-    return shadow_root()->first_child_of_type<SVGElement>();
+    return const_cast<DOM::ShadowRoot&>(*shadow_root()).first_child_of_type<SVGElement>();
 }
 
 JS::GCPtr<SVGElement> SVGUseElement::animated_instance_root() const

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -687,7 +687,7 @@ void ConnectionFromClient::clone_dom_node(u64 page_id, i32 node_id)
         return;
     }
 
-    auto dom_node_clone = dom_node->clone_node(nullptr, true);
+    auto dom_node_clone = MUST(dom_node->clone_node(nullptr, true));
     dom_node->parent_node()->insert_before(dom_node_clone, dom_node->next_sibling());
 
     async_did_finish_editing_dom_node(page_id, dom_node_clone->unique_id());

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1018,7 +1018,7 @@ Messages::WebDriverClient::GetElementShadowRootResponse WebDriverConnection::get
     auto* element = TRY(get_known_connected_element(element_id));
 
     // 4. Let shadow root be element's shadow root.
-    auto* shadow_root = element->shadow_root_internal();
+    auto shadow_root = element->shadow_root();
 
     // 5. If shadow root is null, return error with error code no such shadow root.
     if (!shadow_root)


### PR DESCRIPTION
This PR adds the ability to create shadow DOM trees in pure HTML, without a single line of JavaScript.

```html
<div>
<template shadowrootmode="open">
this becomes the shadow tree inside the div element!
</template>
this text is a normal child of the div element.
</div>
```

This required updating a bunch of algorithms in the HTML parser & serializer, the DOM node cloning algorithm (which can now throw!), and more.

I ended up doing all this because the extension I'm using to save full pages as a single HTML file in Firefox (for debugging with Ladybird) started outputting HTML files with declarative shadow DOMs! :sweat_smile:

This passes a lot of the WPT tests, but then a lot of them fail because we don't yet have `Element.setHTMLUnsafe()`. That'll be an exercise for another day!