### PR TITLE
LibWeb: Use fast path for input boxes

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
     if (auto* layout_node = this->layout_node(); layout_node && layout_node->is_text_node())
         static_cast<Layout::TextNode&>(*layout_node).invalidate_text_for_rendering();
 
-    document().set_needs_layout();
+    document().just_typed_into_input_box(this); // Schedules fast path layout update
 
     if (m_segmenter)
         m_segmenter->set_segmented_text(m_data);

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Layout/BlockContainer.h>
+#include <LibWeb/Layout/LayoutState.h>
 #include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Layout {
@@ -24,6 +25,12 @@ BlockContainer::~BlockContainer() = default;
 Painting::PaintableWithLines const* BlockContainer::paintable_with_lines() const
 {
     return static_cast<Painting::PaintableWithLines const*>(Box::paintable_box());
+}
+
+void BlockContainer::store_layout_inside_run_info(LayoutState* layout_state, AvailableSpace const available_space)
+{
+    document().save_layout_state(layout_state);
+    m_run_available_space = const_cast<AvailableSpace&>(available_space);
 }
 
 JS::GCPtr<Painting::Paintable> BlockContainer::create_paintable() const

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.h
@@ -7,7 +7,11 @@
 #pragma once
 
 #include <LibWeb/Layout/Box.h>
+#include <LibWeb/Layout/AvailableSpace.h>
 #include <LibWeb/Layout/LineBox.h>
+#include <LibWeb/Layout/Node.h>
+
+class LayoutState;
 
 namespace Web::Layout {
 
@@ -22,7 +26,12 @@ public:
 
     Painting::PaintableWithLines const* paintable_with_lines() const;
 
+    void store_layout_inside_run_info(LayoutState*, AvailableSpace const);
+
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
+
+    // Save info for layout invalidation input box fast path
+    AvailableSpace m_run_available_space = AvailableSpace(AvailableSize::make_definite(0), AvailableSize::make_definite(0));
 
 private:
     virtual bool is_block_container() const final { return true; }


### PR DESCRIPTION
Typing into input boxes is slow, as the entire page layout is invalidated and redone.  This PR makes a "fast-path" so only the necessary portions of the page are invalidated.

First, when the webpage is laid out fresh (initial load or relayout), the details necessary to create each input box are saved in the BlockContainer object in the layout tree.

Second, when the user types into an input box, the Document object for that webpage tracks whether that is the only change that has occurred since the last relayout.

Third, when the document updates its layout, if only an input box has been typed into, the document calls .run() on a FormattingContext object created just for the BlockContainer associated with the input box (instead of calling .run() on the root FormattingContext).