### PR TITLE
LibCore: Include full definition for LocalSocket

### DIFF
--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -13,6 +13,7 @@
 #include <AK/Forward.h>
 #include <AK/Span.h>
 #include <LibCore/File.h>
+#include <LibCore/Socket.h>
 
 namespace Core {
 


### PR DESCRIPTION
clang 19 (git) complains that LocalSocket is an incomplete type and errors out. Including the full definition fixes the build.

The full error generated by clang looks like this:
FAILED: Lagom/Userland/Libraries/LibWebView/CMakeFiles/LibWebView.dir/ProcessManager.cpp.o
/usr/bin/ccache /home/doc/.local/bin/clang++ -DENABLE_COMPILETIME_FORMAT_CHECK -DENABLE_PUBLIC_SUFFIX=1 -DLibWebView_EXPORTS -I/home/doc/programming/ladybird -I/home/doc/programming/ladybird/Userland/Services -I/home/doc/programming/ladybird/Userland/Libraries -I/home/doc/programming/ladybird/Build/ladybird/Lagom -I/home/doc/programming/ladybird/Build/ladybird/Lagom/Userland/Services -I/home/doc/programming/ladybird/Build/ladybird/Lagom/Userland/Libraries -I/home/doc/programming/ladybird/Meta/Lagom/../.. -I/home/doc/programming/ladybird/Meta/Lagom/../../Userland -I/home/doc/programming/ladybird/Meta/Lagom/../../Userland/Libraries -I/home/doc/programming/ladybird/Meta/Lagom/../../Userland/Services -I/home/doc/programming/ladybird/Build/ladybird -isystem /home/doc/programming/ladybird/Build/ladybird/vcpkg_installed/x64-linux/include -O2 -g -DNDEBUG -std=c++23 -fPIC -fcolor-diagnostics -Wall -Wextra -fno-exceptions -ffp-contract=off -Wno-invalid-offsetof -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wpadded-bitfield -Werror -fconstexpr-steps=16777216 -Wno-implicit-const-int-float-conversion -Wno-user-defined-literals -Wno-vla-cxx-extension -fno-semantic-interposition -fvisibility-inlines-hidden -Wno-maybe-uninitialized -Wno-shorten-64-to-32 -fsigned-char -ggnu-pubnames -fPIC -D_FILE_OFFSET_BITS=64 -O2 -g1 -Wno-overloaded-virtual -Wno-unused-private-field -MD -MT Lagom/Userland/Libraries/LibWebView/CMakeFiles/LibWebView.dir/ProcessManager.cpp.o -MF Lagom/Userland/Libraries/LibWebView/CMakeFiles/LibWebView.dir/ProcessManager.cpp.o.d -o Lagom/Userland/Libraries/LibWebView/CMakeFiles/LibWebView.dir/ProcessManager.cpp.o -c /home/doc/programming/ladybird/Userland/Libraries/LibWebView/ProcessManager.cpp
In file included from /home/doc/programming/ladybird/Userland/Libraries/LibWebView/ProcessManager.cpp:9:
In file included from /home/doc/programming/ladybird/Userland/Libraries/LibCore/EventLoop.h:14:
/home/doc/programming/ladybird/AK/NonnullOwnPtr.h:133:9: error: deleting pointer to incomplete type 'Core::LocalSocket' may cause undefined behavior [-Werror,-Wdelete-incomplete]
  133 |         delete ptr;
         |         ^      ~~~
/home/doc/programming/ladybird/AK/NonnullOwnPtr.h:50:9: note: in instantiation of member function 'AK::NonnullOwnPtr<Core::LocalSocket>::clear' requested here
   50 |         clear();
        |         ^
/home/doc/programming/ladybird/Userland/Libraries/LibCore/Process.h:144:12: note: in instantiation of member function 'AK::NonnullOwnPtr<Core::LocalSocket>::~NonnullOwnPtr' requested here
  144 |     struct ProcessAndIPCSocket {
         |            ^
/home/doc/programming/ladybird/Userland/Libraries/LibCore/Forward.h:28:7: note: forward declaration of 'Core::LocalSocket'
   28 | class LocalSocket;
        |       ^
1 error generated.