### PR TITLE
LibWeb+WebContent: make Skia backend a compile-time option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ if (ENABLE_QT)
     find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
 endif()
 
+serenity_option(ENABLE_SKIA ON CACHE BOOL "Enable ladybird Skia painting backend")
+
 include(CTest) # for BUILD_TESTING option, default ON
 
 add_subdirectory(Ladybird)

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -31,6 +31,7 @@ There are some optional features that can be enabled during compilation that are
 - `SERENITY_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set manually unless managing a distribution package.
 - `ENABLE_NETWORK_DOWNLOADS`: allows downloading files from the internet during the build. Default on, turning off enables offline builds. For offline builds, the structure of the SERENITY_CACHE_DIR must be set up the way that the build expects.
 - `ENABLE_ACCELERATED_GRAPHICS`: builds features that use accelerated graphics APIs to speed up painting and drawing using native graphics libraries. 
+- `ENABLE_SKIA`: builds the Skia painting backend (default: ON).
 
 Many parts of the codebase have debug functionality, mostly consisting of additional messages printed to the debug console. This is done via the `<component_name>_DEBUG` macros, which can be enabled individually at build time. They are listed in [this file](../Meta/CMake/all_the_debug_macros.cmake).
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -544,7 +544,6 @@ set(SOURCES
     Painting/ClippableAndScrollable.cpp
     Painting/DisplayList.cpp
     Painting/DisplayListPlayerCPU.cpp
-    Painting/DisplayListPlayerSkia.cpp
     Painting/DisplayListRecorder.cpp
     Painting/GradientPainting.cpp
     Painting/FilterPainting.cpp
@@ -753,17 +752,22 @@ set(GENERATED_SOURCES
     Worker/WebWorkerServerEndpoint.h
 )
 
-find_package(unofficial-skia CONFIG REQUIRED)
-
 serenity_lib(LibWeb web)
 
-target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibAudio LibMedia LibWasm LibXML LibIDL LibURL LibTLS unofficial::skia::skia)
+target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibAudio LibMedia LibWasm LibXML LibIDL LibURL LibTLS)
 
 if (HAS_ACCELERATED_GRAPHICS)
     target_link_libraries(LibWeb PRIVATE ${ACCEL_GFX_LIBS})
     target_sources(LibWeb PRIVATE Painting/DisplayListPlayerGPU.cpp)
     target_link_libraries(LibWeb PRIVATE LibAccelGfx)
     target_compile_definitions(LibWeb PRIVATE HAS_ACCELERATED_GRAPHICS)
+endif()
+
+if (ENABLE_SKIA)
+    find_package(unofficial-skia CONFIG REQUIRED)
+    target_link_libraries(LibWeb PRIVATE unofficial::skia::skia)
+    target_sources(LibWeb PRIVATE Painting/DisplayListPlayerSkia.cpp)
+    target_compile_definitions(LibWeb PRIVATE ENABLE_SKIA)
 endif()
 
 generate_js_bindings(LibWeb)

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -34,7 +34,9 @@ TraversableNavigable::TraversableNavigable(JS::NonnullGCPtr<Page> page)
 {
 #ifdef AK_OS_MACOS
     m_metal_context = Core::get_metal_context();
+#ifdef ENABLE_SKIA
     m_skia_backend_context = Painting::DisplayListPlayerSkia::create_metal_context(*m_metal_context);
+#endif
 #endif
 }
 
@@ -1204,6 +1206,7 @@ void TraversableNavigable::paint(DevicePixelRect const& content_rect, Painting::
             has_warned_about_configuration = true;
         }
 #endif
+#ifdef ENABLE_SKIA
     } else if (display_list_player_type == DisplayListPlayerType::Skia) {
 #ifdef AK_OS_MACOS
         if (m_metal_context && m_skia_backend_context && is<Painting::IOSurfaceBackingStore>(target)) {
@@ -1216,6 +1219,7 @@ void TraversableNavigable::paint(DevicePixelRect const& content_rect, Painting::
 #endif
         Painting::DisplayListPlayerSkia player(target.bitmap());
         display_list.execute(player);
+#endif
     } else {
         Painting::DisplayListPlayerCPU player(target.bitmap());
         display_list.execute(player);

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -12,7 +12,9 @@
 #include <LibWeb/HTML/SessionHistoryTraversalQueue.h>
 #include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/Page/Page.h>
+#ifdef ENABLE_SKIA
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
+#endif
 #include <WebContent/BackingStoreManager.h>
 
 #ifdef AK_OS_MACOS

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -16,7 +16,9 @@
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerCPU.h>
+#ifdef ENABLE_SKIA
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
+#endif
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
@@ -106,11 +108,13 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
         display_list.execute(executor);
         break;
     }
+#ifdef ENABLE_SKIA
     case DisplayListPlayerType::Skia: {
         Painting::DisplayListPlayerSkia executor { *bitmap };
         display_list.execute(executor);
         break;
     }
+#endif
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Services/WebContent/CMakeLists.txt
+++ b/Userland/Services/WebContent/CMakeLists.txt
@@ -31,3 +31,7 @@ if (HAS_ACCELERATED_GRAPHICS)
     target_compile_definitions(WebContent PRIVATE HAS_ACCELERATED_GRAPHICS)
     target_link_libraries(WebContent PRIVATE LibAccelGfx)
 endif()
+
+if (ENABLE_SKIA)
+    target_compile_definitions(WebContent PRIVATE ENABLE_SKIA)
+endif()

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -32,7 +32,9 @@
 namespace WebContent {
 
 static bool s_use_gpu_painter = false;
+#ifdef ENABLE_SKIA
 static bool s_use_skia_painter = false;
+#endif
 
 JS_DEFINE_ALLOCATOR(PageClient);
 
@@ -43,7 +45,11 @@ void PageClient::set_use_gpu_painter()
 
 void PageClient::set_use_skia_painter()
 {
+#ifdef ENABLE_SKIA
     s_use_skia_painter = true;
+#else
+    warnln("Skia painter is not available in this build.");
+#endif
 }
 
 JS::NonnullGCPtr<PageClient> PageClient::create(JS::VM& vm, PageHost& page_host, u64 id)
@@ -743,8 +749,10 @@ Web::DisplayListPlayerType PageClient::display_list_player_type() const
 {
     if (s_use_gpu_painter)
         return Web::DisplayListPlayerType::GPU;
+#ifdef ENABLE_SKIA
     if (s_use_skia_painter)
         return Web::DisplayListPlayerType::Skia;
+#endif
     return Web::DisplayListPlayerType::CPU;
 }
 


### PR DESCRIPTION
Similar in spirit to how the GPU graphics backend can be controlled by `ENABLE_ACCELERATED_GRAPHICS`, this pull request adds a CMake option to en-/disable the Skia graphics backend (`ENABLE_SKIA`, default `ON`).

This is more consistent and makes Ladybird easier to build, because Skia is quite complicated to build and link Ladybird against.

Further, I assume, disabling Skia makes Ladybird easier to port to less-common CPU architectures or big-endian platforms (Skia officially does not support big-endian byte order).

The `--enable-skia-painting` command line option is kept in place, but does not do anything other than to print a warning on stderr when used on a build with Skia disabled.