### PR TITLE
LibWeb: Stub missing attributes in SVGLength & HTMLImageElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -38,4 +38,8 @@ interface HTMLImageElement : HTMLElement {
 
     [CEReactions, LegacyNullToEmptyString, Reflect] attribute DOMString border;
 
+    // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlimageelement-interface
+    [FIXME] readonly attribute long x;
+    [FIXME] readonly attribute long y;
+
 };

--- a/Userland/Libraries/LibWeb/HTML/History.idl
+++ b/Userland/Libraries/LibWeb/HTML/History.idl
@@ -1,8 +1,11 @@
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#scrollrestoration
+enum ScrollRestoration { "auto", "manual" };
+
 // https://html.spec.whatwg.org/multipage/history.html#the-history-interface
 [Exposed=Window]
 interface History {
     readonly attribute unsigned long length;
-    // FIXME: attribute ScrollRestoration scrollRestoration;
+    [FIXME] attribute ScrollRestoration scrollRestoration;
     readonly attribute any state;
     undefined go(optional long delta = 0);
     undefined back();

--- a/Userland/Libraries/LibWeb/SVG/SVGLength.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGLength.idl
@@ -15,12 +15,10 @@ interface SVGLength {
 
     readonly attribute unsigned short unitType;
 
-    // FIXME: Support setraises().
-    attribute float value; // setraises(DOMException);
+    attribute float value;
+    [FIXME] attribute float valueInSpecifiedUnits;
+    [FIXME] attribute DOMString valueAsString;
 
-    // attribute float valueInSpecifiedUnits setraises(DOMException);
-    // attribute DOMString valueAsString setraises(DOMException);
-
-    // void newValueSpecifiedUnits(in unsigned short unitType, in float valueInSpecifiedUnits) raises(DOMException);
-    // void convertToSpecifiedUnits(in unsigned short unitType) raises(DOMException);
+    [FIXME] undefined newValueSpecifiedUnits(unsigned short unitType, float valueInSpecifiedUnits);
+    [FIXME] undefined convertToSpecifiedUnits(unsigned short unitType);
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Layout/SVGGraphicsBox.h>
 #include <LibWeb/SVG/AttributeNames.h>
+#include <LibWeb/SVG/SVGAnimatedRect.h>
 #include <LibWeb/SVG/SVGSymbolElement.h>
 #include <LibWeb/SVG/SVGUseElement.h>
 
@@ -29,6 +30,13 @@ void SVGSymbolElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGSymbolElement);
+    m_view_box_for_bindings = heap().allocate<SVGAnimatedRect>(realm, realm);
+}
+
+void SVGSymbolElement::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_view_box_for_bindings);
 }
 
 // https://svgwg.org/svg2-draft/struct.html#SymbolNotes
@@ -45,8 +53,14 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
 void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
 {
     Base::attribute_changed(name, old_value, value);
-    if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox))
+    if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox)) {
         m_view_box = try_parse_view_box(value.value_or(String {}));
+        m_view_box_for_bindings->set_nulled(!m_view_box.has_value());
+        if (m_view_box.has_value()) {
+            m_view_box_for_bindings->set_base_val(Gfx::DoubleRect { m_view_box->min_x, m_view_box->min_y, m_view_box->width, m_view_box->height });
+            m_view_box_for_bindings->set_anim_val(Gfx::DoubleRect { m_view_box->min_x, m_view_box->min_y, m_view_box->width, m_view_box->height });
+        }
+    }
 }
 
 bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -28,10 +28,13 @@ public:
         return {};
     }
 
+    JS::NonnullGCPtr<SVGAnimatedRect> view_box_for_bindings() { return *m_view_box_for_bindings; }
+
 private:
     SVGSymbolElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
@@ -40,6 +43,8 @@ private:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
 
     Optional<ViewBox> m_view_box;
+
+    JS::GCPtr<SVGAnimatedRect> m_view_box_for_bindings;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.idl
@@ -6,4 +6,4 @@ interface SVGSymbolElement : SVGGraphicsElement {
 
 };
 
-// FIXME: SVGSymbolElement includes SVGFitToViewBox;
+SVGSymbolElement includes SVGFitToViewBox;


### PR DESCRIPTION
Work towards [GH-24168](https://github.com/SerenityOS/serenity/issues/24168).

| Interface | Name | Status |
| --- | --- | --- |
| SVGSymbolElement | viewBox | Implemented |
| SVGSymbolElement | preserveAspectRatio | Stubbed |
| SVGLength | valueInSpecifiedUnits | Stubbed |
| SVGLength | valueAsString | Stubbed |
| SVGLength | newValueSpecifiedUnits | Stubbed |
| SVGLength | convertToSpecifiedUnits | Stubbed |
| HTMLImageElement | x | Stubbed |
| HTMLImageElement | y | Stubbed |
| History | scrollRestoration | Stubbed |