### PR TITLE
AK: Enable ASSERT in debug builds only

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -21,7 +21,7 @@ static constexpr bool TODO = false;
 #define TODO_PPC64() VERIFY(TODO)   /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #define TODO_PPC() VERIFY(TODO)     /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 
-#ifdef NDEBUG
+#ifndef NDEBUG
 extern "C" __attribute__((noreturn)) void ak_assertion_failed(char const*);
 #    define ASSERT(expr)                                                               \
         (__builtin_expect(!(expr), 0)                                                  \


### PR DESCRIPTION
NDEBUG is defined in release builds. So we want to enable the ASSERT macro when it *isn't* defined.