### PR TITLE
LibWeb: Replace "+" in value with a space while decoding search params

### DIFF
--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SOURCES
     TestMicrosyntax.cpp
     TestMimeSniff.cpp
     TestNumbers.cpp
+    TestURLSearchParams.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibWeb/TestURLSearchParams.cpp
+++ b/Tests/LibWeb/TestURLSearchParams.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2024, Alisson Lauffer <alissonvitortc@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibWeb/DOMURL/URLSearchParams.h>
+
+TEST_CASE(url_search_params)
+{
+    auto params = MUST(Web::DOMURL::url_decode("test test+test%20test=test test+test%20test"sv));
+
+    EXPECT_EQ(params[0].name, "test test test test"sv);
+    EXPECT_EQ(params[0].value, "test test test test"sv);
+}

--- a/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -108,10 +108,11 @@ ErrorOr<Vector<QueryParam>> url_decode(StringView input)
 
         // 4. Replace any 0x2B (+) in name and value with 0x20 (SP).
         auto space_decoded_name = name.replace("+"sv, " "sv, ReplaceMode::All);
+        auto space_decoded_value = value.replace("+"sv, " "sv, ReplaceMode::All);
 
         // 5. Let nameString and valueString be the result of running UTF-8 decode without BOM on the percent-decoding of name and value, respectively.
         auto name_string = TRY(String::from_byte_string(URL::percent_decode(space_decoded_name)));
-        auto value_string = TRY(String::from_byte_string(URL::percent_decode(value)));
+        auto value_string = TRY(String::from_byte_string(URL::percent_decode(space_decoded_value)));
 
         TRY(output.try_empend(move(name_string), move(value_string)));
     }


### PR DESCRIPTION
I found a little inconsistency in URLSearchParams where it did not replace the plus sign with a space in search params values, only in names.

It's funny how the code actually mentions "in name and value", but only did it for the name.

Ladybird before:
![image](https://github.com/user-attachments/assets/72cfd152-9712-42bd-8c5d-ad90798865f2)

Firefox and Ladybird after:
![image](https://github.com/user-attachments/assets/0c5d58b7-52f1-4a63-8c41-1b6783e5bcb2)
