### PR TITLE
LibWasm: Give names to functions exported to JS via `ref.func`

### DIFF
--- a/Tests/LibWasm/test-wasm.cpp
+++ b/Tests/LibWasm/test-wasm.cpp
@@ -142,7 +142,8 @@ private:
                 // Noop, this just needs to exist.
                 return Wasm::Result { Vector<Wasm::Value> {} };
             },
-            type });
+            type,
+            "__TEST" });
     }
 
     static HashMap<Wasm::Linker::Name, Wasm::ExternValue> s_spec_test_namespace;

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -348,18 +348,21 @@ private:
 
 class HostFunction {
 public:
-    explicit HostFunction(AK::Function<Result(Configuration&, Vector<Value>&)> function, FunctionType const& type)
+    explicit HostFunction(AK::Function<Result(Configuration&, Vector<Value>&)> function, FunctionType const& type, ByteString name)
         : m_function(move(function))
         , m_type(type)
+        , m_name(move(name))
     {
     }
 
     auto& function() { return m_function; }
     auto& type() const { return m_type; }
+    auto& name() const { return m_name; }
 
 private:
     AK::Function<Result(Configuration&, Vector<Value>&)> m_function;
     FunctionType m_type;
+    ByteString m_name;
 };
 
 using FunctionInstance = Variant<WasmFunction, HostFunction>;

--- a/Userland/Libraries/LibWasm/WASI/Wasi.cpp
+++ b/Userland/Libraries/LibWasm/WASI/Wasi.cpp
@@ -971,7 +971,8 @@ struct InvocationOf<impl> {
             FunctionType {
                 move(arguments_types),
                 { ValueType(ValueType::I32) },
-            });
+            },
+            function_name);
     }
 };
 

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -695,7 +695,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                             result.append(Wasm::Value { result_type, 0ull });
                         return Wasm::Result { move(result) };
                     },
-                    type));
+                    type,
+                    entry.name));
                 exports.set(entry, *address);
             }
 


### PR DESCRIPTION
Resolves the FIXME. This also requires that host functions have names. We could make it an optional parameter or something, but I figured that the information is important enough. Let me know if that's an okay assumption.

Also, is this something we should test for?

See the relevant spec section: https://webassembly.github.io/spec/js-api/index.html#name-of-the-webassembly-function