### PR TITLE
LibWeb: Implement a minimal version of `Window.find()`

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-find.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find.txt
@@ -1,0 +1,7 @@
+  window.find(): false
+window.find("this"): true, selection from: 0 to 4
+window.find("this"): false
+window.find("A"): true, selection from: 8 to 9
+window.find("t"): true, selection from: 10 to 11
+window.find("t"): true, selection from: 13 to 14
+window.find("t"): false

--- a/Tests/LibWeb/Text/input/HTML/Window-find.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-find.html
@@ -1,0 +1,40 @@
+<script src="../include.js"></script>
+<div id="textContainer">
+    <div style="display: none">This is hidden</div>
+    <div style="visibility: hidden">This is also hidden</div>
+    <span>this is a test</span>
+</div>
+<script>
+    function windowFindTest(string) {
+        const result = window.find(string);
+        const selection = window.getSelection();
+        if (result && selection && selection.rangeCount === 1) {
+            const range = selection.getRangeAt(0);
+            println(`window.find("${string}"): ${result}, selection from: ${range.startOffset} to ${range.endOffset}`);
+        } else {
+            println(`window.find("${string}"): ${result}`);
+        }
+    }
+
+    function testBody() {
+        println(`window.find(): ${window.find()}`);
+        windowFindTest("this");
+        windowFindTest("this");
+        windowFindTest("A");
+        windowFindTest("t");
+        windowFindTest("t");
+        windowFindTest("t");
+        document.getElementById("textContainer").remove();
+    }
+
+    test(() => {
+        // This hides the test output until the test is complete.
+        const testOutputTextContainer = document.getElementById("out");
+        try {
+            testOutputTextContainer.style.display = "none";
+            testBody();
+        } finally {
+            testOutputTextContainer.style.display = "block";
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5166,6 +5166,9 @@ Vector<JS::Handle<DOM::Range>> Document::find_matching_text(String const& query,
         return text_blocks;
     };
 
+    // Ensure the layout tree exists before searching for text matches.
+    update_layout();
+
     auto text_blocks = gather_text_blocks();
     if (text_blocks.is_empty())
         return {};

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1712,4 +1712,26 @@ Window::NamedObjects Window::named_objects(StringView name)
     return objects;
 }
 
+bool Window::find(String const& string)
+{
+    if (string.is_empty())
+        return false;
+
+    auto& page = this->page();
+    Optional<Page::FindInPageResult> result;
+    if (auto last_query = page.last_find_in_page_query(); last_query.has_value() && last_query->string == string) {
+        result = page.find_in_page_next_match();
+    } else {
+        Page::FindInPageQuery query {
+            string,
+            CaseSensitivity::CaseInsensitive,
+            Page::WrapAround::No,
+        };
+
+        result = page.find_in_page(query);
+    }
+
+    return result.has_value() && result->total_match_count.has_value() && *result->total_match_count > 0;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -233,6 +233,8 @@ public:
     [[nodiscard]] Vector<FlyString> supported_property_names() const override;
     [[nodiscard]] WebIDL::ExceptionOr<JS::Value> named_item_value(FlyString const&) const override;
 
+    bool find(String const& string);
+
 private:
     explicit Window(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -113,6 +113,9 @@ interface Window : EventTarget {
 
     undefined captureEvents();
     undefined releaseEvents();
+
+    // This function is non-standard.
+    boolean find(optional DOMString string = "");
 };
 Window includes AnimationFrameProvider;
 Window includes GlobalEventHandlers;

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -619,15 +619,21 @@ Page::FindInPageResult Page::perform_find_in_page_query(FindInPageQuery const& q
 
     if (direction.has_value()) {
         if (direction.value() == SearchDirection::Forward) {
-            if (m_find_in_page_match_index >= all_matches.size() - 1)
+            if (m_find_in_page_match_index >= all_matches.size() - 1) {
+                if (query.wrap_around == WrapAround::No)
+                    return {};
                 m_find_in_page_match_index = 0;
-            else
+            } else {
                 m_find_in_page_match_index++;
+            }
         } else {
-            if (m_find_in_page_match_index == 0)
+            if (m_find_in_page_match_index == 0) {
+                if (query.wrap_around == WrapAround::No)
+                    return {};
                 m_find_in_page_match_index = all_matches.size() - 1;
-            else
+            } else {
                 m_find_in_page_match_index--;
+            }
         }
     }
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -206,6 +206,7 @@ public:
     FindInPageResult find_in_page(FindInPageQuery const&);
     FindInPageResult find_in_page_next_match();
     FindInPageResult find_in_page_previous_match();
+    Optional<FindInPageQuery> last_find_in_page_query() const { return m_last_find_in_page_query; }
 
 private:
     explicit Page(JS::NonnullGCPtr<PageClient>);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -190,9 +190,14 @@ public:
 
     void clear_selection();
 
+    enum class WrapAround {
+        Yes,
+        No,
+    };
     struct FindInPageQuery {
         String string {};
         CaseSensitivity case_sensitivity { CaseSensitivity::CaseInsensitive };
+        WrapAround wrap_around { WrapAround::Yes };
     };
     struct FindInPageResult {
         size_t current_match_index { 0 };


### PR DESCRIPTION
This is a non-standard API that other browsers implement, which highlights matching text in the current window.

This is just a thin wrapper around our find in page functionality, the main motivation for adding this API is that it allows us to write tests for our find in page implementation.