### PR TITLE
LibThreading: Resolve race conditions in ThreadPool

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -510,6 +510,7 @@ if (BUILD_TESTING)
         LibCompress
         LibTest
         LibTextCodec
+        LibThreading
         LibUnicode
         LibURL
         LibXML

--- a/Meta/gn/secondary/Tests/BUILD.gn
+++ b/Meta/gn/secondary/Tests/BUILD.gn
@@ -2,6 +2,7 @@ group("Tests") {
   deps = [
     "//Tests/AK",
     "//Tests/LibJS",
+    "//Tests/LibThreading",
     "//Tests/LibURL",
     "//Tests/LibWeb",
   ]

--- a/Tests/LibThreading/CMakeLists.txt
+++ b/Tests/LibThreading/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestThread.cpp
+    TestThreadPool.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibThreading/TestThreadPool.cpp
+++ b/Tests/LibThreading/TestThreadPool.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Braydn Moore <braydn.moore@uwaterloo.ca>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Time.h>
+#include <LibCore/ElapsedTimer.h>
+#include <LibTest/TestCase.h>
+#include <LibThreading/ThreadPool.h>
+
+using namespace AK::TimeLiterals;
+
+TEST_CASE(thread_pool_deadlock)
+{
+    static constexpr auto RUN_TIMEOUT = 120_sec;
+    static constexpr u64 NUM_RUNS = 1000;
+    static constexpr u64 MAX_VALUE = 1 << 15;
+
+    for (u64 i = 0; i < NUM_RUNS; ++i) {
+        u64 expected_value = (MAX_VALUE * (MAX_VALUE + 1)) / 2;
+        Atomic<u64> sum;
+
+        // heap allocate the ThreadPool in case it deadlocks. Exiting in the
+        // case of a deadlock will purposefully leak memory to avoid calling the
+        // destructor and hanging the test
+        auto* thread_pool = new Threading::ThreadPool<u64>(
+            [&sum](u64 current_val) {
+                sum += current_val;
+            });
+
+        for (u64 j = 0; j <= MAX_VALUE; ++j) {
+            thread_pool->submit(j);
+        }
+
+        auto join_thread = Threading::Thread::construct([thread_pool]() -> intptr_t {
+            thread_pool->wait_for_all();
+            delete thread_pool;
+            return 0;
+        });
+
+        join_thread->start();
+        auto timer = Core::ElapsedTimer::start_new(Core::TimerType::Precise);
+        while (!join_thread->has_exited() && timer.elapsed_milliseconds() < RUN_TIMEOUT.to_milliseconds())
+            ;
+        EXPECT(join_thread->has_exited());
+        // exit since the current pool is deadlocked and we have no way of
+        // unblocking the pool other than having the OS teardown the process
+        // struct
+        if (!join_thread->has_exited()) {
+            return;
+        }
+
+        (void)join_thread->join();
+        EXPECT_EQ(sum.load(), expected_value);
+    }
+}

--- a/Userland/Libraries/LibThreading/ThreadPool.h
+++ b/Userland/Libraries/LibThreading/ThreadPool.h
@@ -22,6 +22,7 @@ struct ThreadPoolLooper {
     {
         Optional<typename Pool::Work> entry;
         while (true) {
+            pool.m_busy_count++;
             entry = pool.m_work_queue.with_locked([&](auto& queue) -> Optional<typename Pool::Work> {
                 if (queue.is_empty())
                     return {};
@@ -29,6 +30,8 @@ struct ThreadPoolLooper {
             });
             if (entry.has_value())
                 break;
+
+            pool.m_busy_count--;
             if (pool.m_should_exit)
                 return IterationDecision::Break;
 
@@ -47,8 +50,9 @@ struct ThreadPoolLooper {
             pool.m_mutex.unlock();
         }
 
-        pool.m_busy_count++;
         pool.m_handler(entry.release_value());
+        pool.m_busy_count--;
+        pool.m_work_done.signal();
         return IterationDecision::Continue;
     }
 };
@@ -124,8 +128,6 @@ private:
                 Looper<ThreadPool> thread_looper;
                 for (; !m_should_exit;) {
                     auto result = thread_looper.next(*this, true);
-                    m_busy_count--;
-                    m_work_done.signal();
                     if (result == IterationDecision::Break)
                         break;
                 }

--- a/Userland/Libraries/LibThreading/ThreadPool.h
+++ b/Userland/Libraries/LibThreading/ThreadPool.h
@@ -36,6 +36,13 @@ struct ThreadPoolLooper {
                 return IterationDecision::Continue;
 
             pool.m_mutex.lock();
+            // broadcast on m_work_done here since it is possible the
+            // wait_for_all loop missed the previous broadcast when work was
+            // actually done. Without this broadcast the ThreadPool could
+            // deadlock as there is no remaining work to be done, so this thread
+            // never resumes and the wait_for_all loop never wakes as there is no
+            // more work to be completed.
+            pool.m_work_done.broadcast();
             pool.m_work_available.wait();
             pool.m_mutex.unlock();
         }
@@ -76,7 +83,9 @@ public:
     {
         m_should_exit.store(true, AK::MemoryOrder::memory_order_release);
         for (auto& worker : m_workers) {
-            m_work_available.broadcast();
+            while (!worker->has_exited()) {
+                m_work_available.broadcast();
+            }
             (void)worker->join();
         }
     }
@@ -91,18 +100,19 @@ public:
 
     void wait_for_all()
     {
-        while (true) {
-            if (m_work_queue.with_locked([](auto& queue) { return queue.is_empty(); }))
-                break;
-            m_mutex.lock();
-            m_work_done.wait();
-            m_mutex.unlock();
+        {
+            MutexLocker lock(m_mutex);
+            m_work_done.wait_while([this]() {
+                return m_work_queue.with_locked([](auto& queue) {
+                    return !queue.is_empty();
+                });
+            });
         }
-
-        while (m_busy_count.load(AK::MemoryOrder::memory_order_acquire) > 0) {
-            m_mutex.lock();
-            m_work_done.wait();
-            m_mutex.unlock();
+        {
+            MutexLocker lock(m_mutex);
+            m_work_done.wait_while([this] {
+                return m_busy_count.load(AK::MemoryOrder::memory_order_acquire) > 0;
+            });
         }
     }
 


### PR DESCRIPTION
This PR first aims to fix race conditions in `ThreadPool` involving deadlocks waiting on `m_work_available` and `m_work_done` condition variables. 

Second, it updates the "busy section" as indicated by the `m_busy_count` variable to avoid an early return from `wait_for_all` and a potential underflow of `m_busy_count`. 

Lastly, the `LibThreading` tests are enabled and a test for deadlocks is added for `ThreadPool`.

The individual commit messages provide further detail for the individual changes.