### PR TITLE
LibWeb: Fix layout issues with floats and block level pseudo elements

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/out-of-flows-not-inserted-into-generated-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/out-of-flows-not-inserted-into-generated-box.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x42 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17] baseline: 13.296875
+            "foo"
+        TextNode <#text>
+      BlockContainer <div> at (8,25) content-size 27.640625x17 floating [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,25 27.640625x17] baseline: 13.296875
+            "bar"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x42]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784x34]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,25 27.640625x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/block-and-inline/out-of-flows-not-inserted-into-generated-box.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/out-of-flows-not-inserted-into-generated-box.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html><style>
+    body::before {
+        content: "foo";
+        display: block;
+    }
+    div {
+        float: left;
+    }
+</style><body><div>bar

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -164,6 +164,14 @@ public:
     u32 initial_quote_nesting_level() const { return m_initial_quote_nesting_level; }
     void set_initial_quote_nesting_level(u32 value) { m_initial_quote_nesting_level = value; }
 
+    // An element is called out of flow if it is floated, absolutely positioned, or is the root element.
+    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
+    bool is_out_of_flow() const { return is_floating() || is_absolutely_positioned(); }
+
+    // An element is called in-flow if it is not out-of-flow.
+    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
+    bool is_in_flow() const { return !is_out_of_flow(); }
+
 protected:
     Node(DOM::Document&, DOM::Node*);
 

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -99,6 +99,7 @@ static Layout::Node& insertion_parent_for_block_node(Layout::NodeWithStyle& layo
     if (layout_node.is_out_of_flow()
         && !layout_parent.display().is_flex_inside()
         && !layout_parent.display().is_grid_inside()
+        && !layout_parent.last_child()->is_generated()
         && layout_parent.last_child()->is_anonymous()
         && layout_parent.last_child()->children_are_inline()) {
         // Block is out-of-flow & previous sibling was wrapped in an anonymous block.


### PR DESCRIPTION
If a pseudo element (`::before` or `::after`) is a block `display` (for instance `body::before { display: block; }`) then some adjacent element is added as a child to the pseudo element's generated wrapper element if the adjacent element is a floating element. This essentially means that the element would be added as an inline element to the pseudo element.

This fixes some layout issues on the Swedish tax agency's site (skatteverket.se), such as the logo being really small and some list items being misaligned :)

This PR also includes a small refactor where out-of-flow and in-flow is added to functions to `Layout::Node` as `is_out_of_flow()` and `is_flow()`.