### PR TITLE
AK+LibWeb: Avoid allocating UTF-16 strings only the UTF-16 length is needed

### DIFF
--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -131,6 +131,15 @@ ErrorOr<void> code_point_to_utf16(Utf16Data& string, u32 code_point, Endianness 
     return {};
 }
 
+size_t utf16_code_unit_length_from_utf8(StringView string)
+{
+    // FIXME: The CPU-specific implementations behave differently on null inputs. We treat null views as an empty string.
+    if (string.is_empty())
+        return 0;
+
+    return simdutf::utf16_length_from_utf8(string.characters_without_null_termination(), string.length());
+}
+
 bool Utf16View::is_high_surrogate(u16 code_unit)
 {
     return (code_unit >= high_surrogate_min) && (code_unit <= high_surrogate_max);

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -26,6 +26,8 @@ ErrorOr<Utf16Data> utf8_to_utf16(Utf8View const&, Endianness = Endianness::Host)
 ErrorOr<Utf16Data> utf32_to_utf16(Utf32View const&, Endianness = Endianness::Host);
 ErrorOr<void> code_point_to_utf16(Utf16Data&, u32, Endianness = Endianness::Host);
 
+size_t utf16_code_unit_length_from_utf8(StringView);
+
 class Utf16View;
 
 class Utf16CodePointIterator {

--- a/Tests/AK/TestUtf16.cpp
+++ b/Tests/AK/TestUtf16.cpp
@@ -89,6 +89,14 @@ TEST_CASE(decode_utf16)
     EXPECT_EQ(i, expected.size());
 }
 
+TEST_CASE(utf16_code_unit_length_from_utf8)
+{
+    EXPECT_EQ(AK::utf16_code_unit_length_from_utf8(""sv), 0uz);
+    EXPECT_EQ(AK::utf16_code_unit_length_from_utf8("abc"sv), 3uz);
+    EXPECT_EQ(AK::utf16_code_unit_length_from_utf8("😀"sv), 2uz);
+    EXPECT_EQ(AK::utf16_code_unit_length_from_utf8("Привет, мир! 😀 γειά σου κόσμος こんにちは世界"sv), 39uz);
+}
+
 TEST_CASE(null_view)
 {
     Utf16View view;

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Utf16View.h>
 #include <LibUnicode/Forward.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/Node.h>
@@ -30,9 +31,7 @@ public:
 
     unsigned length_in_utf16_code_units() const
     {
-        // FIXME: This is inefficient!
-        auto utf16_data = MUST(AK::utf8_to_utf16(m_data));
-        return Utf16View { utf16_data }.length_in_code_units();
+        return AK::utf16_code_unit_length_from_utf8(m_data);
     }
 
     WebIDL::ExceptionOr<String> substring_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units) const;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Utf16View.h>
 #include <LibWeb/Bindings/HTMLTextAreaElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/StyleProperties.h>
@@ -189,9 +190,7 @@ String HTMLTextAreaElement::api_value() const
 u32 HTMLTextAreaElement::text_length() const
 {
     // The textLength IDL attribute must return the length of the element's API value.
-    // FIXME: This is inefficient!
-    auto utf16_data = MUST(AK::utf8_to_utf16(api_value()));
-    return Utf16View { utf16_data }.length_in_code_units();
+    return AK::utf16_code_unit_length_from_utf8(api_value());
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity


### PR DESCRIPTION
In a benchmark of computing the length of a very large text node, this is 3.5x faster.