### PR TITLE
LibWeb/Fetch: Add missing forbidden header name & correct check

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -725,7 +725,7 @@ bool is_forbidden_request_header(Header const& header)
     if (name.is_one_of_ignoring_ascii_case(
             "X-HTTP-Method"sv,
             "X-HTTP-Method-Override"sv,
-            "X-Method"sv)) {
+            "X-Method-Override"sv)) {
         // 1. Let parsedValues be the result of getting, decoding, and splitting value.
         auto parsed_values = get_decode_and_split_header_value(header.value);
 

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -702,6 +702,7 @@ bool is_forbidden_request_header(Header const& header)
             "Keep-Alive"sv,
             "Origin"sv,
             "Referer"sv,
+            "Set-Cookie"sv,
             "TE"sv,
             "Trailer"sv,
             "Transfer-Encoding"sv,


### PR DESCRIPTION
Fixes for web platform tests:
- http://wpt.live/fetch/api/request/request-headers.any.html
- http://wpt.live/fetch/api/basic/request-forbidden-headers.any.html