### PR TITLE
UI/Qt: Reduce flicker when populating autocomplete

### DIFF
--- a/Ladybird/Qt/AutoComplete.cpp
+++ b/Ladybird/Qt/AutoComplete.cpp
@@ -124,8 +124,11 @@ ErrorOr<void> AutoComplete::got_network_response(QNetworkReply* reply)
         return Error::from_string_view("Invalid engine name"sv);
     }
 
+    constexpr size_t MAX_AUTOCOMPLETE_RESULTS = 6;
     if (results.is_empty()) {
         results.append(m_query);
+    } else if (results.size() > MAX_AUTOCOMPLETE_RESULTS) {
+        results.shrink(MAX_AUTOCOMPLETE_RESULTS);
     }
 
     m_auto_complete_model->replace_suggestions(move(results));

--- a/Ladybird/Qt/AutoComplete.h
+++ b/Ladybird/Qt/AutoComplete.h
@@ -45,6 +45,13 @@ public:
         endResetModel();
     }
 
+    void replace_suggestions(Vector<String> suggestions)
+    {
+        beginInsertRows({}, m_suggestions.size(), m_suggestions.size());
+        m_suggestions = suggestions;
+        endInsertRows();
+    }
+
 private:
     AK::Vector<String> m_suggestions;
 };
@@ -71,9 +78,9 @@ private:
 
     ErrorOr<void> got_network_response(QNetworkReply* reply);
 
-    ErrorOr<void> parse_google_autocomplete(Vector<JsonValue> const&);
-    ErrorOr<void> parse_duckduckgo_autocomplete(Vector<JsonValue> const&);
-    ErrorOr<void> parse_yahoo_autocomplete(JsonObject const&);
+    ErrorOr<Vector<String>> parse_google_autocomplete(Vector<JsonValue> const&);
+    ErrorOr<Vector<String>> parse_duckduckgo_autocomplete(Vector<JsonValue> const&);
+    ErrorOr<Vector<String>> parse_yahoo_autocomplete(JsonObject const&);
 
     QNetworkAccessManager* m_manager;
     AutoCompleteModel* m_auto_complete_model;


### PR DESCRIPTION
Previously, autocomplete was cleared before the results for the current query were retrieved. The new results would then be added when the network request completed. This resulted in a noticable flicker. The results are now updated when the request for the current query is completed.

There is a small behavior change in that the query itself is no longer included in the autocomplete dropdown unless the list would otherwise be empty.

I've also included a commit the number of autocomplete results to 6. This stops there being enough results to require a scrollbar on the dropdown.

Before:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/4e351813-b6d9-459a-b21c-fb4e13b3bc6f


After:


https://github.com/LadybirdBrowser/ladybird/assets/2817754/895d8ac8-60e2-445f-af43-0fc0901c6b0e

