### PR TITLE
Tests: Enable WPT/run.sh to run an arbitrary subset of tests

### DIFF
--- a/Tests/LibWeb/WPT/run.sh
+++ b/Tests/LibWeb/WPT/run.sh
@@ -36,10 +36,15 @@ for arg in "$@"; do
         wpt_run_log_filename="$(realpath "${arg#*=}")"
         shift
         ;;
+    -*)
+      echo "Unknown argument $arg"
+      exit 1
+      ;;
     *)
-        echo "Unknown argument ${arg}"
-        exit 1
-        ;;
+      TEST_FILE=$(realpath "$arg")
+      TEST_FILES+=("$TEST_FILE")
+      shift
+      ;;
     esac
 done
 
@@ -73,7 +78,7 @@ fi
 python3 ./concat-extract-metadata.py --extract metadata.txt metadata
 
 # Run tests.
-python3 ./wpt/wpt run ladybird \
+python3 ./wpt/wpt run \
                   --webdriver-binary "${WEBDRIVER_BINARY}" \
                   --no-fail-on-unexpected \
                   --no-fail-on-unexpected-pass \
@@ -83,7 +88,9 @@ python3 ./wpt/wpt run ladybird \
                   --manifest ./MANIFEST.json \
                   --webdriver-arg="--certificate=${PWD}/wpt/tools/certs/cacert.pem" \
                   --webdriver-arg="--certificate=${LADYBIRD_SOURCE_DIR}/Build/lagom/cacert.pem" \
-                  --log-raw "${wpt_run_log_filename}"
+                  --log-raw "${wpt_run_log_filename}" \
+                  ladybird \
+                  ${TEST_FILES:+"${TEST_FILES[@]}"}
 
 # Update expectations metadata files if requested
 if [[ $update_expectations_metadata == true ]]; then


### PR DESCRIPTION
The change causes `Tests/LibWeb/WPT/run.sh` to run an arbitrary subset of tests you give it as arguments. If you don’t specify any arguments, it has the same behavior as it does without this patch: It just runs an explicit subset of test names hardcoded into the script.

Otherwise without this change, `Tests/LibWeb/WPT/run.sh` doesn’t have the ability to run any tests other than the explicit subset of test names hardcoded into the script
