### PR TITLE
LibWeb: Implement :modal pseudo class

### DIFF
--- a/Tests/LibWeb/Layout/expected/dialog-open-modal.txt
+++ b/Tests/LibWeb/Layout/expected/dialog-open-modal.txt
@@ -1,0 +1,20 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      TextNode <#text>
+  Box <dialog#modal> at (358.84375,19) content-size 82.3125x562 positioned flex-container(row) [FFC] children: not-inline
+    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+      TextNode <#text>
+    BlockContainer <span> at (358.84375,19) content-size 82.3125x562 flex-item [BFC] children: inline
+      frag 0 from TextNode start: 0, length: 10, rect: [358.84375,19 82.3125x17] baseline: 13.296875
+          "I'm a node"
+      TextNode <#text>
+    BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+  PaintableBox (Box<DIALOG>#modal) [339.84375,0 120.3125x600]
+    PaintableWithLines (BlockContainer<SPAN>) [358.84375,19 82.3125x562]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/dialog-open-non-modal.txt
+++ b/Tests/LibWeb/Layout/expected/dialog-open-non-modal.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: inline
+      BlockContainer <dialog> at (358.84375,27) content-size 82.3125x17 positioned [BFC] children: inline
+        TextNode <#text>
+        InlineNode <span>
+          frag 0 from TextNode start: 0, length: 10, rect: [358.84375,27 82.3125x17] baseline: 13.296875
+              "I'm a node"
+          TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIALOG>) [339.84375,8 120.3125x55]
+        InlinePaintable (InlineNode<SPAN>)
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/top-layer.txt
+++ b/Tests/LibWeb/Layout/expected/top-layer.txt
@@ -2,15 +2,15 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x0 children: inline
       TextNode <#text>
-  BlockContainer <dialog#dialog> at (196.671875,35) content-size 406.65625x49 positioned [BFC] children: not-inline
-    BlockContainer <p> at (196.671875,51) content-size 406.65625x17 children: inline
-      frag 0 from TextNode start: 0, length: 50, rect: [196.671875,51 406.65625x17] baseline: 13.296875
+  BlockContainer <dialog#dialog> at (196.671875,19) content-size 406.65625x562 positioned [BFC] children: not-inline
+    BlockContainer <p> at (196.671875,35) content-size 406.65625x17 children: inline
+      frag 0 from TextNode start: 0, length: 50, rect: [196.671875,35 406.65625x17] baseline: 13.296875
           "Dialog's layout node should be a child of viewport"
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
-  PaintableWithLines (BlockContainer<DIALOG>#dialog) [177.671875,16 444.65625x87]
-    PaintableWithLines (BlockContainer<P>) [196.671875,51 406.65625x17]
+  PaintableWithLines (BlockContainer<DIALOG>#dialog) [177.671875,0 444.65625x600]
+    PaintableWithLines (BlockContainer<P>) [196.671875,35 406.65625x17]
       TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/dialog-open-modal.html
+++ b/Tests/LibWeb/Layout/input/dialog-open-modal.html
@@ -1,0 +1,16 @@
+<style>
+    :modal {
+        display: flex;
+    }
+</style>
+
+<dialog id="modal">
+    <span>I'm a node</span>
+</dialog>
+
+<script>
+    document.addEventListener("DOMContentLoaded", () => {
+        let modal = document.getElementById('modal');
+        modal.showModal();
+    });
+</script>

--- a/Tests/LibWeb/Layout/input/dialog-open-non-modal.html
+++ b/Tests/LibWeb/Layout/input/dialog-open-non-modal.html
@@ -1,0 +1,9 @@
+<style>
+    :modal {
+        display: flex;
+    }
+</style>
+
+<dialog open>
+    <span>I'm a node</span>
+</dialog>

--- a/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Userland/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -71,6 +71,9 @@
   "local-link": {
     "argument": ""
   },
+  "modal": {
+    "argument": ""
+  },
   "muted": {
     "argument": ""
   },

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -542,6 +542,15 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     case CSS::PseudoClass::Open:
     case CSS::PseudoClass::Closed:
         return matches_open_state_pseudo_class(element, pseudo_class.type == CSS::PseudoClass::Open);
+    case CSS::PseudoClass::Modal: {
+        // https://drafts.csswg.org/selectors/#modal-state
+        if (is<HTML::HTMLDialogElement>(element)) {
+            auto const& dialog_element = static_cast<HTML::HTMLDialogElement const&>(element);
+            return dialog_element.is_modal();
+        }
+        // FIXME: fullscreen elements are also modal.
+        return false;
+    }
     }
 
     return false;

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -30,6 +30,8 @@ public:
     // https://www.w3.org/TR/html-aria/#el-dialog
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::dialog; }
 
+    bool is_modal() const { return m_is_modal; }
+
 private:
     HTMLDialogElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
Adds the `:modal` pseudo class which matches dialogs opened with showModal().

Passes all but 1 assertions within the first subtest of https://wpt.live/css/selectors/modal-pseudo-class.html

<img width="862" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/32498324/c589a30e-4167-4b22-832d-63bcc336da02">

That final assertion seems to be failing due to a spec bug: https://github.com/whatwg/html/issues/10452

I'll do a follow up PR to fix this in Ladybird once the spec is updated.