### PR TITLE
LibCore+LibWebView: Use Error::from_syscall to report get/setrlimit errors, and make non-fatal

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1853,7 +1853,7 @@ ErrorOr<rlimit> get_resource_limits(int resource)
     rlimit limits;
 
     if (::getrlimit(resource, &limits) != 0)
-        return Error::from_errno(errno);
+        return Error::from_syscall("getrlimit"sv, -errno);
 
     return limits;
 }
@@ -1864,7 +1864,7 @@ ErrorOr<void> set_resource_limits(int resource, rlim_t limit)
     limits.rlim_cur = limit;
 
     if (::setrlimit(resource, &limits) != 0)
-        return Error::from_errno(errno);
+        return Error::from_syscall("setrlimit"sv, -errno);
 
     return {};
 }

--- a/Userland/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Userland/Libraries/LibWebView/ChromeProcess.cpp
@@ -26,7 +26,8 @@ private:
 ErrorOr<ChromeProcess> ChromeProcess::create()
 {
     // Increase the open file limit, as the default limits on Linux cause us to run out of file descriptors with around 15 tabs open.
-    TRY(Core::System::set_resource_limits(RLIMIT_NOFILE, 8192));
+    if (auto result = Core::System::set_resource_limits(RLIMIT_NOFILE, 8192); result.is_error())
+        warnln("Unable to increase open file limit: {}", result.error());
 
     return ChromeProcess {};
 }


### PR DESCRIPTION
If `setrlimit` fails, let's just report the error rather than failing to start the browser at all.