### PR TITLE
Meta: Script to configure clangd according to build type

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -67,3 +67,16 @@ Some OS distributions don't ship bleeding-edge clang-format binaries. Below are 
 
 1) If you have a Debian-based (apt-based) distribution, use the [LLVM apt repositories](https://apt.llvm.org) to install the latest release of clang-format.
 2) Compile LLVM from source as described in the LLVM documentation [here](https://llvm.org/docs/GettingStarted.html#compiling-the-llvm-suite-source-code).
+
+## Clangd Configuration
+
+Clangd will automatically look for configuration information in files
+named `.clangd` in each of the parent directories of the file being
+edited. The Ladybird source code repository has a top-level `.clangd`
+configuration file in the root directory. One of the configuration
+stanzas in that file specifies the location for a compilation database.
+Depending on your build configuration (e.g., Debug, default, Sanitizer,
+etc), the path to the compilation database in that file may not be
+correct. The result is that clangd will have a difficult time
+understanding all your include directories. To resolve the problem, you
+can use the `Meta/configure-clangd.sh` script.

--- a/Meta/configure-clangd.sh
+++ b/Meta/configure-clangd.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+function usage {
+    echo "$0 <.clangd file path> [release|debug]"
+    echo "Update local clangd configuration with the proper"
+    echo "compilation database according to the selected build type."
+}
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.." || exit 1
+
+# Check if the user has sed.
+
+if ! which sed >/dev/null 2>&1; then
+    echo "Error: No sed found. Cannot configure .clangd automatically."
+    exit 1
+fi
+
+# Check if the user specified the right number of parameters.
+if [ $# -ne 2 ]; then
+    usage 
+    exit 1
+fi
+
+clangd_file_path=$1
+if [ ! -f "$clangd_file_path" ]; then
+    echo "Error: ${clangd_file_path} is not a regular file."
+    echo
+    usage
+    exit 1
+fi
+
+build_type=""
+case $2 in
+    Debug)
+        build_type="-debug"
+        ;;
+    default)
+        build_type=""
+        ;;
+    Sanitizer)
+        build_type="-sanitizers"
+        ;;
+    *)
+        echo "Invalid build configuration specified: $2"
+        usage
+        exit 1
+esac
+
+sed -i '' "s/\(^[  ]*CompilationDatabase:\).*$/\1 Build\/ladybird${build_type}/" "$clangd_file_path"


### PR DESCRIPTION
Add a simple shell script to update the local clangd configuration according to the type of build selected by the user.