### PR TITLE
UI/Qt: Ignore tab bar middle clicks if the user didn't click on a tab

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -1156,8 +1156,10 @@ bool BrowserWindow::eventFilter(QObject* obj, QEvent* event)
         if (mouse_event->button() == Qt::MouseButton::MiddleButton) {
             if (obj == m_tabs_container) {
                 auto const tab_index = m_tabs_container->tabBar()->tabAt(mouse_event->pos());
-                close_tab(tab_index);
-                return true;
+                if (tab_index != -1) {
+                    close_tab(tab_index);
+                    return true;
+                }
             }
         }
     }


### PR DESCRIPTION
This avoids a segfault that would previously occur when middle clicking to close a tab if only 1 tab was open.

Fixes #310