### PR TITLE
AK: Add equality operator for Checked<T> == Checked<T>

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -431,6 +431,12 @@ private:
 };
 
 template<typename T>
+constexpr bool operator==(Checked<T> const& a, Checked<T> const& b)
+{
+    return a.value() == b.value();
+}
+
+template<typename T>
 constexpr Checked<T> operator+(Checked<T> const& a, Checked<T> const& b)
 {
     Checked<T> c { a };


### PR DESCRIPTION
I have some WIP code that happens to compare structs that contain a `Checked<T>`, which revealed that we were missing this operator. I based this on the existing `Checked == int` operators, but I am *not* confident that this is the correct solution. Should == also check for overflow in both values? Should it (and the existing `operator==`s) not use `value()` because that VERIFYs? No idea! So here this is separately for discussion while I poke away at that other change.