### PR TITLE
Everywhere: Transition ImageDecoder to be single-instance, owned by UI     

### DIFF
--- a/Ladybird/AppKit/Application/Application.h
+++ b/Ladybird/AppKit/Application/Application.h
@@ -22,6 +22,7 @@ class WebViewBridge;
 - (instancetype)init;
 
 - (ErrorOr<void>)launchRequestServer:(Vector<ByteString> const&)certificates;
+- (ErrorOr<void>)launchImageDecoder;
 - (ErrorOr<NonnullRefPtr<WebView::WebContentClient>>)launchWebContent:(Ladybird::WebViewBridge&)web_view_bridge;
 - (ErrorOr<IPC::File>)launchWebWorker;
 

--- a/Ladybird/AppKit/Application/Application.mm
+++ b/Ladybird/AppKit/Application/Application.mm
@@ -41,6 +41,11 @@
     return m_application_bridge->launch_request_server(certificates);
 }
 
+- (ErrorOr<void>)launchImageDecoder
+{
+    return m_application_bridge->launch_image_decoder();
+}
+
 - (ErrorOr<NonnullRefPtr<WebView::WebContentClient>>)launchWebContent:(Ladybird::WebViewBridge&)web_view_bridge
 {
     return m_application_bridge->launch_web_content(web_view_bridge);

--- a/Ladybird/AppKit/Application/ApplicationBridge.cpp
+++ b/Ladybird/AppKit/Application/ApplicationBridge.cpp
@@ -9,6 +9,7 @@
 #include <Ladybird/AppKit/UI/LadybirdWebViewBridge.h>
 #include <Ladybird/HelperProcess.h>
 #include <Ladybird/Utilities.h>
+#include <LibImageDecoderClient/Client.h>
 #include <LibProtocol/RequestClient.h>
 #include <LibWebView/WebContentClient.h>
 
@@ -19,6 +20,7 @@ namespace Ladybird {
 // is limited to .cpp files (i.e. not .h files that an Objective-C file can include).
 struct ApplicationBridgeImpl {
     RefPtr<Protocol::RequestClient> request_server_client;
+    RefPtr<ImageDecoderClient::Client> image_decoder_client;
 };
 
 ApplicationBridge::ApplicationBridge()
@@ -37,13 +39,47 @@ ErrorOr<void> ApplicationBridge::launch_request_server(Vector<ByteString> const&
     return {};
 }
 
+static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decoder()
+{
+    auto image_decoder_paths = TRY(get_paths_for_helper_process("ImageDecoder"sv));
+    return launch_image_decoder_process(image_decoder_paths);
+}
+
+ErrorOr<void> ApplicationBridge::launch_image_decoder()
+{
+    m_impl->image_decoder_client = TRY(launch_new_image_decoder());
+
+    m_impl->image_decoder_client->on_death = [this] {
+        m_impl->image_decoder_client = nullptr;
+        if (auto err = this->launch_image_decoder(); err.is_error()) {
+            dbgln("Failed to restart image decoder: {}", err.error());
+            VERIFY_NOT_REACHED();
+        }
+
+        auto num_clients = WebView::WebContentClient::client_count();
+        auto new_sockets = m_impl->image_decoder_client->send_sync_but_allow_failure<Messages::ImageDecoderServer::ConnectNewClients>(num_clients);
+        if (!new_sockets || new_sockets->sockets().size() == 0) {
+            dbgln("Failed to connect {} new clients to ImageDecoder", num_clients);
+            VERIFY_NOT_REACHED();
+        }
+
+        WebView::WebContentClient::for_each_client([sockets = new_sockets->take_sockets()](WebView::WebContentClient& client) mutable {
+            client.async_connect_to_image_decoder(sockets.take_last());
+            return IterationDecision::Continue;
+        });
+    };
+
+    return {};
+}
+
 ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ApplicationBridge::launch_web_content(WebViewBridge& web_view_bridge)
 {
     // FIXME: Fail to open the tab, rather than crashing the whole application if this fails
     auto request_server_socket = TRY(connect_new_request_server_client(*m_impl->request_server_client));
+    auto image_decoder_socket = TRY(connect_new_image_decoder_client(*m_impl->image_decoder_client));
 
     auto web_content_paths = TRY(get_paths_for_helper_process("WebContent"sv));
-    auto web_content = TRY(launch_web_content_process(web_view_bridge, web_content_paths, web_view_bridge.web_content_options(), move(request_server_socket)));
+    auto web_content = TRY(launch_web_content_process(web_view_bridge, web_content_paths, web_view_bridge.web_content_options(), move(image_decoder_socket), move(request_server_socket)));
 
     return web_content;
 }

--- a/Ladybird/AppKit/Application/ApplicationBridge.h
+++ b/Ladybird/AppKit/Application/ApplicationBridge.h
@@ -22,6 +22,7 @@ public:
     ~ApplicationBridge();
 
     ErrorOr<void> launch_request_server(Vector<ByteString> const& certificates);
+    ErrorOr<void> launch_image_decoder();
     ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content(WebViewBridge&);
     ErrorOr<IPC::File> launch_web_worker();
 

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -136,6 +136,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
     TRY([application launchRequestServer:certificates]);
 
+    TRY([application launchImageDecoder]);
+
     StringBuilder command_line_builder;
     command_line_builder.join(' ', arguments.strings);
     Ladybird::WebContentOptions web_content_options {

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -160,14 +160,7 @@ ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient& cl
         return Error::from_string_literal("Failed to connect to RequestServer");
 
     auto socket = new_socket->take_client_socket();
-
-    // FIXME: IPC::Files transferred over the wire are always set O_CLOEXEC during decoding.
-    //        Perhaps we should add an option to IPC::File to allow the receiver to decide whether to
-    //        make it O_CLOEXEC or not. Or an attribute in the .ipc file?
-    auto fd = socket.fd();
-    auto fd_flags = MUST(Core::System::fcntl(fd, F_GETFD));
-    fd_flags &= ~FD_CLOEXEC;
-    MUST(Core::System::fcntl(fd, F_SETFD, fd_flags));
+    TRY(socket.clear_close_on_exec());
 
     return socket;
 }

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -122,7 +122,13 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths)
 {
-    return launch_server_process<ImageDecoderClient::Client>("ImageDecoder"sv, candidate_image_decoder_paths, {}, RegisterWithProcessManager::Yes, Ladybird::EnableCallgrindProfiling::No);
+    Vector<ByteString> arguments;
+    if (auto server = mach_server_name(); server.has_value()) {
+        arguments.append("--mach-server-name"sv);
+        arguments.append(server.value());
+    }
+
+    return launch_server_process<ImageDecoderClient::Client>("ImageDecoder"sv, candidate_image_decoder_paths, arguments, RegisterWithProcessManager::Yes, Ladybird::EnableCallgrindProfiling::No);
 }
 
 ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, NonnullRefPtr<Protocol::RequestClient> request_client)

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -21,6 +21,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     WebView::ViewImplementation& view,
     ReadonlySpan<ByteString> candidate_web_content_paths,
     Ladybird::WebContentOptions const&,
+    IPC::File image_decoder_socket,
     Optional<IPC::File> request_server_socket = {});
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths);
@@ -28,3 +29,4 @@ ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(Rea
 ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root, Vector<ByteString> const& certificates);
 
 ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient&);
+ErrorOr<IPC::File> connect_new_image_decoder_client(ImageDecoderClient::Client&);

--- a/Ladybird/ImageCodecPlugin.h
+++ b/Ladybird/ImageCodecPlugin.h
@@ -14,10 +14,12 @@ namespace Ladybird {
 
 class ImageCodecPlugin final : public Web::Platform::ImageCodecPlugin {
 public:
-    ImageCodecPlugin() = default;
+    explicit ImageCodecPlugin(NonnullRefPtr<ImageDecoderClient::Client>);
     virtual ~ImageCodecPlugin() override;
 
     virtual NonnullRefPtr<Core::Promise<Web::Platform::DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(Web::Platform::DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected) override;
+
+    void set_client(NonnullRefPtr<ImageDecoderClient::Client>);
 
 private:
     RefPtr<ImageDecoderClient::Client> m_client;

--- a/Ladybird/ImageDecoder/main.cpp
+++ b/Ladybird/ImageDecoder/main.cpp
@@ -12,11 +12,25 @@
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 
-ErrorOr<int> serenity_main(Main::Arguments)
+#if defined(AK_OS_MACOS)
+#    include <LibCore/Platform/ProcessStatisticsMach.h>
+#endif
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     AK::set_rich_debug_enabled(true);
 
+    Core::ArgsParser args_parser;
+    StringView mach_server_name;
+    args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
+    args_parser.parse(arguments);
+
     Core::EventLoop event_loop;
+
+#if defined(AK_OS_MACOS)
+    if (!mach_server_name.is_empty())
+        Core::Platform::register_with_mach_server(mach_server_name);
+#endif
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<ImageDecoder::ConnectionFromClient>());
 

--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -7,6 +7,8 @@
 #include "Application.h"
 #include "StringUtils.h"
 #include "TaskManagerWindow.h"
+#include <Ladybird/HelperProcess.h>
+#include <Ladybird/Utilities.h>
 #include <LibWebView/URL.h>
 #include <QFileOpenEvent>
 
@@ -41,6 +43,38 @@ bool Application::event(QEvent* event)
     }
 
     return QApplication::event(event);
+}
+
+static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decoder()
+{
+    auto paths = TRY(get_paths_for_helper_process("ImageDecoder"sv));
+    return launch_image_decoder_process(paths);
+}
+
+ErrorOr<void> Application::initialize_image_decoder()
+{
+    m_image_decoder_client = TRY(launch_new_image_decoder());
+
+    m_image_decoder_client->on_death = [this] {
+        m_image_decoder_client = nullptr;
+        if (auto err = this->initialize_image_decoder(); err.is_error()) {
+            dbgln("Failed to restart image decoder: {}", err.error());
+            VERIFY_NOT_REACHED();
+        }
+
+        auto num_clients = WebView::WebContentClient::client_count();
+        auto new_sockets = m_image_decoder_client->send_sync_but_allow_failure<Messages::ImageDecoderServer::ConnectNewClients>(num_clients);
+        if (!new_sockets || new_sockets->sockets().size() == 0) {
+            dbgln("Failed to connect {} new clients to ImageDecoder", num_clients);
+            VERIFY_NOT_REACHED();
+        }
+
+        WebView::WebContentClient::for_each_client([sockets = new_sockets->take_sockets()](WebView::WebContentClient& client) mutable {
+            client.async_connect_to_image_decoder(sockets.take_last());
+            return IterationDecision::Continue;
+        });
+    };
+    return {};
 }
 
 void Application::show_task_manager_window()

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -9,6 +9,7 @@
 #include <AK/Function.h>
 #include <AK/HashTable.h>
 #include <Ladybird/Qt/BrowserWindow.h>
+#include <LibImageDecoderClient/Client.h>
 #include <LibProtocol/RequestClient.h>
 #include <LibURL/URL.h>
 #include <QApplication>
@@ -27,6 +28,9 @@ public:
     Function<void(URL::URL)> on_open_file;
     RefPtr<Protocol::RequestClient> request_server_client;
 
+    NonnullRefPtr<ImageDecoderClient::Client> image_decoder_client() const { return *m_image_decoder_client; }
+    ErrorOr<void> initialize_image_decoder();
+
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     void show_task_manager_window();
@@ -38,6 +42,8 @@ public:
 private:
     TaskManagerWindow* m_task_manager_window { nullptr };
     BrowserWindow* m_active_window { nullptr };
+
+    RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
 };
 
 }

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -549,8 +549,11 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
             request_server_socket = AK::move(socket);
         }
 
+        auto image_decoder = static_cast<Ladybird::Application*>(QApplication::instance())->image_decoder_client();
+        auto image_decoder_socket = connect_new_image_decoder_client(*image_decoder).release_value_but_fixme_should_propagate_errors();
+
         auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-        auto new_client = launch_web_content_process(*this, candidate_web_content_paths, m_web_content_options, AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
+        auto new_client = launch_web_content_process(*this, candidate_web_content_paths, m_web_content_options, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
 
         m_client_state.client = new_client;
     } else {

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -166,7 +166,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
     auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
     auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_serenity_resource_root, certificates));
-    app.request_server_client = protocol_client;
+    app.request_server_client = move(protocol_client);
+
+    TRY(app.initialize_image_decoder());
 
     StringBuilder command_line_builder;
     command_line_builder.join(' ', arguments.strings);

--- a/Userland/Libraries/LibIPC/File.h
+++ b/Userland/Libraries/LibIPC/File.h
@@ -63,6 +63,17 @@ public:
         return exchange(m_fd, -1);
     }
 
+    // FIXME: IPC::Files transferred over the wire are always set O_CLOEXEC during decoding.
+    //        Perhaps we should add an option to IPC::File to allow the receiver to decide whether to
+    //        make it O_CLOEXEC or not. Or an attribute in the .ipc file?
+    ErrorOr<void> clear_close_on_exec()
+    {
+        auto fd_flags = TRY(Core::System::fcntl(m_fd, F_GETFD));
+        fd_flags &= ~FD_CLOEXEC;
+        TRY(Core::System::fcntl(m_fd, F_SETFD, fd_flags));
+        return {};
+    }
+
 private:
     explicit File(int fd)
         : m_fd(fd)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -11,7 +11,7 @@
 
 namespace WebView {
 
-static HashTable<WebContentClient*> s_clients;
+HashTable<WebContentClient*> WebContentClient::s_clients;
 
 Optional<ViewImplementation&> WebContentClient::view_for_pid_and_page_id(pid_t pid, u64 page_id)
 {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -28,6 +28,11 @@ class WebContentClient final
 public:
     static Optional<ViewImplementation&> view_for_pid_and_page_id(pid_t pid, u64 page_id);
 
+    template<CallableAs<IterationDecision, WebContentClient&> Callback>
+    static void for_each_client(Callback callback);
+
+    static size_t client_count() { return s_clients.size(); }
+
     WebContentClient(NonnullOwnPtr<Core::LocalSocket>, ViewImplementation&);
     ~WebContentClient();
 
@@ -121,6 +126,17 @@ private:
     HashMap<u64, ViewImplementation*> m_views;
 
     ProcessHandle m_process_handle;
+
+    static HashTable<WebContentClient*> s_clients;
 };
+
+template<CallableAs<IterationDecision, WebContentClient&> Callback>
+void WebContentClient::for_each_client(Callback callback)
+{
+    for (auto& it : s_clients) {
+        if (callback(*it) == IterationDecision::Break)
+            return;
+    }
+}
 
 }

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.h
@@ -39,6 +39,9 @@ private:
 
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&, Optional<Gfx::IntSize> const& ideal_size, Optional<ByteString> const& mime_type) override;
     virtual void cancel_decoding(i64 image_id) override;
+    virtual Messages::ImageDecoderServer::ConnectNewClientsResponse connect_new_clients(size_t count) override;
+
+    ErrorOr<IPC::File> connect_new_client();
 
     NonnullRefPtr<Job> make_decode_image_job(i64 image_id, Core::AnonymousBuffer, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type);
 

--- a/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Userland/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -4,4 +4,6 @@ endpoint ImageDecoderServer
 {
     decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (i64 image_id)
     cancel_decoding(i64 image_id) =|
+
+    connect_new_clients(size_t count) => (Vector<IPC::File> sockets)
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -104,6 +104,12 @@ void ConnectionFromClient::connect_to_webdriver(u64 page_id, ByteString const& w
     }
 }
 
+void ConnectionFromClient::connect_to_image_decoder(IPC::File const& image_decoder_socket)
+{
+    if (on_image_decoder_connection)
+        on_image_decoder_connection(image_decoder_socket);
+}
+
 void ConnectionFromClient::update_system_theme(u64 page_id, Core::AnonymousBuffer const& theme_buffer)
 {
     auto page = this->page(page_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -45,6 +45,8 @@ public:
     PageHost& page_host() { return *m_page_host; }
     PageHost const& page_host() const { return *m_page_host; }
 
+    Function<void(IPC::File const&)> on_image_decoder_connection;
+
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
 
@@ -54,6 +56,7 @@ private:
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String const& handle) override;
     virtual void connect_to_webdriver(u64 page_id, ByteString const& webdriver_ipc_path) override;
+    virtual void connect_to_image_decoder(IPC::File const& image_decoder_socket) override;
     virtual void update_system_theme(u64 page_id, Core::AnonymousBuffer const&) override;
     virtual void update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> const&, u32) override;
     virtual void load_url(u64 page_id, URL::URL const&) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -665,9 +665,6 @@ ErrorOr<void> PageClient::connect_to_webdriver(ByteString const& webdriver_ipc_p
     VERIFY(!m_webdriver);
     m_webdriver = TRY(WebDriverConnection::connect(*this, webdriver_ipc_path));
 
-    if (m_owner.on_webdriver_connection)
-        m_owner.on_webdriver_connection(*m_webdriver);
-
     return {};
 }
 

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -24,8 +24,6 @@ public:
     static NonnullOwnPtr<PageHost> create(ConnectionFromClient& client) { return adopt_own(*new PageHost(client)); }
     virtual ~PageHost();
 
-    Function<void(WebDriverConnection&)> on_webdriver_connection;
-
     Optional<PageClient&> page(u64 index);
     PageClient& create_page();
     void remove_page(Badge<PageClient>, u64 index);

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -17,6 +17,7 @@ endpoint WebContentServer
     set_window_handle(u64 page_id, String handle) =|
 
     connect_to_webdriver(u64 page_id, ByteString webdriver_ipc_path) =|
+    connect_to_image_decoder(IPC::File socket_fd) =|
 
     update_system_theme(u64 page_id, Core::AnonymousBuffer theme_buffer) =|
     update_screen_rects(u64 page_id, Vector<Web::DevicePixelRect> rects, u32 main_screen_index) =|


### PR DESCRIPTION
This is the same behavior as RequestServer, with the added benefit that
we know how to gracefully reconnect ImageDecoder to all WebContent
processes on restart.