### PR TITLE
LibWeb/CSS: Treat counters() function with 1 argument as invalid

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-counters/counters-function-single-argument.txt
+++ b/Tests/LibWeb/Layout/expected/css-counters/counters-function-single-argument.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 19, rect: [8,8 162.109375x17] baseline: 13.296875
+          "PASS (didn't crash)"
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/css-counters/counters-function-single-argument.html
+++ b/Tests/LibWeb/Layout/input/css-counters/counters-function-single-argument.html
@@ -1,0 +1,5 @@
+<style>
+    html {
+        content: counters(index);
+    }
+</style>PASS (didn't crash)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3003,7 +3003,7 @@ RefPtr<StyleValue> Parser::parse_counter_value(TokenStream<ComponentValue>& toke
         auto& function = token.function();
         TokenStream function_tokens { function.values() };
         auto function_values = parse_a_comma_separated_list_of_component_values(function_tokens);
-        if (function_values.is_empty() || function_values.size() > 3)
+        if (function_values.size() < 2 || function_values.size() > 3)
             return nullptr;
 
         TokenStream name_tokens { function_values[0] };


### PR DESCRIPTION
Fixes #887.