### PR TITLE
Ladybird+LibWeb+WebContent: Always use Skia CPU backend in tests mode

### DIFF
--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -135,7 +135,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Web::set_chrome_process_executable_path(executable_path);
 
     if (use_skia_painter) {
-        WebContent::PageClient::set_use_skia_painter();
+        // Always use the CPU backend for layout tests, as the GPU backend is not deterministic
+        WebContent::PageClient::set_use_skia_painter(is_layout_test_mode ? WebContent::PageClient::UseSkiaPainter::CPUBackend : WebContent::PageClient::UseSkiaPainter::GPUBackendIfAvailable);
     }
 
     if (enable_http_cache) {

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -278,7 +278,8 @@ struct PaintOptions {
 
 enum class DisplayListPlayerType {
     CPU,
-    Skia
+    SkiaGPUIfAvailable,
+    SkiaCPU,
 };
 
 class PageClient : public JS::Cell {

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -105,7 +105,8 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
         display_list.execute(executor);
         break;
     }
-    case DisplayListPlayerType::Skia: {
+    case DisplayListPlayerType::SkiaGPUIfAvailable:
+    case DisplayListPlayerType::SkiaCPU: {
         Painting::DisplayListPlayerSkia executor { *bitmap };
         display_list.execute(executor);
         break;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -27,7 +27,12 @@ public:
 
     virtual ~PageClient() override;
 
-    static void set_use_skia_painter();
+    enum class UseSkiaPainter {
+        No,
+        CPUBackend,
+        GPUBackendIfAvailable,
+    };
+    static void set_use_skia_painter(UseSkiaPainter);
 
     virtual void schedule_repaint() override;
     virtual bool is_ready_to_paint() const override;


### PR DESCRIPTION
Enforce the use of the CPU backend in test mode to ensure that ref-tests produce consistent results across different computers, as this consistency cannot be achieved with the GPU backend.