### PR TITLE
LibWeb: Stub/implement some missing attributes/functions

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2786,6 +2786,8 @@ static Vector<Interface const&> create_an_inheritance_stack(IDL::Interface const
 
         // 2. Push I onto stack.
         inheritance_chain.append(*imported_interface_iterator);
+
+        current_interface = &*imported_interface_iterator;
     }
 
     // 4. Return stack.

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -5,23 +5,34 @@
 // https://dom.spec.whatwg.org/#node
 [Exposed=Window]
 interface Node : EventTarget {
-
+    const unsigned short ELEMENT_NODE = 1;
+    const unsigned short ATTRIBUTE_NODE = 2;
+    const unsigned short TEXT_NODE = 3;
+    const unsigned short CDATA_SECTION_NODE = 4;
+    const unsigned short ENTITY_REFERENCE_NODE = 5; // legacy
+    const unsigned short ENTITY_NODE = 6; // legacy
+    const unsigned short PROCESSING_INSTRUCTION_NODE = 7;
+    const unsigned short COMMENT_NODE = 8;
+    const unsigned short DOCUMENT_NODE = 9;
+    const unsigned short DOCUMENT_TYPE_NODE = 10;
+    const unsigned short DOCUMENT_FRAGMENT_NODE = 11;
+    const unsigned short NOTATION_NODE = 12; // legacy
     readonly attribute unsigned short nodeType;
     readonly attribute DOMString nodeName;
 
     readonly attribute USVString baseURI;
 
+    readonly attribute boolean isConnected;
+    readonly attribute Document? ownerDocument;
+    Node getRootNode(optional GetRootNodeOptions options = {});
+    readonly attribute Node? parentNode;
+    readonly attribute Element? parentElement;
     boolean hasChildNodes();
     [SameObject] readonly attribute NodeList childNodes;
     readonly attribute Node? firstChild;
     readonly attribute Node? lastChild;
     readonly attribute Node? previousSibling;
     readonly attribute Node? nextSibling;
-    readonly attribute Node? parentNode;
-    readonly attribute Element? parentElement;
-    readonly attribute boolean isConnected;
-    readonly attribute Document? ownerDocument;
-    Node getRootNode(optional GetRootNodeOptions options = {});
 
     [CEReactions] attribute DOMString? nodeValue;
     // FIXME: [LegacyNullToEmptyString] is not allowed on nullable types as per the Web IDL spec.
@@ -30,36 +41,23 @@ interface Node : EventTarget {
     [LegacyNullToEmptyString, CEReactions] attribute DOMString? textContent;
     [CEReactions] undefined normalize();
 
-    [CEReactions] Node appendChild(Node node);
-    [ImplementedAs=pre_insert, CEReactions] Node insertBefore(Node node, Node? child);
-    [CEReactions] Node replaceChild(Node node, Node child);
-    [ImplementedAs=pre_remove, CEReactions] Node removeChild(Node child);
     [ImplementedAs=clone_node_binding, CEReactions] Node cloneNode(optional boolean deep = false);
-    boolean contains(Node? other);
     boolean isEqualNode(Node? otherNode);
     boolean isSameNode(Node? otherNode);
 
-    const unsigned short ELEMENT_NODE = 1;
-    const unsigned short ATTRIBUTE_NODE = 2;
-    const unsigned short TEXT_NODE = 3;
-    const unsigned short CDATA_SECTION_NODE = 4;
-    const unsigned short ENTITY_REFERENCE_NODE = 5;
-    const unsigned short ENTITY_NODE = 6;
-    const unsigned short PROCESSING_INSTRUCTION_NODE = 7;
-    const unsigned short COMMENT_NODE = 8;
-    const unsigned short DOCUMENT_NODE = 9;
-    const unsigned short DOCUMENT_TYPE_NODE = 10;
-    const unsigned short DOCUMENT_FRAGMENT_NODE = 11;
-    const unsigned short NOTATION_NODE = 12;
-
+    const unsigned short DOCUMENT_POSITION_DISCONNECTED = 0x01;
+    const unsigned short DOCUMENT_POSITION_PRECEDING = 0x02;
+    const unsigned short DOCUMENT_POSITION_FOLLOWING = 0x04;
+    const unsigned short DOCUMENT_POSITION_CONTAINS = 0x08;
+    const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 0x10;
+    const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 0x20;
     unsigned short compareDocumentPosition(Node? otherNode);
-    // Node.compareDocumentPosition() constants
-    const unsigned short DOCUMENT_POSITION_DISCONNECTED = 1;
-    const unsigned short DOCUMENT_POSITION_PRECEDING = 2;
-    const unsigned short DOCUMENT_POSITION_FOLLOWING = 4;
-    const unsigned short DOCUMENT_POSITION_CONTAINS = 8;
-    const unsigned short DOCUMENT_POSITION_CONTAINED_BY = 16;
-    const unsigned short DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = 32;
+    boolean contains(Node? other);
+
+    [ImplementedAs=pre_insert, CEReactions] Node insertBefore(Node node, Node? child);
+    [CEReactions] Node appendChild(Node node);
+    [CEReactions] Node replaceChild(Node node, Node child);
+    [ImplementedAs=pre_remove, CEReactions] Node removeChild(Node child);
 };
 
 dictionary GetRootNodeOptions {

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -54,6 +54,10 @@ interface Node : EventTarget {
     unsigned short compareDocumentPosition(Node? otherNode);
     boolean contains(Node? other);
 
+    [FIXME] DOMString? lookupPrefix(DOMString? namespace);
+    [FIXME] DOMString? lookupNamespaceURI(DOMString? prefix);
+    [FIXME] boolean isDefaultNamespace(DOMString? namespace);
+
     [ImplementedAs=pre_insert, CEReactions] Node insertBefore(Node node, Node? child);
     [CEReactions] Node appendChild(Node node);
     [CEReactions] Node replaceChild(Node node, Node child);

--- a/Userland/Libraries/LibWeb/DOM/Text.idl
+++ b/Userland/Libraries/LibWeb/DOM/Text.idl
@@ -8,7 +8,7 @@ interface Text : CharacterData {
     constructor(optional DOMString data = "");
 
     [NewObject] Text splitText(unsigned long offset);
-
+    [FIXME] readonly attribute DOMString wholeText;
 };
 
 Text includes Slottable;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
@@ -22,10 +22,10 @@ interface HTMLTrackElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString label;
     [CEReactions, Reflect] attribute boolean default;
 
-    // FIXME: [const unsigned short NONE = 0;
-    // FIXME: [const unsigned short LOADING = 1;
-    // FIXME: [const unsigned short LOADED = 2;
-    // FIXME: [const unsigned short ERROR = 3;
+    const unsigned short NONE = 0;
+    const unsigned short LOADING = 1;
+    const unsigned short LOADED = 2;
+    const unsigned short ERROR = 3;
     [FIXME] readonly attribute unsigned short readyState;
 
     readonly attribute TextTrack track;

--- a/Userland/Libraries/LibWeb/HighResolutionTime/Performance.idl
+++ b/Userland/Libraries/LibWeb/HighResolutionTime/Performance.idl
@@ -13,6 +13,7 @@ typedef sequence<PerformanceEntry> PerformanceEntryList;
 interface Performance : EventTarget {
     DOMHighResTimeStamp now();
     readonly attribute DOMHighResTimeStamp timeOrigin;
+    [Default] object toJSON();
 
     readonly attribute PerformanceTiming timing;
 

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.cpp
@@ -683,6 +683,29 @@ bool KeyboardEvent::get_modifier_state(String const& key_arg) const
     return false;
 }
 
+// https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent
+void KeyboardEvent::init_keyboard_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, String const& key, WebIDL::UnsignedLong location, bool ctrl_key, bool alt_key, bool shift_key, bool meta_key)
+{
+    // Initializes attributes of a KeyboardEvent object. This method has the same behavior as UIEvent.initUIEvent().
+    // The value of detail remains undefined.
+
+    // 1. If this’s dispatch flag is set, then return.
+    if (dispatched())
+        return;
+
+    // 2. Initialize this with type, bubbles, and cancelable.
+    initialize_event(type, bubbles, cancelable);
+
+    // Implementation Defined: Initialise other values.
+    m_view = view;
+    m_key = key;
+    m_location = location;
+    m_ctrl_key = ctrl_key;
+    m_alt_key = alt_key;
+    m_shift_key = shift_key;
+    m_meta_key = meta_key;
+}
+
 JS::NonnullGCPtr<KeyboardEvent> KeyboardEvent::create(JS::Realm& realm, FlyString const& event_name, KeyboardEventInit const& event_init)
 {
     return realm.heap().allocate<KeyboardEvent>(realm, realm, event_name, event_init);

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -62,6 +62,8 @@ public:
 
     virtual u32 which() const override { return m_key_code; }
 
+    void init_keyboard_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, String const& key, WebIDL::UnsignedLong location, bool ctrl_key, bool alt_key, bool shift_key, bool meta_key);
+
 private:
     KeyboardEvent(JS::Realm&, FlyString const& event_name, KeyboardEventInit const& event_init);
 

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.idl
@@ -29,6 +29,9 @@ interface KeyboardEvent : UIEvent {
 
     boolean getModifierState(DOMString keyArg);
 
+    // https://w3c.github.io/uievents/#dom-keyboardevent-initkeyboardevent
+    undefined initKeyboardEvent(DOMString typeArg, optional boolean bubblesArg = false, optional boolean cancelableArg = false, optional Window? viewArg = null, optional DOMString keyArg = "", optional unsigned long locationArg = 0, optional boolean ctrlKey = false, optional boolean altKey = false, optional boolean shiftKey = false, optional boolean metaKey = false);
+
 };
 
 // https://www.w3.org/TR/uievents/#dictdef-keyboardeventinit

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -96,6 +96,33 @@ bool MouseEvent::get_modifier_state(String const& key_arg) const
     return false;
 }
 
+// https://w3c.github.io/uievents/#dom-mouseevent-initmouseevent
+void MouseEvent::init_mouse_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, WebIDL::Long detail, WebIDL::Long screen_x, WebIDL::Long screen_y, WebIDL::Long client_x, WebIDL::Long client_y, bool ctrl_key, bool alt_key, bool shift_key, bool meta_key, WebIDL::Short button, DOM::EventTarget* related_target)
+{
+    // Initializes attributes of a MouseEvent object. This method has the same behavior as UIEvent.initUIEvent().
+
+    // 1. If this’s dispatch flag is set, then return.
+    if (dispatched())
+        return;
+
+    // 2. Initialize this with type, bubbles, and cancelable.
+    initialize_event(type, bubbles, cancelable);
+
+    // Implementation Defined: Initialise other values.
+    m_view = view;
+    m_detail = detail;
+    m_screen_x = screen_x;
+    m_screen_y = screen_y;
+    m_client_x = client_x;
+    m_client_y = client_y;
+    m_ctrl_key = ctrl_key;
+    m_shift_key = shift_key;
+    m_alt_key = alt_key;
+    m_meta_key = meta_key;
+    m_button = button;
+    m_related_target = related_target;
+}
+
 // https://www.w3.org/TR/uievents/#dom-mouseevent-button
 static i16 determine_button(unsigned mouse_button)
 {

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -68,6 +68,8 @@ public:
 
     virtual u32 which() const override { return m_button + 1; }
 
+    void init_mouse_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, WebIDL::Long detail, WebIDL::Long screen_x, WebIDL::Long screen_y, WebIDL::Long client_x, WebIDL::Long client_y, bool ctrl_key, bool alt_key, bool shift_key, bool meta_key, WebIDL::Short button, DOM::EventTarget* related_target);
+
 protected:
     MouseEvent(JS::Realm&, FlyString const& event_name, MouseEventInit const& event_init, double page_x, double page_y, double offset_x, double offset_y);
 

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -32,6 +32,9 @@ interface MouseEvent : UIEvent {
     readonly attribute EventTarget? relatedTarget;
 
     boolean getModifierState(DOMString keyArg);
+
+    // https://w3c.github.io/uievents/#dom-mouseevent-initmouseevent
+    undefined initMouseEvent(DOMString typeArg, optional boolean bubblesArg = false, optional boolean cancelableArg = false, optional Window? viewArg = null, optional long detailArg = 0, optional long screenXArg = 0, optional long screenYArg = 0, optional long clientXArg = 0, optional long clientYArg = 0, optional boolean ctrlKeyArg = false, optional boolean altKeyArg = false, optional boolean shiftKeyArg = false, optional boolean metaKeyArg = false, optional short buttonArg = 0, optional EventTarget? relatedTargetArg = null);
 };
 
 // https://w3c.github.io/uievents/#idl-mouseeventinit

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
@@ -33,7 +33,16 @@ public:
 
     void init_ui_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, int detail)
     {
-        init_event(type, bubbles, cancelable);
+        // Initializes attributes of an UIEvent object. This method has the same behavior as initEvent().
+
+        // 1. If this’s dispatch flag is set, then return.
+        if (dispatched())
+            return;
+
+        // 2. Initialize this with type, bubbles, and cancelable.
+        initialize_event(type, bubbles, cancelable);
+
+        // Implementation Defined: Initialise other values.
         m_view = view;
         m_detail = detail;
     }


### PR DESCRIPTION
Work towards [GH-24168](https://github.com/SerenityOS/serenity/issues/24168).

| Interface | Name | Status |
| --- | --- | --- |
| Node | lookupPrefix | Stubbed |
| Node | lookupNamespaceURI | Stubbed |
| Node | isDefaultNamespace | Stubbed |
| Performance | toJSON | Implemented |
| HTMLTrackElement | NONE | Implemented |
| HTMLTrackElement | LOADING | Implemented |
| HTMLTrackElement | LOADED | Implemented |
| HTMLTrackElement | ERROR | Implemented |
| KeyboardEvent | initKeyboardEvent | Implemented |
| MouseEvent | initMouseEvent | Implemented |
| Text | wholeText | Stubbed |