### PR TITLE
LibWebView: Append remaining source after consuming all tokens

### DIFF
--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -85,6 +85,8 @@ String highlight_source(URL::URL const& url, StringView source)
             append_source(token->end_position().byte_offset);
         }
     }
+    // Character tokens have an `m_end_position` of `{ 0 }`, so we should append the remainder of the source.
+    append_source(source.length());
 
     builder.append(R"~~~(
 </pre>


### PR DESCRIPTION
Since "Character" tokens do not have an "end position", viewing source drops the source contents following the final non-"Character" token.

By appending the remainder of the source after consuming all of the tokens, we avoid this issue.