### PR TITLE
LibWasm/WASI: Don't convert enums and u8s into i64

### DIFF
--- a/Userland/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Userland/Libraries/LibWasm/WASI/Wasi.cpp
@@ -909,7 +909,20 @@ ErrorOr<HostFunction> Implementation::function_by_name(StringView name)
 namespace ABI {
 
 template<typename T>
-auto CompatibleValueType = IsOneOf<T, i8, i16, i32>
+struct HostTypeImpl {
+    using Type = T;
+};
+
+template<Enum T>
+struct HostTypeImpl<T> {
+    using Type = UnderlyingType<T>;
+};
+
+template<typename T>
+using HostType = typename HostTypeImpl<T>::Type;
+
+template<typename T>
+auto CompatibleValueType = IsOneOf<HostType<T>, i8, i16, i32, u8, u16>
     ? Wasm::ValueType(Wasm::ValueType::I32)
     : Wasm::ValueType(Wasm::ValueType::I64);
 


### PR DESCRIPTION
Doing so results in incorrect values being created, ultimately leading to traps or errors.

(cherry picked from commit f6c3b333334f7bb5314a844804cb259cf277005e)