### PR TITLE
Meta: Add .clangd config file (with CompilationDatabase path specified)

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,6 @@
+CompileFlags:
+  CompilationDatabase: Build/ladybird
+
+Diagnostics:
+  UnusedIncludes: None
+  MissingIncludes: None

--- a/Documentation/EmacsConfiguration.md
+++ b/Documentation/EmacsConfiguration.md
@@ -4,20 +4,10 @@ Emacs can be configured with `lsp-mode` and `clangd` to work well.
 
 ### clangd
 
-The official clangd extension can be used for C++ comprehension. You
-can use the following `.clangd` file placed in the project root:
+The official clangd extension can be used for C++ comprehension.
 
-```yaml
-CompileFlags:
-  CompilationDatabase: Build/ladybird
-
-Diagnostics:
-  UnusedIncludes: None
-  MissingIncludes: None
-```
-
-Run cmake (`Meta/ladybird.sh run ladybird` or similar) at least once for this
-to work, as it will generate the `Build/ladybird/compile_commands.json`
+Run cmake (`Meta/ladybird.sh run ladybird` or similar) at least once for clangd
+to work, as doing so will generate the `Build/ladybird/compile_commands.json`
 that is needed by `clangd`.
 
 ### lsp-mode

--- a/Documentation/HelixConfiguration.md
+++ b/Documentation/HelixConfiguration.md
@@ -1,17 +1,5 @@
 # Helix Configuration
-Helix comes with support for `clangd` and `clang-format` out of the box! However, a small bit of configuration is needed for it to work correctly with Ladybird.
-
-The following `.clangd` should be placed in the project root:
-```yaml
-CompileFlags:
-  CompilationDatabase: Build/ladybird
-
-Diagnostics:
-  UnusedIncludes: None
-  MissingIncludes: None
-```
-
-You also need to configure the clangd server to not insert headers improperly. To do this, create a `.helix/languages.toml` file in the project root:
+Helix comes with support for `clangd` and `clang-format` out of the box! However, you also need to configure the clangd server to not insert headers improperly. To do this, create a `.helix/languages.toml` file in the project root:
 ```toml
 [language-server.ladybird]
 command = "clangd"

--- a/Documentation/NvimConfiguration.md
+++ b/Documentation/NvimConfiguration.md
@@ -7,17 +7,7 @@ project:
 2. With [coc.nvim](https://github.com/neoclide/coc.nvim) (from scratch, potentially out of date)
 
 For both setups, make sure you ran `./Meta/ladybird.sh run ladybird` at least 
-once. Additionally, clangd should be configured with the following (in the
-`.clangd` file at the root of the project):
-
-```yaml
-CompileFlags:
-  CompilationDatabase: Build/ladybird
-
-Diagnostics:
-  UnusedIncludes: None
-  MissingIncludes: None
-```
+once.
 
 ## With nvim-lspconfig
 

--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -24,19 +24,6 @@ Clangd has the best support for modern compilers, especially if configured as no
 The official clangd extension can be used for C++ comprehension. It is recommended in general, as it is most likely to work on all platforms.
 
 clangd uses ``compile_commands.json`` files to understand the project. CMake will generate these in Build/ladybird.
-Depending on which configuration you use most, set the CompilationDatabase configuration item in the below ``.clangd`` file accordingly. It goes at the root of your checkout (``ladybird/.clangd``):
-
-```yaml
-CompileFlags:
-  CompilationDatabase: Build/ladybird
-  
-Diagnostics:
-  UnusedIncludes: None
-  MissingIncludes: None
-```
-
-The UnusedIncludes and MissingIncludes flags are used to disable the [Include Cleaner](https://clangd.llvm.org/design/include-cleaner) feature of newer clangd releases.
-It can be re-enabled if you don't mind the noisy inlay hints and problems in the problem view.
 
 Run ``./Meta/ladybird.sh run ladybird`` at least once to generate the ``compile_commands.json`` file.
 


### PR DESCRIPTION
This change adds a `.clangd` file in the repo root, for the (initial) purpose of specifying the `CompilationDatabase` path — so that clangd (and people’s editors) can find and use the `Build/ladybird/compile_commands.json` file

Otherwise (without this change) nobody’s editors will actually be able to use all the clangd-provided features — because clangd by default just looks directly (non-recursively) only in the source directory (repo root) — and not within the `Build` directory at all.

Currently, people can work around this by symlinking the `Build/ladybird/compile_commands.json` file into the repo root. But it’d be more convenient for developer ergonomics if they didn’t have to do that, and if everything would instead “Just Work” for them out of the box.