### PR TITLE
Meta: Handle LAGOM_EXECUTABLE in gdb command properly

### DIFF
--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -161,6 +161,13 @@ run_gdb() {
     if [ "$PASS_ARG_TO_GDB" != "" ]; then
         GDB_ARGS+=( "$PASS_ARG_TO_GDB" )
     fi
+    if [ "$LAGOM_EXECUTABLE" = "ladybird" ]; then
+        if [ "$(uname -s)" = "Darwin" ]; then
+            LAGOM_EXECUTABLE="Ladybird.app"
+        else
+            LAGOM_EXECUTABLE="Ladybird"
+        fi
+    fi
     gdb "$BUILD_DIR/bin/$LAGOM_EXECUTABLE" "${GDB_ARGS[@]}"
 }
 


### PR DESCRIPTION
Hi,

In the [documentation](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/BuildInstructionsLadybird.md#using-ladybirdsh), it says

> The simplest way to build and run ladybird is via the ladybird.sh script:
> ```bash
> # From /path/to/ladybird
> ./Meta/ladybird.sh run ladybird
> ./Meta/ladybird.sh gdb ladybird
> ```

So when the user types `gdb ladybird`, we need to convert `LAGOM_EXECUTABLE` to the package name.

Otherwise, `gdb` will throw an error: `/path/to/ladybird/Build/ladybird/bin/ladybird: No such file or directory.`

Thanks