### PR TITLE
LibWeb: Don't dispatch click events to disabled FormAssociatedElements

### DIFF
--- a/Tests/LibWeb/Layout/expected/input-as-button-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/input-as-button-align-center.txt
@@ -4,9 +4,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <input.btn> at (13,10) content-size 290x296 children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 290x296 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,150) content-size 290x16 flex-item [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 31, rect: [37,150 242.4375x16] baseline: 12.5
-                "Should be located in the center"
-            TextNode <#text>
+            frag 0 from BlockContainer start: 0, length: 0, rect: [37,150 242.4375x16] baseline: 12.5
+            BlockContainer <span> at (37,150) content-size 242.4375x16 inline-block [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 31, rect: [37,150 242.4375x16] baseline: 12.5
+                  "Should be located in the center"
+              TextNode <#text>
       BlockContainer <(anonymous)> at (8,308) content-size 784x0 children: inline
         TextNode <#text>
 
@@ -16,5 +18,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<INPUT>.btn) [8,8 300x300]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 290x296]
           PaintableWithLines (BlockContainer(anonymous)) [13,150 290x16]
-            TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<SPAN>) [37,150 242.4375x16]
+              TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,308 784x0]

--- a/Tests/LibWeb/Layout/expected/input-as-button-shrink-to-fit.txt
+++ b/Tests/LibWeb/Layout/expected/input-as-button-shrink-to-fit.txt
@@ -4,9 +4,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <input.btn> at (13,10) content-size 195.734375x32 children: not-inline
         BlockContainer <(anonymous)> at (13,10) content-size 195.734375x32 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,18) content-size 195.734375x16 flex-item [BFC] children: inline
-            frag 0 from TextNode start: 0, length: 26, rect: [13,18 195.734375x16] baseline: 12.5
-                "Width should shrink to fit"
-            TextNode <#text>
+            frag 0 from BlockContainer start: 0, length: 0, rect: [13,18 195.734375x16] baseline: 12.5
+            BlockContainer <span> at (13,18) content-size 195.734375x16 inline-block [BFC] children: inline
+              frag 0 from TextNode start: 0, length: 26, rect: [13,18 195.734375x16] baseline: 12.5
+                  "Width should shrink to fit"
+              TextNode <#text>
       BlockContainer <(anonymous)> at (8,44) content-size 784x0 children: inline
         TextNode <#text>
 
@@ -16,5 +18,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<INPUT>.btn) [8,8 205.734375x36]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 195.734375x32]
           PaintableWithLines (BlockContainer(anonymous)) [13,18 195.734375x16]
-            TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer<SPAN>) [13,18 195.734375x16]
+              TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,44 784x0]

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -52,6 +52,15 @@ button, input[type=submit], input[type=button], input[type=reset], select {
     cursor: default;
 }
 
+button:disabled, input[type=submit]:disabled, input[type=button]:disabled, input[type=reset]:disabled, select:disabled {
+    /* FIXME: There isn't a <system-color> keyword for this, so this is a slightly lightened
+     *        version of our light ButtonFace color. Once we support `color-scheme: dark`
+     *        we'll need to use a different color for that.
+     */
+    background-color: #e5e0d7;
+    color: GrayText;
+}
+
 input[type=image] {
     cursor: pointer;
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -778,9 +778,11 @@ void HTMLInputElement::create_button_input_shadow_tree()
 {
     auto shadow_root = heap().allocate<DOM::ShadowRoot>(realm(), document(), *this, Bindings::ShadowRootMode::Closed);
     set_shadow_root(shadow_root);
-
+    auto text_container = MUST(DOM::create_element(document(), HTML::TagNames::span, Namespace::HTML));
+    MUST(text_container->set_attribute(HTML::AttributeNames::style, "display: inline-block; pointer-events: none;"_string));
     m_text_node = heap().allocate<DOM::Text>(realm(), document(), value());
-    MUST(shadow_root->append_child(*m_text_node));
+    MUST(text_container->append_child(*m_text_node));
+    MUST(shadow_root->append_child(*text_container));
 }
 
 void HTMLInputElement::create_text_input_shadow_tree()

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -47,6 +47,13 @@ static JS::GCPtr<DOM::Node> dom_node_for_event_dispatch(Painting::Paintable& pai
 
 static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, JS::GCPtr<DOM::Node>& node, Layout::Node*& layout_node)
 {
+    auto* current_ancestor_node = node.ptr();
+    do {
+        if (is<HTML::FormAssociatedElement>(current_ancestor_node) && !dynamic_cast<HTML::FormAssociatedElement*>(current_ancestor_node)->enabled()) {
+            return false;
+        }
+    } while ((current_ancestor_node = current_ancestor_node->parent()));
+
     layout_node = &paintable.layout_node();
     while (layout_node && node && !node->is_element() && layout_node->parent()) {
         layout_node = layout_node->parent();


### PR DESCRIPTION
User interaction events are now no longer dispatched to form associated elements if they are disabled. Disabled form associated elements also no longer receive focus when clicked.

I've also added some styling to disabled buttons, so that you can tell when a button is disabled

I had trouble coming up with a reliable test for these changes. It's not clear how to test for an event that doesn't fire without having some arbitrary timeout.

With these changes the "Projects" buttons in [Universal paperclips](https://www.decisionproblem.com/paperclips/) now behave as expected:
![image](https://github.com/user-attachments/assets/37e7631e-ee05-4fac-ae9b-015e4ff55c1a)

