### PR TITLE
LibThreading: Guard closing the background thread on the thread existing

### DIFF
--- a/Userland/Libraries/LibThreading/BackgroundAction.cpp
+++ b/Userland/Libraries/LibThreading/BackgroundAction.cpp
@@ -49,6 +49,9 @@ static void init()
 
 void Threading::quit_background_thread()
 {
+    if (!s_background_thread)
+        return;
+
     s_background_thread_should_run.store(false, AK::MemoryOrder::memory_order_release);
 
     pthread_mutex_lock(&s_mutex);


### PR DESCRIPTION
This prevents a crash in ImageDecoder when it's closed before any image decoding requests have been made.

cc @AtkinsSJ 