### PR TITLE
LibWeb: Use system colors for input type range and progress as default

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -80,7 +80,7 @@ input[type=range]::-webkit-slider-runnable-track, input[type=range]::-webkit-sli
 input[type=range]::-webkit-slider-runnable-track {
     height: 4px;
     margin-top: 6px;
-    background-color:  hsl(217, 71%, 53%);
+    background-color: AccentColor;
     border: 1px solid rgba(0, 0, 0, 0.5);
 }
 input[type=range]::-webkit-slider-thumb {
@@ -89,7 +89,7 @@ input[type=range]::-webkit-slider-thumb {
     height: 16px;
     transform: translateX(-50%);
     border-radius: 50%;
-    background-color: hsl(0, 0%, 96%);
+    background-color: Background;
     outline: 1px solid rgba(0, 0, 0, 0.5);
 }
 
@@ -128,11 +128,11 @@ progress::-webkit-progress-bar, progress::-webkit-progress-value {
     height: 100%;
 }
 progress::-webkit-progress-bar {
-    background-color: hsl(0, 0%, 96%);
+    background-color: Background;
     border: 1px solid rgba(0, 0, 0, 0.5);
 }
 progress::-webkit-progress-value {
-    background-color: hsl(204, 86%, 53%);
+    background-color: AccentColor;
 }
 
 /* 15.3.1 Hidden elements


### PR DESCRIPTION
Instead of using fixed arbitrary colors for the background of the bar, 
AccentColor and Background are now used.