### PR TITLE
LibWeb: Add selection API for textarea and input elements 

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -1,4 +1,4 @@
-/*
+/*range.cpp
  * Copyright (c) 2020, the SerenityOS developers.
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022-2023, Andreas Kling <kling@serenityos.org>
@@ -117,6 +117,10 @@ void Range::update_associated_selection()
         auto event = DOM::Event::create(document->realm(), HTML::EventNames::selectionchange, event_init);
         document->dispatch_event(event);
     }));
+
+    // FIXME: When an input or textarea element provide a text selection and its selection changes (in either extent or direction), 
+    // the user agent must queue a task on the user interaction task source to fire an event named selectionchange, which 
+    // bubbles but is not cancelable, at the element.
 }
 
 // https://dom.spec.whatwg.org/#concept-range-root

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -209,7 +209,6 @@ void HTMLTextAreaElement::set_custom_validity(String const& error)
     dbgln("(STUBBED) HTMLTextAreaElement::set_custom_validity(\"{}\"). Called on: {}", error, debug_description());
 }
 
-
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
 WebIDL::UnsignedLong HTMLTextAreaElement::selection_start() const
 {
@@ -218,7 +217,7 @@ WebIDL::UnsignedLong HTMLTextAreaElement::selection_start() const
     // 2. If there is no selection, return the code unit offset within the relevant value to the character that
     //    immediately follows the text entry cursor.
     // NOTE: There does not appear to be a concept of selection state (in the spec) after the first selection is made.
-    //       Before it we can check if the values have been cached, but 
+    //       Before it we can check if the values have been cached, but
 
     // 3. Return the code unit offset within the relevant value to the character that immediately follows the start of
     //           the selection.
@@ -228,7 +227,7 @@ WebIDL::UnsignedLong HTMLTextAreaElement::selection_start() const
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionstart-2
 WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_start(WebIDL::UnsignedLong value)
 {
-    // 1. If this element is an input element, and selectionStart does not apply to this element, throw an 
+    // 1. If this element is an input element, and selectionStart does not apply to this element, throw an
     //    "InvalidStateError" DOMException.
 
     // 2. Let end be the value of this element's selectionEnd attribute.
@@ -253,7 +252,6 @@ WebIDL::UnsignedLong HTMLTextAreaElement::selection_end() const
     // 3. Return the code unit offset within the relevant value to the character that immediately follows the end of
     //    the selection.
     return m_cached_selection_end;
-    
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionend-3
@@ -284,13 +282,13 @@ WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_range(Optional<WebI
     if (!end.has_value())
         end = 0;
 
-    // 3. Set the selection of the text control to the sequence of code units within the relevant value starting with 
+    // 3. Set the selection of the text control to the sequence of code units within the relevant value starting with
     //    the code unit at the startth position (in logical order) and ending with the code unit at the (end-1)th position.
     auto length = text_length();
-    //    Arguments greater than the length of the relevant value point at the end of the text control. 
-    end =  min(end.value(), length);
-    //    If end is less than or equal to start then the start of the selection and the end of the selection must both be placed 
-    //    immediately before the character with offset end. 
+    //    Arguments greater than the length of the relevant value point at the end of the text control.
+    end = min(end.value(), length);
+    //    If end is less than or equal to start then the start of the selection and the end of the selection must both be placed
+    //    immediately before the character with offset end.
     start = min(start.value(), length);
     // FIXME: In UAs where there is no concept of an empty selection, this must set the cursor to be just before the character with offset end.
 
@@ -305,7 +303,7 @@ WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_range(Optional<WebI
     // 5. Set the selection direction of the text control to direction.
     if (!cache_selection_state(start.value(), end.value(), _direction))
         // 6. If the previous steps caused the selection of the text control to be modified (in either extent or direction), then queue an element
-        //    task on the user interaction task source given the element to fire an event named select at the element, with the bubbles attribute 
+        //    task on the user interaction task source given the element to fire an event named select at the element, with the bubbles attribute
         //    initialized to true.
         queue_an_element_task(HTML::Task::Source::UserInteraction, [this]() {
             auto select_event = DOM::Event::create(realm(), HTML::EventNames::select, { .bubbles = true });

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -141,6 +141,18 @@ private:
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-api-value
     mutable Optional<String> m_api_value;
+
+    enum TextAreaSelectionDirection {
+        None,
+        Forward,
+        Backward
+    };
+    bool cache_selection_state(unsigned start, unsigned end, TextAreaSelectionDirection direction);
+    WebIDL::UnsignedLong m_cached_selection_start { 0 };
+    WebIDL::UnsignedLong m_cached_selection_end { 0 };
+    TextAreaSelectionDirection m_cached_selection_direction { None };
+
+    bool m_has_cached_selection { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -90,6 +90,8 @@ public:
     WebIDL::UnsignedLong selection_end() const;
     WebIDL::ExceptionOr<void> set_selection_end(WebIDL::UnsignedLong);
 
+    WebIDL::ExceptionOr<void> set_selection_range(Optional<WebIDL::UnsignedLong> start, Optional<WebIDL::UnsignedLong> end, Optional<String> direction);
+
     WebIDL::Long max_length() const;
     WebIDL::ExceptionOr<void> set_max_length(WebIDL::Long);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -40,5 +40,5 @@ interface HTMLTextAreaElement : HTMLElement {
     [FIXME] attribute DOMString selectionDirection;
     [FIXME] undefined setRangeText(DOMString replacement);
     [FIXME] undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
-    [FIXME] undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
+    undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 };

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -307,10 +307,7 @@ WebIDL::ExceptionOr<void> Selection::set_base_and_extent(JS::NonnullGCPtr<DOM::N
         return WebIDL::IndexSizeError::create(realm(), "Focus offset points outside of the focus node"_fly_string);
 
     // 2. If the roots of anchorNode or focusNode are not the document associated with this, abort these steps.
-    if (&anchor_node->root() != m_document.ptr())
-        return {};
-
-    if (&focus_node->root() != m_document.ptr())
+    if (!(m_document->is_shadow_including_inclusive_ancestor_of(anchor_node) || m_document->is_shadow_including_inclusive_ancestor_of(focus_node)))
         return {};
 
     // 3. Let anchor be the boundary point (anchorNode, anchorOffset) and let focus be the boundary point (focusNode, focusOffset).


### PR DESCRIPTION
Currently, the selection API is not implemented for textarea and input elements. This PR aims to implement them as per the spec ([teaxtarea](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select)/[input](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select))

There are some differences as to how this may be implemented, and I welcome any input.

- [ ] react to [selectionchange event](https://www.w3.org/TR/selection-api/#selectionchange-event) from user
- [ ] getters and setters for [selectionStart](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart) and [selectionEnd](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionend)
- [ ] implement [select](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-select)
- [ ] implement [setSelectionRange](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange)
- [ ] implement [setRangeText](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setrangetext)

depends on #359 