### PR TITLE
Readme: Change ladybird.dev to ladybird.org in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ladybird
 
-[Ladybird](https://ladybird.dev) is a truly independent web browser, using a novel engine based on web standards.
+[Ladybird](https://ladybird.org) is a truly independent web browser, using a novel engine based on web standards.
 
 > [!IMPORTANT]
 > Ladybird is in a pre-alpha state, and only suitable for use by developers


### PR DESCRIPTION
Issue: #575 

The first link to the main website of the projet in the README was still refering to the old URL https://ladybird.dev, instead of https://ladybird.org. This has been updated.