### PR TITLE
LibWeb: Improve find in page performance on large documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5111,65 +5111,13 @@ void Document::set_needs_to_refresh_scroll_state(bool b)
 
 Vector<JS::Handle<DOM::Range>> Document::find_matching_text(String const& query, CaseSensitivity case_sensitivity)
 {
-    if (!document_element() || !document_element()->layout_node())
+    if (!layout_node())
         return {};
-
-    struct TextPosition {
-        DOM::Text& dom_node;
-        size_t start_offset { 0 };
-    };
-
-    struct TextBlock {
-        String text;
-        Vector<TextPosition> positions;
-    };
-
-    auto gather_text_blocks = [&]() -> Vector<TextBlock> {
-        StringBuilder builder;
-        size_t current_start_position = 0;
-        Vector<TextPosition> text_positions;
-        Vector<TextBlock> text_blocks;
-        document_element()->layout_node()->for_each_in_inclusive_subtree([&](auto const& layout_node) {
-            if (layout_node.display().is_none() || !layout_node.paintable() || !layout_node.paintable()->is_visible())
-                return TraversalDecision::Continue;
-
-            if (layout_node.is_block_container()) {
-                if (!builder.is_empty()) {
-                    text_blocks.append({ builder.to_string_without_validation(), text_positions });
-                    current_start_position = 0;
-                    text_positions.clear_with_capacity();
-                    builder.clear();
-                }
-                return TraversalDecision::Continue;
-            }
-
-            if (layout_node.is_text_node()) {
-                auto const& text_node = verify_cast<Layout::TextNode>(layout_node);
-                auto& dom_node = const_cast<DOM::Text&>(text_node.dom_node());
-                if (text_positions.is_empty()) {
-                    text_positions.empend(dom_node);
-                } else {
-                    text_positions.empend(dom_node, current_start_position);
-                }
-
-                auto const& current_node_text = text_node.text_for_rendering();
-                current_start_position += current_node_text.bytes_as_string_view().length();
-                builder.append(move(current_node_text));
-            }
-
-            return TraversalDecision::Continue;
-        });
-
-        if (!builder.is_empty())
-            text_blocks.append({ builder.to_string_without_validation(), text_positions });
-
-        return text_blocks;
-    };
 
     // Ensure the layout tree exists before searching for text matches.
     update_layout();
 
-    auto text_blocks = gather_text_blocks();
+    auto const& text_blocks = layout_node()->text_blocks();
     if (text_blocks.is_empty())
         return {};
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5137,10 +5137,8 @@ Vector<JS::Handle<DOM::Range>> Document::find_matching_text(String const& query,
             for (; i < text_block.positions.size() - 1 && match_index.value() > text_block.positions[i + 1].start_offset; ++i)
                 match_start_position = &text_block.positions[i + 1];
 
-            auto range = create_range();
             auto start_position = match_index.value() - match_start_position->start_offset;
             auto& start_dom_node = match_start_position->dom_node;
-            (void)range->set_start(start_dom_node, start_position);
 
             auto* match_end_position = match_start_position;
             for (; i < text_block.positions.size() - 1 && (match_index.value() + query.bytes_as_string_view().length() > text_block.positions[i + 1].start_offset); ++i)
@@ -5148,9 +5146,8 @@ Vector<JS::Handle<DOM::Range>> Document::find_matching_text(String const& query,
 
             auto& end_dom_node = match_end_position->dom_node;
             auto end_position = match_index.value() + query.bytes_as_string_view().length() - match_end_position->start_offset;
-            (void)range->set_end(end_dom_node, end_position);
 
-            matches.append(range);
+            matches.append(Range::create(start_dom_node, start_position, end_dom_node, end_position));
             match_start_position = match_end_position;
             offset = match_index.value() + query.bytes_as_string_view().length() + 1;
             if (offset >= text.bytes_as_string_view().length())

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -27,4 +27,67 @@ JS::GCPtr<Painting::Paintable> Viewport::create_paintable() const
     return Painting::ViewportPaintable::create(*this);
 }
 
+void Viewport::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    if (!m_text_blocks.has_value())
+        return;
+
+    for (auto& text_block : *m_text_blocks) {
+        for (auto& text_position : text_block.positions)
+            visitor.visit(text_position.dom_node);
+    }
+}
+
+Vector<Viewport::TextBlock> const& Viewport::text_blocks()
+{
+    if (!m_text_blocks.has_value())
+        update_text_blocks();
+
+    return *m_text_blocks;
+}
+
+void Viewport::update_text_blocks()
+{
+    StringBuilder builder;
+    size_t current_start_position = 0;
+    Vector<TextPosition> text_positions;
+    Vector<TextBlock> text_blocks;
+    for_each_in_inclusive_subtree([&](auto const& layout_node) {
+        if (layout_node.display().is_none() || !layout_node.paintable() || !layout_node.paintable()->is_visible())
+            return TraversalDecision::Continue;
+
+        if (layout_node.is_box()) {
+            if (!builder.is_empty()) {
+                text_blocks.append({ builder.to_string_without_validation(), text_positions });
+                current_start_position = 0;
+                text_positions.clear_with_capacity();
+                builder.clear();
+            }
+            return TraversalDecision::Continue;
+        }
+
+        if (layout_node.is_text_node()) {
+            auto const& text_node = verify_cast<Layout::TextNode>(layout_node);
+            auto& dom_node = const_cast<DOM::Text&>(text_node.dom_node());
+            if (text_positions.is_empty()) {
+                text_positions.empend(dom_node);
+            } else {
+                text_positions.empend(dom_node, current_start_position);
+            }
+
+            auto const& current_node_text = text_node.text_for_rendering();
+            current_start_position += current_node_text.bytes_as_string_view().length();
+            builder.append(move(current_node_text));
+        }
+
+        return TraversalDecision::Continue;
+    });
+
+    if (!builder.is_empty())
+        text_blocks.append({ builder.to_string_without_validation(), text_positions });
+
+    m_text_blocks = move(text_blocks);
+}
+
 }

--- a/Userland/Libraries/LibWeb/Layout/Viewport.h
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.h
@@ -19,12 +19,28 @@ public:
     explicit Viewport(DOM::Document&, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~Viewport() override;
 
+    struct TextPosition {
+        JS::NonnullGCPtr<DOM::Text> dom_node;
+        size_t start_offset { 0 };
+    };
+    struct TextBlock {
+        String text;
+        Vector<TextPosition> positions;
+    };
+    Vector<TextBlock> const& text_blocks();
+
     const DOM::Document& dom_node() const { return static_cast<const DOM::Document&>(*Node::dom_node()); }
+
+    virtual void visit_edges(Visitor&) override;
 
 private:
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
+    void update_text_blocks();
+
     virtual bool is_viewport() const override { return true; }
+
+    Optional<Vector<TextBlock>> m_text_blocks;
 };
 
 template<>


### PR DESCRIPTION
This PR makes 2 changes, which greatly improve the performance of find in page on pages with a lot of text. 

See the descriptions of the individual commits for details.

There is still more work that could be done to improve performance further. Case-insensitive matching is still slow on documents containing very large text blocks, such as [this copy](https://raw.githubusercontent.com/mmcky/nyu-econ-370/master/notebooks/data/book-war-and-peace.txt) of War & Peace.

I've included a test on one of the longest articles on Wikipedia.

Before:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/b825e5ac-9d25-4225-a1d3-c0bbbd2dd981


After:


https://github.com/LadybirdBrowser/ladybird/assets/2817754/d0bd32ae-747f-4999-ad8e-103509755cac

Note: For both of the above tests, I waited a good 30 seconds for the page to finish loading before doing the query. Find in page still performs poorly if done while the document is partially loaded.