### PR TITLE
Everywhere: Don't install code generators and test binaries

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -106,6 +106,7 @@ jobs:
 
           cmake -GNinja -S Meta/Lagom -B ${{ github.workspace }}/tools-build \
             -DLAGOM_TOOLS_ONLY=ON \
+            -DINSTALL_LAGOM_TOOLS=ON \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/tool-install \
             -DSERENITY_CACHE_DIR=${{ github.workspace }}/Build/caches \
             -DCMAKE_C_COMPILER=gcc-13 \

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -1,14 +1,19 @@
 function(lagom_tool tool)
-    cmake_parse_arguments(LAGOM_TOOL "" "" "SOURCES;LIBS" ${ARGN})
+    cmake_parse_arguments(LAGOM_TOOL "" "INSTALL" "SOURCES;LIBS" ${ARGN})
     add_executable(${tool} ${SOURCES} ${LAGOM_TOOL_SOURCES})
     # alias for parity with exports
     add_executable(Lagom::${tool} ALIAS ${tool})
     target_link_libraries(${tool} AK LibCoreMinimal LibFileSystem GenericClangPlugin ${LAGOM_TOOL_LIBS})
-    install(
-        TARGETS ${tool}
-        EXPORT LagomTargets
-        RUNTIME COMPONENT Lagom_Runtime
-    )
+    if (NOT DEFINED LAGOM_TOOL_INSTALL)
+        set(LAGOM_TOOL_INSTALL ${INSTALL_LAGOM_TOOLS})
+    endif()
+    if (DEFINED LAGOM_TOOL_INSTALL AND LAGOM_TOOL_INSTALL)
+        install(
+            TARGETS ${tool}
+            EXPORT LagomTargets
+            RUNTIME COMPONENT Lagom_Runtime
+        )
+    endif()
 endfunction()
 
 add_subdirectory(CodeGenerators)

--- a/Tests/LibAudio/CMakeLists.txt
+++ b/Tests/LibAudio/CMakeLists.txt
@@ -7,7 +7,3 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibAudio LIBS LibAudio LibFileSystem)
 endforeach()
-
-install(DIRECTORY ${FLAC_SPEC_TEST_PATH} DESTINATION usr/Tests/LibAudio/FLAC)
-
-install(DIRECTORY WAV DESTINATION usr/Tests/LibAudio)

--- a/Tests/LibCompress/CMakeLists.txt
+++ b/Tests/LibCompress/CMakeLists.txt
@@ -12,6 +12,3 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibCompress LIBS LibCompress)
 endforeach()
-
-install(DIRECTORY brotli-test-files DESTINATION usr/Tests/LibCompress)
-install(DIRECTORY deflate-test-files DESTINATION usr/Tests/LibCompress)

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -19,5 +19,3 @@ target_link_libraries(TestLibCorePromise PRIVATE LibThreading)
 # NOTE: Required because of the LocalServer tests
 target_link_libraries(TestLibCoreStream PRIVATE LibThreading)
 target_link_libraries(TestLibCoreSharedSingleProducerCircularQueue PRIVATE LibThreading)
-
-install(FILES long_lines.txt 10kb.txt small.txt DESTINATION usr/Tests/LibCore)

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -18,5 +18,3 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     serenity_test("${source}" LibGfx LIBS LibGfx)
 endforeach()
-
-install(DIRECTORY test-inputs DESTINATION usr/Tests/LibGfx)

--- a/Tests/LibJS/CMakeLists.txt
+++ b/Tests/LibJS/CMakeLists.txt
@@ -1,7 +1,5 @@
 serenity_testjs_test(test-js.cpp test-js LIBS LibUnicode)
 
-install(TARGETS test-js RUNTIME DESTINATION bin OPTIONAL)
-
 serenity_test(test-invalid-unicode-js.cpp LibJS LIBS LibJS LibUnicode)
 
 serenity_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
@@ -9,9 +7,7 @@ serenity_test(test-value-js.cpp LibJS LIBS LibJS LibUnicode)
 add_executable(test262-runner test262-runner.cpp)
 target_link_libraries(test262-runner PRIVATE LibJS LibCore LibUnicode)
 serenity_set_implicit_links(test262-runner)
-install(TARGETS test262-runner RUNTIME DESTINATION bin OPTIONAL)
 
 add_executable(test-test262 test-test262.cpp)
 target_link_libraries(test-test262 PRIVATE LibMain LibCore LibFileSystem)
 serenity_set_implicit_links(test-test262)
-install(TARGETS test-test262 RUNTIME DESTINATION bin OPTIONAL)

--- a/Tests/LibWasm/CMakeLists.txt
+++ b/Tests/LibWasm/CMakeLists.txt
@@ -1,2 +1,1 @@
 serenity_testjs_test(test-wasm.cpp test-wasm LIBS LibWasm LibJS LibCrypto)
-install(TARGETS test-wasm RUNTIME DESTINATION bin OPTIONAL)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -14,5 +14,3 @@ foreach(source IN LISTS TEST_SOURCES)
 endforeach()
 
 target_link_libraries(TestFetchURL PRIVATE LibURL)
-
-install(FILES tokenizer-test.html DESTINATION usr/Tests/LibWeb)


### PR DESCRIPTION
These files are not needed in the final installation.

Generators and test binaries are only used during the compilation process.