### PR TITLE
LibWeb: Keep Intrinsic Dimensions

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/use-intrinsic-sizing-keywords-to-size-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/flex/use-intrinsic-sizing-keywords-to-size-flex-item.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x32 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x16 flex-container(row) [FFC] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 16x16 flex-item [SVG] children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 8x8 children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x32]
+    PaintableBox (Box<BODY>) [8,8 784x16]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 16x16]
+        SVGPathPaintable (SVGGeometryBox<rect>) [8,8 8x8]

--- a/Tests/LibWeb/Layout/input/flex/use-intrinsic-sizing-keywords-to-size-flex-item.html
+++ b/Tests/LibWeb/Layout/input/flex/use-intrinsic-sizing-keywords-to-size-flex-item.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html><style>
+    body {
+        display: flex;
+        flex-direction: row;
+    }
+</style><body><svg width="16" height="16" viewBox="0 0 24 24"><rect x=0 y=0 width=12 height=12></svg>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -642,7 +642,15 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
     //         - using stretch-fit main size if the flex basis is indefinite and there is no cross size to resolve the ratio against.
     //         - in response to cross size min/max constraints.
     if (item.box->has_natural_aspect_ratio()) {
-        if (!item.used_flex_basis_is_definite && !has_definite_cross_size(item)) {
+        auto has_intrinsic_dimensions = false;
+        if (item.box->is_replaced_box()) {
+            auto box = dynamic_cast<ReplacedBox*>(item.box.ptr());
+            if (box->has_intrinsic_height() || box->has_intrinsic_width()) {
+                has_intrinsic_dimensions = true;
+            }
+        }
+
+        if (!item.used_flex_basis_is_definite && !has_definite_cross_size(item) && !has_intrinsic_dimensions) {
             item.flex_base_size = inner_main_size(m_flex_container_state);
         }
         item.flex_base_size = adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(child_box, item.flex_base_size, computed_cross_min_size(child_box), computed_cross_max_size(child_box));

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -32,8 +32,12 @@ void ImageBox::visit_edges(JS::Cell::Visitor& visitor)
 
 void ImageBox::prepare_for_replaced_layout()
 {
-    set_natural_width(m_image_provider.intrinsic_width());
-    set_natural_height(m_image_provider.intrinsic_height());
+    auto intrinsic_width = m_image_provider.intrinsic_width();
+    auto intrinsic_height = m_image_provider.intrinsic_height();
+    set_intrinsic_width(intrinsic_width);
+    set_intrinsic_height(intrinsic_height);
+    set_natural_width(intrinsic_width);
+    set_natural_height(intrinsic_height);
     set_natural_aspect_ratio(m_image_provider.intrinsic_aspect_ratio());
 
     if (renders_as_alt_text()) {

--- a/Userland/Libraries/LibWeb/Layout/ReplacedBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ReplacedBox.h
@@ -21,6 +21,15 @@ public:
     DOM::Element const& dom_node() const { return verify_cast<DOM::Element>(*Node::dom_node()); }
     DOM::Element& dom_node() { return verify_cast<DOM::Element>(*Node::dom_node()); }
 
+    Optional<CSSPixels> intrinsic_width() const { return m_intrinsic_width; }
+    Optional<CSSPixels> intrinsic_height() const { return m_intrinsic_height; }
+
+    bool has_intrinsic_width() const { return intrinsic_width().has_value(); }
+    bool has_intrinsic_height() const { return intrinsic_height().has_value(); }
+
+    void set_intrinsic_width(Optional<CSSPixels> width) { m_intrinsic_width = width; }
+    void set_intrinsic_height(Optional<CSSPixels> height) { m_intrinsic_height = height; }
+
     virtual void prepare_for_replaced_layout() { }
 
     virtual bool can_have_children() const override { return false; }


### PR DESCRIPTION
This PR fixes a bug in calculation of the width of an image in a flex when the width and height are explicitly specified in attributes.