### PR TITLE
LibWebView: Prevent displaying two scroll bars in the inspector console

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -75,7 +75,7 @@ body {
     border-radius: 0.5rem;
 
     margin-top: 30px;
-    padding: 8px;
+    padding: 8px 0px 0px 4px;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -73,6 +73,15 @@ const selectTopTab = (tabButton, tabID) => {
 const selectBottomTab = (tabButton, tabID) => {
     selectedBottomTab = selectTab(tabButton, tabID, selectedBottomTab, selectedBottomTabButton);
     selectedBottomTabButton = tabButton;
+
+    let inspectorBottom = document.getElementById("inspector-bottom");
+    inspectorBottom.scrollTo(0, 0);
+
+    if (tabID === "console") {
+        inspectorBottom.style.overflow = "hidden";
+    } else {
+        inspectorBottom.style.overflow = "scroll";
+    }
 };
 
 let initialTopTabButton = document.getElementById("dom-tree-button");


### PR DESCRIPTION
We currently display scroll bars for the JS console and its parent tab container. We want the console output to be separately scrollable from the tab content, but since both containers are scrollable, we end up with nested scroll bars. This also makes actually scrolling feel pretty awkward.

Prevent this by making the tab container non-scrollable when the JS console is shown.

Before:
![before](https://github.com/user-attachments/assets/b725f7c5-101c-4d60-8f8c-bec54bce7264)

After:
![after](https://github.com/user-attachments/assets/c0ea39a2-b994-4399-9529-04b1c9e12ba1)

