### PR TITLE
LibWeb: Check for failed response when fetching images and favicons

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -584,6 +584,11 @@ WebIDL::ExceptionOr<void> HTMLLinkElement::load_fallback_favicon_if_needed(JS::N
         auto process_body_error = JS::create_heap_function(realm.heap(), [](JS::Value) {
         });
 
+        // Check for failed favicon response
+        if (!Fetch::Infrastructure::is_ok_status(response->status()) || !response->body()) {
+            return;
+        }
+
         // 3. Use response's unsafe response as an icon as if it had been declared using the icon keyword.
         if (auto body = response->unsafe_response()->body())
             body->fully_read(realm, process_body, process_body_error, global);

--- a/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SharedImageRequest.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Statuses.h>
 #include <LibWeb/HTML/AnimatedBitmapDecodedImageData.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/SharedImageRequest.h>
@@ -94,10 +95,13 @@ void SharedImageRequest::fetch_image(JS::Realm& realm, JS::NonnullGCPtr<Fetch::I
             handle_failed_fetch();
         });
 
-        if (response->body())
-            response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() });
-        else
+        // Check for failed fetch response
+        if (!Fetch::Infrastructure::is_ok_status(response->status()) || !response->body()) {
             handle_failed_fetch();
+            return;
+        }
+
+        response->body()->fully_read(realm, process_body, process_body_error, JS::NonnullGCPtr { realm.global_object() });
     };
 
     m_state = State::Fetching;


### PR DESCRIPTION
We would attempt to decode the body data as an image regardless of the response status, so I added a couple checks.