### PR TITLE
LibWeb: Update DOMStringList to match PlatformObject changes

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/DOMStringList.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringList.cpp
@@ -56,17 +56,10 @@ bool DOMStringList::contains(StringView string)
     return m_list.contains_slow(string);
 }
 
-bool DOMStringList::is_supported_property_index(u32 index) const
-{
-    // The DOMStringList interface supports indexed properties. The supported property indices are the indices of this's
-    // associated list.
-    return index < m_list.size();
-}
-
-WebIDL::ExceptionOr<JS::Value> DOMStringList::item_value(size_t index) const
+Optional<JS::Value> DOMStringList::item_value(size_t index) const
 {
     if (index + 1 > m_list.size())
-        return JS::js_undefined();
+        return {};
 
     return JS::PrimitiveString::create(vm(), m_list.at(index));
 }

--- a/Userland/Libraries/LibWeb/HTML/DOMStringList.h
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringList.h
@@ -22,8 +22,7 @@ public:
     Optional<String> item(u32 index) const;
     bool contains(StringView string);
 
-    virtual bool is_supported_property_index(u32) const override;
-    virtual WebIDL::ExceptionOr<JS::Value> item_value(size_t index) const override;
+    virtual Optional<JS::Value> item_value(size_t index) const override;
 
 private:
     explicit DOMStringList(JS::Realm&, Vector<String>);


### PR DESCRIPTION
- is_supported_property_index() no longer needs to be overridden
- item_value() now returns Optional

Fixes CI!