### PR TITLE
Add customElements.getName

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -337,6 +337,21 @@ Variant<JS::Handle<WebIDL::CallbackType>, JS::Value> CustomElementRegistry::get(
     return JS::js_undefined();
 }
 
+// https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-getname
+Optional<String> CustomElementRegistry::get_name(JS::Handle<WebIDL::CallbackType> const& constructor) const
+{
+    // 1. If this CustomElementRegistry contains an entry with constructor constructor, then return that entry's name.
+    auto existing_definition_iterator = m_custom_element_definitions.find_if([&constructor](auto const& definition) {
+        return definition->constructor().callback == constructor.cell()->callback;
+    });
+
+    if (!existing_definition_iterator.is_end())
+        return (*existing_definition_iterator)->name();
+
+    // 2. Return null.
+    return {};
+}
+
 // https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-whendefined
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> CustomElementRegistry::when_defined(String const& name)
 {

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
@@ -26,6 +26,7 @@ public:
 
     JS::ThrowCompletionOr<void> define(String const& name, WebIDL::CallbackType* constructor, ElementDefinitionOptions options);
     Variant<JS::Handle<WebIDL::CallbackType>, JS::Value> get(String const& name) const;
+    Optional<String> get_name(JS::Handle<WebIDL::CallbackType> const& constructor) const;
     WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> when_defined(String const& name);
     void upgrade(JS::NonnullGCPtr<DOM::Node> root) const;
 

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.idl
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.idl
@@ -5,6 +5,7 @@
 interface CustomElementRegistry {
     [CEReactions] undefined define(DOMString name, CustomElementConstructor constructor, optional ElementDefinitionOptions options = {});
     (CustomElementConstructor or undefined) get(DOMString name);
+    DOMString? getName(CustomElementConstructor constructor);
     Promise<CustomElementConstructor> whenDefined(DOMString name);
     [CEReactions] undefined upgrade(Node root);
 };


### PR DESCRIPTION
This adds the CustomElementRegistry getName function, as [specified](https://html.spec.whatwg.org/multipage/custom-elements.html#dom-customelementregistry-getname).

Verified that it works by visiting [wpt.live getName tests](https://wpt.live/custom-elements/CustomElementRegistry-getName.html) and seeing that the test passes.
