### PR TITLE
Documentation: Add info on macOS Qt X11R6 linking warning (non-problem)

### DIFF
--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -31,3 +31,17 @@ MinProtocol = TLSv1.2
 CipherString = DEFAULT@SECLEVEL=1
 Options = UnsafeLegacyRenegotiation
 ```
+
+#### “Targets may link only to libraries. CMake is dropping the item” message (when building with the Qt chrome on macOS)
+
+When building with the Qt chrome on macOS, you may encounter the following message:
+
+> CMake Warning at /opt/homebrew/Cellar/qt/6.7.0_1/lib/cmake/Qt6/FindWrapOpenGL.cmake:48 (target_link_libraries):
+> Target "ladybird" requests linking to directory "/usr/X11R6/lib". Targets
+> may link only to libraries. CMake is dropping the item.
+
+…followed by 14-line stack trace, the top of which is this:
+
+> Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
+
+…and all of it shown in bright yellow, making you think it must be important and something must need to be fixed. But that’s not the case. Instead, despite that, you’ll be able to build successfully with the Qt chrome.


### PR DESCRIPTION
I ran into this message when running a Qt-chrome build on macOS — related to https://github.com/LadybirdBrowser/ladybird/pull/843, so I could make Sam a screenshot of the UI from the build.

And I assumed at first that the warning must have been indicating the build was broken, and I wasted some time trying to figure out how to fix it.

But it turns out that the message doesn’t really indicate anything’s broken. It’s a non-problem. So, let’s add it to the docs so that we can help other people avoid unnecessarily wasting time on it, the way I did.