### PR TITLE
LibWeb+UI/Qt: Display 'title' tooltips only when the mouse stops moving

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -532,7 +532,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [self reload];
     };
 
-    m_web_view_bridge->on_enter_tooltip_area = [weak_self](auto, auto const& tooltip) {
+    m_web_view_bridge->on_enter_tooltip_area = [weak_self](auto const& tooltip) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -532,6 +532,22 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [self reload];
     };
 
+    m_web_view_bridge->on_request_tooltip_override = [weak_self](auto, auto const& tooltip) {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+        self.toolTip = Ladybird::string_to_ns_string(tooltip);
+    };
+
+    m_web_view_bridge->on_stop_tooltip_override = [weak_self]() {
+        LadybirdWebView* self = weak_self;
+        if (self == nil) {
+            return;
+        }
+        self.toolTip = nil;
+    };
+
     m_web_view_bridge->on_enter_tooltip_area = [weak_self](auto const& tooltip) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -23,6 +23,7 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
 #include <QAbstractScrollArea>
+#include <QTimer>
 #include <QUrl>
 
 class QKeyEvent;
@@ -102,6 +103,9 @@ private:
     void enqueue_native_event(Web::KeyEvent::Type, QKeyEvent const& event);
     void finish_handling_key_event(Web::KeyEvent const&);
     void update_screen_rects();
+
+    Optional<ByteString> m_tooltip_text;
+    QTimer m_tooltip_hover_timer;
 
     bool m_should_show_line_box_borders { false };
 

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -104,6 +104,7 @@ private:
     void finish_handling_key_event(Web::KeyEvent const&);
     void update_screen_rects();
 
+    bool m_tooltip_override { false };
     Optional<ByteString> m_tooltip_text;
     QTimer m_tooltip_hover_timer;
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -567,7 +567,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint viewport_position, CSSPixelPoi
     if (hovered_node_changed) {
         JS::GCPtr<HTML::HTMLElement const> hovered_html_element = document.hovered_node() ? document.hovered_node()->enclosing_html_element_with_attribute(HTML::AttributeNames::title) : nullptr;
         if (hovered_html_element && hovered_html_element->title().has_value()) {
-            page.client().page_did_enter_tooltip_area(viewport_position, hovered_html_element->title()->to_byte_string());
+            page.client().page_did_enter_tooltip_area(hovered_html_element->title()->to_byte_string());
         } else {
             page.client().page_did_leave_tooltip_area();
         }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -327,6 +327,8 @@ public:
     virtual void page_did_request_image_context_menu(CSSPixelPoint, URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Gfx::Bitmap const*) { }
     virtual void page_did_request_media_context_menu(CSSPixelPoint, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Page::MediaContextMenu) { }
     virtual void page_did_middle_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
+    virtual void page_did_request_tooltip_override(CSSPixelPoint, ByteString const&) { }
+    virtual void page_did_stop_tooltip_override() { }
     virtual void page_did_enter_tooltip_area(ByteString const&) { }
     virtual void page_did_leave_tooltip_area() { }
     virtual void page_did_hover_link(URL::URL const&) { }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -327,7 +327,7 @@ public:
     virtual void page_did_request_image_context_menu(CSSPixelPoint, URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Gfx::Bitmap const*) { }
     virtual void page_did_request_media_context_menu(CSSPixelPoint, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Page::MediaContextMenu) { }
     virtual void page_did_middle_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
-    virtual void page_did_enter_tooltip_area(CSSPixelPoint, ByteString const&) { }
+    virtual void page_did_enter_tooltip_area(ByteString const&) { }
     virtual void page_did_leave_tooltip_area() { }
     virtual void page_did_hover_link(URL::URL const&) { }
     virtual void page_did_unhover_link() { }

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -351,7 +351,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousemove(Badge<E
                 set_volume(media_element, *cached_layout_boxes.volume_scrub_rect, position);
 
                 auto volume = static_cast<u8>(media_element.volume() * 100.0);
-                browsing_context().page().client().page_did_enter_tooltip_area(position, ByteString::formatted("{}%", volume));
+                browsing_context().page().client().page_did_enter_tooltip_area(ByteString::formatted("{}%", volume));
             }
 
             break;

--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -302,7 +302,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<Eve
             break;
 
         case HTML::HTMLMediaElement::MouseTrackingComponent::Volume:
-            browsing_context().page().client().page_did_leave_tooltip_area();
+            browsing_context().page().client().page_did_stop_tooltip_override();
             break;
         }
 
@@ -351,7 +351,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousemove(Badge<E
                 set_volume(media_element, *cached_layout_boxes.volume_scrub_rect, position);
 
                 auto volume = static_cast<u8>(media_element.volume() * 100.0);
-                browsing_context().page().client().page_did_enter_tooltip_area(ByteString::formatted("{}%", volume));
+                browsing_context().page().client().page_did_request_tooltip_override({ position.x(), cached_layout_boxes.volume_scrub_rect->y() }, ByteString::formatted("{}%", volume));
             }
 
             break;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -163,7 +163,7 @@ public:
     Function<void()> on_refresh;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
     Function<void(Gfx::StandardCursor)> on_cursor_change;
-    Function<void(Gfx::IntPoint, ByteString const&)> on_enter_tooltip_area;
+    Function<void(ByteString const&)> on_enter_tooltip_area;
     Function<void()> on_leave_tooltip_area;
     Function<void(String const& message)> on_request_alert;
     Function<void(String const& message)> on_request_confirm;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -163,6 +163,8 @@ public:
     Function<void()> on_refresh;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
     Function<void(Gfx::StandardCursor)> on_cursor_change;
+    Function<void(Gfx::IntPoint, ByteString const&)> on_request_tooltip_override;
+    Function<void()> on_stop_tooltip_override;
     Function<void(ByteString const&)> on_enter_tooltip_area;
     Function<void()> on_leave_tooltip_area;
     Function<void(String const& message)> on_request_alert;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -170,11 +170,11 @@ void WebContentClient::did_change_url(u64 page_id, URL::URL const& url)
     }
 }
 
-void WebContentClient::did_enter_tooltip_area(u64 page_id, Gfx::IntPoint content_position, ByteString const& title)
+void WebContentClient::did_enter_tooltip_area(u64 page_id, ByteString const& title)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_enter_tooltip_area)
-            view->on_enter_tooltip_area(view->to_widget_position(content_position), title);
+            view->on_enter_tooltip_area(title);
     }
 }
 

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -170,6 +170,22 @@ void WebContentClient::did_change_url(u64 page_id, URL::URL const& url)
     }
 }
 
+void WebContentClient::did_request_tooltip_override(u64 page_id, Gfx::IntPoint position, ByteString const& title)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_request_tooltip_override)
+            view->on_request_tooltip_override(view->to_widget_position(position), title);
+    }
+}
+
+void WebContentClient::did_stop_tooltip_override(u64 page_id)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_stop_tooltip_override)
+            view->on_stop_tooltip_override();
+    }
+}
+
 void WebContentClient::did_enter_tooltip_area(u64 page_id, ByteString const& title)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -55,6 +55,8 @@ private:
     virtual void did_layout(u64 page_id, Gfx::IntSize) override;
     virtual void did_change_title(u64 page_id, ByteString const&) override;
     virtual void did_change_url(u64 page_id, URL::URL const&) override;
+    virtual void did_request_tooltip_override(u64 page_id, Gfx::IntPoint, ByteString const&) override;
+    virtual void did_stop_tooltip_override(u64 page_id) override;
     virtual void did_enter_tooltip_area(u64 page_id, ByteString const&) override;
     virtual void did_leave_tooltip_area(u64 page_id) override;
     virtual void did_hover_link(u64 page_id, URL::URL const&) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -55,7 +55,7 @@ private:
     virtual void did_layout(u64 page_id, Gfx::IntSize) override;
     virtual void did_change_title(u64 page_id, ByteString const&) override;
     virtual void did_change_url(u64 page_id, URL::URL const&) override;
-    virtual void did_enter_tooltip_area(u64 page_id, Gfx::IntPoint, ByteString const&) override;
+    virtual void did_enter_tooltip_area(u64 page_id, ByteString const&) override;
     virtual void did_leave_tooltip_area(u64 page_id) override;
     virtual void did_hover_link(u64 page_id, URL::URL const&) override;
     virtual void did_unhover_link(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -313,6 +313,17 @@ Gfx::IntRect PageClient::page_did_request_fullscreen_window()
     return client().did_request_fullscreen_window(m_id);
 }
 
+void PageClient::page_did_request_tooltip_override(Web::CSSPixelPoint position, ByteString const& title)
+{
+    auto device_position = page().css_to_device_point(position);
+    client().async_did_request_tooltip_override(m_id, { device_position.x(), device_position.y() }, title);
+}
+
+void PageClient::page_did_stop_tooltip_override()
+{
+    client().async_did_leave_tooltip_area(m_id);
+}
+
 void PageClient::page_did_enter_tooltip_area(ByteString const& title)
 {
     client().async_did_enter_tooltip_area(m_id, title);

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -313,10 +313,9 @@ Gfx::IntRect PageClient::page_did_request_fullscreen_window()
     return client().did_request_fullscreen_window(m_id);
 }
 
-void PageClient::page_did_enter_tooltip_area(Web::CSSPixelPoint content_position, ByteString const& title)
+void PageClient::page_did_enter_tooltip_area(ByteString const& title)
 {
-    auto device_position = page().css_to_device_point(content_position);
-    client().async_did_enter_tooltip_area(m_id, { device_position.x(), device_position.y() }, title);
+    client().async_did_enter_tooltip_area(m_id, title);
 }
 
 void PageClient::page_did_leave_tooltip_area()

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -118,7 +118,7 @@ private:
     virtual Gfx::IntRect page_did_request_maximize_window() override;
     virtual Gfx::IntRect page_did_request_minimize_window() override;
     virtual Gfx::IntRect page_did_request_fullscreen_window() override;
-    virtual void page_did_enter_tooltip_area(Web::CSSPixelPoint, ByteString const&) override;
+    virtual void page_did_enter_tooltip_area(ByteString const&) override;
     virtual void page_did_leave_tooltip_area() override;
     virtual void page_did_hover_link(URL::URL const&) override;
     virtual void page_did_unhover_link() override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -118,6 +118,8 @@ private:
     virtual Gfx::IntRect page_did_request_maximize_window() override;
     virtual Gfx::IntRect page_did_request_minimize_window() override;
     virtual Gfx::IntRect page_did_request_fullscreen_window() override;
+    virtual void page_did_request_tooltip_override(Web::CSSPixelPoint, ByteString const&) override;
+    virtual void page_did_stop_tooltip_override() override;
     virtual void page_did_enter_tooltip_area(ByteString const&) override;
     virtual void page_did_leave_tooltip_area() override;
     virtual void page_did_hover_link(URL::URL const&) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -27,6 +27,8 @@ endpoint WebContentClient
     did_layout(u64 page_id, Gfx::IntSize content_size) =|
     did_change_title(u64 page_id, ByteString title) =|
     did_change_url(u64 page_id, URL::URL url) =|
+    did_request_tooltip_override(u64 page_id, Gfx::IntPoint position, ByteString title) =|
+    did_stop_tooltip_override(u64 page_id) =|
     did_enter_tooltip_area(u64 page_id, ByteString title) =|
     did_leave_tooltip_area(u64 page_id) =|
     did_hover_link(u64 page_id, URL::URL url) =|

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -27,7 +27,7 @@ endpoint WebContentClient
     did_layout(u64 page_id, Gfx::IntSize content_size) =|
     did_change_title(u64 page_id, ByteString title) =|
     did_change_url(u64 page_id, URL::URL url) =|
-    did_enter_tooltip_area(u64 page_id, Gfx::IntPoint content_position, ByteString title) =|
+    did_enter_tooltip_area(u64 page_id, ByteString title) =|
     did_leave_tooltip_area(u64 page_id) =|
     did_hover_link(u64 page_id, URL::URL url) =|
     did_unhover_link(u64 page_id) =|


### PR DESCRIPTION
Now instead of sending the position in which the user entered the tooltip area, send just the text, and let the chrome figure out how to display it.

In the case of Qt, wait for 600 milliseconds of no mouse movement, then display it under the mouse cursor.
