### PR TITLE
LibWebView: Process remaining text after last HTML token

### DIFF
--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -86,6 +86,7 @@ String highlight_source(URL::URL const& url, StringView source)
         }
     }
 
+    append_source(source.length());
     builder.append(R"~~~(
 </pre>
 </body>


### PR DESCRIPTION
This patch ensures all source content is processed, including text after the last tag.
It resolves issue with truncated output in view source functionality and improves handling of self-closing tags and trailing text.

Before:
<img width="678" alt="Screenshot 2024-07-03 at 12 56 18 AM" src="https://github.com/LadybirdBrowser/ladybird/assets/2846046/c595bdd1-5b8a-4bc3-92ac-949ace296d6b">


After:
<img width="678" alt="Screenshot 2024-07-03 at 12 56 52 AM" src="https://github.com/LadybirdBrowser/ladybird/assets/2846046/1b455ac6-deaf-48a6-895a-fb1abd5f80cb">
