### PR TITLE
Tests: Skip `css-keyframe-fill-forwards.html` ref test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -5,3 +5,4 @@ Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-echo.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html
+Ref/css-keyframe-fill-forwards.html


### PR DESCRIPTION
This test is currently causing intermittent CI failures.

Ref: #296