### PR TITLE
 LibWebView: Add keyboard navigation to the Inspector

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -692,6 +692,8 @@ private:
 
     void tear_down_layout_tree();
 
+    void update_active_element();
+
     void run_unloading_cleanup_steps();
 
     void evaluate_media_rules();

--- a/Userland/Libraries/LibWeb/DOM/Utils.h
+++ b/Userland/Libraries/LibWeb/DOM/Utils.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2020, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2024, circl <circl.lastname@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/ShadowRoot.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#retarget
+template<typename T>
+T* retarget(T* a, T* b)
+{
+    // To retarget an object A against an object B, repeat these steps until they return an object:
+    for (;;) {
+        // 1. If one of the following is true then return A.
+        // - A is not a node
+        if (!is<Node>(a))
+            return a;
+
+        // - A’s root is not a shadow root
+        auto* a_node = verify_cast<Node>(a);
+        auto& a_root = a_node->root();
+        if (!is<ShadowRoot>(a_root))
+            return a;
+
+        // - B is a node and A’s root is a shadow-including inclusive ancestor of B
+        if (is<Node>(b) && a_root.is_shadow_including_inclusive_ancestor_of(verify_cast<Node>(*b)))
+            return a;
+
+        // 2. Set A to A’s root’s host.
+        auto& a_shadow_root = verify_cast<ShadowRoot>(a_root);
+        a = a_shadow_root.host();
+    }
+}
+
+}


### PR DESCRIPTION
Now keep a track of the DOM nodes which are actually visible in the Inspector, and allow the user to navigate the tree using the keyboard.