### PR TITLE
LibWeb: Append fetch record to client's fetch group when request is a subresource

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -246,8 +246,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Infrastructure::FetchController>> fetch(JS:
 
     // 16. If request is a subresource request, then:
     if (request.is_subresource_request()) {
-        // FIXME: 1. Let record be a new fetch record whose request is request and controller is fetchParams’s controller.
-        // FIXME: 2. Append record to request’s client’s fetch group list of fetch records.
+        // 1. Let record be a new fetch record whose request is request and controller is fetchParams’s controller.
+        auto record = Infrastructure::FetchRecord::create(vm, request, fetch_params->controller());
+
+        // 2. Append record to request’s client’s fetch group list of fetch records.
+        request.client()->fetch_group().append(record);
     }
 
     // 17. Run main fetch given fetchParams.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -90,6 +90,8 @@ public:
     JS::Realm& realm();
     JS::Object& global_object();
     EventLoop& responsible_event_loop();
+
+    // https://fetch.spec.whatwg.org/#concept-fetch-group
     Vector<JS::NonnullGCPtr<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
 
     RunScriptDecision can_run_script();


### PR DESCRIPTION
This should resolve all known FIXMEs related to the fetch record and fetch group concepts.