### PR TITLE
AK+LibJS: Performance improvements for resolving large rope strings

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Badge.h>
 #include <AK/Error.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
@@ -301,6 +302,23 @@ public:
     operator ReadonlyBytes() const { return bytes(); }
 
     ALWAYS_INLINE size_t capacity() const { return m_inline ? inline_capacity : m_outline_capacity; }
+    ALWAYS_INLINE bool is_inline() const { return m_inline; }
+
+    struct OutlineBuffer {
+        Bytes buffer;
+        size_t capacity { 0 };
+    };
+    Optional<OutlineBuffer> leak_outline_buffer(Badge<StringBuilder>)
+    {
+        if (m_inline)
+            return {};
+
+        auto buffer = bytes();
+        m_inline = true;
+        m_size = 0;
+
+        return OutlineBuffer { buffer, capacity() };
+    }
 
 private:
     void move_from(ByteBuffer&& other)

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -16,6 +16,8 @@ namespace AK {
 namespace Detail {
 template<size_t inline_capacity>
 class ByteBuffer;
+
+class StringData;
 }
 
 enum class TrailingCodePointTransformation : u8;

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -96,6 +96,23 @@ ErrorOr<String> String::from_stream(Stream& stream, size_t byte_count)
     return result;
 }
 
+ErrorOr<String> String::from_string_builder(Badge<StringBuilder>, StringBuilder& builder)
+{
+    if (!Utf8View { builder.string_view() }.validate())
+        return Error::from_string_literal("String::from_string_builder: Input was not valid UTF-8");
+
+    String result;
+    result.replace_with_string_builder(builder);
+    return result;
+}
+
+String String::from_string_builder_without_validation(Badge<StringBuilder>, StringBuilder& builder)
+{
+    String result;
+    result.replace_with_string_builder(builder);
+    return result;
+}
+
 ErrorOr<String> String::repeated(u32 code_point, size_t count)
 {
     VERIFY(is_unicode(code_point));

--- a/AK/String.h
+++ b/AK/String.h
@@ -57,6 +57,9 @@ public:
 
     [[nodiscard]] static String from_utf8_without_validation(ReadonlyBytes);
 
+    static ErrorOr<String> from_string_builder(Badge<StringBuilder>, StringBuilder&);
+    [[nodiscard]] static String from_string_builder_without_validation(Badge<StringBuilder>, StringBuilder&);
+
     // Creates a new String from a sequence of UTF-16 encoded code points.
     static ErrorOr<String> from_utf16(Utf16View const&);
 

--- a/AK/StringBase.cpp
+++ b/AK/StringBase.cpp
@@ -90,6 +90,19 @@ bool StringBase::operator==(StringBase const& other) const
     return bytes() == other.bytes();
 }
 
+void StringBase::replace_with_string_builder(StringBuilder& builder)
+{
+    if (builder.length() <= MAX_SHORT_STRING_BYTE_COUNT) {
+        return replace_with_new_short_string(builder.length(), [&](Bytes buffer) {
+            builder.string_view().bytes().copy_to(buffer);
+        });
+    }
+
+    destroy_string();
+
+    m_data = &StringData::create_from_string_builder(builder).leak_ref();
+}
+
 ErrorOr<Bytes> StringBase::replace_with_uninitialized_buffer(size_t byte_count)
 {
     if (byte_count <= MAX_SHORT_STRING_BYTE_COUNT)

--- a/AK/StringBase.h
+++ b/AK/StringBase.h
@@ -92,6 +92,8 @@ protected:
             callback(buffer);
     }
 
+    void replace_with_string_builder(StringBuilder&);
+
     // This is not a trivial operation with storage, so it does not belong here. Unfortunately, it
     // is impossible to implement it without access to StringData.
     ErrorOr<StringBase> substring_from_byte_offset_with_shared_superstring(size_t start, size_t byte_count) const;

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -11,6 +11,7 @@
 #include <AK/FlyString.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/StringData.h>
 #include <AK/StringView.h>
 #include <AK/UnicodeUtils.h>
 #include <AK/Utf16View.h>
@@ -18,16 +19,33 @@
 
 namespace AK {
 
+static constexpr auto STRING_BASE_PREFIX_SIZE = sizeof(Detail::StringData);
+
+static ErrorOr<StringBuilder::Buffer> create_buffer(size_t capacity)
+{
+    StringBuilder::Buffer buffer;
+
+    if (capacity > StringBuilder::inline_capacity)
+        TRY(buffer.try_ensure_capacity(STRING_BASE_PREFIX_SIZE + capacity));
+
+    TRY(buffer.try_resize(STRING_BASE_PREFIX_SIZE));
+    return buffer;
+}
+
 ErrorOr<StringBuilder> StringBuilder::create(size_t initial_capacity)
 {
-    StringBuilder builder;
-    TRY(builder.m_buffer.try_ensure_capacity(initial_capacity));
-    return builder;
+    auto buffer = TRY(create_buffer(initial_capacity));
+    return StringBuilder { move(buffer) };
 }
 
 StringBuilder::StringBuilder(size_t initial_capacity)
+    : m_buffer(MUST(create_buffer(initial_capacity)))
 {
-    m_buffer.ensure_capacity(initial_capacity);
+}
+
+StringBuilder::StringBuilder(Buffer buffer)
+    : m_buffer(move(buffer))
+{
 }
 
 inline ErrorOr<void> StringBuilder::will_append(size_t size)
@@ -47,12 +65,12 @@ inline ErrorOr<void> StringBuilder::will_append(size_t size)
 
 size_t StringBuilder::length() const
 {
-    return m_buffer.size();
+    return m_buffer.size() - STRING_BASE_PREFIX_SIZE;
 }
 
 bool StringBuilder::is_empty() const
 {
-    return m_buffer.is_empty();
+    return length() == 0;
 }
 
 void StringBuilder::trim(size_t count)
@@ -122,14 +140,18 @@ ByteString StringBuilder::to_byte_string() const
     return ByteString((char const*)data(), length());
 }
 
-ErrorOr<String> StringBuilder::to_string() const
+ErrorOr<String> StringBuilder::to_string()
 {
-    return String::from_utf8(string_view());
+    if (m_buffer.is_inline())
+        return String::from_utf8(string_view());
+    return String::from_string_builder({}, *this);
 }
 
-String StringBuilder::to_string_without_validation() const
+String StringBuilder::to_string_without_validation()
 {
-    return String::from_utf8_without_validation(string_view().bytes());
+    if (m_buffer.is_inline())
+        return String::from_utf8_without_validation(string_view().bytes());
+    return String::from_string_builder_without_validation({}, *this);
 }
 
 FlyString StringBuilder::to_fly_string_without_validation() const
@@ -144,22 +166,22 @@ ErrorOr<FlyString> StringBuilder::to_fly_string() const
 
 u8* StringBuilder::data()
 {
-    return m_buffer.data();
+    return m_buffer.data() + STRING_BASE_PREFIX_SIZE;
 }
 
 u8 const* StringBuilder::data() const
 {
-    return m_buffer.data();
+    return m_buffer.data() + STRING_BASE_PREFIX_SIZE;
 }
 
 StringView StringBuilder::string_view() const
 {
-    return StringView { data(), m_buffer.size() };
+    return m_buffer.span().slice(STRING_BASE_PREFIX_SIZE);
 }
 
 void StringBuilder::clear()
 {
-    m_buffer.clear();
+    m_buffer.resize(STRING_BASE_PREFIX_SIZE);
 }
 
 ErrorOr<void> StringBuilder::try_append_code_point(u32 code_point)
@@ -269,6 +291,16 @@ ErrorOr<void> StringBuilder::try_append_escaped_for_json(StringView string)
                 TRY(try_append(ch));
         }
     }
+    return {};
+}
+
+auto StringBuilder::leak_buffer_for_string_construction(Badge<Detail::StringData>) -> Optional<Buffer::OutlineBuffer>
+{
+    if (auto buffer = m_buffer.leak_outline_buffer({}); buffer.has_value()) {
+        clear();
+        return buffer;
+    }
+
     return {};
 }
 

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -18,32 +18,6 @@
 
 namespace AK {
 
-inline ErrorOr<void> StringBuilder::will_append(size_t size)
-{
-    if (m_use_inline_capacity_only == UseInlineCapacityOnly::Yes) {
-        VERIFY(m_buffer.capacity() == StringBuilder::inline_capacity);
-        Checked<size_t> current_pointer = m_buffer.size();
-        current_pointer += size;
-        VERIFY(!current_pointer.has_overflow());
-        if (current_pointer <= StringBuilder::inline_capacity) {
-            return {};
-        }
-        return Error::from_errno(ENOMEM);
-    }
-
-    Checked<size_t> needed_capacity = m_buffer.size();
-    needed_capacity += size;
-    VERIFY(!needed_capacity.has_overflow());
-    // Prefer to completely use the existing capacity first
-    if (needed_capacity <= m_buffer.capacity())
-        return {};
-    Checked<size_t> expanded_capacity = needed_capacity;
-    expanded_capacity *= 2;
-    VERIFY(!expanded_capacity.has_overflow());
-    TRY(m_buffer.try_ensure_capacity(expanded_capacity.value()));
-    return {};
-}
-
 ErrorOr<StringBuilder> StringBuilder::create(size_t initial_capacity)
 {
     StringBuilder builder;
@@ -56,9 +30,19 @@ StringBuilder::StringBuilder(size_t initial_capacity)
     m_buffer.ensure_capacity(initial_capacity);
 }
 
-StringBuilder::StringBuilder(UseInlineCapacityOnly use_inline_capacity_only)
-    : m_use_inline_capacity_only(use_inline_capacity_only)
+inline ErrorOr<void> StringBuilder::will_append(size_t size)
 {
+    Checked<size_t> needed_capacity = m_buffer.size();
+    needed_capacity += size;
+    VERIFY(!needed_capacity.has_overflow());
+    // Prefer to completely use the existing capacity first
+    if (needed_capacity <= m_buffer.capacity())
+        return {};
+    Checked<size_t> expanded_capacity = needed_capacity;
+    expanded_capacity *= 2;
+    VERIFY(!expanded_capacity.has_overflow());
+    TRY(m_buffer.try_ensure_capacity(expanded_capacity.value()));
+    return {};
 }
 
 size_t StringBuilder::length() const

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -18,6 +18,7 @@ class StringBuilder {
 public:
     static constexpr size_t inline_capacity = 256;
 
+    using Buffer = Detail::ByteBuffer<inline_capacity>;
     using OutputType = ByteString;
 
     static ErrorOr<StringBuilder> create(size_t initial_capacity = inline_capacity);
@@ -61,8 +62,8 @@ public:
 
     [[nodiscard]] ByteString to_byte_string() const;
 
-    [[nodiscard]] String to_string_without_validation() const;
-    ErrorOr<String> to_string() const;
+    [[nodiscard]] String to_string_without_validation();
+    ErrorOr<String> to_string();
 
     [[nodiscard]] FlyString to_fly_string_without_validation() const;
     ErrorOr<FlyString> to_fly_string() const;
@@ -95,12 +96,16 @@ public:
         return {};
     }
 
+    Optional<Buffer::OutlineBuffer> leak_buffer_for_string_construction(Badge<Detail::StringData>);
+
 private:
+    explicit StringBuilder(Buffer);
+
     ErrorOr<void> will_append(size_t);
     u8* data();
     u8 const* data() const;
 
-    Detail::ByteBuffer<inline_capacity> m_buffer;
+    Buffer m_buffer;
 };
 
 }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -23,12 +23,6 @@ public:
     static ErrorOr<StringBuilder> create(size_t initial_capacity = inline_capacity);
 
     explicit StringBuilder(size_t initial_capacity = inline_capacity);
-
-    enum class UseInlineCapacityOnly {
-        Yes,
-        No,
-    };
-    explicit StringBuilder(UseInlineCapacityOnly use_inline_capacity_only);
     ~StringBuilder() = default;
 
     ErrorOr<void> try_append(StringView);
@@ -106,7 +100,6 @@ private:
     u8* data();
     u8 const* data() const;
 
-    UseInlineCapacityOnly m_use_inline_capacity_only { UseInlineCapacityOnly::No };
     Detail::ByteBuffer<inline_capacity> m_buffer;
 };
 

--- a/AK/StringData.h
+++ b/AK/StringData.h
@@ -6,7 +6,11 @@
 
 #pragma once
 
+#include <AK/Error.h>
+#include <AK/FlyString.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
+#include <AK/StringBase.h>
 #include <AK/kmalloc.h>
 
 namespace AK::Detail {

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.cpp
@@ -254,6 +254,7 @@ void PrimitiveString::resolve_rope_if_needed(EncodingPreference preference) cons
     // This vector will hold all the pieces of the rope that need to be assembled
     // into the resolved string.
     Vector<PrimitiveString const*> pieces;
+    size_t approximate_length = 0;
 
     // NOTE: We traverse the rope tree without using recursion, since we'd run out of
     //       stack space quickly when handling a long sequence of unresolved concatenations.
@@ -267,6 +268,9 @@ void PrimitiveString::resolve_rope_if_needed(EncodingPreference preference) cons
             stack.append(current->m_lhs);
             continue;
         }
+
+        if (current->has_utf8_string())
+            approximate_length += current->utf8_string_view().length();
         pieces.append(current);
     }
 
@@ -286,7 +290,7 @@ void PrimitiveString::resolve_rope_if_needed(EncodingPreference preference) cons
     }
 
     // Now that we have all the pieces, we can concatenate them using a StringBuilder.
-    StringBuilder builder;
+    StringBuilder builder(approximate_length);
 
     // We keep track of the previous piece in order to handle surrogate pairs spread across two pieces.
     PrimitiveString const* previous = nullptr;


### PR DESCRIPTION
This makes 2 changes to improve rope string resolution:
1. Allow `StringBuilder` to transfer ownership of its string buffer to `String`, so we don't have to re-allocate and copy the string data
2. Allocate the resolved rope's `StringBuilder` capacity up front

For a ballpark idea of how we perform relative to other rope string implementations, I compared us to [fatal's rope string](https://github.com/facebook/fatal/blob/main/fatal/string/rope.h).

<details>
<summary>Benchmark code</summary><p>

```c++
static auto vm = JS::VM::create().release_value();

static auto create_libjs_rope()
{
    auto string = JS::PrimitiveString::create(vm, MUST(String::repeated("abcdef"_string, 200)));

    auto rope = JS::PrimitiveString::create(vm, string, string);
    for (size_t i = 0; i < 1'000'000; ++i)
        rope = JS::PrimitiveString::create(vm, rope, string);

    return rope;
}

static auto create_fatal_rope()
{
    auto string = ByteString::repeated("abcdef"sv, 200);

    auto rope = fatal::rope(string.characters(), string.characters());
    for (size_t i = 0; i < 1'000'000; ++i)
        rope.append(string.characters());

    return rope;
}

static auto libjs_rope = create_libjs_rope();
static auto fatal_rope = create_fatal_rope();

BENCHMARK_CASE(bench_libjs)
{
    auto resolved = libjs_rope->utf8_string();
    dbgln("libjs rope length = {}", resolved.bytes_as_string_view().length());
}

BENCHMARK_CASE(bench_fatal)
{
    std::string resolved = fatal_rope.to_string();
    dbgln("fatal rope length = {}", resolved.size());
}
```
</p></details>

| | Resolve Time |
|-|-|
| LibJS (before) | 2.07s |
| LibJS (after) | 0.466s |
| fatal | 0.478s |

The savings here amount to about ~0.5s for pre-allocating the `StringBuilder` and ~1.0s for handing the builder's buffer off without reallocation.