### PR TITLE
LibWeb: Join text clip paths before application in Skia painter

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -359,15 +359,17 @@ static SkSamplingOptions to_skia_sampling_options(Gfx::ScalingMode scaling_mode)
     }
 }
 
-#define APPLY_PATH_CLIP_IF_NEEDED                                  \
-    ScopeGuard restore_path_clip { [&] {                           \
-        if (command.clip_paths.size() > 0)                         \
-            surface().canvas().restore();                          \
-    } };                                                           \
-    if (command.clip_paths.size() > 0) {                           \
-        surface().canvas().save();                                 \
-        for (auto const& path : command.clip_paths)                \
-            surface().canvas().clipPath(to_skia_path(path), true); \
+#define APPLY_PATH_CLIP_IF_NEEDED                     \
+    ScopeGuard restore_path_clip { [&] {              \
+        if (command.clip_paths.size() > 0)            \
+            surface().canvas().restore();             \
+    } };                                              \
+    if (command.clip_paths.size() > 0) {              \
+        surface().canvas().save();                    \
+        SkPath clip_path;                             \
+        for (auto const& path : command.clip_paths)   \
+            clip_path.addPath(to_skia_path(path));    \
+        surface().canvas().clipPath(clip_path, true); \
     }
 
 DisplayListPlayerSkia::SkiaSurface& DisplayListPlayerSkia::surface() const


### PR DESCRIPTION
Each item in clip_paths represents a glyph run, and applying them as a clip in intersection mode one by one results in an empty clip. Instead, now all clip paths are joined and applied as a clip together.

This change fixes rendering of "background-clip: text" when an element has more than one glyph run.

Fixed ref-test: Tests/LibWeb/Ref/css-background-clip-text.html