### PR TITLE
More WebAudio Stubbing

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/WebAudio/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/WebAudio/BUILD.gn
@@ -10,6 +10,8 @@ source_set("WebAudio") {
     "AudioBufferSourceNode.h",
     "AudioContext.cpp",
     "AudioContext.h",
+    "AudioDestinationNode.cpp",
+    "AudioDestinationNode.h",
     "AudioNode.cpp",
     "AudioNode.h",
     "AudioParam.cpp",

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/idl_files.gni
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/idl_files.gni
@@ -321,6 +321,7 @@ standard_idl_files = [
   "//Userland/Libraries/LibWeb/WebAudio/AudioBuffer.idl",
   "//Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.idl",
   "//Userland/Libraries/LibWeb/WebAudio/AudioContext.idl",
+  "//Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.idl",
   "//Userland/Libraries/LibWeb/WebAudio/AudioNode.idl",
   "//Userland/Libraries/LibWeb/WebAudio/AudioParam.idl",
   "//Userland/Libraries/LibWeb/WebAudio/AudioScheduledSourceNode.idl",

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -718,6 +718,7 @@ class AudioBuffer;
 class AudioBufferSourceNode;
 class AudioDestinationNode;
 class AudioContext;
+class AudioDestinationNode;
 class AudioNode;
 class AudioParam;
 class AudioScheduledSourceNode;

--- a/Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.cpp
@@ -6,19 +6,101 @@
 
 #include <LibWeb/Bindings/AudioScheduledSourceNodePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/WebAudio/AudioBuffer.h>
 #include <LibWeb/WebAudio/AudioBufferSourceNode.h>
+#include <LibWeb/WebAudio/AudioParam.h>
 #include <LibWeb/WebAudio/AudioScheduledSourceNode.h>
 
 namespace Web::WebAudio {
 
 JS_DEFINE_ALLOCATOR(AudioBufferSourceNode);
 
-AudioBufferSourceNode::AudioBufferSourceNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, AudioBufferSourceOptions const&)
+AudioBufferSourceNode::AudioBufferSourceNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, AudioBufferSourceOptions const& options)
     : AudioScheduledSourceNode(realm, context)
+    , m_buffer(options.buffer)
+    , m_playback_rate(AudioParam::create(realm, options.playback_rate, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::ARate))
+    , m_detune(AudioParam::create(realm, options.detune, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::ARate))
+    , m_loop(options.loop)
+    , m_loop_start(options.loop_start)
+    , m_loop_end(options.loop_end)
 {
 }
 
 AudioBufferSourceNode::~AudioBufferSourceNode() = default;
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-buffer
+WebIDL::ExceptionOr<void> AudioBufferSourceNode::set_buffer(JS::GCPtr<AudioBuffer> buffer)
+{
+    m_buffer = buffer;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-buffer
+JS::GCPtr<AudioBuffer> AudioBufferSourceNode::buffer() const
+{
+    return m_buffer;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-playbackrate
+JS::NonnullGCPtr<AudioParam> AudioBufferSourceNode::playback_rate() const
+{
+    return m_playback_rate;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-detune
+JS::NonnullGCPtr<AudioParam> AudioBufferSourceNode::detune() const
+{
+    return m_detune;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-loop
+WebIDL::ExceptionOr<void> AudioBufferSourceNode::set_loop(bool loop)
+{
+    m_loop = loop;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-loop
+bool AudioBufferSourceNode::loop() const
+{
+    return m_loop;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-loopstart
+WebIDL::ExceptionOr<void> AudioBufferSourceNode::set_loop_start(double loop_start)
+{
+    m_loop_start = loop_start;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-loopstart
+double AudioBufferSourceNode::loop_start() const
+{
+    return m_loop_start;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-loopend
+WebIDL::ExceptionOr<void> AudioBufferSourceNode::set_loop_end(double loop_end)
+{
+    m_loop_end = loop_end;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-loopend
+double AudioBufferSourceNode::loop_end() const
+{
+    return m_loop_end;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audiobuffersourcenode-start`
+WebIDL::ExceptionOr<void> AudioBufferSourceNode::start(Optional<double> when, Optional<double> offset, Optional<double> duration)
+{
+    (void)when;
+    (void)offset;
+    (void)duration;
+    dbgln("FIXME: Implement AudioBufferSourceNode::start(when, offset, duration)");
+    return {};
+}
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioBufferSourceNode>> AudioBufferSourceNode::create(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, AudioBufferSourceOptions const& options)
 {
@@ -44,6 +126,9 @@ void AudioBufferSourceNode::initialize(JS::Realm& realm)
 void AudioBufferSourceNode::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_buffer);
+    visitor.visit(m_playback_rate);
+    visitor.visit(m_detune);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <LibWeb/Bindings/AudioBufferSourceNodePrototype.h>
+#include <LibWeb/WebAudio/AudioBuffer.h>
+#include <LibWeb/WebAudio/AudioParam.h>
 #include <LibWeb/WebAudio/AudioScheduledSourceNode.h>
 
 namespace Web::WebAudio {
@@ -29,6 +31,19 @@ class AudioBufferSourceNode : public AudioScheduledSourceNode {
 public:
     virtual ~AudioBufferSourceNode() override;
 
+    WebIDL::ExceptionOr<void> set_buffer(JS::GCPtr<AudioBuffer>);
+    JS::GCPtr<AudioBuffer> buffer() const;
+    JS::NonnullGCPtr<AudioParam> playback_rate() const;
+    JS::NonnullGCPtr<AudioParam> detune() const;
+    WebIDL::ExceptionOr<void> set_loop(bool);
+    bool loop() const;
+    WebIDL::ExceptionOr<void> set_loop_start(double);
+    double loop_start() const;
+    WebIDL::ExceptionOr<void> set_loop_end(double);
+    double loop_end() const;
+
+    WebIDL::ExceptionOr<void> start(Optional<double>, Optional<double>, Optional<double>);
+
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioBufferSourceNode>> create(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, AudioBufferSourceOptions const& = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioBufferSourceNode>> construct_impl(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, AudioBufferSourceOptions const& = {});
 
@@ -37,6 +52,14 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+
+private:
+    JS::GCPtr<AudioBuffer> m_buffer;
+    JS::NonnullGCPtr<AudioParam> m_playback_rate;
+    JS::NonnullGCPtr<AudioParam> m_detune;
+    bool m_loop { false };
+    double m_loop_start { 0.0 };
+    double m_loop_end { 0.0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.idl
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioBufferSourceNode.idl
@@ -16,11 +16,11 @@ dictionary AudioBufferSourceOptions {
 [Exposed=Window]
 interface AudioBufferSourceNode : AudioScheduledSourceNode {
     constructor(BaseAudioContext context, optional AudioBufferSourceOptions options = {});
-    [FIXME] attribute AudioBuffer? buffer;
-    [FIXME] readonly attribute AudioParam playbackRate;
-    [FIXME] readonly attribute AudioParam detune;
-    [FIXME] attribute boolean loop;
-    [FIXME] attribute double loopStart;
-    [FIXME] attribute double loopEnd;
-    [FIXME] undefined start(optional double when = 0, optional double offset, optional double duration);
+    attribute AudioBuffer? buffer;
+    readonly attribute AudioParam playbackRate;
+    readonly attribute AudioParam detune;
+    attribute boolean loop;
+    attribute double loopStart;
+    attribute double loopEnd;
+    undefined start(optional double when = 0, optional double offset, optional double duration);
 };

--- a/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.cpp
@@ -1,13 +1,15 @@
 /*
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2024, Bar Yemini <bar.ye651@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Bindings/AudioDestinationNodePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
-#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/WebAudio/AudioDestinationNode.h>
+#include <LibWeb/WebAudio/AudioNode.h>
+#include <LibWeb/WebAudio/BaseAudioContext.h>
 
 namespace Web::WebAudio {
 
@@ -19,6 +21,18 @@ AudioDestinationNode::AudioDestinationNode(JS::Realm& realm, JS::NonnullGCPtr<Ba
 }
 
 AudioDestinationNode::~AudioDestinationNode() = default;
+
+// https://webaudio.github.io/web-audio-api/#dom-audiodestinationnode-maxchannelcount
+WebIDL::UnsignedLong AudioDestinationNode::max_channel_count()
+{
+    dbgln("FIXME: Implement Audio::DestinationNode::max_channel_count()");
+    return 2;
+}
+
+JS::NonnullGCPtr<AudioDestinationNode> AudioDestinationNode::construct_impl(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context)
+{
+    return realm.heap().allocate<AudioDestinationNode>(realm, realm, context);
+}
 
 void AudioDestinationNode::initialize(JS::Realm& realm)
 {

--- a/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.h
@@ -1,12 +1,16 @@
 /*
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2024, Bar Yemini <bar.ye651@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <LibWeb/Bindings/AudioDestinationNodePrototype.h>
 #include <LibWeb/WebAudio/AudioNode.h>
+#include <LibWeb/WebAudio/BaseAudioContext.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::WebAudio {
 
@@ -17,6 +21,10 @@ class AudioDestinationNode : public AudioNode {
 
 public:
     virtual ~AudioDestinationNode() override;
+
+    WebIDL::UnsignedLong max_channel_count();
+
+    static JS::NonnullGCPtr<AudioDestinationNode> construct_impl(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>);
 
 protected:
     AudioDestinationNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>);

--- a/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.idl
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.idl
@@ -3,5 +3,5 @@
 // https://webaudio.github.io/web-audio-api/#AudioDestinationNode
 [Exposed=Window]
 interface AudioDestinationNode : AudioNode {
-    [FIXME] readonly attribute unsigned long maxChannelCount;
+    readonly attribute unsigned long maxChannelCount;
 };

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
@@ -24,18 +24,26 @@ AudioNode::~AudioNode() = default;
 // https://webaudio.github.io/web-audio-api/#dom-audionode-connect
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioNode>> AudioNode::connect(JS::NonnullGCPtr<AudioNode> destination_node, WebIDL::UnsignedLong output, WebIDL::UnsignedLong input)
 {
+    // There can only be one connection between a given output of one specific node and a given input of another specific node.
+    // Multiple connections with the same termini are ignored.
+
+    // If the destination parameter is an AudioNode that has been created using another AudioContext, an InvalidAccessError MUST be thrown.
+    if (m_context != destination_node->m_context) {
+        return WebIDL::InvalidAccessError::create(realm(), "Cannot connect to an AudioNode in a different AudioContext"_fly_string);
+    }
+
     (void)output;
     (void)input;
-    dbgln("FIXME: Implement AudioNode::connect (AudioNode)");
+    dbgln("FIXME: Implement Audio::connect(AudioNode)");
     return destination_node;
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audionode-connect-destinationparam-output
-WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioNode>> AudioNode::connect(JS::NonnullGCPtr<AudioParam> destination_param, WebIDL::UnsignedLong output)
+void AudioNode::connect(JS::NonnullGCPtr<AudioParam> destination_param, WebIDL::UnsignedLong output)
 {
     (void)destination_param;
     (void)output;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioNode::connect (AudioParam)"_fly_string);
+    dbgln("FIXME: Implement AudioNode::connect(AudioParam)");
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audionode-disconnect
@@ -88,6 +96,60 @@ void AudioNode::disconnect(JS::NonnullGCPtr<AudioParam> destination_param, WebID
     (void)destination_param;
     (void)output;
     dbgln("FIXME: Implement AudioNode::disconnect(destination_param, output)");
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-numberofinputs
+WebIDL::UnsignedLong AudioNode::number_of_inputs()
+{
+    dbgln("FIXME: Implement AudioNode::number_of_inputs()");
+    return 0;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-numberofoutputs
+WebIDL::UnsignedLong AudioNode::number_of_outputs()
+{
+    dbgln("FIXME: Implement AudioNode::number_of_outputs()");
+    return 0;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelcount
+WebIDL::ExceptionOr<void> AudioNode::set_channel_count(WebIDL::UnsignedLong channel_count)
+{
+    (void)channel_count;
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioNode::set_channel_count(channel_count)"_fly_string);
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelcount
+WebIDL::UnsignedLong AudioNode::channel_count()
+{
+    dbgln("FIXME: Implement AudioNode::channel_count()");
+    return 2;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelcountmode
+WebIDL::ExceptionOr<void> AudioNode::set_channel_count_mode(Bindings::ChannelCountMode channel_count_mode)
+{
+    m_channel_count_mode = channel_count_mode;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelcountmode
+Bindings::ChannelCountMode AudioNode::channel_count_mode()
+{
+    return m_channel_count_mode;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelinterpretation
+WebIDL::ExceptionOr<void> AudioNode::set_channel_interpretation(Bindings::ChannelInterpretation channel_interpretation)
+{
+    m_channel_interpretation = channel_interpretation;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelinterpretation
+Bindings::ChannelInterpretation AudioNode::channel_interpretation()
+{
+    return m_channel_interpretation;
 }
 
 void AudioNode::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.h
@@ -31,7 +31,7 @@ public:
     virtual ~AudioNode() override;
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioNode>> connect(JS::NonnullGCPtr<AudioNode> destination_node, WebIDL::UnsignedLong output = 0, WebIDL::UnsignedLong input = 0);
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioNode>> connect(JS::NonnullGCPtr<AudioParam> destination_param, WebIDL::UnsignedLong output = 0);
+    void connect(JS::NonnullGCPtr<AudioParam> destination_param, WebIDL::UnsignedLong output = 0);
 
     void disconnect();
     void disconnect(WebIDL::UnsignedLong output);
@@ -48,6 +48,15 @@ public:
         return m_context;
     }
 
+    WebIDL::UnsignedLong number_of_inputs();
+    WebIDL::UnsignedLong number_of_outputs();
+    WebIDL::ExceptionOr<void> set_channel_count(WebIDL::UnsignedLong);
+    WebIDL::UnsignedLong channel_count();
+    WebIDL::ExceptionOr<void> set_channel_count_mode(Bindings::ChannelCountMode);
+    Bindings::ChannelCountMode channel_count_mode();
+    WebIDL::ExceptionOr<void> set_channel_interpretation(Bindings::ChannelInterpretation);
+    Bindings::ChannelInterpretation channel_interpretation();
+
 protected:
     AudioNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>);
 
@@ -56,6 +65,8 @@ protected:
 
 private:
     JS::NonnullGCPtr<BaseAudioContext> m_context;
+    Bindings::ChannelCountMode m_channel_count_mode { Bindings::ChannelCountMode::Max };
+    Bindings::ChannelInterpretation m_channel_interpretation { Bindings::ChannelInterpretation::Speakers };
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.idl
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.idl
@@ -38,9 +38,9 @@ interface AudioNode : EventTarget {
     undefined disconnect(AudioParam destinationParam);
     undefined disconnect(AudioParam destinationParam, unsigned long output);
     readonly attribute BaseAudioContext context;
-    [FIXME] readonly attribute unsigned long numberOfInputs;
-    [FIXME] readonly attribute unsigned long numberOfOutputs;
-    [FIXME] attribute unsigned long channelCount;
-    [FIXME] attribute ChannelCountMode channelCountMode;
-    [FIXME] attribute ChannelInterpretation channelInterpretation;
+    readonly attribute unsigned long numberOfInputs;
+    readonly attribute unsigned long numberOfOutputs;
+    attribute unsigned long channelCount;
+    attribute ChannelCountMode channelCountMode;
+    attribute ChannelInterpretation channelInterpretation;
 };

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -21,6 +21,7 @@ namespace Web::WebAudio {
 
 BaseAudioContext::BaseAudioContext(JS::Realm& realm, float sample_rate)
     : DOM::EventTarget(realm)
+    , m_destination(AudioDestinationNode::construct_impl(realm, *this))
     , m_sample_rate(sample_rate)
 {
 }
@@ -37,18 +38,6 @@ void BaseAudioContext::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_destination);
-}
-
-// https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-destination
-JS::NonnullGCPtr<AudioDestinationNode> BaseAudioContext::destination()
-{
-    auto& realm = this->realm();
-
-    dbgln("FIXME: Properly implement BaseAudioContext::destination");
-
-    if (!m_destination)
-        m_destination = realm.heap().allocate<AudioDestinationNode>(realm, realm, *this);
-    return *m_destination;
 }
 
 void BaseAudioContext::set_onstatechange(WebIDL::CallbackType* event_handler)

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.h
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/Bindings/BaseAudioContextPrototype.h>
 #include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/WebAudio/AudioDestinationNode.h>
 #include <LibWeb/WebAudio/BiquadFilterNode.h>
 #include <LibWeb/WebIDL/Types.h>
 
@@ -32,6 +33,7 @@ public:
     static constexpr float MIN_SAMPLE_RATE { 8000 };
     static constexpr float MAX_SAMPLE_RATE { 192000 };
 
+    JS::NonnullGCPtr<AudioDestinationNode> destination() const { return m_destination; }
     float sample_rate() const { return m_sample_rate; }
     double current_time() const { return m_current_time; }
     Bindings::AudioContextState state() const { return m_control_thread_state; }
@@ -55,14 +57,13 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<DynamicsCompressorNode>> create_dynamics_compressor();
     JS::NonnullGCPtr<GainNode> create_gain();
 
-    JS::NonnullGCPtr<AudioDestinationNode> destination();
-
 protected:
     explicit BaseAudioContext(JS::Realm&, float m_sample_rate = 0);
 
-    virtual void initialize(JS::Realm&) override;
+    JS::NonnullGCPtr<AudioDestinationNode> m_destination;
 
-    virtual void visit_edges(Cell::Visitor& visitor) override;
+    virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Cell::Visitor&) override;
 
 private:
     float m_sample_rate { 0 };
@@ -70,7 +71,6 @@ private:
 
     Bindings::AudioContextState m_control_thread_state = Bindings::AudioContextState::Suspended;
     Bindings::AudioContextState m_rendering_thread_state = Bindings::AudioContextState::Suspended;
-    JS::GCPtr<AudioDestinationNode> m_destination;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.cpp
@@ -4,21 +4,74 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/Bindings/AudioParamPrototype.h>
 #include <LibWeb/Bindings/BiquadFilterNodePrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/WebAudio/AudioNode.h>
+#include <LibWeb/WebAudio/AudioParam.h>
 #include <LibWeb/WebAudio/BiquadFilterNode.h>
 
 namespace Web::WebAudio {
 
 JS_DEFINE_ALLOCATOR(BiquadFilterNode);
 
-BiquadFilterNode::BiquadFilterNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, BiquadFilterOptions const&)
+BiquadFilterNode::BiquadFilterNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, BiquadFilterOptions const& options)
     : AudioNode(realm, context)
+    , m_frequency(AudioParam::create(realm, options.frequency, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::ARate))
+    , m_detune(AudioParam::create(realm, options.detune, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::ARate))
+    , m_q(AudioParam::create(realm, options.q, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::ARate))
+    , m_gain(AudioParam::create(realm, options.gain, NumericLimits<float>::lowest(), NumericLimits<float>::max(), Bindings::AutomationRate::ARate))
 {
 }
 
 BiquadFilterNode::~BiquadFilterNode() = default;
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-type
+WebIDL::ExceptionOr<void> BiquadFilterNode::set_type(Bindings::BiquadFilterType type)
+{
+    m_type = type;
+    return {};
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-type
+Bindings::BiquadFilterType BiquadFilterNode::type() const
+{
+    return m_type;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-frequency
+JS::NonnullGCPtr<AudioParam> BiquadFilterNode::frequency() const
+{
+    return m_frequency;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-detune
+JS::NonnullGCPtr<AudioParam> BiquadFilterNode::detune() const
+{
+    return m_detune;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-q
+JS::NonnullGCPtr<AudioParam> BiquadFilterNode::q() const
+{
+    return m_q;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-gain
+JS::NonnullGCPtr<AudioParam> BiquadFilterNode::gain() const
+{
+    return m_gain;
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-biquadfilternode-getfrequencyresponse
+WebIDL::ExceptionOr<void> BiquadFilterNode::get_frequency_response(JS::Handle<WebIDL::BufferSource> const& frequency_hz, JS::Handle<WebIDL::BufferSource> const& mag_response, JS::Handle<WebIDL::BufferSource> const& phase_response)
+{
+    (void)frequency_hz;
+    (void)mag_response;
+    (void)phase_response;
+    dbgln("FIXME: Implement BiquadFilterNode::get_frequency_response(Float32Array, Float32Array, Float32Array)");
+    return {};
+}
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<BiquadFilterNode>> BiquadFilterNode::create(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, BiquadFilterOptions const& options)
 {
@@ -44,6 +97,10 @@ void BiquadFilterNode::initialize(JS::Realm& realm)
 void BiquadFilterNode::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
+    visitor.visit(m_frequency);
+    visitor.visit(m_detune);
+    visitor.visit(m_q);
+    visitor.visit(m_gain);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Bindings/BiquadFilterNodePrototype.h>
 #include <LibWeb/WebAudio/AudioNode.h>
+#include <LibWeb/WebAudio/AudioParam.h>
 
 namespace Web::WebAudio {
 
@@ -28,6 +29,14 @@ class BiquadFilterNode : public AudioNode {
 public:
     virtual ~BiquadFilterNode() override;
 
+    WebIDL::ExceptionOr<void> set_type(Bindings::BiquadFilterType);
+    Bindings::BiquadFilterType type() const;
+    JS::NonnullGCPtr<AudioParam> frequency() const;
+    JS::NonnullGCPtr<AudioParam> detune() const;
+    JS::NonnullGCPtr<AudioParam> q() const;
+    JS::NonnullGCPtr<AudioParam> gain() const;
+    WebIDL::ExceptionOr<void> get_frequency_response(JS::Handle<WebIDL::BufferSource> const&, JS::Handle<WebIDL::BufferSource> const&, JS::Handle<WebIDL::BufferSource> const&);
+
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<BiquadFilterNode>> create(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, BiquadFilterOptions const& = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<BiquadFilterNode>> construct_impl(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, BiquadFilterOptions const& = {});
 
@@ -36,6 +45,13 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
+
+private:
+    Bindings::BiquadFilterType m_type { Bindings::BiquadFilterType::Lowpass };
+    JS::NonnullGCPtr<AudioParam> m_frequency;
+    JS::NonnullGCPtr<AudioParam> m_detune;
+    JS::NonnullGCPtr<AudioParam> m_q;
+    JS::NonnullGCPtr<AudioParam> m_gain;
 };
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.idl
+++ b/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.idl
@@ -24,10 +24,10 @@ dictionary BiquadFilterOptions : AudioNodeOptions {
 [Exposed=Window]
 interface BiquadFilterNode : AudioNode {
     constructor (BaseAudioContext context, optional BiquadFilterOptions options = {});
-    [FIXME] attribute BiquadFilterType type;
-    [FIXME] readonly attribute AudioParam frequency;
-    [FIXME] readonly attribute AudioParam detune;
-    [FIXME] readonly attribute AudioParam Q;
-    [FIXME] readonly attribute AudioParam gain;
-    [FIXME] undefined getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
+    attribute BiquadFilterType type;
+    readonly attribute AudioParam frequency;
+    readonly attribute AudioParam detune;
+    readonly attribute AudioParam Q;
+    readonly attribute AudioParam gain;
+    undefined getFrequencyResponse (Float32Array frequencyHz, Float32Array magResponse, Float32Array phaseResponse);
 };

--- a/Userland/Libraries/LibWeb/WebAudio/GainNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/GainNode.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/WebAudio/AudioNode.h>
 #include <LibWeb/WebAudio/AudioParam.h>
 #include <LibWeb/WebAudio/BaseAudioContext.h>
 #include <LibWeb/WebAudio/GainNode.h>

--- a/Userland/Libraries/LibWeb/WebAudio/GainNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/GainNode.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <LibWeb/Bindings/GainNodePrototype.h>
-#include <LibWeb/WebAudio/AudioScheduledSourceNode.h>
+#include <LibWeb/WebAudio/AudioNode.h>
 
 namespace Web::WebAudio {
 


### PR DESCRIPTION
This gets http://www.puzzlescript.net/ fully working 🥳 (well except audio :sweat_smile: also `https` doesn't work and the codemirror editor is a little buggy) in Ladybird!
This includes the [editor](https://www.puzzlescript.net/editor.html), games in the [gallery](http://www.puzzlescript.net/Gallery/index.html), and puzzlescript games on [itch.io](https://itch.io/games/tag-puzzlescript) (excluding some of the ones based on puzzlescript forks).

I forgot to pull and accidentally redid most of https://github.com/LadybirdBrowser/ladybird/pull/800 hopefully I rebased correctly