### PR TITLE
UI/Qt: Set a minimum size policy for the navigation control toolbar

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -91,6 +91,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_toolbar->addAction(&m_window->reload_action());
     m_toolbar->addWidget(m_location_edit);
     m_toolbar->addAction(&m_window->new_tab_action());
+    m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
     m_hamburger_button_action = m_toolbar->addWidget(m_hamburger_button);
     m_toolbar->setIconSize({ 16, 16 });
     // This is a little awkward, but without this Qt shrinks the button to the size of the icon.


### PR DESCRIPTION
This prevents the user being able to shrink the window to the point that the location bar and other controls are no longer visible.

Before:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/7e002ee6-7515-46b8-9647-858d8b8add1e

After:

https://github.com/LadybirdBrowser/ladybird/assets/2817754/5d18c1ef-45a3-4bd1-a687-bbe840205758

