### PR TITLE
Documentation: Add a bit of history to the FAQ

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -32,3 +32,13 @@ Simple, my friend! Just refer to the [build instructions](BuildInstructionsLadyb
 If it builds on CI, it should build for you too. You may need to rebuild the toolchain. If that doesn't help, try it with a clean repo.
 
 If you can't figure out what to do, ask in the `#build-problems` channel on Discord.
+
+## Where did Ladybird come from?
+
+For full details, see the [Ladybird: A new cross-platform browser project](https://awesomekling.substack.com/p/ladybird-a-new-cross-platform-browser-project) announcement from 12 September 2022.
+
+Here’s a very short summary: Work on what eventually became Ladybird started on 15 June 2019, as _LibHTML_ — the beginnings of an HTML viewer for [SerenityOS](https://github.com/SerenityOS/serenity) — with a commit titled [“LibHTML: Start working on a simple HTML library”](https://github.com/SerenityOS/serenity/commit/a67e8238389), and with this commit description:
+
+> _I'd like to have rich text, and we might as well use HTML for that. :^)_
+
+LibHTML eventually became [LibWeb](https://github.com/LadybirdBrowser/ladybird/tree/master/Userland/Libraries/LibWeb) — which in turn eventually grew into being the core part of the browser engine and browser to which, on 4 July 2022, [the name _Ladybird_ was given](https://www.youtube.com/watch?v=X38MTKHt3_I&t=29s).


### PR DESCRIPTION
People do ask… — e.g., new folks showing up on the Discord server — and the FAQ is a place we’re already pointing them to, so it seems like maybe an appropriate/useful place to have this too.

Anyway, for reviewers, here are some comments:

- Wording: I’m not wedded to any of the particular wording, so any and all reviewers should please feel free to directly commit any changes you want to this. But if you prefer to make commit suggestions (from the GitHub web UI), that’d be find too.

- LibJS: As currently written, the patch here doesn’t mention LibJS at all. Maybe it should, I dunno. But for now I intentionally omitted it in the interest of trying to keep things shorter/simpler — and since this is after all a FAQ… (That said, I think it’d also be fine to include it.)