### PR TITLE
LibWasm: Make float operations fully spec-compliant

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -519,10 +519,10 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         configuration.stack().push(Value(ValueType { ValueType::I64 }, instruction.arguments().get<i64>()));
         return;
     case Instructions::f32_const.value():
-        configuration.stack().push(Value(ValueType { ValueType::F32 }, static_cast<double>(instruction.arguments().get<float>())));
+        configuration.stack().push(Value(Value::AnyValueType(instruction.arguments().get<float>())));
         return;
     case Instructions::f64_const.value():
-        configuration.stack().push(Value(ValueType { ValueType::F64 }, instruction.arguments().get<double>()));
+        configuration.stack().push(Value(Value::AnyValueType(instruction.arguments().get<double>())));
         return;
     case Instructions::block.value(): {
         size_t arity = 0;

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -652,8 +652,8 @@ struct Convert {
     template<typename Lhs>
     ResultT operator()(Lhs lhs) const
     {
-        auto signed_interpretation = bit_cast<MakeSigned<Lhs>>(lhs);
-        return static_cast<ResultT>(signed_interpretation);
+        auto interpretation = bit_cast<Lhs>(lhs);
+        return static_cast<ResultT>(interpretation);
     }
 
     static StringView name() { return "convert"sv; }
@@ -688,7 +688,7 @@ struct Demote {
             return nanf(""); // FIXME: Ensure canonical NaN remains canonical
 
         if (isinf(lhs))
-            return __builtin_huge_valf();
+            return copysignf(__builtin_huge_valf(), lhs);
 
         return static_cast<float>(lhs);
     }

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -329,14 +329,12 @@ struct Minimum {
     auto operator()(Lhs lhs, Rhs rhs) const
     {
         if constexpr (IsFloatingPoint<Lhs> || IsFloatingPoint<Rhs>) {
-            if (isnan(lhs))
-                return lhs;
-            if (isnan(rhs))
-                return rhs;
-            if (isinf(lhs))
-                return lhs > 0 ? rhs : lhs;
-            if (isinf(rhs))
-                return rhs > 0 ? lhs : rhs;
+            if (isnan(lhs) || isnan(rhs)) {
+                return isnan(lhs) ? lhs : rhs;
+            }
+            if (lhs == 0 && rhs == 0) {
+                return signbit(lhs) ? lhs : rhs;
+            }
         }
         return min(lhs, rhs);
     }
@@ -349,14 +347,12 @@ struct Maximum {
     auto operator()(Lhs lhs, Rhs rhs) const
     {
         if constexpr (IsFloatingPoint<Lhs> || IsFloatingPoint<Rhs>) {
-            if (isnan(lhs))
-                return lhs;
-            if (isnan(rhs))
-                return rhs;
-            if (isinf(lhs))
-                return lhs > 0 ? lhs : rhs;
-            if (isinf(rhs))
-                return rhs > 0 ? rhs : lhs;
+            if (isnan(lhs) || isnan(rhs)) {
+                return isnan(lhs) ? lhs : rhs;
+            }
+            if (lhs == 0 && rhs == 0) {
+                return signbit(lhs) ? rhs : lhs;
+            }
         }
         return max(lhs, rhs);
     }


### PR DESCRIPTION
All tests related to floats now fully pass!

There are now 11 non-SIMD tests that don't pass on my machine.