### PR TITLE
LibWeb: Implement min option for ReadableStreamBYOBReader.read()

### DIFF
--- a/Tests/LibWeb/Text/expected/Streams/ReadableStreamBYOBReader-read-min.txt
+++ b/Tests/LibWeb/Text/expected/Streams/ReadableStreamBYOBReader-read-min.txt
@@ -1,0 +1,4 @@
+This -⌄
+ will not be processed as one chunk
+This -> will be processed as one chunk
+Stream closed

--- a/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-min.html
+++ b/Tests/LibWeb/Text/input/Streams/ReadableStreamBYOBReader-read-min.html
@@ -1,0 +1,68 @@
+<script src="../include.js"></script>
+<script>
+    const CHUNK1 = "This -⌄";
+    const CHUNK2 = " will not be processed as one chunk";
+    const CHUNK3 = "This ->";
+    const CHUNK4 = " will be processed as one chunk";
+    const CHUNK5 = "WHF!";
+
+    // A read is fulfilled when there are N or more elements available in the stream.
+    // We start off by allowing a read to be fulfilled with 1 element available.
+    let minElementsAvailable = 1;
+    let pullCount = 0;
+    const readableStream = new ReadableStream({
+        start(controller) {
+
+        },
+        pull(controller) {
+            ++pullCount;
+            const encoder = new TextEncoder();
+            if (pullCount === 1) {
+                controller.enqueue(encoder.encode(CHUNK1));
+            } else if (pullCount === 2) {
+                controller.enqueue(encoder.encode(CHUNK2));
+            } else if (pullCount === 3) {
+                controller.enqueue(encoder.encode(CHUNK3));
+            } else if (pullCount === 4) {
+                controller.enqueue(encoder.encode(CHUNK4));
+                // FIXME: Move/remove this controller.close() when we resolve the FIXME right below.
+                controller.close();
+            }
+            // FIXME: This should have been fulfilled since we are closing the controller at this point, currently we do not.
+            //} else if (pullCount === 5) {
+                // controller.enqueue(encoder.encode(CHUNK5));
+                // controller.close();
+            //}
+
+            // Now a read will only be fulfilled when at least 8 elements is available in the stream.
+            if (pullCount === 2) {
+                minElementsAvailable = 8;
+            }
+        },
+        type: "bytes",
+    });
+
+    async function readStream(stream) {
+        const reader = stream.getReader({ mode: "byob" });
+
+        let buffer = new ArrayBuffer(200);
+        let offset = 0;
+        let byteLength = 40;
+        while (true) {
+            let result = await reader.read(new Uint8Array(buffer, offset, byteLength), { min: minElementsAvailable });
+            if (result.done) {
+                println("Stream closed");
+                break;
+            }
+            println(new TextDecoder().decode(result.value));
+
+            buffer = result.value.buffer;
+            offset += result.value.byteLength;
+        }
+    }
+
+    asyncTest(async done => {
+        await readStream(readableStream);
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -15,6 +15,7 @@
 #include <LibWeb/WebIDL/CallbackType.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Promise.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::Streams {
 
@@ -61,8 +62,8 @@ void readable_stream_reader_generic_release(ReadableStreamGenericReaderMixin&);
 void readable_stream_default_reader_error_read_requests(ReadableStreamDefaultReader&, JS::Value error);
 void readable_stream_byob_reader_error_read_into_requests(ReadableStreamBYOBReader&, JS::Value error);
 JS::Value readable_byte_stream_controller_convert_pull_into_descriptor(JS::Realm&, PullIntoDescriptor const&);
-void readable_byte_stream_controller_pull_into(ReadableByteStreamController&, WebIDL::ArrayBufferView&, ReadIntoRequest&);
-void readable_stream_byob_reader_read(ReadableStreamBYOBReader&, WebIDL::ArrayBufferView&, ReadIntoRequest&);
+void readable_byte_stream_controller_pull_into(ReadableByteStreamController&, WebIDL::ArrayBufferView&, u64 min, ReadIntoRequest&);
+void readable_stream_byob_reader_read(ReadableStreamBYOBReader&, WebIDL::ArrayBufferView&, u64 min, ReadIntoRequest&);
 void readable_byte_stream_controller_fill_head_pull_into_descriptor(ReadableByteStreamController const&, u64 size, PullIntoDescriptor&);
 
 void readable_stream_default_reader_read(ReadableStreamDefaultReader&, ReadRequest&);

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.cpp
@@ -155,6 +155,7 @@ void ReadableByteStreamController::pull_steps(JS::NonnullGCPtr<ReadRequest> read
             .byte_offset = 0,
             .byte_length = *m_auto_allocate_chunk_size,
             .bytes_filled = 0,
+            .minimum_fill = 1,
             .element_size = 1,
             .view_constructor = *realm.intrinsics().uint8_array_constructor(),
             .reader_type = ReaderType::Default,

--- a/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableByteStreamController.h
@@ -41,6 +41,10 @@ struct PullIntoDescriptor {
     // A nonnegative integer number of bytes that have been written into the buffer so far
     u64 bytes_filled;
 
+    // https://streams.spec.whatwg.org/#pull-into-descriptor-minimum-fill
+    // A positive integer representing the minimum number of bytes that must be written into the buffer before the associated read() request may be fulfilled. By default, this equals the element size.
+    u64 minimum_fill;
+
     // https://streams.spec.whatwg.org/#pull-into-descriptor-element-size
     // A positive integer representing the number of bytes that can be written into the buffer at a time, using views of the type described by the view constructor
     u64 element_size;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
@@ -13,8 +13,14 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Streams/ReadableStreamGenericReader.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::Streams {
+
+// https://streams.spec.whatwg.org/#dictdef-readablestreambyobreaderreadoptions
+struct ReadableStreamBYOBReaderReadOptions {
+    WebIDL::UnsignedLongLong min = 1;
+};
 
 // https://streams.spec.whatwg.org/#read-into-request
 class ReadIntoRequest : public JS::Cell {
@@ -45,7 +51,7 @@ public:
 
     virtual ~ReadableStreamBYOBReader() override = default;
 
-    JS::NonnullGCPtr<JS::Promise> read(JS::Handle<WebIDL::ArrayBufferView>&);
+    JS::NonnullGCPtr<JS::Promise> read(JS::Handle<WebIDL::ArrayBufferView>&, ReadableStreamBYOBReaderReadOptions options = {});
 
     void release_lock();
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.idl
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.idl
@@ -7,8 +7,12 @@
 interface ReadableStreamBYOBReader {
     constructor(ReadableStream stream);
 
-    Promise<ReadableStreamReadResult> read(ArrayBufferView view);
+    Promise<ReadableStreamReadResult> read(ArrayBufferView view, optional ReadableStreamBYOBReaderReadOptions options = {});
 
     undefined releaseLock();
 };
 ReadableStreamBYOBReader includes ReadableStreamGenericReader;
+
+dictionary ReadableStreamBYOBReaderReadOptions {
+    [EnforceRange] unsigned long long min = 1;
+};


### PR DESCRIPTION
When the min option is given the read will only be fulfilled when there are min or more elements available in the readable byte stream.

When the min option is not given the default value for min is 1.