### PR TITLE
LibWeb: Adding the minimum client hints from low-entropy headers table

### DIFF
--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -14,6 +14,7 @@
 struct TabSettings {
     BOOL should_show_line_box_borders { NO };
     BOOL scripting_enabled { YES };
+    BOOL client_hints_enabled { YES };
     BOOL block_popups { YES };
     BOOL same_origin_policy_enabled { NO };
     ByteString user_agent_name { "Disabled"sv };

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -355,15 +355,26 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 - (void)setUserAgentSpoof:(NSMenuItem*)sender
 {
     ByteString const user_agent_name = [[sender title] UTF8String];
-    ByteString user_agent = "";
+    WebView::UserAgent user_agent;
     if (user_agent_name == "Disabled"sv) {
-        user_agent = Web::default_user_agent;
+        user_agent = WebView::UserAgent {
+            .name = "default"sv,
+            .user_agent = Web::default_user_agent,
+            .sec_user_agent = Web::default_sec_user_agent,
+            .platform = Web::default_os,
+            .support_client_hints = Web::default_enable_client_hints,
+            .is_mobile = Web::default_is_mobile
+        };
     } else {
         user_agent = WebView::user_agents.get(user_agent_name).value();
     }
     m_settings.user_agent_name = user_agent_name;
 
-    [self debugRequest:"spoof-user-agent" argument:user_agent];
+    [self debugRequest:"spoof-user-agent" argument:user_agent.user_agent];
+    [self debugRequest:"client-hints-enabled" argument:user_agent.support_client_hints ? "on" : "off"];
+    [self debugRequest:"client-hints-platform" argument:user_agent.platform];
+    [self debugRequest:"client-hints-user-agent" argument:user_agent.sec_user_agent];
+    [self debugRequest:"client-hints-is-mobile" argument:user_agent.is_mobile ? "yes" : "no"];
     [self debugRequest:"clear-cache" argument:""]; // clear the cache to ensure requests are re-done with the new user agent
 }
 

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -482,8 +482,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     set_user_agent_string(Web::default_user_agent);
     auto* disable_spoofing = add_user_agent("Disabled"sv, Web::default_user_agent);
     disable_spoofing->setChecked(true);
-    for (auto const& user_agent : WebView::user_agents)
-        add_user_agent(user_agent.key, user_agent.value.to_byte_string());
+    for (auto const& user_agent : WebView::user_agents) {
+        add_user_agent(user_agent.key, user_agent.value.user_agent.to_byte_string());
+    }
 
     auto* custom_user_agent_action = new QAction("Custom...", this);
     custom_user_agent_action->setCheckable(true);
@@ -1110,6 +1111,12 @@ void BrowserWindow::set_window_rect(Optional<Web::DevicePixels> x, Optional<Web:
         height = 600;
 
     setGeometry(x.value().value(), y.value().value(), width.value().value(), height.value().value());
+}
+
+void BrowserWindow::set_user_agent_string(ByteString const& user_agent_name)
+{
+    auto user_agent = WebView::user_agents.get(user_agent_name).value();
+    m_user_agent_string = user_agent.user_agent;
 }
 
 void BrowserWindow::set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme)

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -169,7 +169,8 @@ private:
     void set_window_rect(Optional<Web::DevicePixels> x, Optional<Web::DevicePixels> y, Optional<Web::DevicePixels> width, Optional<Web::DevicePixels> height);
 
     ByteString user_agent_string() const { return m_user_agent_string; }
-    void set_user_agent_string(ByteString const& user_agent_string) { m_user_agent_string = user_agent_string; }
+    void set_user_agent_string(ByteString const& user_agent_name);
+
     ByteString navigator_compatibility_mode() const { return m_navigator_compatibility_mode; }
     void set_navigator_compatibility_mode(ByteString const& navigator_compatibility_mode) { m_navigator_compatibility_mode = navigator_compatibility_mode; }
 

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -97,6 +97,11 @@ public:
     String const& user_agent() const { return m_user_agent; }
     void set_user_agent(String user_agent) { m_user_agent = move(user_agent); }
 
+    void set_enable_client_hints(bool enable_client_hints) { m_enable_client_hints = enable_client_hints; }
+    void set_client_hints_user_agent(String user_agent) { m_sec_user_agent = move(user_agent); }
+    void set_is_mobile(bool is_mobile) { m_is_mobile = is_mobile; }
+    void set_os(String os) { m_os = move(os); }
+
     String const& platform() const { return m_platform; }
     void set_platform(String platform) { m_platform = move(platform); }
 
@@ -122,7 +127,13 @@ private:
     HashTable<NonnullRefPtr<ResourceLoaderConnectorRequest>> m_active_requests;
     NonnullRefPtr<ResourceLoaderConnector> m_connector;
     String m_user_agent;
+    String m_sec_user_agent;
     String m_platform;
+    String m_os;
+    String m_browser_name;
+    String m_browser_version;
+    bool m_is_mobile;
+    bool m_enable_client_hints;
     NavigatorCompatibilityMode m_navigator_compatibility_mode;
     bool m_enable_do_not_track { false };
     Optional<JS::GCPtr<Page>> m_page {};

--- a/Userland/Libraries/LibWeb/Loader/UserAgent.h
+++ b/Userland/Libraries/LibWeb/Loader/UserAgent.h
@@ -30,30 +30,43 @@ namespace Web {
 
 #if defined(AK_OS_SERENITY)
 #    define OS_STRING "SerenityOS"
+#    define IS_MOBILE false
 #elif defined(AK_OS_ANDROID)
 #    define OS_STRING "Android 10"
+#    define IS_MOBILE true
 #elif defined(AK_OS_LINUX)
 #    define OS_STRING "Linux"
+#    define IS_MOBILE false
 #elif defined(AK_OS_MACOS)
 #    define OS_STRING "macOS"
+#    define IS_MOBILE false
 #elif defined(AK_OS_IOS)
 #    define OS_STRING "iOS"
+#    define IS_MOBILE true
 #elif defined(AK_OS_WINDOWS)
 #    define OS_STRING "Windows"
+#    define IS_MOBILE false
 #elif defined(AK_OS_FREEBSD)
 #    define OS_STRING "FreeBSD"
+#    define IS_MOBILE false
 #elif defined(AK_OS_OPENBSD)
 #    define OS_STRING "OpenBSD"
+#    define IS_MOBILE false
 #elif defined(AK_OS_NETBSD)
 #    define OS_STRING "NetBSD"
+#    define IS_MOBILE false
 #elif defined(AK_OS_DRAGONFLY)
 #    define OS_STRING "DragonFly"
+#    define IS_MOBILE false
 #elif defined(AK_OS_SOLARIS)
 #    define OS_STRING "SunOS"
+#    define IS_MOBILE false
 #elif defined(AK_OS_HAIKU)
 #    define OS_STRING "Haiku"
+#    define IS_MOBILE false
 #elif defined(AK_OS_GNU_HURD)
 #    define OS_STRING "GNU/Hurd"
+#    define IS_MOBILE false
 #else
 #    error Unknown OS
 #endif
@@ -65,10 +78,18 @@ enum class NavigatorCompatibilityMode {
 };
 
 #define BROWSER_NAME "Ladybird"
-#define BROWSER_VERSION "1.0"
+#define BROWSER_MAJOR_VERSION "1"
+#define BROWSER_MINOR_VERSION "0"
+#define BROWSER_VERSION BROWSER_MAJOR_VERSION "." BROWSER_MINOR_VERSION
 
 constexpr auto default_user_agent = "Mozilla/5.0 (" OS_STRING "; " CPU_STRING ") " BROWSER_NAME "/" BROWSER_VERSION ""sv;
+constexpr auto default_sec_user_agent = "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"116\", \"Google Chrome\";v=\"116\""sv;
 constexpr auto default_platform = OS_STRING " " CPU_STRING ""sv;
+constexpr auto default_os = OS_STRING ""sv;
 constexpr auto default_navigator_compatibility_mode = NavigatorCompatibilityMode::Chrome;
+constexpr auto default_is_mobile = IS_MOBILE;
+constexpr auto default_enable_client_hints = true;
 
+constexpr auto browser_name = BROWSER_NAME ""sv;
+constexpr auto browser_major_version = BROWSER_MAJOR_VERSION ""sv;
 }

--- a/Userland/Libraries/LibWebView/UserAgent.cpp
+++ b/Userland/Libraries/LibWebView/UserAgent.cpp
@@ -8,13 +8,57 @@
 
 namespace WebView {
 
-HashMap<StringView, StringView> const user_agents = {
-    { "Chrome Linux Desktop"sv, "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"sv },
-    { "Firefox Linux Desktop"sv, "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0"sv },
-    { "Safari macOS Desktop"sv, "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15"sv },
-    { "Chrome Android Mobile"sv, "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.114 Mobile Safari/537.36"sv },
-    { "Firefox Android Mobile"sv, "Mozilla/5.0 (Android 13; Mobile; rv:109.0) Gecko/116.0 Firefox/116.0"sv },
-    { "Safari iOS Mobile"sv, "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"sv },
+HashMap<StringView, UserAgent> const user_agents = {
+    { "Chrome Linux Desktop"sv,
+        UserAgent {
+            .name = "Chrome Linux Desktop"sv,
+            .user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36"sv,
+            .sec_user_agent = "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"116\", \"Google Chrome\";v=\"116\""sv,
+            .platform = "linux"sv,
+            .support_client_hints = true,
+            .is_mobile = false } },
+    {
+        "Firefox Linux Desktop"sv,
+        UserAgent {
+            .name = "Firefox Linux Desktop"sv,
+            .user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/116.0"sv,
+            .sec_user_agent = ""sv,
+            .platform = "linux"sv,
+            .support_client_hints = false,
+            .is_mobile = false },
+    },
+    { "Safari macOS Desktop"sv,
+        UserAgent {
+            .name = "Safari macOS Desktop"sv,
+            .user_agent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 13_5_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.5 Safari/605.1.15"sv,
+            .sec_user_agent = ""sv,
+            .platform = "macOS"sv,
+            .support_client_hints = false,
+            .is_mobile = false } },
+    { "Chrome Android Mobile"sv,
+        UserAgent {
+            .name = "Chrome Android Mobile"sv,
+            .user_agent = "Mozilla/5.0 (Linux; Android 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.5845.114 Mobile Safari/537.36"sv,
+            .sec_user_agent = "\"Not/A)Brand\";v=\"8\", \"Chromium\";v=\"116\", \"Brave\";v=\"116\""sv,
+            .platform = "Android"sv,
+            .support_client_hints = true,
+            .is_mobile = true } },
+    { "Firefox Android Mobile"sv,
+        UserAgent {
+            .name = "Firefox Android Mobile"sv,
+            .user_agent = "Mozilla/5.0 (Android 13; Mobile; rv:109.0) Gecko/116.0 Firefox/116.0"sv,
+            .sec_user_agent = ""sv,
+            .platform = "Android"sv,
+            .support_client_hints = false,
+            .is_mobile = true } },
+    { "Safari iOS Mobile"sv,
+        UserAgent {
+            .name = "Safari iOS Mobile"sv,
+            .user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1"sv,
+            .sec_user_agent = ""sv,
+            .platform = "iOS"sv,
+            .support_client_hints = false,
+            .is_mobile = true } }
 };
 
 }

--- a/Userland/Libraries/LibWebView/UserAgent.h
+++ b/Userland/Libraries/LibWebView/UserAgent.h
@@ -11,6 +11,15 @@
 
 namespace WebView {
 
-extern HashMap<StringView, StringView> const user_agents;
+struct UserAgent {
+    StringView name;
+    StringView user_agent;
+    StringView sec_user_agent;
+    StringView platform;
+    bool support_client_hints;
+    bool is_mobile;
+};
+
+extern HashMap<StringView, UserAgent> const user_agents;
 
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -44,6 +44,7 @@
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWebView/Attribute.h>
+// #include <LibWebView/UserAgent.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/PageHost.h>
@@ -356,6 +357,26 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
 
     if (request == "clear-cache") {
         Web::ResourceLoader::the().clear_cache();
+        return;
+    }
+
+    if (request == "client-hints-enabled") {
+        Web::ResourceLoader::the().set_enable_client_hints(argument == "on");
+        return;
+    }
+
+    if (request == "client-hints-user-agent") {
+        Web::ResourceLoader::the().set_client_hints_user_agent(MUST(String::from_byte_string(argument)));
+        return;
+    }
+
+    if (request == "client-hints-is-mobile") {
+        Web::ResourceLoader::the().set_is_mobile(argument == "yes");
+        return;
+    }
+
+    if (request == "client-hints-platform") {
+        Web::ResourceLoader::the().set_os(MUST(String::from_byte_string(argument)));
         return;
     }
 


### PR DESCRIPTION
A couple of sites I've found load with errors or don't load at all due to the requests not containing the ["User-Agent Client Hints"](https://wicg.github.io/client-hints-infrastructure/#intro) headers.

Example sites are:
- [https://www.akamai.com/us/en/clientrep-lookup/](https://www.akamai.com/us/en/clientrep-lookup/)
- [https://www.godaddy.com/](https://www.godaddy.com/)

<img width="628" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/12079442/ce86be41-41f3-472b-8a4a-cbe54f9b3d20">

This PR implements the [MVP](https://wicg.github.io/client-hints-infrastructure/#low-entropy-hint-table) headers required to "pass" and get these sites loading.

Additionally provides a toggle in the menu to enable/disable the client hints for debugging purposes.

<img width="425" alt="image" src="https://github.com/LadybirdBrowser/ladybird/assets/12079442/22d8ab4a-e06c-467b-9ef0-15c86aabfb00">