### PR TITLE
LibWeb: Add missing edge visit for TextTrack in HTMLTrackElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -29,6 +29,12 @@ void HTMLTrackElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLTrackElement);
 }
 
+void HTMLTrackElement::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_track);
+}
+
 void HTMLTrackElement::attribute_changed(FlyString const& name, Optional<String> const& value)
 {
     HTMLElement::attribute_changed(name, value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.h
@@ -25,6 +25,7 @@ private:
     HTMLTrackElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
 
     // ^DOM::Element
     virtual void attribute_changed(FlyString const& name, Optional<String> const& value) override;


### PR DESCRIPTION
I had a 'did I?' moment when I saw https://github.com/LadybirdBrowser/ladybird/commit/67e3ac8916d7354c8485b4bbe9c4162392e0e99c was merged.