### PR TITLE
LibWeb: Add commit hash to Version output in About Ladybird page

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -121,6 +121,11 @@ target_include_directories(headless-browser PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(headless-browser PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_link_libraries(headless-browser PRIVATE AK LibCore LibWeb LibWebView LibWebSocket LibCrypto LibFileSystem LibHTTP LibImageDecoderClient LibJS LibGfx LibMain LibTLS LibIPC LibDiff LibProtocol LibURL)
 
+execute_process(COMMAND git rev-parse --short HEAD
+                OUTPUT_VARIABLE LADYBIRD_COMMIT_HASH
+                OUTPUT_STRIP_TRAILING_WHITESPACE)
+target_compile_definitions(LibWeb PUBLIC LADYBIRD_COMMIT_HASH="${LADYBIRD_COMMIT_HASH}")
+
 add_custom_target(run
     COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" "$<TARGET_FILE:ladybird>" $ENV{LAGOM_ARGS}
     USES_TERMINAL

--- a/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -88,7 +88,11 @@ ErrorOr<String> load_about_version_page()
     StringBuilder builder;
     SourceGenerator generator { builder, '%', '%' };
     generator.set("browser_name", BROWSER_NAME);
+#if defined(LADYBIRD_COMMIT_HASH)
+    generator.set("browser_version", MUST(String::formatted("{} ({})", BROWSER_VERSION, LADYBIRD_COMMIT_HASH)));
+#else
     generator.set("browser_version", BROWSER_VERSION);
+#endif
     generator.set("arch_name", CPU_STRING);
     generator.set("os_name", OS_STRING);
     generator.set("user_agent", default_user_agent);


### PR DESCRIPTION
### Use case

While trying to help Sam assess whether the page in https://github.com/LadybirdBrowser/ladybird/pull/843 was working as expected for macOS, I made a screenshot of a build with the About Ladybird page shown. I only afterward realized that I’d mistakenly built from the master branch rather than from Sam’s PR.

That made me realize: Having the About Ladybird page show the commit hash for the HEAD commit of the branch I’d built from would help in general for a case like that one. It would both help me confirm that the build I was running and looking at was actually built from the branch I’d intended — and it would do the same for anybody else with whom I might share build screenshots or whatever.

<details>
<summary>More…</summary>

I can imagine that it’d also be useful in any case where we might want to share any actual builds with others — that is, if I were to provide a build for somebody else to download.

A real-world case where I’ve run into the need to do that in the past when working on other engines is: When I was implementing a accessibility-related feature and wanted some accessibility practitioners I know to test a build I’ve made with AT software (e.g., screen readers) that I don’t have myself. In those cases, they’re not set up to run a build themselves.

So anyway, in those cases, we may go through multiple builds — so it’s useful both for me and for them to be able to doublecheck the commit hash so that we can know for certain which build (among the multiple builds I’ve shared with them) they’re testing with at some given point.
</details>