### PR TITLE
Ladybird/AppKit: Fix crash on invalid title

### DIFF
--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -339,7 +339,12 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 {
     [[self tabController] onTitleChange:title];
 
-    self.title = Ladybird::string_to_ns_string(title);
+    NSString* converted_title = Ladybird::string_to_ns_string(title);
+    if (converted_title == nil) {
+        NSLog(@"Error converting title to NSString!");
+        converted_title = @"";
+    }
+    self.title = converted_title;
     [self updateTabTitleAndFavicon];
 }
 


### PR DESCRIPTION
When string conversion fails, a nil value will return, that crashes AppKit, when updating the title of the window.
reproducible on: https://twitter.com/awesomekling/status/1690724674018156544 (with spoofed user agent)
