### PR TITLE
Meta+CMake: Improve macOS debugging experience

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -204,8 +204,22 @@ After running Ladybird as suggested above with `./Meta/ladybird.sh run ladybird`
 
 Now breakpoints, stepping and variable inspection will work.
 
-### Debugging with Xcode on macOS
+### Debugging with Xcode or Instruments on macOS
 
+If all you want to do is use Instruments, then an Xcode project is not required.
+
+Simply run the `ladybird.sh` script as normal, and then make sure to codesign the Ladybird binary with the proper entitlements to allow Instruments to attach to it.
+
+```
+./Meta/ladybird.sh build
+ ninja -C build/ladybird apply-debug-entitlements
+ # or
+ codesign -s - -v -f --entitlements Meta/debug.plist Build/ladybird/bin/Ladybird.app
+```
+
+Now you can open the Instruments app and point it to the Ladybird app bundle.
+
+If you want to use Xcode itself for debugging, you will need to generate an Xcode project.
 The `ladybird.sh` build script does not know how to generate Xcode projects, so creating the project must be done manually.
 
 ```

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -107,10 +107,17 @@ add_custom_target(run
     VERBATIM
 )
 
-add_custom_target(debug-ladybird
-    COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" gdb -ex "set follow-fork-mode child" "$<TARGET_FILE:ladybird>"
-    USES_TERMINAL
-)
+if (APPLE)
+    add_custom_target(debug-ladybird
+        COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" lldb "$<TARGET_BUNDLE_DIR:ladybird>"
+        USES_TERMINAL
+    )
+else()
+    add_custom_target(debug-ladybird
+        COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" gdb "$<TARGET_FILE:ladybird>"
+        USES_TERMINAL
+    )
+endif()
 
 add_subdirectory(ImageDecoder)
 add_subdirectory(RequestServer)

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -34,6 +34,17 @@ function(create_ladybird_bundle target_name)
         add_custom_command(TARGET ${target_name} POST_BUILD
             COMMAND "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" "${bundle_dir}/Contents/lib"
         )
+
+        if (NOT CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
+            add_custom_command(TARGET ${target_name} POST_BUILD
+                COMMAND codesign -s - -v -f --entitlements "${LADYBIRD_SOURCE_DIR}/Meta/debug.plist" "${bundle_dir}"
+            )
+        else()
+            add_custom_target(apply-debug-entitlements
+                COMMAND codesign -s - -v -f --entitlements "${LADYBIRD_SOURCE_DIR}/Meta/debug.plist" "${bundle_dir}"
+                USES_TERMINAL
+            )
+        endif()
     endif()
 
     if (APPLE)

--- a/Meta/debug.plist
+++ b/Meta/debug.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -142,6 +142,14 @@ run_gdb() {
     local GDB_ARGS=()
     local PASS_ARG_TO_GDB=""
     local LAGOM_EXECUTABLE=""
+    local GDB=gdb
+    if ! command -v "$GDB" > /dev/null 2>&1; then
+      GDB=lldb
+      if ! command -v "$GDB" > /dev/null 2>&1; then
+        die "Please install gdb or lldb!"
+      fi
+    fi
+
     for arg in "${CMD_ARGS[@]}"; do
         if [ "$PASS_ARG_TO_GDB" != "" ]; then
             GDB_ARGS+=( "$PASS_ARG_TO_GDB" "$arg" )
@@ -168,7 +176,7 @@ run_gdb() {
             LAGOM_EXECUTABLE="Ladybird"
         fi
     fi
-    gdb "$BUILD_DIR/bin/$LAGOM_EXECUTABLE" "${GDB_ARGS[@]}"
+    "$GDB" "$BUILD_DIR/bin/$LAGOM_EXECUTABLE" "${GDB_ARGS[@]}"
 }
 
 build_and_run_lagom_target() {


### PR DESCRIPTION
- use lldb instead of gdb
- code sign with get-task-allow in debug builds (or upon request) to make opening the app in Instruments.app easier.