### PR TITLE
CMake: Force vcpkg to use CMAKE_CXX_COMPILER as specified to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ if (VCPKG_TARGET_ANDROID)
     include("Ladybird/Android/vcpkg_android.cmake")
 endif()
 
+# Pass additional information to vcpkg toolchain files if we are using vcpkg.
+if (CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg.cmake$")
+    set(CMAKE_PROJECT_ladybird_INCLUDE_BEFORE "Meta/CMake/vcpkg/generate_vcpkg_toolchain_variables.cmake")
+endif()
+
 project(ladybird
         VERSION 0.1.0
         LANGUAGES C CXX

--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -12,29 +12,11 @@ The recommended extensions for VS Code include:
 
 ## Configuration
 
-To be compatible with `./Meta/ladybird.sh`, we must set CC and CXX to the correct compilers for *both* configure and build. This can be done in the `.vscode/settings.json` file.
-
-```json
-{
-  "cmake.configureEnvironment": {
-    "CC": "clang-18",
-    "CXX": "clang++-18"
-  },
-  "cmake.buildEnvironment": {
-    "CC": "clang-18",
-    "CXX": "clang++-18"
-  },
-  "clangd.path": "clangd-18"
-}
-```
-
 Run `./Meta/ladybird.sh build` at least once to kick off downloading and building vcpkg dependencies.
 
 The CMake Tools plugin should automatically detect the `CMakePresets.json` at the root of the repository.
 Selecting and activating the `default` preset should be enough to get started after the initial build.
 You can also use the `Debug` preset to build with debug symbols, or the `Sanitizer` preset to build with ASAN/UBSAN.
-
-If building through VsCode itself causes vcpkg to rebuild the world, verify that the environment settings match the `CMAKE_CXX_COMPILER` line in the build directory's `CMakeCache.txt`.
 
 For additional settings recommendations, see the [Settings](#settings) section below.
 
@@ -153,14 +135,7 @@ These belong in the `.vscode/settings.json` of Serenity.
     // git commit message length
     "git.inputValidationLength": 72,
     "git.inputValidationSubjectLength": 72,
-    "cmake.configureEnvironment": {
-      "CC": "clang-18",
-      "CXX": "clang++-18"
-    },
-    "cmake.buildEnvironment": {
-      "CC": "clang-18",
-      "CXX": "clang++-18"
-    },
+    // If clangd was obtained from a package manager, its path can be set here.
     "clangd.path": "clangd-18",
     "clangd.arguments": [
         "--header-insertion=never" // See https://github.com/clangd/clangd/issues/1247

--- a/Meta/CMake/vcpkg/base-triplets/arm64-linux.cmake
+++ b/Meta/CMake/vcpkg/base-triplets/arm64-linux.cmake
@@ -2,4 +2,4 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../user-variables.cmake OPTIONAL)
+include(${CMAKE_CURRENT_LIST_DIR}/base.cmake)

--- a/Meta/CMake/vcpkg/base-triplets/arm64-osx.cmake
+++ b/Meta/CMake/vcpkg/base-triplets/arm64-osx.cmake
@@ -3,4 +3,4 @@ set(VCPKG_TARGET_ARCHITECTURE arm64)
 set(VCPKG_OSX_ARCHITECTURES arm64)
 set(VCPKG_CRT_LINKAGE dynamic)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../user-variables.cmake OPTIONAL)
+include(${CMAKE_CURRENT_LIST_DIR}/base.cmake)

--- a/Meta/CMake/vcpkg/base-triplets/base.cmake
+++ b/Meta/CMake/vcpkg/base-triplets/base.cmake
@@ -1,0 +1,2 @@
+include(${CMAKE_CURRENT_LIST_DIR}/../user-variables.cmake OPTIONAL)
+include(${_VCPKG_INSTALLED_DIR}/../build-vcpkg-variables.cmake OPTIONAL)

--- a/Meta/CMake/vcpkg/base-triplets/x64-linux.cmake
+++ b/Meta/CMake/vcpkg/base-triplets/x64-linux.cmake
@@ -2,4 +2,4 @@ set(VCPKG_CMAKE_SYSTEM_NAME Linux)
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../user-variables.cmake OPTIONAL)
+include(${CMAKE_CURRENT_LIST_DIR}/base.cmake)

--- a/Meta/CMake/vcpkg/base-triplets/x64-osx.cmake
+++ b/Meta/CMake/vcpkg/base-triplets/x64-osx.cmake
@@ -3,4 +3,4 @@ set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_OSX_ARCHITECTURES x86_64)
 set(VCPKG_CRT_LINKAGE dynamic)
 
-include(${CMAKE_CURRENT_LIST_DIR}/../user-variables.cmake OPTIONAL)
+include(${CMAKE_CURRENT_LIST_DIR}/base.cmake)

--- a/Meta/CMake/vcpkg/generate_vcpkg_toolchain_variables.cmake
+++ b/Meta/CMake/vcpkg/generate_vcpkg_toolchain_variables.cmake
@@ -1,0 +1,11 @@
+# The generated file here is read by vcpkg/base-triplets/base.cmake to ensure consistency between the project
+# build and the vcpkg build.
+set(EXTRA_VCPKG_VARIABLES "")
+if (NOT "${CMAKE_C_COMPILER}" STREQUAL "")
+    string(APPEND EXTRA_VCPKG_VARIABLES "set(ENV{CC} ${CMAKE_C_COMPILER})\n")
+endif()
+if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
+    string(APPEND EXTRA_VCPKG_VARIABLES "set(ENV{CXX} ${CMAKE_CXX_COMPILER})\n")
+endif()
+
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/build-vcpkg-variables.cmake" "${EXTRA_VCPKG_VARIABLES}")


### PR DESCRIPTION
Override the vcpkg/scripts/detect_compiler behavior of always pulling
$CC and $CXX at the time that vcpkg install is determined to need called
by forcing $ENV{CXX} and $ENV{CC} to our CMake-determined compiler.

This prevents strange behavior such as running the following:

./Meta/ladybird.sh run
    make changes...
ninja -C Build/ladybird

Where the second build step would be run without CC or CXX set in the
environment, causing a total cache miss from vcpkg and a full rebuild.

It also helps prevent full rebuilds when an IDE passes a slightly
different compiler to the build step than ladybird.sh.