### PR TITLE
Everywhere: Remove Serenity specific code from tests

### DIFF
--- a/Tests/LibAudio/TestPlaybackStream.cpp
+++ b/Tests/LibAudio/TestPlaybackStream.cpp
@@ -21,18 +21,14 @@
 //        current session ID is 0, and AudioServer's socket address depends on the current sid.
 //        If we can fix that, this test can run on CI.
 //        https://github.com/SerenityOS/serenity/issues/20538
-#if defined(AK_OS_SERENITY)
-#    define STREAM_TEST BENCHMARK_CASE
-#else
-#    define STREAM_TEST TEST_CASE
-#endif
+#define STREAM_TEST TEST_CASE
 
 STREAM_TEST(create_and_destroy_playback_stream)
 {
     Core::EventLoop event_loop;
 
     bool has_implementation = false;
-#if defined(AK_OS_SERENITY) || defined(HAVE_PULSEAUDIO) || defined(AK_OS_MACOS)
+#if defined(HAVE_PULSEAUDIO) || defined(AK_OS_MACOS)
     has_implementation = true;
 #endif
 

--- a/Tests/LibAudio/TestWav.cpp
+++ b/Tests/LibAudio/TestWav.cpp
@@ -39,12 +39,7 @@ static void run_test(StringView file_name, int const num_samples, int const chan
     auto out_file = TRY_OR_FAIL(FileSystem::TempFile::create_temp_file());
     auto out_path = out_file->path();
 
-// This makes sure that the tests will run both on target and in Lagom.
-#ifdef AK_OS_SERENITY
-    ByteString in_path = ByteString::formatted("/usr/Tests/LibAudio/WAV/{}", file_name);
-#else
     ByteString in_path = ByteString::formatted("WAV/{}", file_name);
-#endif
 
     auto loader = TRY_OR_FAIL(Audio::Loader::create(in_path));
 

--- a/Tests/LibCompress/TestBrotli.cpp
+++ b/Tests/LibCompress/TestBrotli.cpp
@@ -68,12 +68,7 @@ TEST_CASE(dictionary_use_after_uncompressed_block)
 
 static void run_test(StringView const file_name)
 {
-    // This makes sure that the tests will run both on target and in Lagom.
-#ifdef AK_OS_SERENITY
-    ByteString path = ByteString::formatted("/usr/Tests/LibCompress/brotli-test-files/{}", file_name);
-#else
     ByteString path = ByteString::formatted("brotli-test-files/{}", file_name);
-#endif
 
     auto cmp_file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
     auto cmp_data = MUST(cmp_file->read_until_eof());
@@ -139,12 +134,7 @@ TEST_CASE(brotli_single_x)
 
 TEST_CASE(brotli_decompress_zero_one_bin)
 {
-    // This makes sure that the tests will run both on target and in Lagom.
-#ifdef AK_OS_SERENITY
-    ByteString path = "/usr/Tests/LibCompress/brotli-test-files/zero-one.bin";
-#else
     ByteString path = "brotli-test-files/zero-one.bin";
-#endif
 
     ByteString path_compressed = ByteString::formatted("{}.br", path);
 

--- a/Tests/LibCompress/TestDeflate.cpp
+++ b/Tests/LibCompress/TestDeflate.cpp
@@ -14,11 +14,7 @@
 #include <LibCore/File.h>
 #include <cstring>
 
-#ifdef AK_OS_SERENITY
-#    define TEST_INPUT(x) ("/usr/Tests/LibCompress/deflate-test-files/" x)
-#else
-#    define TEST_INPUT(x) ("deflate-test-files/" x)
-#endif
+#define TEST_INPUT(x) ("deflate-test-files/" x)
 
 TEST_CASE(canonical_code_simple)
 {

--- a/Tests/LibGfx/BenchmarkJPEGLoader.cpp
+++ b/Tests/LibGfx/BenchmarkJPEGLoader.cpp
@@ -8,11 +8,7 @@
 #include <LibGfx/ImageFormats/JPEGLoader.h>
 #include <LibTest/TestCase.h>
 
-#ifdef AK_OS_SERENITY
-#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
-#else
-#    define TEST_INPUT(x) ("test-inputs/" x)
-#endif
+#define TEST_INPUT(x) ("test-inputs/" x)
 
 auto small_image = Core::File::open(TEST_INPUT("jpg/rgb24.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value();
 auto big_image = Core::File::open(TEST_INPUT("jpg/big_image.jpg"sv), Core::File::OpenMode::Read).release_value()->read_until_eof().release_value();

--- a/Tests/LibGfx/TestICCProfile.cpp
+++ b/Tests/LibGfx/TestICCProfile.cpp
@@ -16,11 +16,7 @@
 #include <LibGfx/ImageFormats/WebPLoader.h>
 #include <LibTest/TestCase.h>
 
-#ifdef AK_OS_SERENITY
-#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
-#else
-#    define TEST_INPUT(x) ("test-inputs/" x)
-#endif
+#define TEST_INPUT(x) ("test-inputs/" x)
 
 TEST_CASE(png)
 {

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -22,11 +22,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#ifdef AK_OS_SERENITY
-#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
-#else
-#    define TEST_INPUT(x) ("test-inputs/" x)
-#endif
+#define TEST_INPUT(x) ("test-inputs/" x)
 
 static ErrorOr<Gfx::ImageFrameDescriptor> expect_single_frame(Gfx::ImageDecoderPlugin& plugin_decoder)
 {

--- a/Tests/LibGfx/TestWOFF.cpp
+++ b/Tests/LibGfx/TestWOFF.cpp
@@ -7,11 +7,7 @@
 #include <LibGfx/Font/WOFF/Font.h>
 #include <LibTest/TestCase.h>
 
-#ifdef AK_OS_SERENITY
-#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
-#else
-#    define TEST_INPUT(x) ("test-inputs/" x)
-#endif
+#define TEST_INPUT(x) ("test-inputs/" x)
 
 TEST_CASE(malformed_woff)
 {

--- a/Tests/LibGfx/TestWOFF2.cpp
+++ b/Tests/LibGfx/TestWOFF2.cpp
@@ -7,11 +7,7 @@
 #include <LibGfx/Font/WOFF2/Font.h>
 #include <LibTest/TestCase.h>
 
-#ifdef AK_OS_SERENITY
-#    define TEST_INPUT(x) ("/usr/Tests/LibGfx/test-inputs/" x)
-#else
-#    define TEST_INPUT(x) ("test-inputs/" x)
-#endif
+#define TEST_INPUT(x) ("test-inputs/" x)
 
 TEST_CASE(tolerate_incorrect_sfnt_size)
 {

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -544,22 +544,15 @@ static bool g_in_assert = false;
 // FIXME: Use a SIGABRT handler here instead of overriding internal libc assertion handlers.
 //        Fixing this will likely require updating the test driver as well to pull the assertion failure
 //        message out of stderr rather than from the json object printed to stdout.
-#ifdef AK_OS_SERENITY
-void __assertion_failed(char const* assertion)
-{
-    handle_failed_assert(assertion);
-}
-#else
-#    ifdef ASSERT_FAIL_HAS_INT /* Set by CMake */
+#ifdef ASSERT_FAIL_HAS_INT /* Set by CMake */
 extern "C" __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, int line, char const* function)
-#    else
+#else
 extern "C" __attribute__((__noreturn__)) void __assert_fail(char const* assertion, char const* file, unsigned int line, char const* function)
-#    endif
+#endif
 {
     auto full_message = ByteString::formatted("{}:{}: {}: Assertion `{}' failed.", file, line, function, assertion);
     handle_failed_assert(full_message.characters());
 }
-#endif
 
 constexpr int exit_wrong_arguments = 2;
 constexpr int exit_stdout_setup_failed = 1;

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -223,12 +223,7 @@ TEST_CASE(doctype)
 //       If that changes, or something is added to the test HTML, the hash needs to be adjusted.
 TEST_CASE(regression)
 {
-    // This makes sure that the tests will run both on target and in Lagom.
-#ifdef AK_OS_SERENITY
-    StringView path = "/usr/Tests/LibWeb/tokenizer-test.html"sv;
-#else
     StringView path = "tokenizer-test.html"sv;
-#endif
 
     auto file = MUST(Core::File::open(path, Core::File::OpenMode::Read));
     auto file_size = MUST(file->size());


### PR DESCRIPTION
We no longer run our tests on Serenity.