### PR TITLE
LibWeb: Implement popover methods

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -98,6 +98,9 @@
   "open": {
     "argument": ""
   },
+  "popover-open": {
+    "argument": ""
+  },
   "paused": {
     "argument": ""
   },

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -542,6 +542,16 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     case CSS::PseudoClass::Open:
     case CSS::PseudoClass::Closed:
         return matches_open_state_pseudo_class(element, pseudo_class.type == CSS::PseudoClass::Open);
+    case CSS::PseudoClass::PopoverOpen: {
+        // https://html.spec.whatwg.org/#selector-popover-open
+        // The :popover-open pseudo-class is defined to match any HTML element whose popover attribute is not in the no popover state and whose popover visibility state is showing.
+        if (is<HTML::HTMLElement>(element) && element.has_attribute(HTML::AttributeNames::popover)) {
+            auto& html_element = static_cast<HTML::HTMLElement const&>(element);
+            return html_element.popover_visibility_state() == HTML::HTMLElement::PopoverVisibilityState::Showing;
+        }
+
+        return false;
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -211,6 +211,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(ping)                       \
     __ENUMERATE_HTML_ATTRIBUTE(placeholder)                \
     __ENUMERATE_HTML_ATTRIBUTE(playsinline)                \
+    __ENUMERATE_HTML_ATTRIBUTE(popover)                    \
     __ENUMERATE_HTML_ATTRIBUTE(poster)                     \
     __ENUMERATE_HTML_ATTRIBUTE(preload)                    \
     __ENUMERATE_HTML_ATTRIBUTE(readonly)                   \

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -93,7 +93,9 @@ WebIDL::ExceptionOr<void> HTMLDialogElement::show_modal()
     if (!is_connected())
         return WebIDL::InvalidStateError::create(realm(), "Dialog not connected"_fly_string);
 
-    // FIXME: 4. If this is in the popover showing state, then throw an "InvalidStateError" DOMException.
+    // 4. If this is in the popover showing state, then throw an "InvalidStateError" DOMException.
+    if (popover_visibility_state() == PopoverVisibilityState::Showing)
+        return WebIDL::InvalidStateError::create(realm(), "Dialog not connected"_fly_string);
 
     // 5. Add an open attribute to this, whose value is the empty string.
     TRY(set_attribute(AttributeNames::open, {}));

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -30,6 +30,8 @@ public:
     // https://www.w3.org/TR/html-aria/#el-dialog
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::dialog; }
 
+    bool is_modal() { return m_is_modal; }
+
 private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBaseElement.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
+#include <LibWeb/HTML/HTMLDialogElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLLabelElement.h>
 #include <LibWeb/HTML/NavigableContainer.h>
@@ -63,6 +64,7 @@ void HTMLElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_dataset);
     visitor.visit(m_labels);
     visitor.visit(m_attached_internals);
+    visitor.visit(m_popover_invoker);
 }
 
 JS::NonnullGCPtr<DOMStringMap> HTMLElement::dataset()
@@ -671,6 +673,221 @@ WebIDL::ExceptionOr<void> HTMLElement::set_popover(Optional<String> value)
 
     remove_attribute(HTML::AttributeNames::popover);
     return {};
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#check-popover-validity
+WebIDL::ExceptionOr<bool> HTMLElement::check_popover_validity(bool expected_to_be_showing, bool throw_exception, JS::GCPtr<DOM::Document> expected_document)
+{
+    // 1. If element's popover attribute is in the no popover state, then:
+    if (!popover().has_value()) {
+        // 1.1. If throwExceptions is true, then throw a "NotSupportedError" DOMException.
+        if (throw_exception)
+            return WebIDL::NotSupportedError::create(realm(), "Element is not a popover"_fly_string);
+        // 1.2. Return false.
+        return false;
+    }
+
+    // 2. If any of the following are true:
+    // - expectedToBeShowing is true and element's popover visibility state is not showing; or
+    // - expectedToBeShowing is false and element's popover visibility state is not hidden,
+    if ((expected_to_be_showing && m_popover_visibility_state != PopoverVisibilityState::Showing) || (!expected_to_be_showing && m_popover_visibility_state != PopoverVisibilityState::Hidden)) {
+        // then return false.
+        return false;
+    }
+
+    // 3. If any of the following are true:
+    // - element is not connected;
+    // - expectedDocument is not null and element's node document is not expectedDocument;
+    // - element is a dialog element and its is modal flage is set to true; or
+    // - FIXME: element's fullscreen flag is set,
+    // then:
+    // 3.1 If throwExceptions is true, then throw an "InvalidStateError" DOMException.
+    // 3.2 Return false.
+    if (!is_connected() || (expected_document && &document() != expected_document) || (is<HTMLDialogElement>(*this) && verify_cast<HTMLDialogElement>(*this).is_modal())) {
+        if (throw_exception)
+            return WebIDL::InvalidStateError::create(realm(), "Element is not in a valid state to show a popover"_fly_string);
+        return false;
+    }
+
+    // 4. Return true.
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#dom-showpopover
+WebIDL::ExceptionOr<void> HTMLElement::show_popover_for_bindings()
+{
+    // 1. The showPopover() method steps are to run show popover given this, true, and null.
+    return show_popover(true, nullptr);
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#show-popover
+WebIDL::ExceptionOr<void> HTMLElement::show_popover(bool throw_exception, JS::GCPtr<HTMLElement> invoker)
+{
+    // 1. If the result of running check popover validity given element, false, throwExceptions, and null is false, then return.
+    if (!TRY(check_popover_validity(false, throw_exception, nullptr)))
+        return {};
+
+    // 2. Let document be element's node document.
+    auto& document = this->document();
+
+    // 3. Assert: element's popover invoker is null.
+    VERIFY(!m_popover_invoker);
+
+    // 4. Assert: element is not in document's top layer.
+    VERIFY(!in_top_layer());
+
+    // 5. Let nestedShow be element's popover showing or hiding.
+    auto nested_show = m_popover_showing_or_hiding;
+
+    // 6. Set element's popover showing or hiding to true.
+    m_popover_showing_or_hiding = true;
+
+    // 7. Let cleanupShowingFlag be the following steps:
+    auto cleanup_showing_flag = JS::create_heap_function(this->heap(), [&nested_show, this] {
+        // 7.1. If nestedShow is false, then set element's popover showing or hiding to false.
+        if (!nested_show)
+            m_popover_showing_or_hiding = false;
+    });
+
+    // FIXME: 8. If the result of firing an event named beforetoggle, using ToggleEvent, with the cancelable attribute initialized to true, the oldState attribute initialized to "closed", and the newState attribute initialized to "open" at element is false, then run cleanupShowingFlag and return.
+
+    // FIXME: 9. If the result of running check popover validity given element, false, throwExceptions, and document is false, then run cleanupShowingFlag and return.
+
+    // 10. Let shouldRestoreFocus be false.
+    bool should_restore_focus = false;
+
+    // 11. If element's popover attribute is in the auto state, then:
+    if (popover().has_value() && popover().value() == "auto"sv) {
+        // FIXME: 11.1. Let originalType be the value of element's popover attribute.
+        // FIXME: 11.2. Let ancestor be the result of running the topmost popover ancestor algorithm given element, invoker, and true.
+        // FIXME: 11.3. If ancestor is null, then set ancestor to document.
+        // FIXME: 11.4. Run hide all popovers until given ancestor, false, and not nestedShow.
+        // FIXME: 11.5. If originalType is not equal to the value of element's popover attribute, then throw a "InvalidStateError" DOMException.
+        // FIXME: 11.6. If the result of running check popover validity given element, false, throwExceptions, and document is false, then run cleanupShowingFlag and return.
+        // FIXME: 11.7. If the result of running topmost auto popover on document is null, then set shouldRestoreFocus to true.
+        // FIXME: 11.8. Set element's popover close watcher to the result of establishing a close watcher given element's relevant global object, with:
+        // - cancelAction being to return true.
+        // - closeAction being to hide a popover given element, true, true, and false.
+    }
+
+    // FIXME: 12. Set element's previously focused element to null.
+    // FIXME: 13. Let originallyFocusedElement be document's focused area of the document's DOM anchor.
+
+    // 14. Add an element to the top layer given element.
+    document.add_an_element_to_the_top_layer(*this);
+    // 15. Set element's popover visibility state to showing.
+    m_popover_visibility_state = PopoverVisibilityState::Showing;
+    // 16. Set element's popover invoker to invoker.
+    m_popover_invoker = invoker;
+
+    // FIXME: 17. Run the popover focusing steps given element.
+
+    // 18. If shouldRestoreFocus is true and element's popover attribute is not in the no popover state
+    if (should_restore_focus && popover().has_value()) {
+        // FIXME: then set element's previously focused element to originallyFocusedElement.
+    }
+
+    // FIXME: 19. Queue a popover toggle event task given element, "closed", and "open".
+    // 20. Run cleanupShowingFlag.
+    cleanup_showing_flag->function()();
+
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#dom-hidepopover
+WebIDL::ExceptionOr<void> HTMLElement::hide_popover_for_bindings()
+{
+    // The hidePopover() method steps are to run the hide popover algorithm given this, true, true, and true.
+    return hide_popover(true, true, true);
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#hide-popover-algorithm
+WebIDL::ExceptionOr<void> HTMLElement::hide_popover(bool, bool fire_events, bool throw_exceptions)
+{
+    // 1. If the result of running check popover validity given element, true, throwExceptions, and null is false, then return.
+    if (!TRY(check_popover_validity(true, throw_exceptions, nullptr)))
+        return {};
+
+    // 2. Let document be element's node document.
+    auto& document = this->document();
+
+    // 3. Let nestedHide be element's popover showing or hiding.
+    auto nested_hide = m_popover_showing_or_hiding;
+
+    // 4. Set element's popover showing or hiding to true.
+    m_popover_showing_or_hiding = true;
+
+    // 5. If nestedHide is true, then set fireEvents to false.
+    if (nested_hide)
+        fire_events = false;
+
+    // 6. Let cleanupSteps be the following steps:
+    auto cleanup_steps = JS::create_heap_function(this->heap(), [&nested_hide, this] {
+        // 6.1. If nestedHide is false, then set element's popover showing or hiding to false.
+        if (nested_hide)
+            m_popover_showing_or_hiding = false;
+        // FIXME: 6.2. If element's popover close watcher is not null, then:
+        // FIXME: 6.2.1. Destroy element's popover close watcher.
+        // FIXME: 6.2.2. Set element's popover close watcher to null.
+    });
+
+    // 7. If element's popover attribute is in the auto state, then:
+    if (popover().has_value() && popover().value() == "auto"sv) {
+        // FIXME: 7.1. Run hide all popovers until given element, focusPreviousElement, and fireEvents.
+        // FIXME: 7.2. If the result of running check popover validity given element, true, and throwExceptions is false, then run cleanupSteps and return.
+    }
+    // FIXME: 8. Let autoPopoverListContainsElement be true if document's showing auto popover list's last item is element, otherwise false.
+
+    // 9. Set element's popover invoker to null.
+    m_popover_invoker = nullptr;
+
+    // 10. If fireEvents is true:
+    if (fire_events) {
+        // FIXME: 10.1. Fire an event named beforetoggle, using ToggleEvent, with the oldState attribute initialized to "open" and the newState attribute initialized to "closed" at element.
+        // FIXME: 10.2. If autoPopoverListContainsElement is true and document's showing auto popover list's last item is not element, then run hide all popovers until given element, focusPreviousElement, and false.
+        // FIXME: 10.3. If the result of running check popover validity given element, true, throwExceptions, and null is false, then run cleanupSteps and return.
+        // 10.4. Request an element to be removed from the top layer given element.
+        document.request_an_element_to_be_remove_from_the_top_layer(*this);
+    } else {
+        // 11. Otherwise, remove an element from the top layer immediately given element.
+        document.remove_an_element_from_the_top_layer_immediately(*this);
+    }
+
+    // 12. Set element's popover visibility state to hidden.
+    m_popover_visibility_state = PopoverVisibilityState::Hidden;
+
+    // FIXME: 13. If fireEvents is true, then queue a popover toggle event task given element, "open", and "closed".
+
+    // FIXME: 14. Let previouslyFocusedElement be element's previously focused element.
+
+    // FIXME: 15. If previouslyFocusedElement is not null, then:
+    // FIXME: 15.1. Set element's previously focused element to null.
+    // FIXME: 15.2. If focusPreviousElement is true and document's focused area of the document's DOM anchor is a shadow-including inclusive descendant of element, then run the focusing steps for previouslyFocusedElement; the viewport should not be scrolled by doing this step.
+
+    // 16. Run cleanupSteps.
+    cleanup_steps->function()();
+
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#dom-togglepopover
+WebIDL::ExceptionOr<bool> HTMLElement::toggle_popover(Optional<bool> force)
+{
+    // 1. If this's popover visibility state is showing, and force is not present or false, then run the hide popover algorithm given this, true, true, and true.
+    if (popover_visibility_state() == PopoverVisibilityState::Showing && (!force.has_value() || !force.value()))
+        TRY(hide_popover(true, true, true));
+    // 2. Otherwise, if force is not present or true, then run show popover given this true, and null.
+    else if (!force.has_value() || force.value())
+        TRY(show_popover(true, nullptr));
+    // 3. Otherwise:
+    else {
+        // 3.1 Let expectedToBeShowing be true if this's popover visibility state is showing; otherwise false.
+        bool expected_to_be_showing = popover_visibility_state() == PopoverVisibilityState::Showing;
+        // 3.2 Run check popover validity given expectedToBeShowing, true, and null.
+        TRY(check_popover_validity(expected_to_be_showing, true, nullptr));
+    }
+    // 4. Return true if this's popover visibility state is showing; otherwise false.
+    return popover_visibility_state() == PopoverVisibilityState::Showing;
 }
 
 void HTMLElement::did_receive_focus()

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -645,6 +645,34 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInternals>> HTMLElement::attach_inte
     return { internals };
 }
 
+// https://html.spec.whatwg.org/multipage/popover.html#dom-popover
+Optional<StringView> HTMLElement::popover() const
+{
+    // FIXME: This should probably be `Reflect` in the IDL.
+    // The popover IDL attribute must reflect the popover attribute, limited to only known values.
+    auto value = get_attribute(HTML::AttributeNames::popover);
+
+    if (!value.has_value())
+        return {};
+
+    if (value.value().is_empty() || value.value().equals_ignoring_case("auto"_string))
+        return "auto"sv;
+
+    return "manual"sv;
+}
+
+// https://html.spec.whatwg.org/multipage/popover.html#dom-popover
+WebIDL::ExceptionOr<void> HTMLElement::set_popover(Optional<String> value)
+{
+    // FIXME: This should probably be `Reflect` in the IDL.
+    // The popover IDL attribute must reflect the popover attribute, limited to only known values.
+    if (value.has_value())
+        return set_attribute(HTML::AttributeNames::popover, value.value());
+
+    remove_attribute(HTML::AttributeNames::popover);
+    return {};
+}
+
 void HTMLElement::did_receive_focus()
 {
     if (m_content_editable_state != ContentEditableState::True)

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
@@ -77,8 +78,23 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInternals>> attach_internals();
 
+    enum class PopoverVisibilityState {
+        Hidden,
+        Showing,
+    };
+    PopoverVisibilityState popover_visibility_state() const { return m_popover_visibility_state; }
+
     WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
     Optional<StringView> popover() const;
+
+    WebIDL::ExceptionOr<void> show_popover_for_bindings();
+    WebIDL::ExceptionOr<void> hide_popover_for_bindings();
+    WebIDL::ExceptionOr<bool> toggle_popover(Optional<bool> force);
+
+    WebIDL::ExceptionOr<void> show_popover(bool throw_exceptions, JS::GCPtr<HTMLElement> invoker);
+    WebIDL::ExceptionOr<void> hide_popover(bool focus_previous_element, bool fire_events, bool throw_exceptions);
+
+    WebIDL::ExceptionOr<bool> check_popover_validity(bool expected_to_be_showing, bool throw_exception, JS::GCPtr<DOM::Document>);
 
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
@@ -117,6 +133,17 @@ private:
 
     // https://html.spec.whatwg.org/multipage/interaction.html#click-in-progress-flag
     bool m_click_in_progress { false };
+
+    // Popover API
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-visibility-state
+    PopoverVisibilityState m_popover_visibility_state { PopoverVisibilityState::Hidden };
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-invoker
+    JS::GCPtr<HTMLElement> m_popover_invoker;
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-showing-or-hiding
+    bool m_popover_showing_or_hiding { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -77,6 +77,9 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInternals>> attach_internals();
 
+    WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
+    Optional<StringView> popover() const;
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -35,7 +35,7 @@ interface HTMLElement : Element {
     [FIXME] undefined showPopover();
     [FIXME] undefined hidePopover();
     [FIXME] boolean togglePopover(optional boolean force);
-    [FIXME, CEReactions] attribute DOMString? popover;
+    [CEReactions] attribute DOMString? popover;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
     readonly attribute Element? offsetParent;

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -4,6 +4,12 @@
 #import <DOM/Element.idl>
 #import <DOM/EventHandler.idl>
 
+[InvalidValueDefault=manual]
+enum PopoverState {
+    "auto",
+    "manual"
+};
+
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlelement
 [Exposed=Window]
 interface HTMLElement : Element {
@@ -32,9 +38,9 @@ interface HTMLElement : Element {
     ElementInternals attachInternals();
 
     // The popover API
-    [FIXME] undefined showPopover();
-    [FIXME] undefined hidePopover();
-    [FIXME] boolean togglePopover(optional boolean force);
+    [ImplementedAs=show_popover_for_bindings] undefined showPopover();
+    [ImplementedAs=hide_popover_for_bindings] undefined hidePopover();
+    boolean togglePopover(optional boolean force);
     [CEReactions] attribute DOMString? popover;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface


### PR DESCRIPTION
Implements basic of showPopover, hidePopover and togglePopover.

Follow on from #336 

This improves the pass rate of various WPTs inside of wpt.live/html/semantics/popovers/