### PR TITLE
LibWeb: Support grid template function fit-content

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/fit-content-1.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-1.txt
@@ -1,0 +1,21 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      Box <div.container> at (8,8) content-size 784x17 [GFC] children: not-inline
+        BlockContainer <div.one> at (8,8) content-size 6.34375x17 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,8 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <div.two> at (14.34375,8) content-size 8.8125x17 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [14.34375,8 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      PaintableBox (Box<DIV>.container) [8,8 784x17]
+        PaintableWithLines (BlockContainer<DIV>.one) [8,8 6.34375x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.two) [14.34375,8 8.8125x17]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/fit-content-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fit-content-2.txt
@@ -1,0 +1,46 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
+      Box <div#container> at (18,18) content-size 764x180 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div> at (23,23) content-size 156.984375x170 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 15, rect: [23,23 126.109375x17] baseline: 13.296875
+              "Item as wide as"
+          frag 1 from TextNode start: 16, length: 12, rect: [23,40 98.125x17] baseline: 13.296875
+              "the content."
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div> at (194.984375,23) content-size 290x170 [BFC] children: inline
+          frag 0 from TextNode start: 1, length: 34, rect: [194.984375,23 278.625x17] baseline: 13.296875
+              "Item with more text in it. Because"
+          frag 1 from TextNode start: 36, length: 33, rect: [194.984375,40 274.53125x17] baseline: 13.296875
+              "the contents of it are wider than"
+          frag 2 from TextNode start: 70, length: 35, rect: [194.984375,57 289.90625x17] baseline: 13.296875
+              "the maximum width, it is clamped at"
+          frag 3 from TextNode start: 106, length: 11, rect: [194.984375,74 86.609375x17] baseline: 13.296875
+              "300 pixels."
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div> at (499.984375,23) content-size 277.015625x170 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 13, rect: [499.984375,23 102.53125x17] baseline: 13.296875
+              "Flexible item"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableBox (Box<DIV>#container) [8,8 784x200]
+        PaintableWithLines (BlockContainer<DIV>) [18,18 166.984375x180]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [189.984375,18 300x180]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [494.984375,18 287.015625x180]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]

--- a/Tests/LibWeb/Layout/input/grid/fit-content-1.html
+++ b/Tests/LibWeb/Layout/input/grid/fit-content-1.html
@@ -1,0 +1,15 @@
+<style>
+.container {
+    display: grid;
+    background-color: lightsalmon;
+    grid-template-columns: fit-content(150px) fit-content(150px);
+}
+
+.one {
+    background-color: lightblue;
+}
+
+.two {
+    background-color: yellowgreen;
+}
+</style><div class="container"><div class="one">1</div><div class="two">2</div></div>

--- a/Tests/LibWeb/Layout/input/grid/fit-content-2.html
+++ b/Tests/LibWeb/Layout/input/grid/fit-content-2.html
@@ -1,0 +1,25 @@
+<style>
+#container {
+  display: grid;
+  grid-template-columns: fit-content(300px) fit-content(300px) 1fr;
+  grid-gap: 5px;
+  box-sizing: border-box;
+  height: 200px;
+  width: 100%;
+  background-color: #8cffa0;
+  padding: 10px;
+}
+
+#container > div {
+  background-color: #8ca0ff;
+  padding: 5px;
+}
+</style><div id="container">
+<div>Item as wide as the content.</div>
+<div>
+Item with more text in it. Because the contents of it are wider than the
+maximum width, it is clamped at 300 pixels.
+</div>
+<div>Flexible item</div>
+</div>
+

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -250,6 +250,7 @@ private:
     Optional<Gfx::UnicodeRange> parse_unicode_range(StringView);
     Vector<Gfx::UnicodeRange> parse_unicode_ranges(TokenStream<ComponentValue>&);
     Optional<GridSize> parse_grid_size(ComponentValue const&);
+    Optional<GridFitContent> parse_fit_content(Vector<ComponentValue> const&);
     Optional<GridMinMax> parse_min_max(Vector<ComponentValue> const&);
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -137,6 +137,7 @@ class FrequencyOrCalculated;
 class FrequencyPercentage;
 class FrequencyStyleValue;
 class GridAutoFlowStyleValue;
+class GridFitContent;
 class GridMinMax;
 class GridRepeat;
 class GridSize;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -19,14 +19,6 @@
 
 namespace Web::Layout {
 
-// NOTE: We use a custom clamping function here instead of AK::clamp(), since the AK version
-//       will VERIFY(max >= min) and CSS explicitly allows that (see css-values-4.)
-template<typename T>
-[[nodiscard]] constexpr T css_clamp(T const& value, T const& min, T const& max)
-{
-    return ::max(min, ::min(value, max));
-}
-
 CSSPixels FlexFormattingContext::get_pixel_width(Box const& box, CSS::Size const& size) const
 {
     return calculate_inner_width(box, containing_block_width_as_available_size(box), size);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -13,6 +13,14 @@
 
 namespace Web::Layout {
 
+// NOTE: We use a custom clamping function here instead of AK::clamp(), since the AK version
+//       will VERIFY(max >= min) and CSS explicitly allows that (see css-values-4.)
+template<typename T>
+[[nodiscard]] constexpr T css_clamp(T const& value, T const& min, T const& max)
+{
+    return ::max(min, ::min(value, max));
+}
+
 class FormattingContext {
 public:
     virtual ~FormattingContext();


### PR DESCRIPTION
Before([tweakers.net](https://tweakers.net)):
![screenshot-2024-07-22-22-55-25-viewport](https://github.com/user-attachments/assets/2d4812f9-9b63-478a-b63a-1fbd5ebb8447)

After:
![screenshot-2024-07-22-22-53-27-viewport](https://github.com/user-attachments/assets/5d484072-c5e0-43a0-aca1-5366179b29b6)


Before(fit-content-2 test):
<img width="962" alt="image" src="https://github.com/user-attachments/assets/6cecc2b3-cbca-4ebb-8d83-f938ac998f61">

After:
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/b2e98815-6f78-430f-9b46-9bbc9cfaa8db">
