### PR TITLE
LibWeb: Don't crash on CSS `all: revert`

### DIFF
--- a/Tests/LibWeb/Text/expected/css/revert-all.txt
+++ b/Tests/LibWeb/Text/expected/css/revert-all.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/revert-all.html
+++ b/Tests/LibWeb/Text/input/css/revert-all.html
@@ -1,0 +1,9 @@
+<style>
+div { all: revert; }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -859,13 +859,7 @@ void StyleComputer::set_all_properties(DOM::Element& element, Optional<CSS::Sele
         auto property_id = (CSS::PropertyID)i;
 
         if (value.is_revert()) {
-            style.set_property(
-                property_id,
-                style_for_revert.property(property_id),
-                style_for_revert.is_property_inherited(property_id)
-                    ? StyleProperties::Inherited::Yes
-                    : StyleProperties::Inherited::No,
-                important);
+            style.revert_property(property_id, style_for_revert);
             continue;
         }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -88,6 +88,13 @@ void StyleProperties::set_property(CSS::PropertyID id, NonnullRefPtr<StyleValue 
     set_property_inherited(id, inherited);
 }
 
+void StyleProperties::revert_property(CSS::PropertyID id, StyleProperties const& style_for_revert)
+{
+    m_property_values[to_underlying(id)] = style_for_revert.m_property_values[to_underlying(id)];
+    set_property_important(id, style_for_revert.is_property_important(id) ? Important::Yes : Important::No);
+    set_property_inherited(id, style_for_revert.is_property_inherited(id) ? Inherited::Yes : Inherited::No);
+}
+
 void StyleProperties::set_animated_property(CSS::PropertyID id, NonnullRefPtr<StyleValue const> value)
 {
     m_animated_property_values.set(id, move(value));

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -54,6 +54,7 @@ public:
     void set_animated_property(CSS::PropertyID, NonnullRefPtr<StyleValue const> value);
     NonnullRefPtr<StyleValue const> property(CSS::PropertyID) const;
     RefPtr<StyleValue const> maybe_null_property(CSS::PropertyID) const;
+    void revert_property(CSS::PropertyID, StyleProperties const& style_for_revert);
 
     JS::GCPtr<CSS::CSSStyleDeclaration const> animation_name_source() const { return m_animation_name_source; }
     void set_animation_name_source(JS::GCPtr<CSS::CSSStyleDeclaration const> declaration) { m_animation_name_source = declaration; }


### PR DESCRIPTION
Not every value in a StyleProperties will be non-null by the time we perform `revert`, so let's make a specialized function for reverting a property instead of using the path that requires the value to be non-null.