### PR TITLE
AK: Fix {:c} formatter for big-endian

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -888,7 +888,12 @@ ErrorOr<void> Formatter<T>::format(FormatBuilder& builder, T value)
         m_mode = Mode::String;
 
         Formatter<StringView> formatter { *this };
-        return formatter.format(builder, StringView { reinterpret_cast<char const*>(&value), 1 });
+
+        // convert value to single byte, important for big-endian because the LSB is the last byte.
+        VERIFY(value >= 0 && value <= 127);
+        char const c = (value & 0x7f);
+
+        return formatter.format(builder, StringView { &c, 1 });
     }
 
     if (m_precision.has_value())


### PR DESCRIPTION
Just casting an integer type to a char pointer does not work on big endian.
Instead, the value needs to be properly converted into a char.

I uncommented the 7-bit ASCII check while at it. I think it's better to be safer than necessary to spot cases where high ASCII/UTF-8 support would be needed earlier.