### PR TITLE
Meta: Remove myself from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,12 +1,4 @@
-/AK/CircularBuffer.* @timschumi
-/AK/MaybeOwned.h @timschumi
-/AK/*Stream.* @timschumi
 /Lagom/Tools/CodeGenerators/LibWeb @AtkinsSJ
-/Tests/LibCompress @timschumi
-/Userland/Libraries/LibArchive @timschumi
-/Userland/Libraries/LibCompress @timschumi
-/Userland/Libraries/LibCore/File.* @timschumi
-/Userland/Libraries/LibCore/Socket.* @timschumi
 /Userland/Libraries/LibCrypto @alimpfard
 /Userland/Libraries/LibHTTP @alimpfard
 /Userland/Libraries/LibJS/Runtime/Intl @trflynn89
@@ -21,8 +13,4 @@
 /Userland/Libraries/LibXML @alimpfard
 /Userland/Services/RequestServer @alimpfard
 /Userland/Services/WebDriver @trflynn89
-/Userland/Utilities/gzip.cpp @timschumi
-/Userland/Utilities/lzcat.cpp @timschumi
-/Userland/Utilities/tar.cpp @timschumi
 /Userland/Utilities/wasm.cpp @alimpfard
-/Userland/Utilities/xzcat.cpp @timschumi


### PR DESCRIPTION
I don't expect Ladybird to be the upstream to any of these (some of them even having been removed already), so it's not much use for me to be notified on any unrelated changes.

Of course, if anything comes up Ladybird-side that actually requires my input, I'll be happy to provide that.