### PR TITLE
AK+LibJS: Add ASSERT() and ASSERT_NOT_REACHED() for debug-only assertions

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -101,4 +101,25 @@ void ak_verification_failed(char const* message)
 #endif
     __builtin_trap();
 }
+
+void ak_assertion_failed(char const* message)
+{
+#if defined(AK_OS_SERENITY) || defined(AK_OS_ANDROID)
+    bool colorize_output = true;
+#elif defined(AK_OS_WINDOWS)
+    bool colorize_output = false;
+#else
+    bool colorize_output = isatty(STDERR_FILENO) == 1;
+#endif
+
+    if (colorize_output)
+        ERRORLN("\033[31;1mASSERTION FAILED\033[0m: {}", message);
+    else
+        ERRORLN("ASSERTION FAILED: {}", message);
+
+#if defined(AK_HAS_BACKTRACE_HEADER)
+    dump_backtrace();
+#endif
+    __builtin_trap();
+}
 }

--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -20,3 +20,15 @@ static constexpr bool TODO = false;
 #define TODO_RISCV64() VERIFY(TODO) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #define TODO_PPC64() VERIFY(TODO)   /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #define TODO_PPC() VERIFY(TODO)     /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+
+#ifdef NDEBUG
+extern "C" __attribute__((noreturn)) void ak_assertion_failed(char const*);
+#    define ASSERT(expr)                                                               \
+        (__builtin_expect(!(expr), 0)                                                  \
+                ? ak_assertion_failed(#expr " at " __FILE__ ":" __stringify(__LINE__)) \
+                : (void)0)
+#    define ASSERT_NOT_REACHED ASSERT(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#else
+#    define ASSERT(expr)
+#    define ASSERT_NOT_REACHED() __builtin_unreachable()
+#endif

--- a/Userland/Libraries/LibJS/Heap/GCPtr.h
+++ b/Userland/Libraries/LibJS/Heap/GCPtr.h
@@ -165,13 +165,13 @@ public:
 
     T* operator->() const
     {
-        VERIFY(m_ptr);
+        ASSERT(m_ptr);
         return m_ptr;
     }
 
     T& operator*() const
     {
-        VERIFY(m_ptr);
+        ASSERT(m_ptr);
         return *m_ptr;
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -212,7 +212,7 @@ public:
     {
         bool is_negative_zero = bit_cast<u64>(value) == NEGATIVE_ZERO_BITS;
         if (value >= NumericLimits<i32>::min() && value <= NumericLimits<i32>::max() && trunc(value) == value && !is_negative_zero) {
-            VERIFY(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
+            ASSERT(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
             m_value.encoded = SHIFTED_INT32_TAG | (static_cast<i32>(value) & 0xFFFFFFFFul);
         } else {
             if (isnan(value)) [[unlikely]]
@@ -232,7 +232,7 @@ public:
         if (value > NumericLimits<i32>::max()) {
             m_value.as_double = static_cast<double>(value);
         } else {
-            VERIFY(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
+            ASSERT(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
             m_value.encoded = SHIFTED_INT32_TAG | (static_cast<i32>(value) & 0xFFFFFFFFul);
         }
     }
@@ -242,7 +242,7 @@ public:
         if (value > NumericLimits<i32>::max()) {
             m_value.as_double = static_cast<double>(value);
         } else {
-            VERIFY(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
+            ASSERT(!(SHIFTED_INT32_TAG & (static_cast<i32>(value) & 0xFFFFFFFFul)));
             m_value.encoded = SHIFTED_INT32_TAG | (static_cast<i32>(value) & 0xFFFFFFFFul);
         }
     }
@@ -463,7 +463,7 @@ private:
 
     Value(u64 tag, u64 val)
     {
-        VERIFY(!(tag & val));
+        ASSERT(!(tag & val));
         m_value.encoded = tag | val;
     }
 
@@ -476,7 +476,7 @@ private:
             return;
         }
 
-        VERIFY((tag & 0x8000000000000000ul) == 0x8000000000000000ul);
+        ASSERT((tag & 0x8000000000000000ul) == 0x8000000000000000ul);
 
         if constexpr (sizeof(PointerType*) < sizeof(u64)) {
             m_value.encoded = tag | reinterpret_cast<u32>(ptr);


### PR DESCRIPTION
Let's move towards using these for things that are "nice to check in
debug builds, but not essential".

This PR adds `ASSERT()` and `ASSERT_NOT_REACHED()` and uses them for a handful of things in LibJS that were hot in profiles (~5%) without adding justifiable value.