### PR TITLE
LibGfx+LibWeb: Support CSS gradient "transition hints" in Skia painter

### DIFF
--- a/Userland/Libraries/LibGfx/GradientPainting.cpp
+++ b/Userland/Libraries/LibGfx/GradientPainting.cpp
@@ -18,7 +18,7 @@ namespace Gfx {
 // Note: This file implements the CSS/Canvas gradients for LibWeb according to the spec.
 // Please do not make ad-hoc changes that may break spec compliance!
 
-static float color_stop_step(ColorStop const& previous_stop, ColorStop const& next_stop, float position)
+float color_stop_step(ColorStop const& previous_stop, ColorStop const& next_stop, float position)
 {
     if (position < previous_stop.position)
         return 0;

--- a/Userland/Libraries/LibGfx/Gradients.h
+++ b/Userland/Libraries/LibGfx/Gradients.h
@@ -16,7 +16,11 @@ struct ColorStop {
     Color color;
     float position = AK::NaN<float>;
     Optional<float> transition_hint = {};
+
+    bool operator==(ColorStop const&) const = default;
 };
+
+float color_stop_step(ColorStop const& previous_stop, ColorStop const& next_stop, float position);
 
 class GradientLine;
 


### PR DESCRIPTION
Skia does not have built-in support for gradient transition hints. So instead of adding custom gradient painting, now we do the same thing as other engines and preprocess color stops by replacing transition hints with a bunch of points lying between adjacent color stops and calculated using non-linear formula from the spec. As a result we get visually close enough rendering we would get by applying spec-formula individually to each point of a gradient.