### PR TITLE
Ladybird/Qt: Only update navigation buttons for current tab

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -905,6 +905,9 @@ void Tab::update_hover_label()
 
 void Tab::update_navigation_buttons_state()
 {
+    if (m_window->current_tab() != this)
+        return;
+
     m_window->go_back_action().setEnabled(m_can_navigate_back);
     m_window->go_forward_action().setEnabled(m_can_navigate_forward);
 }


### PR DESCRIPTION
This resolves a bug where if you opened a link in a new tab and quickly went back to the original, the navigation buttons would update for the new page shortly after.