### PR TITLE
LibWeb+RequestServer: Let RequestServer set HTTP Accept-Encoding header

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -499,9 +499,6 @@ RefPtr<ResourceLoaderConnectorRequest> ResourceLoader::start_network_request(Loa
     if (!headers.contains("User-Agent"))
         headers.set("User-Agent", m_user_agent.to_byte_string());
 
-    if (!headers.contains("Accept-Encoding"))
-        headers.set("Accept-Encoding", "gzip, deflate, br");
-
     auto protocol_request = m_connector->start_request(request.method(), request.url(), headers, request.body(), proxy);
     if (!protocol_request) {
         log_failure(request, "Failed to initiate load"sv);

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -205,11 +205,15 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString const& metho
         return;
     }
 
+    auto headers = request_headers;
+    if (!headers.contains("Accept-Encoding"))
+        headers.set("Accept-Encoding", "gzip, deflate, br");
+
     enqueue(StartRequest {
         .request_id = request_id,
         .method = method,
         .url = url,
-        .request_headers = request_headers,
+        .request_headers = move(headers),
         .request_body = request_body,
         .proxy_data = proxy_data,
     });


### PR DESCRIPTION
Ultimately it's RequestServer who knows which kind of encodings it can handle and decompress, so let's have it set the Accept-Encoding.