### PR TITLE
LibWeb: Update pseudo-elements on hover, fixing Acid2 nose

### DIFF
--- a/Tests/LibWeb/Text/expected/css/update-pseudo-elements-on-hover.txt
+++ b/Tests/LibWeb/Text/expected/css/update-pseudo-elements-on-hover.txt
@@ -1,0 +1,3 @@
+Hi  Not hovering: 16
+Hovering: 78
+Not hovering: 16

--- a/Tests/LibWeb/Text/input/css/update-pseudo-elements-on-hover.html
+++ b/Tests/LibWeb/Text/input/css/update-pseudo-elements-on-hover.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<style>
+    .outer {
+        height: 100px;
+    }
+    .inner {
+        display: inline-block;
+    }
+    .inner::before {
+        content: "Hi";
+        background-color: red;
+    }
+    .outer:hover .inner::before {
+        content: "Long text";
+        background-color: lime;
+    }
+</style>
+<script src="../include.js"></script>
+<div class="outer"><div class="inner"></div></div>
+<script>
+    test(() => {
+        const inner = document.querySelector('.inner');
+        println('Not hovering: ' + inner.clientWidth);
+
+        // Move mouse over .outer
+        internals.movePointerTo(80, 80);
+        println('Hovering: ' + inner.clientWidth);
+
+        // Move mouse away again
+        internals.movePointerTo(200, 200);
+        println('Not hovering: ' + inner.clientWidth);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleInvalidation.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleInvalidation.h
@@ -25,6 +25,7 @@ struct RequiredInvalidationAfterStyleChange {
     }
 
     [[nodiscard]] bool is_none() const { return !repaint && !rebuild_stacking_context_tree && !relayout && !rebuild_layout_tree; }
+    [[nodiscard]] bool is_full() const { return repaint && rebuild_stacking_context_tree && relayout && rebuild_layout_tree; }
     static RequiredInvalidationAfterStyleChange full() { return { true, true, true, true }; }
 };
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -101,8 +101,10 @@ void Element::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_class_list);
     visitor.visit(m_shadow_root);
     visitor.visit(m_custom_element_definition);
-    if (m_pseudo_element_nodes) {
-        visitor.visit(m_pseudo_element_nodes->span());
+    if (m_pseudo_element_data) {
+        for (auto& pseudo_element : *m_pseudo_element_data) {
+            visitor.visit(pseudo_element.layout_node);
+        }
     }
     if (m_registered_intersection_observers) {
         for (auto& registered_intersection_observers : *m_registered_intersection_observers)
@@ -1087,34 +1089,36 @@ void Element::children_changed()
 
 void Element::set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type pseudo_element, JS::GCPtr<Layout::Node> pseudo_element_node)
 {
-    if (!m_pseudo_element_nodes) {
-        if (!pseudo_element_node)
-            return;
-        m_pseudo_element_nodes = make<PseudoElementLayoutNodes>();
-    }
+    auto existing_pseudo_element = get_pseudo_element(pseudo_element);
+    if (!existing_pseudo_element.has_value() && !pseudo_element_node)
+        return;
 
-    (*m_pseudo_element_nodes)[to_underlying(pseudo_element)] = pseudo_element_node;
+    ensure_pseudo_element(pseudo_element).layout_node = move(pseudo_element_node);
 }
 
 JS::GCPtr<Layout::Node> Element::get_pseudo_element_node(CSS::Selector::PseudoElement::Type pseudo_element) const
 {
-    if (!m_pseudo_element_nodes)
-        return nullptr;
-    return (*m_pseudo_element_nodes)[to_underlying(pseudo_element)];
+    if (auto element_data = get_pseudo_element(pseudo_element); element_data.has_value())
+        return element_data->layout_node;
+    return nullptr;
 }
 
 void Element::clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>)
 {
-    m_pseudo_element_nodes = nullptr;
+    if (m_pseudo_element_data) {
+        for (auto& pseudo_element : *m_pseudo_element_data) {
+            pseudo_element.layout_node = nullptr;
+        }
+    }
 }
 
 void Element::serialize_pseudo_elements_as_json(JsonArraySerializer<StringBuilder>& children_array) const
 {
-    if (!m_pseudo_element_nodes)
+    if (!m_pseudo_element_data)
         return;
-    for (size_t i = 0; i < m_pseudo_element_nodes->size(); ++i) {
-        auto& pseudo_element_node = (*m_pseudo_element_nodes)[i];
-        if (!pseudo_element_node)
+    for (size_t i = 0; i < m_pseudo_element_data->size(); ++i) {
+        auto& pseudo_element = (*m_pseudo_element_data)[i].layout_node;
+        if (!pseudo_element)
             continue;
         auto object = MUST(children_array.add_object());
         MUST(object.add("name"sv, MUST(String::formatted("::{}", CSS::Selector::PseudoElement::name(static_cast<CSS::Selector::PseudoElement::Type>(i))))));
@@ -2219,11 +2223,18 @@ void Element::set_computed_css_values(RefPtr<CSS::StyleProperties> style)
     computed_css_values_changed();
 }
 
-auto Element::pseudo_element_custom_properties() const -> PseudoElementCustomProperties&
+Optional<Element::PseudoElement&> Element::get_pseudo_element(CSS::Selector::PseudoElement::Type type) const
 {
-    if (!m_pseudo_element_custom_properties)
-        m_pseudo_element_custom_properties = make<PseudoElementCustomProperties>();
-    return *m_pseudo_element_custom_properties;
+    if (!m_pseudo_element_data)
+        return {};
+    return m_pseudo_element_data->at(to_underlying(type));
+}
+
+Element::PseudoElement& Element::ensure_pseudo_element(CSS::Selector::PseudoElement::Type type) const
+{
+    if (!m_pseudo_element_data)
+        m_pseudo_element_data = make<PseudoElementData>();
+    return m_pseudo_element_data->at(to_underlying(type));
 }
 
 void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement::Type> pseudo_element, HashMap<FlyString, CSS::StyleProperty> custom_properties)
@@ -2232,14 +2243,14 @@ void Element::set_custom_properties(Optional<CSS::Selector::PseudoElement::Type>
         m_custom_properties = move(custom_properties);
         return;
     }
-    pseudo_element_custom_properties()[to_underlying(pseudo_element.value())] = move(custom_properties);
+    ensure_pseudo_element(pseudo_element.value()).custom_properties = move(custom_properties);
 }
 
 HashMap<FlyString, CSS::StyleProperty> const& Element::custom_properties(Optional<CSS::Selector::PseudoElement::Type> pseudo_element) const
 {
     if (!pseudo_element.has_value())
         return m_custom_properties;
-    return pseudo_element_custom_properties()[to_underlying(pseudo_element.value())];
+    return ensure_pseudo_element(pseudo_element.value()).custom_properties;
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scroll

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -449,9 +449,16 @@ private:
     RefPtr<CSS::StyleProperties> m_computed_css_values;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
 
-    using PseudoElementCustomProperties = Array<HashMap<FlyString, CSS::StyleProperty>, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)>;
-    mutable OwnPtr<PseudoElementCustomProperties> m_pseudo_element_custom_properties;
-    PseudoElementCustomProperties& pseudo_element_custom_properties() const;
+    struct PseudoElement {
+        JS::GCPtr<Layout::Node> layout_node;
+        HashMap<FlyString, CSS::StyleProperty> custom_properties;
+    };
+    // TODO: CSS::Selector::PseudoElement::Type includes a lot of pseudo-elements that exist in shadow trees,
+    //       and so we don't want to include data for them here.
+    using PseudoElementData = Array<PseudoElement, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)>;
+    mutable OwnPtr<PseudoElementData> m_pseudo_element_data;
+    Optional<PseudoElement&> get_pseudo_element(CSS::Selector::PseudoElement::Type) const;
+    PseudoElement& ensure_pseudo_element(CSS::Selector::PseudoElement::Type) const;
 
     Optional<CSS::Selector::PseudoElement::Type> m_use_pseudo_element;
 
@@ -460,9 +467,6 @@ private:
 
     Optional<FlyString> m_id;
     Optional<FlyString> m_name;
-
-    using PseudoElementLayoutNodes = Array<JS::GCPtr<Layout::Node>, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)>;
-    OwnPtr<PseudoElementLayoutNodes> m_pseudo_element_nodes;
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#custom-element-reaction-queue
     // All elements have an associated custom element reaction queue, initially empty. Each item in the custom element reaction queue is of one of two types:


### PR DESCRIPTION
[Peek 2024-07-29 16-03 acid2 nose.webm](https://github.com/user-attachments/assets/1af5c9b2-b374-4237-b2a9-a71fb11ae300)

Previously, pseudo-elements would not update their style (or whether they exist) unless something else invalidated the layout tree. This PR makes us invalidate the layout tree if a pseudo-element might change, which fixes it. (We might want to be more judicious with invalidating it in future, though right now that would involve doubling-up the pseudo-element style computation.)