### PR TITLE
LibWeb/DOM: Implement Node.lookupPrefix

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Node-lookupPrefix.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Node-lookupPrefix.txt
@@ -1,0 +1,9 @@
+Prefix for namespace "test" on document: ex
+Prefix for namespace "test" on document fragment: null
+Prefix for namespace "test" on comment node 0: ex
+Prefix null on document: null
+Prefix for absent namespace "no" on document: null
+Prefix for namespace "def" on child: abc
+Prefix null on child: null
+Prefix for namespace "test" (in parent) on child: ex
+Prefix for namespace "def" (from attribute "x") on child: abc

--- a/Tests/LibWeb/Text/input/DOM/Node-lookupPrefix.html
+++ b/Tests/LibWeb/Text/input/DOM/Node-lookupPrefix.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const xmlDoc = new DOMParser().parseFromString(`<root xmlns:ex="test"><!--abc--><child xmlns:abc="def" x="1"></child></root>`, "application/xml");
+        const fragment = document.createDocumentFragment();
+        println(`Prefix for namespace "test" on document: ${xmlDoc.lookupPrefix("test")}`);
+        println(`Prefix for namespace "test" on document fragment: ${fragment.lookupPrefix("test")}`);
+        println(`Prefix for namespace "test" on comment node 0: ${xmlDoc.childNodes[0].lookupPrefix("test")}`);
+        println(`Prefix null on document: ${xmlDoc.lookupPrefix(null)}`);
+        println(`Prefix for absent namespace "no" on document: ${xmlDoc.lookupPrefix("no")}`);
+
+        const child = xmlDoc.querySelector("child");
+        println(`Prefix for namespace "def" on child: ${child.lookupPrefix("def")}`);
+        println(`Prefix null on child: ${child.lookupPrefix(null)}`);
+        println(`Prefix for namespace "test" (in parent) on child: ${child.lookupPrefix("test")}`);
+
+        const attrX = child.getAttributeNode("x");
+        println(`Prefix for namespace "def" (from attribute "x") on child: ${attrX.lookupPrefix("def")}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -106,6 +106,8 @@ public:
 
     void set_prefix(Optional<FlyString> value);
 
+    Optional<String> locate_a_namespace_prefix(Optional<String> const& namespace_) const;
+
     // NOTE: This is for the JS bindings
     Optional<FlyString> const& namespace_uri() const { return m_qualified_name.namespace_(); }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1736,6 +1736,57 @@ Optional<String> Node::lookup_namespace_uri(Optional<String> prefix) const
     return locate_a_namespace(prefix);
 }
 
+// https://dom.spec.whatwg.org/#dom-node-lookupprefix
+Optional<String> Node::lookup_prefix(Optional<String> namespace_) const
+{
+    // 1. If namespace is null or the empty string, then return null.
+    if (!namespace_.has_value() || namespace_->is_empty())
+        return {};
+
+    // 2. Switch on the interface this implements:
+
+    // Element
+    if (is<Element>(*this)) {
+        // Return the result of locating a namespace prefix for it using namespace.
+        auto& element = verify_cast<Element>(*this);
+        return element.locate_a_namespace_prefix(namespace_);
+    }
+
+    // Document
+    if (is<Document>(*this)) {
+        // Return the result of locating a namespace prefix for its document element, if its document element is non-null; otherwise null.
+        auto* document_element = verify_cast<Document>(*this).document_element();
+        if (!document_element)
+            return {};
+
+        return document_element->locate_a_namespace_prefix(namespace_);
+    }
+
+    // DocumentType
+    // DocumentFragment
+    if (is<DocumentType>(*this) || is<DocumentFragment>(*this))
+        // Return null
+        return {};
+
+    // Attr
+    if (is<Attr>(*this)) {
+        // Return the result of locating a namespace prefix for its element, if its element is non-null; otherwise null.
+        auto* element = verify_cast<Attr>(*this).owner_element();
+        if (!element)
+            return {};
+
+        return element->locate_a_namespace_prefix(namespace_);
+    }
+
+    // Otherwise
+    // Return the result of locating a namespace prefix for its parent element, if its parent element is non-null; otherwise null.
+    auto* parent_element = this->parent_element();
+    if (!parent_element)
+        return {};
+
+    return parent_element->locate_a_namespace_prefix(namespace_);
+}
+
 // https://dom.spec.whatwg.org/#dom-node-isdefaultnamespace
 bool Node::is_default_namespace(Optional<String> namespace_) const
 {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -698,6 +698,7 @@ public:
 
     Optional<String> locate_a_namespace(Optional<String> const& prefix) const;
     Optional<String> lookup_namespace_uri(Optional<String> prefix) const;
+    Optional<String> lookup_prefix(Optional<String> namespace_) const;
     bool is_default_namespace(Optional<String> namespace_) const;
 
 protected:

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -54,7 +54,7 @@ interface Node : EventTarget {
     unsigned short compareDocumentPosition(Node? otherNode);
     boolean contains(Node? other);
 
-    [FIXME] DOMString? lookupPrefix(DOMString? namespace);
+    DOMString? lookupPrefix(DOMString? namespace);
     DOMString? lookupNamespaceURI(DOMString? prefix);
     boolean isDefaultNamespace(DOMString? namespace);
 


### PR DESCRIPTION
Adds https://dom.spec.whatwg.org/#dom-node-lookupprefix alongside some tests.

This passes 10 of the 11 cases in the Web Platform Tests: https://wpt.live/dom/nodes/Node-lookupPrefix.xhtml. Case 9 fails due to #840. 