### PR TITLE
LibWasm: Some minor cleanups

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -489,51 +489,6 @@ double BytecodeInterpreter::read_value<double>(ReadonlyBytes data)
     return bit_cast<double>(static_cast<u64>(raw_value));
 }
 
-template<typename V, typename T>
-MakeSigned<T> BytecodeInterpreter::checked_signed_truncate(V value)
-{
-    if (isnan(value) || isinf(value)) { // "undefined", let's just trap.
-        m_trap = Trap { "Signed truncation undefined behavior" };
-        return 0;
-    }
-
-    double truncated;
-    if constexpr (IsSame<float, V>)
-        truncated = truncf(value);
-    else
-        truncated = trunc(value);
-
-    using SignedT = MakeSigned<T>;
-    if (NumericLimits<SignedT>::min() <= truncated && static_cast<double>(NumericLimits<SignedT>::max()) >= truncated)
-        return static_cast<SignedT>(truncated);
-
-    dbgln_if(WASM_TRACE_DEBUG, "Truncate out of range error");
-    m_trap = Trap { "Signed truncation out of range" };
-    return true;
-}
-
-template<typename V, typename T>
-MakeUnsigned<T> BytecodeInterpreter::checked_unsigned_truncate(V value)
-{
-    if (isnan(value) || isinf(value)) { // "undefined", let's just trap.
-        m_trap = Trap { "Unsigned truncation undefined behavior" };
-        return 0;
-    }
-    double truncated;
-    if constexpr (IsSame<float, V>)
-        truncated = truncf(value);
-    else
-        truncated = trunc(value);
-
-    using UnsignedT = MakeUnsigned<T>;
-    if (NumericLimits<UnsignedT>::min() <= truncated && static_cast<double>(NumericLimits<UnsignedT>::max()) >= truncated)
-        return static_cast<UnsignedT>(truncated);
-
-    dbgln_if(WASM_TRACE_DEBUG, "Truncate out of range error");
-    m_trap = Trap { "Unsigned truncation out of range" };
-    return true;
-}
-
 Vector<Value> BytecodeInterpreter::pop_values(Configuration& configuration, size_t count)
 {
     Vector<Value> results;

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -77,12 +77,6 @@ protected:
     template<typename PopType, typename PushType, typename Operator, typename... Args>
     void unary_operation(Configuration&, Args&&...);
 
-    template<typename V, typename T>
-    MakeUnsigned<T> checked_unsigned_truncate(V);
-
-    template<typename V, typename T>
-    MakeSigned<T> checked_signed_truncate(V);
-
     template<typename T>
     T read_value(ReadonlyBytes data);
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -68,7 +68,7 @@ protected:
     Optional<VectorType> pop_vector(Configuration&);
     template<typename M, template<typename> typename SetSign, typename VectorType = Native128ByteVectorOf<M, SetSign>>
     Optional<VectorType> peek_vector(Configuration&);
-    void store_to_memory(Configuration&, Instruction const&, ReadonlyBytes data, u32 base);
+    void store_to_memory(Configuration&, Instruction::MemoryArgument const&, ReadonlyBytes data, u32 base);
     void call_address(Configuration&, FunctionAddress);
 
     template<typename PopTypeLHS, typename PushType, typename Operator, typename PopTypeRHS = PopTypeLHS, typename... Args>


### PR DESCRIPTION
Just removing some dead code in `BytecodeInterpreter` and removing some memory-related checks that don't need because of validation.