### PR TITLE
LibWeb: Return error on modification of a computed CSS style declaration

### DIFF
--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-modify-computed.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-modify-computed.txt
@@ -1,0 +1,2 @@
+Calling setProperty() on a computed CSSStyleDeclaration throws error of type: NoModificationAllowedError
+Calling removeProperty() on a computed CSSStyleDeclaration throws error of type: NoModificationAllowedError

--- a/Tests/LibWeb/Text/input/css/CSSStyleDeclaration-modify-computed.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleDeclaration-modify-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        try {
+            document.defaultView.getComputedStyle(document.documentElement, null).setProperty("foo", "bar");
+            println("FAIL");
+        } catch (e) {
+            println(`Calling setProperty() on a computed CSSStyleDeclaration throws error of type: ${e.name}`);
+        }
+
+        try {
+            document.defaultView.getComputedStyle(document.documentElement, null).removeProperty("foo");
+            println("FAIL");
+        } catch (e) {
+            println(`Calling removeProperty() on a computed CSSStyleDeclaration throws error of type: ${e.name}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -30,8 +30,8 @@ public:
     virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv) = 0;
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) = 0;
 
-    WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority);
-    WebIDL::ExceptionOr<String> remove_property(StringView property_name);
+    virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority);
+    virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name);
 
     String get_property_value(StringView property) const;
     StringView get_property_priority(StringView property) const;

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -569,18 +569,42 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     };
 }
 
+static WebIDL::ExceptionOr<void> cannot_modify_computed_property_error(JS::Realm& realm)
+{
+    return WebIDL::NoModificationAllowedError::create(realm, "Cannot modify properties in result of getComputedStyle()"_fly_string);
+}
+
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
 WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(PropertyID, StringView, StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_fly_string);
+    return cannot_modify_computed_property_error(realm());
+}
+
+// https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
+WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(StringView, StringView, StringView)
+{
+    // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
+    return cannot_modify_computed_property_error(realm());
+}
+
+static WebIDL::ExceptionOr<String> cannot_remove_computed_property_error(JS::Realm& realm)
+{
+    return WebIDL::NoModificationAllowedError::create(realm, "Cannot remove properties from result of getComputedStyle()"_fly_string);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
 WebIDL::ExceptionOr<String> ResolvedCSSStyleDeclaration::remove_property(PropertyID)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot remove properties from result of getComputedStyle()"_fly_string);
+    return cannot_remove_computed_property_error(realm());
+}
+
+// https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
+WebIDL::ExceptionOr<String> ResolvedCSSStyleDeclaration::remove_property(StringView)
+{
+    // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
+    return cannot_remove_computed_property_error(realm());
 }
 
 String ResolvedCSSStyleDeclaration::serialized() const

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -24,7 +24,9 @@ public:
 
     virtual Optional<StyleProperty> property(PropertyID) const override;
     virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority) override;
+    virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name) override;
 
     virtual String serialized() const override;
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;


### PR DESCRIPTION
Previously, calling `setProperty` or `removeProperty` from JS on a CSSStyleDeclaration returned from `getComputedStyle()` would return null. We now return a NoModificationAllowedError instead, which aligns our implementation with the specification.

Makes the following WPT test pass:  http://wpt.live/css/cssom/computed-style-set-property.html