### PR TITLE
LibWeb: Support `accent-color` for range input and progress element

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -91,7 +91,6 @@ input[type=range]::-webkit-slider-thumb {
     height: 16px;
     transform: translateX(-50%);
     border-radius: 50%;
-    background-color: AccentColor;
     outline: 1px solid rgba(0, 0, 0, 0.5);
     z-index: 1;
 }
@@ -133,9 +132,6 @@ progress::-webkit-progress-bar, progress::-webkit-progress-value {
 progress::-webkit-progress-bar {
     background-color: Background;
     border: 1px solid rgba(0, 0, 0, 0.5);
-}
-progress::-webkit-progress-value {
-    background-color: AccentColor;
 }
 
 /* 15.3.1 Hidden elements

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -996,7 +996,6 @@ void HTMLInputElement::create_range_input_shadow_tree()
         display: block;
         position: absolute;
         height: 100%;
-        background-color: AccentColor;
     )~~~"_string));
     MUST(slider_runnable_track->append_child(*m_range_progress_element));
 
@@ -1083,6 +1082,21 @@ void HTMLInputElement::create_range_input_shadow_tree()
         0, "", &realm());
     auto mousedown_callback = realm().heap().allocate_without_realm<WebIDL::CallbackType>(*mousedown_callback_function, Bindings::host_defined_environment_settings_object(realm()));
     add_event_listener_without_options(UIEvents::EventNames::mousedown, DOM::IDLEventListener::create(realm(), mousedown_callback));
+}
+
+void HTMLInputElement::computed_css_values_changed()
+{
+    auto palette = document().page().palette();
+    auto accent_color = palette.color(ColorRole::Accent).to_string();
+
+    auto accent_color_property = computed_css_values()->property(CSS::PropertyID::AccentColor);
+    if (accent_color_property->has_color())
+        accent_color = accent_color_property->to_string();
+
+    if (m_range_progress_element)
+        MUST(m_range_progress_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));
+    if (m_slider_thumb)
+        MUST(m_slider_thumb->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));
 }
 
 void HTMLInputElement::user_interaction_did_change_input_value()

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -212,6 +212,7 @@ private:
 
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;
+    virtual void computed_css_values_changed() override;
 
     // https://html.spec.whatwg.org/multipage/input.html#image-button-state-(type=image):dimension-attributes
     virtual bool supports_dimension_attributes() const override { return type_state() == TypeAttributeState::ImageButton; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -7,12 +7,14 @@
  */
 
 #include <LibWeb/Bindings/HTMLProgressElementPrototype.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/HTML/HTMLProgressElement.h>
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/Namespace.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::HTML {
 
@@ -117,6 +119,19 @@ void HTMLProgressElement::update_progress_value_element()
 {
     if (m_progress_value_element)
         MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", position() * 100))));
+}
+
+void HTMLProgressElement::computed_css_values_changed()
+{
+    auto palette = document().page().palette();
+    auto accent_color = palette.color(ColorRole::Accent).to_string();
+
+    auto accent_color_property = computed_css_values()->property(CSS::PropertyID::AccentColor);
+    if (accent_color_property->has_color())
+        accent_color = accent_color_property->to_string();
+
+    if (m_progress_value_element)
+        MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -42,6 +42,7 @@ private:
 
     // ^DOM::Node
     virtual bool is_html_progress_element() const final { return true; }
+    virtual void computed_css_values_changed() override;
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;


### PR DESCRIPTION
Fixes #466 and #556

Supersedes https://github.com/LadybirdBrowser/ladybird/pull/564 

Screenshot before:
<img src="https://github.com/user-attachments/assets/9a84d581-aba9-4f12-aba9-904f6515067b" width="400">

Screenshot after:
<img src="https://github.com/user-attachments/assets/dab0f39f-5b9a-4041-954f-0cb36dfa6701" width="400">
