### PR TITLE
LibWeb: Save float-intrusion for marker before list elements layout

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -77,7 +77,8 @@ private:
     void place_block_level_element_in_normal_flow_horizontally(Box const& child_box, AvailableSpace const&);
     void place_block_level_element_in_normal_flow_vertically(Box const&, CSSPixels y);
 
-    void layout_list_item_marker(ListItemBox const&);
+    void ensure_sizes_correct_for_left_offset_calculation(ListItemBox const&);
+    void layout_list_item_marker(ListItemBox const&, CSSPixels const& left_space_before_list_item_elements_formatted);
 
     void measure_scrollable_overflow(Box const&, CSSPixels& bottom_edge, CSSPixels& right_edge) const;
 


### PR DESCRIPTION
... to prevent that left-floating elements inside the list element push the list marker into the (non-floating) content of the list element.

Two small test pages. The second is a reduction from ao3.org. The bottom example shows a clear improvement (now the same as Chromium and Firefox), whereas the first example shows no degradation. (Still different from the other two browsers.)

I have tried to use the same const style as in the surrounding code, even if CLion did recommend  I place const qualifiers in a few more places. If this is not recommended and we want to follow the const-notes from clang-tidy, I'll fix that up.

```html
<!DOCTYPE html>

<body>
    <div style="float: left; background-color: red; height: 50px; width: 150px; opacity: 50%;"></div>
    <ul>
        <li> <div>TEXT</div> <div style="float: left;">FLOAT</div> </li>
        <li> <div>TEXT</div> </li>
        <li> <div>TEXT</div> </li>
        <li> <div>TEXT</div> </li>
    </ul>
</body>

</html>
```

```html
<!DOCTYPE html>

<body>
    <ul>
        <li>
            <div style="float: left">1234567890</div>
            <div style="float: left">XYZ</div>
            <div>ABCD</div>
        </li>
    </ul>
</body>

</html>
```

Before:
![Screenshot from 2024-07-03 20-17-42](https://github.com/LadybirdBrowser/ladybird/assets/8158314/edabfdf4-8869-443d-9bd4-7ad9279622fb)
![Screenshot from 2024-07-03 20-17-33](https://github.com/LadybirdBrowser/ladybird/assets/8158314/60da5a0b-3df7-4645-9dee-77765a9c1ad1)

After:
![Screenshot from 2024-07-03 20-34-33](https://github.com/LadybirdBrowser/ladybird/assets/8158314/007dc06d-9ba4-496f-899f-11330d6773d3)
![Screenshot from 2024-07-03 20-34-40](https://github.com/LadybirdBrowser/ladybird/assets/8158314/c693fbff-8dac-4fe9-b6bf-eb31b8de6c49)
