### PR TITLE
Documentation: Add how-to for building with homebrew clang on macOS

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -136,6 +136,13 @@ cmake --preset default -DENABLE_QT=ON
 
 To re-disable the Qt chrome, run the above command with `-DENABLE_QT=OFF`.
 
+On macOS, to build with clang from homebrew:
+
+```
+brew install llvm
+CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ ./Meta/ladybird.sh run
+```
+
 ### Resource files
 
 Ladybird requires resource files from the ladybird/Base/res directory in order to properly load


### PR DESCRIPTION
This patch to the build instructions adds a very short explanation about how to build on macOS with clang from homebrew rather than the Apple-provided clang.

Otherwise, without this change, when people run into problems caused by building with the older clang version provided by Apple, they might not have any idea they can try building with the clang from homebrew instead.

This isn’t just a hypothetical problem — see https://github.com/LadybirdBrowser/ladybird/issues/186#issuecomment-2173267199 and https://github.com/LadybirdBrowser/ladybird/issues/186#issuecomment-2213056182.