### PR TITLE
LibGfx: Do not draw U+FFFD for unknown glyphs

### DIFF
--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -48,19 +48,9 @@ DrawGlyphOrEmoji prepare_draw_glyph_or_emoji(FloatPoint point, Utf8CodePointIter
         };
     }
 
-    // If that failed, but we have a text glyph fallback, draw that.
-    if (font_contains_glyph) {
-        return DrawGlyph {
-            .position = point,
-            .code_point = code_point,
-        };
-    }
-
-    // No suitable glyph found, draw a replacement character.
-    dbgln_if(EMOJI_DEBUG, "Failed to find a glyph or emoji for code_point {}", code_point);
     return DrawGlyph {
         .position = point,
-        .code_point = 0xFFFD,
+        .code_point = code_point,
     };
 }
 


### PR DESCRIPTION
The Replacement Character (U+FFFD) is most commonly used to signal a text encoding error, i.e. when a stream of bytes couldn't be converted to a sequence of code points. For glyphs that don't exist in a particular font, our rendering logic already does the right thing by drawing empty boxes (`.notdef`); let's not forcibly turn these into U+FFFD during rendering.

| before | after |
|-----------|---------|
| ![image](https://github.com/LadybirdBrowser/ladybird/assets/25866827/a36ec53c-7bbb-4943-8556-ba3d71c02dd5)    | ![image](https://github.com/LadybirdBrowser/ladybird/assets/25866827/d8505ef3-8c07-47c6-81e4-204218624f3e) |

(just a tiny pedantic annoyance I noticed while reading Discord scrollback about Arabic font rendering)