### PR TITLE
LibWeb: Make `DocumentType::node_name()` return `DocumentType::name()`

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Node-nodeName.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Node-nodeName.txt
@@ -1,0 +1,9 @@
+Element nodeName: DIV
+Attribute nodeName: testattribute
+Text nodeName: #text
+CDATASection nodeName: #cdata-section
+ProcessingInstruction nodeName: testPI
+Comment nodeName: #comment
+Document nodeName: #document
+DocumentType nodeName: html
+DocumentFragment nodeName: #document-fragment

--- a/Tests/LibWeb/Text/input/DOM/Node-nodeName.html
+++ b/Tests/LibWeb/Text/input/DOM/Node-nodeName.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const element = document.createElement("div");
+        element.setAttribute("testAttribute", "foo");
+        element.innerText = "Text";
+        println(`Element nodeName: ${element.nodeName}`);
+        println(`Attribute nodeName: ${element.attributes[0].nodeName}`);
+        println(`Text nodeName: ${element.childNodes[0].nodeName}`);
+
+        const xmlDocument = new DOMParser().parseFromString(`<xml></xml>`, "application/xml");
+        const CDATASection = xmlDocument.createCDATASection("Test CDATA");
+        println(`CDATASection nodeName: ${CDATASection.nodeName}`);
+
+        const processingInstruction = document.createProcessingInstruction("testPI", "bar");
+        println(`ProcessingInstruction nodeName: ${processingInstruction.nodeName}`);
+
+        const comment = document.createComment("Test comment");
+        println(`Comment nodeName: ${comment.nodeName}`);
+
+        println(`Document nodeName: ${document.nodeName}`);
+        println(`DocumentType nodeName: ${document.doctype.nodeName}`);
+
+        const documentFragment = document.createDocumentFragment();
+        println(`DocumentFragment nodeName: ${documentFragment.nodeName}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.h
@@ -23,7 +23,7 @@ public:
 
     virtual ~DocumentType() override = default;
 
-    virtual FlyString node_name() const override { return "#doctype"_fly_string; }
+    virtual FlyString node_name() const override { return name(); }
 
     String const& name() const { return m_name; }
     void set_name(String const& name) { m_name = name; }


### PR DESCRIPTION
This aligns our implementation with the specification.

Fixes the following WPT tests:
http://wpt.live/dom/nodes/Node-nodeName.html
http://wpt.live/dom/nodes/DOMImplementation-createDocumentType.html