### PR TITLE
LibWebView: Sort vendor-prefixed properties last in the inspector

### DIFF
--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -204,7 +204,20 @@ inspector.createPropertyTables = (computedStyle, resolvedStyle, customProperties
         newTable.setAttribute("id", tableID);
 
         Object.keys(properties)
-            .sort()
+            .sort((a, b) => {
+                let baseResult = a.localeCompare(b);
+                // Manually move vendor-prefixed items after non-prefixed ones.
+                if (a[0] === "-") {
+                    if (b[0] === "-") {
+                        return baseResult;
+                    }
+                    return 1;
+                }
+                if (b[0] === "-") {
+                    return -1;
+                }
+                return baseResult;
+            })
             .forEach(name => {
                 let row = newTable.insertRow();
 


### PR DESCRIPTION
Previously, the legacy `-webkit-foo` properties would all be top of the list, when they are generally not useful to inspect. Instead, put them at the bottom, so that users can still see them if they want to, but they're not in the way.