### PR TITLE
AK+LibTextCodec: Use AK facilities to validate and convert UTF-16 to UTF-8 

### DIFF
--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -11,11 +11,18 @@
 #include <AK/Platform.h>
 
 namespace AK {
+
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 inline constexpr static bool HostIsLittleEndian = true;
 #else
 inline constexpr static bool HostIsLittleEndian = false;
 #endif
+
+enum class Endianness {
+    Host,
+    Big,
+    Little,
+};
 
 template<typename T>
 ALWAYS_INLINE constexpr T convert_between_host_and_little_endian(T value)

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/Checked.h>
+#include <AK/Endian.h>
 #include <AK/FlyString.h>
 #include <AK/Format.h>
 #include <AK/MemMem.h>
@@ -51,15 +52,30 @@ ErrorOr<String> String::from_utf16(Utf16View const& utf16)
 
     String result;
 
-    auto utf8_length = simdutf::utf8_length_from_utf16(
-        reinterpret_cast<char16_t const*>(utf16.data()),
-        utf16.length_in_code_units());
+    auto utf8_length = [&]() {
+        switch (utf16.endianness()) {
+        case Endianness::Host:
+            return simdutf::utf8_length_from_utf16(utf16.char_data(), utf16.length_in_code_units());
+        case Endianness::Big:
+            return simdutf::utf8_length_from_utf16be(utf16.char_data(), utf16.length_in_code_units());
+        case Endianness::Little:
+            return simdutf::utf8_length_from_utf16le(utf16.char_data(), utf16.length_in_code_units());
+        }
+        VERIFY_NOT_REACHED();
+    }();
 
     TRY(result.replace_with_new_string(utf8_length, [&](Bytes buffer) -> ErrorOr<void> {
-        [[maybe_unused]] auto result = simdutf::convert_utf16_to_utf8(
-            reinterpret_cast<char16_t const*>(utf16.data()),
-            utf16.length_in_code_units(),
-            reinterpret_cast<char*>(buffer.data()));
+        [[maybe_unused]] auto result = [&]() {
+            switch (utf16.endianness()) {
+            case Endianness::Host:
+                return simdutf::convert_utf16_to_utf8(utf16.char_data(), utf16.length_in_code_units(), reinterpret_cast<char*>(buffer.data()));
+            case Endianness::Big:
+                return simdutf::convert_utf16be_to_utf8(utf16.char_data(), utf16.length_in_code_units(), reinterpret_cast<char*>(buffer.data()));
+            case Endianness::Little:
+                return simdutf::convert_utf16le_to_utf8(utf16.char_data(), utf16.length_in_code_units(), reinterpret_cast<char*>(buffer.data()));
+            }
+            VERIFY_NOT_REACHED();
+        }();
         ASSERT(result == buffer.size());
 
         return {};

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -15,6 +15,8 @@ TEST_CASE(test_utf8_decode)
     // Bytes for U+1F600 GRINNING FACE
     auto test_string = "\xf0\x9f\x98\x80"sv;
 
+    EXPECT(decoder.validate(test_string));
+
     Vector<u32> processed_code_points;
     MUST(decoder.process(test_string, [&](u32 code_point) {
         return processed_code_points.try_append(code_point);
@@ -31,6 +33,8 @@ TEST_CASE(test_utf16be_decode)
     // This is the output of `python3 -c "print('säk😀'.encode('utf-16be'))"`.
     auto test_string = "\x00s\x00\xe4\x00k\xd8=\xde\x00"sv;
 
+    EXPECT(decoder.validate(test_string));
+
     Vector<u32> processed_code_points;
     MUST(decoder.process(test_string, [&](u32 code_point) {
         return processed_code_points.try_append(code_point);
@@ -40,6 +44,9 @@ TEST_CASE(test_utf16be_decode)
     EXPECT(processed_code_points[1] == 0xE4);
     EXPECT(processed_code_points[2] == 0x6B);
     EXPECT(processed_code_points[3] == 0x1F600);
+
+    auto utf8 = MUST(decoder.to_utf8(test_string));
+    EXPECT_EQ(utf8, "säk😀"sv);
 }
 
 TEST_CASE(test_utf16le_decode)
@@ -48,6 +55,8 @@ TEST_CASE(test_utf16le_decode)
     // This is the output of `python3 -c "print('säk😀'.encode('utf-16le'))"`.
     auto test_string = "s\x00\xe4\x00k\x00=\xd8\x00\xde"sv;
 
+    EXPECT(decoder.validate(test_string));
+
     Vector<u32> processed_code_points;
     MUST(decoder.process(test_string, [&](u32 code_point) {
         return processed_code_points.try_append(code_point);
@@ -57,4 +66,7 @@ TEST_CASE(test_utf16le_decode)
     EXPECT(processed_code_points[1] == 0xE4);
     EXPECT(processed_code_points[2] == 0x6B);
     EXPECT(processed_code_points[3] == 0x1F600);
+
+    auto utf8 = MUST(decoder.to_utf8(test_string));
+    EXPECT_EQ(utf8, "säk😀"sv);
 }


### PR DESCRIPTION
Follow-up to #674 

This allows LibTextCodec to make use of simdutf, and also reduces the number of places with manual UTF-16 implementations. To do so, we must first support non-native endianness in `Utf16View`.