### PR TITLE
LibWeb: No longer return `undefined` on null table entry in Wasm API

### DIFF
--- a/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -106,8 +106,6 @@ WebIDL::ExceptionOr<JS::Value> Table::get(u32 index) const
         return vm.throw_completion<JS::RangeError>("Table element index out of range"sv);
 
     auto& ref = table->elements()[index];
-    if (!ref.ref().has<Wasm::Reference::Null>())
-        return JS::js_undefined();
 
     Wasm::Value wasm_value { ref };
     return Detail::to_js_value(vm, wasm_value);

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -450,7 +450,10 @@ JS::Value to_js_value(JS::VM& vm, Wasm::Value& wasm_value)
     case Wasm::ValueType::F32:
         return JS::Value(static_cast<double>(wasm_value.to<float>().value()));
     case Wasm::ValueType::FunctionReference: {
-        auto address = wasm_value.to<Wasm::Reference::Func>().value().address;
+        auto ref_ = *wasm_value.to<Wasm::Reference>();
+        if (ref_.ref().has<Wasm::Reference::Null>())
+            return JS::js_null();
+        auto address = ref_.ref().get<Wasm::Reference::Func>().address;
         auto& cache = get_cache(realm);
         auto* function = cache.abstract_machine().store().get(address);
         auto name = function->visit(


### PR DESCRIPTION
Return `null` instead, as per the specification.