### PR TITLE
LibWeb+WebContent: Limit the Console client to the top-level navigable client

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -415,12 +415,6 @@ WebIDL::ExceptionOr<void> Document::populate_with_html_head_and_body()
     return {};
 }
 
-void Document::finalize()
-{
-    Base::finalize();
-    page().client().page_did_destroy_document(*this);
-}
-
 void Document::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
@@ -490,6 +484,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
 
     visitor.visit(m_top_layer_elements);
     visitor.visit(m_top_layer_pending_removals);
+    visitor.visit(m_console_client);
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -354,11 +354,17 @@ JS::NonnullGCPtr<Document> Document::create(JS::Realm& realm, URL::URL const& ur
     return realm.heap().allocate<Document>(realm, realm, url);
 }
 
-Document::Document(JS::Realm& realm, const URL::URL& url)
+JS::NonnullGCPtr<Document> Document::create_for_fragment_parsing(JS::Realm& realm)
+{
+    return realm.heap().allocate<Document>(realm, realm, "about:blank"sv, TemporaryDocumentForFragmentParsing::Yes);
+}
+
+Document::Document(JS::Realm& realm, const URL::URL& url, TemporaryDocumentForFragmentParsing temporary_document_for_fragment_parsing)
     : ParentNode(realm, *this, NodeType::DOCUMENT_NODE)
     , m_page(Bindings::host_defined_page(realm))
     , m_style_computer(make<CSS::StyleComputer>(*this))
     , m_url(url)
+    , m_temporary_document_for_fragment_parsing(temporary_document_for_fragment_parsing)
 {
     m_legacy_platform_object_flags = PlatformObject::LegacyPlatformObjectFlags {
         .supports_named_properties = true,
@@ -5253,7 +5259,7 @@ JS::NonnullGCPtr<Document> Document::parse_html_unsafe(JS::VM& vm, StringView ht
     // FIXME: 1. Let compliantHTML to the result of invoking the Get Trusted Type compliant string algorithm with TrustedHTML, this's relevant global object, html, "Document parseHTMLUnsafe", and "script".
 
     // 2. Let document be a new Document, whose content type is "text/html".
-    JS::NonnullGCPtr<DOM::Document> document = Document::create(realm);
+    auto document = Document::create_for_fragment_parsing(realm);
     document->set_content_type("text/html"_string);
 
     // 3. Set document's allow declarative shadow roots to true.

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -93,9 +93,15 @@ public:
         HTML
     };
 
+    enum class TemporaryDocumentForFragmentParsing {
+        No,
+        Yes,
+    };
+
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> create_and_initialize(Type, String content_type, HTML::NavigationParams const&);
 
     [[nodiscard]] static JS::NonnullGCPtr<Document> create(JS::Realm&, URL::URL const& url = "about:blank"sv);
+    [[nodiscard]] static JS::NonnullGCPtr<Document> create_for_fragment_parsing(JS::Realm&);
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> construct_impl(JS::Realm&);
     virtual ~Document() override;
 
@@ -447,8 +453,7 @@ public:
     void set_parser(Badge<HTML::HTMLParser>, HTML::HTMLParser&);
     void detach_parser(Badge<HTML::HTMLParser>);
 
-    void set_is_temporary_document_for_fragment_parsing(Badge<HTML::HTMLParser>) { m_temporary_document_for_fragment_parsing = true; }
-    [[nodiscard]] bool is_temporary_document_for_fragment_parsing() const { return m_temporary_document_for_fragment_parsing; }
+    [[nodiscard]] bool is_temporary_document_for_fragment_parsing() const { return m_temporary_document_for_fragment_parsing == TemporaryDocumentForFragmentParsing::Yes; }
 
     static bool is_valid_name(String const&);
 
@@ -684,7 +689,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
     virtual void finalize() override;
 
-    Document(JS::Realm&, URL::URL const&);
+    Document(JS::Realm&, URL::URL const&, TemporaryDocumentForFragmentParsing = TemporaryDocumentForFragmentParsing::No);
 
 private:
     // ^HTML::GlobalEventHandlers
@@ -889,7 +894,7 @@ private:
 
     RefPtr<Core::Timer> m_active_refresh_timer;
 
-    bool m_temporary_document_for_fragment_parsing { false };
+    TemporaryDocumentForFragmentParsing m_temporary_document_for_fragment_parsing { TemporaryDocumentForFragmentParsing::No };
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#latest-entry
     JS::GCPtr<HTML::SessionHistoryEntry> m_latest_entry;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -16,6 +16,7 @@
 #include <AK/WeakPtr.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/Forward.h>
+#include <LibJS/Console.h>
 #include <LibJS/Forward.h>
 #include <LibURL/URL.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
@@ -684,10 +685,12 @@ public:
     void parse_html_from_a_string(StringView);
     static JS::NonnullGCPtr<Document> parse_html_unsafe(JS::VM&, StringView);
 
+    void set_console_client(JS::GCPtr<JS::ConsoleClient> console_client) { m_console_client = console_client; }
+    JS::GCPtr<JS::ConsoleClient> console_client() const { return m_console_client; }
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
-    virtual void finalize() override;
 
     Document(JS::Realm&, URL::URL const&, TemporaryDocumentForFragmentParsing = TemporaryDocumentForFragmentParsing::No);
 
@@ -945,6 +948,8 @@ private:
 
     // https://dom.spec.whatwg.org/#document-allow-declarative-shadow-roots
     bool m_allow_declarative_shadow_roots { false };
+
+    JS::GCPtr<JS::ConsoleClient> m_console_client;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4269,10 +4269,8 @@ DOM::Document& HTMLParser::document()
 Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& context_element, StringView markup, AllowDeclarativeShadowRoots allow_declarative_shadow_roots)
 {
     // 1. Create a new Document node, and mark it as being an HTML document.
-    auto temp_document = DOM::Document::create(context_element.realm());
+    auto temp_document = DOM::Document::create_for_fragment_parsing(context_element.realm());
     temp_document->set_document_type(DOM::Document::Type::HTML);
-
-    temp_document->set_is_temporary_document_for_fragment_parsing({});
 
     // 2. If the node document of the context element is in quirks mode, then let the Document be in quirks mode.
     //    Otherwise, the node document of the context element is in limited-quirks mode, then let the Document be in limited-quirks mode.

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -311,7 +311,6 @@ public:
     virtual void page_did_start_loading(URL::URL const&, bool is_redirect) { (void)is_redirect; }
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) { }
-    virtual void page_did_destroy_document(Web::DOM::Document&) { }
     virtual void page_did_finish_loading(URL::URL const&) { }
     virtual void page_did_request_cursor_change(Gfx::StandardCursor) { }
     virtual void page_did_request_context_menu(CSSPixelPoint) { }

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -342,8 +342,8 @@ void PageClient::page_did_create_new_document(Web::DOM::Document& document)
 
 void PageClient::page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document& document)
 {
-    VERIFY(m_console_clients.contains(document));
-    m_top_level_document_console_client = *m_console_clients.get(document).value();
+    if (auto console_client = m_console_clients.get(document); console_client.has_value())
+        m_top_level_document_console_client = *console_client.value();
 }
 
 void PageClient::page_did_destroy_document(Web::DOM::Document& document)
@@ -663,6 +663,9 @@ ErrorOr<void> PageClient::connect_to_webdriver(ByteString const& webdriver_ipc_p
 
 void PageClient::initialize_js_console(Web::DOM::Document& document)
 {
+    if (document.is_temporary_document_for_fragment_parsing())
+        return;
+
     auto& realm = document.realm();
     auto console_object = realm.intrinsics().console_object();
     auto console_client = heap().allocate_without_realm<WebContentConsoleClient>(console_object->console(), document.realm(), *this);

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -341,9 +341,14 @@ void PageClient::page_did_create_new_document(Web::DOM::Document& document)
 
 void PageClient::page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document& document)
 {
+    auto& realm = document.realm();
+
     if (auto console_client = document.console_client()) {
         auto& web_content_console_client = verify_cast<WebContentConsoleClient>(*console_client);
         m_top_level_document_console_client = web_content_console_client;
+
+        auto console_object = realm.intrinsics().console_object();
+        console_object->console().set_client(*console_client);
     }
 }
 
@@ -663,9 +668,9 @@ void PageClient::initialize_js_console(Web::DOM::Document& document)
         return;
 
     auto& realm = document.realm();
+
     auto console_object = realm.intrinsics().console_object();
     auto console_client = heap().allocate_without_realm<WebContentConsoleClient>(console_object->console(), document.realm(), *this);
-    console_object->console().set_client(*console_client);
 
     document.set_console_client(console_client);
 }

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -80,7 +80,6 @@ void PageClient::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_page);
-    visitor.ignore(m_console_clients);
 }
 
 ConnectionFromClient& PageClient::client() const
@@ -342,13 +341,10 @@ void PageClient::page_did_create_new_document(Web::DOM::Document& document)
 
 void PageClient::page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document& document)
 {
-    if (auto console_client = m_console_clients.get(document); console_client.has_value())
-        m_top_level_document_console_client = *console_client.value();
-}
-
-void PageClient::page_did_destroy_document(Web::DOM::Document& document)
-{
-    destroy_js_console(document);
+    if (auto console_client = document.console_client()) {
+        auto& web_content_console_client = verify_cast<WebContentConsoleClient>(*console_client);
+        m_top_level_document_console_client = web_content_console_client;
+    }
 }
 
 void PageClient::page_did_finish_loading(URL::URL const& url)
@@ -671,12 +667,7 @@ void PageClient::initialize_js_console(Web::DOM::Document& document)
     auto console_client = heap().allocate_without_realm<WebContentConsoleClient>(console_object->console(), document.realm(), *this);
     console_object->console().set_client(*console_client);
 
-    m_console_clients.set(document, console_client);
-}
-
-void PageClient::destroy_js_console(Web::DOM::Document& document)
-{
-    m_console_clients.remove(document);
+    document.set_console_client(console_client);
 }
 
 void PageClient::js_console_input(ByteString const& js_source)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -76,7 +76,6 @@ public:
     void ready_to_paint();
 
     void initialize_js_console(Web::DOM::Document& document);
-    void destroy_js_console(Web::DOM::Document& document);
     void js_console_input(ByteString const& js_source);
     void run_javascript(ByteString const& js_source);
     void js_console_request_messages(i32 start_index);
@@ -131,7 +130,6 @@ private:
     virtual void page_did_start_loading(URL::URL const&, bool) override;
     virtual void page_did_create_new_document(Web::DOM::Document&) override;
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) override;
-    virtual void page_did_destroy_document(Web::DOM::Document&) override;
     virtual void page_did_finish_loading(URL::URL const&) override;
     virtual void page_did_request_alert(String const&) override;
     virtual void page_did_request_confirm(String const&) override;
@@ -204,8 +202,6 @@ private:
 
     BackingStoreManager m_backing_store_manager;
 
-    // NOTE: These documents are not visited, but manually removed from the map on document finalization.
-    HashMap<JS::RawGCPtr<Web::DOM::Document>, JS::NonnullGCPtr<WebContentConsoleClient>> m_console_clients;
     WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
 
     JS::Handle<JS::GlobalObject> m_console_global_object;


### PR DESCRIPTION
We don't want to set the intrinsic Console object's client to non-top-level clients, created for e.g. subframes. We also want to make sure the Console client is updated if the top-level document has changed.

Fixes #782. Both the second and fourth commits actually individually fix the issue, as the document causing the crash is a temporary document for parsing HTML fragments.

This is a re-land of #787. The issue was that nothing was visiting the console client we were later trying to set as the top-level client. 