### PR TITLE
LibWebView+UI: Migrate Ladybird's command line flags to LibWebView

### DIFF
--- a/Ladybird/AppKit/Application/Application.h
+++ b/Ladybird/AppKit/Application/Application.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,8 +7,9 @@
 #pragma once
 
 #include <AK/Error.h>
-#include <AK/Vector.h>
 #include <LibIPC/Forward.h>
+#include <LibMain/Main.h>
+#include <LibURL/URL.h>
 #include <LibWebView/Forward.h>
 
 #import <Cocoa/Cocoa.h>
@@ -19,9 +20,10 @@ class WebViewBridge;
 
 @interface Application : NSApplication
 
-- (instancetype)init;
+- (void)setupWebViewApplication:(Main::Arguments&)arguments
+                  newTabPageURL:(URL::URL)new_tab_page_url;
 
-- (ErrorOr<void>)launchRequestServer:(Vector<ByteString> const&)certificates;
+- (ErrorOr<void>)launchRequestServer;
 - (ErrorOr<void>)launchImageDecoder;
 - (ErrorOr<NonnullRefPtr<WebView::WebContentClient>>)launchWebContent:(Ladybird::WebViewBridge&)web_view_bridge;
 - (ErrorOr<IPC::File>)launchWebWorker;

--- a/Ladybird/AppKit/Application/Application.mm
+++ b/Ladybird/AppKit/Application/Application.mm
@@ -1,10 +1,9 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteString.h>
 #include <Application/ApplicationBridge.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/ThreadEventQueue.h>
@@ -25,20 +24,17 @@
 
 @implementation Application
 
-- (instancetype)init
-{
-    if (self = [super init]) {
-        m_application_bridge = make<Ladybird::ApplicationBridge>();
-    }
-
-    return self;
-}
-
 #pragma mark - Public methods
 
-- (ErrorOr<void>)launchRequestServer:(Vector<ByteString> const&)certificates
+- (void)setupWebViewApplication:(Main::Arguments&)arguments
+                  newTabPageURL:(URL::URL)new_tab_page_url
 {
-    return m_application_bridge->launch_request_server(certificates);
+    m_application_bridge = Ladybird::ApplicationBridge::create(arguments, move(new_tab_page_url));
+}
+
+- (ErrorOr<void>)launchRequestServer
+{
+    return m_application_bridge->launch_request_server();
 }
 
 - (ErrorOr<void>)launchImageDecoder

--- a/Ladybird/AppKit/Application/ApplicationBridge.cpp
+++ b/Ladybird/AppKit/Application/ApplicationBridge.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteString.h>
 #include <Application/ApplicationBridge.h>
 #include <Ladybird/AppKit/UI/LadybirdWebViewBridge.h>
 #include <Ladybird/HelperProcess.h>
@@ -23,17 +22,17 @@ struct ApplicationBridgeImpl {
     RefPtr<ImageDecoderClient::Client> image_decoder_client;
 };
 
-ApplicationBridge::ApplicationBridge()
+ApplicationBridge::ApplicationBridge(Badge<WebView::Application>, Main::Arguments&)
     : m_impl(make<ApplicationBridgeImpl>())
 {
 }
 
 ApplicationBridge::~ApplicationBridge() = default;
 
-ErrorOr<void> ApplicationBridge::launch_request_server(Vector<ByteString> const& certificates)
+ErrorOr<void> ApplicationBridge::launch_request_server()
 {
     auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-    auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root, certificates));
+    auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root));
 
     m_impl->request_server_client = move(protocol_client);
     return {};
@@ -79,7 +78,7 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> ApplicationBridge::launch_web_
     auto image_decoder_socket = TRY(connect_new_image_decoder_client(*m_impl->image_decoder_client));
 
     auto web_content_paths = TRY(get_paths_for_helper_process("WebContent"sv));
-    auto web_content = TRY(launch_web_content_process(web_view_bridge, web_content_paths, web_view_bridge.web_content_options(), move(image_decoder_socket), move(request_server_socket)));
+    auto web_content = TRY(launch_web_content_process(web_view_bridge, web_content_paths, move(image_decoder_socket), move(request_server_socket)));
 
     return web_content;
 }

--- a/Ladybird/AppKit/Application/ApplicationBridge.h
+++ b/Ladybird/AppKit/Application/ApplicationBridge.h
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <AK/NonnullOwnPtr.h>
-#include <AK/Vector.h>
 #include <LibIPC/Forward.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/Forward.h>
 
 namespace Ladybird {
@@ -16,12 +16,13 @@ namespace Ladybird {
 struct ApplicationBridgeImpl;
 class WebViewBridge;
 
-class ApplicationBridge {
+class ApplicationBridge : public WebView::Application {
+    WEB_VIEW_APPLICATION(ApplicationBridge)
+
 public:
-    ApplicationBridge();
     ~ApplicationBridge();
 
-    ErrorOr<void> launch_request_server(Vector<ByteString> const& certificates);
+    ErrorOr<void> launch_request_server();
     ErrorOr<void> launch_image_decoder();
     ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content(WebViewBridge&);
     ErrorOr<IPC::File> launch_web_worker();

--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,8 +8,6 @@
 
 #include <AK/Optional.h>
 #include <AK/StringView.h>
-#include <AK/Vector.h>
-#include <Ladybird/Types.h>
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
@@ -24,12 +22,7 @@
 
 @interface ApplicationDelegate : NSObject <NSApplicationDelegate>
 
-- (nullable instancetype)init:(Vector<URL::URL>)initial_urls
-                newTabPageURL:(URL::URL)new_tab_page_url
-                withCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar
-            webContentOptions:(Ladybird::WebContentOptions const&)web_content_options
-      webdriverContentIPCPath:(StringView)webdriver_content_ipc_path
-                  allowPopups:(BOOL)allow_popups;
+- (nullable instancetype)initWithCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar;
 
 - (nonnull TabController*)createNewTab:(Optional<URL::URL> const&)url
                                fromTab:(nullable Tab*)tab
@@ -46,8 +39,6 @@
 - (void)removeTab:(nonnull TabController*)controller;
 
 - (WebView::CookieJar&)cookieJar;
-- (Ladybird::WebContentOptions const&)webContentOptions;
-- (Optional<StringView> const&)webdriverContentIPCPath;
 - (Web::CSS::PreferredColorScheme)preferredColorScheme;
 - (Web::CSS::PreferredContrast)preferredContrast;
 - (Web::CSS::PreferredMotion)preferredMotion;

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWebView/Application.h>
 #include <LibWebView/SearchEngine.h>
 
 #import <Application/ApplicationDelegate.h>
@@ -29,14 +30,8 @@
 
 @interface ApplicationDelegate () <TaskManagerDelegate>
 {
-    Vector<URL::URL> m_initial_urls;
-    URL::URL m_new_tab_page_url;
-
     // This will always be populated, but we cannot have a non-default constructible instance variable.
     OwnPtr<WebView::CookieJar> m_cookie_jar;
-
-    Ladybird::WebContentOptions m_web_content_options;
-    Optional<StringView> m_webdriver_content_ipc_path;
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme;
     Web::CSS::PreferredContrast m_preferred_contrast;
@@ -44,8 +39,6 @@
     ByteString m_navigator_compatibility_mode;
 
     WebView::SearchEngine m_search_engine;
-
-    BOOL m_allow_popups;
 }
 
 @property (nonatomic, strong) NSMutableArray<TabController*>* managed_tabs;
@@ -68,12 +61,7 @@
 
 @implementation ApplicationDelegate
 
-- (instancetype)init:(Vector<URL::URL>)initial_urls
-              newTabPageURL:(URL::URL)new_tab_page_url
-              withCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar
-          webContentOptions:(Ladybird::WebContentOptions const&)web_content_options
-    webdriverContentIPCPath:(StringView)webdriver_content_ipc_path
-                allowPopups:(BOOL)allow_popups
+- (instancetype)initWithCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar
 {
     if (self = [super init]) {
         [NSApp setMainMenu:[[NSMenu alloc] init]];
@@ -91,24 +79,13 @@
 
         self.managed_tabs = [[NSMutableArray alloc] init];
 
-        m_initial_urls = move(initial_urls);
-        m_new_tab_page_url = move(new_tab_page_url);
-
         m_cookie_jar = move(cookie_jar);
-
-        m_web_content_options = web_content_options;
-
-        if (!webdriver_content_ipc_path.is_empty()) {
-            m_webdriver_content_ipc_path = webdriver_content_ipc_path;
-        }
 
         m_preferred_color_scheme = Web::CSS::PreferredColorScheme::Auto;
         m_preferred_contrast = Web::CSS::PreferredContrast::Auto;
         m_preferred_motion = Web::CSS::PreferredMotion::Auto;
         m_navigator_compatibility_mode = "chrome";
         m_search_engine = WebView::default_search_engine();
-
-        m_allow_popups = allow_popups;
 
         // Reduce the tooltip delay, as the default delay feels quite long.
         [[NSUserDefaults standardUserDefaults] setObject:@100 forKey:@"NSInitialToolTipDelay"];
@@ -124,7 +101,7 @@
                    activateTab:(Web::HTML::ActivateTab)activate_tab
 {
     auto* controller = [self createNewTab:activate_tab fromTab:tab];
-    [controller loadURL:url.value_or(m_new_tab_page_url)];
+    [controller loadURL:url.value_or(WebView::Application::chrome_options().new_tab_page_url)];
 
     return controller;
 }
@@ -166,16 +143,6 @@
     return *m_cookie_jar;
 }
 
-- (Ladybird::WebContentOptions const&)webContentOptions
-{
-    return m_web_content_options;
-}
-
-- (Optional<StringView> const&)webdriverContentIPCPath
-{
-    return m_webdriver_content_ipc_path;
-}
-
 - (Web::CSS::PreferredColorScheme)preferredColorScheme
 {
     return m_preferred_color_scheme;
@@ -213,7 +180,7 @@
 - (nonnull TabController*)createNewTab:(Web::HTML::ActivateTab)activate_tab
                                fromTab:(nullable Tab*)tab
 {
-    auto* controller = [[TabController alloc] init:!m_allow_popups];
+    auto* controller = [[TabController alloc] init];
     [controller showWindow:nil];
 
     if (tab) {
@@ -740,7 +707,7 @@
 {
     Tab* tab = nil;
 
-    for (auto const& url : m_initial_urls) {
+    for (auto const& url : WebView::Application::chrome_options().urls) {
         auto activate_tab = tab == nil ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No;
 
         auto* controller = [self createNewTab:url
@@ -749,8 +716,6 @@
 
         tab = (Tab*)[controller window];
     }
-
-    m_initial_urls.clear();
 }
 
 - (void)applicationWillTerminate:(NSNotification*)notification

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -104,7 +104,7 @@ struct HideCursor {
         // This returns device pixel ratio of the screen the window is opened in
         auto device_pixel_ratio = [[NSScreen mainScreen] backingScaleFactor];
 
-        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, [delegate webContentOptions], [delegate webdriverContentIPCPath], [delegate preferredColorScheme], [delegate preferredContrast], [delegate preferredMotion]));
+        m_web_view_bridge = MUST(Ladybird::WebViewBridge::create(move(screen_rects), device_pixel_ratio, [delegate preferredColorScheme], [delegate preferredContrast], [delegate preferredMotion]));
         [self setWebViewCallbacks];
 
         m_web_view_bridge->initialize_client();

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Vector.h>
-#include <Ladybird/Types.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Size.h>
@@ -22,12 +21,10 @@ namespace Ladybird {
 
 class WebViewBridge final : public WebView::ViewImplementation {
 public:
-    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
+    static ErrorOr<NonnullOwnPtr<WebViewBridge>> create(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
     virtual ~WebViewBridge() override;
 
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) override;
-
-    WebContentOptions const& web_content_options() const { return m_web_content_options; }
 
     float device_pixel_ratio() const { return m_device_pixel_ratio; }
     void set_device_pixel_ratio(float device_pixel_ratio);
@@ -59,7 +56,7 @@ public:
     Function<void()> on_zoom_level_changed;
 
 private:
-    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, WebContentOptions const&, Optional<StringView> webdriver_content_ipc_path, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
+    WebViewBridge(Vector<Web::DevicePixelRect> screen_rects, float device_pixel_ratio, Web::CSS::PreferredColorScheme, Web::CSS::PreferredContrast, Web::CSS::PreferredMotion);
 
     virtual void update_zoom() override;
     virtual Web::DevicePixelSize viewport_size() const override;
@@ -68,9 +65,6 @@ private:
 
     Vector<Web::DevicePixelRect> m_screen_rects;
     Gfx::IntSize m_viewport_size;
-
-    WebContentOptions m_web_content_options;
-    Optional<StringView> m_webdriver_content_ipc_path;
 
     Web::CSS::PreferredColorScheme m_preferred_color_scheme { Web::CSS::PreferredColorScheme::Auto };
     Web::CSS::PreferredContrast m_preferred_contrast { Web::CSS::PreferredContrast::Auto };

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,7 +22,7 @@ struct TabSettings {
 
 @interface TabController : NSWindowController <NSWindowDelegate>
 
-- (instancetype)init:(BOOL)block_popups;
+- (instancetype)init;
 
 - (void)loadURL:(URL::URL const&)url;
 - (void)loadHTML:(StringView)html url:(URL::URL const&)url;

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -1,10 +1,11 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Loader/UserAgent.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
@@ -82,7 +83,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 @synthesize new_tab_toolbar_item = _new_tab_toolbar_item;
 @synthesize tab_overview_toolbar_item = _tab_overview_toolbar_item;
 
-- (instancetype)init:(BOOL)block_popups
+- (instancetype)init
 {
     if (self = [super init]) {
         self.toolbar = [[NSToolbar alloc] initWithIdentifier:TOOLBAR_IDENTIFIER];
@@ -91,7 +92,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [self.toolbar setAllowsUserCustomization:NO];
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];
 
-        m_settings = { .block_popups = block_popups };
+        m_settings = { .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES };
         m_can_navigate_back = false;
         m_can_navigate_forward = false;
     }

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,9 +7,7 @@
 #include <AK/Enumerate.h>
 #include <Ladybird/DefaultSettings.h>
 #include <Ladybird/MachPortServer.h>
-#include <Ladybird/Types.h>
 #include <Ladybird/Utilities.h>
-#include <LibCore/ArgsParser.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
@@ -30,33 +28,10 @@
 #    error "This project requires ARC"
 #endif
 
-static Vector<URL::URL> sanitize_urls(Vector<ByteString> const& raw_urls)
-{
-    Vector<URL::URL> sanitized_urls;
-    for (auto const& raw_url : raw_urls) {
-        if (auto url = WebView::sanitize_url(raw_url); url.has_value())
-            sanitized_urls.append(url.release_value());
-    }
-
-    if (sanitized_urls.is_empty()) {
-        URL::URL new_tab_page_url = Browser::default_new_tab_url;
-        sanitized_urls.append(move(new_tab_page_url));
-    }
-
-    return sanitized_urls;
-}
-
-enum class NewWindow {
-    No,
-    Yes,
-};
-
-static void open_urls_from_client(Vector<ByteString> const& raw_urls, NewWindow new_window)
+static void open_urls_from_client(Vector<URL::URL> const& urls, WebView::NewWindow new_window)
 {
     ApplicationDelegate* delegate = [NSApp delegate];
-    Tab* tab = new_window == NewWindow::Yes ? nil : [delegate activeTab];
-
-    auto urls = sanitize_urls(raw_urls);
+    Tab* tab = new_window == WebView::NewWindow::Yes ? nil : [delegate activeTab];
 
     for (auto [i, url] : enumerate(urls)) {
         auto activate_tab = i == 0 ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No;
@@ -76,51 +51,33 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Application* application = [Application sharedApplication];
 
     Core::EventLoopManager::install(*new Ladybird::CFEventLoopManager);
-    WebView::Application web_view_app(arguments.argc, arguments.argv);
+    [application setupWebViewApplication:arguments newTabPageURL:Browser::default_new_tab_url];
 
     platform_init();
 
-    Vector<ByteString> raw_urls;
-    Vector<ByteString> certificates;
-    StringView webdriver_content_ipc_path;
-    bool debug_web_content = false;
-    bool log_all_js_exceptions = false;
-    bool enable_http_cache = false;
-    bool new_window = false;
-    bool force_new_process = false;
-    bool allow_popups = false;
-
-    Core::ArgsParser args_parser;
-    args_parser.set_general_help("The Ladybird web browser");
-    args_parser.add_positional_argument(raw_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
-    args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
-    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content");
-    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
-    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
-    args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
-    args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
-    args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
-    args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
-    args_parser.parse(arguments);
-
     auto chrome_process = TRY(WebView::ChromeProcess::create());
-    if (!force_new_process && TRY(chrome_process.connect(raw_urls, new_window)) == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
-        outln("Opening in existing process");
-        return 0;
+
+    if (auto const& chrome_options = WebView::Application::chrome_options(); chrome_options.force_new_process == WebView::ForceNewProcess::No) {
+        auto disposition = TRY(chrome_process.connect(chrome_options.raw_urls, chrome_options.new_window));
+
+        if (disposition == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
+            outln("Opening in existing process");
+            return 0;
+        }
     }
 
     chrome_process.on_new_tab = [&](auto const& raw_urls) {
-        open_urls_from_client(raw_urls, NewWindow::No);
+        open_urls_from_client(raw_urls, WebView::NewWindow::No);
     };
 
     chrome_process.on_new_window = [&](auto const& raw_urls) {
-        open_urls_from_client(raw_urls, NewWindow::Yes);
+        open_urls_from_client(raw_urls, WebView::NewWindow::Yes);
     };
 
     auto mach_port_server = make<Ladybird::MachPortServer>();
     set_mach_server_name(mach_port_server->server_port_name());
-    mach_port_server->on_receive_child_mach_port = [&web_view_app](auto pid, auto port) {
-        web_view_app.set_process_mach_port(pid, move(port));
+    mach_port_server->on_receive_child_mach_port = [&](auto pid, auto port) {
+        WebView::Application::the().set_process_mach_port(pid, move(port));
     };
     mach_port_server->on_receive_backing_stores = [](Ladybird::MachPortServer::BackingStoresMessage message) {
         if (auto view = WebView::WebContentClient::view_for_pid_and_page_id(message.pid, message.page_id); view.has_value())
@@ -131,28 +88,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto cookie_jar = TRY(WebView::CookieJar::create(*database));
 
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
-    TRY([application launchRequestServer:certificates]);
+    TRY([application launchRequestServer]);
 
     TRY([application launchImageDecoder]);
 
-    StringBuilder command_line_builder;
-    command_line_builder.join(' ', arguments.strings);
-    Ladybird::WebContentOptions web_content_options {
-        .command_line = MUST(command_line_builder.to_string()),
-        .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
-        .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,
-        .log_all_js_exceptions = log_all_js_exceptions ? Ladybird::LogAllJSExceptions::Yes : Ladybird::LogAllJSExceptions::No,
-        .enable_http_cache = enable_http_cache ? Ladybird::EnableHTTPCache::Yes : Ladybird::EnableHTTPCache::No,
-    };
-
-    auto* delegate = [[ApplicationDelegate alloc] init:sanitize_urls(raw_urls)
-                                         newTabPageURL:URL::URL { Browser::default_new_tab_url }
-                                         withCookieJar:move(cookie_jar)
-                                     webContentOptions:web_content_options
-                               webdriverContentIPCPath:webdriver_content_ipc_path
-                                           allowPopups:allow_popups];
-
+    auto* delegate = [[ApplicationDelegate alloc] initWithCookieJar:move(cookie_jar)];
     [NSApp setDelegate:delegate];
 
-    return web_view_app.exec();
+    return WebView::Application::the().execute();
 }

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -6,7 +6,6 @@ set(LADYBIRD_SOURCES
 )
 set(LADYBIRD_HEADERS
     HelperProcess.h
-    Types.h
     Utilities.h
 )
 

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include "Types.h"
 #include <AK/Error.h>
 #include <AK/Optional.h>
 #include <AK/Span.h>
@@ -20,13 +19,12 @@
 ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     WebView::ViewImplementation& view,
     ReadonlySpan<ByteString> candidate_web_content_paths,
-    Ladybird::WebContentOptions const&,
     IPC::File image_decoder_socket,
     Optional<IPC::File> request_server_socket = {});
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths);
 ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Protocol::RequestClient>);
-ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root, Vector<ByteString> const& certificates);
+ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root);
 
 ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient&);
 ErrorOr<IPC::File> connect_new_image_decoder_client(ImageDecoderClient::Client&);

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -12,15 +12,18 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibProtocol/RequestClient.h>
 #include <LibURL/URL.h>
+#include <LibWebView/Application.h>
 #include <QApplication>
 
 namespace Ladybird {
 
-class Application : public QApplication {
+class Application
+    : public QApplication
+    , public WebView::Application {
     Q_OBJECT
+    WEB_VIEW_APPLICATION(Application)
 
 public:
-    Application(int& argc, char** argv);
     virtual ~Application() override;
 
     virtual bool event(QEvent* event) override;
@@ -31,15 +34,20 @@ public:
     NonnullRefPtr<ImageDecoderClient::Client> image_decoder_client() const { return *m_image_decoder_client; }
     ErrorOr<void> initialize_image_decoder();
 
-    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, bool allow_popups, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
-    void show_task_manager_window(WebContentOptions const&);
+    void show_task_manager_window();
     void close_task_manager_window();
 
     BrowserWindow& active_window() { return *m_active_window; }
     void set_active_window(BrowserWindow& w) { m_active_window = &w; }
 
 private:
+    virtual void create_platform_arguments(Core::ArgsParser&) override;
+    virtual void create_platform_options(WebView::ChromeOptions&, WebView::WebContentOptions&) override;
+
+    bool m_enable_qt_networking { false };
+
     TaskManagerWindow* m_task_manager_window { nullptr };
     BrowserWindow* m_active_window { nullptr };
 

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -9,7 +9,6 @@
 
 #include "Tab.h"
 #include <Ladybird/Qt/FindInPageWidget.h>
-#include <Ladybird/Types.h>
 #include <LibCore/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
@@ -36,7 +35,7 @@ public:
         Yes,
     };
 
-    BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, WebContentOptions const&, StringView webdriver_content_ipc_path, bool allow_popups, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     WebContentView& view() const { return m_current_tab->view(); }
 
@@ -215,10 +214,6 @@ private:
 
     WebView::CookieJar& m_cookie_jar;
 
-    WebContentOptions m_web_content_options;
-    StringView m_webdriver_content_ipc_path;
-
-    bool m_allow_popups { false };
     IsPopupWindow m_is_popup_window { IsPopupWindow::No };
 };
 

--- a/Ladybird/Qt/InspectorWidget.cpp
+++ b/Ladybird/Qt/InspectorWidget.cpp
@@ -22,7 +22,7 @@ extern bool is_using_dark_system_theme(QWidget&);
 InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
     : QWidget(tab, Qt::Window)
 {
-    m_inspector_view = new WebContentView(this, content_view.web_content_options(), {});
+    m_inspector_view = new WebContentView(this);
 
     if (is_using_dark_system_theme(*this))
         m_inspector_view->update_palette(WebContentView::PaletteMode::Dark);

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -47,7 +47,7 @@ static QIcon default_favicon()
     return icon;
 }
 
-Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
+Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client, size_t page_index)
     : QWidget(window)
     , m_window(window)
 {
@@ -55,7 +55,7 @@ Tab::Tab(BrowserWindow* window, WebContentOptions const& web_content_options, St
     m_layout->setSpacing(0);
     m_layout->setContentsMargins(0, 0, 0, 0);
 
-    m_view = new WebContentView(this, web_content_options, webdriver_content_ipc_path, parent_client, page_index);
+    m_view = new WebContentView(this, parent_client, page_index);
     m_find_in_page = new FindInPageWidget(this, m_view);
     m_find_in_page->setVisible(false);
     m_toolbar = new QToolBar(this);

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -29,7 +29,7 @@ class Tab final : public QWidget {
     Q_OBJECT
 
 public:
-    Tab(BrowserWindow* window, WebContentOptions const&, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
+    Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
     virtual ~Tab() override;
 
     WebContentView& view() { return *m_view; }

--- a/Ladybird/Qt/TaskManagerWindow.cpp
+++ b/Ladybird/Qt/TaskManagerWindow.cpp
@@ -10,9 +10,9 @@
 
 namespace Ladybird {
 
-TaskManagerWindow::TaskManagerWindow(QWidget* parent, WebContentOptions const& web_content_options)
+TaskManagerWindow::TaskManagerWindow(QWidget* parent)
     : QWidget(parent, Qt::WindowFlags(Qt::WindowType::Window))
-    , m_web_view(new WebContentView(this, web_content_options, {}))
+    , m_web_view(new WebContentView(this))
 {
     setLayout(new QVBoxLayout);
     layout()->addWidget(m_web_view);

--- a/Ladybird/Qt/TaskManagerWindow.h
+++ b/Ladybird/Qt/TaskManagerWindow.h
@@ -16,7 +16,7 @@ class TaskManagerWindow : public QWidget {
     Q_OBJECT
 
 public:
-    TaskManagerWindow(QWidget* parent, WebContentOptions const&);
+    explicit TaskManagerWindow(QWidget* parent);
 
 private:
     virtual void showEvent(QShowEvent*) override;

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -11,7 +11,6 @@
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
-#include <Ladybird/Types.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/StandardCursor.h>
@@ -46,7 +45,7 @@ class WebContentView final
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:
-    WebContentView(QWidget* window, WebContentOptions const&, StringView webdriver_content_ipc_path, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
+    WebContentView(QWidget* window, RefPtr<WebView::WebContentClient> parent_client = nullptr, size_t page_index = 0);
     virtual ~WebContentView() override;
 
     Function<String(const URL::URL&, Web::HTML::ActivateTab)> on_tab_open_request;
@@ -85,8 +84,6 @@ public:
 
     QPoint map_point_to_global_position(Gfx::IntPoint) const;
 
-    WebContentOptions const& web_content_options() const { return m_web_content_options; }
-
 signals:
     void urls_dropped(QList<QUrl> const&);
 
@@ -113,9 +110,6 @@ private:
     bool m_should_show_line_box_borders { false };
 
     Gfx::IntSize m_viewport_size;
-
-    WebContentOptions m_web_content_options;
-    StringView m_webdriver_content_ipc_path;
 };
 
 }

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -62,72 +62,32 @@ static ErrorOr<void> handle_attached_debugger()
     return {};
 }
 
-static Vector<URL::URL> sanitize_urls(Vector<ByteString> const& raw_urls)
-{
-    Vector<URL::URL> sanitized_urls;
-    for (auto const& raw_url : raw_urls) {
-        if (auto url = WebView::sanitize_url(raw_url); url.has_value())
-            sanitized_urls.append(url.release_value());
-    }
-    return sanitized_urls;
-}
-
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     AK::set_rich_debug_enabled(true);
 
-    Ladybird::Application app(arguments.argc, arguments.argv);
-
     Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
-    WebView::Application webview_app(arguments.argc, arguments.argv);
-    static_cast<Ladybird::EventLoopImplementationQt&>(Core::EventLoop::current().impl()).set_main_loop();
 
+    auto app = Ladybird::Application::create(arguments, ak_url_from_qstring(Ladybird::Settings::the()->new_tab_page()));
+
+    static_cast<Ladybird::EventLoopImplementationQt&>(Core::EventLoop::current().impl()).set_main_loop();
     TRY(handle_attached_debugger());
 
     platform_init();
 
-    Vector<ByteString> raw_urls;
-    StringView webdriver_content_ipc_path;
-    Vector<ByteString> certificates;
-    bool enable_callgrind_profiling = false;
-    bool disable_sql_database = false;
-    bool enable_qt_networking = false;
-    bool expose_internals_object = false;
-    bool debug_web_content = false;
-    bool log_all_js_exceptions = false;
-    bool enable_idl_tracing = false;
-    bool enable_http_cache = false;
-    bool new_window = false;
-    bool force_new_process = false;
-    bool allow_popups = false;
-
-    Core::ArgsParser args_parser;
-    args_parser.set_general_help("The Ladybird web browser :^)");
-    args_parser.add_positional_argument(raw_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
-    args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
-    args_parser.add_option(enable_callgrind_profiling, "Enable Callgrind profiling", "enable-callgrind-profiling", 'P');
-    args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");
-    args_parser.add_option(enable_qt_networking, "Enable Qt as the backend networking service", "enable-qt-networking");
-    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content");
-    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
-    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
-    args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
-    args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
-    args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
-    args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
-    args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
-    args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
-    args_parser.parse(arguments);
-
     auto chrome_process = TRY(WebView::ChromeProcess::create());
-    if (!force_new_process && TRY(chrome_process.connect(raw_urls, new_window)) == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
-        outln("Opening in existing process");
-        return 0;
+
+    if (app->chrome_options().force_new_process == WebView::ForceNewProcess::No) {
+        auto disposition = TRY(chrome_process.connect(app->chrome_options().raw_urls, app->chrome_options().new_window));
+
+        if (disposition == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
+            outln("Opening in existing process");
+            return 0;
+        }
     }
 
-    chrome_process.on_new_tab = [&](auto const& raw_urls) {
-        auto& window = app.active_window();
-        auto urls = sanitize_urls(raw_urls);
+    chrome_process.on_new_tab = [&](auto const& urls) {
+        auto& window = app->active_window();
         for (size_t i = 0; i < urls.size(); ++i) {
             window.new_tab_from_url(urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);
         }
@@ -136,16 +96,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         window.raise();
     };
 
-    app.on_open_file = [&](auto file_url) {
-        auto& window = app.active_window();
+    app->on_open_file = [&](auto file_url) {
+        auto& window = app->active_window();
         window.view().load(file_url);
     };
 
 #if defined(AK_OS_MACOS)
     auto mach_port_server = make<Ladybird::MachPortServer>();
     set_mach_server_name(mach_port_server->server_port_name());
-    mach_port_server->on_receive_child_mach_port = [&webview_app](auto pid, auto port) {
-        webview_app.set_process_mach_port(pid, move(port));
+    mach_port_server->on_receive_child_mach_port = [&app](auto pid, auto port) {
+        app->set_process_mach_port(pid, move(port));
     };
     mach_port_server->on_receive_backing_stores = [](Ladybird::MachPortServer::BackingStoresMessage message) {
         if (auto view = WebView::WebContentClient::view_for_pid_and_page_id(message.pid, message.page_id); view.has_value())
@@ -156,40 +116,25 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     copy_default_config_files(Ladybird::Settings::the()->directory());
 
     RefPtr<WebView::Database> database;
-    if (!disable_sql_database)
+    if (app->chrome_options().disable_sql_database == WebView::DisableSQLDatabase::No)
         database = TRY(WebView::Database::create());
 
     auto cookie_jar = database ? TRY(WebView::CookieJar::create(*database)) : WebView::CookieJar::create();
 
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
-    if (!enable_qt_networking) {
+    if (app->web_content_options().use_lagom_networking == WebView::UseLagomNetworking::Yes) {
         auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-        auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root, certificates));
-        app.request_server_client = move(protocol_client);
+        auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root));
+        app->request_server_client = move(protocol_client);
     }
 
-    TRY(app.initialize_image_decoder());
-
-    StringBuilder command_line_builder;
-    command_line_builder.join(' ', arguments.strings);
-    Ladybird::WebContentOptions web_content_options {
-        .command_line = MUST(command_line_builder.to_string()),
-        .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
-        .config_path = Ladybird::Settings::the()->directory(),
-        .enable_callgrind_profiling = enable_callgrind_profiling ? Ladybird::EnableCallgrindProfiling::Yes : Ladybird::EnableCallgrindProfiling::No,
-        .use_lagom_networking = enable_qt_networking ? Ladybird::UseLagomNetworking::No : Ladybird::UseLagomNetworking::Yes,
-        .wait_for_debugger = debug_web_content ? Ladybird::WaitForDebugger::Yes : Ladybird::WaitForDebugger::No,
-        .log_all_js_exceptions = log_all_js_exceptions ? Ladybird::LogAllJSExceptions::Yes : Ladybird::LogAllJSExceptions::No,
-        .enable_idl_tracing = enable_idl_tracing ? Ladybird::EnableIDLTracing::Yes : Ladybird::EnableIDLTracing::No,
-        .enable_http_cache = enable_http_cache ? Ladybird::EnableHTTPCache::Yes : Ladybird::EnableHTTPCache::No,
-        .expose_internals_object = expose_internals_object ? Ladybird::ExposeInternalsObject::Yes : Ladybird::ExposeInternalsObject::No,
-    };
+    TRY(app->initialize_image_decoder());
 
     chrome_process.on_new_window = [&](auto const& urls) {
-        app.new_window(sanitize_urls(urls), *cookie_jar, web_content_options, webdriver_content_ipc_path, allow_popups);
+        app->new_window(urls, *cookie_jar);
     };
 
-    auto& window = app.new_window(sanitize_urls(raw_urls), *cookie_jar, web_content_options, webdriver_content_ipc_path, allow_popups);
+    auto& window = app->new_window(app->chrome_options().urls, *cookie_jar);
     window.setWindowTitle("Ladybird");
 
     if (Ladybird::Settings::the()->is_maximized()) {
@@ -203,5 +148,5 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     window.show();
 
-    return webview_app.exec();
+    return app->execute();
 }

--- a/Userland/Libraries/LibWebView/Application.cpp
+++ b/Userland/Libraries/LibWebView/Application.cpp
@@ -5,15 +5,17 @@
  */
 
 #include <AK/Debug.h>
+#include <LibCore/ArgsParser.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/URL.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
 
 Application* Application::s_the = nullptr;
 
-Application::Application(int, char**)
+Application::Application()
 {
     VERIFY(!s_the);
     s_the = this;
@@ -28,7 +30,70 @@ Application::~Application()
     s_the = nullptr;
 }
 
-int Application::exec()
+void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_page_url)
+{
+    Vector<ByteString> raw_urls;
+    Vector<ByteString> certificates;
+    bool new_window = false;
+    bool force_new_process = false;
+    bool allow_popups = false;
+    bool disable_sql_database = false;
+    Optional<StringView> webdriver_content_ipc_path;
+    bool enable_callgrind_profiling = false;
+    bool debug_web_content = false;
+    bool log_all_js_exceptions = false;
+    bool enable_idl_tracing = false;
+    bool enable_http_cache = false;
+    bool expose_internals_object = false;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("The Ladybird web browser :^)");
+    args_parser.add_positional_argument(raw_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
+    args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
+    args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
+    args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
+    args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
+    args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");
+    args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
+    args_parser.add_option(enable_callgrind_profiling, "Enable Callgrind profiling", "enable-callgrind-profiling", 'P');
+    args_parser.add_option(debug_web_content, "Wait for debugger to attach to WebContent", "debug-web-content");
+    args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
+    args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
+    args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
+    args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
+
+    create_platform_arguments(args_parser);
+    args_parser.parse(arguments);
+
+    m_chrome_options = {
+        .urls = sanitize_urls(raw_urls, new_tab_page_url),
+        .raw_urls = move(raw_urls),
+        .new_tab_page_url = move(new_tab_page_url),
+        .certificates = move(certificates),
+        .new_window = new_window ? NewWindow::Yes : NewWindow::No,
+        .force_new_process = force_new_process ? ForceNewProcess::Yes : ForceNewProcess::No,
+        .allow_popups = allow_popups ? AllowPopups::Yes : AllowPopups::No,
+        .disable_sql_database = disable_sql_database ? DisableSQLDatabase::Yes : DisableSQLDatabase::No,
+    };
+
+    if (webdriver_content_ipc_path.has_value())
+        m_chrome_options.webdriver_content_ipc_path = *webdriver_content_ipc_path;
+
+    m_web_content_options = {
+        .command_line = MUST(String::join(' ', arguments.strings)),
+        .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
+        .enable_callgrind_profiling = enable_callgrind_profiling ? EnableCallgrindProfiling::Yes : EnableCallgrindProfiling::No,
+        .wait_for_debugger = debug_web_content ? WaitForDebugger::Yes : WaitForDebugger::No,
+        .log_all_js_exceptions = log_all_js_exceptions ? LogAllJSExceptions::Yes : LogAllJSExceptions::No,
+        .enable_idl_tracing = enable_idl_tracing ? EnableIDLTracing::Yes : EnableIDLTracing::No,
+        .enable_http_cache = enable_http_cache ? EnableHTTPCache::Yes : EnableHTTPCache::No,
+        .expose_internals_object = expose_internals_object ? ExposeInternalsObject::Yes : ExposeInternalsObject::No,
+    };
+
+    create_platform_options(m_chrome_options, m_web_content_options);
+}
+
+int Application::execute()
 {
     int ret = m_event_loop.exec();
     m_in_shutdown = true;

--- a/Userland/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Userland/Libraries/LibWebView/ChromeProcess.cpp
@@ -9,7 +9,9 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/ChromeProcess.h>
+#include <LibWebView/URL.h>
 
 namespace WebView {
 
@@ -31,7 +33,7 @@ ErrorOr<ChromeProcess> ChromeProcess::create()
     return ChromeProcess {};
 }
 
-ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteString> const& raw_urls, bool new_window)
+ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteString> const& raw_urls, NewWindow new_window)
 {
     static constexpr auto process_name = "Ladybird"sv;
 
@@ -51,12 +53,12 @@ ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteStr
     return ProcessDisposition::ContinueMainProcess;
 }
 
-ErrorOr<void> ChromeProcess::connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, bool new_window)
+ErrorOr<void> ChromeProcess::connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, NewWindow new_window)
 {
     auto socket = TRY(Core::LocalSocket::connect(socket_path));
     auto client = UIProcessClient::construct(move(socket));
 
-    if (new_window) {
+    if (new_window == NewWindow::Yes) {
         if (!client->send_sync_but_allow_failure<Messages::UIProcessServer::CreateNewWindow>(raw_urls))
             dbgln("Failed to send CreateNewWindow message to UIProcess");
     } else {
@@ -120,13 +122,13 @@ void UIProcessConnectionFromClient::die()
 void UIProcessConnectionFromClient::create_new_tab(Vector<ByteString> const& urls)
 {
     if (on_new_tab)
-        on_new_tab(urls);
+        on_new_tab(sanitize_urls(urls, Application::chrome_options().new_tab_page_url));
 }
 
 void UIProcessConnectionFromClient::create_new_window(Vector<ByteString> const& urls)
 {
     if (on_new_window)
-        on_new_window(urls);
+        on_new_window(sanitize_urls(urls, Application::chrome_options().new_tab_page_url));
 }
 
 }

--- a/Userland/Libraries/LibWebView/ChromeProcess.h
+++ b/Userland/Libraries/LibWebView/ChromeProcess.h
@@ -14,6 +14,7 @@
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/MultiServer.h>
+#include <LibWebView/Options.h>
 #include <LibWebView/UIProcessClientEndpoint.h>
 #include <LibWebView/UIProcessServerEndpoint.h>
 
@@ -28,8 +29,8 @@ public:
 
     virtual void die() override;
 
-    Function<void(Vector<ByteString> const& urls)> on_new_tab;
-    Function<void(Vector<ByteString> const& urls)> on_new_window;
+    Function<void(Vector<URL::URL> const&)> on_new_tab;
+    Function<void(Vector<URL::URL> const&)> on_new_window;
 
 private:
     UIProcessConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>, int client_id);
@@ -51,15 +52,15 @@ public:
     static ErrorOr<ChromeProcess> create();
     ~ChromeProcess();
 
-    ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, bool new_window);
+    ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, NewWindow new_window);
 
-    Function<void(Vector<ByteString> const& raw_urls)> on_new_tab;
-    Function<void(Vector<ByteString> const& raw_urls)> on_new_window;
+    Function<void(Vector<URL::URL> const&)> on_new_tab;
+    Function<void(Vector<URL::URL> const&)> on_new_window;
 
 private:
     ChromeProcess() = default;
 
-    ErrorOr<void> connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, bool new_window);
+    ErrorOr<void> connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, NewWindow new_window);
     ErrorOr<void> connect_as_server(ByteString const& socket_path);
 
     OwnPtr<IPC::MultiServer<UIProcessConnectionFromClient>> m_server_connection;

--- a/Userland/Libraries/LibWebView/Options.h
+++ b/Userland/Libraries/LibWebView/Options.h
@@ -6,48 +6,84 @@
 
 #pragma once
 
+#include <AK/ByteString.h>
+#include <AK/Optional.h>
 #include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibURL/URL.h>
 
-namespace Ladybird {
+namespace WebView {
+
+enum class NewWindow {
+    No,
+    Yes,
+};
+
+enum class ForceNewProcess {
+    No,
+    Yes,
+};
+
+enum class AllowPopups {
+    No,
+    Yes,
+};
+
+enum class DisableSQLDatabase {
+    No,
+    Yes,
+};
+
+struct ChromeOptions {
+    Vector<URL::URL> urls;
+    Vector<ByteString> raw_urls;
+    URL::URL new_tab_page_url;
+    Vector<ByteString> certificates {};
+    NewWindow new_window { NewWindow::No };
+    ForceNewProcess force_new_process { ForceNewProcess::No };
+    AllowPopups allow_popups { AllowPopups::No };
+    DisableSQLDatabase disable_sql_database { DisableSQLDatabase::No };
+    Optional<ByteString> webdriver_content_ipc_path {};
+};
 
 enum class EnableCallgrindProfiling {
     No,
-    Yes
+    Yes,
 };
 
 enum class IsLayoutTestMode {
     No,
-    Yes
+    Yes,
 };
 
 enum class UseLagomNetworking {
     No,
-    Yes
+    Yes,
 };
 
 enum class WaitForDebugger {
     No,
-    Yes
+    Yes,
 };
 
 enum class LogAllJSExceptions {
     No,
-    Yes
+    Yes,
 };
 
 enum class EnableIDLTracing {
     No,
-    Yes
+    Yes,
 };
 
 enum class EnableHTTPCache {
     No,
-    Yes
+    Yes,
 };
 
 enum class ExposeInternalsObject {
     No,
-    Yes
+    Yes,
 };
 
 struct WebContentOptions {

--- a/Userland/Libraries/LibWebView/URL.cpp
+++ b/Userland/Libraries/LibWebView/URL.cpp
@@ -72,6 +72,22 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
     return result;
 }
 
+Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls, URL::URL const& new_tab_page_url)
+{
+    Vector<URL::URL> sanitized_urls;
+    sanitized_urls.ensure_capacity(raw_urls.size());
+
+    for (auto const& raw_url : raw_urls) {
+        if (auto url = sanitize_url(raw_url); url.has_value())
+            sanitized_urls.unchecked_append(url.release_value());
+    }
+
+    if (sanitized_urls.is_empty())
+        sanitized_urls.append(new_tab_page_url);
+
+    return sanitized_urls;
+}
+
 static URLParts break_file_url_into_parts(URL::URL const& url, StringView url_string)
 {
     auto scheme = url_string.substring_view(0, url.scheme().bytes_as_string_view().length() + "://"sv.length());

--- a/Userland/Libraries/LibWebView/URL.h
+++ b/Userland/Libraries/LibWebView/URL.h
@@ -20,6 +20,7 @@ enum class AppendTLD {
     Yes,
 };
 Optional<URL::URL> sanitize_url(StringView, Optional<StringView> search_engine = {}, AppendTLD = AppendTLD::No);
+Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls, URL::URL const& new_tab_page_url);
 
 struct URLParts {
     StringView scheme_and_subdomain;


### PR DESCRIPTION
Currently, if we want to add a new e.g. WebContent command line option, we have to add it to all of Qt, AppKit, and headless-browser. (Or worse, we only add it to one of these, and we have feature disparity).

To prevent this, this moves command line flags to `WebView::Application`. The flags are assigned to `ChromeOptions` and `WebContentOptions` structs. Each chrome can still add its platform-specific options; for example, the Qt chrome has a flag to enable Qt networking.

There should be no behavior change here, other than that AppKit will now support command line flags that were previously only supported by Qt.