### PR TITLE
LibWebView: Emit “submit an issue” suggestion when Ladybird crashes

### DIFF
--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -444,6 +444,7 @@ void ViewImplementation::handle_resize()
 void ViewImplementation::handle_web_content_process_crash()
 {
     dbgln("WebContent process crashed!");
+    dbgln("Consider raising an issue at https://github.com/LadybirdBrowser/ladybird/issues");
 
     ++m_crash_count;
     constexpr size_t max_reasonable_crash_count = 5U;


### PR DESCRIPTION
Not sure if this is overkill at this point — since people running Ladybird know about the repo and know enough to build from the sources, etc.

But who knows, it may help to get a few more people filing good issues who might not have otherwise.

At least it doesn’t seem especially annoying or harmful.

Anyway, I don’t feel strongly about — so no worries if this is just closed without merging. It’s just an idea.