### PR TITLE
LibWeb/CSS: Make StringStyleValue hold a FlyString

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/Optional.h>
 #include <LibGfx/FontCascadeList.h>
 #include <LibGfx/ScalingMode.h>
@@ -49,7 +50,7 @@ struct QuotesData {
         Auto,
         Specified,
     } type;
-    Vector<Array<String, 2>> strings {};
+    Vector<Array<FlyString, 2>> strings {};
 };
 
 struct ResolvedBackdropFilter {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2912,7 +2912,7 @@ RefPtr<StyleValue> Parser::parse_string_value(TokenStream<ComponentValue>& token
     auto peek = tokens.peek_token();
     if (peek.is(Token::Type::String)) {
         (void)tokens.next_token();
-        return StringStyleValue::create(peek.token().string().to_string());
+        return StringStyleValue::create(peek.token().string());
     }
 
     return nullptr;
@@ -4761,7 +4761,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(TokenStream<ComponentValue>& 
             (void)tokens.next_token(); // String
             if (!next_is_comma_or_eof())
                 return nullptr;
-            font_families.append(StringStyleValue::create(peek.token().string().to_string()));
+            font_families.append(StringStyleValue::create(peek.token().string()));
             (void)tokens.next_token(); // Comma
             continue;
         }
@@ -7088,7 +7088,7 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
 
     if (peek_token.is(Token::Type::String)) {
         if (auto property = any_property_accepts_type(property_ids, ValueType::String); property.has_value())
-            return PropertyAndValue { *property, StringStyleValue::create(tokens.next_token().token().string().to_string()) };
+            return PropertyAndValue { *property, StringStyleValue::create(tokens.next_token().token().string()) };
     }
 
     if (auto property = any_property_accepts_type(property_ids, ValueType::Url); property.has_value()) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1742,7 +1742,7 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
         if (animation_name.is_null())
             return OptionalNone {};
         if (animation_name->is_string())
-            return animation_name->as_string().string_value();
+            return animation_name->as_string().string_value().to_string();
         return animation_name->to_string();
     }();
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -997,12 +997,6 @@ Vector<Vector<String>> StyleProperties::grid_template_areas() const
     return value->as_grid_template_area().grid_template_area();
 }
 
-String StyleProperties::grid_area() const
-{
-    auto value = property(CSS::PropertyID::GridArea);
-    return value->as_string().string_value();
-}
-
 Optional<CSS::ObjectFit> StyleProperties::object_fit() const
 {
     auto value = property(CSS::PropertyID::ObjectFit);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -656,13 +656,13 @@ StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(u32 in
     auto get_quote_string = [&](bool open, auto depth) {
         switch (quotes_data.type) {
         case QuotesData::Type::None:
-            return String {};
+            return FlyString {};
         case QuotesData::Type::Auto:
             // FIXME: "A typographically appropriate used value for quotes is automatically chosen by the UA
             //        based on the content language of the element and/or its parent."
             if (open)
-                return depth == 0 ? "“"_string : "‘"_string;
-            return depth == 0 ? "”"_string : "’"_string;
+                return depth == 0 ? "“"_fly_string : "‘"_fly_string;
+            return depth == 0 ? "”"_fly_string : "’"_fly_string;
         case QuotesData::Type::Specified:
             // If the depth is greater than the number of pairs, the last pair is repeated.
             auto& level = quotes_data.strings[min(depth, quotes_data.strings.size() - 1)];

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -132,7 +132,6 @@ public:
     CSS::GridTrackPlacement grid_row_start() const;
     Optional<CSS::BorderCollapse> border_collapse() const;
     Vector<Vector<String>> grid_template_areas() const;
-    String grid_area() const;
     Optional<CSS::ObjectFit> object_fit() const;
     CSS::ObjectPosition object_position() const;
     Optional<CSS::TableLayout> table_layout() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
@@ -1,37 +1,37 @@
 /*
- * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022-2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/String.h>
+#include <AK/FlyString.h>
 #include <LibWeb/CSS/StyleValue.h>
 
 namespace Web::CSS {
 
 class StringStyleValue : public StyleValueWithDefaultOperators<StringStyleValue> {
 public:
-    static ValueComparingNonnullRefPtr<StringStyleValue> create(String const& string)
+    static ValueComparingNonnullRefPtr<StringStyleValue> create(FlyString const& string)
     {
         return adopt_ref(*new (nothrow) StringStyleValue(string));
     }
     virtual ~StringStyleValue() override = default;
 
-    String string_value() const { return m_string; }
+    FlyString string_value() const { return m_string; }
     String to_string() const override { return serialize_a_string(m_string); }
 
     bool properties_equal(StringStyleValue const& other) const { return m_string == other.m_string; }
 
 private:
-    explicit StringStyleValue(String const& string)
+    explicit StringStyleValue(FlyString const& string)
         : StyleValueWithDefaultOperators(Type::String)
         , m_string(string)
     {
     }
 
-    String m_string;
+    FlyString m_string;
 };
 
 }


### PR DESCRIPTION
We already have a FlyString of its value from parsing, and most users want a FlyString from it, so let's use that instead of converting and forwards.

The two users that did want a String are:
- Quotes, which make sense as FlyString instead, so I've converted that.
- Animation names, which should probably be FlyString too, but the code also allows for other kinds of StyleValue, and I don't want to dive into this right now to figure out if that's needed or not.

Another user was this unused and incorrect-looking `StyleProperties::grid_area()` method, so I've just removed that.