### PR TITLE
LibWeb: Support Gecko and WebKit navigator compatibility modes

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -497,6 +497,30 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
         }
     });
 
+    auto* navigator_compatibility_mode_menu = debug_menu->addMenu("Navigator Compatibility Mode");
+    navigator_compatibility_mode_menu->setIcon(load_icon_from_uri("resource://icons/16x16/spoof.png"sv));
+
+    auto* navigator_compatibility_mode_group = new QActionGroup(this);
+
+    auto add_navigator_compatibility_mode = [this, &navigator_compatibility_mode_group, &navigator_compatibility_mode_menu](auto name, auto const& compatibility_mode) {
+        auto* action = new QAction(qstring_from_ak_string(name), this);
+        action->setCheckable(true);
+        navigator_compatibility_mode_group->addAction(action);
+        navigator_compatibility_mode_menu->addAction(action);
+        QObject::connect(action, &QAction::triggered, this, [this, compatibility_mode] {
+            for_each_tab([compatibility_mode](auto& tab) {
+                tab.set_navigator_compatibility_mode(compatibility_mode);
+            });
+            set_navigator_compatibility_mode(compatibility_mode);
+        });
+        return action;
+    };
+    auto* chrome_compatibility_mode = add_navigator_compatibility_mode("Chrome"_string, "chrome"sv.to_byte_string());
+    chrome_compatibility_mode->setChecked(true);
+    add_navigator_compatibility_mode("Gecko"_string, "gecko"sv.to_byte_string());
+    add_navigator_compatibility_mode("WebKit"_string, "webkit"sv.to_byte_string());
+    set_navigator_compatibility_mode("chrome");
+
     debug_menu->addSeparator();
 
     m_enable_scripting_action = new QAction("Enable Scripting", this);
@@ -782,6 +806,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
     tab->set_block_popups(m_block_pop_ups_action->isChecked());
     tab->set_same_origin_policy(m_enable_same_origin_policy_action->isChecked());
     tab->set_user_agent_string(user_agent_string());
+    tab->set_navigator_compatibility_mode(navigator_compatibility_mode());
     tab->set_enable_do_not_track(Settings::the()->enable_do_not_track());
 }
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -173,6 +173,8 @@ private:
 
     ByteString user_agent_string() const { return m_user_agent_string; }
     void set_user_agent_string(ByteString const& user_agent_string) { m_user_agent_string = user_agent_string; }
+    ByteString navigator_compatibility_mode() const { return m_navigator_compatibility_mode; }
+    void set_navigator_compatibility_mode(ByteString const& navigator_compatibility_mode) { m_navigator_compatibility_mode = navigator_compatibility_mode; }
 
     QScreen* m_current_screen;
     double m_device_pixel_ratio { 0 };
@@ -200,6 +202,7 @@ private:
     QAction* m_enable_same_origin_policy_action { nullptr };
 
     ByteString m_user_agent_string {};
+    ByteString m_navigator_compatibility_mode {};
 
     SettingsDialog* m_settings_dialog { nullptr };
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -997,6 +997,11 @@ void Tab::set_user_agent_string(ByteString const& user_agent)
     debug_request("clear-cache");
 }
 
+void Tab::set_navigator_compatibility_mode(ByteString const& compatibility_mode)
+{
+    debug_request("navigator-compatibility-mode", compatibility_mode);
+}
+
 void Tab::set_enable_do_not_track(bool enable)
 {
     m_view->set_enable_do_not_track(enable);

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -72,6 +72,7 @@ public:
     void set_same_origin_policy(bool);
     void set_scripting(bool);
     void set_user_agent_string(ByteString const&);
+    void set_navigator_compatibility_mode(ByteString const&);
 
     void set_enable_do_not_track(bool);
 

--- a/Userland/Libraries/LibWeb/HTML/NavigatorID.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorID.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,29 +8,49 @@
 #include <AK/ByteString.h>
 #include <LibWeb/HTML/NavigatorID.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+#include <LibWeb/Loader/UserAgent.h>
 
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-appversion
 String NavigatorIDMixin::app_version() const
 {
+    auto navigator_compatibility_mode = ResourceLoader::the().navigator_compatibility_mode();
+
     // Must return the appropriate string that starts with "5.0 (", as follows:
 
     // Let trail be the substring of default `User-Agent` value that follows the "Mozilla/" prefix.
     auto user_agent_string = ResourceLoader::the().user_agent();
-
     auto trail = MUST(user_agent_string.substring_from_byte_offset(strlen("Mozilla/"), user_agent_string.bytes().size() - strlen("Mozilla/")));
 
     // If the navigator compatibility mode is Chrome or WebKit
-    // NOTE: We are using Chrome for now. Make sure to update all APIs if you add a toggle for this.
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::Chrome || navigator_compatibility_mode == NavigatorCompatibilityMode::WebKit) {
+        dbgln("Call to NavigatorIDMixin::app_version, using Chrome or WebKit compatibility mode");
 
-    // Return trail.
-    return trail;
+        // Return trail.
+        return trail;
+    }
 
     // If the navigator compatibility mode is Gecko
-    //    If trail starts with "5.0 (Windows", then return "5.0 (Windows)".
-    //    Otherwise, return the prefix of trail up to but not including the first U+003B (;), concatenated with the
-    //        character U+0029 RIGHT PARENTHESIS. For example, "5.0 (Macintosh)", "5.0 (Android 10)", or "5.0 (X11)".
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::Gecko) {
+        dbgln("Call to NavigatorIDMixin::app_version, using Gecko compatibility mode");
+
+        // If trail starts with "5.0 (Windows", then return "5.0 (Windows)".
+        if (trail.starts_with_bytes("5.0 (Windows"sv, CaseSensitivity::CaseSensitive))
+            return "5.0 (Windows)"_string;
+
+        // Otherwise, return the prefix of trail up to but not including the first U+003B (;), concatenated with the
+        // character U+0029 RIGHT PARENTHESIS. For example, "5.0 (Macintosh)", "5.0 (Android 10)", or "5.0 (X11)".
+        if (auto index = trail.find_byte_offset(';'); index.has_value()) {
+            StringBuilder output;
+            output.append(MUST(trail.substring_from_byte_offset(0, *index)));
+            output.append(')');
+            return MUST(output.to_string());
+        }
+        return trail;
+    }
+
+    VERIFY_NOT_REACHED();
 }
 
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-platform
@@ -43,11 +64,71 @@ String NavigatorIDMixin::platform() const
     return ResourceLoader::the().platform();
 }
 
+// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-productsub
+String NavigatorIDMixin::product_sub() const
+{
+    auto navigator_compatibility_mode = ResourceLoader::the().navigator_compatibility_mode();
+
+    // Must return the appropriate string from the following list:
+
+    // If the navigator compatibility mode is Chrome or WebKit
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::Chrome || navigator_compatibility_mode == NavigatorCompatibilityMode::WebKit) {
+        dbgln("Call to NavigatorIDMixin::product_sub, using Chrome or WebKit compatibility mode");
+
+        // The string "20030107".
+        return "20030107"_string;
+    }
+
+    // If the navigator compatibility mode is Gecko
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::Gecko) {
+        dbgln("Call to NavigatorIDMixin::product_sub, using Gecko compatibility mode");
+
+        // The string "20100101".
+        return "20100101"_string;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
 // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent
 String NavigatorIDMixin::user_agent() const
 {
     // Must return the default `User-Agent` value.
     return ResourceLoader::the().user_agent();
+}
+
+// https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-vendor
+String NavigatorIDMixin::vendor() const
+{
+    auto navigator_compatibility_mode = ResourceLoader::the().navigator_compatibility_mode();
+
+    // Must return the appropriate string from the following list:
+
+    // If the navigator compatibility mode is Chrome
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::Chrome) {
+        dbgln("Call to NavigatorIDMixin::vendor, using Chrome compatibility mode");
+
+        // The string "Google Inc.".
+        return "Google Inc."_string;
+    }
+
+    // If the navigator compatibility mode is Gecko
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::Gecko) {
+        dbgln("Call to NavigatorIDMixin::vendor, using Gecko compatibility mode");
+
+        // The empty string.
+        return ""_string;
+    }
+
+    // If the navigator compatibility mode is WebKit
+    if (navigator_compatibility_mode == NavigatorCompatibilityMode::WebKit) {
+        dbgln("Call to NavigatorIDMixin::vendor, using WebKit compatibility mode");
+
+        // The string "Apple Computer, Inc.".
+        return "Apple Computer, Inc."_string;
+    }
+
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/NavigatorID.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorID.h
@@ -32,18 +32,18 @@ public:
     String product() const { return "Gecko"_string; }
 
     // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-productsub
-    String product_sub() const { return "20030107"_string; } // Compatibility mode "Chrome"
+    String product_sub() const;
 
     // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-useragent
     String user_agent() const;
 
     // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-vendor
-    String vendor() const { return "Google Inc."_string; } // Compatibility mode "Chrome"
+    String vendor() const;
 
     // https://html.spec.whatwg.org/multipage/system-state.html#dom-navigator-vendorsub
     String vendor_sub() const { return String {}; }
 
-    // NOTE: If the navigator compatibility mode is Gecko, then the user agent must also support the following partial interface:
+    // FIXME: If the navigator compatibility mode is Gecko, then the user agent must also support the following partial interface:
     //       bool taint_enabled()
     //       ByteString oscpu()
 };

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -20,7 +20,6 @@
 #include <LibWeb/Loader/ProxyMappings.h>
 #include <LibWeb/Loader/Resource.h>
 #include <LibWeb/Loader/ResourceLoader.h>
-#include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/Timer.h>
 
@@ -60,6 +59,7 @@ ResourceLoader::ResourceLoader(NonnullRefPtr<ResourceLoaderConnector> connector)
     : m_connector(move(connector))
     , m_user_agent(MUST(String::from_utf8(default_user_agent)))
     , m_platform(MUST(String::from_utf8(default_platform)))
+    , m_navigator_compatibility_mode(default_navigator_compatibility_mode)
 {
 }
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -16,6 +16,7 @@
 #include <LibProtocol/Request.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Loader/Resource.h>
+#include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Page/Page.h>
 
 namespace Web {
@@ -99,6 +100,9 @@ public:
     String const& platform() const { return m_platform; }
     void set_platform(String platform) { m_platform = move(platform); }
 
+    NavigatorCompatibilityMode navigator_compatibility_mode() { return m_navigator_compatibility_mode; }
+    void set_navigator_compatibility_mode(NavigatorCompatibilityMode mode) { m_navigator_compatibility_mode = mode; }
+
     bool enable_do_not_track() const { return m_enable_do_not_track; }
     void set_enable_do_not_track(bool enable) { m_enable_do_not_track = enable; }
 
@@ -119,6 +123,7 @@ private:
     NonnullRefPtr<ResourceLoaderConnector> m_connector;
     String m_user_agent;
     String m_platform;
+    NavigatorCompatibilityMode m_navigator_compatibility_mode;
     bool m_enable_do_not_track { false };
     Optional<JS::GCPtr<Page>> m_page {};
 };

--- a/Userland/Libraries/LibWeb/Loader/UserAgent.h
+++ b/Userland/Libraries/LibWeb/Loader/UserAgent.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,10 +54,17 @@ namespace Web {
 #    error Unknown OS
 #endif
 
+enum class NavigatorCompatibilityMode {
+    Chrome,
+    Gecko,
+    WebKit
+};
+
 #define BROWSER_NAME "Ladybird"
 #define BROWSER_VERSION "1.0"
 
 constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") " BROWSER_NAME "/" BROWSER_VERSION ""sv;
 constexpr auto default_platform = OS_STRING " " CPU_STRING ""sv;
+constexpr auto default_navigator_compatibility_mode = NavigatorCompatibilityMode::Chrome;
 
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -37,6 +37,7 @@
 #include <LibWeb/Loader/ContentFilter.h>
 #include <LibWeb/Loader/ProxyMappings.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+#include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Painting/StackingContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
@@ -396,6 +397,23 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
                 load_url(page_id, url);
             }
         }
+        return;
+    }
+
+    if (request == "navigator-compatibility-mode") {
+        Web::NavigatorCompatibilityMode compatibility_mode;
+        if (argument == "chrome") {
+            compatibility_mode = Web::NavigatorCompatibilityMode::Chrome;
+        } else if (argument == "gecko") {
+            compatibility_mode = Web::NavigatorCompatibilityMode::Gecko;
+        } else if (argument == "webkit") {
+            compatibility_mode = Web::NavigatorCompatibilityMode::WebKit;
+        } else {
+            dbgln("Unknown navigator compatibility mode '{}', defaulting to Chrome", argument);
+            compatibility_mode = Web::NavigatorCompatibilityMode::Chrome;
+        }
+
+        Web::ResourceLoader::the().set_navigator_compatibility_mode(compatibility_mode);
         return;
     }
 }


### PR DESCRIPTION
I will continue to work on this tomorrow, adding options to the GUI to change this setting :)

I'll also look into how to support a partial interface that should be implemented when the setting is Gecko.

```idl
partial interface mixin NavigatorID {
  [Exposed=Window] boolean taintEnabled(); // constant false
  [Exposed=Window] readonly attribute DOMString oscpu;
};
```