### PR TITLE
LibWeb: Fix <select> element behavior when its changed from JavaScript

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLSelectElement-options-available-after-add.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLSelectElement-options-available-after-add.txt
@@ -1,0 +1,1 @@
+Option 1  PASS (correct value)

--- a/Tests/LibWeb/Text/expected/HTML/HTMLSelectElement-options-available-at-load.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLSelectElement-options-available-at-load.txt
@@ -1,0 +1,1 @@
+Option 1  PASS (correct value)

--- a/Tests/LibWeb/Text/input/HTML/HTMLSelectElement-options-available-after-add.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLSelectElement-options-available-after-add.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<select id="select-test"></select>
+<script>
+    test(() => {
+        const s = document.getElementById("select-test");
+
+        const opt1 = document.createElement("option");
+        opt1.innerText = "Option 1";
+        s.add(opt1);
+
+        const opt2 = document.createElement("option");
+        opt2.innerText = "Option 2";
+        s.add(opt2);
+
+        if (s.value === "Option 1" && s.selectedOptions[0].selected) {
+            println("PASS (correct value)");
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLSelectElement-options-available-at-load.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLSelectElement-options-available-at-load.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<select id="select-test">
+    <option>Option 1</option>
+    <option>Option 2</option>
+</select>
+<script>
+    test(() => {
+        const s = document.getElementById("select-test");
+        if (s.value === "Option 1" && s.selectedOptions[0].selected) {
+            println("PASS (correct value)");
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -857,12 +857,7 @@ void Element::make_html_uppercased_qualified_name()
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task
 int Element::queue_an_element_task(HTML::Task::Source source, Function<void()> steps)
 {
-    auto task = HTML::Task::create(vm(), source, &document(), JS::create_heap_function(heap(), move(steps)));
-    auto id = task->id();
-
-    HTML::main_thread_event_loop().task_queue().add(move(task));
-
-    return id;
+    return queue_a_task(source, HTML::main_thread_event_loop(), document(), JS::create_heap_function(heap(), move(steps)));
 }
 
 // https://html.spec.whatwg.org/multipage/syntax.html#void-elements

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -400,7 +400,7 @@ int queue_a_task(HTML::Task::Source source, JS::GCPtr<EventLoop> event_loop, JS:
     auto task = HTML::Task::create(event_loop->vm(), source, document, steps);
 
     // 8. Let queue be the task queue to which source is associated on event loop.
-    auto& queue = event_loop->task_queue();
+    auto& queue = source == HTML::Task::Source::Microtask ? event_loop->microtask_queue() : event_loop->task_queue();
 
     // 9. Append task to queue.
     queue.add(task);

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -133,7 +133,16 @@ HTMLOptionElement* HTMLSelectElement::named_item(FlyString const& name)
 WebIDL::ExceptionOr<void> HTMLSelectElement::add(HTMLOptionOrOptGroupElement element, Optional<HTMLElementOrElementIndex> before)
 {
     // Similarly, the add(element, before) method must act like its namesake method on that same options collection.
-    return const_cast<HTMLOptionsCollection&>(*options()).add(move(element), move(before));
+    TRY(const_cast<HTMLOptionsCollection&>(*options()).add(move(element), move(before)));
+
+    // If the inserted element is the first and only element, mark it as selected
+    auto options = list_of_options();
+    if (options.size() == 1) {
+        options.at(0)->set_selected(true);
+        update_inner_text_element();
+    }
+
+    return {};
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-select-remove


### PR DESCRIPTION
`value` and `selectedOptions` fields of a `<select>` element are expected to have values immediately after a new `<option>` is added or when any script is executed on the page load.

This PR includes two separate changes:
- Update selectedness of the first inserted option if there were no other options, and also update the current displayed value in the `<select>` element. This makes the first example in #795 to start working.
- Schedule a form_associated_element_was_inserted task on a micro task queue. This seems to fix the case when the elements are already statically defined in the page HTML code, see the second example in #795.

[Example](https://syscalls.mebeim.net/?table=x86/64/x64/latest) of a real web page which starts to load after with this change.

Fixes #795