### PR TITLE
LibWeb/DOM: Work around GCC 14 warning on always true `is<T>()`

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Utils.h
+++ b/Userland/Libraries/LibWeb/DOM/Utils.h
@@ -13,8 +13,7 @@
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#retarget
-template<typename T>
-T* retarget(T* a, T* b)
+inline EventTarget* retarget_impl(EventTarget* a, EventTarget* b)
 {
     // To retarget an object A against an object B, repeat these steps until they return an object:
     for (;;) {
@@ -37,6 +36,13 @@ T* retarget(T* a, T* b)
         auto& a_shadow_root = verify_cast<ShadowRoot>(a_root);
         a = a_shadow_root.host();
     }
+}
+
+// https://dom.spec.whatwg.org/#retarget
+template<typename T>
+T* retarget(T* a, T* b)
+{
+    return static_cast<T*>(retarget_impl(a, b));
 }
 
 }


### PR DESCRIPTION
GCC 14 emits a warning when an always succeeding `dynamic_cast`'s return value is compared to NULL inside the `AK::is<T>(U)` template when `T` == `U`.

While warning on tautological `is` calls seems useful, it's a bit awkward when it comes from a function template where the cast may fail in some instantiation. There is a GCC bug open for it: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=115664

Work around the warning by performing the algorithm on the base type (`EventTarget`), with a wrapper that casts it to the more specialized input type.