### PR TITLE
UI/Qt: Don't crash when launching Inspector with Qt networking enabled

### DIFF
--- a/Ladybird/Qt/InspectorWidget.cpp
+++ b/Ladybird/Qt/InspectorWidget.cpp
@@ -22,7 +22,7 @@ extern bool is_using_dark_system_theme(QWidget&);
 InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
     : QWidget(tab, Qt::Window)
 {
-    m_inspector_view = new WebContentView(this, {}, {});
+    m_inspector_view = new WebContentView(this, content_view.web_content_options(), {});
 
     if (is_using_dark_system_theme(*this))
         m_inspector_view->update_palette(WebContentView::PaletteMode::Dark);

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -85,6 +85,8 @@ public:
 
     QPoint map_point_to_global_position(Gfx::IntPoint) const;
 
+    WebContentOptions const& web_content_options() const { return m_web_content_options; }
+
 signals:
     void urls_dropped(QList<QUrl> const&);
 


### PR DESCRIPTION
Regressed in #441.