### PR TITLE
LibWeb: Set correct prototype for `WorkerLocation`

### DIFF
--- a/Tests/LibWeb/Text/expected/Worker/Worker-location.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-location.txt
@@ -1,0 +1,1 @@
+location global object URL final segment: Worker-location.js

--- a/Tests/LibWeb/Text/input/Worker/Worker-location.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-location.html
@@ -1,0 +1,11 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let work = new Worker("Worker-location.js");
+        work.onmessage = (evt) => {
+            const locationURL = new URL(evt.data);
+            println(`location global object URL final segment: ${locationURL.pathname.split('/').pop()}`);
+            done();
+        };
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Worker/Worker-location.js
+++ b/Tests/LibWeb/Text/input/Worker/Worker-location.js
@@ -1,0 +1,1 @@
+postMessage(location.toString());

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -142,6 +142,12 @@ WorkerLocation::WorkerLocation(WorkerGlobalScope& global_scope)
 
 WorkerLocation::~WorkerLocation() = default;
 
+void WorkerLocation::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+    WEB_SET_PROTOTYPE_FOR_INTERFACE(WorkerLocation);
+}
+
 void WorkerLocation::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibWeb/HTML/WorkerLocation.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerLocation.h
@@ -31,6 +31,7 @@ public:
 private:
     explicit WorkerLocation(WorkerGlobalScope&);
 
+    virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::NonnullGCPtr<WorkerGlobalScope> m_global_scope;


### PR DESCRIPTION
This fixes: https://wpt.live/workers/WorkerLocation.htm and 15 other similar tests which previously timed out.