### PR TITLE
UI/Qt+WebDriver: Add a `--use-default-settings` option

### DIFF
--- a/Ladybird/Qt/Settings.h
+++ b/Ladybird/Qt/Settings.h
@@ -26,9 +26,13 @@ public:
 
     static Settings* the()
     {
-        static Settings instance;
-        return &instance;
+        if (!s_the)
+            s_the = adopt_own(*new Settings());
+
+        return s_the;
     }
+
+    static void set_use_default_settings(bool use_default_settings);
 
     Optional<QPoint> last_position();
     void set_last_position(QPoint const& last_position);
@@ -77,6 +81,9 @@ protected:
 private:
     OwnPtr<QSettings> m_qsettings;
     WebView::SearchEngine m_search_engine;
+
+    static bool s_use_default_settings;
+    static OwnPtr<Settings> s_the;
 };
 
 }

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -99,6 +99,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool new_window = false;
     bool force_new_process = false;
     bool allow_popups = false;
+    bool use_default_settings = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -117,7 +118,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
     args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
     args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
+    args_parser.add_option(use_default_settings, "Use browser default settings", "use-default-settings");
     args_parser.parse(arguments);
+
+    Ladybird::Settings::set_use_default_settings(use_default_settings);
 
     WebView::ChromeProcess chrome_process;
     if (!force_new_process && TRY(chrome_process.connect(raw_urls, new_window)) == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {

--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -32,7 +32,7 @@ static ErrorOr<pid_t> launch_process(StringView application, ReadonlySpan<char c
     return result;
 }
 
-static ErrorOr<pid_t> launch_browser(ByteString const& socket_path, bool use_qt_networking)
+static ErrorOr<pid_t> launch_browser(ByteString const& socket_path, bool use_qt_networking, bool use_default_settings)
 {
     auto arguments = Vector {
         "--webdriver-content-path",
@@ -49,6 +49,9 @@ static ErrorOr<pid_t> launch_browser(ByteString const& socket_path, bool use_qt_
     arguments.append("--force-new-process");
     if (use_qt_networking)
         arguments.append("--enable-qt-networking");
+
+    if (use_default_settings)
+        arguments.append("--use-default-settings");
 
     arguments.append("about:blank");
 
@@ -75,12 +78,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto listen_address = "0.0.0.0"sv;
     int port = 8000;
     bool enable_qt_networking = false;
+    bool use_default_settings = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(listen_address, "IP address to listen on", "listen-address", 'l', "listen_address");
     args_parser.add_option(port, "Port to listen on", "port", 'p', "port");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(enable_qt_networking, "Launch browser with Qt networking enabled", "enable-qt-networking");
+    args_parser.add_option(use_default_settings, "Launch browser with default settings", "use-default-settings");
+
     args_parser.parse(arguments);
 
     auto ipv4_address = IPv4Address::from_string(listen_address);
@@ -117,7 +123,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         auto launch_browser_callback = [&](ByteString const& socket_path) {
-            return launch_browser(socket_path, enable_qt_networking);
+            return launch_browser(socket_path, enable_qt_networking, use_default_settings);
         };
 
         auto maybe_client = WebDriver::Client::try_create(maybe_buffered_socket.release_value(), { move(launch_browser_callback), launch_headless_browser }, server);


### PR DESCRIPTION
This option makes the browser UI ignore any previous user settings and use its defaults. If any settings are changed, they are not saved on exit.

Setting this flag is useful when running WPT tests, as it ensures the tests run in a consistent environment.
