### PR TITLE
LibMedia: Add ffmpeg as a vcpkg dependency

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -25,7 +25,7 @@ runs:
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 
         sudo apt-get update
-        sudo apt-get install autoconf autoconf-archive automake build-essential cmake libavcodec-dev fonts-liberation2 zip curl tar ccache clang-18 clang++-18 lld-18 gcc-13 g++-13 libstdc++-13-dev ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
+        sudo apt-get install autoconf autoconf-archive automake build-essential cmake fonts-liberation2 zip curl tar ccache clang-18 clang++-18 lld-18 gcc-13 g++-13 libstdc++-13-dev nasm ninja-build unzip qt6-base-dev qt6-tools-dev-tools libqt6svg6-dev qt6-multimedia-dev libgl1-mesa-dev libpulse-dev libssl-dev libegl1-mesa-dev
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
@@ -51,7 +51,7 @@ runs:
         set -e
         sudo xcode-select --switch /Applications/Xcode_15.4.app
         brew update
-        brew install autoconf autoconf-archive automake coreutils bash ffmpeg ninja wabt ccache unzip qt llvm@18
+        brew install autoconf autoconf-archive automake coreutils bash nasm ninja wabt ccache unzip qt llvm@18
 
     - name: 'Install vcpkg'
       shell: bash

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -9,7 +9,7 @@ NOTE: In all of the below lists of packages, the Qt6 multimedia package is not n
 On Debian/Ubuntu required packages include, but are not limited to:
 
 ```
-sudo apt install autoconf autoconf-archive automake build-essential cmake libavcodec-dev libgl1-mesa-dev ninja-build qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev ccache fonts-liberation2 zip unzip curl tar
+sudo apt install autoconf autoconf-archive automake build-essential cmake libgl1-mesa-dev nasm ninja-build qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev ccache fonts-liberation2 zip unzip curl tar
 ```
 
 For Ubuntu 20.04 and above, ensure that the Qt6 Wayland packages are available:
@@ -21,12 +21,12 @@ sudo apt install qt6-wayland
 On Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed base-devel cmake ffmpeg libgl ninja qt6-base qt6-tools qt6-wayland qt6-multimedia ccache ttf-liberation curl unzip zip tar autoconf-archive
+sudo pacman -S --needed base-devel cmake libgl nasm ninja qt6-base qt6-tools qt6-wayland qt6-multimedia ccache ttf-liberation curl unzip zip tar autoconf-archive
 ```
 
 On Fedora or derivatives:
 ```
-sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel qt6-qtmultimedia-devel ccache liberation-sans-fonts curl zip unzip tar autoconf-archive
+sudo dnf install cmake libglvnd-devel nasm ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel qt6-qtmultimedia-devel ccache liberation-sans-fonts curl zip unzip tar autoconf-archive
 ```
 
 On openSUSE:
@@ -56,7 +56,7 @@ Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake cmake ffmpeg ninja ccache pkg-config
+brew install autoconf autoconf-archive automake cmake nasm ninja ccache pkg-config
 ```
 
 If you also plan to use the Qt chrome on macOS:

--- a/Userland/Libraries/LibMedia/CMakeLists.txt
+++ b/Userland/Libraries/LibMedia/CMakeLists.txt
@@ -14,5 +14,9 @@ target_link_libraries(LibMedia PRIVATE LibCore LibIPC LibGfx LibThreading)
 
 # Third-party
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(AVCODEC REQUIRED IMPORTED_TARGET libavcodec)
-target_link_libraries(LibMedia PRIVATE PkgConfig::AVCODEC)
+
+pkg_check_modules(FFMPEG REQUIRED IMPORTED_TARGET libavcodec)
+target_link_libraries(LibMedia PRIVATE PkgConfig::FFMPEG)
+if (NOT APPLE)
+    target_link_options(LibMedia PRIVATE "-Wl,-Bsymbolic")
+endif()

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,10 @@
 {
   "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
-  "dependencies": [
+   "dependencies": [
+    {
+      "name": "ffmpeg",
+      "features": [ "avcodec" ]
+    },
     {
       "name": "fontconfig",
       "platform": "linux | freebsd | openbsd"
@@ -16,6 +20,10 @@
     "woff2"
   ],
   "overrides": [
+    {
+      "name": "ffmpeg",
+      "version": "6.1.1#7"
+    },
     {
       "name": "fontconfig",
       "version": "2.14.2#1"


### PR DESCRIPTION
Fixes #254

I've verified that LibMedia/CMakeLists.txt here works with both a system-installed and vcpkg-installed ffmpeg. I did have to blow away my CMake cache between switching.