### PR TITLE
 LibWeb+LibCore: Use Vulkan backend for Skia on Linux

### DIFF
--- a/Meta/CMake/vulkan.cmake
+++ b/Meta/CMake/vulkan.cmake
@@ -1,0 +1,7 @@
+if (NOT APPLE)
+    find_package(Vulkan QUIET)
+    if (Vulkan_FOUND)
+        set(HAS_VULKAN ON CACHE BOOL "" FORCE)
+        add_compile_definitions(USE_VULKAN=1)
+    endif()
+endif()

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(vulkan)
+
 # These are the minimal set of sources needed to build the code generators. We separate them to allow
 # LibCore to depend on generated sources.
 set(SOURCES
@@ -79,6 +81,11 @@ else()
     )
 endif()
 
+if (HAS_VULKAN)
+    include_directories(${Vulkan_INCLUDE_DIR})
+    list(APPEND SOURCES VulkanContext.cpp)
+endif()
+
 if (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
     list(APPEND SOURCES MachPort.cpp)
 endif()
@@ -102,4 +109,8 @@ endif()
 
 if (ANDROID)
     target_link_libraries(LibCore PRIVATE log)
+endif()
+
+if (HAS_VULKAN)
+    target_link_libraries(LibCore PUBLIC ${Vulkan_LIBRARIES})
 endif()

--- a/Userland/Libraries/LibCore/VulkanContext.cpp
+++ b/Userland/Libraries/LibCore/VulkanContext.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Vector.h>
+#include <LibCore/VulkanContext.h>
+
+namespace Core {
+
+ErrorOr<VkInstance> create_instance(uint32_t api_version)
+{
+    VkInstance instance;
+
+    VkApplicationInfo app_info {};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "Ladybird";
+    app_info.applicationVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.pEngineName = nullptr;
+    app_info.engineVersion = VK_MAKE_VERSION(1, 0, 0);
+    app_info.apiVersion = api_version;
+
+    VkInstanceCreateInfo create_info {};
+    create_info.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    create_info.pApplicationInfo = &app_info;
+
+    if (vkCreateInstance(&create_info, nullptr, &instance) != VK_SUCCESS) {
+        return Error::from_string_view("Application instance creation failed"sv);
+    }
+
+    return instance;
+}
+
+ErrorOr<VkPhysicalDevice> pick_physical_device(VkInstance instance)
+{
+    uint32_t device_count = 0;
+    vkEnumeratePhysicalDevices(instance, &device_count, nullptr);
+
+    if (device_count == 0)
+        return Error::from_string_view("Can't find any physical devices available"sv);
+
+    Vector<VkPhysicalDevice> devices;
+    devices.resize(device_count);
+    vkEnumeratePhysicalDevices(instance, &device_count, devices.data());
+
+    VkPhysicalDevice picked_device = VK_NULL_HANDLE;
+    // Pick discrete GPU or the first device in the list
+    for (auto const& device : devices) {
+        if (picked_device == VK_NULL_HANDLE)
+            picked_device = device;
+
+        VkPhysicalDeviceProperties device_properties;
+        vkGetPhysicalDeviceProperties(device, &device_properties);
+        if (device_properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU)
+            picked_device = device;
+    }
+
+    if (picked_device != VK_NULL_HANDLE)
+        return picked_device;
+
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<VkDevice> create_logical_device(VkPhysicalDevice physical_device)
+{
+    VkDevice device;
+
+    uint32_t queue_family_count = 0;
+    vkGetPhysicalDeviceQueueFamilyProperties(physical_device, &queue_family_count, nullptr);
+    Vector<VkQueueFamilyProperties> queue_families;
+    queue_families.resize(queue_family_count);
+    vkGetPhysicalDeviceQueueFamilyProperties(physical_device, &queue_family_count, queue_families.data());
+
+    int graphics_queue_family_index = -1;
+    for (int i = 0; i < static_cast<int>(queue_families.size()); i++) {
+        if (queue_families[i].queueFlags & VK_QUEUE_GRAPHICS_BIT) {
+            graphics_queue_family_index = i;
+            break;
+        }
+    }
+
+    VkDeviceQueueCreateInfo queue_create_info {};
+    queue_create_info.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    queue_create_info.queueFamilyIndex = graphics_queue_family_index;
+    queue_create_info.queueCount = 1;
+
+    float const queue_priority = 1.0f;
+    queue_create_info.pQueuePriorities = &queue_priority;
+
+    VkPhysicalDeviceFeatures deviceFeatures {};
+
+    VkDeviceCreateInfo create_device_info {};
+    create_device_info.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    create_device_info.pQueueCreateInfos = &queue_create_info;
+    create_device_info.queueCreateInfoCount = 1;
+    create_device_info.pEnabledFeatures = &deviceFeatures;
+
+    if (vkCreateDevice(physical_device, &create_device_info, nullptr, &device) != VK_SUCCESS) {
+        return Error::from_string_view("Logical device creation failed"sv);
+    }
+
+    return device;
+}
+
+ErrorOr<VulkanContext> create_vulkan_context()
+{
+    uint32_t const api_version = VK_API_VERSION_1_0;
+    auto* instance = TRY(create_instance(api_version));
+    auto* physical_device = TRY(pick_physical_device(instance));
+    auto* logical_device = TRY(create_logical_device(physical_device));
+
+    VkQueue graphics_queue;
+    vkGetDeviceQueue(logical_device, 0, 0, &graphics_queue);
+
+    return VulkanContext {
+        .api_version = api_version,
+        .instance = instance,
+        .physical_device = physical_device,
+        .logical_device = logical_device,
+        .graphics_queue = graphics_queue,
+    };
+}
+
+}

--- a/Userland/Libraries/LibCore/VulkanContext.h
+++ b/Userland/Libraries/LibCore/VulkanContext.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if !defined(USE_VULKAN)
+static_assert(false, "This file must only be used when Vulkan is available");
+#endif
+
+#include <AK/Forward.h>
+#include <AK/Function.h>
+#include <vulkan/vulkan.h>
+
+namespace Core {
+
+struct VulkanContext {
+    uint32_t api_version { VK_API_VERSION_1_0 };
+    VkInstance instance { VK_NULL_HANDLE };
+    VkPhysicalDevice physical_device { VK_NULL_HANDLE };
+    VkDevice logical_device { VK_NULL_HANDLE };
+    VkQueue graphics_queue { VK_NULL_HANDLE };
+};
+
+ErrorOr<VulkanContext> create_vulkan_context();
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(libweb_generators)
+include(vulkan)
 
 set(SOURCES
     Animations/Animatable.cpp

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -29,8 +29,11 @@ TraversableNavigable::TraversableNavigable(JS::NonnullGCPtr<Page> page)
     , m_session_history_traversal_queue(vm().heap().allocate_without_realm<SessionHistoryTraversalQueue>())
 {
 #ifdef AK_OS_MACOS
-    m_metal_context = Core::get_metal_context();
-    m_skia_backend_context = Painting::DisplayListPlayerSkia::create_metal_context(*m_metal_context);
+    auto display_list_player_type = page->client().display_list_player_type();
+    if (display_list_player_type == DisplayListPlayerType::Skia) {
+        m_metal_context = Core::get_metal_context();
+        m_skia_backend_context = Painting::DisplayListPlayerSkia::create_metal_context(*m_metal_context);
+    }
 #endif
 }
 

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -19,6 +19,10 @@
 #    include <LibCore/MetalContext.h>
 #endif
 
+#ifdef USE_VULKAN
+#    include <LibCore/VulkanContext.h>
+#endif
+
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#traversable-navigable
@@ -130,8 +134,9 @@ private:
 
     String m_window_handle;
 
-#ifdef AK_OS_MACOS
     OwnPtr<Web::Painting::SkiaBackendContext> m_skia_backend_context;
+
+#ifdef AK_OS_MACOS
     OwnPtr<Core::MetalContext> m_metal_context;
 #endif
 };

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -14,6 +14,10 @@
 #    include <LibCore/MetalContext.h>
 #endif
 
+#ifdef USE_VULKAN
+#    include <LibCore/VulkanContext.h>
+#endif
+
 namespace Web::Painting {
 
 class SkiaBackendContext {
@@ -69,6 +73,11 @@ public:
     void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override {};
 
     DisplayListPlayerSkia(Gfx::Bitmap&);
+
+#ifdef USE_VULKAN
+    static OwnPtr<SkiaBackendContext> create_vulkan_context(Core::VulkanContext&);
+    DisplayListPlayerSkia(SkiaBackendContext&, Gfx::Bitmap&);
+#endif
 
 #ifdef AK_OS_MACOS
     static OwnPtr<SkiaBackendContext> create_metal_context(Core::MetalContext const&);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,7 +22,10 @@
     },
     {
       "name": "skia",
-      "platform": "linux | freebsd | openbsd"
+      "platform": "linux | freebsd | openbsd",
+      "features": [
+        "vulkan"
+      ]
     },
     "sqlite3",
     "woff2"


### PR DESCRIPTION
Skia now uses GPU-accelerated painting on Linux if Vulkan is available.
Most of the performance gain is currently negated by reading the GPU
backend back into RAM to pass it to the Browser process. In the future,
this could be improved by sharing GPU-allocated memory across the
Browser and WebContent processes.