### PR TITLE
LibWeb/CSS: Use correct initial values for CSS properties

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -728,7 +728,7 @@
     "affects-layout": false,
     "animation-type": "by-computed-value",
     "inherited": true,
-    "initial": "-libweb-palette-base-text",
+    "initial": "canvastext",
     "valid-types": [
       "color"
     ],

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -946,7 +946,7 @@
   },
   "font": {
     "inherited": true,
-    "initial": "normal medium sans-serif",
+    "initial": "normal medium serif",
     "longhands": [
       "font-family",
       "font-size",
@@ -960,7 +960,7 @@
   "font-family": {
     "animation-type": "discrete",
     "inherited": true,
-    "initial": "sans-serif",
+    "initial": "serif",
     "valid-types": [
       "custom-ident",
       "string"


### PR DESCRIPTION
This PR ensures the correct initial values for the `font`, `font-family` and `color` CSS properties are used.

Fixes the following WPT test: http://wpt.live/infrastructure/assumptions/html-elements.html