### PR TITLE
LibCore+LibWebView+UI: Raise the chrome process open file limit

### DIFF
--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -103,7 +103,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
     args_parser.parse(arguments);
 
-    WebView::ChromeProcess chrome_process;
+    auto chrome_process = TRY(WebView::ChromeProcess::create());
     if (!force_new_process && TRY(chrome_process.connect(raw_urls, new_window)) == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
         outln("Opening in existing process");
         return 0;

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -119,7 +119,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
     args_parser.parse(arguments);
 
-    WebView::ChromeProcess chrome_process;
+    auto chrome_process = TRY(WebView::ChromeProcess::create());
     if (!force_new_process && TRY(chrome_process.connect(raw_urls, new_window)) == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
         outln("Opening in existing process");
         return 0;

--- a/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
+++ b/Userland/Libraries/LibCore/EventLoopImplementationUnix.cpp
@@ -272,7 +272,13 @@ struct ThreadData {
         if (wake_pipe_fds[1] != -1)
             close(wake_pipe_fds[1]);
 
-        wake_pipe_fds = MUST(Core::System::pipe2(O_CLOEXEC));
+        auto result = Core::System::pipe2(O_CLOEXEC);
+        if (result.is_error()) {
+            warnln("\033[31;1mFailed to create event loop pipe:\033[0m {}", result.error());
+            VERIFY_NOT_REACHED();
+        }
+
+        wake_pipe_fds = result.release_value();
 
         // The wake pipe informs us of POSIX signals as well as manual calls to wake()
         VERIFY(poll_fds.size() == 0);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1848,4 +1848,25 @@ ErrorOr<Bytes> allocate(size_t count, size_t size)
     return Bytes { data, size * count };
 }
 
+ErrorOr<rlimit> get_resource_limits(int resource)
+{
+    rlimit limits;
+
+    if (::getrlimit(resource, &limits) != 0)
+        return Error::from_errno(errno);
+
+    return limits;
+}
+
+ErrorOr<void> set_resource_limits(int resource, rlim_t limit)
+{
+    auto limits = TRY(get_resource_limits(resource));
+    limits.rlim_cur = limit;
+
+    if (::setrlimit(resource, &limits) != 0)
+        return Error::from_errno(errno);
+
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -22,6 +22,7 @@
 #include <signal.h>
 #include <spawn.h>
 #include <sys/ioctl.h>
+#include <sys/resource.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -288,5 +289,8 @@ ErrorOr<String> resolve_executable_from_environment(StringView filename, int fla
 ErrorOr<ByteString> current_executable_path();
 
 ErrorOr<Bytes> allocate(size_t count, size_t size);
+
+ErrorOr<rlimit> get_resource_limits(int resource);
+ErrorOr<void> set_resource_limits(int resource, rlim_t limit);
 
 }

--- a/Userland/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Userland/Libraries/LibWebView/ChromeProcess.cpp
@@ -7,6 +7,7 @@
 #include <AK/ByteString.h>
 #include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibWebView/ChromeProcess.h>
 
@@ -21,6 +22,14 @@ class UIProcessClient final
 private:
     UIProcessClient(NonnullOwnPtr<Core::LocalSocket>);
 };
+
+ErrorOr<ChromeProcess> ChromeProcess::create()
+{
+    // Increase the open file limit, as the default limits on Linux cause us to run out of file descriptors with around 15 tabs open.
+    TRY(Core::System::set_resource_limits(RLIMIT_NOFILE, 8192));
+
+    return ChromeProcess {};
+}
 
 ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteString> const& raw_urls, bool new_window)
 {

--- a/Userland/Libraries/LibWebView/ChromeProcess.h
+++ b/Userland/Libraries/LibWebView/ChromeProcess.h
@@ -40,7 +40,7 @@ private:
 
 class ChromeProcess {
     AK_MAKE_NONCOPYABLE(ChromeProcess);
-    AK_MAKE_NONMOVABLE(ChromeProcess);
+    AK_MAKE_DEFAULT_MOVABLE(ChromeProcess);
 
 public:
     enum class ProcessDisposition : u8 {
@@ -48,7 +48,7 @@ public:
         ExitProcess,
     };
 
-    ChromeProcess() = default;
+    static ErrorOr<ChromeProcess> create();
     ~ChromeProcess();
 
     ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, bool new_window);
@@ -57,6 +57,8 @@ public:
     Function<void(Vector<ByteString> const& raw_urls)> on_new_window;
 
 private:
+    ChromeProcess() = default;
+
     ErrorOr<void> connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, bool new_window);
     ErrorOr<void> connect_as_server(ByteString const& socket_path);
 


### PR DESCRIPTION
The default limit (at least on Linux) causes us to run out of file
descriptors at around 15 tabs. Increase this limit to 8k. This is a
rather arbitrary number, but matches the limit set by Chrome.

Fixes #760