### PR TITLE
CSS: Add support for text-overflow property

### DIFF
--- a/Tests/LibWeb/Ref/reference/text-overflow.html
+++ b/Tests/LibWeb/Ref/reference/text-overflow.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<style>
+  div {
+    overflow: hidden;
+    white-space: nowrap;
+    width: 75px;
+  }
+</style>
+<div>This text gets clipped</div>
+<div>This tex…</div>

--- a/Tests/LibWeb/Ref/text-overflow.html
+++ b/Tests/LibWeb/Ref/text-overflow.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<link rel="match" href="reference/text-overflow.html" />
+<style>
+  div {
+    overflow: hidden;
+    white-space: nowrap;
+    width: 75px;
+  }
+  .clip {
+    text-overflow: clip;
+  }
+  .ellipsis {
+    text-overflow: ellipsis;
+  }
+</style>
+<div class="clip">This text gets clipped</div>
+<div class="ellipsis">This text gets an ellipsis</div>

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -197,6 +197,7 @@ text-decoration-style: solid
 text-decoration-thickness: auto
 text-indent: 0px
 text-justify: auto
+text-overflow: clip
 text-shadow: none
 text-transform: none
 top: auto

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -110,6 +110,7 @@ public:
     static CSS::Length text_decoration_thickness() { return Length::make_auto(); }
     static CSS::TextDecorationStyle text_decoration_style() { return CSS::TextDecorationStyle::Solid; }
     static CSS::TextTransform text_transform() { return CSS::TextTransform::None; }
+    static CSS::TextOverflow text_overflow() { return CSS::TextOverflow::Clip; }
     static CSS::LengthPercentage text_indent() { return CSS::Length::make_px(0); }
     static CSS::Display display() { return CSS::Display { CSS::DisplayOutside::Inline, CSS::DisplayInside::Flow }; }
     static Color color() { return Color::Black; }
@@ -367,6 +368,7 @@ public:
     CSS::TextDecorationStyle text_decoration_style() const { return m_noninherited.text_decoration_style; }
     Color text_decoration_color() const { return m_noninherited.text_decoration_color; }
     CSS::TextTransform text_transform() const { return m_inherited.text_transform; }
+    CSS::TextOverflow text_overflow() const { return m_noninherited.text_overflow; }
     Vector<ShadowData> const& text_shadow() const { return m_inherited.text_shadow; }
     CSS::Positioning position() const { return m_noninherited.position; }
     CSS::WhiteSpace white_space() const { return m_inherited.white_space; }
@@ -551,6 +553,7 @@ protected:
         CSS::LengthPercentage text_decoration_thickness { InitialValues::text_decoration_thickness() };
         CSS::TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
         Color text_decoration_color { InitialValues::color() };
+        CSS::TextOverflow text_overflow { InitialValues::text_overflow() };
         CSS::Positioning position { InitialValues::position() };
         CSS::Size width { InitialValues::width() };
         CSS::Size min_width { InitialValues::min_width() };
@@ -675,6 +678,7 @@ public:
     void set_text_transform(CSS::TextTransform value) { m_inherited.text_transform = value; }
     void set_text_shadow(Vector<ShadowData>&& value) { m_inherited.text_shadow = move(value); }
     void set_text_indent(CSS::LengthPercentage value) { m_inherited.text_indent = move(value); }
+    void set_text_overflow(CSS::TextOverflow value) { m_noninherited.text_overflow = value; }
     void set_webkit_text_fill_color(Color value) { m_inherited.webkit_text_fill_color = value; }
     void set_position(CSS::Positioning position) { m_noninherited.position = position; }
     void set_white_space(CSS::WhiteSpace value) { m_inherited.white_space = value; }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -369,6 +369,10 @@
     "middle",
     "end"
   ],
+  "text-overflow": [
+    "clip",
+    "ellipsis"
+  ],
   "scrollbar-gutter": [
     "auto",
     "stable",

--- a/Userland/Libraries/LibWeb/CSS/Identifiers.json
+++ b/Userland/Libraries/LibWeb/CSS/Identifiers.json
@@ -141,6 +141,7 @@
   "ease-in",
   "ease-in-out",
   "ease-out",
+  "ellipsis",
   "enabled",
   "end",
   "evenodd",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -2438,6 +2438,15 @@
       "text-justify"
     ]
   },
+  "text-overflow": {
+    "affects-layout": false,
+    "animation-type": "discrete",
+    "inherited": false,
+    "initial": "clip",
+    "valid-types": [
+      "text-overflow"
+    ]
+  },
   "text-shadow": {
     "affects-layout": false,
     "animation-type": "custom",

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -610,6 +610,12 @@ Optional<CSS::TextJustify> StyleProperties::text_justify() const
     return value_id_to_text_justify(value->to_identifier());
 }
 
+Optional<CSS::TextOverflow> StyleProperties::text_overflow() const
+{
+    auto value = property(CSS::PropertyID::TextOverflow);
+    return value_id_to_text_overflow(value->to_identifier());
+}
+
 Optional<CSS::PointerEvents> StyleProperties::pointer_events() const
 {
     auto value = property(CSS::PropertyID::PointerEvents);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -74,6 +74,7 @@ public:
     Optional<CSS::TextAnchor> text_anchor() const;
     Optional<CSS::TextAlign> text_align() const;
     Optional<CSS::TextJustify> text_justify() const;
+    Optional<CSS::TextOverflow> text_overflow() const;
     CSS::Length border_spacing_horizontal() const;
     CSS::Length border_spacing_vertical() const;
     Optional<CSS::CaptionSide> caption_side() const;

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -337,6 +337,44 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
                 // putting it on the next line.
                 if (is_whitespace && next_width > 0 && line_builder.break_if_needed(item.border_box_width() + next_width))
                     break;
+            } else if (text_node.computed_values().text_overflow() == CSS::TextOverflow::Ellipsis
+                && text_node.computed_values().overflow_x() != CSS::Overflow::Visible) {
+                // We may need to do an ellipsis if the text is too long for the container
+                constexpr u32 ellipsis_codepoint = 0x2026;
+                if (m_available_space.has_value()
+                    && item.width.to_double() > m_available_space.value().width.to_px_or_zero().to_double()) {
+                    // Do the ellipsis
+                    auto& glyph_run = item.glyph_run;
+
+                    auto available_width = m_available_space.value().width.to_px_or_zero().to_double();
+                    auto ellipsis_width = glyph_run->font().glyph_width(ellipsis_codepoint);
+                    auto max_text_width = available_width - ellipsis_width;
+
+                    auto& glyphs = glyph_run->glyphs();
+                    auto last_glyph_index = 0;
+                    auto last_glyph_position = Gfx::FloatPoint();
+
+                    for (auto const& glyph_or_emoji : glyphs) {
+                        auto this_position = Gfx::FloatPoint();
+                        glyph_or_emoji.visit(
+                            [&](Gfx::DrawGlyph glyph) {
+                                this_position = glyph.position;
+                            },
+                            [&](Gfx::DrawEmoji emoji) {
+                                this_position = emoji.position;
+                            });
+                        if (this_position.x() > max_text_width)
+                            break;
+
+                        last_glyph_index++;
+                        last_glyph_position = this_position;
+                    }
+
+                    auto remove_item_count = glyphs.size() - last_glyph_index;
+                    glyphs.remove(last_glyph_index - 1, remove_item_count);
+
+                    glyphs.append(Gfx::DrawGlyph(last_glyph_position, ellipsis_codepoint));
+                }
             }
             line_builder.append_text_chunk(
                 text_node,
@@ -414,5 +452,4 @@ void InlineFormattingContext::set_vertical_float_clearance(CSSPixels vertical_fl
 {
     m_vertical_float_clearance = vertical_float_clearance;
 }
-
 }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -586,6 +586,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (auto text_indent = computed_style.length_percentage(CSS::PropertyID::TextIndent); text_indent.has_value())
         computed_values.set_text_indent(text_indent.release_value());
 
+    if (auto text_overflow = computed_style.text_overflow(); text_overflow.has_value())
+        computed_values.set_text_overflow(text_overflow.release_value());
+
     auto white_space = computed_style.white_space();
     if (white_space.has_value())
         computed_values.set_white_space(white_space.value());


### PR DESCRIPTION
This patch adds support for the text-overflow property.
All the neccessary plumbing throughout the CSS landscape is done and then the conditional display of ellipses (...) is implemented in TextNode.

Top: text-overflow: clip
Bottom: text-overflow: ellipsis
![image](https://github.com/user-attachments/assets/c734eb4e-02da-4b5d-9ac8-fea68547cf27)
