### PR TITLE
CI: Add notes-push.yml, for updating commit Notes on push to master

### DIFF
--- a/.github/workflows/notes-push.yml
+++ b/.github/workflows/notes-push.yml
@@ -1,0 +1,17 @@
+name: Push notes
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: fregante/setup-git-user@v2
+      - run: |
+          git fetch origin "refs/notes/*:refs/notes/*"
+          curl -fsSLO https://sideshowbarker.github.io/git-gloss/git-gloss && bash ./git-gloss
+          git push origin "refs/notes/*"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change, for each commit pushed/merged to master:

- causes new git Notes with GitHub PR/issue/reviewer/author links to be auto-generated for that commit

- pushes the updated `refs/notes/commits` tree+references back to the repo
