### PR TITLE
BindingsGenerator+HTML: Partially implement HTMLInputElement's selection{Start,End}

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -388,6 +388,35 @@ static void generate_to_string(SourceGenerator& scoped_generator, ParameterType 
     }
 }
 
+static void generate_from_integral(SourceGenerator& scoped_generator, IDL::Type const& type)
+{
+    struct TypeMap {
+        StringView idl_type;
+        StringView cpp_type;
+    };
+    static constexpr auto idl_type_map = to_array<TypeMap>({
+        { "byte"sv, "WebIDL::Byte"sv },
+        { "octet"sv, "WebIDL::Octet"sv },
+        { "short"sv, "WebIDL::Short"sv },
+        { "unsigned short"sv, "WebIDL::UnsignedShort"sv },
+        { "long"sv, "WebIDL::Long"sv },
+        { "unsigned long"sv, "WebIDL::UnsignedLong"sv },
+        { "long long"sv, "double"sv },
+        { "unsigned long long"sv, "double"sv },
+    });
+
+    auto it = find_if(idl_type_map.begin(), idl_type_map.end(), [&](auto const& entry) {
+        return entry.idl_type == type.name();
+    });
+
+    VERIFY(it != idl_type_map.end());
+    scoped_generator.set("cpp_type"sv, it->cpp_type);
+
+    scoped_generator.append(R"~~~(
+    @result_expression@ JS::Value(static_cast<@cpp_type@>(@value@));
+)~~~");
+}
+
 template<typename ParameterType>
 static void generate_to_integral(SourceGenerator& scoped_generator, ParameterType const& parameter, bool optional, Optional<ByteString> const& optional_default_value)
 {
@@ -1741,22 +1770,8 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
     @result_expression@ JS::Value(@value@);
 )~~~");
         }
-    } else if (type.name() == "short" || type.name() == "long" || type.name() == "unsigned short") {
-        scoped_generator.append(R"~~~(
-    @result_expression@ JS::Value((i32)@value@);
-)~~~");
-    } else if (type.name() == "unsigned long") {
-        scoped_generator.append(R"~~~(
-    @result_expression@ JS::Value((u32)@value@);
-)~~~");
-    } else if (type.name() == "long long") {
-        scoped_generator.append(R"~~~(
-    @result_expression@ JS::Value((double)@value@);
-)~~~");
-    } else if (type.name() == "unsigned long long") {
-        scoped_generator.append(R"~~~(
-    @result_expression@ JS::Value((double)@value@);
-)~~~");
+    } else if (type.is_integer()) {
+        generate_from_integral(scoped_generator, type);
     } else if (type.name() == "Location" || type.name() == "Promise" || type.name() == "Uint8Array" || type.name() == "Uint8ClampedArray" || type.name() == "any") {
         scoped_generator.append(R"~~~(
     @result_expression@ @value@;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -412,9 +412,15 @@ static void generate_from_integral(SourceGenerator& scoped_generator, IDL::Type 
     VERIFY(it != idl_type_map.end());
     scoped_generator.set("cpp_type"sv, it->cpp_type);
 
-    scoped_generator.append(R"~~~(
+    if (type.is_nullable()) {
+        scoped_generator.append(R"~~~(
+    @result_expression@ JS::Value(static_cast<@cpp_type@>(@value@.release_value()));
+)~~~");
+    } else {
+        scoped_generator.append(R"~~~(
     @result_expression@ JS::Value(static_cast<@cpp_type@>(@value@));
 )~~~");
+    }
 }
 
 template<typename ParameterType>

--- a/Tests/LibWeb/Text/expected/input-selection-start-selection-end.txt
+++ b/Tests/LibWeb/Text/expected/input-selection-start-selection-end.txt
@@ -1,0 +1,7 @@
+Well hello friends    text selectionStart: 0
+text selectionEnd: 0
+date selectionStart: null
+date selectionEnd: null
+text selectionStart: 18
+text selectionEnd: 18
+date input setting selectionStart error: InvalidStateError: setSelectionStart does not apply to this input type

--- a/Tests/LibWeb/Text/input/input-selection-start-selection-end.html
+++ b/Tests/LibWeb/Text/input/input-selection-start-selection-end.html
@@ -1,0 +1,24 @@
+<input type="text" id="ladybird-text-input"></input>
+<input type="date" id="ladybird-date-input"></input>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let textInput = document.getElementById("ladybird-text-input");
+        let dateInput = document.getElementById("ladybird-date-input");
+
+        println(`text selectionStart: ${textInput.selectionStart}`);
+        println(`text selectionEnd: ${textInput.selectionEnd}`);
+        println(`date selectionStart: ${dateInput.selectionStart}`);
+        println(`date selectionEnd: ${dateInput.selectionEnd}`);
+
+        textInput.value = "Well hello friends";
+        println(`text selectionStart: ${textInput.selectionStart}`);
+        println(`text selectionEnd: ${textInput.selectionEnd}`);
+
+        try {
+            dateInput.selectionStart = 0;
+        } catch (e) {
+            println(`date input setting selectionStart error: ${e}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -29,7 +29,7 @@ void FormAssociatedElement::set_form(HTMLFormElement* form)
 bool FormAssociatedElement::enabled() const
 {
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled
-    auto const& html_element = const_cast<FormAssociatedElement&>(*this).form_associated_element_to_html_element();
+    auto const& html_element = form_associated_element_to_html_element();
 
     // A form control is disabled if any of the following conditions are met:
     // 1. The element is a button, input, select, textarea, or form-associated custom element, and the disabled attribute is specified on this element (regardless of its value).

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -152,4 +152,61 @@ void FormAssociatedElement::reset_form_owner()
     }
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
+WebIDL::UnsignedLong FormAssociatedElement::selection_start() const
+{
+    // FIXME: 1. If this element is an input element, and selectionStart does not apply to this element, return null.
+
+    // 2. If there is no selection, return the code unit offset within the relevant value to the character that
+    //    immediately follows the text entry cursor.
+    if (auto navigable = form_associated_element_to_html_element().document().navigable()) {
+        if (auto cursor = navigable->cursor_position())
+            return cursor->offset();
+    }
+
+    // FIXME: 3. Return the code unit offset within the relevant value to the character that immediately follows the start of
+    //           the selection.
+    return 0;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionstart-2
+WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_start(WebIDL::UnsignedLong)
+{
+    // FIXME: 1. If this element is an input element, and selectionStart does not apply to this element, throw an
+    //    "InvalidStateError" DOMException.
+
+    // FIXME: 2. Let end be the value of this element's selectionEnd attribute.
+    // FIXME: 3. If end is less than the given value, set end to the given value.
+    // FIXME: 4. Set the selection range with the given value, end, and the value of this element's selectionDirection attribute.
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionend
+WebIDL::UnsignedLong FormAssociatedElement::selection_end() const
+{
+    // FIXME: 1. If this element is an input element, and selectionEnd does not apply to this element, return null.
+
+    // 2. If there is no selection, return the code unit offset within the relevant value to the character that
+    //    immediately follows the text entry cursor.
+    if (auto navigable = form_associated_element_to_html_element().document().navigable()) {
+        if (auto cursor = navigable->cursor_position())
+            return cursor->offset();
+    }
+
+    // FIXME: 3. Return the code unit offset within the relevant value to the character that immediately follows the end of
+    //           the selection.
+    return 0;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionend-3
+WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_end(WebIDL::UnsignedLong)
+{
+    // FIXME: 1. If this element is an input element, and selectionEnd does not apply to this element, throw an
+    //    "InvalidStateError" DOMException.
+
+    // FIXME: 2. Set the selection range with the value of this element's selectionStart attribute, the given value, and the
+    //           value of this element's selectionDirection attribute.
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -155,7 +155,8 @@ void FormAssociatedElement::reset_form_owner()
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
 WebIDL::UnsignedLong FormAssociatedElement::selection_start() const
 {
-    // FIXME: 1. If this element is an input element, and selectionStart does not apply to this element, return null.
+    // 1. If this element is an input element, and selectionStart does not apply to this element, return null.
+    // NOTE: This is done by HTMLInputElement before calling this function
 
     // 2. If there is no selection, return the code unit offset within the relevant value to the character that
     //    immediately follows the text entry cursor.
@@ -170,10 +171,11 @@ WebIDL::UnsignedLong FormAssociatedElement::selection_start() const
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionstart-2
-WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_start(WebIDL::UnsignedLong)
+WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_start(Optional<WebIDL::UnsignedLong> const&)
 {
-    // FIXME: 1. If this element is an input element, and selectionStart does not apply to this element, throw an
+    // 1. If this element is an input element, and selectionStart does not apply to this element, throw an
     //    "InvalidStateError" DOMException.
+    // NOTE: This is done by HTMLInputElement before calling this function
 
     // FIXME: 2. Let end be the value of this element's selectionEnd attribute.
     // FIXME: 3. If end is less than the given value, set end to the given value.
@@ -184,7 +186,8 @@ WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_start(WebIDL::Uns
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionend
 WebIDL::UnsignedLong FormAssociatedElement::selection_end() const
 {
-    // FIXME: 1. If this element is an input element, and selectionEnd does not apply to this element, return null.
+    // 1. If this element is an input element, and selectionEnd does not apply to this element, return null.
+    // NOTE: This is done by HTMLInputElement before calling this function
 
     // 2. If there is no selection, return the code unit offset within the relevant value to the character that
     //    immediately follows the text entry cursor.
@@ -199,10 +202,11 @@ WebIDL::UnsignedLong FormAssociatedElement::selection_end() const
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionend-3
-WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_end(WebIDL::UnsignedLong)
+WebIDL::ExceptionOr<void> FormAssociatedElement::set_selection_end(Optional<WebIDL::UnsignedLong> const&)
 {
-    // FIXME: 1. If this element is an input element, and selectionEnd does not apply to this element, throw an
+    // 1. If this element is an input element, and selectionEnd does not apply to this element, throw an
     //    "InvalidStateError" DOMException.
+    // NOTE: This is done by HTMLInputElement before calling this function
 
     // FIXME: 2. Set the selection range with the value of this element's selectionStart attribute, the given value, and the
     //           value of this element's selectionDirection attribute.

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -83,6 +83,7 @@ public:
     virtual String value() const { return String {}; }
 
     virtual HTMLElement& form_associated_element_to_html_element() = 0;
+    HTMLElement const& form_associated_element_to_html_element() const { return const_cast<FormAssociatedElement&>(*this).form_associated_element_to_html_element(); }
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset-control
     virtual void reset_algorithm() {};

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -90,10 +90,10 @@ public:
     virtual void reset_algorithm() {};
 
     WebIDL::UnsignedLong selection_start() const;
-    WebIDL::ExceptionOr<void> set_selection_start(WebIDL::UnsignedLong);
+    WebIDL::ExceptionOr<void> set_selection_start(Optional<WebIDL::UnsignedLong> const&);
 
     WebIDL::UnsignedLong selection_end() const;
-    WebIDL::ExceptionOr<void> set_selection_end(WebIDL::UnsignedLong);
+    WebIDL::ExceptionOr<void> set_selection_end(Optional<WebIDL::UnsignedLong> const&);
 
 protected:
     FormAssociatedElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
@@ -87,6 +88,12 @@ public:
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset-control
     virtual void reset_algorithm() {};
+
+    WebIDL::UnsignedLong selection_start() const;
+    WebIDL::ExceptionOr<void> set_selection_start(WebIDL::UnsignedLong);
+
+    WebIDL::UnsignedLong selection_end() const;
+    WebIDL::ExceptionOr<void> set_selection_end(WebIDL::UnsignedLong);
 
 protected:
     FormAssociatedElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, Adam Hodgen <ant1441@gmail.com>
  * Copyright (c) 2022, Andrew Kaster <akaster@serenityos.org>
- * Copyright (c) 2023, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
  * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -2070,6 +2070,52 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_range(u32 start, u32 e
     return {};
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionstart-2
+WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_start_for_bindings(Optional<WebIDL::UnsignedLong> const& value)
+{
+    // 1. If this element is an input element, and selectionStart does not apply to this element, throw an
+    //    "InvalidStateError" DOMException.
+    if (!selection_or_range_applies())
+        return WebIDL::InvalidStateError::create(realm(), "setSelectionStart does not apply to this input type"_fly_string);
+
+    // NOTE: Steps continued below:
+    return set_selection_start(value);
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
+Optional<WebIDL::UnsignedLong> HTMLInputElement::selection_start_for_bindings() const
+{
+    // 1. If this element is an input element, and selectionStart does not apply to this element, return null.
+    if (!selection_or_range_applies())
+        return {};
+
+    // NOTE: Steps continued below:
+    return selection_start();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionend-3
+WebIDL::ExceptionOr<void> HTMLInputElement::set_selection_end_for_bindings(Optional<WebIDL::UnsignedLong> const& value)
+{
+    // 1. If this element is an input element, and selectionEnd does not apply to this element, throw an
+    //    "InvalidStateError" DOMException.
+    if (!selection_or_range_applies())
+        return WebIDL::InvalidStateError::create(realm(), "setSelectionEnd does not apply to this input type"_fly_string);
+
+    // NOTE: Steps continued below:
+    return set_selection_end(value);
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionend
+Optional<WebIDL::UnsignedLong> HTMLInputElement::selection_end_for_bindings() const
+{
+    // 1. If this element is an input element, and selectionEnd does not apply to this element, return null.
+    if (!selection_or_range_applies())
+        return {};
+
+    // NOTE: Steps continued below:
+    return selection_end();
+}
+
 Optional<ARIA::Role> HTMLInputElement::default_role() const
 {
     // https://www.w3.org/TR/html-aria/#el-input-button
@@ -2192,6 +2238,21 @@ bool HTMLInputElement::has_input_activation_behavior() const
     case TypeAttributeState::RadioButton:
     case TypeAttributeState::ResetButton:
     case TypeAttributeState::SubmitButton:
+        return true;
+    default:
+        return false;
+    }
+}
+
+// https://html.spec.whatwg.org/multipage/input.html#do-not-apply
+bool HTMLInputElement::selection_or_range_applies() const
+{
+    switch (type_state()) {
+    case TypeAttributeState::Text:
+    case TypeAttributeState::Search:
+    case TypeAttributeState::Telephone:
+    case TypeAttributeState::URL:
+    case TypeAttributeState::Password:
         return true;
     default:
         return false;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -196,6 +196,13 @@ public:
     bool value_as_number_applies() const;
     bool step_applies() const;
     bool step_up_or_down_applies() const;
+    bool selection_or_range_applies() const;
+
+    WebIDL::ExceptionOr<void> set_selection_start_for_bindings(Optional<WebIDL::UnsignedLong> const&);
+    Optional<WebIDL::UnsignedLong> selection_start_for_bindings() const;
+
+    WebIDL::ExceptionOr<void> set_selection_end_for_bindings(Optional<WebIDL::UnsignedLong> const&);
+    Optional<WebIDL::UnsignedLong> selection_end_for_bindings() const;
 
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -58,8 +58,8 @@ interface HTMLInputElement : HTMLElement {
     readonly attribute NodeList? labels;
 
     undefined select();
-    [FIXME] attribute unsigned long? selectionStart;
-    [FIXME] attribute unsigned long? selectionEnd;
+    [ImplementedAs=selection_start_for_bindings] attribute unsigned long? selectionStart;
+    [ImplementedAs=selection_end_for_bindings] attribute unsigned long? selectionEnd;
     [FIXME] attribute DOMString? selectionDirection;
     [FIXME] undefined setRangeText(DOMString replacement);
     [FIXME] undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -214,63 +214,6 @@ void HTMLTextAreaElement::set_custom_validity(String const& error)
     dbgln("(STUBBED) HTMLTextAreaElement::set_custom_validity(\"{}\"). Called on: {}", error, debug_description());
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
-WebIDL::UnsignedLong HTMLTextAreaElement::selection_start() const
-{
-    // 1. If this element is an input element, and selectionStart does not apply to this element, return null.
-
-    // 2. If there is no selection, return the code unit offset within the relevant value to the character that
-    //    immediately follows the text entry cursor.
-    if (auto navigable = document().navigable()) {
-        if (auto cursor = navigable->cursor_position())
-            return cursor->offset();
-    }
-
-    // FIXME: 3. Return the code unit offset within the relevant value to the character that immediately follows the start of
-    //           the selection.
-    return 0;
-}
-
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionstart-2
-WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_start(WebIDL::UnsignedLong)
-{
-    // 1. If this element is an input element, and selectionStart does not apply to this element, throw an
-    //    "InvalidStateError" DOMException.
-
-    // FIXME: 2. Let end be the value of this element's selectionEnd attribute.
-    // FIXME: 3. If end is less than the given value, set end to the given value.
-    // FIXME: 4. Set the selection range with the given value, end, and the value of this element's selectionDirection attribute.
-    return {};
-}
-
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionend
-WebIDL::UnsignedLong HTMLTextAreaElement::selection_end() const
-{
-    // 1. If this element is an input element, and selectionEnd does not apply to this element, return null.
-
-    // 2. If there is no selection, return the code unit offset within the relevant value to the character that
-    //    immediately follows the text entry cursor.
-    if (auto navigable = document().navigable()) {
-        if (auto cursor = navigable->cursor_position())
-            return cursor->offset();
-    }
-
-    // FIXME: 3. Return the code unit offset within the relevant value to the character that immediately follows the end of
-    //           the selection.
-    return 0;
-}
-
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#textFieldSelection:dom-textarea/input-selectionend-3
-WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_end(WebIDL::UnsignedLong)
-{
-    // 1. If this element is an input element, and selectionEnd does not apply to this element, throw an
-    //    "InvalidStateError" DOMException.
-
-    // FIXME: 2. Set the selection range with the value of this element's selectionStart attribute, the given value, and the
-    //           value of this element's selectionDirection attribute.
-    return {};
-}
-
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength
 WebIDL::Long HTMLTextAreaElement::max_length() const
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -84,12 +84,6 @@ public:
     bool report_validity();
     void set_custom_validity(String const& error);
 
-    WebIDL::UnsignedLong selection_start() const;
-    WebIDL::ExceptionOr<void> set_selection_start(WebIDL::UnsignedLong);
-
-    WebIDL::UnsignedLong selection_end() const;
-    WebIDL::ExceptionOr<void> set_selection_end(WebIDL::UnsignedLong);
-
     WebIDL::Long max_length() const;
     WebIDL::ExceptionOr<void> set_max_length(WebIDL::Long);
 


### PR DESCRIPTION
Get the functionality we already have working in HTMLTextAreaElement put into a common place for use in HTMLInputElement.