### PR TITLE
LibMedia: Support videos with BT470BG color matrix

### DIFF
--- a/Userland/Libraries/LibMedia/Color/ColorConverter.cpp
+++ b/Userland/Libraries/LibMedia/Color/ColorConverter.cpp
@@ -76,19 +76,20 @@ DecoderErrorOr<ColorConverter> ColorConverter::create(u8 bit_depth, CodingIndepe
 
     // https://kdashg.github.io/misc/colors/from-coeffs.html
     switch (input_cicp.matrix_coefficients()) {
-    case MatrixCoefficients::BT709:
-        color_conversion_matrix = {
-            1.0f, 0.0f, 0.78740f, 0.0f,       // y
-            1.0f, -0.09366f, -0.23406f, 0.0f, // u
-            1.0f, 0.92780f, 0.0f, 0.0f,       // v
-            0.0f, 0.0f, 0.0f, 1.0f,           // w
-        };
-        break;
+    case MatrixCoefficients::BT470BG:
     case MatrixCoefficients::BT601:
         color_conversion_matrix = {
             1.0f, 0.0f, 0.70100f, 0.0f,       // y
             1.0f, -0.17207f, -0.35707f, 0.0f, // u
             1.0f, 0.88600f, 0.0f, 0.0f,       // v
+            0.0f, 0.0f, 0.0f, 1.0f,           // w
+        };
+        break;
+    case MatrixCoefficients::BT709:
+        color_conversion_matrix = {
+            1.0f, 0.0f, 0.78740f, 0.0f,       // y
+            1.0f, -0.09366f, -0.23406f, 0.0f, // u
+            1.0f, 0.92780f, 0.0f, 0.0f,       // v
             0.0f, 0.0f, 0.0f, 1.0f,           // w
         };
         break;

--- a/Userland/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Userland/Libraries/LibMedia/PlaybackManager.cpp
@@ -250,11 +250,13 @@ void PlaybackManager::decode_and_queue_one_sample()
             cicp.adopt_specified_values(container_cicp);
             cicp.default_code_points_if_unspecified({ ColorPrimaries::BT709, TransferCharacteristics::BT709, MatrixCoefficients::BT709, VideoFullRangeFlag::Studio });
 
-            // BT.601, BT.709 and BT.2020 have a similar transfer function to sRGB, so other applications
+            // BT.470 M, B/G, BT.601, BT.709 and BT.2020 have a similar transfer function to sRGB, so other applications
             // (Chromium, VLC) forgo transfer characteristics conversion. We will emulate that behavior by
             // handling those as sRGB instead, which causes no transfer function change in the output,
             // unless display color management is later implemented.
             switch (cicp.transfer_characteristics()) {
+            case TransferCharacteristics::BT470BG:
+            case TransferCharacteristics::BT470M:
             case TransferCharacteristics::BT601:
             case TransferCharacteristics::BT709:
             case TransferCharacteristics::BT2020BitDepth10:

--- a/Userland/Libraries/LibMedia/VideoFrame.cpp
+++ b/Userland/Libraries/LibMedia/VideoFrame.cpp
@@ -185,10 +185,11 @@ static ALWAYS_INLINE DecoderErrorOr<void> convert_to_bitmap_selecting_converter(
 
     if (bit_depth == 8 && cicp.transfer_characteristics() == output_cicp.transfer_characteristics() && cicp.color_primaries() == output_cicp.color_primaries() && cicp.video_full_range_flag() == VideoFullRangeFlag::Studio) {
         switch (cicp.matrix_coefficients()) {
-        case MatrixCoefficients::BT709:
-            return convert_to_bitmap_subsampled<subsampling_horizontal, subsampling_vertical>([](T y, T u, T v) { return ColorConverter::convert_simple_yuv_to_rgb<MatrixCoefficients::BT709, VideoFullRangeFlag::Studio>(y, u, v); }, width, height, plane_y, plane_u, plane_v, bitmap);
+        case MatrixCoefficients::BT470BG:
         case MatrixCoefficients::BT601:
             return convert_to_bitmap_subsampled<subsampling_horizontal, subsampling_vertical>([](T y, T u, T v) { return ColorConverter::convert_simple_yuv_to_rgb<MatrixCoefficients::BT601, VideoFullRangeFlag::Studio>(y, u, v); }, width, height, plane_y, plane_u, plane_v, bitmap);
+        case MatrixCoefficients::BT709:
+            return convert_to_bitmap_subsampled<subsampling_horizontal, subsampling_vertical>([](T y, T u, T v) { return ColorConverter::convert_simple_yuv_to_rgb<MatrixCoefficients::BT709, VideoFullRangeFlag::Studio>(y, u, v); }, width, height, plane_y, plane_u, plane_v, bitmap);
         default:
             break;
         }


### PR DESCRIPTION
BT.470 B/G "Matrix coefficients" doesn't work in current master branch.

<img width="942" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/12079442/9cfaa6c1-1426-4ac9-aadd-16484258f644">

Handle BT.470 B/G color matrix the same as BT.601. This seemed to work fine with the limited number of videos I tested.

You can generate a video with the BT.470 color matrix by identifying the current color matrix:

```bash
ffprobe -v error -select_streams v:0 -show_entries stream=color_space -of default=noprint_wrappers=1:nokey=1 video.webm 
bt709
```

Then converting the color matrix like so:

```bash
ffmpeg -i input.webm -vf "colormatrix=bt709:bt470bg" output.webm
```

The colors appear to match pretty well using the existing matrix.
<img width="646" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/12079442/94586948-9d61-49ae-b972-aae372537b60">
<img width="646" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/12079442/855f4eab-2f3d-4cf9-8cf0-ba917f17b27a">
