### PR TITLE
Documentation: Remove LibGUI mention in VSCode configuration

### DIFF
--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -47,7 +47,7 @@ Run ``./Meta/ladybird.sh run ladybird`` at least once to generate the ``compile_
 ### DSL syntax highlighting
 
 There's a syntax highlighter extension for SerenityOS DSLs called "SerenityOS DSL Syntax Highlight", available [here](https://marketplace.visualstudio.com/items?itemName=kleinesfilmroellchen.serenity-dsl-syntaxhighlight) or [here](https://open-vsx.org/extension/kleinesfilmroellchen/serenity-dsl-syntaxhighlight).
-The extension provides syntax highlighting for LibIPC's IPC files, LibGUI's GUI Markup Language (GML), [Web IDL](https://webidl.spec.whatwg.org/), and LibJS's
+The extension provides syntax highlighting for LibIPC's IPC files, [Web IDL](https://webidl.spec.whatwg.org/), and LibJS's
 serialization format (no extension) as output by js with the -d option.
 
 ### Microsoft C/C++ tools


### PR DESCRIPTION
Since this fork no longer supports LibGUI, we should not mention it here to avoid confusion from contributors who aren't familiar with SerenityOS.