### PR TITLE
CI: Add clang and llvm dev dependencies for plugins

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -26,8 +26,8 @@ runs:
 
         sudo apt-get update
         sudo apt-get install autoconf autoconf-archive automake build-essential ccache clang-18 clang++-18 cmake curl fonts-liberation2 \
-            gcc-13 g++-13 libavcodec-dev libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev libstdc++-13-dev lld-18 nasm ninja-build \
-            qt6-base-dev qt6-tools-dev-tools tar unzip zip
+            gcc-13 g++-13 libavcodec-dev libclang-18-dev libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev libstdc++-13-dev lld-18 \
+            llvm-18-dev nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100


### PR DESCRIPTION
This should fix the broken master linux clang CI