### PR TITLE
WebDriver: Add option to use Qt networking

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationBridge.cpp
+++ b/Ladybird/AppKit/Application/ApplicationBridge.cpp
@@ -87,7 +87,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ApplicationBridge::launch_web_
 ErrorOr<IPC::File> ApplicationBridge::launch_web_worker()
 {
     auto web_worker_paths = TRY(get_paths_for_helper_process("WebWorker"sv));
-    auto worker_client = TRY(launch_web_worker_process(web_worker_paths, *m_impl->request_server_client));
+    auto worker_client = TRY(launch_web_worker_process(web_worker_paths, m_impl->request_server_client));
 
     return worker_client->dup_socket();
 }

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -122,14 +122,16 @@ ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(
     return launch_server_process<ImageDecoderClient::Client>("ImageDecoder"sv, candidate_image_decoder_paths, arguments, Ladybird::EnableCallgrindProfiling::No);
 }
 
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, NonnullRefPtr<Protocol::RequestClient> request_client)
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Protocol::RequestClient> request_client)
 {
-    auto socket = TRY(connect_new_request_server_client(move(request_client)));
-
-    Vector<ByteString> arguments {
-        "--request-server-socket"sv,
-        ByteString::number(socket.fd()),
-    };
+    Vector<ByteString> arguments;
+    if (request_client) {
+        auto socket = TRY(connect_new_request_server_client(*request_client));
+        arguments.append("--request-server-socket"sv);
+        arguments.append(ByteString::number(socket.fd()));
+        arguments.append("--use-lagom-networking"sv);
+        return launch_server_process<Web::HTML::WebWorkerClient>("WebWorker"sv, candidate_web_worker_paths, move(arguments), Ladybird::EnableCallgrindProfiling::No);
+    }
 
     return launch_server_process<Web::HTML::WebWorkerClient>("WebWorker"sv, candidate_web_worker_paths, move(arguments), Ladybird::EnableCallgrindProfiling::No);
 }

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -25,7 +25,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     Optional<IPC::File> request_server_socket = {});
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths);
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, NonnullRefPtr<Protocol::RequestClient>);
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Protocol::RequestClient>);
 ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root, Vector<ByteString> const& certificates);
 
 ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient&);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -131,9 +131,12 @@ WebContentView::WebContentView(QWidget* window, WebContentOptions const& web_con
         finish_handling_key_event(event);
     };
 
-    on_request_worker_agent = []() {
-        auto& request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
-        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), *request_server_client));
+    on_request_worker_agent = [&]() {
+        RefPtr<Protocol::RequestClient> request_server_client {};
+        if (m_web_content_options.use_lagom_networking == Ladybird::UseLagomNetworking::Yes)
+            request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
+
+        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), request_server_client));
         return worker_client->dup_socket();
     };
 }

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -159,11 +159,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto cookie_jar = database ? TRY(WebView::CookieJar::create(*database)) : WebView::CookieJar::create();
 
-    // NOTE: WebWorker *always* needs a request server connection, even if WebContent uses Qt Networking
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
-    auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-    auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_serenity_resource_root, certificates));
-    app.request_server_client = move(protocol_client);
+    if (!enable_qt_networking) {
+        auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
+        auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_serenity_resource_root, certificates));
+        app.request_server_client = move(protocol_client);
+    }
 
     TRY(app.initialize_image_decoder());
 

--- a/Ladybird/WebWorker/CMakeLists.txt
+++ b/Ladybird/WebWorker/CMakeLists.txt
@@ -2,10 +2,6 @@ include(fontconfig)
 
 set(WEBWORKER_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebWorker)
 
-set(CMAKE_AUTOMOC OFF)
-set(CMAKE_AUTORCC OFF)
-set(CMAKE_AUTOUIC OFF)
-
 set(WEBWORKER_SOURCES
     "${WEBWORKER_SOURCE_DIR}/ConnectionFromClient.cpp"
     "${WEBWORKER_SOURCE_DIR}/DedicatedWorkerHost.cpp"
@@ -18,6 +14,7 @@ set(WEBWORKER_SOURCES
 # FIXME: Add Android service
 
 add_library(webworker STATIC ${WEBWORKER_SOURCES})
+set_target_properties(webworker PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 
 target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
@@ -28,6 +25,23 @@ if (HAS_FONTCONFIG)
     target_link_libraries(webworker PRIVATE Fontconfig::Fontconfig)
 endif()
 
-add_executable(WebWorker main.cpp)
+if (ENABLE_QT)
+    qt_add_executable(WebWorker
+            ../Qt/EventLoopImplementationQt.cpp
+            ../Qt/EventLoopImplementationQtEventTarget.cpp
+            ../Qt/RequestManagerQt.cpp
+            ../Qt/StringUtils.cpp
+            ../Qt/WebSocketQt.cpp
+            ../Qt/WebSocketImplQt.cpp
+            main.cpp
+    )
+    target_link_libraries(WebWorker PRIVATE Qt::Core Qt::Network)
+    target_link_libraries(WebWorker PRIVATE webworker LibWebSocket)
+    target_compile_definitions(WebWorker PRIVATE HAVE_QT=1)
+
+else()
+    add_executable(WebWorker main.cpp)
+endif()
+
 target_include_directories(WebWorker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_link_libraries(WebWorker PRIVATE webworker)

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -25,6 +25,12 @@
 #include <LibWebView/WebSocketClientAdapter.h>
 #include <WebWorker/ConnectionFromClient.h>
 
+#if defined(HAVE_QT)
+#    include <Ladybird/Qt/EventLoopImplementationQt.h>
+#    include <Ladybird/Qt/RequestManagerQt.h>
+#    include <QCoreApplication>
+#endif
+
 static ErrorOr<void> initialize_lagom_networking(int request_server_socket);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -33,20 +39,32 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     int request_server_socket { -1 };
     StringView serenity_resource_root;
+    bool use_lagom_networking { false };
 
     Core::ArgsParser args_parser;
     args_parser.add_option(request_server_socket, "File descriptor of the request server socket", "request-server-socket", 's', "request-server-socket");
     args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
+    args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
     args_parser.parse(arguments);
+
+#if defined(HAVE_QT)
+    QCoreApplication app(arguments.argc, arguments.argv);
+    Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
+#endif
+    Core::EventLoop event_loop;
 
     platform_init();
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
-    Core::EventLoop event_loop;
 
     Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(false));
 
-    TRY(initialize_lagom_networking(request_server_socket));
+#if defined(HAVE_QT)
+    if (!use_lagom_networking)
+        Web::ResourceLoader::initialize(Ladybird::RequestManagerQt::create());
+    else
+#endif
+        TRY(initialize_lagom_networking(request_server_socket));
 
     TRY(Web::Bindings::initialize_main_thread_vm());
 

--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -83,6 +83,7 @@ python3 ./wpt/wpt run ladybird \
                   --manifest ./MANIFEST.json \
                   --webdriver-arg="--certificate=${PWD}/wpt/tools/certs/cacert.pem" \
                   --webdriver-arg="--certificate=${LADYBIRD_SOURCE_DIR}/Build/lagom/cacert.pem" \
+                  --webdriver-arg="--enable-qt-networking" \
                   --log-raw "${wpt_run_log_filename}"
 
 # Update expectations metadata files if requested


### PR DESCRIPTION
Using Qt networking when running web platform tests improves performance significantly. The time to run the subset of tests we run on CI drops from 21.9 seconds to 8.2 seconds on my machine.