### PR TITLE
Meta: Make YCM return flags as Python list

### DIFF
--- a/.ycm_extra_conf.py
+++ b/.ycm_extra_conf.py
@@ -71,7 +71,7 @@ def Settings(**kwargs):  # noqa: N802
         return {}
 
     return {
-        'flags': compilation_info.compiler_flags_,
+        'flags': list(compilation_info.compiler_flags_),
         'include_paths_relative_to_dir': DIR_OF_THIS_SCRIPT,
         'override_filename': filename
     }


### PR DESCRIPTION
As per YCM's own .ycm_extra_conf.py:
```python
final_flags = list( compilation_info.compiler_flags_ )
```
Before this change clangd would crash.