### PR TITLE
LibWeb/Fetch: Don’t cache redirects

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1459,6 +1459,10 @@ private:
             // FIXME: Implement must-understand cache directive
         }
 
+        // FIXME: This is just for now, ad-hoc — not adhering to any particular spec.
+        if (response.status() == 301 || response.status() == 302 || response.status() == 303 || response.status() == 307 || response.status() == 308)
+            return false;
+
         // - the no-store cache directive is not present in the response (see Section 5.2.2.5);
         if (request.cache_mode() == Infrastructure::Request::CacheMode::NoStore)
             return false;


### PR DESCRIPTION
This change disables caching for 301, 302, 303, 307, and 308 responses. Fixes https://github.com/LadybirdBrowser/ladybird/issues/863

Not sure if this is the best solution — I mean, just making redirects uncacheable from the get-go — but if it’s suboptimal, I’m happy to try refining the patch further in any way needed.