### PR TITLE
RequestServer+LibHTTP: Cancel requests on client exit

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -576,6 +576,13 @@ void Job::finish_up()
 {
     VERIFY(!m_has_scheduled_finish);
     m_state = State::Finished;
+
+    if (is_cancelled()) {
+        stop_timer();
+        m_has_scheduled_finish = true;
+        return;
+    }
+
     if (!m_can_stream_response) {
         auto maybe_flattened_buffer = ByteBuffer::create_uninitialized(m_buffered_size);
         if (maybe_flattened_buffer.is_error())

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -101,7 +101,7 @@ struct JobData {
 #endif
 
     template<typename T>
-    static JobData create(NonnullRefPtr<T> job, [[maybe_unused]] URL::URL url)
+    static JobData create(WeakPtr<T> job, [[maybe_unused]] URL::URL url)
     {
         return JobData {
             [job](auto& socket) { job->start(socket); },

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -23,7 +23,7 @@ class ConnectionFromClient final
     C_OBJECT(ConnectionFromClient);
 
 public:
-    ~ConnectionFromClient() override = default;
+    ~ConnectionFromClient() override;
 
     virtual void die() override;
 

--- a/Userland/Services/RequestServer/HttpRequest.h
+++ b/Userland/Services/RequestServer/HttpRequest.h
@@ -23,6 +23,7 @@ public:
     HTTP::Job const& job() const { return m_job; }
 
     virtual URL::URL url() const override { return m_job->url(); }
+    virtual void cancel() override { m_job->cancel(); }
 
 private:
     explicit HttpRequest(ConnectionFromClient&, NonnullRefPtr<HTTP::Job>, NonnullOwnPtr<Core::File>&&, i32);

--- a/Userland/Services/RequestServer/HttpsRequest.h
+++ b/Userland/Services/RequestServer/HttpsRequest.h
@@ -22,6 +22,7 @@ public:
     HTTP::HttpsJob const& job() const { return m_job; }
 
     virtual URL::URL url() const override { return m_job->url(); }
+    virtual void cancel() override { m_job->cancel(); }
 
 private:
     explicit HttpsRequest(ConnectionFromClient&, NonnullRefPtr<HTTP::HttpsJob>, NonnullOwnPtr<Core::File>&&, i32);

--- a/Userland/Services/RequestServer/Request.h
+++ b/Userland/Services/RequestServer/Request.h
@@ -34,6 +34,8 @@ public:
     void set_request_fd(int fd) { m_request_fd = fd; }
     int request_fd() const { return m_request_fd; }
 
+    virtual void cancel() = 0;
+
     void did_finish(bool success);
     void did_progress(Optional<u64> total_size, u64 downloaded_size);
     void set_status_code(u32 status_code) { m_status_code = status_code; }


### PR DESCRIPTION
That usually happens in "exceptional" states when the client exits unexpectedly (crash, force quit mid-load, etc), leading to the job flush timer firing and attempting to write to a nonexistent object (the client).

This commit makes RS simply cancel such jobs; cancelled jobs in this state simply go away instead of sending notifications around.