### PR TITLE
Tests: Drop --enable-qt-networking arg in WPT/run.sh

### DIFF
--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -83,7 +83,6 @@ python3 ./wpt/wpt run ladybird \
                   --manifest ./MANIFEST.json \
                   --webdriver-arg="--certificate=${PWD}/wpt/tools/certs/cacert.pem" \
                   --webdriver-arg="--certificate=${LADYBIRD_SOURCE_DIR}/Build/lagom/cacert.pem" \
-                  --webdriver-arg="--enable-qt-networking" \
                   --log-raw "${wpt_run_log_filename}"
 
 # Update expectations metadata files if requested


### PR DESCRIPTION
--enable-qt-networking doesn't exist on the AppKit chrome
