### PR TITLE
LibJS: Don't crash when dumping a backtrace

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Executable.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.cpp
@@ -98,15 +98,15 @@ Optional<Executable::ExceptionHandlers const&> Executable::exception_handlers_fo
     return {};
 }
 
-UnrealizedSourceRange Executable::source_range_at(size_t offset) const
+Optional<UnrealizedSourceRange> Executable::source_range_at(size_t offset) const
 {
     if (offset >= bytecode.size())
-        return {};
+        return OptionalNone {};
     auto it = InstructionStreamIterator(bytecode.span().slice(offset), this);
     VERIFY(!it.at_end());
     auto mapping = source_map.get(offset);
     if (!mapping.has_value())
-        return {};
+        return OptionalNone {};
     return UnrealizedSourceRange {
         .source_code = source_code,
         .start_offset = mapping->source_start_offset,

--- a/Userland/Libraries/LibJS/Bytecode/Executable.h
+++ b/Userland/Libraries/LibJS/Bytecode/Executable.h
@@ -100,7 +100,7 @@ public:
 
     [[nodiscard]] Optional<ExceptionHandlers const&> exception_handlers_for_offset(size_t offset) const;
 
-    [[nodiscard]] UnrealizedSourceRange source_range_at(size_t offset) const;
+    [[nodiscard]] Optional<UnrealizedSourceRange> source_range_at(size_t offset) const;
 
     void dump() const;
 

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -444,8 +444,15 @@ void VM::dump_backtrace() const
     for (ssize_t i = m_execution_context_stack.size() - 1; i >= 0; --i) {
         auto& frame = m_execution_context_stack[i];
         if (frame->executable && frame->program_counter.has_value()) {
-            auto source_range = frame->executable->source_range_at(frame->program_counter.value()).realize();
-            dbgln("-> {} @ {}:{},{}", frame->function_name ? frame->function_name->utf8_string() : ""_string, source_range.filename(), source_range.start.line, source_range.start.column);
+            auto unrealized_source_range = frame->executable->source_range_at(frame->program_counter.value());
+            if (unrealized_source_range.has_value()) {
+                auto source_range = unrealized_source_range->realize();
+                dbgln("-> {} @ {}:{},{}", frame->function_name ? frame->function_name->utf8_string() : ""_string, source_range.filename(), source_range.start.line, source_range.start.column);
+                continue;
+            }
+        }
+        if (frame->executable) {
+            dbgln("-> {} @ {}", frame->function_name ? frame->function_name->utf8_string() : ""_string, frame->executable->source_code->filename());
         } else {
             dbgln("-> {}", frame->function_name ? frame->function_name->utf8_string() : ""_string);
         }


### PR DESCRIPTION
Previously, we would crash when attempting to log a backtrace with the `--log-all-js-exceptions` option enabled. A crash would occur if the program counter value for the current frame was larger than the current executable bytecode size, or if a source mapping couldn't be found for the current program counter value.

This change doesn't fix the underlying issue(s) and backtraces will now sometimes print less information than they otherwise should, but I believe this is an improvement on the previous behavior.

This can be tested by visiting https://reddit.com with the `--log-all-js-exceptions` option enabled. 