### PR TITLE
LibWeb: Make details and summary elements display:block in the UA style

### DIFF
--- a/Tests/LibWeb/Layout/expected/details-closed.txt
+++ b/Tests/LibWeb/Layout/expected/details-closed.txt
@@ -1,24 +1,22 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
-      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
-        InlineNode <details>
-      ListItemBox <summary> at (32,8) content-size 760x17 children: inline
-        frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17] baseline: 13.296875
-            "I'm a summary"
-        TextNode <#text>
-        ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline
-      BlockContainer <slot> at (8,25) content-size 784x0 children: not-inline
+      BlockContainer <details> at (8,8) content-size 784x17 children: not-inline
+        ListItemBox <summary> at (32,8) content-size 760x17 children: inline
+          frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17] baseline: 13.296875
+              "I'm a summary"
+          TextNode <#text>
+          ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline
+        BlockContainer <slot> at (8,25) content-size 784x0 children: not-inline
       BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
-        InlinePaintable (InlineNode<DETAILS>)
-      PaintableWithLines (ListItemBox<SUMMARY>) [32,8 760x17]
-        TextPaintable (TextNode<#text>)
-        MarkerPaintable (ListItemMarkerBox(anonymous)) [8,8 12x17]
-      PaintableWithLines (BlockContainer<SLOT>) [8,25 784x0]
+      PaintableWithLines (BlockContainer<DETAILS>) [8,8 784x17]
+        PaintableWithLines (ListItemBox<SUMMARY>) [32,8 760x17]
+          TextPaintable (TextNode<#text>)
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [8,8 12x17]
+        PaintableWithLines (BlockContainer<SLOT>) [8,25 784x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]

--- a/Tests/LibWeb/Layout/expected/details-open.txt
+++ b/Tests/LibWeb/Layout/expected/details-open.txt
@@ -1,33 +1,31 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
-      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
-        InlineNode <details>
-      ListItemBox <summary> at (32,8) content-size 760x17 children: inline
-        frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17] baseline: 13.296875
-            "I'm a summary"
-        TextNode <#text>
-        ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline
-      BlockContainer <slot> at (8,25) content-size 784x17 children: inline
-        TextNode <#text>
-        TextNode <#text>
-        InlineNode <span>
-          frag 0 from TextNode start: 0, length: 10, rect: [8,25 82.3125x17] baseline: 13.296875
-              "I'm a node"
+      BlockContainer <details> at (8,8) content-size 784x34 children: not-inline
+        ListItemBox <summary> at (32,8) content-size 760x17 children: inline
+          frag 0 from TextNode start: 0, length: 13, rect: [32,8 114.625x17] baseline: 13.296875
+              "I'm a summary"
           TextNode <#text>
-        TextNode <#text>
+          ListItemMarkerBox <(anonymous)> at (8,8) content-size 12x17 children: not-inline
+        BlockContainer <slot> at (8,25) content-size 784x17 children: inline
+          TextNode <#text>
+          TextNode <#text>
+          InlineNode <span>
+            frag 0 from TextNode start: 0, length: 10, rect: [8,25 82.3125x17] baseline: 13.296875
+                "I'm a node"
+            TextNode <#text>
+          TextNode <#text>
       BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
-      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
-        InlinePaintable (InlineNode<DETAILS>)
-      PaintableWithLines (ListItemBox<SUMMARY>) [32,8 760x17]
-        TextPaintable (TextNode<#text>)
-        MarkerPaintable (ListItemMarkerBox(anonymous)) [8,8 12x17]
-      PaintableWithLines (BlockContainer<SLOT>) [8,25 784x17]
-        InlinePaintable (InlineNode<SPAN>)
+      PaintableWithLines (BlockContainer<DETAILS>) [8,8 784x34]
+        PaintableWithLines (ListItemBox<SUMMARY>) [32,8 760x17]
           TextPaintable (TextNode<#text>)
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [8,8 12x17]
+        PaintableWithLines (BlockContainer<SLOT>) [8,25 784x17]
+          InlinePaintable (InlineNode<SPAN>)
+            TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]

--- a/Tests/LibWeb/Layout/expected/details-summary-default-ua-style.txt
+++ b/Tests/LibWeb/Layout/expected/details-summary-default-ua-style.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x153 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x137 children: not-inline
+      BlockContainer <details> at (68,68) content-size 664x17 children: not-inline
+        ListItemBox <summary> at (92,68) content-size 640x17 children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [92,68 36.84375x17] baseline: 13.296875
+              "hello"
+          TextNode <#text>
+          ListItemMarkerBox <(anonymous)> at (68,68) content-size 12x17 children: not-inline
+        BlockContainer <slot> at (68,85) content-size 664x0 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x153]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x137]
+      PaintableWithLines (BlockContainer<DETAILS>) [8,8 784x137]
+        PaintableWithLines (ListItemBox<SUMMARY>) [92,68 640x17]
+          TextPaintable (TextNode<#text>)
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [68,68 12x17]
+        PaintableWithLines (BlockContainer<SLOT>) [68,85 664x0]

--- a/Tests/LibWeb/Layout/input/details-summary-default-ua-style.html
+++ b/Tests/LibWeb/Layout/input/details-summary-default-ua-style.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+     details {
+        border: 10px solid black;
+        padding: 50px;
+      }
+</style><details><summary>hello

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -801,9 +801,13 @@ input[type=image i][align=bottom i], object[align=bottom i] {
     vertical-align: bottom;
 }
 
-/* 15.5.4 The details and summary elements
+/* 15.5.5 The details and summary elements
  * https://html.spec.whatwg.org/multipage/rendering.html#the-details-and-summary-elements
  */
+
+details, summary {
+    display: block;
+}
 
 details > summary:first-of-type {
     display: list-item;


### PR DESCRIPTION
This is the expected behavior per the HTML spec. Fixes an issue where styling these elements wouldn't have the expected effect unless you also set the display property.

Visual progression on https://brave.com

Before:
![Screenshot from 2024-07-20 11-18-27](https://github.com/user-attachments/assets/cfadf712-bc60-4cf9-a8a4-cadc0b8353c6)

After:
![Screenshot from 2024-07-20 11-19-00](https://github.com/user-attachments/assets/2a5dadb3-a4c2-4297-9fbb-0d3941fe13de)

