### PR TITLE
LibWasm: Clean up module sections API

### DIFF
--- a/Userland/Libraries/LibWasm/Printer/Printer.cpp
+++ b/Userland/Libraries/LibWasm/Printer/Printer.cpp
@@ -64,6 +64,8 @@ void Printer::print(Wasm::BlockType const& type)
 
 void Printer::print(Wasm::CodeSection const& section)
 {
+    if (section.functions().is_empty())
+        return;
     print_indent();
     print("(section code\n");
     {
@@ -97,6 +99,8 @@ void Printer::print(Wasm::CustomSection const& section)
 
 void Printer::print(Wasm::DataCountSection const& section)
 {
+    if (!section.count().has_value())
+        return;
     print_indent();
     print("(section data count\n");
     if (section.count().has_value()) {
@@ -110,6 +114,8 @@ void Printer::print(Wasm::DataCountSection const& section)
 
 void Printer::print(Wasm::DataSection const& section)
 {
+    if (section.data().is_empty())
+        return;
     print_indent();
     print("(section data\n");
     {
@@ -163,6 +169,8 @@ void Printer::print(Wasm::DataSection::Data const& data)
 
 void Printer::print(Wasm::ElementSection const& section)
 {
+    if (section.segments().is_empty())
+        return;
     print_indent();
     print("(section element\n");
     {
@@ -218,6 +226,8 @@ void Printer::print(Wasm::ElementSection::Element const& element)
 
 void Printer::print(Wasm::ExportSection const& section)
 {
+    if (section.entries().is_empty())
+        return;
     print_indent();
     print("(section export\n");
     {
@@ -282,6 +292,8 @@ void Printer::print(Wasm::CodeSection::Func const& func)
 
 void Printer::print(Wasm::FunctionSection const& section)
 {
+    if (section.types().is_empty())
+        return;
     print_indent();
     print("(section function\n");
     {
@@ -329,6 +341,8 @@ void Printer::print(Wasm::FunctionType const& type)
 
 void Printer::print(Wasm::GlobalSection const& section)
 {
+    if (section.entries().is_empty())
+        return;
     print_indent();
     print("(section global\n");
     {
@@ -384,6 +398,8 @@ void Printer::print(Wasm::GlobalType const& type)
 
 void Printer::print(Wasm::ImportSection const& section)
 {
+    if (section.imports().is_empty())
+        return;
     print_indent();
     print("(section import\n");
     {
@@ -493,6 +509,8 @@ void Printer::print(Wasm::Locals const& local)
 
 void Printer::print(Wasm::MemorySection const& section)
 {
+    if (section.memories().is_empty())
+        return;
     print_indent();
     print("(section memory\n");
     {
@@ -534,8 +552,20 @@ void Printer::print(Wasm::Module const& module)
     {
         TemporaryChange change { m_indent, m_indent + 1 };
         print("(module\n");
-        for (auto& section : module.sections())
-            section.visit([this](auto const& value) { print(value); });
+        for (auto& custom_section : module.custom_sections())
+            print(custom_section);
+        print(module.type_section());
+        print(module.import_section());
+        print(module.function_section());
+        print(module.table_section());
+        print(module.memory_section());
+        print(module.global_section());
+        print(module.export_section());
+        print(module.start_section());
+        print(module.element_section());
+        print(module.code_section());
+        print(module.data_section());
+        print(module.data_count_section());
     }
     print_indent();
     print(")\n");
@@ -543,11 +573,13 @@ void Printer::print(Wasm::Module const& module)
 
 void Printer::print(Wasm::StartSection const& section)
 {
+    if (!section.function().has_value())
+        return;
     print_indent();
     print("(section start\n");
     {
         TemporaryChange change { m_indent, m_indent + 1 };
-        print(section.function());
+        print(*section.function());
     }
     print_indent();
     print(")\n");
@@ -561,6 +593,8 @@ void Printer::print(Wasm::StartSection::StartFunction const& function)
 
 void Printer::print(Wasm::TableSection const& section)
 {
+    if (section.tables().is_empty())
+        return;
     print_indent();
     print("(section table\n");
     {
@@ -601,6 +635,8 @@ void Printer::print(Wasm::TableType const& type)
 
 void Printer::print(Wasm::TypeSection const& section)
 {
+    if (section.types().is_empty())
+        return;
     print_indent();
     print("(section type\n");
     {

--- a/Userland/Libraries/LibWasm/Types.h
+++ b/Userland/Libraries/LibWasm/Types.h
@@ -56,6 +56,7 @@ enum class ParseError {
     OutOfMemory,
     SectionSizeMismatch,
     InvalidUtf8,
+    DuplicateSection,
 };
 
 ByteString parse_error_to_byte_string(ParseError);
@@ -522,6 +523,8 @@ class TypeSection {
 public:
     static constexpr u8 section_id = 1;
 
+    TypeSection() = default;
+
     explicit TypeSection(Vector<FunctionType> types)
         : m_types(move(types))
     {
@@ -569,6 +572,8 @@ public:
 public:
     static constexpr u8 section_id = 2;
 
+    ImportSection() = default;
+
     explicit ImportSection(Vector<Import> imports)
         : m_imports(move(imports))
     {
@@ -585,6 +590,8 @@ private:
 class FunctionSection {
 public:
     static constexpr u8 section_id = 3;
+
+    FunctionSection() = default;
 
     explicit FunctionSection(Vector<TypeIndex> types)
         : m_types(move(types))
@@ -619,6 +626,8 @@ public:
 public:
     static constexpr u8 section_id = 4;
 
+    TableSection() = default;
+
     explicit TableSection(Vector<Table> tables)
         : m_tables(move(tables))
     {
@@ -651,6 +660,8 @@ public:
 
 public:
     static constexpr u8 section_id = 5;
+
+    MemorySection() = default;
 
     explicit MemorySection(Vector<Memory> memories)
         : m_memories(move(memories))
@@ -703,6 +714,8 @@ public:
 public:
     static constexpr u8 section_id = 6;
 
+    GlobalSection() = default;
+
     explicit GlobalSection(Vector<Global> entries)
         : m_entries(move(entries))
     {
@@ -741,6 +754,8 @@ public:
 
     static constexpr u8 section_id = 7;
 
+    ExportSection() = default;
+
     explicit ExportSection(Vector<Export> entries)
         : m_entries(move(entries))
     {
@@ -773,7 +788,9 @@ public:
 
     static constexpr u8 section_id = 8;
 
-    explicit StartSection(StartFunction func)
+    StartSection() = default;
+
+    explicit StartSection(Optional<StartFunction> func)
         : m_function(move(func))
     {
     }
@@ -783,7 +800,7 @@ public:
     static ParseResult<StartSection> parse(Stream& stream);
 
 private:
-    StartFunction m_function;
+    Optional<StartFunction> m_function;
 };
 
 class ElementSection {
@@ -806,6 +823,8 @@ public:
     };
 
     static constexpr u8 section_id = 9;
+
+    ElementSection() = default;
 
     explicit ElementSection(Vector<Element> segs)
         : m_segments(move(segs))
@@ -879,6 +898,8 @@ public:
 
     static constexpr u8 section_id = 10;
 
+    CodeSection() = default;
+
     explicit CodeSection(Vector<Code> funcs)
         : m_functions(move(funcs))
     {
@@ -921,6 +942,8 @@ public:
 
     static constexpr u8 section_id = 11;
 
+    DataSection() = default;
+
     explicit DataSection(Vector<Data> data)
         : m_data(move(data))
     {
@@ -937,6 +960,8 @@ private:
 class DataCountSection {
 public:
     static constexpr u8 section_id = 12;
+
+    DataCountSection() = default;
 
     explicit DataCountSection(Optional<u32> count)
         : m_count(move(count))
@@ -959,57 +984,37 @@ public:
         Valid,
     };
 
-    using AnySection = Variant<
-        CustomSection,
-        TypeSection,
-        ImportSection,
-        FunctionSection,
-        TableSection,
-        MemorySection,
-        GlobalSection,
-        ExportSection,
-        StartSection,
-        ElementSection,
-        CodeSection,
-        DataSection,
-        DataCountSection>;
-
     static constexpr Array<u8, 4> wasm_magic { 0, 'a', 's', 'm' };
     static constexpr Array<u8, 4> wasm_version { 1, 0, 0, 0 };
 
-    explicit Module(Vector<AnySection> sections)
-        : m_sections(move(sections))
-    {
-    }
+    Module() = default;
 
-    auto& sections() const { return m_sections; }
-    auto& type(TypeIndex index) const
-    {
-        FunctionType const* type = nullptr;
-        for_each_section_of_type<TypeSection>([&](TypeSection const& section) {
-            type = &section.types().at(index.value());
-        });
-
-        VERIFY(type != nullptr);
-        return *type;
-    }
-
-    template<typename T, typename Callback>
-    void for_each_section_of_type(Callback&& callback) const
-    {
-        for (auto& section : m_sections) {
-            if (auto ptr = section.get_pointer<T>())
-                callback(*ptr);
-        }
-    }
-    template<typename T, typename Callback>
-    void for_each_section_of_type(Callback&& callback)
-    {
-        for (auto& section : m_sections) {
-            if (auto ptr = section.get_pointer<T>())
-                callback(*ptr);
-        }
-    }
+    auto& custom_sections() { return m_custom_sections; }
+    auto& custom_sections() const { return m_custom_sections; }
+    auto& type_section() const { return m_type_section; }
+    auto& type_section() { return m_type_section; }
+    auto& import_section() const { return m_import_section; }
+    auto& import_section() { return m_import_section; }
+    auto& function_section() { return m_function_section; }
+    auto& function_section() const { return m_function_section; }
+    auto& table_section() { return m_table_section; }
+    auto& table_section() const { return m_table_section; }
+    auto& memory_section() { return m_memory_section; }
+    auto& memory_section() const { return m_memory_section; }
+    auto& global_section() { return m_global_section; }
+    auto& global_section() const { return m_global_section; }
+    auto& export_section() { return m_export_section; }
+    auto& export_section() const { return m_export_section; }
+    auto& start_section() { return m_start_section; }
+    auto& start_section() const { return m_start_section; }
+    auto& element_section() { return m_element_section; }
+    auto& element_section() const { return m_element_section; }
+    auto& code_section() { return m_code_section; }
+    auto& code_section() const { return m_code_section; }
+    auto& data_section() { return m_data_section; }
+    auto& data_section() const { return m_data_section; }
+    auto& data_count_section() { return m_data_count_section; }
+    auto& data_count_section() const { return m_data_count_section; }
 
     void set_validation_status(ValidationStatus status, Badge<Validator>) { set_validation_status(status); }
     ValidationStatus validation_status() const { return m_validation_status; }
@@ -1021,7 +1026,20 @@ public:
 private:
     void set_validation_status(ValidationStatus status) { m_validation_status = status; }
 
-    Vector<AnySection> m_sections;
+    Vector<CustomSection> m_custom_sections;
+    TypeSection m_type_section;
+    ImportSection m_import_section;
+    FunctionSection m_function_section;
+    TableSection m_table_section;
+    MemorySection m_memory_section;
+    GlobalSection m_global_section;
+    ExportSection m_export_section;
+    StartSection m_start_section;
+    ElementSection m_element_section;
+    CodeSection m_code_section;
+    DataSection m_data_section;
+    DataCountSection m_data_count_section;
+
     ValidationStatus m_validation_status { ValidationStatus::Unchecked };
     Optional<ByteString> m_validation_error;
 };

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -181,7 +181,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<Wasm::ModuleInstance>> instantiate_module(JS
             TRY(import_name.type.visit(
                 [&](Wasm::TypeIndex index) -> JS::ThrowCompletionOr<void> {
                     dbgln("Trying to resolve a function {}::{}, type index {}", import_name.module, import_name.name, index.value());
-                    auto& type = module.type(index);
+                    auto& type = module.type_section().types()[index.value()];
                     // FIXME: IsCallable()
                     if (!import_.is_function())
                         return {};

--- a/Userland/Utilities/wasm.cpp
+++ b/Userland/Utilities/wasm.cpp
@@ -672,7 +672,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             for (auto& entry : linker.unresolved_imports()) {
                 if (!entry.type.has<Wasm::TypeIndex>())
                     continue;
-                auto type = parse_result.value().type(entry.type.get<Wasm::TypeIndex>());
+                auto type = parse_result.value().type_section().types()[entry.type.get<Wasm::TypeIndex>().value()];
                 auto address = machine.store().allocate(Wasm::HostFunction(
                     [name = entry.name, type = type](auto&, auto& arguments) -> Wasm::Result {
                         StringBuilder argument_builder;


### PR DESCRIPTION
Remove `for_each_section_of_type` in favor of making the module's sections defined as distinct fields. This means it is no longer possible to have two of the same section (which is invalid in WebAssembly, for anything other than custom sections). We previously didn't account for this behavior because the Wasm testsuite only checks that we don't have duplicate start sections (which we handled in the validator phase).

This also makes `Module` a little bit easier to work with, since we no longer need to wrap everything in `for_each_section_of_type`.