### PR TITLE
LibWeb: Also invalidate placeholder style on focus change

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1137,6 +1137,9 @@ void HTMLInputElement::did_receive_focus()
         return;
     m_text_node->invalidate_style();
 
+    if (m_placeholder_text_node)
+        m_placeholder_text_node->invalidate_style();
+
     document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
 }
 
@@ -1144,6 +1147,9 @@ void HTMLInputElement::did_lose_focus()
 {
     if (m_text_node)
         m_text_node->invalidate_style();
+
+    if (m_placeholder_text_node)
+        m_placeholder_text_node->invalidate_style();
 
     commit_pending_changes();
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -72,6 +72,9 @@ void HTMLTextAreaElement::did_receive_focus()
         return;
     m_text_node->invalidate_style();
 
+    if (m_placeholder_text_node)
+        m_placeholder_text_node->invalidate_style();
+
     document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
 }
 
@@ -79,6 +82,9 @@ void HTMLTextAreaElement::did_lose_focus()
 {
     if (m_text_node)
         m_text_node->invalidate_style();
+
+    if (m_placeholder_text_node)
+        m_placeholder_text_node->invalidate_style();
 
     // The change event fires when the value is committed, if that makes sense for the control,
     // or else when the control loses focus


### PR DESCRIPTION
Follow-on from #499 to also account for placeholder styles