### PR TITLE
LibJS: Change Intl.Locale.prototype.firstDayOfWeek to be a string

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -55,8 +55,8 @@ public:
     void set_collation(String collation) { m_collation = move(collation); }
 
     bool has_first_day_of_week() const { return m_first_day_of_week.has_value(); }
-    u8 first_day_of_week() const { return m_first_day_of_week.value(); }
-    void set_first_day_of_week(u8 first_day_of_week) { m_first_day_of_week = first_day_of_week; }
+    String const& first_day_of_week() const { return m_first_day_of_week.value(); }
+    void set_first_day_of_week(String first_day_of_week) { m_first_day_of_week = move(first_day_of_week); }
 
     bool has_hour_cycle() const { return m_hour_cycle.has_value(); }
     String const& hour_cycle() const { return m_hour_cycle.value(); }
@@ -72,14 +72,14 @@ public:
 private:
     explicit Locale(Object& prototype);
 
-    String m_locale;                     // [[Locale]]
-    Optional<String> m_calendar;         // [[Calendar]]
-    Optional<String> m_case_first;       // [[CaseFirst]]
-    Optional<String> m_collation;        // [[Collation]]
-    Optional<u8> m_first_day_of_week;    // [[FirstDayOfWeek]]
-    Optional<String> m_hour_cycle;       // [[HourCycle]]
-    Optional<String> m_numbering_system; // [[NumberingSystem]]
-    bool m_numeric { false };            // [[Numeric]]
+    String m_locale;                      // [[Locale]]
+    Optional<String> m_calendar;          // [[Calendar]]
+    Optional<String> m_case_first;        // [[CaseFirst]]
+    Optional<String> m_collation;         // [[Collation]]
+    Optional<String> m_first_day_of_week; // [[FirstDayOfWeek]]
+    Optional<String> m_hour_cycle;        // [[HourCycle]]
+    Optional<String> m_numbering_system;  // [[NumberingSystem]]
+    bool m_numeric { false };             // [[Numeric]]
 };
 
 // Table 1: WeekInfo Record Fields, https://tc39.es/proposal-intl-locale-info/#table-locale-weekinfo-record
@@ -95,8 +95,8 @@ NonnullGCPtr<Array> hour_cycles_of_locale(VM&, Locale const& locale);
 NonnullGCPtr<Array> numbering_systems_of_locale(VM&, Locale const&);
 NonnullGCPtr<Array> time_zones_of_locale(VM&, StringView region);
 StringView character_direction_of_locale(Locale const&);
-Optional<u8> weekday_to_number(StringView);
-StringView weekday_to_string(StringView);
+StringView weekday_to_string(StringView weekday);
+Optional<u8> string_to_weekday_value(StringView weekday);
 WeekInfo week_info_of_locale(Locale const&);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocalePrototype.cpp
@@ -117,12 +117,14 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::base_name)
     __JS_ENUMERATE(calendar)                   \
     __JS_ENUMERATE(case_first)                 \
     __JS_ENUMERATE(collation)                  \
+    __JS_ENUMERATE(first_day_of_week)          \
     __JS_ENUMERATE(hour_cycle)                 \
     __JS_ENUMERATE(numbering_system)
 
 // 14.3.7 get Intl.Locale.prototype.calendar, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.calendar
 // 14.3.8 get Intl.Locale.prototype.caseFirst, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.caseFirst
 // 14.3.9 get Intl.Locale.prototype.collation, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.collation
+// 1.4.10 get Intl.Locale.prototype.firstDayOfWeek, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.firstDayOfWeek
 // 14.3.10 get Intl.Locale.prototype.hourCycle, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.hourCycle
 // 14.3.12 get Intl.Locale.prototype.numberingSystem, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numberingSystem
 #define __JS_ENUMERATE(keyword)                                       \
@@ -135,17 +137,6 @@ JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::base_name)
     }
 JS_ENUMERATE_LOCALE_KEYWORD_PROPERTIES
 #undef __JS_ENUMERATE
-
-// 1.4.10 get Intl.Locale.prototype.firstDayOfWeek, https://tc39.es/proposal-intl-locale-info/#sec-Intl.Locale.prototype.firstDayOfWeek
-JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::first_day_of_week)
-{
-    // 1. Let loc be the this value.
-    // 2. Perform ? RequireInternalSlot(loc, [[InitializedLocale]]).
-    auto locale_object = TRY(typed_this_object(vm));
-
-    // 3. Return loc.[[FirstDayOfWeek]].
-    return locale_object->has_first_day_of_week() ? Value { locale_object->first_day_of_week() } : js_undefined();
-}
 
 // 14.3.11 get Intl.Locale.prototype.numeric, https://tc39.es/ecma402/#sec-Intl.Locale.prototype.numeric
 JS_DEFINE_NATIVE_FUNCTION(LocalePrototype::numeric)

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.firstDayOfWeek.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Locale/Locale.prototype.firstDayOfWeek.js
@@ -6,7 +6,7 @@ describe("errors", () => {
     });
 
     test("invalid options", () => {
-        [100, Infinity, NaN, "hello", 152n, true].forEach(value => {
+        [123456789, "a", "longerthan8chars"].forEach(value => {
             expect(() => {
                 new Intl.Locale("en", { firstDayOfWeek: value }).firstDayOfWeek;
             }).toThrowWithMessage(
@@ -15,29 +15,31 @@ describe("errors", () => {
             );
         });
     });
-
-    // FIXME: Spec issue: It is not yet clear if the following invalid values should throw. For now, this tests our
-    //        existing workaround behavior, which returns "undefined" for invalid extensions.
-    //        https://github.com/tc39/proposal-intl-locale-info/issues/78
-    test("invalid extensions", () => {
-        [100, Infinity, NaN, "hello", 152n, true].forEach(value => {
-            expect(new Intl.Locale(`en-u-fw-${value}`).firstDayOfWeek).toBeUndefined();
-        });
-    });
 });
 
 describe("normal behavior", () => {
-    test("valid options", () => {
+    test("standard options", () => {
         expect(new Intl.Locale("en").firstDayOfWeek).toBeUndefined();
 
-        ["mon", "tue", "wed", "thu", "fri", "sat", "sun"].forEach((day, index) => {
-            expect(new Intl.Locale(`en-u-fw-${day}`).firstDayOfWeek).toBe(index + 1);
-            expect(new Intl.Locale("en", { firstDayOfWeek: day }).firstDayOfWeek).toBe(index + 1);
-            expect(new Intl.Locale("en", { firstDayOfWeek: index + 1 }).firstDayOfWeek).toBe(
-                index + 1
-            );
+        ["sun", "mon", "tue", "wed", "thu", "fri", "sat", "sun"].forEach((day, index) => {
+            expect(new Intl.Locale(`en-u-fw-${day}`).firstDayOfWeek).toBe(day);
+
+            expect(new Intl.Locale("en", { firstDayOfWeek: day }).firstDayOfWeek).toBe(day);
+            expect(new Intl.Locale("en", { firstDayOfWeek: index }).firstDayOfWeek).toBe(day);
+
             expect(new Intl.Locale("en-u-fw-mon", { firstDayOfWeek: day }).firstDayOfWeek).toBe(
-                index + 1
+                day
+            );
+            expect(new Intl.Locale("en-u-fw-mon", { firstDayOfWeek: index }).firstDayOfWeek).toBe(
+                day
+            );
+        });
+    });
+
+    test("non-standard options", () => {
+        [100, Infinity, NaN, "hello", 152n, true].forEach(value => {
+            expect(new Intl.Locale("en", { firstDayOfWeek: value }).firstDayOfWeek).toBe(
+                value.toString()
             );
         });
     });


### PR DESCRIPTION
This is a normative change in the Intl Locale Info proposal. See:

https://github.com/tc39/proposal-intl-locale-info/commit/5cb45fd
https://github.com/tc39/proposal-intl-locale-info/commit/6d80e69
https://github.com/tc39/proposal-intl-locale-info/commit/04039b8

test262 diff:
```
Diff Tests:
    test/intl402/Locale/constructor-options-firstDayOfWeek-valid.js ❌ -> ✅
    test/intl402/Locale/prototype/firstDayOfWeek/valid-id.js        ❌ -> ✅
    test/intl402/Locale/prototype/firstDayOfWeek/valid-options.js   ❌ -> ✅
```

(We now pass all tests under `test/intl402/Locale`)