### PR TITLE
LibWeb/CSS: Use default font metrics when computing `:root` font size

### DIFF
--- a/Tests/LibWeb/Ref/reference/root-rem.html
+++ b/Tests/LibWeb/Ref/reference/root-rem.html
@@ -1,0 +1,1 @@
+<span style="font-size: 1.2rem">Foo</span>

--- a/Tests/LibWeb/Ref/root-rem.html
+++ b/Tests/LibWeb/Ref/root-rem.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="match" href="reference/root-rem.html" />
+<style>
+    :root {
+        font-size: 1.2rem;
+    }
+</style>
+<span id="message">Foo</span>
+<script>
+    document.body.offsetTop;
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -171,7 +171,7 @@ private:
     void compute_font(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void compute_math_depth(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void compute_defaulted_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
-    void absolutize_values(StyleProperties&) const;
+    void absolutize_values(StyleProperties&, DOM::Element const*) const;
     void resolve_effective_overflow_values(StyleProperties&) const;
     void transform_box_type_if_needed(StyleProperties&, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type>) const;
 


### PR DESCRIPTION
Prevents repeatedly building font size when using `rem` in the `:root` element.

Fixes #139 and #339. Resetera font is still larger than it should be, but it no longer continuously grows until crash.