### PR TITLE
LibWeb: Resolve background size and offset only after style invalidation

### DIFF
--- a/Tests/LibWeb/Ref/reference/scrollable-contains-box-with-gradient-background-ref.html
+++ b/Tests/LibWeb/Ref/reference/scrollable-contains-box-with-gradient-background-ref.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style type="text/css">
+    * {
+        scrollbar-width: none;
+    }
+
+    .box {
+        width: 180px;
+        height: 64px;
+        background: linear-gradient(rgb(109, 152, 204), rgb(138, 100, 229));
+        border-radius: 100px;
+    }
+
+    .scrollable {
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+        border: 10px solid orchid;
+    }
+</style>
+<div class="scrollable">
+    <div class="box"></div>
+</div>

--- a/Tests/LibWeb/Ref/scrollable-contains-box-with-gradient-background.html
+++ b/Tests/LibWeb/Ref/scrollable-contains-box-with-gradient-background.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/scrollable-contains-box-with-gradient-background-ref.html" />
+<style type="text/css">
+    * {
+        scrollbar-width: none;
+    }
+
+    .box {
+        width: 180px;
+        height: 64px;
+        background: linear-gradient(rgb(109, 152, 204), rgb(138, 100, 229));
+        border-radius: 100px;
+    }
+
+    #scrollable {
+        width: 200px;
+        height: 200px;
+        overflow: scroll;
+        border: 10px solid orchid;
+    }
+</style>
+<div id="scrollable">
+    <div style="height: 100px"></div>
+    <div class="box"></div>
+    <div style="height: 200px"></div>
+</div>
+<script>
+    const scrollContainer = document.getElementById("scrollable");
+    scrollContainer.scrollTop = 100;
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -43,9 +43,13 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
             if (!m_document)
                 return;
 
-            // FIXME: Do less than a full repaint if possible?
-            if (auto navigable = m_document->navigable())
+            if (auto navigable = m_document->navigable()) {
+                // Once the image has loaded, we need to re-resolve CSS properties that depend on the image's dimensions.
+                m_document->set_needs_to_resolve_paint_only_properties();
+
+                // FIXME: Do less than a full repaint if possible?
                 navigable->set_needs_display();
+            }
 
             auto image_data = m_resource_request->image_data();
             if (image_data->is_animated() && image_data->frame_count() > 1) {

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
@@ -12,6 +12,41 @@
 
 namespace Web::Painting {
 
-void paint_background(PaintContext&, Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelRect const&, Color background_color, CSS::ImageRendering, Vector<CSS::BackgroundLayerData> const*, BorderRadiiData const&);
+struct ResolvedBackgroundLayerData {
+    RefPtr<CSS::AbstractImageStyleValue const> background_image;
+    CSS::BackgroundAttachment attachment;
+    CSS::BackgroundBox clip;
+    CSS::PositionEdge position_edge_x;
+    CSS::PositionEdge position_edge_y;
+    CSSPixels offset_x;
+    CSSPixels offset_y;
+    CSSPixelRect background_positioning_area;
+    CSSPixelRect image_rect;
+    CSS::Repeat repeat_x;
+    CSS::Repeat repeat_y;
+};
+
+struct BackgroundBox {
+    CSSPixelRect rect;
+    BorderRadiiData radii;
+
+    inline void shrink(CSSPixels top, CSSPixels right, CSSPixels bottom, CSSPixels left)
+    {
+        rect.shrink(top, right, bottom, left);
+        radii.shrink(top, right, bottom, left);
+    }
+};
+
+struct ResolvedBackground {
+    BackgroundBox color_box;
+    Vector<ResolvedBackgroundLayerData> layers;
+    bool needs_text_clip { false };
+    CSSPixelRect background_rect {};
+    Color color {};
+};
+
+ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> const& layers, Layout::NodeWithStyleAndBoxModelMetrics const& layout_node, Color background_color, CSSPixelRect const& border_rect, BorderRadiiData const& border_radii);
+
+void paint_background(PaintContext&, Layout::NodeWithStyleAndBoxModelMetrics const&, CSS::ImageRendering, ResolvedBackground resolved_background, BorderRadiiData const&);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -75,7 +75,7 @@ void InlinePaintable::paint(PaintContext& context, PaintPhase phase) const
             absolute_fragment_rect.set_height(absolute_fragment_rect.height() + box_model().padding.top + box_model().padding.bottom);
 
             auto const& border_radii_data = fragment.border_radii_data();
-            paint_background(context, layout_node(), absolute_fragment_rect, computed_values().background_color(), computed_values().image_rendering(), &computed_values().background_layers(), border_radii_data);
+            paint_background(context, layout_node(), computed_values().image_rendering(), fragment.resolved_background(), border_radii_data);
 
             if (!box_shadow_data().is_empty()) {
                 auto borders_data = BordersData {
@@ -248,7 +248,7 @@ void InlinePaintable::resolve_paint_properties()
     auto const& layout_node = this->layout_node();
     auto& fragments = this->fragments();
 
-    // Border radii
+    // Border radii and background layers
     auto const& top_left_border_radius = computed_values.border_top_left_radius();
     auto const& top_right_border_radius = computed_values.border_top_right_radius();
     auto const& bottom_right_border_radius = computed_values.border_bottom_right_radius();
@@ -277,6 +277,9 @@ void InlinePaintable::resolve_paint_properties()
             bottom_right_border_radius,
             bottom_left_border_radius);
         fragment.set_border_radii_data(border_radii_data);
+
+        auto resolved_background = resolve_background_layers(computed_values.background_layers(), layout_node, computed_values.background_color(), absolute_fragment_rect, border_radii_data);
+        fragment.set_resolved_background(move(resolved_background));
     }
 
     auto const& box_shadow_data = computed_values.box_shadow();

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/Layout/InlineNode.h>
+#include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/ClippableAndScrollable.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableFragment.h>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/ClipFrame.h>
@@ -262,6 +263,8 @@ private:
 
     Optional<CSSPixelPoint> m_last_mouse_tracking_position;
     Optional<ScrollDirection> m_scroll_thumb_dragging_direction;
+
+    ResolvedBackground m_resolved_background;
 };
 
 class PaintableWithLines : public PaintableBox {

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Layout/LineBoxFragment.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/PixelUnits.h>
 
@@ -37,6 +38,9 @@ public:
     Vector<ShadowData> const& shadows() const { return m_shadows; }
     void set_shadows(Vector<ShadowData>&& shadows) { m_shadows = shadows; }
 
+    ResolvedBackground const& resolved_background() const { return m_resolved_background; }
+    void set_resolved_background(ResolvedBackground resolved_background) { m_resolved_background = resolved_background; }
+
     CSSPixelRect const absolute_rect() const;
 
     RefPtr<Gfx::GlyphRun> glyph_run() const { return m_glyph_run; }
@@ -60,6 +64,7 @@ private:
     Painting::BorderRadiiData m_border_radii_data;
     RefPtr<Gfx::GlyphRun> m_glyph_run;
     Vector<ShadowData> m_shadows;
+    ResolvedBackground m_resolved_background;
 };
 
 }


### PR DESCRIPTION
This change fixes layering violation by moving to_px() calls to happen before display list recording. Also it should make display list recording a bit faster by resolving background properties beforehand.