### PR TITLE
LibWeb: Unify accent color of input/progress elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -91,7 +91,7 @@ input[type=range]::-webkit-slider-thumb {
     height: 16px;
     transform: translateX(-50%);
     border-radius: 50%;
-    background-color: AccentColor;
+    background-color: -libweb-palette-accent;
     outline: 1px solid rgba(0, 0, 0, 0.5);
     z-index: 1;
 }
@@ -135,7 +135,7 @@ progress::-webkit-progress-bar {
     border: 1px solid rgba(0, 0, 0, 0.5);
 }
 progress::-webkit-progress-value {
-    background-color: AccentColor;
+    background-color: -libweb-palette-accent;
 }
 
 /* 15.3.1 Hidden elements

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -3,6 +3,7 @@
   "-libweb-left",
   "-libweb-right",
   "-libweb-link",
+  "-libweb-palette-accent",
   "-libweb-palette-active-link",
   "-libweb-palette-active-window-border1",
   "-libweb-palette-active-window-border2",

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/IdentifierStyleValue.cpp
@@ -51,6 +51,7 @@ bool IdentifierStyleValue::is_color(ValueID value_id)
     case ValueID::Infobackground:
     case ValueID::Infotext:
     case ValueID::LibwebLink:
+    case ValueID::LibwebPaletteAccent:
     case ValueID::LibwebPaletteActiveLink:
     case ValueID::LibwebPaletteActiveWindowBorder1:
     case ValueID::LibwebPaletteActiveWindowBorder2:
@@ -289,6 +290,8 @@ Color IdentifierStyleValue::to_color(Optional<Layout::NodeWithStyle const&> node
         return palette.color(ColorRole::RubberBandBorder);
     case CSS::ValueID::LibwebPaletteLink:
         return palette.color(ColorRole::Link);
+    case CSS::ValueID::LibwebPaletteAccent:
+        return palette.color(ColorRole::Accent);
     case CSS::ValueID::LibwebPaletteActiveLink:
         return palette.color(ColorRole::ActiveLink);
     case CSS::ValueID::LibwebPaletteVisitedLink:

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -996,7 +996,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
         display: block;
         position: absolute;
         height: 100%;
-        background-color: AccentColor;
+        background-color: -libweb-palette-accent;
     )~~~"_string));
     MUST(slider_runnable_track->append_child(*m_range_progress_element));
 


### PR DESCRIPTION
Replace `background-color: AccentColor;` by `background-color: -libweb-palette-accent;` for `<input type="range">` and `<progress> elements`.
To make this work, extend `IdentifierStyleValue` by `LibwebPaletteAccent`.

Fixes #556

Screenshot after change:
![screenshot_after](https://github.com/LadybirdBrowser/ladybird/assets/8593614/454b6678-0f6b-49e3-b465-61c5d58f9417)