### PR TITLE
UI/AppKit: Make the header buttons more accessible

### DIFF
--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -379,7 +379,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     if (tooltip) {
         [button setToolTip:tooltip];
     }
-    [button setBordered:NO];
+
+    [button setBordered:YES];
 
     return button;
 }


### PR DESCRIPTION
By Setting `setBordered` property on header buttons to `Yes` this path makes the whole button clickable. Previously the only the icon was clickable, now it's easy to click.