### PR TITLE
AK: Implement FloatExtractors and floating-point conversions for big-endian

### DIFF
--- a/AK/FloatingPoint.h
+++ b/AK/FloatingPoint.h
@@ -25,9 +25,15 @@ union FloatExtractor<f128> {
     static constexpr int exponent_bits = 15;
     static constexpr unsigned exponent_max = 32767;
     struct [[gnu::packed]] {
+#    if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        ComponentType sign : 1;
+        ComponentType exponent : 15;
+        ComponentType mantissa : 112;
+#    else
         ComponentType mantissa : 112;
         ComponentType exponent : 15;
         ComponentType sign : 1;
+#    endif
     };
     f128 d;
 };
@@ -51,9 +57,15 @@ union FloatExtractor<f80> {
         // However, since all bit-fiddling float code assumes IEEE floats, it cannot handle this properly.
         // If we pretend that 80-bit floats are IEEE floats with 64-bit mantissas, almost everything works correctly
         // and we just need a few special cases.
+#    if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        ComponentType sign : 1;
+        ComponentType exponent : 15;
+        ComponentType mantissa : 64;
+#    else
         ComponentType mantissa : 64;
         ComponentType exponent : 15;
         ComponentType sign : 1;
+#    endif
     };
     f80 d;
 };
@@ -76,9 +88,15 @@ union FloatExtractor<f64> {
         //        very intuitive and portable behaviour on windows, but it doesn't
         //        work with the msvc ABI.
         //        See <https://github.com/llvm/llvm-project/issues/24757>
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        ComponentType sign : 1;
+        ComponentType exponent : 11;
+        ComponentType mantissa : 52;
+#else
         ComponentType mantissa : 52;
         ComponentType exponent : 11;
         ComponentType sign : 1;
+#endif
     };
     f64 d;
 };
@@ -93,9 +111,15 @@ union FloatExtractor<f32> {
     static constexpr int exponent_bits = 8;
     static constexpr ComponentType exponent_max = 255;
     struct [[gnu::packed]] {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        ComponentType sign : 1;
+        ComponentType exponent : 8;
+        ComponentType mantissa : 23;
+#else
         ComponentType mantissa : 23;
         ComponentType exponent : 8;
         ComponentType sign : 1;
+#endif
     };
     f32 d;
 };

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -8,6 +8,7 @@
 
 #include <AK/BuiltinWrappers.h>
 #include <AK/Concepts.h>
+#include <AK/Endian.h>
 #include <AK/FloatingPoint.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtraDetails.h>
@@ -765,14 +766,21 @@ constexpr T log2(T x)
 
     // FIXME: Handle denormalized numbers separately
 
-    FloatExtractor<T> mantissa_ext {
-        .mantissa = ext.mantissa,
-        .exponent = FloatExtractor<T>::exponent_bias,
-        .sign = ext.sign
-    };
-
     // (1 <= mantissa < 2)
-    T m = mantissa_ext.d;
+    T m;
+    if constexpr (HostIsLittleEndian) {
+        m = ((FloatExtractor<T>) {
+                 .mantissa = ext.mantissa,
+                 .exponent = FloatExtractor<T>::exponent_bias,
+                 .sign = ext.sign })
+                .d;
+    } else {
+        m = ((FloatExtractor<T>) {
+                 .sign = ext.sign,
+                 .exponent = FloatExtractor<T>::exponent_bias,
+                 .mantissa = ext.mantissa })
+                .d;
+    }
 
     // This is a reconstruction of one of Sun's algorithms
     // They use a transformation to lower the problem space,


### PR DESCRIPTION
Fixes FloatExtractors and implements `read_eight_digits` for big-endian CPUs.

The `read_eight_digits` implementation could certainly be optimized further with some shifting and masking like in the little-endian case, but it's the best I could come up with.
