### PR TITLE
Meta: No longer ignore `test-wasm` results during testing

### DIFF
--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -218,11 +218,10 @@ ALWAYS_INLINE static T shuffle_or_0_impl(T a, Control control, IndexSequence<Idx
     using E = ElementOf<T>;
 
     if constexpr (__has_builtin(__builtin_shuffle)) {
-        // GCC does a very bad job at optimizing the masking, while not recognizing the shuffle idiom
-        // So we jinx its __builtin_shuffle to work with out of bounds indices
-        // TODO: verify that this masking logic is correct (for machines with __builtin_shuffle)
-        auto mask = (control >= 0) | (control < N);
-        return __builtin_shuffle(a, control & mask) & ~mask;
+        auto vector = __builtin_shuffle(a, control);
+        for (size_t i = 0; i < N; ++i)
+            vector[i] = control[i] < 0 || control[i] >= N ? 0 : vector[i];
+        return vector;
     }
     // 1. Set all out of bounds values to ~0
     // Note: This is done so that  the optimization mentioned down below works

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -581,12 +581,8 @@ if (BUILD_TESTING)
         ../../Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp)
     target_link_libraries(test-wasm AK LibCore LibFileSystem LibTest LibWasm LibJS LibCrypto)
     add_test(
-        NAME WasmParser
+        NAME Wasm
         COMMAND test-wasm --show-progress=false ${CMAKE_CURRENT_BINARY_DIR}/Userland/Libraries/LibWasm/Tests
-    )
-    set_tests_properties(WasmParser PROPERTIES
-        SKIP_RETURN_CODE 1
-        ENVIRONMENT LADYBIRD_SOURCE_DIR=${SERENITY_PROJECT_ROOT}
     )
 endif()
 


### PR DESCRIPTION
Since the Wasm runtime should be fully spec-compliant, we want to make sure that the spec-tests always pass.

We don't have full spec-compliance on gcc ladybird, but this PR will at least help to see the failures in CI.