### PR TITLE
LibWeb: First pass at CSS counters

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -22,9 +22,28 @@ bool is_animatable_property(JsonObject& properties, StringView property_name);
 static bool type_name_is_enum(StringView type_name)
 {
     return !AK::first_is_one_of(type_name,
-        "angle"sv, "background-position"sv, "basic-shape"sv, "color"sv, "custom-ident"sv, "easing-function"sv, "flex"sv, "frequency"sv, "image"sv,
-        "integer"sv, "length"sv, "number"sv, "paint"sv, "percentage"sv, "position"sv, "ratio"sv, "rect"sv,
-        "resolution"sv, "string"sv, "time"sv, "url"sv);
+        "angle"sv,
+        "background-position"sv,
+        "basic-shape"sv,
+        "color"sv,
+        "counter"sv,
+        "custom-ident"sv,
+        "easing-function"sv,
+        "flex"sv,
+        "frequency"sv,
+        "image"sv,
+        "integer"sv,
+        "length"sv,
+        "number"sv,
+        "paint"sv,
+        "percentage"sv,
+        "position"sv,
+        "ratio"sv,
+        "rect"sv,
+        "resolution"sv,
+        "string"sv,
+        "time"sv,
+        "url"sv);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -183,6 +202,7 @@ enum class ValueType {
     BackgroundPosition,
     BasicShape,
     Color,
+    Counter,
     CustomIdent,
     EasingFunction,
     FilterValueList,
@@ -732,6 +752,8 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
                     property_generator.appendln("        case ValueType::BasicShape:");
                 } else if (type_name == "color") {
                     property_generator.appendln("        case ValueType::Color:");
+                } else if (type_name == "counter") {
+                    property_generator.appendln("        case ValueType::Counter:");
                 } else if (type_name == "custom-ident") {
                     property_generator.appendln("        case ValueType::CustomIdent:");
                 } else if (type_name == "easing-function") {

--- a/Tests/LibWeb/Layout/expected/css-counters/basic.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/basic.txt
@@ -1,0 +1,134 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x314 children: not-inline
+      BlockContainer <div> at (8,16) content-size 784x149 children: not-inline
+        BlockContainer <p> at (8,16) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [37,16 44.75x17] baseline: 13.296875
+              "Never"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,16 28.8125x17] baseline: 13.296875
+                "1.1: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,49) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [39,49 52.15625x17] baseline: 13.296875
+              "Gonna"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,49 31.28125x17] baseline: 13.296875
+                "1.2: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,82) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [40,82 34.71875x17] baseline: 13.296875
+              "Give"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,82 31.5625x17] baseline: 13.296875
+                "1.3: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,115) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [38,115 31.21875x17] baseline: 13.296875
+              "You"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,115 30.21875x17] baseline: 13.296875
+                "1.4: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,148) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 2, rect: [39,148 20.71875x17] baseline: 13.296875
+              "Up"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,148 30.921875x17] baseline: 13.296875
+                "1.5: "
+            TextNode <#text>
+          TextNode <#text>
+      BlockContainer <div> at (8,181) content-size 784x149 children: not-inline
+        BlockContainer <p> at (8,181) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [39,181 44.75x17] baseline: 13.296875
+              "Never"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,181 31.28125x17] baseline: 13.296875
+                "2.1: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,214) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [42,214 52.15625x17] baseline: 13.296875
+              "Gonna"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,214 33.75x17] baseline: 13.296875
+                "2.2: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,247) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [42,247 26.4375x17] baseline: 13.296875
+              "Let"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,247 34.03125x17] baseline: 13.296875
+                "2.3: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,280) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [41,280 31.21875x17] baseline: 13.296875
+              "You"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,280 32.6875x17] baseline: 13.296875
+                "2.4: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <p> at (8,313) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [41,313 42.328125x17] baseline: 13.296875
+              "Down"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 5, rect: [8,313 33.390625x17] baseline: 13.296875
+                "2.5: "
+            TextNode <#text>
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,346) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x314] overflow: [8,16 784x330]
+      PaintableWithLines (BlockContainer<DIV>) [8,16 784x149]
+        PaintableWithLines (BlockContainer<P>) [8,16 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,49 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,82 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,115 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,148 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,181 784x149]
+        PaintableWithLines (BlockContainer<P>) [8,181 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,214 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,247 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,280 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<P>) [8,313 784x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,346 784x0]

--- a/Tests/LibWeb/Layout/expected/css-counters/counters-function.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/counters-function.txt
@@ -1,0 +1,254 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x255 children: not-inline
+      BlockContainer <div.ol> at (24,8) content-size 768x255 children: not-inline
+        BlockContainer <(anonymous)> at (24,8) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,8) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [42,8 14.265625x17] baseline: 13.296875
+              "A"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [24,8 18.125x17] baseline: 13.296875
+                "1: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (24,25) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,25) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [45,25 9.34375x17] baseline: 13.296875
+              "B"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [24,25 20.59375x17] baseline: 13.296875
+                "2: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (24,42) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,42) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [45,42 10.3125x17] baseline: 13.296875
+              "C"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [24,42 20.875x17] baseline: 13.296875
+                "3: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (24,59) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,59) content-size 768x153 children: not-inline
+          BlockContainer <(anonymous)> at (24,59) content-size 768x17 children: inline
+            InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 2, rect: [24,59 11.53125x17] baseline: 13.296875
+                  "4:"
+              TextNode <#text>
+            TextNode <#text>
+          BlockContainer <div.ol> at (40,76) content-size 752x136 children: not-inline
+            BlockContainer <(anonymous)> at (40,76) content-size 752x0 children: inline
+              TextNode <#text>
+            BlockContainer <div.li> at (40,76) content-size 752x17 children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [70,76 11.140625x17] baseline: 13.296875
+                  "D"
+              InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 5, rect: [40,76 30.21875x17] baseline: 13.296875
+                    "4.1: "
+                TextNode <#text>
+              TextNode <#text>
+            BlockContainer <(anonymous)> at (40,93) content-size 752x0 children: inline
+              TextNode <#text>
+            BlockContainer <div.li> at (40,93) content-size 752x17 children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [73,93 11.859375x17] baseline: 13.296875
+                  "E"
+              InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 5, rect: [40,93 32.6875x17] baseline: 13.296875
+                    "4.2: "
+                TextNode <#text>
+              TextNode <#text>
+            BlockContainer <(anonymous)> at (40,110) content-size 752x0 children: inline
+              TextNode <#text>
+            BlockContainer <div.li> at (40,110) content-size 752x68 children: not-inline
+              BlockContainer <(anonymous)> at (40,110) content-size 752x17 children: inline
+                InlineNode <(anonymous)>
+                  frag 0 from TextNode start: 0, length: 4, rect: [40,110 24.96875x17] baseline: 13.296875
+                      "4.3:"
+                  TextNode <#text>
+                TextNode <#text>
+              BlockContainer <div.ol> at (56,127) content-size 736x51 children: not-inline
+                BlockContainer <(anonymous)> at (56,127) content-size 736x0 children: inline
+                  TextNode <#text>
+                BlockContainer <div.li> at (56,127) content-size 736x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [100,127 12.546875x17] baseline: 13.296875
+                      "F"
+                  InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 7, rect: [56,127 43.65625x17] baseline: 13.296875
+                        "4.3.1: "
+                    TextNode <#text>
+                  TextNode <#text>
+                BlockContainer <(anonymous)> at (56,144) content-size 736x0 children: inline
+                  TextNode <#text>
+                BlockContainer <div.li> at (56,144) content-size 736x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [102,144 13.234375x17] baseline: 13.296875
+                      "G"
+                  InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 7, rect: [56,144 46.125x17] baseline: 13.296875
+                        "4.3.2: "
+                    TextNode <#text>
+                  TextNode <#text>
+                BlockContainer <(anonymous)> at (56,161) content-size 736x0 children: inline
+                  TextNode <#text>
+                BlockContainer <div.li> at (56,161) content-size 736x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [102,161 12.234375x17] baseline: 13.296875
+                      "H"
+                  InlineNode <(anonymous)>
+                    frag 0 from TextNode start: 0, length: 7, rect: [56,161 46.40625x17] baseline: 13.296875
+                        "4.3.3: "
+                    TextNode <#text>
+                  TextNode <#text>
+                BlockContainer <(anonymous)> at (56,178) content-size 736x0 children: inline
+                  TextNode <#text>
+              BlockContainer <(anonymous)> at (40,178) content-size 752x0 children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> at (40,178) content-size 752x0 children: inline
+              TextNode <#text>
+            BlockContainer <div.li> at (40,178) content-size 752x17 children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [72,178 4.59375x17] baseline: 13.296875
+                  "I"
+              InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 5, rect: [40,178 31.625x17] baseline: 13.296875
+                    "4.4: "
+                TextNode <#text>
+              TextNode <#text>
+            BlockContainer <(anonymous)> at (40,195) content-size 752x0 children: inline
+              TextNode <#text>
+            BlockContainer <div.li> at (40,195) content-size 752x17 children: inline
+              frag 0 from TextNode start: 0, length: 1, rect: [72,195 8.90625x17] baseline: 13.296875
+                  "J"
+              InlineNode <(anonymous)>
+                frag 0 from TextNode start: 0, length: 5, rect: [40,195 32.328125x17] baseline: 13.296875
+                    "4.5: "
+                TextNode <#text>
+              TextNode <#text>
+            BlockContainer <(anonymous)> at (40,212) content-size 752x0 children: inline
+              TextNode <#text>
+          BlockContainer <(anonymous)> at (24,212) content-size 768x0 children: inline
+            TextNode <#text>
+        BlockContainer <(anonymous)> at (24,212) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,212) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [44,212 9.8125x17] baseline: 13.296875
+              "K"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [24,212 20.234375x17] baseline: 13.296875
+                "5: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (24,229) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,229) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [45,229 10.859375x17] baseline: 13.296875
+              "L"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [24,229 20.515625x17] baseline: 13.296875
+                "6: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (24,246) content-size 768x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.li> at (24,246) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [45,246 11.765625x17] baseline: 13.296875
+              "M"
+          InlineNode <(anonymous)>
+            frag 0 from TextNode start: 0, length: 3, rect: [24,246 20.5x17] baseline: 13.296875
+                "7: "
+            TextNode <#text>
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (24,263) content-size 768x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,263) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x255]
+      PaintableWithLines (BlockContainer<DIV>.ol) [8,8 784x255]
+        PaintableWithLines (BlockContainer(anonymous)) [24,8 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,8 768x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [24,25 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,25 768x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [24,42 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,42 768x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [24,59 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,59 768x153]
+          PaintableWithLines (BlockContainer(anonymous)) [24,59 768x17]
+            InlinePaintable (InlineNode(anonymous))
+              TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>.ol) [24,76 768x136]
+            PaintableWithLines (BlockContainer(anonymous)) [40,76 752x0]
+            PaintableWithLines (BlockContainer<DIV>.li) [40,76 752x17]
+              InlinePaintable (InlineNode(anonymous))
+                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer(anonymous)) [40,93 752x0]
+            PaintableWithLines (BlockContainer<DIV>.li) [40,93 752x17]
+              InlinePaintable (InlineNode(anonymous))
+                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer(anonymous)) [40,110 752x0]
+            PaintableWithLines (BlockContainer<DIV>.li) [40,110 752x68]
+              PaintableWithLines (BlockContainer(anonymous)) [40,110 752x17]
+                InlinePaintable (InlineNode(anonymous))
+                  TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<DIV>.ol) [40,127 752x51]
+                PaintableWithLines (BlockContainer(anonymous)) [56,127 736x0]
+                PaintableWithLines (BlockContainer<DIV>.li) [56,127 736x17]
+                  InlinePaintable (InlineNode(anonymous))
+                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [56,144 736x0]
+                PaintableWithLines (BlockContainer<DIV>.li) [56,144 736x17]
+                  InlinePaintable (InlineNode(anonymous))
+                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [56,161 736x0]
+                PaintableWithLines (BlockContainer<DIV>.li) [56,161 736x17]
+                  InlinePaintable (InlineNode(anonymous))
+                    TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [56,178 736x0]
+              PaintableWithLines (BlockContainer(anonymous)) [40,178 752x0]
+            PaintableWithLines (BlockContainer(anonymous)) [40,178 752x0]
+            PaintableWithLines (BlockContainer<DIV>.li) [40,178 752x17]
+              InlinePaintable (InlineNode(anonymous))
+                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer(anonymous)) [40,195 752x0]
+            PaintableWithLines (BlockContainer<DIV>.li) [40,195 752x17]
+              InlinePaintable (InlineNode(anonymous))
+                TextPaintable (TextNode<#text>)
+              TextPaintable (TextNode<#text>)
+            PaintableWithLines (BlockContainer(anonymous)) [40,212 752x0]
+          PaintableWithLines (BlockContainer(anonymous)) [24,212 768x0]
+        PaintableWithLines (BlockContainer(anonymous)) [24,212 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,212 768x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [24,229 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,229 768x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [24,246 768x0]
+        PaintableWithLines (BlockContainer<DIV>.li) [24,246 768x17]
+          InlinePaintable (InlineNode(anonymous))
+            TextPaintable (TextNode<#text>)
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [24,263 768x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,263 784x0]

--- a/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/hidden-elements.txt
@@ -1,0 +1,67 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x149 children: not-inline
+      BlockContainer <p> at (8,16) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [26,16 14.265625x17] baseline: 13.296875
+            "A"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,16 18.125x17] baseline: 13.296875
+              "1: "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <p> at (8,49) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [29,49 9.34375x17] baseline: 13.296875
+            "B"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,49 20.59375x17] baseline: 13.296875
+              "2: "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <p> at (8,82) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [29,82 10.3125x17] baseline: 13.296875
+            "C"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,82 20.875x17] baseline: 13.296875
+              "3: "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <p> at (8,115) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [28,115 11.140625x17] baseline: 13.296875
+            "D"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,115 19.53125x17] baseline: 13.296875
+              "4: "
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <p> at (8,148) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [28,148 11.859375x17] baseline: 13.296875
+            "E"
+        InlineNode <(anonymous)>
+          frag 0 from TextNode start: 0, length: 3, rect: [8,148 20.234375x17] baseline: 13.296875
+              "5: "
+          TextNode <#text>
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x149]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x17]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<P>) [8,49 784x17]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<P>) [8,82 784x17]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<P>) [8,115 784x17]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<P>) [8,148 784x17]
+        InlinePaintable (InlineNode(anonymous))
+          TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/css-counters/basic.html
+++ b/Tests/LibWeb/Layout/input/css-counters/basic.html
@@ -1,0 +1,12 @@
+<style>
+div {
+    counter-increment: line;
+    counter-reset: word;
+}
+p {
+    counter-increment: word;
+}
+p::before {
+    content: counter(line) "." counter(word) ": ";
+}
+</style><div><p>Never<p>Gonna<p>Give<p>You<p>Up</div><div><p>Never<p>Gonna<p>Let<p>You<p>Down</div>

--- a/Tests/LibWeb/Layout/input/css-counters/counters-function.html
+++ b/Tests/LibWeb/Layout/input/css-counters/counters-function.html
@@ -1,0 +1,36 @@
+<style>
+div.ol {
+    counter-reset: index;
+    padding-left: 1em;
+}
+div.li {
+    counter-increment: index;
+}
+div.li::before {
+    content: counters(index, ".") ": ";
+}
+</style>
+
+<div class="ol">
+    <div class="li">A</div>
+    <div class="li">B</div>
+    <div class="li">C</div>
+    <div class="li">
+        <div class="ol">
+            <div class="li">D</div>
+            <div class="li">E</div>
+            <div class="li">
+                <div class="ol">
+                    <div class="li">F</div>
+                    <div class="li">G</div>
+                    <div class="li">H</div>
+                </div>
+            </div>
+            <div class="li">I</div>
+            <div class="li">J</div>
+        </div>
+    </div>
+    <div class="li">K</div>
+    <div class="li">L</div>
+    <div class="li">M</div>
+</div>

--- a/Tests/LibWeb/Layout/input/css-counters/hidden-elements.html
+++ b/Tests/LibWeb/Layout/input/css-counters/hidden-elements.html
@@ -1,0 +1,8 @@
+<style>
+p {
+    counter-increment: a;
+}
+p::before {
+    content: counter(a) ": ";
+}
+</style><p>A<p>B<p>C<p style="display:none">SECRET<p>D<p>E

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -88,6 +88,9 @@ column-count: auto
 column-gap: auto
 content: normal
 content-visibility: visible
+counter-increment: none
+counter-reset: none
+counter-set: none
 cursor: auto
 cx: 0px
 cy: 0px
@@ -120,7 +123,7 @@ grid-row-start: auto
 grid-template-areas: 
 grid-template-columns: 
 grid-template-rows: 
-height: 2074px
+height: 2125px
 image-rendering: auto
 inline-size: auto
 inset-block-end: auto

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -111,6 +111,7 @@ set(SOURCES
     CSS/StyleValues/ConicGradientStyleValue.cpp
     CSS/StyleValues/ContentStyleValue.cpp
     CSS/StyleValues/CounterDefinitionsStyleValue.cpp
+    CSS/StyleValues/CounterStyleValue.cpp
     CSS/StyleValues/DisplayStyleValue.cpp
     CSS/StyleValues/EasingStyleValue.cpp
     CSS/StyleValues/EdgeStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -33,6 +33,7 @@ set(SOURCES
     CSS/AnimationEvent.cpp
     CSS/CalculatedOr.cpp
     CSS/Clip.cpp
+    CSS/CountersSet.cpp
     CSS/CSS.cpp
     CSS/CSSAnimation.cpp
     CSS/CSSConditionRule.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -110,6 +110,7 @@ set(SOURCES
     CSS/StyleValues/ColorStyleValue.cpp
     CSS/StyleValues/ConicGradientStyleValue.cpp
     CSS/StyleValues/ContentStyleValue.cpp
+    CSS/StyleValues/CounterDefinitionsStyleValue.cpp
     CSS/StyleValues/DisplayStyleValue.cpp
     CSS/StyleValues/EasingStyleValue.cpp
     CSS/StyleValues/EdgeStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -36,6 +36,7 @@ Optional<CSSNumericType::BaseType> CSSNumericType::base_type_from_value_type(Val
     case ValueType::BackgroundPosition:
     case ValueType::BasicShape:
     case ValueType::Color:
+    case ValueType::Counter:
     case ValueType::CustomIdent:
     case ValueType::EasingFunction:
     case ValueType::FilterValueList:

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/CalculatedOr.h>
 #include <LibWeb/CSS/Clip.h>
 #include <LibWeb/CSS/ColumnCount.h>
+#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Display.h>
 #include <LibWeb/CSS/GridTrackPlacement.h>
 #include <LibWeb/CSS/GridTrackSize.h>
@@ -313,6 +314,12 @@ struct ContentData {
     // FIXME: Data is a list of identifiers, strings and image values.
     String data {};
     String alt_text {};
+};
+
+struct CounterData {
+    FlyString name;
+    bool is_reversed;
+    Optional<CounterValue> value;
 };
 
 struct BorderRadiusData {
@@ -632,6 +639,9 @@ protected:
         LengthPercentage y { InitialValues::x() };
 
         CSS::ScrollbarWidth scrollbar_width { InitialValues::scrollbar_width() };
+        Vector<CounterData, 0> counter_increment;
+        Vector<CounterData, 0> counter_reset;
+        Vector<CounterData, 0> counter_set;
     } m_noninherited;
 };
 
@@ -774,6 +784,10 @@ public:
     void set_math_depth(int value) { m_inherited.math_depth = value; }
 
     void set_scrollbar_width(CSS::ScrollbarWidth value) { m_noninherited.scrollbar_width = value; }
+
+    void set_counter_increment(Vector<CounterData> value) { m_noninherited.counter_increment = move(value); }
+    void set_counter_reset(Vector<CounterData> value) { m_noninherited.counter_reset = move(value); }
+    void set_counter_set(Vector<CounterData> value) { m_noninherited.counter_set = move(value); }
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/CountersSet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CountersSet.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "CountersSet.h"
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/Node.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-lists-3/#instantiate-counter
+Counter& CountersSet::instantiate_a_counter(FlyString name, i32 originating_element_id, bool reversed, Optional<CounterValue> value)
+{
+    // 1. Let counters be element’s CSS counters set.
+    auto* element = DOM::Node::from_unique_id(originating_element_id);
+
+    // 2. Let innermost counter be the last counter in counters with the name name.
+    //    If innermost counter’s originating element is element or a previous sibling of element,
+    //    remove innermost counter from counters.
+    auto innermost_counter = last_counter_with_name(name);
+    if (innermost_counter.has_value()) {
+        auto* originating_node = DOM::Node::from_unique_id(innermost_counter->originating_element_id);
+        VERIFY(originating_node);
+        auto& innermost_element = verify_cast<DOM::Element>(*originating_node);
+
+        if (&innermost_element == element
+            || (innermost_element.parent() == element->parent() && innermost_element.is_before(*element))) {
+
+            m_counters.remove_first_matching([&innermost_counter](auto& it) {
+                return it.name == innermost_counter->name
+                    && it.originating_element_id == innermost_counter->originating_element_id;
+            });
+        }
+    }
+
+    // 3. Append a new counter to counters with name name, originating element element,
+    //    reversed being reversed, and initial value value (if given)
+    m_counters.append({
+        .name = move(name),
+        .originating_element_id = originating_element_id,
+        .reversed = reversed,
+        .value = value,
+    });
+
+    return m_counters.last();
+}
+
+// https://drafts.csswg.org/css-lists-3/#propdef-counter-set
+void CountersSet::set_a_counter(FlyString name, i32 originating_element_id, CounterValue value)
+{
+    if (auto existing_counter = last_counter_with_name(name); existing_counter.has_value()) {
+        existing_counter->value = value;
+        return;
+    }
+
+    // If there is not currently a counter of the given name on the element, the element instantiates
+    // a new counter of the given name with a starting value of 0 before setting or incrementing its value.
+    // https://drafts.csswg.org/css-lists-3/#valdef-counter-set-counter-name-integer
+    auto& counter = instantiate_a_counter(name, originating_element_id, false, 0);
+    counter.value = value;
+}
+
+// https://drafts.csswg.org/css-lists-3/#propdef-counter-increment
+void CountersSet::increment_a_counter(FlyString name, i32 originating_element_id, CounterValue amount)
+{
+    if (auto existing_counter = last_counter_with_name(name); existing_counter.has_value()) {
+        // FIXME: How should we handle existing counters with no value? Can that happen?
+        VERIFY(existing_counter->value.has_value());
+        existing_counter->value->saturating_add(amount.value());
+        return;
+    }
+
+    // If there is not currently a counter of the given name on the element, the element instantiates
+    // a new counter of the given name with a starting value of 0 before setting or incrementing its value.
+    // https://drafts.csswg.org/css-lists-3/#valdef-counter-set-counter-name-integer
+    auto& counter = instantiate_a_counter(name, originating_element_id, false, 0);
+    counter.value->saturating_add(amount.value());
+}
+
+Optional<Counter&> CountersSet::last_counter_with_name(FlyString const& name)
+{
+    for (auto& counter : m_counters.in_reverse()) {
+        if (counter.name == name)
+            return counter;
+    }
+    return {};
+}
+
+Optional<Counter&> CountersSet::counter_with_same_name_and_creator(FlyString const& name, i32 originating_element_id)
+{
+    return m_counters.first_matching([&](auto& it) {
+        return it.name == name && it.originating_element_id == originating_element_id;
+    });
+}
+
+void CountersSet::append_copy(Counter const& counter)
+{
+    m_counters.append(counter);
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/CountersSet.h
+++ b/Userland/Libraries/LibWeb/CSS/CountersSet.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Checked.h>
+#include <AK/FlyString.h>
+#include <AK/Optional.h>
+
+namespace Web::CSS {
+
+// "UAs may have implementation-specific limits on the maximum or minimum value of a counter.
+// If a counter reset, set, or increment would push the value outside of that range, the value
+// must be clamped to that range." - https://drafts.csswg.org/css-lists-3/#auto-numbering
+// So, we use a Checked<i32> and saturating addition/subtraction.
+using CounterValue = Checked<i32>;
+
+// https://drafts.csswg.org/css-lists-3/#counter
+struct Counter {
+    FlyString name;
+    i32 originating_element_id; // "creator"
+    bool reversed { false };
+    Optional<CounterValue> value;
+};
+
+// https://drafts.csswg.org/css-lists-3/#css-counters-set
+class CountersSet {
+public:
+    CountersSet() = default;
+    ~CountersSet() = default;
+
+    Counter& instantiate_a_counter(FlyString name, i32 originating_element_id, bool reversed, Optional<CounterValue>);
+    void set_a_counter(FlyString name, i32 originating_element_id, CounterValue value);
+    void increment_a_counter(FlyString name, i32 originating_element_id, CounterValue amount);
+    void append_copy(Counter const&);
+
+    Optional<Counter&> last_counter_with_name(FlyString const& name);
+    Optional<Counter&> counter_with_same_name_and_creator(FlyString const& name, i32 originating_element_id);
+
+    Vector<Counter> const& counters() const { return m_counters; }
+    bool is_empty() const { return m_counters.is_empty(); }
+
+private:
+    Vector<Counter> m_counters;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
@@ -90,15 +90,6 @@ static void log_parse_error(SourceLocation const& location = SourceLocation::cur
 }
 
 namespace Web::CSS::Parser {
-
-static bool contains_single_none_ident(TokenStream<ComponentValue>& tokens)
-{
-    if (tokens.remaining_token_count() > 1)
-        return false;
-    if (auto token = tokens.peek_token(); token.is_ident("none"sv))
-        return true;
-    return false;
-}
 
 ErrorOr<Parser> Parser::create(ParsingContext const& context, StringView input, StringView encoding)
 {
@@ -3343,6 +3334,20 @@ RefPtr<StyleValue> Parser::parse_simple_comma_separated_value_list(PropertyID pr
     });
 }
 
+RefPtr<StyleValue> Parser::parse_all_as_single_none_value(TokenStream<ComponentValue>& tokens)
+{
+    auto transaction = tokens.begin_transaction();
+    tokens.skip_whitespace();
+    auto maybe_none = tokens.next_token();
+    tokens.skip_whitespace();
+
+    if (tokens.has_next_token() || !maybe_none.is_ident("none"sv))
+        return {};
+
+    transaction.commit();
+    return IdentifierStyleValue::create(ValueID::None);
+}
+
 static void remove_property(Vector<PropertyID>& properties, PropertyID property_to_remove)
 {
     properties.remove_first_matching([&](auto it) { return it == property_to_remove; });
@@ -3986,8 +3991,8 @@ RefPtr<StyleValue> Parser::parse_border_radius_shorthand_value(TokenStream<Compo
 RefPtr<StyleValue> Parser::parse_shadow_value(TokenStream<ComponentValue>& tokens, AllowInsetKeyword allow_inset_keyword)
 {
     // "none"
-    if (contains_single_none_ident(tokens))
-        return parse_identifier_value(tokens);
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
 
     return parse_comma_separated_value_list(tokens, [this, allow_inset_keyword](auto& tokens) {
         return parse_single_shadow_value(tokens, allow_inset_keyword);
@@ -4298,12 +4303,10 @@ RefPtr<StyleValue> Parser::parse_display_value(TokenStream<ComponentValue>& toke
 
 RefPtr<StyleValue> Parser::parse_filter_value_list_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
 
-    if (contains_single_none_ident(tokens)) {
-        transaction.commit();
-        return parse_identifier_value(tokens);
-    }
+    auto transaction = tokens.begin_transaction();
 
     // FIXME: <url>s are ignored for now
     // <filter-value-list> = [ <filter-function> | <url> ]+
@@ -5543,10 +5546,8 @@ RefPtr<StyleValue> Parser::parse_transform_value(TokenStream<ComponentValue>& to
     // <transform> = none | <transform-list>
     // <transform-list> = <transform-function>+
 
-    if (contains_single_none_ident(tokens)) {
-        tokens.next_token(); // none
-        return IdentifierStyleValue::create(ValueID::None);
-    }
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
 
     StyleValueVector transformations;
     auto transaction = tokens.begin_transaction();
@@ -5797,10 +5798,8 @@ RefPtr<StyleValue> Parser::parse_transform_origin_value(TokenStream<ComponentVal
 
 RefPtr<StyleValue> Parser::parse_transition_value(TokenStream<ComponentValue>& tokens)
 {
-    if (contains_single_none_ident(tokens)) {
-        tokens.next_token(); // none
-        return IdentifierStyleValue::create(ValueID::None);
-    }
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
 
     Vector<TransitionStyleValue::Transition> transitions;
     auto transaction = tokens.begin_transaction();
@@ -6085,13 +6084,10 @@ Optional<CSS::ExplicitGridTrack> Parser::parse_track_sizing_function(ComponentVa
 
 RefPtr<StyleValue> Parser::parse_grid_track_size_list(TokenStream<ComponentValue>& tokens, bool allow_separate_line_name_blocks)
 {
-    auto transaction = tokens.begin_transaction();
-
-    if (contains_single_none_ident(tokens)) {
-        tokens.next_token();
-        transaction.commit();
+    if (auto none = parse_all_as_single_none_value(tokens))
         return GridTrackSizeListStyleValue::make_none();
-    }
+
+    auto transaction = tokens.begin_transaction();
 
     Vector<Variant<ExplicitGridTrack, GridLineNames>> track_list;
     auto last_object_was_line_names = false;
@@ -6582,10 +6578,8 @@ RefPtr<StyleValue> Parser::parse_grid_template_areas_value(TokenStream<Component
     // none | <string>+
     Vector<Vector<String>> grid_area_rows;
 
-    if (contains_single_none_ident(tokens)) {
-        (void)tokens.next_token(); // none
+    if (auto none = parse_all_as_single_none_value(tokens))
         return GridTemplateAreaStyleValue::create(move(grid_area_rows));
-    }
 
     auto transaction = tokens.begin_transaction();
     while (tokens.has_next_token() && tokens.peek_token().is(Token::Type::String)) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
@@ -2887,6 +2888,118 @@ RefPtr<StyleValue> Parser::parse_color_value(TokenStream<ComponentValue>& tokens
             transaction.commit();
             return IdentifierStyleValue::create(ident.value());
         }
+    }
+
+    return nullptr;
+}
+
+// https://drafts.csswg.org/css-lists-3/#counter-functions
+RefPtr<StyleValue> Parser::parse_counter_value(TokenStream<ComponentValue>& tokens)
+{
+    auto parse_counter_name = [](TokenStream<ComponentValue>& tokens) -> Optional<FlyString> {
+        // https://drafts.csswg.org/css-lists-3/#typedef-counter-name
+        // Counters are referred to in CSS syntax using the <counter-name> type, which represents
+        // their name as a <custom-ident>. A <counter-name> name cannot match the keyword none;
+        // such an identifier is invalid as a <counter-name>.
+        auto transaction = tokens.begin_transaction();
+        tokens.skip_whitespace();
+
+        auto& token = tokens.next_token();
+        if (!token.is(Token::Type::Ident) || token.token().ident() == "none"sv)
+            return {};
+
+        tokens.skip_whitespace();
+        if (tokens.has_next_token())
+            return {};
+
+        transaction.commit();
+        return token.token().ident();
+    };
+
+    auto parse_counter_style = [](TokenStream<ComponentValue>& tokens) -> RefPtr<StyleValue> {
+        // https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style
+        // <counter-style> = <counter-style-name> | <symbols()>
+        // For now we just support <counter-style-name>, found here:
+        // https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style-name
+        // <counter-style-name> is a <custom-ident> that is not an ASCII case-insensitive match for none.
+        auto transaction = tokens.begin_transaction();
+        tokens.skip_whitespace();
+
+        auto& token = tokens.next_token();
+        if (!token.is(Token::Type::Ident) || token.token().ident() == "none"sv)
+            return {};
+
+        tokens.skip_whitespace();
+        if (tokens.has_next_token())
+            return {};
+
+        transaction.commit();
+        return CustomIdentStyleValue::create(token.token().ident());
+    };
+
+    auto transaction = tokens.begin_transaction();
+    auto token = tokens.next_token();
+    if (token.is_function("counter"sv)) {
+        // counter() = counter( <counter-name>, <counter-style>? )
+        auto& function = token.function();
+        TokenStream function_tokens { function.values() };
+        auto function_values = parse_a_comma_separated_list_of_component_values(function_tokens);
+        if (function_values.is_empty() || function_values.size() > 2)
+            return nullptr;
+
+        TokenStream name_tokens { function_values[0] };
+        auto counter_name = parse_counter_name(name_tokens);
+        if (!counter_name.has_value())
+            return nullptr;
+
+        RefPtr<StyleValue> counter_style;
+        if (function_values.size() > 1) {
+            TokenStream counter_style_tokens { function_values[1] };
+            counter_style = parse_counter_style(counter_style_tokens);
+            if (!counter_style)
+                return nullptr;
+        } else {
+            // In both cases, if the <counter-style> argument is omitted it defaults to `decimal`.
+            counter_style = CustomIdentStyleValue::create("decimal"_fly_string);
+        }
+
+        transaction.commit();
+        return CounterStyleValue::create_counter(counter_name.release_value(), counter_style.release_nonnull());
+    }
+
+    if (token.is_function("counters"sv)) {
+        // counters() = counters( <counter-name>, <string>, <counter-style>? )
+        auto& function = token.function();
+        TokenStream function_tokens { function.values() };
+        auto function_values = parse_a_comma_separated_list_of_component_values(function_tokens);
+        if (function_values.is_empty() || function_values.size() > 3)
+            return nullptr;
+
+        TokenStream name_tokens { function_values[0] };
+        auto counter_name = parse_counter_name(name_tokens);
+        if (!counter_name.has_value())
+            return nullptr;
+
+        TokenStream string_tokens { function_values[1] };
+        string_tokens.skip_whitespace();
+        RefPtr<StyleValue> join_string = parse_string_value(string_tokens);
+        string_tokens.skip_whitespace();
+        if (!join_string || string_tokens.has_next_token())
+            return nullptr;
+
+        RefPtr<StyleValue> counter_style;
+        if (function_values.size() > 2) {
+            TokenStream counter_style_tokens { function_values[2] };
+            counter_style = parse_counter_style(counter_style_tokens);
+            if (!counter_style)
+                return nullptr;
+        } else {
+            // In both cases, if the <counter-style> argument is omitted it defaults to `decimal`.
+            counter_style = CustomIdentStyleValue::create("decimal"_fly_string);
+        }
+
+        transaction.commit();
+        return CounterStyleValue::create_counters(counter_name.release_value(), join_string->as_string().string_value(), counter_style.release_nonnull());
     }
 
     return nullptr;
@@ -7119,6 +7232,11 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
     if (auto property = any_property_accepts_type(property_ids, ValueType::Color); property.has_value()) {
         if (auto maybe_color = parse_color_value(tokens))
             return PropertyAndValue { *property, maybe_color };
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Counter); property.has_value()) {
+        if (auto maybe_counter = parse_counter_value(tokens))
+            return PropertyAndValue { *property, maybe_counter };
     }
 
     if (auto property = any_property_accepts_type(property_ids, ValueType::Image); property.has_value()) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -44,6 +44,7 @@
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
@@ -2891,6 +2892,63 @@ RefPtr<StyleValue> Parser::parse_color_value(TokenStream<ComponentValue>& tokens
     return nullptr;
 }
 
+RefPtr<StyleValue> Parser::parse_counter_definitions_value(TokenStream<ComponentValue>& tokens, AllowReversed allow_reversed, i32 default_value_if_not_reversed)
+{
+    // If AllowReversed is Yes, parses:
+    //   [ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+
+    // Otherwise parses:
+    //   [ <counter-name> <integer>? ]+
+
+    // FIXME: This disabled parsing of `reversed()` counters. Remove this line once they're supported.
+    allow_reversed = AllowReversed::No;
+
+    auto transaction = tokens.begin_transaction();
+    tokens.skip_whitespace();
+
+    Vector<CounterDefinition> counter_definitions;
+    while (tokens.has_next_token()) {
+        auto per_item_transaction = tokens.begin_transaction();
+        CounterDefinition definition {};
+
+        // <counter-name> | <reversed-counter-name>
+        auto& token = tokens.next_token();
+        if (token.is(Token::Type::Ident)) {
+            definition.name = token.token().ident();
+            definition.is_reversed = false;
+        } else if (allow_reversed == AllowReversed::Yes && token.is_function("reversed"sv)) {
+            TokenStream function_tokens { token.function().values() };
+            function_tokens.skip_whitespace();
+            auto& name_token = function_tokens.next_token();
+            if (!name_token.is(Token::Type::Ident))
+                break;
+            function_tokens.skip_whitespace();
+            if (function_tokens.has_next_token())
+                break;
+
+            definition.name = name_token.token().ident();
+            definition.is_reversed = true;
+        } else {
+            break;
+        }
+        tokens.skip_whitespace();
+
+        // <integer>?
+        definition.value = parse_integer_value(tokens);
+        if (!definition.value && !definition.is_reversed)
+            definition.value = IntegerStyleValue::create(default_value_if_not_reversed);
+
+        counter_definitions.append(move(definition));
+        tokens.skip_whitespace();
+        per_item_transaction.commit();
+    }
+
+    if (counter_definitions.is_empty())
+        return {};
+
+    transaction.commit();
+    return CounterDefinitionsStyleValue::create(move(counter_definitions));
+}
+
 RefPtr<StyleValue> Parser::parse_ratio_value(TokenStream<ComponentValue>& tokens)
 {
     if (auto ratio = parse_ratio(tokens); ratio.has_value())
@@ -4168,6 +4226,36 @@ RefPtr<StyleValue> Parser::parse_content_value(TokenStream<ComponentValue>& toke
 
     transaction.commit();
     return ContentStyleValue::create(StyleValueList::create(move(content_values), StyleValueList::Separator::Space), move(alt_text));
+}
+
+// https://drafts.csswg.org/css-lists-3/#propdef-counter-increment
+RefPtr<StyleValue> Parser::parse_counter_increment_value(TokenStream<ComponentValue>& tokens)
+{
+    // [ <counter-name> <integer>? ]+ | none
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
+
+    return parse_counter_definitions_value(tokens, AllowReversed::No, 1);
+}
+
+// https://drafts.csswg.org/css-lists-3/#propdef-counter-reset
+RefPtr<StyleValue> Parser::parse_counter_reset_value(TokenStream<ComponentValue>& tokens)
+{
+    // [ <counter-name> <integer>? | <reversed-counter-name> <integer>? ]+ | none
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
+
+    return parse_counter_definitions_value(tokens, AllowReversed::Yes, 0);
+}
+
+// https://drafts.csswg.org/css-lists-3/#propdef-counter-set
+RefPtr<StyleValue> Parser::parse_counter_set_value(TokenStream<ComponentValue>& tokens)
+{
+    // [ <counter-name> <integer>? ]+ | none
+    if (auto none = parse_all_as_single_none_value(tokens))
+        return none;
+
+    return parse_counter_definitions_value(tokens, AllowReversed::No, 0);
 }
 
 // https://www.w3.org/TR/css-display-3/#the-display-properties
@@ -6736,6 +6824,18 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
         return ParseError::SyntaxError;
     case PropertyID::Content:
         if (auto parsed_value = parse_content_value(tokens); parsed_value && !tokens.has_next_token())
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::CounterIncrement:
+        if (auto parsed_value = parse_counter_increment_value(tokens); parsed_value && !tokens.has_next_token())
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::CounterReset:
+        if (auto parsed_value = parse_counter_reset_value(tokens); parsed_value && !tokens.has_next_token())
+            return parsed_value.release_nonnull();
+        return ParseError::SyntaxError;
+    case PropertyID::CounterSet:
+        if (auto parsed_value = parse_counter_set_value(tokens); parsed_value && !tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::Display:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -287,6 +287,7 @@ private:
     RefPtr<StyleValue> parse_number_or_percentage_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_identifier_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_color_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_counter_value(TokenStream<ComponentValue>&);
     enum class AllowReversed {
         No,
         Yes,

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -302,6 +302,7 @@ private:
     template<typename ParseFunction>
     RefPtr<StyleValue> parse_comma_separated_value_list(TokenStream<ComponentValue>&, ParseFunction);
     RefPtr<StyleValue> parse_simple_comma_separated_value_list(PropertyID, TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_all_as_single_none_value(TokenStream<ComponentValue>&);
 
     RefPtr<StyleValue> parse_aspect_ratio_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_background_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -287,6 +287,11 @@ private:
     RefPtr<StyleValue> parse_number_or_percentage_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_identifier_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_color_value(TokenStream<ComponentValue>&);
+    enum class AllowReversed {
+        No,
+        Yes,
+    };
+    RefPtr<StyleValue> parse_counter_definitions_value(TokenStream<ComponentValue>&, AllowReversed, i32 default_value_if_not_reversed);
     RefPtr<StyleValue> parse_rect_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_ratio_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_string_value(TokenStream<ComponentValue>&);
@@ -313,6 +318,9 @@ private:
     RefPtr<StyleValue> parse_border_radius_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_border_radius_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_content_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_counter_increment_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_counter_reset_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_counter_set_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_display_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_flex_flow_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -966,6 +966,7 @@
     "initial": "normal",
     "__comment": "FIXME: This accepts a whole lot of other types and identifiers!",
     "valid-types": [
+      "counter",
       "string"
     ],
     "valid-identifiers": [

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1,39 +1,63 @@
 {
   "-webkit-align-content": {
-    "logical-alias-for": ["align-content"]
+    "logical-alias-for": [
+      "align-content"
+    ]
   },
   "-webkit-align-items": {
-    "logical-alias-for": ["align-items"]
+    "logical-alias-for": [
+      "align-items"
+    ]
   },
   "-webkit-align-self": {
-    "logical-alias-for": ["align-self"]
+    "logical-alias-for": [
+      "align-self"
+    ]
   },
   "-webkit-animation": {
-    "logical-alias-for": ["animation"]
+    "logical-alias-for": [
+      "animation"
+    ]
   },
   "-webkit-animation-delay": {
-    "logical-alias-for": ["animation-delay"]
+    "logical-alias-for": [
+      "animation-delay"
+    ]
   },
   "-webkit-animation-direction": {
-    "logical-alias-for": ["animation-direction"]
+    "logical-alias-for": [
+      "animation-direction"
+    ]
   },
   "-webkit-animation-duration": {
-    "logical-alias-for": ["animation-duration"]
+    "logical-alias-for": [
+      "animation-duration"
+    ]
   },
   "-webkit-animation-fill-mode": {
-    "logical-alias-for": ["animation-fill-mode"]
+    "logical-alias-for": [
+      "animation-fill-mode"
+    ]
   },
   "-webkit-animation-iteration-count": {
-    "logical-alias-for": ["animation-iteration-count"]
+    "logical-alias-for": [
+      "animation-iteration-count"
+    ]
   },
   "-webkit-animation-name": {
-    "logical-alias-for": ["animation-name"]
+    "logical-alias-for": [
+      "animation-name"
+    ]
   },
   "-webkit-animation-play-state": {
-    "logical-alias-for": ["animation-play-state"]
+    "logical-alias-for": [
+      "animation-play-state"
+    ]
   },
   "-webkit-animation-timing-function": {
-    "logical-alias-for": ["animation-timing-function"]
+    "logical-alias-for": [
+      "animation-timing-function"
+    ]
   },
   "-webkit-appearance": {
     "logical-alias-for": [
@@ -42,88 +66,142 @@
     "max-values": 1
   },
   "-webkit-background-clip": {
-    "logical-alias-for": ["background-clip"]
+    "logical-alias-for": [
+      "background-clip"
+    ]
   },
   "-webkit-background-origin": {
-    "logical-alias-for": ["background-origin"]
+    "logical-alias-for": [
+      "background-origin"
+    ]
   },
   "-webkit-border-bottom-left-radius": {
-    "logical-alias-for": ["border-bottom-left-radius"]
+    "logical-alias-for": [
+      "border-bottom-left-radius"
+    ]
   },
   "-webkit-border-bottom-right-radius": {
-    "logical-alias-for": ["border-bottom-right-radius"]
+    "logical-alias-for": [
+      "border-bottom-right-radius"
+    ]
   },
   "-webkit-border-radius": {
-    "logical-alias-for": ["border-radius"]
+    "logical-alias-for": [
+      "border-radius"
+    ]
   },
   "-webkit-border-top-left-radius": {
-    "logical-alias-for": ["border-top-left-radius"]
+    "logical-alias-for": [
+      "border-top-left-radius"
+    ]
   },
   "-webkit-border-top-right-radius": {
-    "logical-alias-for": ["border-top-right-radius"]
+    "logical-alias-for": [
+      "border-top-right-radius"
+    ]
   },
   "-webkit-box-shadow": {
-    "logical-alias-for": ["box-shadow"]
+    "logical-alias-for": [
+      "box-shadow"
+    ]
   },
   "-webkit-box-sizing": {
-    "logical-alias-for": ["box-sizing"]
+    "logical-alias-for": [
+      "box-sizing"
+    ]
   },
   "-webkit-flex": {
-    "logical-alias-for": ["flex"]
+    "logical-alias-for": [
+      "flex"
+    ]
   },
   "-webkit-flex-basis": {
-    "logical-alias-for": ["flex-basis"]
+    "logical-alias-for": [
+      "flex-basis"
+    ]
   },
   "-webkit-flex-direction": {
-    "logical-alias-for": ["flex-direction"]
+    "logical-alias-for": [
+      "flex-direction"
+    ]
   },
   "-webkit-flex-flow": {
-    "logical-alias-for": ["flex-flow"]
+    "logical-alias-for": [
+      "flex-flow"
+    ]
   },
   "-webkit-flex-grow": {
-    "logical-alias-for": ["flex-grow"]
+    "logical-alias-for": [
+      "flex-grow"
+    ]
   },
   "-webkit-flex-shrink": {
-    "logical-alias-for": ["flex-shrink"]
+    "logical-alias-for": [
+      "flex-shrink"
+    ]
   },
   "-webkit-flex-wrap": {
-    "logical-alias-for": ["flex-wrap"]
+    "logical-alias-for": [
+      "flex-wrap"
+    ]
   },
   "-webkit-justify-content": {
-    "logical-alias-for": ["justify-content"]
+    "logical-alias-for": [
+      "justify-content"
+    ]
   },
   "-webkit-mask": {
-    "logical-alias-for": ["mask"]
+    "logical-alias-for": [
+      "mask"
+    ]
   },
   "-webkit-order": {
-    "logical-alias-for": ["order"]
+    "logical-alias-for": [
+      "order"
+    ]
   },
   "-webkit-text-fill-color": {
     "animation-type": "by-computed-value",
     "inherited": true,
     "initial": "currentColor",
-    "valid-types": ["color"]
+    "valid-types": [
+      "color"
+    ]
   },
   "-webkit-transform": {
-    "logical-alias-for": ["transform"]
+    "logical-alias-for": [
+      "transform"
+    ]
   },
   "-webkit-transform-origin": {
-    "logical-alias-for": ["transform-origin"]
+    "logical-alias-for": [
+      "transform-origin"
+    ]
   },
   "-webkit-transition": {
-    "logical-alias-for": ["transition"]
+    "logical-alias-for": [
+      "transition"
+    ]
   },
   "-webkit-transition-delay": {
-    "logical-alias-for": ["transition-delay"]
+    "logical-alias-for": [
+      "transition-delay"
+    ]
   },
   "-webkit-transition-duration": {
-    "logical-alias-for": ["transition-duration"]
+    "logical-alias-for": [
+      "transition-duration"
+    ]
   },
   "-webkit-transition-property": {
-    "logical-alias-for": ["transition-property"]
+    "logical-alias-for": [
+      "transition-property"
+    ]
   },
   "-webkit-transition-timing-function": {
-    "logical-alias-for": ["transition-timing-function"]
+    "logical-alias-for": [
+      "transition-timing-function"
+    ]
   },
   "accent-color": {
     "animation-type": "by-computed-value",
@@ -459,8 +537,8 @@
     ]
   },
   "border-bottom-color": {
-      "affects-layout": false,
-      "animation-type": "by-computed-value",
+    "affects-layout": false,
+    "animation-type": "by-computed-value",
     "initial": "currentcolor",
     "inherited": false,
     "valid-types": [
@@ -842,7 +920,9 @@
     "animation-type": "discrete",
     "inherited": true,
     "initial": "nonzero",
-    "valid-types": [ "fill-rule" ]
+    "valid-types": [
+      "fill-rule"
+    ]
   },
   "color": {
     "affects-layout": false,
@@ -994,7 +1074,9 @@
     "animation-type": "discrete",
     "inherited": true,
     "initial": "nonzero",
-    "valid-types": [ "fill-rule" ]
+    "valid-types": [
+      "fill-rule"
+    ]
   },
   "flex": {
     "inherited": false,
@@ -1459,11 +1541,11 @@
     ]
   },
   "inline-size": {
-      "logical-alias-for": [
-        "width"
-      ],
-      "initial": "auto",
-      "max-values": 1
+    "logical-alias-for": [
+      "width"
+    ],
+    "initial": "auto",
+    "max-values": 1
   },
   "inset": {
     "inherited": false,
@@ -2280,7 +2362,9 @@
     "animation-type": "by-computed-value",
     "inherited": false,
     "initial": "auto",
-    "valid-types": [ "scrollbar-width" ],
+    "valid-types": [
+      "scrollbar-width"
+    ],
     "valid-identifiers": [
       "auto",
       "thin",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -986,6 +986,42 @@
       "content-visibility"
     ]
   },
+  "counter-increment": {
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "none",
+    "valid-types": [
+      "custom-ident",
+      "integer [-∞,∞]"
+    ],
+    "valid-identifiers": [
+      "none"
+    ]
+  },
+  "counter-reset": {
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "none",
+    "valid-types": [
+      "custom-ident",
+      "integer [-∞,∞]"
+    ],
+    "valid-identifiers": [
+      "none"
+    ]
+  },
+  "counter-set": {
+    "animation-type": "by-computed-value",
+    "inherited": false,
+    "initial": "none",
+    "valid-types": [
+      "custom-ident",
+      "integer [-∞,∞]"
+    ],
+    "valid-identifiers": [
+      "none"
+    ]
+  },
   "cursor": {
     "affects-layout": false,
     "animation-type": "discrete",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,6 +12,7 @@
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
@@ -647,7 +648,7 @@ Optional<CSS::Clear> StyleProperties::clear() const
     return value_id_to_clear(value->to_identifier());
 }
 
-StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(u32 initial_quote_nesting_level) const
+StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(DOM::Element& element, u32 initial_quote_nesting_level) const
 {
     auto value = property(CSS::PropertyID::Content);
     auto quotes_data = quotes();
@@ -710,8 +711,10 @@ StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(u32 in
                     dbgln("`{}` is not supported in `content` (yet?)", item->to_string());
                     break;
                 }
+            } else if (item->is_counter()) {
+                builder.append(item->as_counter().resolve(element));
             } else {
-                // TODO: Implement counters, images, and other things.
+                // TODO: Implement images, and other things.
                 dbgln("`{}` is not supported in `content` (yet?)", item->to_string());
             }
         }
@@ -723,8 +726,10 @@ StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(u32 in
             for (auto const& item : content_style_value.alt_text()->values()) {
                 if (item->is_string()) {
                     alt_text_builder.append(item->as_string().string_value());
+                } else if (item->is_counter()) {
+                    alt_text_builder.append(item->as_counter().resolve(element));
                 } else {
-                    // TODO: Implement counters
+                    dbgln("`{}` is not supported in `content` alt-text (yet?)", item->to_string());
                 }
             }
             content_data.alt_text = MUST(alt_text_builder.to_string());

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -85,7 +85,7 @@ public:
         CSS::ContentData content_data;
         u32 final_quote_nesting_level { 0 };
     };
-    ContentDataAndQuoteNestingLevel content(u32 initial_quote_nesting_level) const;
+    ContentDataAndQuoteNestingLevel content(DOM::Element&, u32 initial_quote_nesting_level) const;
     Optional<CSS::ContentVisibility> content_visibility() const;
     Optional<CSS::Cursor> cursor() const;
     Optional<CSS::WhiteSpace> white_space() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -177,6 +177,7 @@ public:
     int math_depth() const { return m_math_depth; }
 
     QuotesData quotes() const;
+    Vector<CounterData> counter_data(PropertyID) const;
 
     Optional<CSS::ScrollbarWidth> scrollbar_width() const;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/CSS/StyleValues/ColorStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ConicGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -21,6 +21,7 @@
 #include <LibWeb/CSS/StyleValues/ConicGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/ContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CounterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -92,6 +92,7 @@ using StyleValueVector = Vector<ValueComparingNonnullRefPtr<StyleValue const>>;
     __ENUMERATE_STYLE_VALUE_TYPE(Color, color)                             \
     __ENUMERATE_STYLE_VALUE_TYPE(ConicGradient, conic_gradient)            \
     __ENUMERATE_STYLE_VALUE_TYPE(Content, content)                         \
+    __ENUMERATE_STYLE_VALUE_TYPE(CounterDefinitions, counter_definitions)  \
     __ENUMERATE_STYLE_VALUE_TYPE(CustomIdent, custom_ident)                \
     __ENUMERATE_STYLE_VALUE_TYPE(Display, display)                         \
     __ENUMERATE_STYLE_VALUE_TYPE(Easing, easing)                           \

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -92,6 +92,7 @@ using StyleValueVector = Vector<ValueComparingNonnullRefPtr<StyleValue const>>;
     __ENUMERATE_STYLE_VALUE_TYPE(Color, color)                             \
     __ENUMERATE_STYLE_VALUE_TYPE(ConicGradient, conic_gradient)            \
     __ENUMERATE_STYLE_VALUE_TYPE(Content, content)                         \
+    __ENUMERATE_STYLE_VALUE_TYPE(Counter, counter)                         \
     __ENUMERATE_STYLE_VALUE_TYPE(CounterDefinitions, counter_definitions)  \
     __ENUMERATE_STYLE_VALUE_TYPE(CustomIdent, custom_ident)                \
     __ENUMERATE_STYLE_VALUE_TYPE(Display, display)                         \

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "CounterDefinitionsStyleValue.h"
+#include <LibWeb/CSS/Serialize.h>
+
+namespace Web::CSS {
+
+String CounterDefinitionsStyleValue::to_string() const
+{
+    StringBuilder stb;
+
+    for (auto const& counter_definition : m_counter_definitions) {
+        if (!stb.is_empty())
+            stb.append(' ');
+
+        if (counter_definition.is_reversed)
+            stb.appendff("reversed({})", counter_definition.name);
+        else
+            stb.append(counter_definition.name);
+
+        if (counter_definition.value)
+            stb.appendff(" {}", counter_definition.value->to_string());
+    }
+
+    return stb.to_string_without_validation();
+}
+
+bool CounterDefinitionsStyleValue::properties_equal(CounterDefinitionsStyleValue const& other) const
+{
+    if (m_counter_definitions.size() != other.counter_definitions().size())
+        return false;
+
+    for (auto i = 0u; i < m_counter_definitions.size(); i++) {
+        auto const& ours = m_counter_definitions[i];
+        auto const& theirs = other.counter_definitions()[i];
+        if (ours.name != theirs.name || ours.is_reversed != theirs.is_reversed || ours.value != theirs.value)
+            return false;
+    }
+    return true;
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+struct CounterDefinition {
+    FlyString name;
+    bool is_reversed;
+    ValueComparingRefPtr<StyleValue const> value;
+};
+
+/**
+ * Holds a list of CounterDefinitions.
+ * Shared between counter-increment, counter-reset, and counter-set properties that have (almost) identical grammar.
+ */
+class CounterDefinitionsStyleValue : public StyleValueWithDefaultOperators<CounterDefinitionsStyleValue> {
+public:
+    static ValueComparingNonnullRefPtr<CounterDefinitionsStyleValue> create(Vector<CounterDefinition> counter_definitions)
+    {
+        return adopt_ref(*new (nothrow) CounterDefinitionsStyleValue(move(counter_definitions)));
+    }
+    virtual ~CounterDefinitionsStyleValue() override = default;
+
+    auto const& counter_definitions() const { return m_counter_definitions; }
+    virtual String to_string() const override;
+
+    bool properties_equal(CounterDefinitionsStyleValue const& other) const;
+
+private:
+    explicit CounterDefinitionsStyleValue(Vector<CounterDefinition> counter_definitions)
+        : StyleValueWithDefaultOperators(Type::CounterDefinitions)
+        , m_counter_definitions(move(counter_definitions))
+    {
+    }
+
+    Vector<CounterDefinition> m_counter_definitions;
+};
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -1,13 +1,18 @@
 /*
+ * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "CounterStyleValue.h"
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
+#include <LibWeb/CSS/ValueID.h>
+#include <LibWeb/DOM/Element.h>
 
 namespace Web::CSS {
 
@@ -23,6 +28,107 @@ CounterStyleValue::CounterStyleValue(CounterFunction function, FlyString counter
 }
 
 CounterStyleValue::~CounterStyleValue() = default;
+
+// https://drafts.csswg.org/css-counter-styles-3/#generate-a-counter
+static String generate_a_counter_representation(StyleValue const& counter_style, i32 value)
+{
+    // When asked to generate a counter representation using a particular counter style for a particular
+    // counter value, follow these steps:
+    // TODO: 1. If the counter style is unknown, exit this algorithm and instead generate a counter representation
+    //    using the decimal style and the same counter value.
+    // TODO: 2. If the counter value is outside the range of the counter style, exit this algorithm and instead
+    //    generate a counter representation using the counter style’s fallback style and the same counter value.
+    // TODO: 3. Using the counter value and the counter algorithm for the counter style, generate an initial
+    //    representation for the counter value.
+    //    If the counter value is negative and the counter style uses a negative sign, instead generate an
+    //    initial representation using the absolute value of the counter value.
+    // TODO: 4. Prepend symbols to the representation as specified in the pad descriptor.
+    // TODO: 5. If the counter value is negative and the counter style uses a negative sign, wrap the representation
+    //    in the counter style’s negative sign as specified in the negative descriptor.
+    // TODO: 6. Return the representation.
+
+    // FIXME: Below is an ad-hoc implementation until we support @counter-style.
+    //  It's based largely on the ListItemMarkerBox code, with minimal adjustments.
+    if (counter_style.is_custom_ident()) {
+        auto counter_style_name = counter_style.as_custom_ident().custom_ident();
+        auto identifier = value_id_from_string(counter_style_name);
+        if (identifier.has_value()) {
+            auto list_style_type = value_id_to_list_style_type(*identifier);
+            if (list_style_type.has_value()) {
+                switch (*list_style_type) {
+                case ListStyleType::Square:
+                    return "▪"_string;
+                case ListStyleType::Circle:
+                    return "◦"_string;
+                case ListStyleType::Disc:
+                    return "•"_string;
+                case ListStyleType::DisclosureClosed:
+                    return "▸"_string;
+                case ListStyleType::DisclosureOpen:
+                    return "▾"_string;
+                case ListStyleType::Decimal:
+                    return MUST(String::formatted("{}", value));
+                case ListStyleType::DecimalLeadingZero:
+                    // This is weird, but in accordance to spec.
+                    if (value < 10)
+                        return MUST(String::formatted("0{}", value));
+                    return MUST(String::formatted("{}", value));
+                case ListStyleType::LowerAlpha:
+                case ListStyleType::LowerLatin:
+                    return MUST(String::from_byte_string(ByteString::bijective_base_from(value - 1).to_lowercase()));
+                case ListStyleType::UpperAlpha:
+                case ListStyleType::UpperLatin:
+                    return MUST(String::from_byte_string(ByteString::bijective_base_from(value - 1)));
+                case ListStyleType::LowerRoman:
+                    return MUST(String::from_byte_string(ByteString::roman_number_from(value).to_lowercase()));
+                case ListStyleType::UpperRoman:
+                    return MUST(String::from_byte_string(ByteString::roman_number_from(value)));
+                default:
+                    break;
+                }
+            }
+        }
+    }
+    // FIXME: Handle `symbols()` function for counter_style.
+
+    dbgln("FIXME: Unsupported counter style '{}'", counter_style.to_string());
+    return MUST(String::formatted("{}", value));
+}
+
+String CounterStyleValue::resolve(DOM::Element& element) const
+{
+    // "If no counter named <counter-name> exists on an element where counter() or counters() is used,
+    // one is first instantiated with a starting value of 0."
+    auto& counters_set = element.ensure_counters_set();
+    if (!counters_set.last_counter_with_name(m_properties.counter_name).has_value())
+        counters_set.instantiate_a_counter(m_properties.counter_name, element.unique_id(), false, 0);
+
+    // counter( <counter-name>, <counter-style>? )
+    // "Represents the value of the innermost counter in the element’s CSS counters set named <counter-name>
+    // using the counter style named <counter-style>."
+    if (m_properties.function == CounterFunction::Counter) {
+        // NOTE: This should always be present because of the handling of a missing counter above.
+        auto& counter = counters_set.last_counter_with_name(m_properties.counter_name).value();
+        return generate_a_counter_representation(m_properties.counter_style, counter.value.value_or(0).value());
+    }
+
+    // counters( <counter-name>, <string>, <counter-style>? )
+    // "Represents the values of all the counters in the element’s CSS counters set named <counter-name>
+    // using the counter style named <counter-style>, sorted in outermost-first to innermost-last order
+    // and joined by the specified <string>."
+    // NOTE: The way counters sets are inherited, this should be the order they appear in the counters set.
+    StringBuilder stb;
+    for (auto const& counter : counters_set.counters()) {
+        if (counter.name != m_properties.counter_name)
+            continue;
+
+        auto counter_string = generate_a_counter_representation(m_properties.counter_style, counter.value.value_or(0).value());
+        if (!stb.is_empty())
+            stb.append(m_properties.join_string);
+        stb.append(counter_string);
+    }
+    return stb.to_string_without_validation();
+}
 
 // https://drafts.csswg.org/cssom-1/#ref-for-typedef-counter
 String CounterStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "CounterStyleValue.h"
+#include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
+#include <LibWeb/CSS/StyleValues/StringStyleValue.h>
+
+namespace Web::CSS {
+
+CounterStyleValue::CounterStyleValue(CounterFunction function, FlyString counter_name, ValueComparingNonnullRefPtr<StyleValue const> counter_style, FlyString join_string)
+    : StyleValueWithDefaultOperators(Type::Counter)
+    , m_properties {
+        .function = function,
+        .counter_name = move(counter_name),
+        .counter_style = move(counter_style),
+        .join_string = move(join_string)
+    }
+{
+}
+
+CounterStyleValue::~CounterStyleValue() = default;
+
+// https://drafts.csswg.org/cssom-1/#ref-for-typedef-counter
+String CounterStyleValue::to_string() const
+{
+    // The return value of the following algorithm:
+    // 1. Let s be the empty string.
+    StringBuilder s;
+
+    // 2. If <counter> has three CSS component values append the string "counters(" to s.
+    if (m_properties.function == CounterFunction::Counters)
+        s.append("counters("sv);
+
+    // 3. If <counter> has two CSS component values append the string "counter(" to s.
+    else if (m_properties.function == CounterFunction::Counter)
+        s.append("counter("sv);
+
+    // 4. Let list be a list of CSS component values belonging to <counter>,
+    //    omitting the last CSS component value if it is "decimal".
+    Vector<RefPtr<StyleValue const>> list;
+    list.append(CustomIdentStyleValue::create(m_properties.counter_name));
+    if (m_properties.function == CounterFunction::Counters)
+        list.append(StringStyleValue::create(m_properties.join_string.to_string()));
+    if (m_properties.counter_style->to_identifier() != ValueID::Decimal)
+        list.append(m_properties.counter_style);
+
+    // 5. Let each item in list be the result of invoking serialize a CSS component value on that item.
+    // 6. Append the result of invoking serialize a comma-separated list on list to s.
+    serialize_a_comma_separated_list(s, list, [](auto& builder, auto& item) {
+        builder.append(item->to_string());
+    });
+
+    // 7. Append ")" (U+0029) to s.
+    s.append(")"sv);
+
+    // 8. Return s.
+    return MUST(s.to_string());
+}
+
+bool CounterStyleValue::properties_equal(CounterStyleValue const& other) const
+{
+    return m_properties == other.m_properties;
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-lists-3/#counter-functions
+class CounterStyleValue : public StyleValueWithDefaultOperators<CounterStyleValue> {
+public:
+    enum class CounterFunction {
+        Counter,
+        Counters,
+    };
+
+    static ValueComparingNonnullRefPtr<CounterStyleValue> create_counter(FlyString counter_name, ValueComparingNonnullRefPtr<StyleValue const> counter_style)
+    {
+        return adopt_ref(*new (nothrow) CounterStyleValue(CounterFunction::Counter, move(counter_name), move(counter_style), {}));
+    }
+    static ValueComparingNonnullRefPtr<CounterStyleValue> create_counters(FlyString counter_name, FlyString join_string, ValueComparingNonnullRefPtr<StyleValue const> counter_style)
+    {
+        return adopt_ref(*new (nothrow) CounterStyleValue(CounterFunction::Counters, move(counter_name), move(counter_style), move(join_string)));
+    }
+    virtual ~CounterStyleValue() override;
+
+    CounterFunction function_type() const { return m_properties.function; }
+    auto counter_name() const { return m_properties.counter_name; }
+    auto counter_style() const { return m_properties.counter_style; }
+    auto join_string() const { return m_properties.join_string; }
+
+    String resolve(DOM::Element&) const;
+
+    virtual String to_string() const override;
+
+    bool properties_equal(CounterStyleValue const& other) const;
+
+private:
+    explicit CounterStyleValue(CounterFunction, FlyString counter_name, ValueComparingNonnullRefPtr<StyleValue const> counter_style, FlyString join_string);
+
+    struct Properties {
+        CounterFunction function;
+        FlyString counter_name;
+        ValueComparingNonnullRefPtr<StyleValue const> counter_style;
+        FlyString join_string;
+        bool operator==(Properties const&) const = default;
+    } m_properties;
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2717,16 +2717,27 @@ CSS::CountersSet& Element::ensure_counters_set()
 }
 
 // https://drafts.csswg.org/css-lists-3/#auto-numbering
-void Element::resolve_counters(CSS::StyleProperties&)
+void Element::resolve_counters(CSS::StyleProperties& style)
 {
     // Resolving counter values on a given element is a multi-step process:
 
     // 1. Existing counters are inherited from previous elements.
     inherit_counters();
 
-    // TODO: 2. New counters are instantiated (counter-reset).
-    // TODO: 3. Counter values are incremented (counter-increment).
-    // TODO: 4. Counter values are explicitly set (counter-set).
+    // 2. New counters are instantiated (counter-reset).
+    auto counter_reset = style.counter_data(CSS::PropertyID::CounterReset);
+    for (auto const& counter : counter_reset)
+        ensure_counters_set().instantiate_a_counter(counter.name, unique_id(), counter.is_reversed, counter.value);
+
+    // 3. Counter values are incremented (counter-increment).
+    auto counter_increment = style.counter_data(CSS::PropertyID::CounterIncrement);
+    for (auto const& counter : counter_increment)
+        ensure_counters_set().increment_a_counter(counter.name, unique_id(), *counter.value);
+
+    // 4. Counter values are explicitly set (counter-set).
+    auto counter_set = style.counter_data(CSS::PropertyID::CounterSet);
+    for (auto const& counter : counter_set)
+        ensure_counters_set().set_a_counter(counter.name, unique_id(), *counter.value);
 
     // 5. Counter values are used (counter()/counters()).
     // NOTE: This happens when we process the `content` property.

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2702,4 +2702,92 @@ WebIDL::ExceptionOr<void> Element::set_html_unsafe(StringView html)
     return {};
 }
 
+Optional<CSS::CountersSet const&> Element::counters_set()
+{
+    if (!m_counters_set)
+        return {};
+    return *m_counters_set;
+}
+
+CSS::CountersSet& Element::ensure_counters_set()
+{
+    if (!m_counters_set)
+        m_counters_set = make<CSS::CountersSet>();
+    return *m_counters_set;
+}
+
+// https://drafts.csswg.org/css-lists-3/#auto-numbering
+void Element::resolve_counters(CSS::StyleProperties&)
+{
+    // Resolving counter values on a given element is a multi-step process:
+
+    // 1. Existing counters are inherited from previous elements.
+    inherit_counters();
+
+    // TODO: 2. New counters are instantiated (counter-reset).
+    // TODO: 3. Counter values are incremented (counter-increment).
+    // TODO: 4. Counter values are explicitly set (counter-set).
+
+    // 5. Counter values are used (counter()/counters()).
+    // NOTE: This happens when we process the `content` property.
+}
+
+// https://drafts.csswg.org/css-lists-3/#inherit-counters
+void Element::inherit_counters()
+{
+    // 1. If element is the root of its document tree, the element has an initially-empty CSS counters set.
+    //    Return.
+    auto* parent = parent_element();
+    if (parent == nullptr) {
+        // NOTE: We represent an empty counters set with `m_counters_set = nullptr`.
+        m_counters_set = nullptr;
+        return;
+    }
+
+    // 2. Let element counters, representing element’s own CSS counters set, be a copy of the CSS counters
+    //    set of element’s parent element.
+    OwnPtr<CSS::CountersSet> element_counters;
+    // OPTIMIZATION: If parent has a set, we create a copy. Otherwise, we avoid allocating one until we need
+    // to add something to it.
+    auto ensure_element_counters = [&]() {
+        if (!element_counters)
+            element_counters = make<CSS::CountersSet>();
+    };
+    if (parent->has_non_empty_counters_set()) {
+        element_counters = make<CSS::CountersSet>();
+        *element_counters = *parent_element()->counters_set();
+    }
+
+    // 3. Let sibling counters be the CSS counters set of element’s preceding sibling (if it has one),
+    //    or an empty CSS counters set otherwise.
+    //    For each counter of sibling counters, if element counters does not already contain a counter with
+    //    the same name, append a copy of counter to element counters.
+    if (auto* const sibling = previous_sibling_of_type<Element>(); sibling && sibling->has_non_empty_counters_set()) {
+        auto& sibling_counters = sibling->counters_set().release_value();
+        ensure_element_counters();
+        for (auto const& counter : sibling_counters.counters()) {
+            if (!element_counters->last_counter_with_name(counter.name).has_value())
+                element_counters->append_copy(counter);
+        }
+    }
+
+    // 4. Let value source be the CSS counters set of the element immediately preceding element in tree order.
+    //    For each source counter of value source, if element counters contains a counter with the same name
+    //    and creator, then set the value of that counter to source counter’s value.
+    if (auto* const previous = previous_element_in_pre_order(); previous && previous->has_non_empty_counters_set()) {
+        // NOTE: If element_counters is empty (AKA null) then we can skip this since nothing will match.
+        if (element_counters) {
+            auto& value_source = previous->counters_set().release_value();
+            for (auto const& source_counter : value_source.counters()) {
+                auto maybe_existing_counter = element_counters->counter_with_same_name_and_creator(source_counter.name, source_counter.originating_element_id);
+                if (maybe_existing_counter.has_value())
+                    maybe_existing_counter->value = source_counter.value;
+            }
+        }
+    }
+
+    VERIFY(!element_counters || !element_counters->is_empty());
+    m_counters_set = move(element_counters);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2724,6 +2724,13 @@ void Element::resolve_counters(CSS::StyleProperties& style)
     // 1. Existing counters are inherited from previous elements.
     inherit_counters();
 
+    // https://drafts.csswg.org/css-lists-3/#counters-without-boxes
+    // An element that does not generate a box (for example, an element with display set to none,
+    // or a pseudo-element with content set to none) cannot set, reset, or increment a counter.
+    // The counter properties are still valid on such an element, but they must have no effect.
+    if (style.display().is_none())
+        return;
+
     // 2. New counters are instantiated (counter-reset).
     auto counter_reset = style.counter_data(CSS::PropertyID::CounterReset);
     for (auto const& counter : counter_reset)

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -11,6 +11,7 @@
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
+#include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
 #include <LibWeb/CSS/StyleProperty.h>
@@ -399,6 +400,12 @@ public:
     void set_in_top_layer(bool in_top_layer) { m_in_top_layer = in_top_layer; }
     bool in_top_layer() const { return m_in_top_layer; }
 
+    bool has_non_empty_counters_set() const { return m_counters_set; }
+    Optional<CSS::CountersSet const&> counters_set();
+    CSS::CountersSet& ensure_counters_set();
+    void resolve_counters(CSS::StyleProperties&);
+    void inherit_counters();
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -476,6 +483,8 @@ private:
     Array<CSSPixelPoint, 3> m_scroll_offset;
 
     bool m_in_top_layer { false };
+
+    OwnPtr<CSS::CountersSet> m_counters_set;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -119,6 +119,7 @@ class Clip;
 class ColorStyleValue;
 class ConicGradientStyleValue;
 class ContentStyleValue;
+class CounterDefinitionsStyleValue;
 class CustomIdentStyleValue;
 class Display;
 class DisplayStyleValue;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -119,6 +119,7 @@ class Clip;
 class ColorStyleValue;
 class ConicGradientStyleValue;
 class ContentStyleValue;
+class CounterStyleValue;
 class CounterDefinitionsStyleValue;
 class CustomIdentStyleValue;
 class Display;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -860,6 +860,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 
     computed_values.set_math_depth(computed_style.math_depth());
     computed_values.set_quotes(computed_style.quotes());
+    computed_values.set_counter_increment(computed_style.counter_data(CSS::PropertyID::CounterIncrement));
+    computed_values.set_counter_reset(computed_style.counter_data(CSS::PropertyID::CounterReset));
+    computed_values.set_counter_set(computed_style.counter_data(CSS::PropertyID::CounterSet));
 
     if (auto object_fit = computed_style.object_fit(); object_fit.has_value())
         computed_values.set_object_fit(object_fit.value());

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -751,8 +751,6 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (auto outline_width = computed_style.property(CSS::PropertyID::OutlineWidth); outline_width->is_length())
         computed_values.set_outline_width(outline_width->as_length().length());
 
-    // FIXME: Stop generating the content twice. (First time is in TreeBuilder.)
-    computed_values.set_content(computed_style.content(initial_quote_nesting_level()).content_data);
     computed_values.set_grid_auto_columns(computed_style.grid_auto_columns());
     computed_values.set_grid_auto_rows(computed_style.grid_auto_rows());
     computed_values.set_grid_template_columns(computed_style.grid_template_columns());

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -334,9 +334,11 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         element.clear_pseudo_element_nodes({});
         VERIFY(!element.needs_style_update());
         style = element.computed_css_values();
+        element.resolve_counters(*style);
         display = style->display();
         if (display.is_none())
             return;
+        // TODO: Implement changing element contents with the `content` property.
         if (context.layout_svg_mask_or_clip_path) {
             if (is<SVG::SVGMaskElement>(dom_node))
                 layout_node = document.heap().allocate_without_realm<Layout::SVGMaskBox>(document, static_cast<SVG::SVGMaskElement&>(dom_node), *style);

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -198,7 +198,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Se
         return;
 
     auto initial_quote_nesting_level = m_quote_nesting_level;
-    auto [pseudo_element_content, final_quote_nesting_level] = pseudo_element_style->content(initial_quote_nesting_level);
+    auto [pseudo_element_content, final_quote_nesting_level] = pseudo_element_style->content(element, initial_quote_nesting_level);
     m_quote_nesting_level = final_quote_nesting_level;
     auto pseudo_element_display = pseudo_element_style->display();
     // ::before and ::after only exist if they have content. `content: normal` computes to `none` for them.


### PR DESCRIPTION
Some screenshots:

![image](https://github.com/user-attachments/assets/322bd7f6-5453-4e17-9c0c-5cda90e034cc)

![image](https://github.com/user-attachments/assets/dd548b87-7418-41ff-9321-190c27191cc2)

The main limitation here is that pseudo-elements can't modify counter values. I repeatedly banged into walls while trying to make that work. There's probably a way (I mean, the other browsers have done it, and I don't think Firefox is capable of warping reality) but I'll leave it for now and hopefully have some kind of epiphany. :sweat_smile: 