### PR TITLE
LibWasm: Ignore tests that check that we don't support 2+ memories

### DIFF
--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -292,6 +292,11 @@ _test.skip = test.skip;
 
 
 def gen_invalid(invalid: AssertInvalid, ctx: Context):
+    # TODO: Remove this once the multiple memories proposal is standardized.
+    # We support the multiple memories proposal, so spec-tests that check that
+    # we don't do not make any sense to include right now.
+    if invalid.message == "multiple memories":
+        return
     if ctx.has_unclosed:
         print("});")
         ctx.has_unclosed = False


### PR DESCRIPTION
Since we support the multi-memory proposal, we should skip tests that validate that we have only one memory. Once multi-memory gets included in the main WebAssembly specification (and the testsuite is updated), we can revert this commit.