### PR TITLE
LibWasm: Remove `Wasm::ValueType::Kind::Null*` variants

### DIFF
--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -308,12 +308,6 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyModule::wasm_invoke)
             }
             arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Extern { static_cast<u64>(double_value) } }));
             break;
-        case Wasm::ValueType::Kind::NullFunctionReference:
-            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Null { Wasm::ValueType(Wasm::ValueType::Kind::FunctionReference) } }));
-            break;
-        case Wasm::ValueType::Kind::NullExternReference:
-            arguments.append(Wasm::Value(Wasm::Reference { Wasm::Reference::Null { Wasm::ValueType(Wasm::ValueType::Kind::ExternReference) } }));
-            break;
         }
     }
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -108,14 +108,6 @@ public:
         case ValueType::Kind::F64:
             m_value = bit_cast<double>(raw_value);
             break;
-        case ValueType::Kind::NullFunctionReference:
-            VERIFY(raw_value == 0);
-            m_value = Reference { Reference::Null { ValueType(ValueType::Kind::FunctionReference) } };
-            break;
-        case ValueType::Kind::NullExternReference:
-            VERIFY(raw_value == 0);
-            m_value = Reference { Reference::Null { ValueType(ValueType::Kind::ExternReference) } };
-            break;
         case ValueType::Kind::V128:
             m_value = u128(0ull, bit_cast<u64>(raw_value));
             break;
@@ -184,7 +176,7 @@ public:
                 return type.ref().visit(
                     [](Reference::Func const&) { return ValueType::Kind::FunctionReference; },
                     [](Reference::Null const& null_type) {
-                        return null_type.type.kind() == ValueType::ExternReference ? ValueType::Kind::NullExternReference : ValueType::Kind::NullFunctionReference;
+                        return null_type.type.kind();
                     },
                     [](Reference::Extern const&) { return ValueType::Kind::ExternReference; });
             }));

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -165,8 +165,6 @@ public:
         V128,
         FunctionReference,
         ExternReference,
-        NullFunctionReference,
-        NullExternReference,
     };
 
     explicit ValueType(Kind kind)
@@ -176,7 +174,7 @@ public:
 
     bool operator==(ValueType const&) const = default;
 
-    auto is_reference() const { return m_kind == ExternReference || m_kind == FunctionReference || m_kind == NullExternReference || m_kind == NullFunctionReference; }
+    auto is_reference() const { return m_kind == ExternReference || m_kind == FunctionReference; }
     auto is_vector() const { return m_kind == V128; }
     auto is_numeric() const { return !is_reference() && !is_vector(); }
     auto kind() const { return m_kind; }
@@ -200,10 +198,6 @@ public:
             return "funcref";
         case ExternReference:
             return "externref";
-        case NullFunctionReference:
-            return "ref.null externref";
-        case NullExternReference:
-            return "ref.null funcref";
         }
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -412,10 +412,9 @@ JS::ThrowCompletionOr<Wasm::Value> to_webassembly_value(JS::VM& vm, JS::Value va
         auto number = TRY(value.to_double(vm));
         return Wasm::Value { static_cast<float>(number) };
     }
-    case Wasm::ValueType::FunctionReference:
-    case Wasm::ValueType::NullFunctionReference: {
+    case Wasm::ValueType::FunctionReference: {
         if (value.is_null())
-            return Wasm::Value { Wasm::ValueType(Wasm::ValueType::NullExternReference), 0ull };
+            return Wasm::Value { Wasm::ValueType(Wasm::ValueType::FunctionReference), 0ull };
 
         if (value.is_function()) {
             auto& function = value.as_function();
@@ -429,7 +428,6 @@ JS::ThrowCompletionOr<Wasm::Value> to_webassembly_value(JS::VM& vm, JS::Value va
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "Exported function");
     }
     case Wasm::ValueType::ExternReference:
-    case Wasm::ValueType::NullExternReference:
         TODO();
     case Wasm::ValueType::V128:
         return vm.throw_completion<JS::TypeError>("Cannot convert a vector value to a javascript value"sv);
@@ -453,11 +451,8 @@ JS::Value to_js_value(JS::VM& vm, Wasm::Value& wasm_value)
     case Wasm::ValueType::FunctionReference:
         // FIXME: What's the name of a function reference that isn't exported?
         return create_native_function(vm, wasm_value.to<Wasm::Reference::Func>().value().address, "FIXME_IHaveNoIdeaWhatThisShouldBeCalled");
-    case Wasm::ValueType::NullFunctionReference:
-        return JS::js_null();
     case Wasm::ValueType::V128:
     case Wasm::ValueType::ExternReference:
-    case Wasm::ValueType::NullExternReference:
         TODO();
     }
     VERIFY_NOT_REACHED();


### PR DESCRIPTION
As far as I know, they're not in the spec and don't serve any purposes in the internals of LibWasm.