### PR TITLE
UI/Qt: Move New Tab button in tab bar

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -72,6 +72,7 @@ public:
 
 BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, bool allow_popups, Tab* parent_tab, Optional<u64> page_index)
     : m_tabs_container(new TabWidget(this))
+    , m_new_tab_button_toolbar(new QToolBar("New Tab", m_tabs_container))
     , m_cookie_jar(cookie_jar)
     , m_web_content_options(web_content_options)
     , m_webdriver_content_ipc_path(webdriver_content_ipc_path)
@@ -661,6 +662,11 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
         }
     }
 
+    m_new_tab_button_toolbar->addAction(m_new_tab_action);
+    m_new_tab_button_toolbar->setMovable(false);
+    m_new_tab_button_toolbar->setStyleSheet("QToolBar { background: transparent; }");
+    m_new_tab_button_toolbar->setIconSize(QSize(16, 16));
+
     setCentralWidget(m_tabs_container);
     setContextMenuPolicy(Qt::PreventContextMenu);
 }
@@ -672,6 +678,20 @@ void BrowserWindow::set_current_tab(Tab* tab)
         update_displayed_zoom_level();
         tab->update_navigation_buttons_state();
     }
+}
+
+void BrowserWindow::update_new_tab_button()
+{
+    if (m_new_tab_button_toolbar == nullptr || m_tabs_container == nullptr || m_tabs_container->count() < 1)
+        return;
+    QSize tab_bar_size = m_tabs_container->tabBar()->sizeHint();
+    int window_width = this->rect().width();
+    QRect new_rect;
+    new_rect.setX(qMin(tab_bar_size.width(), window_width - 32));
+    new_rect.setWidth(32);
+    new_rect.setHeight(32);
+    m_tabs_container->tabBar()->setMaximumWidth(window_width - 32);
+    m_new_tab_button_toolbar->setGeometry(new_rect);
 }
 
 void BrowserWindow::debug_request(ByteString const& request, ByteString const& argument)
@@ -814,6 +834,8 @@ void BrowserWindow::initialize_tab(Tab* tab)
     tab->set_navigator_compatibility_mode(navigator_compatibility_mode());
     tab->set_enable_do_not_track(Settings::the()->enable_do_not_track());
     tab->view().set_preferred_color_scheme(m_preferred_color_scheme);
+
+    update_new_tab_button();
 }
 
 void BrowserWindow::activate_tab(int index)
@@ -826,6 +848,8 @@ void BrowserWindow::close_tab(int index)
     auto* tab = m_tabs_container->widget(index);
     m_tabs_container->removeTab(index);
     tab->deleteLater();
+
+    update_new_tab_button();
 
     if (m_tabs_container->count() == 0)
         close();
@@ -1153,6 +1177,7 @@ void BrowserWindow::resizeEvent(QResizeEvent* event)
     for_each_tab([&](auto& tab) {
         tab.view().set_window_size({ frameSize().width() * m_device_pixel_ratio, frameSize().height() * m_device_pixel_ratio });
     });
+    update_new_tab_button();
 }
 
 void BrowserWindow::moveEvent(QMoveEvent* event)

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -179,9 +179,13 @@ private:
     Web::CSS::PreferredColorScheme m_preferred_color_scheme;
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme);
 
+    void update_new_tab_button();
+
     QTabWidget* m_tabs_container { nullptr };
     Tab* m_current_tab { nullptr };
     QMenu* m_zoom_menu { nullptr };
+
+    QToolBar* m_new_tab_button_toolbar { nullptr };
 
     QMenu* m_hamburger_menu { nullptr };
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -90,7 +90,6 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_toolbar->addAction(&m_window->go_forward_action());
     m_toolbar->addAction(&m_window->reload_action());
     m_toolbar->addWidget(m_location_edit);
-    m_toolbar->addAction(&m_window->new_tab_action());
     m_toolbar->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
     m_hamburger_button_action = m_toolbar->addWidget(m_hamburger_button);
     m_toolbar->setIconSize({ 16, 16 });


### PR DESCRIPTION
Uses the tab bar's width to determine the location of the button. The button is hidden if the window is small enough

This is in reference to #252

![image](https://github.com/user-attachments/assets/38f952a9-9d8c-4200-9a98-1e68bd531992)
![image](https://github.com/user-attachments/assets/f6d4894c-37c6-4122-a813-000ae1899987)
![image](https://github.com/user-attachments/assets/44cba7a7-c58c-4cf0-841b-454ebd4220bf)
![image](https://github.com/user-attachments/assets/da18743e-b7a3-4229-a2c6-a2dfb79f174f)

QToolBar with a single action is used instead of just a QToolButton, there is an issue where the button is completely black when just using a button. If that is resolved, it could be used instead.