### PR TITLE
LibWeb: Add initial implementation of global.reportError()

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
+++ b/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
@@ -1,0 +1,5 @@
+message = Reporting an Error!
+filename = 
+lineno = 0
+colno = 0
+error = Error: Reporting an Error!

--- a/Tests/LibWeb/Text/input/HTML/WindowOrWorkerGlobalScope-reportError.html
+++ b/Tests/LibWeb/Text/input/HTML/WindowOrWorkerGlobalScope-reportError.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        window.onerror = (message, filename, lineno, colno, error) => {
+            println(`message = ${message}`);
+            println(`filename = ${filename}`);
+            println(`lineno = ${lineno}`);
+            println(`colno = ${colno}`);
+            println(`error = ${error}`);
+
+            return true;
+        };
+
+        window.reportError(new Error('Reporting an Error!'));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -64,6 +64,7 @@ public:
     using WindowOrWorkerGlobalScopeMixin::create_image_bitmap;
     using WindowOrWorkerGlobalScopeMixin::fetch;
     using WindowOrWorkerGlobalScopeMixin::queue_microtask;
+    using WindowOrWorkerGlobalScopeMixin::report_error;
     using WindowOrWorkerGlobalScopeMixin::set_interval;
     using WindowOrWorkerGlobalScopeMixin::set_timeout;
     using WindowOrWorkerGlobalScopeMixin::structured_clone;

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -76,6 +76,8 @@ public:
 
     JS::NonnullGCPtr<IndexedDB::IDBFactory> indexed_db();
 
+    void report_error(JS::Value e);
+
 protected:
     void initialize(JS::Realm&);
     void visit_edges(JS::Cell::Visitor&);
@@ -114,6 +116,8 @@ private:
     JS::GCPtr<IndexedDB::IDBFactory> m_indexed_db;
 
     mutable JS::GCPtr<JS::Object> m_supported_entry_types_array;
+
+    bool m_error_reporting_mode { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.idl
@@ -17,7 +17,8 @@ interface mixin WindowOrWorkerGlobalScope {
     readonly attribute boolean isSecureContext;
     readonly attribute boolean crossOriginIsolated;
 
-    [FIXME] undefined reportError(any e);
+    // https://html.spec.whatwg.org/multipage/webappapis.html#dom-reporterror
+    undefined reportError(any e);
 
     // base64 utility methods
     DOMString btoa(DOMString data);


### PR DESCRIPTION
This pull requests add a initial implementation of global.reportError() function.

refs: https://html.spec.whatwg.org/multipage/webappapis.html#runtime-script-errors

Example document to check the behaviour:

```html
<!DOCTYPE html>
<html>
  <head></head>
  <body>
    <script>
      window.onerror = (message, filename, lineno, colno, error) => {
        console.log('Caught an error.', {message, filename, lineno, colno, error});
      };

      window.reportError(new Error('Reporting an Error!'));
    </script>
  </body>
</html>
```