### PR TITLE
LibWeb+WebContent: Support ctrl/cmd-clicking a link to open it in a new tab

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -80,6 +80,14 @@ void HTMLAnchorElement::activation_behavior(Web::DOM::Event const& event)
     if (href().is_empty())
         return;
 
+    // AD-HOC: Do not activate the element for clicks with the ctrl/cmd modifier present. This lets
+    //         the chrome open the link in a new tab.
+    if (is<UIEvents::MouseEvent>(event)) {
+        auto const& mouse_event = static_cast<UIEvents::MouseEvent const&>(event);
+        if (mouse_event.platform_ctrl_key())
+            return;
+    }
+
     // 2. Let hyperlinkSuffix be null.
     Optional<String> hyperlink_suffix {};
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -312,7 +312,7 @@ bool EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPixelPoint
                     JS::NonnullGCPtr<DOM::Document> document = *m_navigable->active_document();
                     auto href = link->href();
                     auto url = document->parse_url(href);
-                    dbgln("Web::EventHandler: Clicking on a link to {}", url);
+
                     if (button == UIEvents::MouseButton::Middle) {
                         m_navigable->page().client().page_did_middle_click_link(url, link->target().to_byte_string(), modifiers);
                     } else if (button == UIEvents::MouseButton::Secondary) {

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -313,7 +313,9 @@ bool EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPixelPoint
                     auto href = link->href();
                     auto url = document->parse_url(href);
 
-                    if (button == UIEvents::MouseButton::Middle) {
+                    if (button == UIEvents::MouseButton::Primary && (modifiers & UIEvents::Mod_PlatformCtrl) != 0) {
+                        m_navigable->page().client().page_did_click_link(url, link->target().to_byte_string(), modifiers);
+                    } else if (button == UIEvents::MouseButton::Middle) {
                         m_navigable->page().client().page_did_middle_click_link(url, link->target().to_byte_string(), modifiers);
                     } else if (button == UIEvents::MouseButton::Secondary) {
                         m_navigable->page().client().page_did_request_link_context_menu(viewport_position, url, link->target().to_byte_string(), modifiers);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -317,6 +317,7 @@ public:
     virtual void page_did_request_link_context_menu(CSSPixelPoint, URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_request_image_context_menu(CSSPixelPoint, URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Gfx::Bitmap const*) { }
     virtual void page_did_request_media_context_menu(CSSPixelPoint, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers, Page::MediaContextMenu) { }
+    virtual void page_did_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_middle_click_link(URL::URL const&, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers) { }
     virtual void page_did_request_tooltip_override(CSSPixelPoint, ByteString const&) { }
     virtual void page_did_stop_tooltip_override() { }

--- a/Userland/Libraries/LibWeb/UIEvents/KeyCode.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyCode.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/EnumBits.h>
+#include <AK/Platform.h>
 #include <AK/Types.h>
 
 namespace Web::UIEvents {
@@ -169,6 +170,12 @@ enum KeyModifier {
     Mod_Mask = Mod_Alt | Mod_Ctrl | Mod_Shift | Mod_Super | Mod_AltGr | Mod_Keypad,
 
     Is_Press = 0x80,
+
+#if defined(AK_OS_MACOS)
+    Mod_PlatformCtrl = Mod_Super,
+#else
+    Mod_PlatformCtrl = Mod_Ctrl,
+#endif
 };
 
 AK_ENUM_BITWISE_OPERATORS(KeyModifier);

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -56,6 +56,15 @@ public:
     bool alt_key() const { return m_alt_key; }
     bool meta_key() const { return m_meta_key; }
 
+    bool platform_ctrl_key() const
+    {
+#if defined(AK_OS_MACOS)
+        return meta_key();
+#else
+        return ctrl_key();
+#endif
+    }
+
     double movement_x() const { return m_movement_x; }
     double movement_y() const { return m_movement_y; }
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -324,6 +324,11 @@ void PageClient::page_did_unhover_link()
     client().async_did_unhover_link(m_id);
 }
 
+void PageClient::page_did_click_link(URL::URL const& url, ByteString const& target, unsigned modifiers)
+{
+    client().async_did_click_link(m_id, url, target, modifiers);
+}
+
 void PageClient::page_did_middle_click_link(URL::URL const& url, ByteString const& target, unsigned modifiers)
 {
     client().async_did_middle_click_link(m_id, url, target, modifiers);

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -324,7 +324,7 @@ void PageClient::page_did_unhover_link()
     client().async_did_unhover_link(m_id);
 }
 
-void PageClient::page_did_middle_click_link(URL::URL const& url, [[maybe_unused]] ByteString const& target, [[maybe_unused]] unsigned modifiers)
+void PageClient::page_did_middle_click_link(URL::URL const& url, ByteString const& target, unsigned modifiers)
 {
     client().async_did_middle_click_link(m_id, url, target, modifiers);
 }

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -122,6 +122,7 @@ private:
     virtual void page_did_leave_tooltip_area() override;
     virtual void page_did_hover_link(URL::URL const&) override;
     virtual void page_did_unhover_link() override;
+    virtual void page_did_click_link(URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_middle_click_link(URL::URL const&, ByteString const& target, unsigned modifiers) override;
     virtual void page_did_request_context_menu(Web::CSSPixelPoint) override;
     virtual void page_did_request_link_context_menu(Web::CSSPixelPoint, URL::URL const&, ByteString const& target, unsigned modifiers) override;


### PR DESCRIPTION
Completely unrelated to any videos that may have been released today :wink: 

The spec does not define activation behavior of ctrl/cmd clicks, so we have to go a bit ad-hoc here. When an anchor element is clicked with the cmd (on macOS) or ctrl (on other platforms) modifier pressed, we will skip activation of that element and pass the event on to the chrome. We still dispatch the event to allow scripts to cancel the event.