### PR TITLE
LibWasm: Small optimizations pack

### DIFF
--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -1257,11 +1257,9 @@ ParseResult<CodeSection::Code> CodeSection::Code::parse(Stream& stream)
         return with_eof_check(stream, ParseError::InvalidSize);
     size_t size = size_or_error.release_value();
 
-    auto constrained_stream = ConstrainedStream { MaybeOwned<Stream>(stream), size };
-
     // Emprically, if there are `size` bytes to be read, then there's around
     // `size / 2` instructions, so we pass that as our size hint.
-    auto func = TRY(Func::parse(constrained_stream, size / 2));
+    auto func = TRY(Func::parse(stream, size / 2));
 
     return Code { static_cast<u32>(size), func };
 }

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -1246,7 +1246,7 @@ ParseResult<CodeSection::Func> CodeSection::Func::parse(Stream& stream, size_t s
     ScopeLogger<WASM_BINPARSER_DEBUG> logger("Func"sv);
     auto locals = TRY(parse_vector<Locals>(stream));
     auto body = TRY(Expression::parse(stream, size_hint));
-    return Func { locals, body };
+    return Func { move(locals), move(body) };
 }
 
 ParseResult<CodeSection::Code> CodeSection::Code::parse(Stream& stream)
@@ -1261,14 +1261,14 @@ ParseResult<CodeSection::Code> CodeSection::Code::parse(Stream& stream)
     // `size / 2` instructions, so we pass that as our size hint.
     auto func = TRY(Func::parse(stream, size / 2));
 
-    return Code { static_cast<u32>(size), func };
+    return Code { static_cast<u32>(size), move(func) };
 }
 
 ParseResult<CodeSection> CodeSection::parse(Stream& stream)
 {
     ScopeLogger<WASM_BINPARSER_DEBUG> logger("CodeSection"sv);
     auto result = TRY(parse_vector<Code>(stream));
-    return CodeSection { result };
+    return CodeSection { move(result) };
 }
 
 ParseResult<DataSection::Data> DataSection::Data::parse(Stream& stream)

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -676,7 +676,7 @@ public:
 
     auto& instructions() const { return m_instructions; }
 
-    static ParseResult<Expression> parse(Stream& stream);
+    static ParseResult<Expression> parse(Stream& stream, Optional<size_t> size_hint = {});
 
 private:
     Vector<Instruction> m_instructions;
@@ -855,7 +855,7 @@ public:
         auto& locals() const { return m_locals; }
         auto& body() const { return m_body; }
 
-        static ParseResult<Func> parse(Stream& stream);
+        static ParseResult<Func> parse(Stream& stream, size_t size_hint);
 
     private:
         Vector<Locals> m_locals;


### PR DESCRIPTION
Speeds up spidermonkey.wasm instantiation by around 110ms (280ms -> 170ms).