### PR TITLE
LibWebView+UI: Allow debugging and profiling any helper process

### DIFF
--- a/Ladybird/ImageDecoder/main.cpp
+++ b/Ladybird/ImageDecoder/main.cpp
@@ -9,6 +9,7 @@
 #include <ImageDecoder/ConnectionFromClient.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Process.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 
@@ -22,8 +23,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     StringView mach_server_name;
+    bool wait_for_debugger = false;
+
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
+    args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.parse(arguments);
+
+    if (wait_for_debugger)
+        Core::Process::wait_for_debugger_and_break();
 
     Core::EventLoop event_loop;
 

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
+#include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibIPC/SingleServer.h>
@@ -38,12 +39,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView serenity_resource_root;
     Vector<ByteString> certificates;
     StringView mach_server_name;
+    bool wait_for_debugger = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
+    args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.parse(arguments);
+
+    if (wait_for_debugger)
+        Core::Process::wait_for_debugger_and_break();
 
     // Ensure the certificates are read out here.
     if (certificates.is_empty())

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
+#include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
@@ -41,13 +42,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView serenity_resource_root;
     Vector<ByteString> certificates;
     bool use_lagom_networking { false };
+    bool wait_for_debugger = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(request_server_socket, "File descriptor of the request server socket", "request-server-socket", 's', "request-server-socket");
     args_parser.add_option(serenity_resource_root, "Absolute path to directory for serenity resources", "serenity-resource-root", 'r', "serenity-resource-root");
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
+    args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.parse(arguments);
+
+    if (wait_for_debugger)
+        Core::Process::wait_for_debugger_and_break();
 
 #if defined(HAVE_QT)
     QCoreApplication app(arguments.argc, arguments.argv);

--- a/Userland/Libraries/LibWebView/Options.h
+++ b/Userland/Libraries/LibWebView/Options.h
@@ -11,6 +11,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibURL/URL.h>
+#include <LibWebView/ProcessType.h>
 
 namespace WebView {
 
@@ -43,6 +44,7 @@ struct ChromeOptions {
     ForceNewProcess force_new_process { ForceNewProcess::No };
     AllowPopups allow_popups { AllowPopups::No };
     DisableSQLDatabase disable_sql_database { DisableSQLDatabase::No };
+    Optional<ProcessType> debug_helper_process {};
     Optional<ByteString> webdriver_content_ipc_path {};
 };
 
@@ -57,11 +59,6 @@ enum class IsLayoutTestMode {
 };
 
 enum class UseLagomNetworking {
-    No,
-    Yes,
-};
-
-enum class WaitForDebugger {
     No,
     Yes,
 };
@@ -93,7 +90,6 @@ struct WebContentOptions {
     EnableCallgrindProfiling enable_callgrind_profiling { EnableCallgrindProfiling::No };
     IsLayoutTestMode is_layout_test_mode { IsLayoutTestMode::No };
     UseLagomNetworking use_lagom_networking { UseLagomNetworking::Yes };
-    WaitForDebugger wait_for_debugger { WaitForDebugger::No };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };
     EnableIDLTracing enable_idl_tracing { EnableIDLTracing::No };
     EnableHTTPCache enable_http_cache { EnableHTTPCache::No };

--- a/Userland/Libraries/LibWebView/Options.h
+++ b/Userland/Libraries/LibWebView/Options.h
@@ -45,12 +45,8 @@ struct ChromeOptions {
     AllowPopups allow_popups { AllowPopups::No };
     DisableSQLDatabase disable_sql_database { DisableSQLDatabase::No };
     Optional<ProcessType> debug_helper_process {};
+    Optional<ProcessType> profile_helper_process {};
     Optional<ByteString> webdriver_content_ipc_path {};
-};
-
-enum class EnableCallgrindProfiling {
-    No,
-    Yes,
 };
 
 enum class IsLayoutTestMode {
@@ -87,7 +83,6 @@ struct WebContentOptions {
     String command_line;
     String executable_path;
     Optional<ByteString> config_path {};
-    EnableCallgrindProfiling enable_callgrind_profiling { EnableCallgrindProfiling::No };
     IsLayoutTestMode is_layout_test_mode { IsLayoutTestMode::No };
     UseLagomNetworking use_lagom_networking { UseLagomNetworking::Yes };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };


### PR DESCRIPTION
This removes the `--debug-web-content` and `--enable-callgrind-profiling` flags, and replaces them with `--debug-process=<process-name>` and `--profile-process=<process-name>` flags. For example:

    ladybird --debug-process=WebContent
    ladybird --debug-process=RequestServer

    ladybird --profile-process=WebContent
    ladybird --profile-process=RequestServer

This allows attaching gdb to and profiling any helper process.