### PR TITLE
LibWeb: Remove unused code from DisplayList and DisplayListPlayer

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -80,18 +80,6 @@ void DisplayList::execute(DisplayListPlayer& executor)
 {
     executor.prepare_to_execute(m_corner_clip_max_depth);
 
-    if (executor.needs_update_immutable_bitmap_texture_cache()) {
-        HashMap<u32, Gfx::ImmutableBitmap const*> immutable_bitmaps;
-        for (auto const& command_with_scroll_id : m_commands) {
-            auto& command = command_with_scroll_id.command;
-            if (command.has<DrawScaledImmutableBitmap>()) {
-                auto const& immutable_bitmap = command.get<DrawScaledImmutableBitmap>().bitmap;
-                immutable_bitmaps.set(immutable_bitmap->id(), immutable_bitmap.ptr());
-            }
-        }
-        executor.update_immutable_bitmap_texture_cache(immutable_bitmaps);
-    }
-
     HashTable<u32> skipped_sample_corner_commands;
     size_t next_command_index = 0;
     while (next_command_index < m_commands.size()) {

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -78,8 +78,6 @@ void DisplayList::mark_unnecessary_commands()
 
 void DisplayList::execute(DisplayListPlayer& executor)
 {
-    executor.prepare_to_execute(m_corner_clip_max_depth);
-
     HashTable<u32> skipped_sample_corner_commands;
     size_t next_command_index = 0;
     while (next_command_index < m_commands.size()) {

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -80,25 +80,6 @@ void DisplayList::execute(DisplayListPlayer& executor)
 {
     executor.prepare_to_execute(m_corner_clip_max_depth);
 
-    if (executor.needs_prepare_glyphs_texture()) {
-        HashMap<Gfx::Font const*, HashTable<u32>> unique_glyphs;
-        for (auto& command_with_scroll_id : m_commands) {
-            auto& command = command_with_scroll_id.command;
-            if (command.has<DrawGlyphRun>()) {
-                auto scale = command.get<DrawGlyphRun>().scale;
-                auto const& font = command.get<DrawGlyphRun>().glyph_run->font();
-                auto scaled_font = font.with_size(font.point_size() * static_cast<float>(scale));
-                for (auto const& glyph_or_emoji : command.get<DrawGlyphRun>().glyph_run->glyphs()) {
-                    if (glyph_or_emoji.has<Gfx::DrawGlyph>()) {
-                        auto const& glyph = glyph_or_emoji.get<Gfx::DrawGlyph>();
-                        unique_glyphs.ensure(scaled_font, [] { return HashTable<u32> {}; }).set(glyph.code_point);
-                    }
-                }
-            }
-        }
-        executor.prepare_glyph_texture(unique_glyphs);
-    }
-
     if (executor.needs_update_immutable_bitmap_texture_cache()) {
         HashMap<u32, Gfx::ImmutableBitmap const*> immutable_bitmaps;
         for (auto const& command_with_scroll_id : m_commands) {

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -66,7 +66,6 @@ public:
     virtual void sample_under_corners(SampleUnderCorners const&) = 0;
     virtual void blit_corner_clipping(BlitCornerClipping const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
-    virtual void prepare_to_execute([[maybe_unused]] size_t corner_clip_max_depth) { }
 };
 
 class DisplayList {
@@ -77,9 +76,6 @@ public:
     void mark_unnecessary_commands();
     void execute(DisplayListPlayer&);
 
-    size_t corner_clip_max_depth() const { return m_corner_clip_max_depth; }
-    void set_corner_clip_max_depth(size_t depth) { m_corner_clip_max_depth = depth; }
-
 private:
     struct CommandListItem {
         Optional<i32> scroll_frame_id;
@@ -87,7 +83,6 @@ private:
         bool skip { false };
     };
 
-    size_t m_corner_clip_max_depth { 0 };
     AK::SegmentedVector<CommandListItem, 512> m_commands;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -67,8 +67,6 @@ public:
     virtual void blit_corner_clipping(BlitCornerClipping const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
     virtual void prepare_to_execute([[maybe_unused]] size_t corner_clip_max_depth) { }
-    virtual bool needs_update_immutable_bitmap_texture_cache() const = 0;
-    virtual void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) = 0;
 };
 
 class DisplayList {

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -66,8 +66,6 @@ public:
     virtual void sample_under_corners(SampleUnderCorners const&) = 0;
     virtual void blit_corner_clipping(BlitCornerClipping const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
-    virtual bool needs_prepare_glyphs_texture() const { return false; }
-    virtual void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const& unique_glyphs) = 0;
     virtual void prepare_to_execute([[maybe_unused]] size_t corner_clip_max_depth) { }
     virtual bool needs_update_immutable_bitmap_texture_cache() const = 0;
     virtual void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) = 0;

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1292,10 +1292,6 @@ void DisplayListPlayerSkia::draw_triangle_wave(DrawTriangleWave const&)
 {
 }
 
-void DisplayListPlayerSkia::prepare_to_execute(size_t)
-{
-}
-
 void DisplayListPlayerSkia::sample_under_corners(SampleUnderCorners const& command)
 {
     auto rounded_rect = to_skia_rrect(command.border_rect, command.corner_radii);

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -67,9 +67,6 @@ public:
 
     virtual void prepare_to_execute(size_t corner_clip_max_depth) override;
 
-    bool needs_update_immutable_bitmap_texture_cache() const override { return false; }
-    void update_immutable_bitmap_texture_cache(HashMap<u32, Gfx::ImmutableBitmap const*>&) override {};
-
     DisplayListPlayerSkia(Gfx::Bitmap&);
 
 #ifdef USE_VULKAN

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -65,8 +65,6 @@ public:
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
-    virtual void prepare_to_execute(size_t corner_clip_max_depth) override;
-
     DisplayListPlayerSkia(Gfx::Bitmap&);
 
 #ifdef USE_VULKAN

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -65,9 +65,6 @@ public:
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
-    bool needs_prepare_glyphs_texture() const override { return false; }
-    void prepare_glyph_texture(HashMap<Gfx::Font const*, HashTable<u32>> const&) override {};
-
     virtual void prepare_to_execute(size_t corner_clip_max_depth) override;
 
     bool needs_update_immutable_bitmap_texture_cache() const override { return false; }

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -28,8 +28,6 @@ void DisplayListRecorder::append(Command&& command)
 void DisplayListRecorder::sample_under_corners(u32 id, CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip)
 {
     m_corner_clip_state_stack.append({ id, border_rect });
-    if (m_corner_clip_state_stack.size() > display_list().corner_clip_max_depth())
-        display_list().set_corner_clip_max_depth(m_corner_clip_state_stack.size());
     append(SampleUnderCorners {
         id,
         corner_radii,


### PR DESCRIPTION
Some steps that are no longer needed after LibGfx and LibAccelGfx painters are gone.