### PR TITLE
LibWeb: Implement :host and :host(<compound-selector>) selector matching

### DIFF
--- a/Tests/LibWeb/Layout/expected/host-pseudo-class-basic.txt
+++ b/Tests/LibWeb/Layout/expected/host-pseudo-class-basic.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x63 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x47 children: not-inline
+      BlockContainer <main> at (8,8) content-size 784x47 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [23,23 343.96875x17] baseline: 28.296875
+        BlockContainer <div> at (23,23) content-size 343.96875x17 inline-block [BFC] children: inline
+          InlineNode <span>
+            frag 0 from TextNode start: 0, length: 42, rect: [23,23 343.96875x17] baseline: 13.296875
+                "hello :host and :host(<compound-selector>)"
+            TextNode <#text>
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x63]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x47]
+      PaintableWithLines (BlockContainer<MAIN>) [8,8 784x47]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 373.96875x47]
+          InlinePaintable (InlineNode<SPAN>)
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/host-pseudo-class-basic.html
+++ b/Tests/LibWeb/Layout/input/host-pseudo-class-basic.html
@@ -1,0 +1,4 @@
+<!doctype html><body><template shadowrootmode="open"><main><div><template shadowrootmode="open"><style>
+:host { display: inline-block; border: 5px solid red; }
+:host(div) { padding: 10px; }
+</style><span>hello :host and :host(&lt;compound-selector&gt;)</span>

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -506,7 +506,10 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                 return ParseError::SyntaxError;
             }
 
-            Vector compound_selectors { compound_selector_or_error.release_value().release_value() };
+            auto compound_selector = compound_selector_or_error.release_value().release_value();
+            compound_selector.combinator = Selector::Combinator::None;
+
+            Vector compound_selectors { move(compound_selector) };
             auto selector = Selector::create(move(compound_selectors));
 
             return Selector::SimpleSelector {

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -16,9 +16,9 @@ enum class SelectorKind {
     Relative,
 };
 
-bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type> = {}, JS::GCPtr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal);
+bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, JS::GCPtr<DOM::Element const> shadow_host, Optional<CSS::Selector::PseudoElement::Type> = {}, JS::GCPtr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal);
 
-[[nodiscard]] bool fast_matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&);
+[[nodiscard]] bool fast_matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, JS::GCPtr<DOM::Element const> shadow_host);
 [[nodiscard]] bool can_use_fast_matches(CSS::Selector const&);
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -322,6 +322,12 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
     auto const& root_node = element.root();
     auto shadow_root = is<DOM::ShadowRoot>(root_node) ? static_cast<DOM::ShadowRoot const*>(&root_node) : nullptr;
 
+    JS::GCPtr<DOM::Element const> shadow_host;
+    if (element.is_shadow_host())
+        shadow_host = element;
+    else if (shadow_root)
+        shadow_host = shadow_root->host();
+
     auto const& rule_cache = rule_cache_for_cascade_origin(cascade_origin);
 
     Vector<MatchingRule, 512> rules_to_run;
@@ -366,11 +372,29 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
     Vector<MatchingRule> matching_rules;
     matching_rules.ensure_capacity(rules_to_run.size());
     for (auto const& rule_to_run : rules_to_run) {
-        // FIXME: This needs to be revised when adding support for the :host and ::shadow selectors, which transition shadow tree boundaries
+        // FIXME: This needs to be revised when adding support for the ::shadow selector, as it needs to cross shadow boundaries.
         auto rule_root = rule_to_run.shadow_root;
         auto from_user_agent_or_user_stylesheet = rule_to_run.cascade_origin == CascadeOrigin::UserAgent || rule_to_run.cascade_origin == CascadeOrigin::User;
-        if (rule_root != shadow_root && !from_user_agent_or_user_stylesheet)
+
+        // NOTE: Inside shadow trees, we only match rules that are defined in the shadow tree's style sheets.
+        //       The key exception is the shadow tree's *shadow host*, which needs to match :host rules from inside the shadow root.
+        //       Also note that UA or User style sheets don't have a scope, so they are always relevant.
+        // FIXME: We should reorganize the data so that the document-level StyleComputer doesn't cache *all* rules,
+        //        but instead we'd have some kind of "style scope" at the document level, and also one for each shadow root.
+        //        Then we could only evaluate rules from the current style scope.
+        bool rule_is_relevant_for_current_scope = rule_root == shadow_root
+            || (element.is_shadow_host() && rule_root == element.shadow_root())
+            || from_user_agent_or_user_stylesheet;
+
+        if (!rule_is_relevant_for_current_scope)
             continue;
+
+        // NOTE: When matching an element against a rule from outside the shadow root's style scope,
+        //       we have to pass in null for the shadow host, otherwise combinator traversal will
+        //       be confined to the element itself (since it refuses to cross the shadow boundary).
+        auto shadow_host_to_use = shadow_host;
+        if (element.is_shadow_host() && rule_root != element.shadow_root())
+            shadow_host_to_use = nullptr;
 
         auto const& selector = rule_to_run.rule->selectors()[rule_to_run.selector_index];
 
@@ -378,10 +402,10 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
             continue;
 
         if (rule_to_run.can_use_fast_matches) {
-            if (!SelectorEngine::fast_matches(selector, *rule_to_run.sheet, element))
+            if (!SelectorEngine::fast_matches(selector, *rule_to_run.sheet, element, shadow_host_to_use))
                 continue;
         } else {
-            if (!SelectorEngine::matches(selector, *rule_to_run.sheet, element, pseudo_element))
+            if (!SelectorEngine::matches(selector, *rule_to_run.sheet, element, shadow_host_to_use, pseudo_element))
                 continue;
         }
         matching_rules.append(rule_to_run);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -720,7 +720,7 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
     auto sel = maybe_selectors.value();
     for (auto& s : sel) {
-        if (SelectorEngine::matches(s, {}, *this, {}, static_cast<ParentNode const*>(this)))
+        if (SelectorEngine::matches(s, {}, *this, nullptr, {}, static_cast<ParentNode const*>(this)))
             return true;
     }
     return false;
@@ -739,7 +739,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
         // 4. For each element in elements, if match a selector against an element, using s, element, and scoping root this, returns success, return element.
         for (auto const& selector : selector_list) {
-            if (SelectorEngine::matches(selector, {}, *element, {}, this))
+            if (SelectorEngine::matches(selector, {}, *element, nullptr, {}, this))
                 return true;
         }
         return false;

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/DOM/NodeOperations.h>
 #include <LibWeb/DOM/ParentNode.h>
+#include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/StaticNodeList.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Infra/CharacterTypes.h>
@@ -44,7 +45,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView se
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
-            if (SelectorEngine::matches(selector, {}, element, {}, this)) {
+            if (SelectorEngine::matches(selector, {}, element, nullptr, {}, this)) {
                 result = &element;
                 return TraversalDecision::Break;
             }
@@ -76,7 +77,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(S
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
-            if (SelectorEngine::matches(selector, {}, element, {}, this)) {
+            if (SelectorEngine::matches(selector, {}, element, nullptr, {}, this)) {
                 elements.append(&element);
             }
         }


### PR DESCRIPTION
The `:host` family of pseudo class selectors select the shadow host element when matching against a rule from within the element's shadow tree.
    
This is a bit convoluted due to the fact that the document-level `StyleComputer` keeps track of *all* style rules, and not just the document-level ones.
    
In the future, we should refactor style storage so that shadow roots have their own style scope, and we can simplify a lot of this.

Visual progression on many sites, for example https://reddit.com

Before:
![Screenshot from 2024-07-23 17-15-22](https://github.com/user-attachments/assets/a3ee9af7-417b-4296-9ab0-9f7d6f22b1ff)

After:
![Screenshot from 2024-07-23 17-14-37](https://github.com/user-attachments/assets/001164e9-9389-4379-9d5b-f9befd41d384)
