### PR TITLE
CI: Use single quotes for a literal string in `notes-push.yml`

### DIFF
--- a/.github/workflows/notes-push.yml
+++ b/.github/workflows/notes-push.yml
@@ -7,7 +7,7 @@ permissions:
   contents: write
 jobs:
   build:
-    if: github.repository == "LadybirdBrowser/ladybird"
+    if: github.repository == 'LadybirdBrowser/ladybird'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should stop the "Push notes" job from failing on CI.