### PR TITLE
Ladybird/Qt: Make trackpad scrolling more bearable

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -715,8 +715,8 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
         auto const& wheel_event = static_cast<QWheelEvent const&>(event);
 
         if (auto pixel_delta = -wheel_event.pixelDelta(); !pixel_delta.isNull()) {
-            wheel_delta_x = pixel_delta.x();
-            wheel_delta_y = pixel_delta.y();
+            wheel_delta_x = static_cast<float>(pixel_delta.x()) * static_cast<float>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
+            wheel_delta_y = static_cast<float>(pixel_delta.y()) * static_cast<float>(QApplication::wheelScrollLines()) * m_device_pixel_ratio;
         } else {
             auto angle_delta = -wheel_event.angleDelta();
             float delta_x = -static_cast<float>(angle_delta.x()) / 120.0f;


### PR DESCRIPTION
This performs the same calculation as is done with angle scrolling.

This makes the trackpad scrolling much more bearable on my Framework 13".

I have to confess though, although I read the documentation, I'm not sure this is how those APIs are meant to be used. I intend to have a look at Kirigami over the course of the week to see how it handles scrolling.