### PR TITLE
LibJS: Cache environment index for global declarative bindings

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -31,6 +31,7 @@ struct PropertyLookupCache {
 
 struct GlobalVariableCache : public PropertyLookupCache {
     u64 environment_serial_number { 0 };
+    Optional<u32> environment_binding_index;
 };
 
 struct SourceRecord {


### PR DESCRIPTION
This allows global `let` and `const` variable accesses to be cached
by the GetGlobal instruction, and works even when the access is in a
different translation unit from the declaration.

Knocks a ~10% item off the profile on https://ventrella.com/Clusters/