### PR TITLE
Meta: Unbreak the NixOS development shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1738410390,
-        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
+        "lastModified": 1739446958,
+        "narHash": "sha256-+/bYK3DbPxMIvSL4zArkMX0LQvS7rzBKXnDXLfKyRVc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
+        "rev": "2ff53fe64443980e139eaa286017f53f88336dd0",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -2,12 +2,14 @@
   pkgs ? import <nixpkgs> { },
 }:
 
-pkgs.mkShell {
+(pkgs.buildFHSEnv {
+  name = "nix-shell";
+
   inputsFrom = [
     pkgs.ladybird
   ];
 
-  packages =
+  targetPkgs = pkgs:
     with pkgs;
     with pkgs.qt6Packages;
     with pkgs.nodePackages;
@@ -46,4 +48,4 @@ pkgs.mkShell {
     export QT_PLUGIN_PATH="$QT_PLUGIN_PATH:${pkgs.qt6.qtwayland}/lib/qt-6/plugins"
     export QT_QPA_PLATFORM="wayland;xcb"
   '';
-}
+}).env

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,20 @@ pkgs.mkShell {
       clang-tools
       pre-commit
       prettier
+
+      autoconf
+      autoconf-archive
+      automake
+      curl
+      ffmpeg.dev
+      glibc.dev
+      gnutar
+      libglvnd.dev
+      nasm
+      unzip
+      xorg.libX11.dev
+      xorg.xorgproto
+      zip
     ];
 
   # Fix for: https://github.com/LadybirdBrowser/ladybird/issues/371#issuecomment-2616415434

--- a/shell.nix
+++ b/shell.nix
@@ -11,17 +11,15 @@
 
   targetPkgs = pkgs:
     with pkgs;
-    with pkgs.qt6Packages;
-    with pkgs.nodePackages;
     [
-      qtbase.dev
-      qttools
-      qtwayland.dev
+      qt6Packages.qtbase.dev
+      qt6Packages.qttools
+      qt6Packages.qtwayland.dev
 
       ccache
       clang-tools
+      nodePackages.prettier
       pre-commit
-      prettier
 
       autoconf
       autoconf-archive

--- a/shell.nix
+++ b/shell.nix
@@ -5,13 +5,36 @@
 (pkgs.buildFHSEnv {
   name = "nix-shell";
 
-  inputsFrom = [
-    pkgs.ladybird
-  ];
-
   targetPkgs = pkgs:
     with pkgs;
     [
+      cmake
+      ninja
+      pkg-config
+      python3
+
+      curl
+      ffmpeg
+      fontconfig
+      libavif
+      libGL
+      libjxl
+      libwebp
+      libxcrypt
+      openssl
+      qt6Packages.qtbase
+      qt6Packages.qtmultimedia
+      simdutf
+      (skia.overrideAttrs (prev: {
+        gnFlags = prev.gnFlags ++ [
+          # https://github.com/LadybirdBrowser/ladybird/commit/af3d46dc06829dad65309306be5ea6fbc6a587ec
+          # https://github.com/LadybirdBrowser/ladybird/commit/4d7b7178f9d50fff97101ea18277ebc9b60e2c7c
+          # Remove when/if this gets upstreamed in skia.
+          "extra_cflags+=[\"-DSKCMS_API=__attribute__((visibility(\\\"default\\\")))\"]"
+        ];
+      }))
+      woff2
+
       qt6Packages.qtbase.dev
       qt6Packages.qttools
       qt6Packages.qtwayland.dev
@@ -34,6 +57,13 @@
       xorg.libX11.dev
       xorg.xorgproto
       zip
+
+      # Linux-specific
+      libpulseaudio.dev
+      qt6Packages.qtwayland
+
+      # Darwin-specific (optionals fails for reasons?)
+      #apple-sdk_14
     ];
 
   # Fix for: https://github.com/LadybirdBrowser/ladybird/issues/371#issuecomment-2616415434


### PR DESCRIPTION
Currently still fails to find OpenGL libraries (and depends on an uprev to NixOS/nixpkgs#328685), and therefore a draft:

```
-- Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_glx_LIBRARY OPENGL_INCLUDE_DIR) 
-- Could NOT find OpenGL (missing: OPENGL_opengl_LIBRARY OPENGL_INCLUDE_DIR OpenGL) 
-- Could NOT find WrapOpenGL (missing: WrapOpenGL_FOUND) 
CMake Warning at Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Found package configuration file:

    /usr/lib64/cmake/Qt6Gui/Qt6GuiConfig.cmake

  but it set Qt6Gui_FOUND to FALSE so package "Qt6Gui" is considered to be
  NOT FOUND.  Reason given by package:

  Qt6Gui could not be found because dependency WrapOpenGL could not be found.

  Configuring with --debug-find-pkg=WrapOpenGL might reveal details why the
  package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.

Call Stack (most recent call first):
  /nix/store/ll2b6cslly4v30im7qk34f9y21ziiz1i-cmake-3.29.6/share/cmake-3.29/Modules/CMakeFindDependencyMacro.cmake:76 (find_package)
  /usr/lib/cmake/Qt6/QtPublicDependencyHelpers.cmake:111 (find_dependency)
  /usr/lib64/cmake/Qt6Widgets/Qt6WidgetsDependencies.cmake:42 (_qt_internal_find_qt_dependencies)
  /usr/lib64/cmake/Qt6Widgets/Qt6WidgetsConfig.cmake:43 (include)
  Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  /usr/lib64/cmake/Qt6/Qt6Config.cmake:169 (find_package)
  Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:83 (find_package)


CMake Warning at Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Found package configuration file:

    /usr/lib64/cmake/Qt6Widgets/Qt6WidgetsConfig.cmake

  but it set Qt6Widgets_FOUND to FALSE so package "Qt6Widgets" is considered
  to be NOT FOUND.  Reason given by package:

  Qt6Widgets could not be found because dependency Qt6Gui could not be found.

  Configuring with --debug-find-pkg=Qt6Gui might reveal details why the
  package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.

Call Stack (most recent call first):
  /usr/lib64/cmake/Qt6/Qt6Config.cmake:169 (find_package)
  Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
  CMakeLists.txt:83 (find_package)


CMake Error at Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package):
  Found package configuration file:

    /usr/lib64/cmake/Qt6/Qt6Config.cmake

  but it set Qt6_FOUND to FALSE so package "Qt6" is considered to be NOT
  FOUND.  Reason given by package:

  Failed to find required Qt component "Widgets".

  Expected Config file at
  "/usr/lib64/cmake/Qt6Widgets/Qt6WidgetsConfig.cmake" exists



  Configuring with --debug-find-pkg=Qt6Widgets might reveal details why the
  package was not found.

  Configuring with -DQT_DEBUG_FIND_PACKAGE=ON will print the values of some
  of the path variables that find_package uses to try and find the package.

Call Stack (most recent call first):
  CMakeLists.txt:83 (find_package)
```