### PR TITLE
Documentation: Add ffmpeg-devel package in Fedora instructions

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -47,7 +47,7 @@ sudo pacman -S --needed base-devel cmake ffmpeg libgl ninja qt6-base qt6-tools q
 
 On Fedora or derivatives:
 ```
-sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel qt6-qtmultimedia-devel ccache liberation-sans-fonts curl zip unzip tar autoconf-archive
+sudo dnf install cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-qttools-devel qt6-qtwayland-devel qt6-qtmultimedia-devel ccache liberation-sans-fonts curl zip unzip tar autoconf-archive libavcodec-free-devel
 ```
 
 On openSUSE:


### PR DESCRIPTION
Was unable to build Ladybird due to to the following error on Fedora 40:
```
--   Package 'libavcodec' not found
CMake Error at /usr/share/cmake/Modules/FindPkgConfig.cmake:619 (message):
  The following required packages were not found:

   - libavcodec

Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPkgConfig.cmake:841 (_pkg_check_modules_internal)
  Userland/Libraries/LibMedia/CMakeLists.txt:17 (pkg_check_modules)
```

```
$ pkg-config --libs libavcodec
Package libavcodec was not found in the pkg-config search path.
Perhaps you should add the directory containing `libavcodec.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libavcodec', required by 'virtual:world', not found
```

Installed `ffmpeg-devel` which contains `libavcodec, Ladybird now builds and runs.

```
$ sudo dnf install ffmpeg-devel 
...
Installed:
  ffmpeg-devel-6.1.1-11.fc40.x86_64                                                                                           

$ pkg-config --libs libavcodec
-lavcodec
```
