### PR TITLE
LibJS: Implement `Iterator.prototype [ @@toStringTag ]` and `Iterator.prototype.constructor` according to spec 

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -306,6 +306,8 @@ JS_ENUMERATE_TYPED_ARRAYS
             initialize_constructor(vm, vm.names.Boolean, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);   \
         else if constexpr (IsSame<Namespace::ConstructorName, FunctionConstructor>)                                                                      \
             initialize_constructor(vm, vm.names.Function, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);  \
+        else if constexpr (IsSame<Namespace::ConstructorName, IteratorConstructor>)                                                                      \
+            initialize_constructor(vm, vm.names.Iterator, *m_##snake_namespace##snake_name##_constructor, nullptr);                                      \
         else if constexpr (IsSame<Namespace::ConstructorName, NumberConstructor>)                                                                        \
             initialize_constructor(vm, vm.names.Number, *m_##snake_namespace##snake_name##_constructor, m_##snake_namespace##snake_name##_prototype);    \
         else if constexpr (IsSame<Namespace::ConstructorName, RegExpConstructor>)                                                                        \

--- a/Userland/Libraries/LibJS/Runtime/Iterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.h
@@ -83,6 +83,7 @@ Completion iterator_close(VM&, IteratorRecord const&, Completion);
 Completion async_iterator_close(VM&, IteratorRecord const&, Completion);
 NonnullGCPtr<Object> create_iterator_result_object(VM&, Value, bool done);
 ThrowCompletionOr<MarkedVector<Value>> iterator_to_list(VM&, IteratorRecord&);
+ThrowCompletionOr<void> setter_that_ignores_prototype_properties(VM&, Value this_, Object const& home, PropertyKey const& property, Value value);
 
 using IteratorValueCallback = Function<Optional<Completion>(Value)>;
 Completion get_iterator_values(VM&, Value iterable, IteratorValueCallback callback);

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -10,6 +10,7 @@
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Iterator.h>
+#include <LibJS/Runtime/IteratorConstructor.h>
 #include <LibJS/Runtime/IteratorHelper.h>
 #include <LibJS/Runtime/IteratorPrototype.h>
 #include <LibJS/Runtime/ValueInlines.h>
@@ -43,6 +44,9 @@ void IteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.every, every, 1, attr);
     define_native_function(realm, vm.names.find, find, 1, attr);
 
+    // 3.1.3.1 Iterator.prototype.constructor, https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.constructor
+    define_native_accessor(realm, vm.names.constructor, constructor_getter, constructor_setter, Attribute::Configurable);
+
     // 3.1.3.13 Iterator.prototype [ @@toStringTag ], https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
     define_native_accessor(realm, vm.well_known_symbol_to_string_tag(), to_string_tag_getter, to_string_tag_setter, Attribute::Configurable);
 }
@@ -52,6 +56,27 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::symbol_iterator)
 {
     // 1. Return the this value.
     return vm.this_value();
+}
+
+// 3.1.3.1.1 get Iterator.prototype.constructor, https://tc39.es/proposal-iterator-helpers/#sec-get-iteratorprototype-constructor
+JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::constructor_getter)
+{
+    auto& realm = *vm.current_realm();
+
+    // 1. Return %Iterator%.
+    return realm.intrinsics().iterator_constructor();
+}
+
+// 3.1.3.1.2 set Iterator.prototype.constructor, https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-constructor
+JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::constructor_setter)
+{
+    auto& realm = *vm.current_realm();
+
+    // 1. Perform ? SetterThatIgnoresPrototypeProperties(this value, %Iterator.prototype%, "constructor", v).
+    TRY(setter_that_ignores_prototype_properties(vm, vm.this_value(), realm.intrinsics().iterator_prototype(), vm.names.constructor, vm.argument(0)));
+
+    // 2. Return undefined.
+    return js_undefined();
 }
 
 // 3.1.3.2 Iterator.prototype.map ( mapper ), https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype.map

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -29,9 +29,6 @@ void IteratorPrototype::initialize(Realm& realm)
     auto& vm = this->vm();
     Base::initialize(realm);
 
-    // 3.1.3.13 Iterator.prototype [ @@toStringTag ], https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
-    define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Iterator"_string), Attribute::Configurable | Attribute::Writable);
-
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.well_known_symbol_iterator(), symbol_iterator, 0, attr);
     define_native_function(realm, vm.names.map, map, 1, attr);
@@ -45,6 +42,9 @@ void IteratorPrototype::initialize(Realm& realm)
     define_native_function(realm, vm.names.some, some, 1, attr);
     define_native_function(realm, vm.names.every, every, 1, attr);
     define_native_function(realm, vm.names.find, find, 1, attr);
+
+    // 3.1.3.13 Iterator.prototype [ @@toStringTag ], https://tc39.es/proposal-iterator-helpers/#sec-iteratorprototype-@@tostringtag
+    define_native_accessor(realm, vm.well_known_symbol_to_string_tag(), to_string_tag_getter, to_string_tag_setter, Attribute::Configurable);
 }
 
 // 27.1.2.1 %IteratorPrototype% [ @@iterator ] ( ), https://tc39.es/ecma262/#sec-%iteratorprototype%-@@iterator
@@ -747,6 +747,25 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::find)
         // g. Set counter to counter + 1.
         ++counter;
     }
+}
+
+// 3.1.3.13.1 get Iterator.prototype [ @@toStringTag ], https://tc39.es/proposal-iterator-helpers/#sec-get-iteratorprototype-@@tostringtag
+JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::to_string_tag_getter)
+{
+    // 1. Return "Iterator".
+    return PrimitiveString::create(vm, vm.names.Iterator.as_string());
+}
+
+// 3.1.3.13.2 set Iterator.prototype [ @@toStringTag ], https://tc39.es/proposal-iterator-helpers/#sec-set-iteratorprototype-@@tostringtag
+JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::to_string_tag_setter)
+{
+    auto& realm = *vm.current_realm();
+
+    // 1. Perform ? SetterThatIgnoresPrototypeProperties(this value, %Iterator.prototype%, %Symbol.toStringTag%, v).
+    TRY(setter_that_ignores_prototype_properties(vm, vm.this_value(), realm.intrinsics().iterator_prototype(), vm.well_known_symbol_to_string_tag(), vm.argument(0)));
+
+    // 2. Return undefined.
+    return js_undefined();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
@@ -22,6 +22,9 @@ public:
 private:
     IteratorPrototype(Realm&);
 
+    JS_DECLARE_NATIVE_FUNCTION(constructor_getter);
+    JS_DECLARE_NATIVE_FUNCTION(constructor_setter);
+
     JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);
     JS_DECLARE_NATIVE_FUNCTION(map);
     JS_DECLARE_NATIVE_FUNCTION(filter);

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
@@ -34,6 +34,9 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(some);
     JS_DECLARE_NATIVE_FUNCTION(every);
     JS_DECLARE_NATIVE_FUNCTION(find);
+
+    JS_DECLARE_NATIVE_FUNCTION(to_string_tag_getter);
+    JS_DECLARE_NATIVE_FUNCTION(to_string_tag_setter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.@@toStringTag.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.@@toStringTag.js
@@ -1,3 +1,33 @@
-test("basic functionality", () => {
-    expect(Iterator.prototype[Symbol.toStringTag]).toBe("Iterator");
+const sentinel = "whf :^)";
+
+describe("errors", () => {
+    test("setter called on non-object", () => {
+        let { get, set } = Object.getOwnPropertyDescriptor(Iterator.prototype, Symbol.toStringTag);
+
+        expect(() => {
+            set.call(undefined, sentinel);
+        }).toThrowWithMessage(TypeError, "undefined is not an object");
+    });
+
+    test("cannot set the built-in Iterator's toStringTag", () => {
+        expect(() => {
+            Iterator.prototype[Symbol.toStringTag] = sentinel;
+        }).toThrowWithMessage(
+            TypeError,
+            "Cannot write to non-writable property '[object IteratorPrototype]'"
+        );
+    });
+});
+
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        expect(Iterator.prototype[Symbol.toStringTag]).toBe("Iterator");
+    });
+
+    test("toStringTag setter", () => {
+        let Proto = Object.create(Iterator.prototype);
+        Proto[Symbol.toStringTag] = sentinel;
+
+        expect(Proto[Symbol.toStringTag]).toBe(sentinel);
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.constructor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Iterator/Iterator.prototype.constructor.js
@@ -1,0 +1,33 @@
+const sentinel = "whf :^)";
+
+describe("errors", () => {
+    test("setter called on non-object", () => {
+        let { get, set } = Object.getOwnPropertyDescriptor(Iterator.prototype, "constructor");
+
+        expect(() => {
+            set.call(undefined, sentinel);
+        }).toThrowWithMessage(TypeError, "undefined is not an object");
+    });
+
+    test("cannot set the built-in Iterator's constructor", () => {
+        expect(() => {
+            Iterator.prototype.constructor = sentinel;
+        }).toThrowWithMessage(
+            TypeError,
+            "Cannot write to non-writable property '[object IteratorPrototype]'"
+        );
+    });
+});
+
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        expect(Iterator.prototype.constructor).toBe(Iterator);
+    });
+
+    test("constructor setter", () => {
+        let Proto = Object.create(Iterator.prototype);
+        Proto.constructor = sentinel;
+
+        expect(Proto.constructor).toBe(sentinel);
+    });
+});


### PR DESCRIPTION
The spec oddly allows *setting* these on non built-in Iterator objects.

test262 diff:
```
Diff Tests:
    +4 ✅    -4 ❌

Diff Tests:
    test/built-ins/Iterator/prototype/Symbol.toStringTag/prop-desc.js    ❌ -> ✅
    test/built-ins/Iterator/prototype/Symbol.toStringTag/weird-setter.js ❌ -> ✅
    test/built-ins/Iterator/prototype/constructor/prop-desc.js           ❌ -> ✅
    test/built-ins/Iterator/prototype/constructor/weird-setter.js        ❌ -> ✅
```

We now pass all `Iterator` test262 tests:
```
test/built-ins/Iterator    380/380   (100.00%) [ ✅ 380   ]
```
