### PR TITLE
LibWeb/CSS: Parse custom-idents more consistently

### DIFF
--- a/Tests/LibWeb/Text/expected/css/custom-ident-parsing.txt
+++ b/Tests/LibWeb/Text/expected/css/custom-ident-parsing.txt
@@ -1,0 +1,16 @@
+  Before testing: none
+badger: badger
+none: none
+BANANA: BANANA
+NONE: none
+InHeRiT: none
+revert: none
+initial: none
+unset: none
+george: george
+REVERT: none
+NaCl: NaCl
+default: INVALID
+string: string
+32: INVALID
+done: done

--- a/Tests/LibWeb/Text/input/css/custom-ident-parsing.html
+++ b/Tests/LibWeb/Text/input/css/custom-ident-parsing.html
@@ -1,0 +1,14 @@
+<script src="../include.js"></script>
+<div id="foo"></div>
+<script>
+    test(() => {
+        const foo = document.getElementById("foo");
+        println(`Before testing: ${getComputedStyle(foo).getPropertyValue("animation-name")}`);
+        const cases = [ 'badger', 'none', 'BANANA', 'NONE', 'InHeRiT', 'revert', 'initial', 'unset', 'george', 'REVERT', 'NaCl', 'default', 'string', '32', 'done' ];
+        for (const name of cases) {
+            foo.style.setProperty('animation-name', 'INVALID');
+            foo.style.setProperty('animation-name', name);
+            println(`${name}: ${getComputedStyle(foo).getPropertyValue("animation-name")}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -279,6 +279,7 @@ private:
     Optional<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);
     RefPtr<CalculatedStyleValue> parse_calculated_value(ComponentValue const&);
+    RefPtr<CustomIdentStyleValue> parse_custom_ident_value(TokenStream<ComponentValue>&, std::initializer_list<StringView> blacklist);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
     OwnPtr<CalculationNode> parse_math_function(PropertyID, Function const&);
     OwnPtr<CalculationNode> parse_a_calc_function_node(Function const&);


### PR DESCRIPTION
These have a few rules that we didn't follow in most cases:
- CSS-wide keywords are not allowed. (inherit, initial, etc)
- `default` is not allowed.
- The above and any other disallowed identifiers must be tested case-insensitively.

This introduces a `parse_custom_ident_value()` method, which takes a list of disallowed identifier names, and handles the above rules.