### PR TITLE
Android: Get the build in a working state again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.25)
 
+if (VCPKG_TARGET_ANDROID)
+    # If we are building for Android, we must load vcpkg_android.cmake before the project() declaration.
+    # This ensures that the CMAKE_TOOLCHAIN_FILE is set correctly.
+    # (we cannot set CMAKE_TOOLCHAIN_FILE from Gradle, unfortunately, so this is the only place we can do it.)
+    include("Ladybird/Android/vcpkg_android.cmake")
+endif()
+
 project(ladybird
         VERSION 0.1.0
         LANGUAGES C CXX

--- a/Ladybird/Android/BuildLagomTools.sh
+++ b/Ladybird/Android/BuildLagomTools.sh
@@ -4,24 +4,39 @@ set -eo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-SERENITY_ROOT="$(realpath "${DIR}"/../..)"
+LADYBIRD_SOURCE_DIR="$(realpath "${DIR}"/../..)"
 
 # shellcheck source=/dev/null
-. "${SERENITY_ROOT}/Meta/shell_include.sh"
+. "${LADYBIRD_SOURCE_DIR}/Meta/shell_include.sh"
 
 # shellcheck source=/dev/null
-. "${SERENITY_ROOT}/Meta/find_compiler.sh"
+. "${LADYBIRD_SOURCE_DIR}/Meta/find_compiler.sh"
 
 pick_host_compiler
 
-BUILD_DIR=${BUILD_DIR:-"${SERENITY_ROOT}/Build"}
+BUILD_DIR=${BUILD_DIR:-"${LADYBIRD_SOURCE_DIR}/Build"}
 CACHE_DIR=${CACHE_DIR:-"${BUILD_DIR}/caches"}
 
-cmake -S "$SERENITY_ROOT/Meta/Lagom" -B "$BUILD_DIR/lagom-tools" \
+# HACK: This export of XDG_CACHE_HOME is required to make vcpkg happy.
+# This is because vcpkg tries to find a cache directory by:
+#   1) checking $XDG_CACHE_HOME
+#   2) appending "/.cache" to $HOME
+# The problem is, in the Android build environment, neither of those environment variables are set.
+# This causes vcpkg to fail; so, we set a dummy $XDG_CACHE_HOME, ensuring that vcpkg is happy.
+# (Note that vcpkg appends "/vcpkg" to the cache directory we give it.)
+# (And this also works on macOS, despite the fact that $XDG_CACHE_HOME is a Linux-ism.)
+export XDG_CACHE_HOME="$CACHE_DIR"
+
+cmake -S "${LADYBIRD_SOURCE_DIR}/Meta/Lagom" -B "$BUILD_DIR/lagom-tools" \
     -GNinja -Dpackage=LagomTools \
     -DCMAKE_INSTALL_PREFIX="$BUILD_DIR/lagom-tools-install"  \
     -DCMAKE_C_COMPILER="$CC" \
     -DCMAKE_CXX_COMPILER="$CXX" \
-    -DSERENITY_CACHE_DIR="$CACHE_DIR"
+    -DSERENITY_CACHE_DIR="$CACHE_DIR" \
+    -DCMAKE_TOOLCHAIN_FILE="$LADYBIRD_SOURCE_DIR/Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake" \
+    -DVCPKG_INSTALL_OPTIONS="--no-print-usage" \
+    -DVCPKG_OVERLAY_TRIPLETS="$LADYBIRD_SOURCE_DIR/Meta/CMake/vcpkg/release-triplets" \
+    -DVCPKG_ROOT="$LADYBIRD_SOURCE_DIR/Toolchain/Tarballs/vcpkg" \
+    -DVCPKG_MANIFEST_DIR="$LADYBIRD_SOURCE_DIR"
 
 ninja -C "$BUILD_DIR/lagom-tools" install

--- a/Ladybird/Android/CMakeLists.txt
+++ b/Ladybird/Android/CMakeLists.txt
@@ -9,5 +9,5 @@ add_library(ladybird SHARED
 )
 target_link_libraries(ladybird PRIVATE LibArchive jnigraphics android)
 
-include(Ladybird/cmake/AndroidExtras.cmake)
+include(../cmake/AndroidExtras.cmake)
 create_ladybird_bundle(ladybird)

--- a/Ladybird/Android/build.gradle.kts
+++ b/Ladybird/Android/build.gradle.kts
@@ -34,7 +34,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
             cmake {
-                cppFlags += "-std=c++23"
+                // FIXME: Use -std=c++23 once the Android NDK's clang supports that.
+                cppFlags += "-std=c++2b"
                 arguments += listOf(
                     "-DLagomTools_DIR=$buildDir/lagom-tools-install/share/LagomTools",
                     "-DSERENITY_CACHE_DIR=$cacheDir",

--- a/Ladybird/Android/build.gradle.kts
+++ b/Ladybird/Android/build.gradle.kts
@@ -68,7 +68,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            path = file("../CMakeLists.txt")
+            path = file("../../CMakeLists.txt")
             version = "3.23.0+"
         }
     }

--- a/Ladybird/Android/build.gradle.kts
+++ b/Ladybird/Android/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 
 var buildDir = layout.buildDirectory.get()
 var cacheDir = System.getenv("SERENITY_CACHE_DIR") ?: "$buildDir/caches"
+var sourceDir = layout.projectDirectory.dir("../../").toString()
 
 task<Exec>("buildLagomTools") {
     commandLine = listOf("./BuildLagomTools.sh")
@@ -36,7 +37,9 @@ android {
                 cppFlags += "-std=c++23"
                 arguments += listOf(
                     "-DLagomTools_DIR=$buildDir/lagom-tools-install/share/LagomTools",
-                    "-DSERENITY_CACHE_DIR=$cacheDir"
+                    "-DSERENITY_CACHE_DIR=$cacheDir",
+                    "-DVCPKG_ROOT=$sourceDir/Toolchain/Tarballs/vcpkg",
+                    "-DVCPKG_TARGET_ANDROID=ON"
                 )
             }
         }

--- a/Ladybird/Android/src/main/cpp/WebContentService.cpp
+++ b/Ladybird/Android/src/main/cpp/WebContentService.cpp
@@ -37,8 +37,10 @@ static ErrorOr<NonnullRefPtr<Protocol::RequestClient>> bind_request_server_servi
     return bind_service<Protocol::RequestClient>(&bind_request_server_java);
 }
 
-template ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>, Error>
-bind_service<ImageDecoderClient::Client>(void (*)(int));
+static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> bind_image_decoder_service()
+{
+    return bind_service<ImageDecoderClient::Client>(&bind_image_decoder_java);
+}
 
 static ErrorOr<void> load_content_filters();
 
@@ -49,7 +51,9 @@ ErrorOr<int> service_main(int ipc_socket)
     Core::EventLoop event_loop;
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
-    Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPlugin);
+
+    auto image_decoder_client = TRY(bind_image_decoder_service());
+    Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPlugin(move(image_decoder_client)));
 
     Web::Platform::AudioCodecPlugin::install_creation_hook([](auto loader) {
         (void)loader;

--- a/Ladybird/Android/src/main/cpp/WebViewImplementationNative.cpp
+++ b/Ladybird/Android/src/main/cpp/WebViewImplementationNative.cpp
@@ -69,7 +69,7 @@ void WebViewImplementationNative::paint_into_bitmap(void* android_bitmap_raw, An
     // Software bitmaps only for now!
     VERIFY((info.flags & ANDROID_BITMAP_FLAGS_IS_HARDWARE) == 0);
 
-    auto android_bitmap = MUST(Gfx::Bitmap::create_wrapper(to_gfx_bitmap_format(info.format), { info.width, info.height }, 1, info.stride, android_bitmap_raw));
+    auto android_bitmap = MUST(Gfx::Bitmap::create_wrapper(to_gfx_bitmap_format(info.format), { info.width, info.height }, info.stride, android_bitmap_raw));
     Gfx::Painter painter(android_bitmap);
     if (auto* bitmap = m_client_state.has_usable_bitmap ? m_client_state.front_bitmap.bitmap.ptr() : m_backup_bitmap.ptr())
         painter.blit({ 0, 0 }, *bitmap, bitmap->rect());

--- a/Ladybird/Android/src/main/cpp/WebViewImplementationNative.cpp
+++ b/Ladybird/Android/src/main/cpp/WebViewImplementationNative.cpp
@@ -93,8 +93,7 @@ void WebViewImplementationNative::paint_into_bitmap(void* android_bitmap_raw, An
 
 void WebViewImplementationNative::set_viewport_geometry(int w, int h)
 {
-    m_viewport_rect = { { 0, 0 }, { w, h } };
-    client().async_set_viewport_rect(0, m_viewport_rect);
+    m_viewport_size = { w, h };
     handle_resize();
 }
 

--- a/Ladybird/Android/src/main/cpp/WebViewImplementationNative.h
+++ b/Ladybird/Android/src/main/cpp/WebViewImplementationNative.h
@@ -15,7 +15,7 @@ class WebViewImplementationNative : public WebView::ViewImplementation {
 public:
     WebViewImplementationNative(jobject thiz);
 
-    virtual Web::DevicePixelRect viewport_rect() const override { return m_viewport_rect; }
+    virtual Web::DevicePixelSize viewport_size() const override { return m_viewport_size; }
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint p) const override { return p; }
     virtual Gfx::IntPoint to_widget_position(Gfx::IntPoint p) const override { return p; }
     virtual void update_zoom() override { }
@@ -38,6 +38,6 @@ public:
 
 private:
     jobject m_java_instance = nullptr;
-    Web::DevicePixelRect m_viewport_rect;
+    Web::DevicePixelSize m_viewport_size;
 };
 }

--- a/Ladybird/Android/vcpkg_android.cmake
+++ b/Ladybird/Android/vcpkg_android.cmake
@@ -1,0 +1,96 @@
+# This file is based on the vcpkg Android example from here https://github.com/microsoft/vcpkg-docs/blob/06b496c3f24dbe651fb593a26bee50537eeaf4e5/vcpkg/examples/vcpkg_android_example_cmake_script/cmake/vcpkg_android.cmake
+# It was modified to use CMake variables instead of environment variables, because it's not possible to set environment variables in the Android Gradle plugin.
+#
+# vcpkg_android.cmake
+#
+# Helper script when using vcpkg with cmake. It should be triggered via the variable VCPKG_TARGET_ANDROID
+#
+# For example:
+# if (VCPKG_TARGET_ANDROID)
+#     include("cmake/vcpkg_android.cmake")
+# endif()
+#
+# This script will:
+# 1 & 2. check the presence of needed env variables: ANDROID_NDK and VCPKG_ROOT
+# 3. set VCPKG_TARGET_TRIPLET according to ANDROID_ABI
+# 4. Combine vcpkg and Android toolchains by setting CMAKE_TOOLCHAIN_FILE
+#    and VCPKG_CHAINLOAD_TOOLCHAIN_FILE
+
+# Note: VCPKG_TARGET_ANDROID is not an official vcpkg variable.
+# it is introduced for the need of this script
+
+if (VCPKG_TARGET_ANDROID)
+
+    #
+    # 1. Check the presence of variable ANDROID_NDK
+    #
+    if (NOT DEFINED ANDROID_NDK)
+        message(FATAL_ERROR "Please set CMake variable ANDROID_NDK")
+    endif()
+
+    #
+    # 2. Check the presence of environment variable VCPKG_ROOT
+    #
+    if (NOT DEFINED VCPKG_ROOT)
+        message(FATAL_ERROR "Please set a CMake variable VCPKG_ROOT")
+    endif()
+
+    #
+    # 3. Set VCPKG_TARGET_TRIPLET according to ANDROID_ABI
+    #
+    # There are four different Android ABI, each of which maps to
+    # a vcpkg triplet. The following table outlines the mapping from vcpkg architectures to android architectures
+    #
+    # |VCPKG_TARGET_TRIPLET       | ANDROID_ABI          |
+    # |---------------------------|----------------------|
+    # |arm64-android              | arm64-v8a            |
+    # |arm-android                | armeabi-v7a          |
+    # |x64-android                | x86_64               |
+    # |x86-android                | x86                  |
+    #
+    # The variable must be stored in the cache in order to successfully the two toolchains.
+    #
+    if (ANDROID_ABI MATCHES "arm64-v8a")
+        set(VCPKG_TARGET_TRIPLET "arm64-android" CACHE STRING "" FORCE)
+    elseif(ANDROID_ABI MATCHES "armeabi-v7a")
+        set(VCPKG_TARGET_TRIPLET "arm-android" CACHE STRING "" FORCE)
+    elseif(ANDROID_ABI MATCHES "x86_64")
+        set(VCPKG_TARGET_TRIPLET "x64-android" CACHE STRING "" FORCE)
+    elseif(ANDROID_ABI MATCHES "x86")
+        set(VCPKG_TARGET_TRIPLET "x86-android" CACHE STRING "" FORCE)
+    else()
+        message(FATAL_ERROR "
+        Please specify ANDROID_ABI
+        For example
+        cmake ... -DANDROID_ABI=armeabi-v7a
+
+        Possible ABIs are: arm64-v8a, armeabi-v7a, x64-android, x86-android
+        ")
+    endif()
+    message("vcpkg_android.cmake: VCPKG_TARGET_TRIPLET was set to ${VCPKG_TARGET_TRIPLET}")
+
+    #
+    # 4. Combine vcpkg and Android toolchains
+    #
+
+    # vcpkg and android both provide dedicated toolchains:
+    #
+    # vcpkg_toolchain_file=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+    # android_toolchain_file=$ANDROID_NDK/build/cmake/android.toolchain.cmake
+    #
+    # When using vcpkg, the vcpkg toolchain shall be specified first.
+    # However, vcpkg provides a way to preload and additional toolchain,
+    # with the VCPKG_CHAINLOAD_TOOLCHAIN_FILE option.
+    set(VCPKG_CHAINLOAD_TOOLCHAIN_FILE ${ANDROID_NDK}/build/cmake/android.toolchain.cmake)
+    set(CMAKE_TOOLCHAIN_FILE ${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake)
+    message("vcpkg_android.cmake: CMAKE_TOOLCHAIN_FILE was set to ${CMAKE_TOOLCHAIN_FILE}")
+    message("vcpkg_android.cmake: VCPKG_CHAINLOAD_TOOLCHAIN_FILE was set to ${VCPKG_CHAINLOAD_TOOLCHAIN_FILE}")
+
+    # vcpkg depends on the environment variables ANDROID_NDK_HOME and VCPKG_ROOT being set.
+    # However, we cannot set those through the Android Gradle plugin (we can only set CMake variables).
+    # Therefore, we forward our CMake variables to environment variables.
+    # FIXME: would be nice if vcpkg's android toolchain did not require this...
+    set(ENV{ANDROID_NDK_HOME} ${ANDROID_NDK})
+    set(ENV{VCPKG_ROOT} ${VCPKG_ROOT})
+
+endif(VCPKG_TARGET_ANDROID)

--- a/Ladybird/FontPlugin.cpp
+++ b/Ladybird/FontPlugin.cpp
@@ -173,11 +173,12 @@ void FontPlugin::update_generic_fonts()
 
     // Fallback fonts to look for if Gfx::Font can't load expected font
     // The lists are basically arbitrary, taken from https://www.w3.org/Style/Examples/007/fonts.en.html
-    Vector<FlyString> cursive_fallbacks { "Comic Sans MS"_fly_string, "Comic Sans"_fly_string, "Apple Chancery"_fly_string, "Bradley Hand"_fly_string, "Brush Script MT"_fly_string, "Snell Roundhand"_fly_string, "URW Chancery L"_fly_string };
-    Vector<FlyString> fantasy_fallbacks { "Impact"_fly_string, "Luminari"_fly_string, "Chalkduster"_fly_string, "Jazz LET"_fly_string, "Blippo"_fly_string, "Stencil Std"_fly_string, "Marker Felt"_fly_string, "Trattatello"_fly_string };
-    Vector<FlyString> monospace_fallbacks { "Andale Mono"_fly_string, "Courier New"_fly_string, "Courier"_fly_string, "FreeMono"_fly_string, "OCR A Std"_fly_string, "DejaVu Sans Mono"_fly_string, "Liberation Mono"_fly_string };
-    Vector<FlyString> sans_serif_fallbacks { "Arial"_fly_string, "Helvetica"_fly_string, "Verdana"_fly_string, "Trebuchet MS"_fly_string, "Gill Sans"_fly_string, "Noto Sans"_fly_string, "Avantgarde"_fly_string, "Optima"_fly_string, "Arial Narrow"_fly_string, "Liberation Sans"_fly_string };
-    Vector<FlyString> serif_fallbacks { "Times"_fly_string, "Times New Roman"_fly_string, "Didot"_fly_string, "Georgia"_fly_string, "Palatino"_fly_string, "Bookman"_fly_string, "New Century Schoolbook"_fly_string, "American Typewriter"_fly_string, "Liberation Serif"_fly_string, "Roman"_fly_string };
+    // (We also add Android-specific font names to the list from W3 where required.)
+    Vector<FlyString> cursive_fallbacks { "Comic Sans MS"_fly_string, "Comic Sans"_fly_string, "Apple Chancery"_fly_string, "Bradley Hand"_fly_string, "Brush Script MT"_fly_string, "Snell Roundhand"_fly_string, "URW Chancery L"_fly_string, "Dancing Script"_fly_string };
+    Vector<FlyString> fantasy_fallbacks { "Impact"_fly_string, "Luminari"_fly_string, "Chalkduster"_fly_string, "Jazz LET"_fly_string, "Blippo"_fly_string, "Stencil Std"_fly_string, "Marker Felt"_fly_string, "Trattatello"_fly_string, "Coming Soon"_fly_string };
+    Vector<FlyString> monospace_fallbacks { "Andale Mono"_fly_string, "Courier New"_fly_string, "Courier"_fly_string, "FreeMono"_fly_string, "OCR A Std"_fly_string, "DejaVu Sans Mono"_fly_string, "Droid Sans Mono"_fly_string, "Liberation Mono"_fly_string };
+    Vector<FlyString> sans_serif_fallbacks { "Arial"_fly_string, "Helvetica"_fly_string, "Verdana"_fly_string, "Trebuchet MS"_fly_string, "Gill Sans"_fly_string, "Noto Sans"_fly_string, "Avantgarde"_fly_string, "Optima"_fly_string, "Arial Narrow"_fly_string, "Liberation Sans"_fly_string, "Roboto"_fly_string };
+    Vector<FlyString> serif_fallbacks { "Times"_fly_string, "Times New Roman"_fly_string, "Didot"_fly_string, "Georgia"_fly_string, "Palatino"_fly_string, "Bookman"_fly_string, "New Century Schoolbook"_fly_string, "American Typewriter"_fly_string, "Liberation Serif"_fly_string, "Roman"_fly_string, "Noto Serif"_fly_string };
 
     update_mapping(Web::Platform::GenericFont::Cursive, cursive_fallbacks);
     update_mapping(Web::Platform::GenericFont::Fantasy, fantasy_fallbacks);

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -30,9 +30,10 @@ else()
     set_target_properties(webcontent PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 endif()
 
-target_include_directories(webcontent PUBLIC ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
-target_include_directories(webcontent PUBLIC ${LADYBIRD_SOURCE_DIR}/Userland/)
-target_include_directories(webcontent PUBLIC ${CMAKE_CURRENT_BINARY_DIR}/..)
+target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/Services/>)
+target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/>)
+target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
+
 target_link_libraries(webcontent PUBLIC LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView LibImageDecoderClient)
 
 if (HAVE_PULSEAUDIO)

--- a/Ladybird/cmake/AndroidExtras.cmake
+++ b/Ladybird/cmake/AndroidExtras.cmake
@@ -21,8 +21,6 @@ copy_res_folder(fonts)
 copy_res_folder(icons)
 copy_res_folder(emoji)
 copy_res_folder(themes)
-copy_res_folder(color-palettes)
-copy_res_folder(cursor-themes)
 add_custom_target(copy-autoplay-allowlist
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         "${LADYBIRD_SOURCE_DIR}/Base/home/anon/.config/BrowserAutoplayAllowlist.txt"
@@ -39,6 +37,6 @@ add_custom_target(copy-certs
         "asset-bundle/res/ladybird/cacert.pem"
 )
 add_dependencies(archive-assets copy-autoplay-allowlist copy-content-filters copy-certs)
-add_custom_target(copy-assets COMMAND ${CMAKE_COMMAND} -E copy_if_different ladybird-assets.tar.gz "${CMAKE_SOURCE_DIR}/Android/src/main/assets/")
+add_custom_target(copy-assets COMMAND ${CMAKE_COMMAND} -E copy_if_different ladybird-assets.tar.gz "${CMAKE_SOURCE_DIR}/Ladybird/Android/src/main/assets/")
 add_dependencies(copy-assets archive-assets)
 add_dependencies(ladybird copy-assets)

--- a/Meta/CMake/fontconfig.cmake
+++ b/Meta/CMake/fontconfig.cmake
@@ -1,4 +1,4 @@
-if (NOT APPLE)
+if (NOT APPLE AND NOT ANDROID)
     find_package(Fontconfig REQUIRED)
     set(HAS_FONTCONFIG ON CACHE BOOL "" FORCE)
     add_compile_definitions(USE_FONTCONFIG=1)

--- a/Meta/CMake/use_linker.cmake
+++ b/Meta/CMake/use_linker.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-if (NOT APPLE AND NOT LAGOM_USE_LINKER)
+if (NOT APPLE AND NOT ANDROID AND NOT LAGOM_USE_LINKER)
     find_program(LLD_LINKER NAMES "ld.lld")
     if (LLD_LINKER)
         message(STATUS "Using LLD to link Lagom.")

--- a/Userland/Libraries/LibCore/StandardPaths.cpp
+++ b/Userland/Libraries/LibCore/StandardPaths.cpp
@@ -206,6 +206,10 @@ ErrorOr<Vector<String>> StandardPaths::font_directories()
         "/System/Library/Fonts"_string,
         "/Library/Fonts"_string,
         TRY(String::formatted("{}/Library/Fonts"sv, home_directory())),
+#    elif defined(AK_OS_ANDROID)
+        // FIXME: We should be using the ASystemFontIterator NDK API here.
+        // There is no guarantee that this will continue to exist on future versions of Android.
+        "/system/fonts"_string,
 #    else
         TRY(String::formatted("{}/fonts"sv, data_directory())),
         TRY(String::formatted("{}/X11/fonts"sv, data_directory())),

--- a/Userland/Libraries/LibMedia/CMakeLists.txt
+++ b/Userland/Libraries/LibMedia/CMakeLists.txt
@@ -4,15 +4,22 @@ set(SOURCES
     Color/TransferCharacteristics.cpp
     Containers/Matroska/MatroskaDemuxer.cpp
     Containers/Matroska/Reader.cpp
-    FFmpeg/FFmpegVideoDecoder.cpp
     PlaybackManager.cpp
     VideoFrame.cpp
 )
 
+if (NOT ANDROID)
+    list(APPEND SOURCES FFmpeg/FFmpegVideoDecoder.cpp)
+else()
+    list(APPEND SOURCES FFmpeg/FFmpegVideoDecoderStub.cpp)
+endif()
+
 serenity_lib(LibMedia media)
 target_link_libraries(LibMedia PRIVATE LibCore LibIPC LibGfx LibThreading)
 
-# Third-party
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(AVCODEC REQUIRED IMPORTED_TARGET libavcodec)
-target_link_libraries(LibMedia PRIVATE PkgConfig::AVCODEC)
+if (NOT ANDROID)
+    # Third-party
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(AVCODEC REQUIRED IMPORTED_TARGET libavcodec)
+    target_link_libraries(LibMedia PRIVATE PkgConfig::AVCODEC)
+endif()

--- a/Userland/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoderStub.cpp
+++ b/Userland/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoderStub.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Alex Studer <alex@studer.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/System.h>
+#include <LibMedia/VideoFrame.h>
+
+#include "FFmpegForward.h"
+#include "FFmpegVideoDecoder.h"
+
+namespace Media::FFmpeg {
+
+DecoderErrorOr<NonnullOwnPtr<FFmpegVideoDecoder>> FFmpegVideoDecoder::try_create(CodecID codec_id, ReadonlyBytes codec_initialization_data)
+{
+    (void)codec_id;
+    (void)codec_initialization_data;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+FFmpegVideoDecoder::FFmpegVideoDecoder(AVCodecContext* codec_context, AVPacket* packet, AVFrame* frame)
+    : m_codec_context(codec_context)
+    , m_packet(packet)
+    , m_frame(frame)
+{
+}
+
+FFmpegVideoDecoder::~FFmpegVideoDecoder()
+{
+}
+
+DecoderErrorOr<void> FFmpegVideoDecoder::receive_sample(Duration timestamp, ReadonlyBytes sample)
+{
+    (void)timestamp;
+    (void)sample;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+DecoderErrorOr<NonnullOwnPtr<VideoFrame>> FFmpegVideoDecoder::get_decoded_frame()
+{
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+void FFmpegVideoDecoder::flush()
+{
+}
+
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -27,6 +27,10 @@
         "vulkan"
       ]
     },
+    {
+      "name": "skia",
+      "platform": "android"
+    },
     "sqlite3",
     "woff2"
   ],


### PR DESCRIPTION
This PR fixes various issues with the Android build, and gets it back in a somewhat working state. (Fixes #220)

It is not super stable (sometimes you have to reload a page a few times to get it to work, sometimes some resources aren't loaded properly) but it does somewhat work!

There were a variety of changes - most of them had to do with supporting the new external dependencies, but there were also some name/function signature changes that had to be accommodated in the Android-specific code.

I realize there are quite a few commits here, so let me know if you have any questions/feedback or if you'd like me to split this into multiple PRs!

Screenshots:

<img src="https://github.com/LadybirdBrowser/ladybird/assets/1904587/6c75bffa-5f3a-4920-a983-511dcc442ff4" width="30%" />
<img src="https://github.com/LadybirdBrowser/ladybird/assets/1904587/c78ba31b-978c-4dab-ae1d-5cc88aa65c53" width="30%" />
<img src="https://github.com/LadybirdBrowser/ladybird/assets/1904587/98f35c8a-b126-4a43-8a75-9927a5f1852b" width="30%" />

(I have not yet gotten ladybird.org to load with both correct fonts and correct CSS...I think there are still a few bugs to chase down)