### PR TITLE
Meta: Make ladybird.sh old bash compatible

### DIFF
--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -101,14 +101,18 @@ cmd_with_target() {
         export LADYBIRD_SOURCE_DIR
     fi
 
-    declare -A BUILD_DIRECTORIES
-
     # Note: Keep in sync with buildDir defaults in CMakePresets.json
-    BUILD_DIRECTORIES["default"]="$LADYBIRD_SOURCE_DIR/Build/ladybird"
-    BUILD_DIRECTORIES["Debug"]="$LADYBIRD_SOURCE_DIR/Build/ladybird-debug"
-    BUILD_DIRECTORIES["Sanitizer"]="$LADYBIRD_SOURCE_DIR/Build/ladybird-sanitizers"
-
-    BUILD_DIR="${BUILD_DIRECTORIES[${BUILD_PRESET}]}"
+    case "${BUILD_PRESET}" in
+        "default")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird"
+            ;;
+        "Debug")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird-debug"
+            ;;
+        "Sanitizer")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird-sanitizers"
+            ;;
+    esac
 
     CMAKE_ARGS+=("-DCMAKE_INSTALL_PREFIX=$LADYBIRD_SOURCE_DIR/Build/ladybird-install-${BUILD_PRESET}")
 


### PR DESCRIPTION
On Mac, a very old bash is installed. 
In `ladybird.sh`, `declare -A` is used, but this does not work on old bash version.

```console
$/bin/bash Meta/ladybird.sh run ladybird
Meta/ladybird.sh: line 104: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
```

In this PR, instead of using an associative array, I use case statement to determine $BUID_DIR. This is POSIX compatible and would work across several platforms.

patched version result:

```console
/bin/bash Meta/ladybird.sh run ladybird
~/ghq/github.com/LadybirdBrowser/ladybird/Toolchain/Tarballs ~/ghq/github.com/LadybirdBrowser/ladybird/Toolchain
ninja: Entering directory `/Users/taro3/ghq/github.com/LadybirdBrowser/ladybird/Build/ladybird'
[0/2] Re-checking globbed directories...
ninja: no work to do.
```

(In my machine,  the installed version is of 2007....)
```
/bin/bash --version
GNU bash, version 3.2.57(1)-release (arm64-apple-darwin23)
Copyright (C) 2007 Free Software Foundation, Inc.
```

related discord discussion: https://discord.com/channels/1247070541085671459/1247090705013280769/1261865088667881492
