### PR TITLE
LibWeb: Change where content selection via mouse is allowed

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -70,6 +70,8 @@ public:
     virtual bool has_activation_behavior() const override;
     virtual void activation_behavior(DOM::Event const&) override;
 
+    virtual bool is_child_node_selectable(DOM::Node*) const override { return false; }
+
 private:
     virtual bool is_html_button_element() const override { return true; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -80,6 +80,8 @@ public:
     WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
     Optional<String> popover() const;
 
+    virtual bool is_child_node_selectable(DOM::Node*) const { return true; }
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2290,4 +2290,9 @@ HTMLInputElement::ValueAttributeMode HTMLInputElement::value_attribute_mode() co
     VERIFY_NOT_REACHED();
 }
 
+bool HTMLInputElement::is_child_node_selectable(DOM::Node* node) const
+{
+    return !is_button() && (!node || node->parent_element() != m_placeholder_element);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -197,6 +197,8 @@ public:
     bool step_applies() const;
     bool step_up_or_down_applies() const;
 
+    virtual bool is_child_node_selectable(DOM::Node*) const override;
+
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 


### PR DESCRIPTION
Previously, only DOM nodes with `is_editable()` allowed selection via the mouse. This had the unwanted consequence, that read-only input/textarea elements did not allow selection.

Now, `EventHandler::handle_mousedown()` asks the node's non-shadow parent element over the new virtual method `is_child_node_selectable()`, if selection of the node is allowed.
This method is overridden for `HTMLButtonElement` and `HTMLInputElement`, to disallow selection of buttons and placeholders.

Fixes #579

Honestly, this was a difficult one for me and I'm not sure if there might be a better implementation.