### PR TITLE
Meta: Make all pre-commit CI scripts work with Bash 3.2

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -107,7 +107,7 @@ Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake cmake ffmpeg nasm ninja ccache pkg-config bash
+brew install autoconf autoconf-archive automake cmake ffmpeg nasm ninja ccache pkg-config
 ```
 
 If you also plan to use the Qt chrome on macOS:

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -6,7 +6,10 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "1" ]; then
-    mapfile -t files < <(
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done < <(
         git ls-files -- \
             '*.cpp' \
             '*.h' \

--- a/Meta/lint-gn.sh
+++ b/Meta/lint-gn.sh
@@ -6,7 +6,10 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
-    mapfile -t files < <(
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done < <(
         git ls-files '*.gn' '*.gni'
     )
 else

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -6,7 +6,10 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
-    mapfile -t files < <(
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done < <(
         git ls-files \
             --exclude-from .prettierignore \
             -- \

--- a/Meta/lint-python.sh
+++ b/Meta/lint-python.sh
@@ -6,7 +6,10 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
-    mapfile -t files < <(
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done <  <(
         git ls-files '*.py'
     )
 else

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -6,7 +6,10 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 cd "$script_path/.."
 
 if [ "$#" -eq "0" ]; then
-    mapfile -t files < <(
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done <  <(
         git ls-files -- \
             '*.sh' \
     )


### PR DESCRIPTION
This change makes all the pre-commit CI scripts runnable under Bash 3.2 — by replacing `mapfile` invocations in them with code that first explicitly creates an array, and then uses a while loop to populate the array.

Otherwise, without this change, the scripts all fail to run under Bash 3.2 — due to lack of support for `mapfile`.

Note: Each of these `mapfile` cases is in the `then` part of an if-then-else block in which the existing code in the `else` part is first explicitly creating an array, and then populating in in a loop. So the change in this PR is arguably making the code somewhat more consistent. (Though maybe that’s just a rationalization…)

Fixes https://github.com/LadybirdBrowser/ladybird/issues/283
