### PR TITLE
Fix build on NetBSD.

### DIFF
--- a/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
+++ b/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h
@@ -21,7 +21,7 @@ namespace Detail {
 static auto constexpr coverage_lut = [] {
     Array<u8, 256> coverage_lut {};
     for (u32 sample = 0; sample <= 255; sample++)
-        coverage_lut[sample] = popcount(sample);
+        coverage_lut[sample] = AK::popcount(sample);
     return coverage_lut;
 }();
 


### PR DESCRIPTION
NetBSD provides its own popcount() function.

Fixes
```
In file included from /scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp:12:
/scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h:26:2:   in 'constexpr' expansion of '<lambda closure object>Gfx::Detail::<lambda()>().Gfx::Detail::<lambda()>()'
/scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.h:24:40: error: call to non-'constexpr' function 'unsigned int popcount(unsigned int)'
   24 |         coverage_lut[sample] = popcount(sample);
      |                                ~~~~~~~~^~~~~~~~
In file included from /usr/include/string.h:98,
                 from /scratch/wip/ladybird-git/work/serenity/AK/Error.h:17,
                 from /scratch/wip/ladybird-git/work/serenity/AK/Format.h:13,
                 from /scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/Rect.h:11,
                 from /scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/CornerRadius.h:9,
                 from /scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/AntiAliasingPainter.h:9,
                 from /scratch/wip/ladybird-git/work/serenity/Userland/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp:11:
/usr/include/strings.h:57:17: note: 'unsigned int popcount(unsigned int)' declared here
   57 | unsigned int    popcount(unsigned int) __constfunc;
      |                 ^~~~~~~~
```
Addresses the first part of #438 .