### PR TITLE
LibWasm: Error when parsed section lengths are invalidated

### DIFF
--- a/AK/ConstrainedStream.h
+++ b/AK/ConstrainedStream.h
@@ -22,6 +22,7 @@ public:
     virtual bool is_eof() const override;
     virtual bool is_open() const override;
     virtual void close() override;
+    u64 remaining() const { return m_limit; }
 
 private:
     MaybeOwned<Stream> m_stream;

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -1413,10 +1413,8 @@ ParseResult<Module> Module::parse(Stream& stream)
         return with_eof_check(stream, ParseError::InvalidModuleVersion);
 
     Vector<AnySection> sections;
-    for (;;) {
+    while (!stream.is_eof()) {
         auto section_id_or_error = stream.read_value<u8>();
-        if (stream.is_eof())
-            break;
         if (section_id_or_error.is_error())
             return with_eof_check(stream, ParseError::ExpectedIndex);
 
@@ -1472,7 +1470,7 @@ ParseResult<Module> Module::parse(Stream& stream)
         default:
             return with_eof_check(stream, ParseError::InvalidIndex);
         }
-        if (!section_stream.is_eof())
+        if (section_stream.remaining() != 0)
             return ParseError::SectionSizeMismatch;
     }
 


### PR DESCRIPTION
`custom.wast` now fully passes!