### PR TITLE
LibWeb: An assortment of fixes for `DOM::Node`

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Node-isEqualNode.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Node-isEqualNode.txt
@@ -1,0 +1,11 @@
+element.isEqualNode(element): true
+element.isEqualNode(identicalElement): true
+identicalElement.isEqualNode(element): true
+element.isEqualNode(identicalElementWithCapitalizedName): true
+element.isEqualNode(elementWithDifferentNamespace): false
+element.isEqualNode(elementWithDifferentPrefix): false
+element.isEqualNode(elementWithDifferentLocalName): false
+element.isEqualNode(elementWithAttribute): false
+element.isEqualNode(elementWithAttribute) (after adding non-matching attribute): false
+element.isEqualNode(elementWithAttribute) (after adding matching attribute): false
+element.isEqualNode(elementWithAttribute) (after removing non-matching attribute): true

--- a/Tests/LibWeb/Text/input/DOM/Node-isEqualNode.html
+++ b/Tests/LibWeb/Text/input/DOM/Node-isEqualNode.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const element = document.createElementNS("namespace", "prefix:localName");
+        const identicalElement = document.createElementNS("namespace", "prefix:localName");
+        const identicalElementWithCapitalizedName = document.createElementNS("namespace", "PREFIX:LOCALNAME");
+        const elementWithDifferentNamespace = document.createElementNS("namespace2", "prefix:localName");
+        const elementWithDifferentPrefix = document.createElementNS("namespace", "prefix2:localName");
+        const elementWithDifferentLocalName = document.createElementNS("namespace", "prefix:localName2");
+        const elementWithAttribute = document.createElementNS("namespace", "prefix:localName");
+        elementWithAttribute.setAttribute("foo", "bar");
+
+        println(`element.isEqualNode(element): ${element.isEqualNode(element)}`);
+        println(`element.isEqualNode(identicalElement): ${element.isEqualNode(identicalElement)}`);
+        println(`identicalElement.isEqualNode(element): ${identicalElement.isEqualNode(element)}`);
+        println(`element.isEqualNode(identicalElementWithCapitalizedName): ${element.isEqualNode(identicalElement)}`);
+        println(`element.isEqualNode(elementWithDifferentNamespace): ${element.isEqualNode(elementWithDifferentNamespace)}`);
+        println(`element.isEqualNode(elementWithDifferentPrefix): ${element.isEqualNode(elementWithDifferentPrefix)}`);
+        println(`element.isEqualNode(elementWithDifferentLocalName): ${element.isEqualNode(elementWithDifferentLocalName)}`);
+        println(`element.isEqualNode(elementWithAttribute): ${element.isEqualNode(elementWithAttribute)}`);
+
+        element.setAttribute("foo2", "bar");
+        println(`element.isEqualNode(elementWithAttribute) (after adding non-matching attribute): ${element.isEqualNode(elementWithAttribute)}`);
+
+        element.setAttribute("foo", "bar");
+        println(`element.isEqualNode(elementWithAttribute) (after adding matching attribute): ${element.isEqualNode(elementWithAttribute)}`);
+
+        element.removeAttribute("foo2");
+        println(`element.isEqualNode(elementWithAttribute) (after removing non-matching attribute): ${element.isEqualNode(elementWithAttribute)}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.idl
@@ -8,3 +8,5 @@ interface DocumentType : Node {
     readonly attribute DOMString publicId;
     readonly attribute DOMString systemId;
 };
+
+DocumentType includes ChildNode;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1547,7 +1547,7 @@ bool Node::is_equal_node(Node const* other_node) const
     // A node A equals a node B if all of the following conditions are true:
 
     // A and B implement the same interfaces.
-    if (node_name() != other_node->node_name())
+    if (!node_name().equals_ignoring_ascii_case(other_node->node_name()))
         return false;
 
     // The following are equal, switching on the interface A implements:

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1573,8 +1573,8 @@ bool Node::is_equal_node(Node const* other_node) const
             return false;
         // If A is an element, each attribute in its attribute list has an attribute that equals an attribute in B’s attribute list.
         bool has_same_attributes = true;
-        this_element.for_each_attribute([&](auto& name, auto& value) {
-            if (other_element.get_attribute(name) != value)
+        this_element.for_each_attribute([&](auto const& attribute) {
+            if (other_element.get_attribute_ns(attribute.namespace_uri(), attribute.local_name()) != attribute.value())
                 has_same_attributes = false;
         });
         if (!has_same_attributes)


### PR DESCRIPTION
This PR fixes a couple of issues that I found in `DOM::Node`, while investigating various WPT failures.

See individual commits for details.

Fixes the following WPT tests:
http://wpt.live/dom/nodes/Node-isEqualNode.html
http://wpt.live/dom/nodes/Node-insertBefore.html
http://wpt.live/dom/nodes/ParentNode-append.html
http://wpt.live/dom/nodes/ParentNode-replaceChildren.html