### PR TITLE
LibGfx: Implement even-odd method for Quad::contains() and add tests

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -120,7 +120,7 @@ Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake ccache cmake ffmpeg nasm ninja pkg-config
+brew install autoconf autoconf-archive automake ccache cmake ffmpeg nasm ninja pkg-config shellcheck
 ```
 
 If you wish to use clang from homebrew instead:

--- a/Tests/LibGfx/CMakeLists.txt
+++ b/Tests/LibGfx/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES
     TestMedianCut.cpp
     TestPainter.cpp
     TestRect.cpp
+    TestQuad.cpp
     TestScalingFunctions.cpp
     TestWOFF.cpp
     TestWOFF2.cpp

--- a/Tests/LibGfx/TestQuad.cpp
+++ b/Tests/LibGfx/TestQuad.cpp
@@ -73,3 +73,33 @@ TEST_CASE(quad_contains)
     Gfx::Point<u8> out_bounds_point { 7, 12 };
     EXPECT(quad.contains(out_bounds_point) == false);
 }
+
+TEST_CASE(quad_contains_boundary_points)
+{
+    Gfx::Point<int> p1 { 0, 0 };
+    Gfx::Point<int> p2 { 2, 0 };
+    Gfx::Point<int> p3 { 2, 2 };
+    Gfx::Point<int> p4 { 0, 2 };
+    Gfx::Quad<int> square_quad { p1, p2, p3, p4 };
+    Gfx::Rect<int> square_quad_as_rect = square_quad.bounding_rect();
+
+    auto const& point_at_top_left_vertex = p1;
+    Gfx::Point<int> point_on_top_edge { 1, 0 };
+    EXPECT_EQ(square_quad.contains(point_at_top_left_vertex), square_quad_as_rect.contains(point_at_top_left_vertex));
+    EXPECT_EQ(square_quad.contains(point_on_top_edge), square_quad_as_rect.contains(point_on_top_edge));
+
+    auto const& point_at_top_right_vertex = p2;
+    Gfx::Point<int> point_on_right_edge { 2, 1 };
+    EXPECT_EQ(square_quad.contains(point_at_top_right_vertex), square_quad_as_rect.contains(point_at_top_right_vertex));
+    EXPECT_EQ(square_quad.contains(point_on_right_edge), square_quad_as_rect.contains(point_on_right_edge));
+
+    auto const& point_at_bottom_left_vertex = p4;
+    Gfx::Point<int> point_on_bottom_edge { 1, 2 };
+    EXPECT_EQ(square_quad.contains(point_at_bottom_left_vertex), square_quad_as_rect.contains(point_at_bottom_left_vertex));
+    EXPECT_EQ(square_quad.contains(point_on_bottom_edge), square_quad_as_rect.contains(point_on_bottom_edge));
+
+    auto const& point_at_bottom_right_vertex = p3;
+    Gfx::Point<int> point_on_left_edge { 0, 1 };
+    EXPECT_EQ(square_quad.contains(point_at_bottom_right_vertex), square_quad_as_rect.contains(point_at_bottom_right_vertex));
+    EXPECT_EQ(square_quad.contains(point_on_left_edge), square_quad_as_rect.contains(point_on_left_edge));
+}

--- a/Tests/LibGfx/TestQuad.cpp
+++ b/Tests/LibGfx/TestQuad.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Aaron Van Doren <aaronvandoren6@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Point.h>
+#include <LibGfx/Quad.h>
+#include <LibGfx/Rect.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(quad_points)
+{
+    uint8_t quad_x_left = 1;
+    uint8_t quad_x_right = 5;
+    uint8_t quad_y_top = 10;
+    uint8_t quad_y_bottom = 6;
+
+    Gfx::Point<uint8_t> left_bottom { quad_x_left, quad_y_bottom };
+    Gfx::Point<uint8_t> left_top { quad_x_left, quad_y_top };
+    Gfx::Point<uint8_t> right_bottom { quad_x_right, quad_y_bottom };
+    Gfx::Point<uint8_t> right_top { quad_x_right, quad_y_top };
+
+    Gfx::Quad<uint8_t> quad { left_bottom, left_top, right_bottom, right_top };
+    EXPECT_EQ(quad.p1(), left_bottom);
+    EXPECT_EQ(quad.p2(), left_top);
+    EXPECT_EQ(quad.p3(), right_bottom);
+    EXPECT_EQ(quad.p4(), right_top);
+}
+
+TEST_CASE(quad_bounding_rect)
+{
+    uint8_t quad_width = 5;
+    uint8_t quad_height = 4;
+    uint8_t quad_x_left = 0;
+    uint8_t quad_y_top = 6;
+
+    uint8_t quad_x_right = quad_x_left + quad_width;
+    uint8_t quad_y_bottom = quad_y_top + quad_height;
+
+    Gfx::Point<uint8_t> left_bottom { quad_x_left, quad_y_bottom };
+    Gfx::Point<uint8_t> left_top { quad_x_left, quad_y_top };
+    Gfx::Point<uint8_t> right_bottom { quad_x_right, quad_y_bottom };
+    Gfx::Point<uint8_t> right_top { quad_x_right, quad_y_top };
+    Gfx::Quad<uint8_t> quad = { left_bottom, left_top, right_top, right_bottom };
+
+    auto bounding_rect = quad.bounding_rect();
+    EXPECT_EQ(bounding_rect.x(), quad_x_left);
+    EXPECT_EQ(bounding_rect.y(), quad_y_top);
+    EXPECT_EQ(bounding_rect.width(), quad_width);
+    EXPECT_EQ(bounding_rect.height(), quad_height);
+}
+
+TEST_CASE(quad_contains)
+{
+    u8 quad_width = 5;
+    u8 quad_height = 4;
+    u8 quad_x_left = 0;
+    u8 quad_y_top = 6;
+
+    u8 quad_x_right = quad_x_left + quad_width;
+    u8 quad_y_bottom = quad_y_top + quad_height;
+
+    Gfx::Point<u8> left_bottom { quad_x_left, quad_y_bottom };
+    Gfx::Point<u8> left_top { quad_x_left, quad_y_top };
+    Gfx::Point<u8> right_bottom { quad_x_right, quad_y_bottom };
+    Gfx::Point<u8> right_top { quad_x_right, quad_y_top };
+    Gfx::Quad<u8> quad = { left_bottom, left_top, right_top, right_bottom };
+
+    Gfx::Point<u8> in_bounds_point { 1, 7 };
+    EXPECT(quad.contains(in_bounds_point) == true);
+
+    Gfx::Point<u8> out_bounds_point { 7, 12 };
+    EXPECT(quad.contains(out_bounds_point) == false);
+}

--- a/Userland/Libraries/LibGfx/Quad.h
+++ b/Userland/Libraries/LibGfx/Quad.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibGfx/Point.h>
-#include <LibGfx/Triangle.h>
 
 namespace Gfx {
 
@@ -29,20 +28,45 @@ public:
 
     Rect<T> bounding_rect() const
     {
-        auto top = min(min(m_p1.y(), m_p2.y()), min(m_p3.y(), m_p4.y()));
-        auto right = max(max(m_p1.x(), m_p2.x()), max(m_p3.x(), m_p4.x()));
-        auto bottom = max(max(m_p1.y(), m_p2.y()), max(m_p3.y(), m_p4.y()));
-        auto left = min(min(m_p1.x(), m_p2.x()), min(m_p3.x(), m_p4.x()));
-        return { left, top, right - left, bottom - top };
+        T left = min(min(m_p1.x(), m_p2.x()), min(m_p3.x(), m_p4.x()));
+        T right = max(max(m_p1.x(), m_p2.x()), max(m_p3.x(), m_p4.x()));
+        T width = right - left;
+
+        T top = min(min(m_p1.y(), m_p2.y()), min(m_p3.y(), m_p4.y()));
+        T bottom = max(max(m_p1.y(), m_p2.y()), max(m_p3.y(), m_p4.y()));
+        T height = bottom - top;
+
+        return { left, top, width, height };
     }
 
     bool contains(Point<T> point) const
     {
-        // FIXME: There's probably a smarter way to do this.
-        return Triangle(m_p1, m_p2, m_p3).contains(point)
-            || Triangle(m_p1, m_p3, m_p4).contains(point)
-            || Triangle(m_p2, m_p4, m_p1).contains(point)
-            || Triangle(m_p2, m_p4, m_p3).contains(point);
+        // Even-Odd algorithm: https://www.geeksforgeeks.org/even-odd-method-winding-number-method-inside-outside-test-of-a-polygon/
+        //
+        // 1. "Constructing a line segment between the point (P) to be examined and a known point outside the polygon"
+        //      - We're using horizontal line from (point.x, point.y) to (bounding_rect().left + bounding_rect().width + 1, point.y)
+        //        (i.e. just +1 to right of furthest-right point in quad)
+        //
+        // 2. "The number of times the line segment intersects the polygon boundary is then counted."
+        //      - We count the line's intersections with the quad by checking each quad edge for intersection (1-2, 2-3, 3-4, 4-1)
+        //
+        // 3. "The point (P) is an internal point if the number of polygon edges intersected by this line is odd;
+        //    otherwise, the point is an external point."
+
+        u8 n_intersections_with_quad = 0;
+        Point<T> const* quad_points[5] = { &m_p1, &m_p2, &m_p3, &m_p4, &m_p1 };
+        for (size_t i = 0, j = 1; i < 4 && j < 5; i++, j++) {
+            if ((quad_points[i]->y() > point.y()) == (quad_points[j]->y() > point.y())) {
+                continue;
+            }
+
+            T x_coord_of_intersection_with_edge = (quad_points[j]->x() - quad_points[i]->x()) * (point.y() - quad_points[i]->y()) / (quad_points[j]->y() - quad_points[i]->y()) + quad_points[i]->x();
+            if (point.x() < x_coord_of_intersection_with_edge) {
+                n_intersections_with_quad++;
+            }
+        }
+
+        return ((n_intersections_with_quad % 2) == 1);
     }
 
 private:


### PR DESCRIPTION
First PR :)

LibGfx: Addressed simple `FIXME` comment to improve implementation of LibGfx::Quad::contains():
- Now uses [even-odd method](https://www.geeksforgeeks.org/even-odd-method-winding-number-method-inside-outside-test-of-a-polygon/) to determine if point is inside/outside
- Added `TestQuad.cpp` for basic verification of current functions

Docs: Added homebrew package `shellcheck` to build instructions documentation because I needed that to build on macOS
