### PR TITLE
LibWeb: A handful of fixes for some element querying methods

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/getElementById-empty-string.txt
+++ b/Tests/LibWeb/Text/expected/DOM/getElementById-empty-string.txt
@@ -1,0 +1,1 @@
+  document.getElementById(""): null

--- a/Tests/LibWeb/Text/expected/DOM/getElementsByClassName-empty-string.txt
+++ b/Tests/LibWeb/Text/expected/DOM/getElementsByClassName-empty-string.txt
@@ -1,0 +1,1 @@
+  document.getElementsByClassName("").length: 0

--- a/Tests/LibWeb/Text/expected/DOM/getElementsName-empty-string.txt
+++ b/Tests/LibWeb/Text/expected/DOM/getElementsName-empty-string.txt
@@ -1,0 +1,1 @@
+  document.getElementsByName("").length: 0

--- a/Tests/LibWeb/Text/input/DOM/getElementById-empty-string.html
+++ b/Tests/LibWeb/Text/input/DOM/getElementById-empty-string.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id=""></div>
+<script>
+    test(() => {
+        println(`document.getElementById(""): ${document.getElementById("")}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/getElementsByClassName-empty-string.html
+++ b/Tests/LibWeb/Text/input/DOM/getElementsByClassName-empty-string.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div class=""></div>
+<script>
+    test(() => {
+        println(`document.getElementsByClassName("").length: ${document.getElementsByClassName("").length}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/getElementsName-empty-string.html
+++ b/Tests/LibWeb/Text/input/DOM/getElementsName-empty-string.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div name=""></div>
+<script>
+    test(() => {
+        println(`document.getElementsByName("").length: ${document.getElementsByName("").length}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/HTMLCollection.h>
+#include <LibWeb/DOM/LiveNodeList.h>
 #include <LibWeb/DOM/NodeIterator.h>
 #include <LibWeb/DOM/ProcessingInstruction.h>
 #include <LibWeb/DOM/Range.h>
@@ -1394,10 +1395,12 @@ void Document::set_hovered_node(Node* node)
     }
 }
 
-JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_name(FlyString const& name)
+JS::NonnullGCPtr<NodeList> Document::get_elements_by_name(FlyString const& name)
 {
-    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [name](Element const& element) {
-        return element.name() == name;
+    return LiveNodeList::create(realm(), *this, LiveNodeList::Scope::Descendants, [name](auto const& node) {
+        if (!is<Element>(node))
+            return false;
+        return verify_cast<Element>(node).name() == name;
     });
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1401,21 +1401,6 @@ JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_name(FlyString const&
     });
 }
 
-JS::NonnullGCPtr<HTMLCollection> Document::get_elements_by_class_name(StringView class_names)
-{
-    Vector<FlyString> list_of_class_names;
-    for (auto& name : class_names.split_view(' ')) {
-        list_of_class_names.append(FlyString::from_utf8(name).release_value_but_fixme_should_propagate_errors());
-    }
-    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
-        for (auto& name : list_of_class_names) {
-            if (!element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
-                return false;
-        }
-        return true;
-    });
-}
-
 // https://html.spec.whatwg.org/multipage/obsolete.html#dom-document-applets
 JS::NonnullGCPtr<HTMLCollection> Document::applets()
 {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -248,7 +248,7 @@ public:
     void schedule_style_update();
     void schedule_layout_update();
 
-    JS::NonnullGCPtr<HTMLCollection> get_elements_by_name(FlyString const&);
+    JS::NonnullGCPtr<NodeList> get_elements_by_name(FlyString const&);
 
     JS::NonnullGCPtr<HTMLCollection> applets();
     JS::NonnullGCPtr<HTMLCollection> anchors();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -249,7 +249,6 @@ public:
     void schedule_layout_update();
 
     JS::NonnullGCPtr<HTMLCollection> get_elements_by_name(FlyString const&);
-    JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(StringView);
 
     JS::NonnullGCPtr<HTMLCollection> applets();
     JS::NonnullGCPtr<HTMLCollection> anchors();

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -73,7 +73,7 @@ interface Document : Node {
     readonly attribute Element? activeElement;
 
     Element? getElementById(DOMString id);
-    HTMLCollection getElementsByName([FlyString] DOMString name);
+    NodeList getElementsByName([FlyString] DOMString name);
     HTMLCollection getElementsByTagName([FlyString] DOMString tagName);
     HTMLCollection getElementsByTagNameNS([FlyString] DOMString? namespace, [FlyString] DOMString localName);
     HTMLCollection getElementsByClassName(DOMString className);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -471,14 +471,18 @@ void Element::attribute_changed(FlyString const& name, Optional<String> const&, 
 
         document().element_name_changed({}, *this);
     } else if (name == HTML::AttributeNames::class_) {
-        auto new_classes = value_or_empty.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
-        m_classes.clear();
-        m_classes.ensure_capacity(new_classes.size());
-        for (auto& new_class : new_classes) {
-            m_classes.unchecked_append(FlyString::from_utf8(new_class).release_value_but_fixme_should_propagate_errors());
+        if (value_or_empty.is_empty()) {
+            m_classes.clear();
+        } else {
+            auto new_classes = value_or_empty.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
+            m_classes.clear();
+            m_classes.ensure_capacity(new_classes.size());
+            for (auto& new_class : new_classes) {
+                m_classes.unchecked_append(FlyString::from_utf8(new_class).release_value_but_fixme_should_propagate_errors());
+            }
+            if (m_class_list)
+                m_class_list->associated_attribute_changed(value_or_empty);
         }
-        if (m_class_list)
-            m_class_list->associated_attribute_changed(value_or_empty);
     } else if (name == HTML::AttributeNames::style) {
         if (!value.has_value()) {
             if (m_inline_style) {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -814,21 +814,6 @@ bool Element::is_document_element() const
     return parent() == &document();
 }
 
-JS::NonnullGCPtr<HTMLCollection> Element::get_elements_by_class_name(StringView class_names)
-{
-    Vector<FlyString> list_of_class_names;
-    for (auto& name : class_names.split_view_if(Infra::is_ascii_whitespace)) {
-        list_of_class_names.append(FlyString::from_utf8(name).release_value_but_fixme_should_propagate_errors());
-    }
-    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
-        for (auto& name : list_of_class_names) {
-            if (!element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
-                return false;
-        }
-        return true;
-    });
-}
-
 // https://dom.spec.whatwg.org/#element-shadow-host
 bool Element::is_shadow_host() const
 {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -457,7 +457,7 @@ void Element::attribute_changed(FlyString const& name, Optional<String> const&, 
     auto value_or_empty = value.value_or(String {});
 
     if (name == HTML::AttributeNames::id) {
-        if (!value.has_value())
+        if (value_or_empty.is_empty())
             m_id = {};
         else
             m_id = value_or_empty;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -464,7 +464,7 @@ void Element::attribute_changed(FlyString const& name, Optional<String> const&, 
 
         document().element_id_changed({}, *this);
     } else if (name == HTML::AttributeNames::name) {
-        if (!value.has_value())
+        if (value_or_empty.is_empty())
             m_name = {};
         else
             m_name = value_or_empty;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -212,8 +212,6 @@ public:
     bool is_target() const;
     bool is_document_element() const;
 
-    JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(StringView);
-
     bool is_shadow_host() const;
     JS::GCPtr<ShadowRoot> shadow_root() { return m_shadow_root; }
     JS::GCPtr<ShadowRoot const> shadow_root() const { return m_shadow_root; }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/DOM/StaticNodeList.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Namespace.h>
 
@@ -223,6 +224,21 @@ WebIDL::ExceptionOr<void> ParentNode::replace_children(Vector<Variant<JS::Handle
     // 3. Replace all with node within this.
     replace_all(*node);
     return {};
+}
+
+JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_class_name(StringView class_names)
+{
+    Vector<FlyString> list_of_class_names;
+    for (auto& name : class_names.split_view_if(Infra::is_ascii_whitespace)) {
+        list_of_class_names.append(FlyString::from_utf8(name).release_value_but_fixme_should_propagate_errors());
+    }
+    return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
+        for (auto& name : list_of_class_names) {
+            if (!element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
+                return false;
+        }
+        return true;
+    });
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -234,10 +234,10 @@ JS::NonnullGCPtr<HTMLCollection> ParentNode::get_elements_by_class_name(StringVi
     }
     return HTMLCollection::create(*this, HTMLCollection::Scope::Descendants, [list_of_class_names = move(list_of_class_names), quirks_mode = document().in_quirks_mode()](Element const& element) {
         for (auto& name : list_of_class_names) {
-            if (!element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
-                return false;
+            if (element.has_class(name, quirks_mode ? CaseSensitivity::CaseInsensitive : CaseSensitivity::CaseSensitive))
+                return true;
         }
-        return true;
+        return false;
     });
 }
 

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -36,6 +36,8 @@ public:
     WebIDL::ExceptionOr<void> append(Vector<Variant<JS::Handle<Node>, String>> const& nodes);
     WebIDL::ExceptionOr<void> replace_children(Vector<Variant<JS::Handle<Node>, String>> const& nodes);
 
+    JS::NonnullGCPtr<HTMLCollection> get_elements_by_class_name(StringView);
+
 protected:
     ParentNode(JS::Realm& realm, Document& document, NodeType type)
         : Node(realm, document, type)


### PR DESCRIPTION
This PR includes changes to align `document.getElementById()`, `document.getElementByClassName()` and `document.getElementByName()` with the specification.

See individual commits for details

Fixes the following WPT tests (and possibly others):
https://wpt.live/dom/nodes/Document-getElementById.html
https://wpt.live/html/dom/documents/dom-tree-accessors/document.getElementsByName/document.getElementsByName-interface.html
http://wpt.live/dom/nodes/getElementsByClassName-01.htm
http://wpt.live/dom/nodes/getElementsByClassName-02.htm