### PR TITLE
LibWeb: A few more `DOM::Node` fixes

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/CDATASection-cloneNode.txt
+++ b/Tests/LibWeb/Text/expected/DOM/CDATASection-cloneNode.txt
@@ -1,0 +1,1 @@
+Cloned CDATASection node data: PASS

--- a/Tests/LibWeb/Text/expected/DOM/Range-containing-CDATASection.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Range-containing-CDATASection.txt
@@ -1,0 +1,1 @@
+range start offset: 0, end offset: 3

--- a/Tests/LibWeb/Text/input/DOM/CDATASection-cloneNode.html
+++ b/Tests/LibWeb/Text/input/DOM/CDATASection-cloneNode.html
@@ -1,0 +1,9 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const xmlDocument = new DOMParser().parseFromString(`<xml></xml>`, "application/xml");
+        const cdata = xmlDocument.createCDATASection("PASS");
+        const clone = cdata.cloneNode();
+        println(`Cloned CDATASection node data: ${clone.data}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/Range-containing-CDATASection.html
+++ b/Tests/LibWeb/Text/input/DOM/Range-containing-CDATASection.html
@@ -1,0 +1,11 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const xmlDocument = new DOMParser().parseFromString(`<xml></xml>`, "application/xml");
+        const cdata = xmlDocument.createCDATASection("DATA");
+        const range = xmlDocument.createRange();
+        range.setStart(cdata, 0);
+        range.setEnd(cdata, 3);
+        println(`range start offset: ${range.startOffset}, end offset: ${range.endOffset}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -978,12 +978,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::clone_node(Document* document,
         // Set copy’s namespace, namespace prefix, local name, and value to those of node.
         auto& attr = static_cast<Attr&>(*this);
         copy = attr.clone(*document);
-    } else if (is<Text>(this)) {
+    }
+    // NOTE: is<Text>() currently returns true only for text nodes, not for descendant types of Text.
+    else if (is<Text>(this) || is<CDATASection>(this)) {
         // Text
-        auto text = verify_cast<Text>(this);
+        auto& text = static_cast<Text&>(*this);
 
         // Set copy’s data to that of node.
-        auto text_copy = heap().allocate<Text>(realm(), *document, text->data());
+        auto text_copy = heap().allocate<Text>(realm(), *document, text.data());
         copy = move(text_copy);
     } else if (is<Comment>(this)) {
         // Comment

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1040,6 +1040,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::clone_node(Document* document,
     }
 
     // 7. Return copy.
+    VERIFY(copy);
     return JS::NonnullGCPtr { *copy };
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -8,6 +8,7 @@
 
 #include <AK/Badge.h>
 #include <AK/FlyString.h>
+#include <AK/GenericShorthands.h>
 #include <AK/JsonObjectSerializer.h>
 #include <AK/RefPtr.h>
 #include <AK/TypeCasts.h>
@@ -69,7 +70,7 @@ public:
     bool is_document() const { return type() == NodeType::DOCUMENT_NODE; }
     bool is_document_type() const { return type() == NodeType::DOCUMENT_TYPE_NODE; }
     bool is_comment() const { return type() == NodeType::COMMENT_NODE; }
-    bool is_character_data() const { return type() == NodeType::TEXT_NODE || type() == NodeType::COMMENT_NODE; }
+    bool is_character_data() const { return first_is_one_of(type(), NodeType::TEXT_NODE, NodeType::COMMENT_NODE, NodeType::CDATA_SECTION_NODE, NodeType::PROCESSING_INSTRUCTION_NODE); }
     bool is_document_fragment() const { return type() == NodeType::DOCUMENT_FRAGMENT_NODE; }
     bool is_parent_node() const { return is_element() || is_document() || is_document_fragment(); }
     bool is_slottable() const { return is_element() || is_text() || is_cdata_section(); }


### PR DESCRIPTION
This PR includes a few fixes to `DOM::Node` that I came across while investigating some unrelated WPT failures.

See individual commits for details.

This fixes a fair number of WPT ranges tests: https://wpt.live/dom/ranges.

Before:

Ran 38 tests finished in 81.2 seconds.
  • 23 ran as expected. 0 tests skipped.
  • 5 tests had errors unexpectedly
  • 10 tests had unexpected subtest results

After:

Ran 38 tests finished in 149.6 seconds.
  • 31 ran as expected. 0 tests skipped.
  • 5 tests had errors unexpectedly
  • 2 tests had unexpected subtest results