### PR TITLE
LibWeb: Use double as the argument for AnimationFrameCallbacks

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -15,7 +15,7 @@
 namespace Web::HTML {
 
 struct AnimationFrameCallbackDriver {
-    using Callback = Function<void(i32)>;
+    using Callback = Function<void(double)>;
 
     AnimationFrameCallbackDriver()
     {


### PR DESCRIPTION
This avoids an unecessary lossy conversion for the current time from double to i32. And avoids an UBSAN failure on macOS that's dependent on the current uptime.