### PR TITLE
LibWeb: Fix handling of find-in-page with pseudo-element content

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -57,7 +57,7 @@ void Viewport::update_text_blocks()
         if (layout_node.display().is_none() || !layout_node.paintable() || !layout_node.paintable()->is_visible())
             return TraversalDecision::Continue;
 
-        if (layout_node.is_box()) {
+        if (layout_node.is_box() || layout_node.is_generated()) {
             if (!builder.is_empty()) {
                 text_blocks.append({ builder.to_string_without_validation(), text_positions });
                 current_start_position = 0;


### PR DESCRIPTION
This change makes find-in-page ignore content that’s been added to the document using CSS `::after` or `::before` pseudo-elements. Ignoring such pseudo-element content for find-in-page matches the behavior in Chrome and Safari (though not in Firefox).

Otherwise, without this change, find-in-page doesn’t ignore the pseudo-element content, and we instead crash in `DOM::Range::common_ancestor_container` after hitting an assert, due to the start container and end container for the matched range not having a common ancestor.

Note: <s>I’ve not found any</s> [There is no spec that normatively defines the required behavior for find-in-page with pseudo-element content](https://matrixlogs.bakkot.com/WHATWG/2024-07-09#L1). But since there are two existing implementations which ignore it — versus one which doesn’t — it seems preferable to match the “prevailing” behavior.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/514