### PR TITLE
LibWeb: Make text selection work inside shadow roots

### DIFF
--- a/Tests/LibWeb/Text/expected/set-selection-inside-shadow-root.txt
+++ b/Tests/LibWeb/Text/expected/set-selection-inside-shadow-root.txt
@@ -1,0 +1,2 @@
+  Selection range count: 1
+Selection start offset: 0, end offset: 1

--- a/Tests/LibWeb/Text/input/set-selection-inside-shadow-root.html
+++ b/Tests/LibWeb/Text/input/set-selection-inside-shadow-root.html
@@ -1,0 +1,21 @@
+<script src="include.js"></script>
+<div id="root"></div>
+<script>
+    function printSelectionDetails(selection) {
+        println(`Selection range count: ${selection.rangeCount}`);
+        if (selection.rangeCount > 0)
+            println(`Selection start offset: ${selection.getRangeAt(0).startOffset}, end offset: ${selection.getRangeAt(0).endOffset}`);
+    }
+
+    test(() => {
+        const rootElement = document.getElementById("root");
+        const shadowRoot = rootElement.attachShadow({ mode: "open" });
+        shadowRoot.innerHTML = "This is some text";
+        const selection = window.getSelection();
+        selection.setBaseAndExtent(shadowRoot, 0, shadowRoot, 1);
+        println(`Selection range count: ${selection.rangeCount}`);
+        println(`Selection start offset: ${selection.getRangeAt(0).startOffset}, end offset: ${selection.getRangeAt(0).endOffset}`);
+
+        shadowRoot.innerHTML = "";
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -546,15 +546,22 @@ bool EventHandler::handle_mousemove(CSSPixelPoint viewport_position, CSSPixelPoi
         }
         if (m_in_mouse_selection) {
             auto hit = paint_root()->hit_test(position, Painting::HitTestType::TextCursor);
+            auto should_set_cursor_position = true;
             if (start_index.has_value() && hit.has_value() && hit->dom_node()) {
-                m_navigable->set_cursor_position(DOM::Position::create(realm, *hit->dom_node(), *start_index));
                 if (auto selection = document.get_selection()) {
                     auto anchor_node = selection->anchor_node();
-                    if (anchor_node)
-                        (void)selection->set_base_and_extent(*anchor_node, selection->anchor_offset(), *hit->paintable->dom_node(), hit->index_in_node);
-                    else
+                    if (anchor_node) {
+                        if (&anchor_node->root() == &hit->dom_node()->root())
+                            (void)selection->set_base_and_extent(*anchor_node, selection->anchor_offset(), *hit->paintable->dom_node(), hit->index_in_node);
+                        else
+                            should_set_cursor_position = false;
+                    } else {
                         (void)selection->set_base_and_extent(*hit->paintable->dom_node(), hit->index_in_node, *hit->paintable->dom_node(), hit->index_in_node);
+                    }
                 }
+                if (should_set_cursor_position)
+                    m_navigable->set_cursor_position(DOM::Position::create(realm, *hit->dom_node(), *start_index));
+
                 document.navigable()->set_needs_display();
             }
         }

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -306,11 +306,8 @@ WebIDL::ExceptionOr<void> Selection::set_base_and_extent(JS::NonnullGCPtr<DOM::N
     if (focus_offset > focus_node->length())
         return WebIDL::IndexSizeError::create(realm(), "Focus offset points outside of the focus node"_fly_string);
 
-    // 2. If the roots of anchorNode or focusNode are not the document associated with this, abort these steps.
-    if (&anchor_node->root() != m_document.ptr())
-        return {};
-
-    if (&focus_node->root() != m_document.ptr())
+    // 2. If document associated with this is not a shadow-including inclusive ancestor of anchorNode or focusNode, abort these steps.
+    if (!(m_document->is_shadow_including_inclusive_ancestor_of(anchor_node) || m_document->is_shadow_including_inclusive_ancestor_of(focus_node)))
         return {};
 
     // 3. Let anchor be the boundary point (anchorNode, anchorOffset) and let focus be the boundary point (focusNode, focusOffset).


### PR DESCRIPTION
This PR makes the changes necessary to allow text selection to work within shadow roots, which allows the user to select text within `<textarea>` and `<input>` elements.

See individual commits for details

Video:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/f9399bfa-2628-44c5-9480-929f36b29508

NOTE: I believe a similar change to that made for `Selection::set_base_and_extent()` should also be made for `Selection::add_range()` to make it behave like other browsers, as the following doesn't work with shadow roots. 

https://github.com/LadybirdBrowser/ladybird/blob/5f06594bbd2d045ac026cbdba7c912249cdd5812/Userland/Libraries/LibWeb/Selection/Selection.cpp#L133-L135

I haven't made that change as part of this PR because the spec text for that method hasn't been updated. 