### PR TITLE
LibWeb: Bring 'construct_entry_list' closer to specs

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -186,10 +186,17 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
             entry_list.append(XHR::FormDataEntry { .name = name.to_string(), .value = control_as_form_associated_element->value() });
         }
 
-        // FIXME: 11. If the element has a dirname attribute, and that attribute's value is not the empty string, then:
-        // FIXME:     1. Let dirname be the value of the element's dirname attribute.
-        // FIXME:     2. Let dir be the string "ltr" if the directionality of the element is 'ltr', and "rtl" otherwise (i.e., when the directionality of the element is 'rtl').
-        // FIXME:     3. Create an entry with dirname and dir, and append it to entry list.
+        // 11. If the element has a dirname attribute, and that attribute's value is not the empty string, then:
+        if (auto attribute = control->get_attribute(HTML::AttributeNames::dirname); attribute.has_value() && !attribute.value().is_empty()) {
+            // 1. Let dirname be the value of the element's dirname attribute.
+            String dirname = attribute.value();
+
+            // 2. Let dir be the string "ltr" if the directionality of the element is 'ltr', and "rtl" otherwise (i.e., when the directionality of the element is 'rtl').
+            String dir = MUST((control->directionality() == DOM::Element::Directionality::Ltr) ? String::from_utf8("ltr"sv) : String::from_utf8("rtr"sv));
+
+            // 3. Create an entry with dirname and dir, and append it to entry list.
+            entry_list.append(XHR::FormDataEntry { .name = dirname, .value = dir });
+        }
     }
     // 6. Let form data be a new FormData object associated with entry list.
     auto form_data = TRY(XHR::FormData::construct_impl(realm, entry_list));


### PR DESCRIPTION
implement step 11 in the specification for [`construct the entry list`](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constructing-the-form-data-set) in the html specs