### PR TITLE
Tests/LibWasm: Don't ignore the result of BigInt::export_data()

### DIFF
--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -285,10 +285,13 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
             }
 
             u128 bits = 0;
-            (void)argument.as_bigint().big_integer().unsigned_value().export_data({ bit_cast<u8*>(&bits), sizeof(bits) });
+            auto bytes = argument.as_bigint().big_integer().unsigned_value().export_data({ bit_cast<u8*>(&bits), sizeof(bits) });
             VERIFY(!argument.as_bigint().big_integer().is_negative());
 
-            arguments.append(Wasm::Value(bits));
+            if constexpr (AK::HostIsLittleEndian)
+                arguments.append(Wasm::Value(bits << (128 - bytes * 8)));
+            else
+                arguments.append(Wasm::Value(bits >> (128 - bytes * 8)));
             break;
         }
         case Wasm::ValueType::Kind::FunctionReference:


### PR DESCRIPTION
Prior to this commit, the test runner was ignoring the result, which meant that values that fit in less than 128 bits were shifted to remove the zero words (which is obviously incorrect).