### PR TITLE
CI: Make notes-push workflow return zero even when “git push” fails

### DIFF
--- a/.github/workflows/notes-push.yml
+++ b/.github/workflows/notes-push.yml
@@ -17,6 +17,6 @@ jobs:
       - run: |
           git fetch origin "refs/notes/*:refs/notes/*"
           curl -fsSLO https://sideshowbarker.github.io/git-gloss/git-gloss && bash ./git-gloss
-          git push origin "refs/notes/*"
+          git push origin "refs/notes/*" || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
It’s possible but unlikely that a push of generated notes back to the remote can fail with a message like

> [remote rejected] ... cannot > lock ref 'refs/notes/commits': is at f3648f50bb but expected 47686bf473

See https://github.com/LadybirdBrowser/ladybird/actions/runs/10054314539

So this change makes the call to “git push” for notes not return 0 even if it fails — because it’s not actually a fatal error when it happens, and not something we need to stop and fix. Instead, it fixes itself.

Specifically: If one CI job for a PR merge/push to master generates some notes but fails to push them to the origin, the notes don’t get dropped on the floor and lost.

Instead, the notes-generator tool looks at the entire history; and if it finds commits that don’t have notes — even if those commits are not part of the PR push/merge it’s operating on — it generates notes for those.

In other words, if notes for one PR push/job fail for some reason to get pushed back to the remote, they get regenerated by the next PR push/job.