### PR TITLE
LibWeb/CSS: Make CSS Parser construction infallible

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -594,11 +594,9 @@ Optional<double> AnimationEffect::transformed_progress() const
 
 RefPtr<CSS::StyleValue const> AnimationEffect::parse_easing_string(JS::Realm& realm, StringView value)
 {
-    auto maybe_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), value);
-    if (maybe_parser.is_error())
-        return {};
+    auto parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), value);
 
-    if (auto style_value = maybe_parser.release_value().parse_as_css_value(CSS::PropertyID::AnimationTimingFunction)) {
+    if (auto style_value = parser.parse_as_css_value(CSS::PropertyID::AnimationTimingFunction)) {
         if (style_value->is_easing())
             return style_value;
     }

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -540,11 +540,9 @@ static WebIDL::ExceptionOr<Vector<BaseKeyframe>> process_a_keyframes_argument(JS
             if (!property_id.has_value())
                 continue;
 
-            auto maybe_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), value_string);
-            if (maybe_parser.is_error())
-                continue;
+            auto parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), value_string);
 
-            if (auto style_value = maybe_parser.release_value().parse_as_css_value(*property_id)) {
+            if (auto style_value = parser.parse_as_css_value(*property_id)) {
                 // Handle 'initial' here so we don't have to get the default value of the property every frame in StyleComputer
                 if (style_value->is_initial())
                     style_value = CSS::property_initial_value(realm, *property_id);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -22,64 +22,55 @@ CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const& cont
         auto media_list = CSS::MediaList::create(context.realm(), {});
         return CSS::CSSStyleSheet::create(context.realm(), rule_list, media_list, location);
     }
-    auto parser = CSS::Parser::Parser::create(context, css).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_css_stylesheet(location);
+    return CSS::Parser::Parser::create(context, css).parse_as_css_stylesheet(location);
 }
 
 CSS::ElementInlineCSSStyleDeclaration* parse_css_style_attribute(CSS::Parser::ParsingContext const& context, StringView css, DOM::Element& element)
 {
     if (css.is_empty())
         return CSS::ElementInlineCSSStyleDeclaration::create(element, {}, {});
-    auto parser = CSS::Parser::Parser::create(context, css).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_style_attribute(element);
+    return CSS::Parser::Parser::create(context, css).parse_as_style_attribute(element);
 }
 
 RefPtr<CSS::StyleValue> parse_css_value(CSS::Parser::ParsingContext const& context, StringView string, CSS::PropertyID property_id)
 {
     if (string.is_empty())
         return nullptr;
-    auto parser = MUST(CSS::Parser::Parser::create(context, string));
-    return parser.parse_as_css_value(property_id);
+    return CSS::Parser::Parser::create(context, string).parse_as_css_value(property_id);
 }
 
 CSS::CSSRule* parse_css_rule(CSS::Parser::ParsingContext const& context, StringView css_text)
 {
-    auto parser = CSS::Parser::Parser::create(context, css_text).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_css_rule();
+    return CSS::Parser::Parser::create(context, css_text).parse_as_css_rule();
 }
 
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingContext const& context, StringView selector_text)
 {
-    auto parser = CSS::Parser::Parser::create(context, selector_text).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_selector();
+    return CSS::Parser::Parser::create(context, selector_text).parse_as_selector();
 }
 
 RefPtr<CSS::MediaQuery> parse_media_query(CSS::Parser::ParsingContext const& context, StringView string)
 {
-    auto parser = CSS::Parser::Parser::create(context, string).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_media_query();
+    return CSS::Parser::Parser::create(context, string).parse_as_media_query();
 }
 
 Vector<NonnullRefPtr<CSS::MediaQuery>> parse_media_query_list(CSS::Parser::ParsingContext const& context, StringView string)
 {
-    auto parser = CSS::Parser::Parser::create(context, string).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_media_query_list();
+    return CSS::Parser::Parser::create(context, string).parse_as_media_query_list();
 }
 
 RefPtr<CSS::Supports> parse_css_supports(CSS::Parser::ParsingContext const& context, StringView string)
 {
     if (string.is_empty())
         return {};
-    auto parser = CSS::Parser::Parser::create(context, string).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_supports();
+    return CSS::Parser::Parser::create(context, string).parse_as_supports();
 }
 
 Optional<CSS::StyleProperty> parse_css_supports_condition(CSS::Parser::ParsingContext const& context, StringView string)
 {
     if (string.is_empty())
         return {};
-    auto parser = CSS::Parser::Parser::create(context, string).release_value_but_fixme_should_propagate_errors();
-    return parser.parse_as_supports_condition();
+    return CSS::Parser::Parser::create(context, string).parse_as_supports_condition();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -93,7 +93,7 @@ static void log_parse_error(SourceLocation const& location = SourceLocation::cur
 
 namespace Web::CSS::Parser {
 
-ErrorOr<Parser> Parser::create(ParsingContext const& context, StringView input, StringView encoding)
+Parser Parser::create(ParsingContext const& context, StringView input, StringView encoding)
 {
     auto tokens = Tokenizer::tokenize(input, encoding);
     return Parser { context, move(tokens) };
@@ -7788,7 +7788,7 @@ NonnullRefPtr<StyleValue> Parser::resolve_unresolved_style_value(ParsingContext 
 
     // If the value is invalid, we fall back to `unset`: https://www.w3.org/TR/css-variables-1/#invalid-at-computed-value-time
 
-    auto parser = MUST(Parser::create(context, ""sv));
+    auto parser = Parser::create(context, ""sv);
     return parser.resolve_unresolved_style_value(element, pseudo_element, property_id, unresolved);
 }
 
@@ -8072,7 +8072,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
         auto attribute_value = element.get_attribute_value(attribute_name);
         if (attribute_type.equals_ignoring_ascii_case("angle"_fly_string)) {
             // Parse a component value from the attribute’s value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             // If the result is a <dimension-token> whose unit matches the given type, the result is the substitution value.
             // Otherwise, there is no substitution value.
             if (component_value.has_value() && component_value->is(Token::Type::Dimension)) {
@@ -8085,7 +8085,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             // Parse a component value from the attribute’s value.
             // If the result is a <hex-color> or a named color ident, the substitution value is that result as a <color>.
             // Otherwise there is no substitution value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             if (component_value.has_value()) {
                 if ((component_value->is(Token::Type::Hash)
                         && Color::from_string(MUST(String::formatted("#{}", component_value->token().hash_value()))).has_value())
@@ -8097,7 +8097,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             }
         } else if (attribute_type.equals_ignoring_ascii_case("flex"_fly_string)) {
             // Parse a component value from the attribute’s value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             // If the result is a <dimension-token> whose unit matches the given type, the result is the substitution value.
             // Otherwise, there is no substitution value.
             if (component_value.has_value() && component_value->is(Token::Type::Dimension)) {
@@ -8108,7 +8108,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             }
         } else if (attribute_type.equals_ignoring_ascii_case("frequency"_fly_string)) {
             // Parse a component value from the attribute’s value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             // If the result is a <dimension-token> whose unit matches the given type, the result is the substitution value.
             // Otherwise, there is no substitution value.
             if (component_value.has_value() && component_value->is(Token::Type::Dimension)) {
@@ -8131,7 +8131,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             }
         } else if (attribute_type.equals_ignoring_ascii_case("length"_fly_string)) {
             // Parse a component value from the attribute’s value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             // If the result is a <dimension-token> whose unit matches the given type, the result is the substitution value.
             // Otherwise, there is no substitution value.
             if (component_value.has_value() && component_value->is(Token::Type::Dimension)) {
@@ -8144,14 +8144,14 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             // Parse a component value from the attribute’s value.
             // If the result is a <number-token>, the result is the substitution value.
             // Otherwise, there is no substitution value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             if (component_value.has_value() && component_value->is(Token::Type::Number)) {
                 dest.append(component_value.release_value());
                 return true;
             }
         } else if (attribute_type.equals_ignoring_ascii_case("percentage"_fly_string)) {
             // Parse a component value from the attribute’s value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             // If the result is a <percentage-token>, the result is the substitution value.
             // Otherwise, there is no substitution value.
             if (component_value.has_value() && component_value->is(Token::Type::Percentage)) {
@@ -8166,7 +8166,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             return true;
         } else if (attribute_type.equals_ignoring_ascii_case("time"_fly_string)) {
             // Parse a component value from the attribute’s value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             // If the result is a <dimension-token> whose unit matches the given type, the result is the substitution value.
             // Otherwise, there is no substitution value.
             if (component_value.has_value() && component_value->is(Token::Type::Dimension)) {
@@ -8186,7 +8186,7 @@ bool Parser::substitute_attr_function(DOM::Element& element, FlyString const& pr
             // Parse a component value from the attribute’s value.
             // If the result is a <number-token>, the substitution value is a dimension with the result’s value, and the given unit.
             // Otherwise, there is no substitution value.
-            auto component_value = MUST(Parser::Parser::create(m_context, attribute_value)).parse_as_component_value();
+            auto component_value = Parser::Parser::create(m_context, attribute_value).parse_as_component_value();
             if (component_value.has_value() && component_value->is(Token::Type::Number)) {
                 if (attribute_value == "%"sv) {
                     dest.empend(Token::create_dimension(component_value->token().number_value(), attribute_type));

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -95,7 +95,7 @@ namespace Web::CSS::Parser {
 
 ErrorOr<Parser> Parser::create(ParsingContext const& context, StringView input, StringView encoding)
 {
-    auto tokens = TRY(Tokenizer::tokenize(input, encoding));
+    auto tokens = Tokenizer::tokenize(input, encoding);
     return Parser { context, move(tokens) };
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -40,7 +40,7 @@ class PropertyDependencyNode;
 
 class Parser {
 public:
-    static ErrorOr<Parser> create(ParsingContext const&, StringView input, StringView encoding = "utf-8"sv);
+    static Parser create(ParsingContext const&, StringView input, StringView encoding = "utf-8"sv);
 
     Parser(Parser&&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -59,17 +59,17 @@ public:
 
 class Tokenizer {
 public:
-    static ErrorOr<Vector<Token>> tokenize(StringView input, StringView encoding);
+    static Vector<Token> tokenize(StringView input, StringView encoding);
 
     [[nodiscard]] static Token create_eof_token();
 
 private:
     explicit Tokenizer(String decoded_input);
 
-    [[nodiscard]] ErrorOr<Vector<Token>> tokenize();
+    [[nodiscard]] Vector<Token> tokenize();
 
     size_t current_byte_offset() const;
-    ErrorOr<String> input_since(size_t offset) const;
+    String input_since(size_t offset) const;
 
     [[nodiscard]] u32 next_code_point();
     [[nodiscard]] u32 peek_code_point(size_t offset = 0) const;
@@ -82,15 +82,15 @@ private:
     [[nodiscard]] static Token create_new_token(Token::Type);
     [[nodiscard]] static Token create_value_token(Token::Type, FlyString&& value, String&& representation);
     [[nodiscard]] static Token create_value_token(Token::Type, u32 value, String&& representation);
-    [[nodiscard]] ErrorOr<Token> consume_a_token();
-    [[nodiscard]] ErrorOr<Token> consume_string_token(u32 ending_code_point);
-    [[nodiscard]] ErrorOr<Token> consume_a_numeric_token();
-    [[nodiscard]] ErrorOr<Token> consume_an_ident_like_token();
+    [[nodiscard]] Token consume_a_token();
+    [[nodiscard]] Token consume_string_token(u32 ending_code_point);
+    [[nodiscard]] Token consume_a_numeric_token();
+    [[nodiscard]] Token consume_an_ident_like_token();
     [[nodiscard]] Number consume_a_number();
     [[nodiscard]] double convert_a_string_to_a_number(StringView);
-    [[nodiscard]] ErrorOr<FlyString> consume_an_ident_sequence();
+    [[nodiscard]] FlyString consume_an_ident_sequence();
     [[nodiscard]] u32 consume_escaped_code_point();
-    [[nodiscard]] ErrorOr<Token> consume_a_url_token();
+    [[nodiscard]] Token consume_a_url_token();
     void consume_the_remnants_of_a_bad_url();
     void consume_comments();
     void consume_as_much_whitespace_as_possible();

--- a/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -45,7 +45,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
             false);
     };
 
-    auto tokens = CSS::Parser::Tokenizer::tokenize(text, "utf-8"sv).release_value_but_fixme_should_propagate_errors();
+    auto tokens = CSS::Parser::Tokenizer::tokenize(text, "utf-8"sv);
     for (auto const& token : tokens) {
         if (token.is(Parser::Token::Type::EndOfFile))
             break;

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFillStrokeStyles.h
@@ -33,12 +33,7 @@ public:
             // 1. If the given value is a string, then:
             [&](String const& string) {
                 // 1. Let context be this's canvas attribute's value, if that is an element; otherwise null.
-                auto maybe_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), string);
-                if (maybe_parser.is_error()) {
-                    dbgln_if(CANVAS_RENDERING_CONTEXT_2D_DEBUG, "CanvasFillStrokeStyles: Failed to create CSS parser.");
-                    return;
-                }
-                auto parser = maybe_parser.release_value();
+                auto parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), string);
 
                 // 2. Let parsedValue be the result of parsing the given value with context if non-null.
                 // FIXME: Parse a color value
@@ -80,12 +75,7 @@ public:
             // 1. If the given value is a string, then:
             [&](String const& string) {
                 // 1. Let context be this's canvas attribute's value, if that is an element; otherwise null.
-                auto maybe_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), string);
-                if (maybe_parser.is_error()) {
-                    dbgln_if(CANVAS_RENDERING_CONTEXT_2D_DEBUG, "CanvasFillStrokeStyles: Failed to create CSS parser.");
-                    return;
-                }
-                auto parser = maybe_parser.release_value();
+                auto parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm), string);
 
                 // 2. Let parsedValue be the result of parsing the given value with context if non-null.
                 // FIXME: Parse a color value

--- a/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
@@ -341,7 +341,7 @@ descriptor_parser:
 // https://html.spec.whatwg.org/multipage/images.html#parse-a-sizes-attribute
 CSS::LengthOrCalculated parse_a_sizes_attribute(DOM::Document const& document, StringView sizes)
 {
-    auto css_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext { document }, sizes).release_value_but_fixme_should_propagate_errors();
+    auto css_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext { document }, sizes);
     return css_parser.parse_as_sizes_attribute();
 }
 


### PR DESCRIPTION
This was only ErrorOr in order to propagate tiny OOMs when tokenizing.