### PR TITLE
LibWasm: Flatten instructions in one continuous loop during parsing

### DIFF
--- a/Userland/Libraries/LibWasm/Opcode.h
+++ b/Userland/Libraries/LibWasm/Opcode.h
@@ -20,6 +20,8 @@ namespace Instructions {
     M(block, 0x02)                            \
     M(loop, 0x03)                             \
     M(if_, 0x04)                              \
+    M(structured_else, 0x05)                  \
+    M(structured_end, 0x0b)                   \
     M(br, 0x0c)                               \
     M(br_if, 0x0d)                            \
     M(br_table, 0x0e)                         \
@@ -217,8 +219,6 @@ namespace Instructions {
     M(table_grow, 0xfc0000000000000full)                    \
     M(table_size, 0xfc00000000000010ull)                    \
     M(table_fill, 0xfc00000000000011ull)                    \
-    M(structured_else, 0xff00000000000000ull)               \
-    M(structured_end, 0xff00000000000001ull)                \
     M(v128_load, 0xfd00000000000000ull)                     \
     M(v128_load8x8_s, 0xfd00000000000001ull)                \
     M(v128_load8x8_u, 0xfd00000000000002ull)                \

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -460,10 +460,11 @@ public:
     {
     }
 
-    static ParseResult<Vector<Instruction>> parse(Stream& stream, InstructionPointer& ip);
+    static ParseResult<Instruction> parse(Stream& stream);
 
     auto& opcode() const { return m_opcode; }
     auto& arguments() const { return m_arguments; }
+    auto& arguments() { return m_arguments; }
 
 private:
     OpCode m_opcode { 0 };


### PR DESCRIPTION
Instead of multiple loops and multiple vectors, parse Wasm expressions in a simple loop. This gets us from ~450ms to instantiate spidermonkey to ~280ms.