### PR TITLE
Ladybird/Qt: Add missing filters for TVG icons

### DIFF
--- a/Ladybird/Qt/Icon.cpp
+++ b/Ladybird/Qt/Icon.cpp
@@ -34,6 +34,8 @@ QIcon create_tvg_icon_with_theme_colors(QString const& name, QPalette const& pal
     };
     icon_engine->add_filter(QIcon::Mode::Normal, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText)));
     icon_engine->add_filter(QIcon::Mode::Disabled, icon_filter(palette.color(QPalette::ColorGroup::Disabled, QPalette::ColorRole::ButtonText)));
+    icon_engine->add_filter(QIcon::Mode::Active, icon_filter(palette.color(QPalette::ColorGroup::Active, QPalette::ColorRole::ButtonText)));
+    icon_engine->add_filter(QIcon::Mode::Selected, icon_filter(palette.color(QPalette::ColorGroup::Normal, QPalette::ColorRole::ButtonText)));
 
     return QIcon(icon_engine);
 }


### PR DESCRIPTION
Ladybird now uses the correct theme colours when hovering over icons.

![image](https://github.com/user-attachments/assets/8790a403-c7d5-42f8-850b-712f46856ff6)
