### PR TITLE
Documentation: Extend openSUSE Leap build instructions.

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -52,8 +52,9 @@ sudo dnf install automake cmake libglvnd-devel ninja-build qt6-qtbase-devel qt6-
 
 On openSUSE:
 ```
-sudo zypper install automake cmake libglvnd-devel ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel ccache liberation-fonts curl zip unzip tar autoconf-archive ffmpeg-7-libavcodec-devel
+sudo zypper install automake cmake libglvnd-devel ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel ccache liberation-fonts curl zip unzip tar autoconf-archive ffmpeg-7-libavcodec-devel gcc13 gcc13-c++
 ```
+The build process requires at least python3.7; openSUSE Leap only features Python 3.6 as default, so it is recommendable to install package python311 and create a virtual environment (venv) in this case.
 
 On NixOS or with Nix:
 ```console


### PR DESCRIPTION
openSUSE comes in two flavors, Leap and Tumbleweed.
The proposed changes address the build instructions for openSUSE Leap.
They are based on my successful execution of ` ./Meta/ladybird.sh run ladybird` on my machine (openSUSE Leap 15.5)