### PR TITLE
LibWeb/HTML: Implement HTMLMediaElement.addTextTrack

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-addTextTrack.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLMediaElement-addTextTrack.txt
@@ -1,0 +1,5 @@
+track.kind: subtitles
+track.label: demo label
+track.language: en-GB
+track.mode: hidden
+addtrack event called

--- a/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-addTextTrack.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLMediaElement-addTextTrack.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const video = document.createElement("video");
+        video.textTracks.addEventListener("addtrack", () => {
+            println(`addtrack event called`);
+        });
+
+        const track = video.addTextTrack("subtitles", "demo label", "en-GB");
+        println(`track.kind: ${track.kind}`);
+        println(`track.label: ${track.label}`);
+        println(`track.language: ${track.language}`);
+        println(`track.mode: ${track.mode}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -465,6 +465,42 @@ double HTMLMediaElement::effective_media_volume() const
     return volume;
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#dom-media-addtexttrack
+JS::NonnullGCPtr<TextTrack> HTMLMediaElement::add_text_track(Bindings::TextTrackKind kind, String const& label, String const& language)
+{
+    // 1. Create a new TextTrack object.
+    auto text_track = TextTrack::create(this->realm());
+
+    // 2. Create a new text track corresponding to the new object, and set its text track kind to kind, its text track
+    //    label to label, its text track language to language, its text track readiness state to the text track loaded
+    //    state, its text track mode to the text track hidden mode, and its text track list of cues to an empty list.
+    text_track->set_kind(kind);
+    text_track->set_label(label);
+    text_track->set_language(language);
+    text_track->set_readiness_state(TextTrack::ReadinessState::Loaded);
+    text_track->set_mode(Bindings::TextTrackMode::Hidden);
+    // FIXME: set text track list of cues to an empty list
+
+    // FIXME: 3. Initially, the text track list of cues is not associated with any rules for updating the text track rendering.
+    //    When a text track cue is added to it, the text track list of cues has its rules permanently set accordingly.
+
+    // FIXME: 4. Add the new text track to the media element's list of text tracks.
+
+    // 5. Queue a media element task given the media element to fire an event named addtrack at the media element's
+    //    textTracks attribute's TextTrackList object, using TrackEvent, with the track attribute initialized to the new
+    //    text track's TextTrack object.
+    queue_a_media_element_task([this, text_track] {
+        TrackEventInit event_init {};
+        event_init.track = JS::make_handle(text_track);
+
+        auto event = TrackEvent::create(this->realm(), HTML::EventNames::addtrack, move(event_init));
+        m_text_tracks->dispatch_event(event);
+    });
+
+    // 6. Return the new TextTrack object.
+    return text_track;
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#media-element-load-algorithm
 WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -107,6 +107,8 @@ public:
     JS::NonnullGCPtr<VideoTrackList> video_tracks() const { return *m_video_tracks; }
     JS::NonnullGCPtr<TextTrackList> text_tracks() const { return *m_text_tracks; }
 
+    JS::NonnullGCPtr<TextTrack> add_text_track(Bindings::TextTrackKind kind, String const& label, String const& language);
+
     WebIDL::ExceptionOr<void> handle_keydown(Badge<Web::EventHandler>, UIEvents::KeyCode);
 
     enum class MouseTrackingComponent {

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -1,6 +1,7 @@
 #import <HTML/AudioTrackList.idl>
 #import <HTML/HTMLElement.idl>
 #import <HTML/MediaError.idl>
+#import <HTML/TextTrack.idl>
 #import <HTML/TextTrackList.idl>
 #import <HTML/TimeRanges.idl>
 #import <HTML/VideoTrackList.idl>
@@ -70,6 +71,6 @@ interface HTMLMediaElement : HTMLElement {
     [SameObject] readonly attribute AudioTrackList audioTracks;
     [SameObject] readonly attribute VideoTrackList videoTracks;
     [SameObject] readonly attribute TextTrackList textTracks;
-    [FIXME] TextTrack addTextTrack(TextTrackKind kind, optional DOMString label = "", optional DOMString language = "");
+    TextTrack addTextTrack(TextTrackKind kind, optional DOMString label = "", optional DOMString language = "");
 
 };

--- a/Userland/Libraries/LibWeb/HTML/TextTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TextTrack.cpp
@@ -75,6 +75,17 @@ void TextTrack::set_id(String id)
     m_id = id;
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#dom-texttrack-mode
+Bindings::TextTrackMode TextTrack::mode()
+{
+    return m_mode;
+}
+
+void TextTrack::set_mode(Bindings::TextTrackMode mode)
+{
+    m_mode = mode;
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#handler-texttrack-oncuechange
 void TextTrack::set_oncuechange(WebIDL::CallbackType* event_handler)
 {

--- a/Userland/Libraries/LibWeb/HTML/TextTrack.h
+++ b/Userland/Libraries/LibWeb/HTML/TextTrack.h
@@ -36,6 +36,9 @@ public:
     String id();
     void set_id(String);
 
+    Bindings::TextTrackMode mode();
+    void set_mode(Bindings::TextTrackMode);
+
     void set_oncuechange(WebIDL::CallbackType*);
     WebIDL::CallbackType* oncuechange();
 
@@ -49,6 +52,8 @@ private:
     String m_language {};
 
     String m_id {};
+
+    Bindings::TextTrackMode m_mode { Bindings::TextTrackMode::Disabled };
 };
 
 Bindings::TextTrackKind text_track_kind_from_string(String);

--- a/Userland/Libraries/LibWeb/HTML/TextTrack.h
+++ b/Userland/Libraries/LibWeb/HTML/TextTrack.h
@@ -21,6 +21,14 @@ class TextTrack final : public DOM::EventTarget {
     JS_DECLARE_ALLOCATOR(TextTrack);
 
 public:
+    // https://html.spec.whatwg.org/multipage/media.html#text-track-readiness-state
+    enum class ReadinessState {
+        NotLoaded,
+        Loading,
+        Loaded,
+        FailedToLoad,
+    };
+
     static JS::NonnullGCPtr<TextTrack> create(JS::Realm&);
     virtual ~TextTrack() override;
 
@@ -42,6 +50,9 @@ public:
     void set_oncuechange(WebIDL::CallbackType*);
     WebIDL::CallbackType* oncuechange();
 
+    ReadinessState readiness_state() { return m_readiness_state; }
+    void set_readiness_state(ReadinessState readiness_state) { m_readiness_state = readiness_state; }
+
 private:
     TextTrack(JS::Realm&);
 
@@ -54,6 +65,8 @@ private:
     String m_id {};
 
     Bindings::TextTrackMode m_mode { Bindings::TextTrackMode::Disabled };
+
+    ReadinessState m_readiness_state { ReadinessState::NotLoaded };
 };
 
 Bindings::TextTrackKind text_track_kind_from_string(String);

--- a/Userland/Libraries/LibWeb/HTML/TextTrack.idl
+++ b/Userland/Libraries/LibWeb/HTML/TextTrack.idl
@@ -16,7 +16,7 @@ interface TextTrack : EventTarget {
     readonly attribute DOMString id;
     [FIXME] readonly attribute DOMString inBandMetadataTrackDispatchType;
 
-    [FIXME] attribute TextTrackMode mode;
+    attribute TextTrackMode mode;
 
     [FIXME] readonly attribute TextTrackCueList? cues;
     [FIXME] readonly attribute TextTrackCueList? activeCues;


### PR DESCRIPTION
Removes some noise from the console when browsing bbc.co.uk :^)