### PR TITLE
WebContent+WebWorker: Use custom certificate paths with Qt networking

### DIFF
--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -77,10 +77,10 @@ ErrorOr<void> Application::initialize_image_decoder()
     return {};
 }
 
-void Application::show_task_manager_window()
+void Application::show_task_manager_window(WebContentOptions const& web_content_options)
 {
     if (!m_task_manager_window) {
-        m_task_manager_window = new TaskManagerWindow(nullptr);
+        m_task_manager_window = new TaskManagerWindow(nullptr, web_content_options);
     }
     m_task_manager_window->show();
     m_task_manager_window->activateWindow();

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -33,7 +33,7 @@ public:
 
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
-    void show_task_manager_window();
+    void show_task_manager_window(WebContentOptions const&);
     void close_task_manager_window();
 
     BrowserWindow& active_window() { return *m_active_window; }

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -349,8 +349,8 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
     task_manager_action->setIcon(load_icon_from_uri("resource://icons/16x16/app-system-monitor.png"sv));
     task_manager_action->setShortcuts({ QKeySequence("Ctrl+Shift+M") });
     inspect_menu->addAction(task_manager_action);
-    QObject::connect(task_manager_action, &QAction::triggered, this, [] {
-        static_cast<Ladybird::Application*>(QApplication::instance())->show_task_manager_window();
+    QObject::connect(task_manager_action, &QAction::triggered, this, [&] {
+        static_cast<Ladybird::Application*>(QApplication::instance())->show_task_manager_window(m_web_content_options);
     });
 
     auto* debug_menu = m_hamburger_menu->addMenu("&Debug");

--- a/Ladybird/Qt/RequestManagerQt.cpp
+++ b/Ladybird/Qt/RequestManagerQt.cpp
@@ -5,15 +5,24 @@
  */
 
 #include "RequestManagerQt.h"
+#include "StringUtils.h"
 #include "WebSocketImplQt.h"
 #include "WebSocketQt.h"
 #include <QNetworkCookie>
 
 namespace Ladybird {
 
-RequestManagerQt::RequestManagerQt()
+RequestManagerQt::RequestManagerQt(Vector<ByteString> const& certificate_paths)
 {
     m_qnam = new QNetworkAccessManager(this);
+    auto ssl_configuration = QSslConfiguration::defaultConfiguration();
+    ssl_configuration.setPeerVerifyMode(QSslSocket::VerifyNone);
+    for (auto const& certificate_path : certificate_paths) {
+        auto certificates = QSslCertificate::fromPath(qstring_from_ak_string(certificate_path));
+        for (auto const& certificate : certificates)
+            ssl_configuration.addCaCertificate(certificate);
+    }
+    QSslConfiguration::setDefaultConfiguration(ssl_configuration);
 
     QObject::connect(m_qnam, &QNetworkAccessManager::finished, this, &RequestManagerQt::reply_finished);
 }

--- a/Ladybird/Qt/RequestManagerQt.h
+++ b/Ladybird/Qt/RequestManagerQt.h
@@ -17,9 +17,9 @@ class RequestManagerQt
     , public Web::ResourceLoaderConnector {
     Q_OBJECT
 public:
-    static NonnullRefPtr<RequestManagerQt> create()
+    static NonnullRefPtr<RequestManagerQt> create(Vector<ByteString> const& certificate_paths)
     {
-        return adopt_ref(*new RequestManagerQt());
+        return adopt_ref(*new RequestManagerQt(certificate_paths));
     }
 
     virtual ~RequestManagerQt() override { }
@@ -34,7 +34,7 @@ private slots:
     void reply_finished(QNetworkReply*);
 
 private:
-    RequestManagerQt();
+    explicit RequestManagerQt(Vector<ByteString> const& certificate_paths);
 
     class Request
         : public Web::ResourceLoaderConnectorRequest {

--- a/Ladybird/Qt/TaskManagerWindow.cpp
+++ b/Ladybird/Qt/TaskManagerWindow.cpp
@@ -10,9 +10,9 @@
 
 namespace Ladybird {
 
-TaskManagerWindow::TaskManagerWindow(QWidget* parent)
+TaskManagerWindow::TaskManagerWindow(QWidget* parent, WebContentOptions const& web_content_options)
     : QWidget(parent, Qt::WindowFlags(Qt::WindowType::Window))
-    , m_web_view(new WebContentView(this, {}, {}))
+    , m_web_view(new WebContentView(this, web_content_options, {}))
 {
     setLayout(new QVBoxLayout);
     layout()->addWidget(m_web_view);

--- a/Ladybird/Qt/TaskManagerWindow.h
+++ b/Ladybird/Qt/TaskManagerWindow.h
@@ -16,7 +16,7 @@ class TaskManagerWindow : public QWidget {
     Q_OBJECT
 
 public:
-    explicit TaskManagerWindow(QWidget* parent);
+    TaskManagerWindow(QWidget* parent, WebContentOptions const&);
 
 private:
     virtual void showEvent(QShowEvent*) override;

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -113,6 +113,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(is_layout_test_mode, "Is layout test mode", "layout-test-mode");
     args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(use_skia_painter, "Enable Skia painter", "use-skia-painting");
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
@@ -150,7 +151,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 #if defined(HAVE_QT)
     if (!use_lagom_networking)
-        Web::ResourceLoader::initialize(Ladybird::RequestManagerQt::create());
+        Web::ResourceLoader::initialize(Ladybird::RequestManagerQt::create(certificates));
     else
 #endif
         TRY(initialize_lagom_networking(request_server_socket));

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -39,12 +39,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     int request_server_socket { -1 };
     StringView serenity_resource_root;
+    Vector<ByteString> certificates;
     bool use_lagom_networking { false };
 
     Core::ArgsParser args_parser;
     args_parser.add_option(request_server_socket, "File descriptor of the request server socket", "request-server-socket", 's', "request-server-socket");
     args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.parse(arguments);
 
 #if defined(HAVE_QT)
@@ -61,7 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 #if defined(HAVE_QT)
     if (!use_lagom_networking)
-        Web::ResourceLoader::initialize(Ladybird::RequestManagerQt::create());
+        Web::ResourceLoader::initialize(Ladybird::RequestManagerQt::create(certificates));
     else
 #endif
         TRY(initialize_lagom_networking(request_server_socket));


### PR DESCRIPTION
This change adds a `--certificate` option to both WebContent and WebWorker, which allows one or more custom root certificate paths to be specified. Certificates are then loaded from these paths when Qt networking is used.

This allows WPT tests that require a https connection to be run locally with Qt networking.