### PR TITLE
LibCore+LibWeb: Use Metal backend for Skia painter on macOS

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1288,7 +1288,6 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 
     static constexpr size_t BITS_PER_COMPONENT = 8;
     static constexpr size_t BITS_PER_PIXEL = 32;
-    static constexpr size_t COMPONENTS_PER_PIXEL = 4;
 
     auto* context = [[NSGraphicsContext currentContext] CGContext];
     CGContextSaveGState(context);
@@ -1309,7 +1308,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         bitmap_size.height(),
         BITS_PER_COMPONENT,
         BITS_PER_PIXEL,
-        COMPONENTS_PER_PIXEL * bitmap.width(),
+        bitmap.pitch(),
         CGColorSpaceCreateDeviceRGB(),
         kCGBitmapByteOrder32Little | kCGImageAlphaFirst,
         provider,

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -403,7 +403,7 @@ void WebContentView::paintEvent(QPaintEvent*)
     }
 
     if (bitmap) {
-        QImage q_image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), QImage::Format_RGB32);
+        QImage q_image(bitmap->scanline_u8(0), bitmap->width(), bitmap->height(), bitmap->pitch(), QImage::Format_RGB32);
         painter.drawImage(QPoint(0, 0), q_image, QRect(0, 0, bitmap_size.width(), bitmap_size.height()));
 
         if (bitmap_size.width() < width()) {

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -85,6 +85,7 @@ endif()
 
 if (APPLE)
     list(APPEND SOURCES IOSurface.cpp)
+    list(APPEND SOURCES MetalContext.mm)
 endif()
 
 serenity_lib(LibCore core)
@@ -96,6 +97,7 @@ if (APPLE)
     target_link_libraries(LibCore PUBLIC "-framework CoreServices")
     target_link_libraries(LibCore PUBLIC "-framework Foundation")
     target_link_libraries(LibCore PUBLIC "-framework IOSurface")
+    target_link_libraries(LibCore PUBLIC "-framework Metal")
 endif()
 
 if (ANDROID)

--- a/Userland/Libraries/LibCore/IOSurface.cpp
+++ b/Userland/Libraries/LibCore/IOSurface.cpp
@@ -124,4 +124,9 @@ void* IOSurfaceHandle::data() const
     return IOSurfaceGetBaseAddress(m_ref_wrapper->ref);
 }
 
+void* IOSurfaceHandle::core_foundation_pointer() const
+{
+    return m_ref_wrapper->ref;
+}
+
 }

--- a/Userland/Libraries/LibCore/IOSurface.cpp
+++ b/Userland/Libraries/LibCore/IOSurface.cpp
@@ -114,6 +114,11 @@ size_t IOSurfaceHandle::bytes_per_element() const
     return IOSurfaceGetBytesPerElement(m_ref_wrapper->ref);
 }
 
+size_t IOSurfaceHandle::bytes_per_row() const
+{
+    return IOSurfaceGetBytesPerRow(m_ref_wrapper->ref);
+}
+
 void* IOSurfaceHandle::data() const
 {
     return IOSurfaceGetBaseAddress(m_ref_wrapper->ref);

--- a/Userland/Libraries/LibCore/IOSurface.h
+++ b/Userland/Libraries/LibCore/IOSurface.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Noncopyable.h>
+#include <AK/OwnPtr.h>
 #include <LibCore/MachPort.h>
 
 namespace Core {
@@ -27,6 +28,7 @@ public:
     size_t width() const;
     size_t height() const;
     size_t bytes_per_element() const;
+    size_t bytes_per_row() const;
     void* data() const;
 
     ~IOSurfaceHandle();

--- a/Userland/Libraries/LibCore/IOSurface.h
+++ b/Userland/Libraries/LibCore/IOSurface.h
@@ -31,6 +31,8 @@ public:
     size_t bytes_per_row() const;
     void* data() const;
 
+    void* core_foundation_pointer() const;
+
     ~IOSurfaceHandle();
 
 private:

--- a/Userland/Libraries/LibCore/MetalContext.h
+++ b/Userland/Libraries/LibCore/MetalContext.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if !defined(AK_OS_MACOS)
+static_assert(false, "This file must only be used for macOS");
+#endif
+
+#include <AK/Forward.h>
+#include <LibCore/IOSurface.h>
+
+namespace Core {
+
+class MetalTexture {
+public:
+    virtual void const* texture() const = 0;
+    virtual size_t width() const = 0;
+    virtual size_t height() const = 0;
+
+    virtual ~MetalTexture() {};
+};
+
+class MetalContext {
+public:
+    virtual void const* device() const = 0;
+    virtual void const* queue() const = 0;
+
+    virtual OwnPtr<MetalTexture> create_texture_from_iosurface(IOSurfaceHandle const&) = 0;
+
+    virtual ~MetalContext() {};
+};
+
+OwnPtr<MetalContext> get_metal_context();
+
+}

--- a/Userland/Libraries/LibCore/MetalContext.mm
+++ b/Userland/Libraries/LibCore/MetalContext.mm
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/OwnPtr.h>
+#include <LibCore/MetalContext.h>
+
+#define FixedPoint FixedPointMacOS
+#define Duration DurationMacOS
+#include <Metal/Metal.h>
+#undef FixedPoint
+#undef Duration
+
+namespace Core {
+
+class MetalTextureImpl final : public MetalTexture {
+public:
+    MetalTextureImpl(id<MTLTexture> texture)
+        : m_texture(texture)
+    {
+    }
+
+    void const* texture() const override { return m_texture; }
+    size_t width() const override { return m_texture.width; }
+    size_t height() const override { return m_texture.height; }
+
+    virtual ~MetalTextureImpl()
+    {
+        [m_texture release];
+    }
+
+private:
+    id<MTLTexture> m_texture;
+};
+
+class MetalContextImpl final : public MetalContext {
+public:
+    MetalContextImpl(id<MTLDevice> device, id<MTLCommandQueue> queue)
+        : m_device(device)
+        , m_queue(queue)
+    {
+    }
+
+    void const* device() const override { return m_device; }
+    void const* queue() const override { return m_queue; }
+
+    OwnPtr<MetalTexture> create_texture_from_iosurface(IOSurfaceHandle const& iosurface) override
+    {
+        auto* const descriptor = [[MTLTextureDescriptor alloc] init];
+        descriptor.pixelFormat = MTLPixelFormatBGRA8Unorm;
+        descriptor.width = iosurface.width();
+        descriptor.height = iosurface.height();
+        descriptor.storageMode = MTLStorageModeShared;
+        descriptor.usage = MTLTextureUsageRenderTarget | MTLTextureUsageShaderRead;
+
+        id<MTLTexture> texture = [m_device newTextureWithDescriptor:descriptor iosurface:(IOSurfaceRef)iosurface.core_foundation_pointer() plane:0];
+        [descriptor release];
+        return make<MetalTextureImpl>(texture);
+    }
+
+    virtual ~MetalContextImpl() override
+    {
+        [m_queue release];
+        [m_device release];
+    }
+
+private:
+    id<MTLDevice> m_device;
+    id<MTLCommandQueue> m_queue;
+};
+
+OwnPtr<MetalContext> get_metal_context()
+{
+    auto device = MTLCreateSystemDefaultDevice();
+    if (!device) {
+        dbgln("Failed to create Metal device");
+        return {};
+    }
+
+    auto queue = [device newCommandQueue];
+    if (!queue) {
+        dbgln("Failed to create Metal command queue");
+        [device release];
+        return {};
+    }
+
+    return make<MetalContextImpl>(device, queue);
+}
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -533,6 +533,7 @@ set(SOURCES
     Page/Page.cpp
     Painting/AudioPaintable.cpp
     Painting/BackgroundPainting.cpp
+    Painting/BackingStore.cpp
     Painting/BorderRadiiData.cpp
     Painting/BorderPainting.cpp
     Painting/BorderRadiusCornerClipper.cpp

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -24,6 +24,7 @@ class XMLDocumentBuilder;
 }
 
 namespace Web::Painting {
+class BackingStore;
 class DisplayListRecorder;
 class SVGGradientPaintStyle;
 using PaintStyle = RefPtr<SVGGradientPaintStyle>;

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1174,8 +1174,10 @@ JS::GCPtr<DOM::Node> TraversableNavigable::currently_focused_area()
     return candidate;
 }
 
-void TraversableNavigable::paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap& target, Web::PaintOptions paint_options)
+void TraversableNavigable::paint(Web::DevicePixelRect const& content_rect, Painting::BackingStore& backing_store, Web::PaintOptions paint_options)
 {
+    auto& target = backing_store.bitmap();
+
     Painting::DisplayList display_list;
     Painting::DisplayListRecorder display_list_recorder(display_list);
 

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -12,7 +12,12 @@
 #include <LibWeb/HTML/SessionHistoryTraversalQueue.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <WebContent/BackingStoreManager.h>
+
+#ifdef AK_OS_MACOS
+#    include <LibCore/MetalContext.h>
+#endif
 
 namespace Web::HTML {
 
@@ -124,6 +129,11 @@ private:
     JS::NonnullGCPtr<SessionHistoryTraversalQueue> m_session_history_traversal_queue;
 
     String m_window_handle;
+
+#ifdef AK_OS_MACOS
+    OwnPtr<Web::Painting::SkiaBackendContext> m_skia_backend_context;
+    OwnPtr<Core::MetalContext> m_metal_context;
+#endif
 };
 
 struct BrowsingContextAndDocument {

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -12,6 +12,7 @@
 #include <LibWeb/HTML/SessionHistoryTraversalQueue.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/Page/Page.h>
+#include <WebContent/BackingStoreManager.h>
 
 namespace Web::HTML {
 
@@ -85,7 +86,7 @@ public:
 
     [[nodiscard]] JS::GCPtr<DOM::Node> currently_focused_area();
 
-    void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions);
+    void paint(Web::DevicePixelRect const&, Painting::BackingStore&, Web::PaintOptions);
 
 private:
     TraversableNavigable(JS::NonnullGCPtr<Page>);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -304,7 +304,7 @@ public:
     virtual CSS::PreferredContrast preferred_contrast() const = 0;
     virtual CSS::PreferredMotion preferred_motion() const = 0;
     virtual void paint_next_frame() = 0;
-    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, PaintOptions = {}) = 0;
+    virtual void paint(DevicePixelRect const&, Painting::BackingStore&, PaintOptions = {}) = 0;
     virtual void page_did_change_title(ByteString const&) { }
     virtual void page_did_change_url(URL::URL const&) { }
     virtual void page_did_request_navigate_back() { }

--- a/Userland/Libraries/LibWeb/Painting/BackingStore.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackingStore.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Bitmap.h>
+#include <LibWeb/Painting/BackingStore.h>
+
+namespace Web::Painting {
+
+BitmapBackingStore::BitmapBackingStore(RefPtr<Gfx::Bitmap> bitmap)
+    : m_bitmap(move(bitmap))
+{
+}
+
+#ifdef AK_OS_MACOS
+IOSurfaceBackingStore::IOSurfaceBackingStore(Core::IOSurfaceHandle&& iosurface_handle)
+    : m_iosurface_handle(move(iosurface_handle))
+{
+    auto bytes_per_row = m_iosurface_handle.bytes_per_row();
+    auto bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, size(), bytes_per_row, m_iosurface_handle.data());
+    m_bitmap_wrapper = bitmap.release_value();
+}
+
+Gfx::IntSize IOSurfaceBackingStore::size() const
+{
+    return { m_iosurface_handle.width(), m_iosurface_handle.height() };
+}
+#endif
+
+};

--- a/Userland/Libraries/LibWeb/Painting/BackingStore.h
+++ b/Userland/Libraries/LibWeb/Painting/BackingStore.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/Noncopyable.h>
+#include <LibGfx/Size.h>
+
+#ifdef AK_OS_MACOS
+#    include <LibCore/IOSurface.h>
+#endif
+
+namespace Web::Painting {
+
+class BackingStore {
+    AK_MAKE_NONCOPYABLE(BackingStore);
+
+public:
+    virtual Gfx::IntSize size() const = 0;
+    virtual Gfx::Bitmap& bitmap() const = 0;
+
+    BackingStore() {};
+    virtual ~BackingStore() {};
+};
+
+class BitmapBackingStore final : public BackingStore {
+public:
+    BitmapBackingStore(RefPtr<Gfx::Bitmap>);
+
+    Gfx::IntSize size() const override { return m_bitmap->size(); }
+    Gfx::Bitmap& bitmap() const override { return *m_bitmap; }
+
+private:
+    RefPtr<Gfx::Bitmap> m_bitmap;
+};
+
+#ifdef AK_OS_MACOS
+class IOSurfaceBackingStore final : public BackingStore {
+public:
+    IOSurfaceBackingStore(Core::IOSurfaceHandle&&);
+
+    Gfx::IntSize size() const override;
+
+    Core::IOSurfaceHandle& iosurface_handle() { return m_iosurface_handle; }
+    Gfx::Bitmap& bitmap() const override { return *m_bitmap_wrapper; }
+
+private:
+    Core::IOSurfaceHandle m_iosurface_handle;
+    RefPtr<Gfx::Bitmap> m_bitmap_wrapper;
+};
+#endif
+
+}

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -76,7 +76,7 @@ public:
     virtual CSS::PreferredMotion preferred_motion() const override { return m_host_page->client().preferred_motion(); }
     virtual void request_file(FileRequest) override { }
     virtual void paint_next_frame() override { }
-    virtual void paint(DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override { }
+    virtual void paint(DevicePixelRect const&, Painting::BackingStore&, Web::PaintOptions = {}) override { }
     virtual void schedule_repaint() override { }
     virtual bool is_ready_to_paint() const override { return true; }
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -418,8 +418,10 @@ void ViewImplementation::did_allocate_iosurface_backing_stores(i32 front_id, Cor
     auto front_size = Gfx::IntSize { front_iosurface.width(), front_iosurface.height() };
     auto back_size = Gfx::IntSize { back_iosurface.width(), back_iosurface.height() };
 
-    auto front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, front_size, front_size.width() * front_iosurface.bytes_per_element(), front_iosurface.data(), [handle = move(front_iosurface)] {});
-    auto back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, back_size, back_size.width() * back_iosurface.bytes_per_element(), back_iosurface.data(), [handle = move(back_iosurface)] {});
+    auto bytes_per_row = front_iosurface.bytes_per_row();
+
+    auto front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, front_size, bytes_per_row, front_iosurface.data(), [handle = move(front_iosurface)] {});
+    auto back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, back_size, bytes_per_row, back_iosurface.data(), [handle = move(back_iosurface)] {});
 
     m_client_state.front_bitmap.bitmap = front_bitmap.release_value_but_fixme_should_propagate_errors();
     m_client_state.front_bitmap.id = front_id;

--- a/Userland/Services/WebContent/BackingStoreManager.h
+++ b/Userland/Services/WebContent/BackingStoreManager.h
@@ -8,6 +8,7 @@
 
 #include <LibCore/Forward.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BackingStore.h>
 #include <WebContent/Forward.h>
 
 namespace WebContent {
@@ -26,7 +27,7 @@ public:
     void reallocate_backing_stores(Gfx::IntSize);
     void restart_resize_timer();
 
-    RefPtr<Gfx::Bitmap> back_bitmap() { return m_back_bitmap; }
+    Web::Painting::BackingStore* back_store() { return m_back_store.ptr(); }
     i32 front_id() const { return m_front_bitmap_id; }
 
     void swap_back_and_front();
@@ -38,8 +39,8 @@ private:
 
     i32 m_front_bitmap_id { -1 };
     i32 m_back_bitmap_id { -1 };
-    RefPtr<Gfx::Bitmap> m_front_bitmap;
-    RefPtr<Gfx::Bitmap> m_back_bitmap;
+    OwnPtr<Web::Painting::BackingStore> m_front_store;
+    OwnPtr<Web::Painting::BackingStore> m_back_store;
     int m_next_bitmap_id { 0 };
 
     RefPtr<Core::Timer> m_backing_store_shrink_timer;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -44,7 +44,7 @@ public:
     ErrorOr<void> connect_to_webdriver(ByteString const& webdriver_ipc_path);
 
     virtual void paint_next_frame() override;
-    virtual void paint(Web::DevicePixelRect const& content_rect, Gfx::Bitmap&, Web::PaintOptions = {}) override;
+    virtual void paint(Web::DevicePixelRect const& content_rect, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
 
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport_size(Web::DevicePixelSize const&);

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1802,7 +1802,10 @@ Messages::WebDriverClient::TakeScreenshotResponse WebDriverConnection::take_scre
     auto root_rect = calculate_absolute_rect_of_element(m_page_client->page(), *document->document_element());
 
     auto encoded_string = TRY(Web::WebDriver::capture_element_screenshot(
-        [&](auto const& rect, auto& bitmap) { m_page_client->paint(rect.template to_type<Web::DevicePixels>(), bitmap); },
+        [&](auto const& rect, auto& bitmap) {
+            auto backing_store = Web::Painting::BitmapBackingStore(bitmap);
+            m_page_client->paint(rect.template to_type<Web::DevicePixels>(), backing_store);
+        },
         m_page_client->page(),
         *document->document_element(),
         root_rect));
@@ -1835,7 +1838,10 @@ Messages::WebDriverClient::TakeElementScreenshotResponse WebDriverConnection::ta
     auto element_rect = calculate_absolute_rect_of_element(m_page_client->page(), *element);
 
     auto encoded_string = TRY(Web::WebDriver::capture_element_screenshot(
-        [&](auto const& rect, auto& bitmap) { m_page_client->paint(rect.template to_type<Web::DevicePixels>(), bitmap); },
+        [&](auto const& rect, auto& bitmap) {
+            auto backing_store = Web::Painting::BitmapBackingStore(bitmap);
+            m_page_client->paint(rect.template to_type<Web::DevicePixels>(), backing_store);
+        },
         m_page_client->page(),
         *element,
         element_rect));

--- a/Userland/Services/WebWorker/PageHost.cpp
+++ b/Userland/Services/WebWorker/PageHost.cpp
@@ -77,7 +77,7 @@ Web::CSS::PreferredMotion PageHost::preferred_motion() const
     return Web::CSS::PreferredMotion::Auto;
 }
 
-void PageHost::paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions)
+void PageHost::paint(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions)
 {
 }
 

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -32,7 +32,7 @@ public:
     virtual Web::CSS::PreferredContrast preferred_contrast() const override;
     virtual Web::CSS::PreferredMotion preferred_motion() const override;
     virtual void paint_next_frame() override {};
-    virtual void paint(Web::DevicePixelRect const&, Gfx::Bitmap&, Web::PaintOptions = {}) override;
+    virtual void paint(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;
     virtual void schedule_repaint() override {};
     virtual bool is_ready_to_paint() const override { return true; }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,9 +9,21 @@
     "libjpeg-turbo",
     {
       "name": "libpng",
-      "features": [ "apng" ]
+      "features": [
+        "apng"
+      ]
     },
-    "skia",
+    {
+      "name": "skia",
+      "platform": "osx",
+      "features": [
+        "metal"
+      ]
+    },
+    {
+      "name": "skia",
+      "platform": "linux | freebsd | openbsd"
+    },
     "sqlite3",
     "woff2"
   ],


### PR DESCRIPTION
If Metal context and IOSurface are available, Skia painter will use
Ganesh GPU backend on macOS, which is noticeably faster than the default
CPU backend.

Painting pipeline:
1. (WebContent) Allocate IOSurface for backing store
2. (WebContent) Allocate MTLTexture that wraps IOSurface
3. (WebContent) Paint into MTLTexture using Skia
4. (Browser) Wrap IOSurface into Gfx::Painter and use
   QPainter/CoreGraphics to blit backing store into viewport.

Things we should improve in the future:
1. Upload textures for images in advance instead of doing that before
   every repaint.
2. Teach AppKit client to read directly from IOSurface instead of
   copying.