### PR TITLE
GitHub: For issue reports, move to using structured template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,116 @@
+name: Report a bug
+description: Create a report to help us reproduce and fix a bug.
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the problem in 1 or 2 short sentences.
+      placeholder: When I … in Ladybird, …
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - macOS
+        - Windows
+        - Android
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction-steps
+    attributes:
+      label: Steps to reproduce
+      description: Describe the exact steps we can follow to reproduce the problem.
+      value: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen when you followed [the steps you described above](#description-reproduction-steps).
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe what actually happened when you followed [the steps you described above](#description-reproduction-steps).
+    validations:
+      required: true
+  - type: markdown
+    id: reduced-test-case
+    attributes:
+      value: |
+        &nbsp; <!-- add some vertical whitespace -->
+        ## Reduced test case
+        Either provide the URL for a [reduced test case](https://github.com/LadybirdBrowser/ladybird/blob/master/ISSUES.md#how-you-can-write-a-reduced-test-case) that reproduces the problem, or else HTML/SVG/etc. source for a reduced test case.
+        > [!IMPORTANT]
+        > A [reduced test case](https://github.com/LadybirdBrowser/ladybird/blob/master/ISSUES.md#how-you-can-write-a-reduced-test-case) may be the most important thing you can give us; without it, we’re much less likely to isolate the cause.
+  - type: input
+    id: reduced-test-case-url
+    attributes:
+      label: URL for a reduced test case
+      description: |
+        Provide the URL for a [reduced test case](https://github.com/LadybirdBrowser/ladybird/blob/master/ISSUES.md#how-you-can-write-a-reduced-test-case) that reproduces the problem (e.g., using a site such as [CodePen](https://codepen.io/pen/), [JS Bin](https://jsbin.com), or [JSFiddle](https://jsfiddle.net)). Or if you don’t have a [reduced test case](https://github.com/LadybirdBrowser/ladybird/blob/master/ISSUES.md#how-you-can-write-a-reduced-test-case), at least provide the URL for a website/page that causes the problem. Otherwise just enter `N/A` here.
+    validations:
+      required: true
+  - type: textarea
+    id: reduced-test-case-source
+    attributes:
+      label: HTML/SVG/etc. source for a reduced test case
+      description: If you’ve not provided the URL for a [reduced test case](https://github.com/LadybirdBrowser/ladybird/blob/master/ISSUES.md#how-you-can-write-a-reduced-test-case) that reproduces the problem, then paste in below the HTML/SVG/etc. source for a reduced test case. Otherwise just enter `N/A` here. What you paste in will be formatted as a code block — so, no need to put code fence backticks around it.
+      value:
+      render: html
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        &nbsp; <!-- add some vertical whitespace -->
+  - type: textarea
+    id: log-output
+    attributes:
+      label: |
+        Log output and (if possible) backtrace
+      description: |
+        Copy and paste the full log output from Ladybird — including error messages — as well as any backtrace that Ladybird reported.
+        What you paste in will be formatted as a code block — so, no need to put code fence backticks around it.
+      value:
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots or screen recordings
+      description: Drag and drop in below any screenshots or screen recordings you’ve made which show the problem.
+  - type: textarea
+    id: build-flags
+    attributes:
+      label: Build flags or config settings
+      description: If you’re building with any non-default build flags or other non-default config settings in your environment, list them out below.
+  - type: checkboxes
+    id: will-patch
+    attributes:
+      label: Contribute a patch?
+      description: |
+        If you plan to contribute patch for this issue yourself, please check the box below — to tell us and others looking at the issue that someone’s already working on it. If you do check this box, please try to send a pull request within 7 days or so.
+      options:
+        - label: I’ll contribute a patch for this myself.
+  - type: markdown
+    attributes:
+      value: |
+        &nbsp; <!-- add some vertical whitespace -->
+        ## :heart: Become a Ladybird supporter
+
+        Ladybird is funded entirely by sponsorships and donations from people and companies who care about the open web.\
+        We accept one-time and recurring monthly donations via [**Donorbox**](https://donorbox.org/ladybird).
+        &nbsp; <!-- add some vertical whitespace -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Join our Discord server
+    url: https://discord.gg/nvfjVJ4Svh
+    about: Chat with the Ladybird maintainers and contributors and other users.
+  - name: Read our FAQ
+    url: https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/FAQ.md
+    about: Read answers for some of the most frequently-asked questions about Ladybird.
+  - name: Read our documentation
+    url: https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/README.md
+    about: Read the docs about building Ladybird, and about configuring your Ladybird development environment.
+  - name: Contribute to Ladybird
+    url: https://github.com/LadybirdBrowser/ladybird/blob/master/CONTRIBUTING.md
+    about: Read about how you can get started contributing to Ladybird.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,8 @@ When contributing to Ladybird, make sure that the changes you wish to make are i
 
 **For your first couple of PRs, start with something small to get familiar with the project and its development processes. Please do not start by adding a large component.**
 
+Read [the Ladybird documentation](https://github.com/LadybirdBrowser/ladybird/blob/master/CONTRIBUTING.md), including the documents in the **Development** section of the `Documentation/README.md` file.
+
 Everyone is welcome to work on the project, and while we have lots of fun, it's a serious kind of fun. :^)
 
 ## Communication

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -32,7 +32,7 @@ CipherString = DEFAULT@SECLEVEL=1
 Options = UnsafeLegacyRenegotiation
 ```
 
-#### “Targets may link only to libraries. CMake is dropping the item” message (when building with the Qt chrome on macOS)
+### “Targets may link only to libraries. CMake is dropping the item” message (when building with the Qt chrome on macOS)
 
 When building with the Qt chrome on macOS, you may encounter the following message:
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,32 +1,7 @@
-# Detailed issue-reporting guidelines
+# Issue-reporting guidelines
 
-When reporting an issue, you should should try to provide:
-
-1. Succinct prose description of the problem (in addition to the issue title).
-
-2. Exact steps for reproducing the problem.
-
-3. Description of what you expect to see happen (the expected behavior) when you follow those steps.
-
-4. Description of what actually happens instead (the actual behavior) when you follow those steps.
-
-5. Either:
-
-   * The URL for a [reduced test case](#how-you-can-write-a-reduced-test-case) that reproduces the problem (e.g., using a site such as https://codepen.io/pen/, https://jsbin.com, or https://jsfiddle.net), or else at least the URL for a website/page that causes the problem.
-
-   * The HTML source for a reduced test case that reproduces the problem.
-
-6. Backtrace and Ladybird log output.
-
-7. Screenshot or screen recording.
-
-8. Operating system (Linux/macOS/Window/Android) in which you’re building or running Ladybird.
-
-9. Browser chrome of the build (Qt/AppKit/AndroidUI).
-
-10. Config/build flags you’re building with.
-
-11. Whether you’re interested yourself in trying to write a patch/PR with the fix for the problem.
+Report problems using our detailed [bug-reporting
+form](https://github.com/LadybirdBrowser/ladybird/issues/new?template=bug_report.yml), which helps to ensure that, for us to reproduce and investigate the problem, your bug report includes the information needed — including a reduced test case.
 
 ## How you can write a reduced test case
 
@@ -46,7 +21,7 @@ Here’s how you can do that:
    <base href="https://ladybird.org/">
    ```
 
-    However, if the problem appears be caused not by anything in the source of the document itself, but instead by something in an external script or external stylesheet, then you’ll also need to create a local copy of the problem script or problem stylesheet.
+    However, if the problem appears to be caused not by anything in the source of the document itself, but instead by something in an external script or external stylesheet, then you’ll also need to create a local copy of the problem script or problem stylesheet.
 
 3. Open/load the `REDUCTION.html` file in Ladybird, and verify that the same problem occurs with it as occurs with the original website/page you copied it from.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,7 @@
 # Security Policy
 
 Ladybird is unreleased software still in early development, and so bugs and vulnerabilities in its code can be safely
-disclosed publicly. The preference is to report security issues as [GitHub issues](https://github.com/LadybirdBrowser/ladybird/issues/new).
+disclosed publicly. The preference is to report security issues as [GitHub issues](https://github.com/LadybirdBrowser/ladybird/issues/new?template=bug_report.yml).
 
 However, private vulnerability reporting is also enabled on the repository. If you find a security issue in Ladybird,
 or in another web browser that you believe affects Ladybird, you may report it privately to the maintainers
@@ -12,7 +12,7 @@ and given a security advisory identifier. The maintainers may include regular co
 process as their expertise requires. Researchers who report security issues privately will be credited in the advisory.
 
 The maintainers reserve the right to reject reports that are not security issues, or that are not in the scope of Ladybird.
-For issues that are determined to not be security issues, please report them as a [GitHub issue](https://github.com/LadybirdBrowser/ladybird/issues/new)
+For issues that are determined to not be security issues, please report them as a [GitHub issue](https://github.com/LadybirdBrowser/ladybird/issues/new?template=bug_report.yml)
 instead. If you choose not to re-report the issue as a generic issue, the maintainers may do so themselves.
 
 Ladybird does not offer bug bounties for security issues at this time.

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -497,7 +497,7 @@ void ViewImplementation::handle_resize()
 void ViewImplementation::handle_web_content_process_crash()
 {
     dbgln("WebContent process crashed!");
-    dbgln("Consider raising an issue at https://github.com/LadybirdBrowser/ladybird/issues");
+    dbgln("Consider raising an issue at https://github.com/LadybirdBrowser/ladybird/issues/new/choose");
 
     ++m_crash_count;
     constexpr size_t max_reasonable_crash_count = 5U;


### PR DESCRIPTION
After working on https://github.com/LadybirdBrowser/ladybird/pull/830, it occurred to me we could further enforce issue-reporting requirements by putting the details from https://github.com/LadybirdBrowser/ladybird/blob/4dbb5aa90d/ISSUES.md#detailed-issue-reporting-guidelines into the issue form itself, rather than just in the docs.

To see what the results look like:

- https://github.com/sideshowbarker/ladybird/issues/new/choose
- https://github.com/sideshowbarker/ladybird/issues/new?template=bug_report.yml

Here are some notes about the different parts:

### https://github.com/sideshowbarker/ladybird/issues/new/choose

- This makes raising issues for things other than bug reports a bit more difficult. But maybe that’s a feature — since the project doesn’t encourage using the issue tracker for questions, feature requests, etc. That said, when users (or us) do want to bypass the bug-reporting form, there’s a _“Don’t see your issue here? Open a [blank issue](https://github.com/LadybirdBrowser/ladybird/issues/new)”_ link at the bottom that can be found and used. Or they/we can just navigate directly to https://github.com/LadybirdBrowser/ladybird/issues/new.
- **Report a security vulnerability** is auto-generated by GitHub. It gives security-bug reporting more prominence than needed for this project at this point, but I’m not sure how it can be suppressed.

### https://github.com/sideshowbarker/ladybird/issues/new?template=bug_report.yml

- The **Become a Ladybird supporter** part at the bottom of the form could of course be omitted. I just put it in so we see what it looks like. But note that for projects which use the GitHub Sponsors mechanism for donations, GitHub auto-generates something similar; example: https://github.com/opencv/opencv/issues/new?template=bug_report.yml#sr-footer-heading.  ![image](https://github.com/user-attachments/assets/7765e076-3011-4e8a-9fa4-b8bd0b8ac351)
  So, a _“You can support this project”_ message at the end of an issue-reporting form is something that GitHub users are accustomed to seeing. And there are other projects which add their own project-specific messages there; example: https://github.com/mui/material-ui/issues/new?template=1.bug.yml#sr-footer-heading.

  ![image](https://github.com/user-attachments/assets/f20ce55c-c651-47d0-a32d-73982e6107be)

Anyway, if the maintainers like this, I’m happy to iterate on it with any further refinements anybody wants — and also happy for anybody to just directly commit changes to the branch.

---

This PR branch also includes an additional commit which makes some changes to related docs — to align them a bit further with the context of the issue-reporting form.