### PR TITLE
RequestServer: Actually hold on to the preload job until it's done

### DIFF
--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -100,8 +100,7 @@ struct JobData {
     }
 #endif
 
-    template<typename T>
-    static JobData create(WeakPtr<T> job, [[maybe_unused]] URL::URL url)
+    static JobData create(auto job, [[maybe_unused]] URL::URL url)
     {
         return JobData {
             [job](auto& socket) { job->start(socket); },

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -162,7 +162,7 @@ void ConnectionFromClient::worker_do_work(Work work)
 
             dbgln("EnsureConnection: Pre-connect to {}", url);
             auto do_preconnect = [=, job = Job::ensure(url)](auto& cache) {
-                ConnectionCache::ensure_connection(cache, url, job->make_weak_ptr<Job>());
+                ConnectionCache::ensure_connection(cache, url, move(job));
             };
 
             if (url.scheme() == "http"sv)


### PR DESCRIPTION
This was some nonsense code left in by mistake, ref commit: 4211639e455c8f58f23304be5312ad48a76e401a

Fixes #904.