### PR TITLE
CI: Make the notes-push.yml workflow fetch the entire repo history

### DIFF
--- a/.github/workflows/notes-push.yml
+++ b/.github/workflows/notes-push.yml
@@ -9,7 +9,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: fregante/setup-git-user@v2
       - run: |
           git fetch origin "refs/notes/*:refs/notes/*"


### PR DESCRIPTION
This change makes the `notes-push.yml`·workflow fetch the entire history on each push, rather than just the one HEAD commit it otherwise sees.

Because we push multiple commits from PR merges, `git-gloss` need access on each push to an arbitrary number of commits (however many commits were pushed in a PR that got merged). There’s no easy way from GH Actions to know how may commits got pushed at the same time. So we instead fetch the whole history.
