### PR TITLE
Ladybird/Qt: Resize the viewport when resize is requested

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -1151,6 +1151,7 @@ void BrowserWindow::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
 
     for_each_tab([&](auto& tab) {
+        tab.view().set_viewport_size({ static_cast<int>(tab.view().width() * m_device_pixel_ratio), static_cast<int>(tab.view().height() * m_device_pixel_ratio) });
         tab.view().set_window_size({ frameSize().width() * m_device_pixel_ratio, frameSize().height() * m_device_pixel_ratio });
     });
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -390,8 +390,9 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     };
 
     view().on_resize_window = [this](auto const& size) {
-        m_window->resize(size.width(), size.height());
-        return Gfx::IntSize { m_window->width(), m_window->height() };
+        auto new_window_size = m_window->size() - m_view->size() + QSize { size.width(), size.height() };
+        m_window->resize(new_window_size);
+        return Gfx::IntSize { m_view->width(), m_view->height() };
     };
 
     view().on_maximize_window = [this]() {

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -459,10 +459,10 @@ void WebContentView::resizeEvent(QResizeEvent* event)
     handle_resize();
 }
 
-void WebContentView::set_viewport_rect(Gfx::IntRect rect)
+void WebContentView::set_viewport_size(Gfx::IntSize size)
 {
-    m_viewport_size = rect.size();
-    client().async_set_viewport_size(m_client_state.page_index, rect.size().to_type<Web::DevicePixels>());
+    m_viewport_size = size;
+    client().async_set_viewport_size(m_client_state.page_index, size.to_type<Web::DevicePixels>());
 }
 
 void WebContentView::set_window_size(Gfx::IntSize size)
@@ -487,9 +487,8 @@ void WebContentView::update_viewport_size()
 {
     auto scaled_width = int(viewport()->width() * m_device_pixel_ratio);
     auto scaled_height = int(viewport()->height() * m_device_pixel_ratio);
-    Gfx::IntRect rect(0, 0, scaled_width, scaled_height);
 
-    set_viewport_rect(rect);
+    set_viewport_size({ scaled_width, scaled_height });
 }
 
 void WebContentView::update_zoom()

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -70,7 +70,7 @@ public:
 
     ErrorOr<String> dump_layout_tree();
 
-    void set_viewport_rect(Gfx::IntRect);
+    void set_viewport_size(Gfx::IntSize);
     void set_window_size(Gfx::IntSize);
     void set_window_position(Gfx::IntPoint);
     void set_device_pixel_ratio(double);


### PR DESCRIPTION
Previously, when a window resize was programmatically requested through WebDriver, we would update the size of the entire window. We now ensure that the portion of the window containing the WebView is set to the size requested.

I haven't updated the AppKit chrome to replicate this behavior in this PR.

Fixes: http://wpt.live/infrastructure/reftest/size.html