### PR TITLE
LibThreading/LibJS: POC parallelized GC marking phase

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -133,6 +133,13 @@ public:
         new (&m_storage) T(forward<U>(value));
     }
 
+    template<typename... Args>
+    ALWAYS_INLINE explicit Optional(Detail::InPlaceT, Args&&... args)
+        : m_has_value(true)
+    {
+        new (&m_storage) T(forward<Args>(args)...);
+    }
+
     ALWAYS_INLINE Optional& operator=(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
     {

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -602,6 +602,11 @@ struct EquivalentFunctionTypeImpl<T (C::*)(Args...) const> {
 template<typename Callable>
 using EquivalentFunctionType = typename EquivalentFunctionTypeImpl<Callable>::Type;
 
+struct InPlaceT {
+    explicit InPlaceT() = default;
+};
+inline constexpr InPlaceT InPlace {};
+
 }
 
 #if !USING_AK_GLOBALLY

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -510,6 +510,7 @@ if (BUILD_TESTING)
         LibCompress
         LibTest
         LibTextCodec
+        LibThreading
         LibUnicode
         LibURL
         LibXML

--- a/Meta/gn/secondary/Tests/BUILD.gn
+++ b/Meta/gn/secondary/Tests/BUILD.gn
@@ -2,6 +2,7 @@ group("Tests") {
   deps = [
     "//Tests/AK",
     "//Tests/LibJS",
+    "//Tests/LibThreading",
     "//Tests/LibURL",
     "//Tests/LibWeb",
   ]

--- a/Tests/LibThreading/CMakeLists.txt
+++ b/Tests/LibThreading/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestThread.cpp
+    TestThreadPool.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibThreading/CMakeLists.txt
+++ b/Tests/LibThreading/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(TEST_SOURCES
     TestThread.cpp
     TestThreadPool.cpp
+    TestWorkStealing.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibThreading/TestThreadPool.cpp
+++ b/Tests/LibThreading/TestThreadPool.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Braydn Moore <braydn.moore@uwaterloo.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Time.h>
+#include <LibTest/TestCase.h>
+#include <LibThreading/ThreadPool.h>
+
+using namespace AK::TimeLiterals;
+
+RANDOMIZED_TEST_CASE(thread_pool_race_condition)
+{
+    static constexpr u64 MIN_SUM_TO = 1 << 10;
+    static constexpr u64 MAX_SUM_TO = 1 << 15;
+    static constexpr auto SUM_SLEEP_TIME = 2_us;
+
+    for (u64 max_value = MIN_SUM_TO; max_value <= MAX_SUM_TO; max_value <<= 1) {
+        u64 expected_value = (max_value * (max_value + 1)) / 2;
+        Atomic<u64> sum;
+        auto thread_pool = Threading::ThreadPool<u64> {
+            [&sum](u64 current_val) {
+                sum += current_val;
+                usleep(SUM_SLEEP_TIME.to_microseconds());
+            },
+        };
+
+        for (u64 i = 0; i <= max_value; ++i) {
+            thread_pool.submit(i);
+        }
+        thread_pool.wait_for_all();
+        EXPECT(sum == expected_value);
+    }
+}

--- a/Tests/LibThreading/TestThreadPool.cpp
+++ b/Tests/LibThreading/TestThreadPool.cpp
@@ -20,7 +20,7 @@ RANDOMIZED_TEST_CASE(thread_pool_race_condition)
         u64 expected_value = (max_value * (max_value + 1)) / 2;
         Atomic<u64> sum;
         auto thread_pool = Threading::ThreadPool<u64> {
-            [&sum](u64 current_val) {
+            [&sum](Function<void(u64)>, u64 current_val) {
                 sum += current_val;
                 usleep(SUM_SLEEP_TIME.to_microseconds());
             },

--- a/Tests/LibThreading/TestWorkStealing.cpp
+++ b/Tests/LibThreading/TestWorkStealing.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024, Braydn Moore <braydn.moore@uwaterloo.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/HashMap.h>
+#include <AK/Noncopyable.h>
+#include <AK/Random.h>
+#include <AK/Vector.h>
+#include <LibTest/TestCase.h>
+#include <LibThreading/MutexProtected.h>
+#include <LibThreading/WorkStealingThreadPool.h>
+#include <pthread.h>
+
+struct ThreadUtilizationTracker {
+    AK_MAKE_NONCOPYABLE(ThreadUtilizationTracker);
+    AK_MAKE_NONMOVABLE(ThreadUtilizationTracker);
+
+public:
+    ThreadUtilizationTracker(size_t num_threads)
+        : m_num_thread(num_threads)
+    {
+    }
+
+    void track_job()
+    {
+        m_total_jobs_done += 1;
+        m_total_jobs_done_per_thread.with_locked([](auto& map) {
+            auto tid = pthread_self();
+            auto count = map.get(tid).value_or(0);
+            map.set(tid, count + 1);
+        });
+    }
+
+    void ensure_even_utilization(double acceptable_utilization_range)
+    {
+        double completely_fair_distribution = 1.0f / m_num_thread;
+        m_total_jobs_done_per_thread.with_locked([this, completely_fair_distribution, acceptable_utilization_range](auto& counts) {
+            EXPECT_EQ(counts.size(), m_num_thread);
+            for (auto const& entry : counts) {
+                double amount_of_work_done = double(entry.value) / double(m_total_jobs_done.load());
+                EXPECT_APPROXIMATE_WITH_ERROR(amount_of_work_done, completely_fair_distribution, acceptable_utilization_range);
+            }
+        });
+    }
+
+private:
+    size_t m_num_thread;
+    AK::Atomic<u64> m_total_jobs_done;
+    Threading::MutexProtected<AK::HashMap<pthread_t, u64>> m_total_jobs_done_per_thread;
+};
+
+template<typename Callback = Function<void()>>
+static void run_threaded_summation(u64 min, u64 max, Optional<size_t> num_threads = {}, Optional<Callback> cb = {})
+{
+    for (u64 max_value = min; max_value <= max; max_value <<= 1) {
+        u64 expected_value = (max_value * (max_value + 1)) / 2;
+        Atomic<u64> sum;
+        auto thread_pool = Threading::WorkStealingThreadPool<u64> {
+            [&sum, &cb, max_value](Function<void(u64)> submit, u64 current_val) {
+                sum += current_val;
+                if (cb.has_value()) {
+                    (*cb)();
+                }
+                for (u64 i = current_val * 4 + 1; i <= max_value && i <= current_val * 4 + 4; ++i) {
+                    submit(i);
+                }
+            },
+            num_threads
+        };
+
+        thread_pool.submit(0);
+        thread_pool.wait_for_all();
+        EXPECT(sum == expected_value);
+    }
+}
+
+TEST_CASE(work_stealing_sum)
+{
+    run_threaded_summation(1 << 10, 1 << 20);
+}
+
+RANDOMIZED_TEST_CASE(work_stealing_sum_race_condition)
+{
+    run_threaded_summation(1 << 6, 1 << 12);
+}
+
+RANDOMIZED_TEST_CASE(work_stealing_thread_utilization_even_job_distribution)
+{
+    static constexpr size_t NUM_THREADS = 8;
+    static constexpr double UTILIZATION_RANGE = 0.05;
+
+    ThreadUtilizationTracker tracker(NUM_THREADS);
+    auto utilization_func = [&tracker]() {
+        tracker.track_job();
+    };
+
+    run_threaded_summation(1 << 15, 1 << 15, NUM_THREADS, AK::Optional<decltype(utilization_func)>(utilization_func));
+    tracker.ensure_even_utilization(UTILIZATION_RANGE);
+}
+
+RANDOMIZED_TEST_CASE(work_stealing_thread_utilization_uneven_job_distribution)
+{
+    static constexpr size_t NUM_ITEMS = 1 << 15;
+    static constexpr double UTILIZATION_RANGE = 0.1;
+    static constexpr size_t MIN_ITEMS_EXPLORED = 1;
+    static constexpr size_t MAX_ITEMS_EXPLORED = 8;
+    static constexpr size_t NUM_THREADS = 8;
+
+    AK::Vector<AK::NonnullOwnPtr<Atomic<bool>>> work;
+    work.ensure_capacity(NUM_ITEMS);
+    for (size_t i = 0; i < NUM_ITEMS; ++i) {
+        work.unchecked_append(make<Atomic<bool>>(false));
+    }
+
+    ThreadUtilizationTracker tracker(NUM_THREADS);
+    {
+        auto thread_pool = Threading::WorkStealingThreadPool<size_t> {
+            [&work, &tracker](Function<void(u64)> submit, size_t current_val) {
+                tracker.track_job();
+                if (work[current_val]->load()) {
+                    return;
+                }
+
+                work[current_val]->store(true);
+                size_t num_to_explore = MIN_ITEMS_EXPLORED + AK::get_random_uniform(MAX_ITEMS_EXPLORED - MIN_ITEMS_EXPLORED + 1);
+
+                for (size_t item = current_val + 1; item <= current_val + num_to_explore && item < NUM_ITEMS; ++item) {
+                    submit(item);
+                }
+            },
+            NUM_THREADS
+        };
+
+        thread_pool.submit(0);
+        thread_pool.wait_for_all();
+        for (auto const& item : work) {
+            EXPECT(item->load());
+        }
+
+        tracker.ensure_even_utilization(UTILIZATION_RANGE);
+    }
+}

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -272,7 +272,7 @@ set(SOURCES
 )
 
 serenity_lib(LibJS js)
-target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibRegex LibSyntax)
+target_link_libraries(LibJS PRIVATE LibCore LibCrypto LibFileSystem LibThreading LibRegex LibSyntax)
 
 # Link LibUnicode publicly to ensure ICU data (which is in libicudata.a) is available in any process using LibJS.
 target_link_libraries(LibJS PUBLIC LibUnicode)

--- a/Userland/Libraries/LibThreading/ThreadPool.h
+++ b/Userland/Libraries/LibThreading/ThreadPool.h
@@ -36,6 +36,7 @@ struct ThreadPoolLooper {
                 return IterationDecision::Continue;
 
             pool.m_mutex.lock();
+            pool.m_work_done.broadcast();
             pool.m_work_available.wait();
             pool.m_mutex.unlock();
         }
@@ -76,7 +77,9 @@ public:
     {
         m_should_exit.store(true, AK::MemoryOrder::memory_order_release);
         for (auto& worker : m_workers) {
-            m_work_available.broadcast();
+            while (!worker->has_exited()) {
+                m_work_available.broadcast();
+            }
             (void)worker->join();
         }
     }
@@ -91,18 +94,19 @@ public:
 
     void wait_for_all()
     {
-        while (true) {
-            if (m_work_queue.with_locked([](auto& queue) { return queue.is_empty(); }))
-                break;
-            m_mutex.lock();
-            m_work_done.wait();
-            m_mutex.unlock();
+        {
+            MutexLocker lock(m_mutex);
+            m_work_done.wait_while([this]() {
+                return m_work_queue.with_locked([](auto& queue) {
+                    return !queue.is_empty();
+                });
+            });
         }
-
-        while (m_busy_count.load(AK::MemoryOrder::memory_order_acquire) > 0) {
-            m_mutex.lock();
-            m_work_done.wait();
-            m_mutex.unlock();
+        {
+            MutexLocker lock(m_mutex);
+            m_work_done.wait_while([this] {
+                return m_busy_count.load(AK::MemoryOrder::memory_order_acquire) > 0;
+            });
         }
     }
 

--- a/Userland/Libraries/LibThreading/WorkStealingThreadPool.h
+++ b/Userland/Libraries/LibThreading/WorkStealingThreadPool.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Braydn Moore <braydn.moore@uwaterloo.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IterationDecision.h>
+#include <LibThreading/ThreadPool.h>
+
+namespace Threading {
+/**
+ * Each work-stealing worker keeps a local work queue in an attempt to access
+ * the global queue as infrequently as possible to improve performance.
+ *
+ * For a given ThreadPool with N threads, a thread accessing the global queue
+ * will drain 1/Nth of the jobs in the global queue into it's local work
+ * queue.
+ *
+ * In an attempt to share the work cooperatively, every
+ * `SHARE_INTERVAL` jobs which are completed a worker will
+ * donate 1/`GLOBAL_DONATE_RATIO` of it's local queue to the if:
+ *   1. The local queue has more than `MIN_NUMBER_OF_LOCAL_JOBS`
+ *   2. The global queue is empty
+ *   3. The global queue lock is not currently held by another worker
+ */
+
+static size_t distribute_id = 0;
+static constexpr size_t WORK_STEALING_SHARE_INTERVAL_DEFAULT = 128;
+static constexpr size_t WORK_STEALING_GLOBAL_DONATE_RATIO_DEFAULT = 2;
+static constexpr size_t WORK_STEALING_MIN_NUMBER_OF_LOCAL_JOBS_DEFAULT = 4;
+
+template<size_t SHARE_INTERVAL = WORK_STEALING_SHARE_INTERVAL_DEFAULT,
+    size_t GLOBAL_DONATE_RATIO = WORK_STEALING_GLOBAL_DONATE_RATIO_DEFAULT,
+    size_t MIN_NUMBER_OF_LOCAL_JOBS = WORK_STEALING_MIN_NUMBER_OF_LOCAL_JOBS_DEFAULT>
+struct WorkStealingLooper {
+
+    template<typename Pool>
+    class Looper {
+    public:
+        Looper()
+            : id(distribute_id++)
+            , m_local_queue()
+            , m_jobs_since_last_share(0)
+            , m_jobs_ran(0)
+        {
+        }
+
+        AK::IterationDecision next(Pool& pool, bool wait)
+        {
+            // The only time a work-stealing looper should yield to the main thread
+            // loop is if there is no local jobs (generally this should also be
+            // after an attempt to replenish the local queue with jobs from the
+            // global queue)
+            VERIFY(m_local_queue.is_empty());
+            while (true) {
+                if (do_work(pool)) {
+                    return IterationDecision::Continue;
+                }
+
+                if (pool.looper_should_exit())
+                    return IterationDecision::Break;
+
+                if (!wait)
+                    return IterationDecision::Continue;
+
+                pool.looper_wait();
+            }
+        }
+
+    private:
+        bool do_work(Pool& pool)
+        {
+            auto guard = pool.looper_enter_busy_section();
+            // Attempt to replenish the local queue with 1/Nth of the global
+            // queue if this worker has no work or exit if requested
+            if (m_local_queue.is_empty()) {
+                pool.looper_with_global_queue([this, num_workers = pool.looper_num_workers()](auto& queue) {
+                    size_t num_jobs = max(1, queue.size() / num_workers);
+                    for (size_t i = 0; i < num_jobs && !queue.is_empty(); ++i) {
+                        m_local_queue.enqueue(queue.dequeue());
+                    }
+                });
+            }
+
+            // if there are still no jobs even after checking the global queue yield
+            if (m_local_queue.is_empty()) {
+                return false;
+            }
+
+            // Run handler on jobs in the local queue
+            while (!m_local_queue.is_empty()) {
+                pool.looper_run_handler([this](typename Pool::Work w) { m_local_queue.enqueue(w); }, m_local_queue.dequeue());
+                ++m_jobs_since_last_share;
+                ++m_jobs_ran;
+                // Share jobs with the global queue if criteria is met
+                if (m_jobs_since_last_share >= SHARE_INTERVAL && m_local_queue.size() >= MIN_NUMBER_OF_LOCAL_JOBS) {
+                    m_jobs_since_last_share = 0;
+                    pool.looper_try_with_global_queue([this, &pool](auto& queue) {
+                        if (!queue.is_empty()) {
+                            return;
+                        }
+
+                        for (size_t i = 0; i < m_local_queue.size() / GLOBAL_DONATE_RATIO; ++i) {
+                            queue.enqueue(m_local_queue.dequeue());
+                        }
+                        pool.looper_signal_work_available();
+                    });
+                }
+            }
+
+            return true;
+        }
+
+        size_t id;
+        Queue<typename Pool::Work> m_local_queue;
+        size_t m_jobs_since_last_share;
+        size_t m_jobs_ran;
+    };
+};
+
+template<typename TWork>
+using WorkStealingThreadPool = ThreadPool<TWork, WorkStealingLooper<>::Looper>;
+}

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -32,7 +32,8 @@ struct ThreadPoolEntry {
     ConnectionFromClient::Work work;
 };
 static Threading::ThreadPool<ThreadPoolEntry, Looper> s_thread_pool {
-    [](ThreadPoolEntry entry) {
+    [](Function<void(ThreadPoolEntry)> submit, ThreadPoolEntry entry) {
+        (void)submit;
         entry.client->worker_do_work(move(entry.work));
     }
 };


### PR DESCRIPTION
Current WIP to use the work-stealing thread pool to parallelize the
marking phase of the GC. Unfortunately it actually seems slower than the
serial implementation.

Attempts to (unsuccessfully) speed up:
- Moving the thread pool creation to a heap member variable to avoid the
overhead of thread pool creation / deletion
- Submit all roots at once instead of locking global thread pool queue
multiple times
- Thread utilization appears to be roughly evenly distributed in terms of work submitted to the thread pool

Other important changes include:
- Deadlock fixes for `ThreadPool`
- In place constructor for `AK::Optional`
- `try_lock` style variants for mutexes
- Work-stealing thread pools