### PR TITLE
LibWebView+WebContent+WebDriver: Add a `--force-cpu-painting` option

### DIFF
--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -99,6 +99,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
         arguments.append("--enable-http-cache"sv);
     if (web_content_options.expose_internals_object == WebView::ExposeInternalsObject::Yes)
         arguments.append("--expose-internals-object"sv);
+    if (web_content_options.force_cpu_painting == WebView::ForceCPUPainting::Yes)
+        arguments.append("--force-cpu-painting"sv);
     if (auto server = mach_server_name(); server.has_value()) {
         arguments.append("--mach-server-name"sv);
         arguments.append(server.value());

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -100,7 +100,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool is_layout_test_mode = false;
     bool expose_internals_object = false;
     bool use_lagom_networking = false;
-    bool use_skia_painter = false;
     bool wait_for_debugger = false;
     bool log_all_js_exceptions = false;
     bool enable_idl_tracing = false;
@@ -116,7 +115,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.add_option(use_lagom_networking, "Enable Lagom servers for networking", "use-lagom-networking");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
-    args_parser.add_option(use_skia_painter, "Enable Skia painter", "use-skia-painting");
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");

--- a/Userland/Libraries/LibWebView/Application.cpp
+++ b/Userland/Libraries/LibWebView/Application.cpp
@@ -45,6 +45,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     bool enable_idl_tracing = false;
     bool enable_http_cache = false;
     bool expose_internals_object = false;
+    bool force_cpu_painting = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -61,6 +62,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
     args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
+    args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
 
     create_platform_arguments(args_parser);
     args_parser.parse(arguments);
@@ -88,6 +90,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
         .enable_idl_tracing = enable_idl_tracing ? EnableIDLTracing::Yes : EnableIDLTracing::No,
         .enable_http_cache = enable_http_cache ? EnableHTTPCache::Yes : EnableHTTPCache::No,
         .expose_internals_object = expose_internals_object ? ExposeInternalsObject::Yes : ExposeInternalsObject::No,
+        .force_cpu_painting = force_cpu_painting ? ForceCPUPainting::Yes : ForceCPUPainting::No,
     };
 
     create_platform_options(m_chrome_options, m_web_content_options);

--- a/Userland/Libraries/LibWebView/Options.h
+++ b/Userland/Libraries/LibWebView/Options.h
@@ -86,6 +86,11 @@ enum class ExposeInternalsObject {
     Yes,
 };
 
+enum class ForceCPUPainting {
+    No,
+    Yes,
+};
+
 struct WebContentOptions {
     String command_line;
     String executable_path;
@@ -98,6 +103,7 @@ struct WebContentOptions {
     EnableIDLTracing enable_idl_tracing { EnableIDLTracing::No };
     EnableHTTPCache enable_http_cache { EnableHTTPCache::No };
     ExposeInternalsObject expose_internals_object { ExposeInternalsObject::No };
+    ForceCPUPainting force_cpu_painting { ForceCPUPainting::No };
 };
 
 }


### PR DESCRIPTION
This option forces Skia to use its CPU backend even when the GPU is available. This improves speed and stability when running Web Platform Tests.

As part of this PR, I've also removed the `--use-skia-painting` option from `WebContent`, as it was was no longer being used anywhere.