### PR TITLE
LibWasm: Remove `Module::functions`

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -329,7 +329,7 @@ private:
 
 class WasmFunction {
 public:
-    explicit WasmFunction(FunctionType const& type, ModuleInstance const& module, Module::Function const& code)
+    explicit WasmFunction(FunctionType const& type, ModuleInstance const& module, CodeSection::Code const& code)
         : m_type(type)
         , m_module(module)
         , m_code(code)
@@ -343,7 +343,7 @@ public:
 private:
     FunctionType m_type;
     ModuleInstance const& m_module;
-    Module::Function const& m_code;
+    CodeSection::Code const& m_code;
 };
 
 class HostFunction {
@@ -537,7 +537,7 @@ class Store {
 public:
     Store() = default;
 
-    Optional<FunctionAddress> allocate(ModuleInstance& module, Module::Function const& function);
+    Optional<FunctionAddress> allocate(ModuleInstance&, CodeSection::Code const&, TypeIndex);
     Optional<FunctionAddress> allocate(HostFunction&&);
     Optional<TableAddress> allocate(TableType const&);
     Optional<MemoryAddress> allocate(MemoryType const&);

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.cpp
@@ -44,14 +44,16 @@ Result Configuration::call(Interpreter& interpreter, FunctionAddress address, Ve
         return Trap {};
     if (auto* wasm_function = function->get_pointer<WasmFunction>()) {
         Vector<Value> locals = move(arguments);
-        locals.ensure_capacity(locals.size() + wasm_function->code().locals().size());
-        for (auto& type : wasm_function->code().locals())
-            locals.empend(type, 0ull);
+        locals.ensure_capacity(locals.size() + wasm_function->code().func().locals().size());
+        for (auto& local : wasm_function->code().func().locals()) {
+            for (size_t i = 0; i < local.n(); ++i)
+                locals.empend(local.type(), 0ull);
+        }
 
         set_frame(Frame {
             wasm_function->module(),
             move(locals),
-            wasm_function->code().body(),
+            wasm_function->code().func().body(),
             wasm_function->type().results().size(),
         });
         m_ip = 0;

--- a/Userland/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Userland/Libraries/LibWasm/Printer/Printer.cpp
@@ -541,33 +541,6 @@ void Printer::print(Wasm::Module const& module)
     print(")\n");
 }
 
-void Printer::print(Wasm::Module::Function const& func)
-{
-    print_indent();
-    print("(function\n");
-    {
-        TemporaryChange change { m_indent, m_indent + 1 };
-        {
-            print_indent();
-            print("(locals\n");
-            {
-                TemporaryChange change { m_indent, m_indent + 1 };
-                for (auto& locals : func.locals())
-                    print(locals);
-            }
-            print_indent();
-            print(")\n");
-        }
-        print_indent();
-        print("(body\n");
-        print(func.body());
-        print_indent();
-        print(")\n");
-    }
-    print_indent();
-    print(")\n");
-}
-
 void Printer::print(Wasm::StartSection const& section)
 {
     print_indent();

--- a/Userland/Libraries/LibWasm/Printer/Printer.h
+++ b/Userland/Libraries/LibWasm/Printer/Printer.h
@@ -50,7 +50,6 @@ struct Printer {
     void print(Wasm::MemorySection::Memory const&);
     void print(Wasm::MemoryType const&);
     void print(Wasm::Module const&);
-    void print(Wasm::Module::Function const&);
     void print(Wasm::Reference const&);
     void print(Wasm::StartSection const&);
     void print(Wasm::StartSection::StartFunction const&);

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -961,25 +961,6 @@ public:
         Valid,
     };
 
-    class Function {
-    public:
-        explicit Function(TypeIndex type, Vector<ValueType> local_types, Expression body)
-            : m_type(type)
-            , m_local_types(move(local_types))
-            , m_body(move(body))
-        {
-        }
-
-        auto& type() const { return m_type; }
-        auto& locals() const { return m_local_types; }
-        auto& body() const { return m_body; }
-
-    private:
-        TypeIndex m_type;
-        Vector<ValueType> m_local_types;
-        Expression m_body;
-    };
-
     using AnySection = Variant<
         CustomSection,
         TypeSection,
@@ -1001,14 +982,9 @@ public:
     explicit Module(Vector<AnySection> sections)
         : m_sections(move(sections))
     {
-        if (!populate_sections()) {
-            m_validation_status = ValidationStatus::Invalid;
-            m_validation_error = "Failed to populate module sections"sv;
-        }
     }
 
     auto& sections() const { return m_sections; }
-    auto& functions() const { return m_functions; }
     auto& type(TypeIndex index) const
     {
         FunctionType const* type = nullptr;
@@ -1045,11 +1021,9 @@ public:
     static ParseResult<Module> parse(Stream& stream);
 
 private:
-    bool populate_sections();
     void set_validation_status(ValidationStatus status) { m_validation_status = status; }
 
     Vector<AnySection> m_sections;
-    Vector<Function> m_functions;
     ValidationStatus m_validation_status { ValidationStatus::Unchecked };
     Optional<ByteString> m_validation_error;
 };


### PR DESCRIPTION
`Module::functions` created clones of all of the functions in the module. It provided a _slightly_ better API, but ended up costing around 40ms when instantiating spidermonkey.

This brings us from 180ms -> 140ms when instantiating spidermonkey.