### PR TITLE
LibWeb: Reschedule HTML event loop processing if navigable needs repaint

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -207,6 +207,8 @@ void EventLoop::process()
     //         loop processing.
     for_each_fully_active_document_in_docs([&](DOM::Document& document) {
         auto navigable = document.navigable();
+        if (navigable && !navigable->has_a_rendering_opportunity() && navigable->needs_repaint())
+            schedule();
         if (navigable && navigable->has_a_rendering_opportunity())
             return;
         auto* browsing_context = document.browsing_context();


### PR DESCRIPTION
This is an attempt to fix the hanging CI on macOS caused by some screenshot requests being stuck unprocessed. With this change, we at least make sure that the HTML event loop processing, which triggers repainting, will happen as long as there are navigables that need to be repainted.