### PR TITLE
LibTextCodec: Implement legacy encoders

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
@@ -21,6 +21,7 @@ struct LookupTable {
     u32 max_code_point;
     Vector<u32> code_points;
     bool generate_accessor;
+    bool generate_inverse_accessor;
 };
 
 struct LookupTables {
@@ -33,7 +34,12 @@ enum class GenerateAccessor {
     Yes,
 };
 
-LookupTable prepare_table(JsonArray const& data, GenerateAccessor generate_accessor = GenerateAccessor::No)
+enum class GenerateInverseAccessor {
+    No,
+    Yes,
+};
+
+LookupTable prepare_table(JsonArray const& data, GenerateAccessor generate_accessor = GenerateAccessor::No, GenerateInverseAccessor generate_inverse_accessor = GenerateInverseAccessor::No)
 {
     Vector<u32> code_points;
     code_points.ensure_capacity(data.size());
@@ -58,7 +64,7 @@ LookupTable prepare_table(JsonArray const& data, GenerateAccessor generate_acces
     } else {
         VERIFY(first_pointer == 0);
     }
-    return { first_pointer, max, move(code_points), generate_accessor == GenerateAccessor::Yes };
+    return { first_pointer, max, move(code_points), generate_accessor == GenerateAccessor::Yes, generate_inverse_accessor == GenerateInverseAccessor::Yes };
 }
 
 void generate_table(SourceGenerator generator, StringView name, LookupTable& table)
@@ -81,6 +87,8 @@ void generate_table(SourceGenerator generator, StringView name, LookupTable& tab
     generator.appendln("\n};");
     if (table.generate_accessor)
         generator.appendln("Optional<u32> index_@name@_code_point(u32 pointer);");
+    if (table.generate_inverse_accessor)
+        generator.appendln("Optional<u32> code_point_@name@_index(u32 code_point);");
 }
 
 ErrorOr<void> generate_header_file(LookupTables& tables, Core::File& file)
@@ -155,6 +163,42 @@ Optional<u32> index_@name@_code_point(u32 pointer)
     }
 }
 
+void generate_inverse_table_accessor(SourceGenerator generator, StringView name, LookupTable& table)
+{
+    generator.set("name", name);
+    generator.set("first_pointer", MUST(String::number(table.first_pointer)));
+    generator.set("size", MUST(String::number(table.code_points.size())));
+
+    // FIXME - Doing a linear search here is really slow, should be generating
+    //         some kind of reverse lookup table.
+
+    if (table.first_pointer > 0) {
+        generator.append(R"~~~(
+Optional<u32> code_point_@name@_index(u32 code_point)
+{
+    for (u32 i = 0; i < s_@name@_index.size(); ++i) {
+        if (s_@name@_index[i] == code_point) {
+            return s_@name@_index_first_pointer + i;
+        }
+    }
+    return {};
+}
+)~~~");
+    } else {
+        generator.append(R"~~~(
+Optional<u32> code_point_@name@_index(u32 code_point)
+{
+    for (u32 i = 0; i < s_@name@_index.size(); ++i) {
+        if (s_@name@_index[i] == code_point) {
+            return i;
+        }
+    }
+    return {};
+}
+)~~~");
+    }
+}
+
 ErrorOr<void> generate_implementation_file(LookupTables& tables, Core::File& file)
 {
     StringBuilder builder;
@@ -169,6 +213,8 @@ namespace TextCodec {
     for (auto& [key, table] : tables.indexes) {
         if (table.generate_accessor)
             generate_table_accessor(generator.fork(), key, table);
+        if (table.generate_inverse_accessor)
+            generate_inverse_table_accessor(generator.fork(), key, table);
     }
 
     generator.appendln("\n}");
@@ -222,7 +268,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         .indexes = {
             { "gb18030"sv, move(gb18030_table) },
             { "big5"sv, prepare_table(data.get("big5"sv)->as_array(), GenerateAccessor::Yes) },
-            { "jis0208"sv, prepare_table(data.get("jis0208"sv)->as_array(), GenerateAccessor::Yes) },
+            { "jis0208"sv, prepare_table(data.get("jis0208"sv)->as_array(), GenerateAccessor::Yes, GenerateInverseAccessor::Yes) },
             { "jis0212"sv, prepare_table(data.get("jis0212"sv)->as_array(), GenerateAccessor::Yes) },
             { "euc_kr"sv, prepare_table(data.get("euc-kr"sv)->as_array(), GenerateAccessor::Yes) },
             { "ibm866"sv, prepare_table(data.get("ibm866"sv)->as_array()) },

--- a/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
@@ -240,7 +240,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto json_data = TRY(json_file->read_until_eof());
     auto data = TRY(JsonValue::from_string(json_data)).as_object();
 
-    auto gb18030_table = prepare_table(data.get("gb18030"sv)->as_array(), GenerateAccessor::Yes);
+    auto gb18030_table = prepare_table(data.get("gb18030"sv)->as_array(), GenerateAccessor::Yes, GenerateInverseAccessor::Yes);
 
     // FIXME: Encoding specification is not updated to GB-18030-2022 yet (https://github.com/whatwg/encoding/issues/312)
     // NOTE: See https://commits.webkit.org/264918@main

--- a/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
@@ -272,6 +272,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             { "jis0212"sv, prepare_table(data.get("jis0212"sv)->as_array(), GenerateAccessor::Yes) },
             { "euc_kr"sv, prepare_table(data.get("euc-kr"sv)->as_array(), GenerateAccessor::Yes, GenerateInverseAccessor::Yes) },
             { "ibm866"sv, prepare_table(data.get("ibm866"sv)->as_array()) },
+            { "iso_2022_jp_katakana"sv, prepare_table(data.get("iso-2022-jp-katakana"sv)->as_array(), GenerateAccessor::Yes) },
             { "iso_8859_2"sv, prepare_table(data.get("iso-8859-2"sv)->as_array()) },
             { "iso_8859_3"sv, prepare_table(data.get("iso-8859-3"sv)->as_array()) },
             { "iso_8859_4"sv, prepare_table(data.get("iso-8859-4"sv)->as_array()) },

--- a/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTextCodec/GenerateEncodingIndexes.cpp
@@ -270,7 +270,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             { "big5"sv, prepare_table(data.get("big5"sv)->as_array(), GenerateAccessor::Yes) },
             { "jis0208"sv, prepare_table(data.get("jis0208"sv)->as_array(), GenerateAccessor::Yes, GenerateInverseAccessor::Yes) },
             { "jis0212"sv, prepare_table(data.get("jis0212"sv)->as_array(), GenerateAccessor::Yes) },
-            { "euc_kr"sv, prepare_table(data.get("euc-kr"sv)->as_array(), GenerateAccessor::Yes) },
+            { "euc_kr"sv, prepare_table(data.get("euc-kr"sv)->as_array(), GenerateAccessor::Yes, GenerateInverseAccessor::Yes) },
             { "ibm866"sv, prepare_table(data.get("ibm866"sv)->as_array()) },
             { "iso_8859_2"sv, prepare_table(data.get("iso-8859-2"sv)->as_array()) },
             { "iso_8859_3"sv, prepare_table(data.get("iso-8859-3"sv)->as_array()) },

--- a/Tests/LibTextCodec/CMakeLists.txt
+++ b/Tests/LibTextCodec/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestTextDecoders.cpp
+    TestTextEncoders.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibTextCodec/TestTextEncoders.cpp
+++ b/Tests/LibTextCodec/TestTextEncoders.cpp
@@ -43,3 +43,21 @@ TEST_CASE(test_euc_jp_encoder)
     EXPECT(processed_bytes[3] == 0xA5);
     EXPECT(processed_bytes[4] == 0xC4);
 }
+
+TEST_CASE(test_euc_kr_encoder)
+{
+    TextCodec::EUCKREncoder encoder;
+    // U+B29F Hangul Syllable Neulh
+    // U+7C97 CJK Unified Ideograph-7C97
+    auto test_string = "\U0000B29F\U00007C97"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
+        return processed_bytes.try_append(byte);
+    }));
+    EXPECT(processed_bytes.size() == 4);
+    EXPECT(processed_bytes[0] == 0x88);
+    EXPECT(processed_bytes[1] == 0x6B);
+    EXPECT(processed_bytes[2] == 0xF0);
+    EXPECT(processed_bytes[3] == 0xD8);
+}

--- a/Tests/LibTextCodec/TestTextEncoders.cpp
+++ b/Tests/LibTextCodec/TestTextEncoders.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2024, Ben Jilks <benjyjilks@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <LibTextCodec/Encoder.h>
+
+TEST_CASE(test_utf8_encode)
+{
+    TextCodec::UTF8Encoder encoder;
+    // Unicode character U+1F600 GRINNING FACE
+    auto test_string = "\U0001F600"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
+        return processed_bytes.try_append(byte);
+    }));
+    EXPECT(processed_bytes.size() == 4);
+    EXPECT(processed_bytes[0] == 0xF0);
+    EXPECT(processed_bytes[1] == 0x9F);
+    EXPECT(processed_bytes[2] == 0x98);
+    EXPECT(processed_bytes[3] == 0x80);
+}
+
+TEST_CASE(test_euc_jp_encoder)
+{
+    TextCodec::EUCJPEncoder encoder;
+    // U+A5 Yen Sign
+    // U+3088 Hiragana Letter Yo
+    // U+30C4 Katakana Letter Tu
+    auto test_string = "\U000000A5\U00003088\U000030C4"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
+        return processed_bytes.try_append(byte);
+    }));
+    EXPECT(processed_bytes.size() == 5);
+    EXPECT(processed_bytes[0] == 0x5C);
+    EXPECT(processed_bytes[1] == 0xA4);
+    EXPECT(processed_bytes[2] == 0xE8);
+    EXPECT(processed_bytes[3] == 0xA5);
+    EXPECT(processed_bytes[4] == 0xC4);
+}

--- a/Tests/LibTextCodec/TestTextEncoders.cpp
+++ b/Tests/LibTextCodec/TestTextEncoders.cpp
@@ -79,3 +79,22 @@ TEST_CASE(test_big5_encoder)
     EXPECT(processed_bytes[2] == 0xD2);
     EXPECT(processed_bytes[3] == 0x71);
 }
+
+TEST_CASE(test_gb18030_encoder)
+{
+    TextCodec::GB18030Encoder encoder;
+    // U+20AC Euro Sign
+    // U+E4C5 Private Use Area
+    auto test_string = "\U000020AC\U0000E4C5"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
+        return processed_bytes.try_append(byte);
+    }));
+
+    EXPECT(processed_bytes.size() == 4);
+    EXPECT(processed_bytes[0] == 0xA2);
+    EXPECT(processed_bytes[1] == 0xE3);
+    EXPECT(processed_bytes[2] == 0xFE);
+    EXPECT(processed_bytes[3] == 0xFE);
+}

--- a/Tests/LibTextCodec/TestTextEncoders.cpp
+++ b/Tests/LibTextCodec/TestTextEncoders.cpp
@@ -61,3 +61,21 @@ TEST_CASE(test_euc_kr_encoder)
     EXPECT(processed_bytes[2] == 0xF0);
     EXPECT(processed_bytes[3] == 0xD8);
 }
+
+TEST_CASE(test_big5_encoder)
+{
+    TextCodec::Big5Encoder encoder;
+    // U+A7 Section Sign
+    // U+70D7 CJK Unified Ideograph-70D7
+    auto test_string = "\U000000A7\U000070D7"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
+        return processed_bytes.try_append(byte);
+    }));
+    EXPECT(processed_bytes.size() == 4);
+    EXPECT(processed_bytes[0] == 0xA1);
+    EXPECT(processed_bytes[1] == 0xB1);
+    EXPECT(processed_bytes[2] == 0xD2);
+    EXPECT(processed_bytes[3] == 0x71);
+}

--- a/Tests/LibTextCodec/TestTextEncoders.cpp
+++ b/Tests/LibTextCodec/TestTextEncoders.cpp
@@ -44,6 +44,26 @@ TEST_CASE(test_euc_jp_encoder)
     EXPECT(processed_bytes[4] == 0xC4);
 }
 
+TEST_CASE(test_shift_jis_encoder)
+{
+    TextCodec::ShiftJISEncoder encoder;
+    // U+A5 Yen Sign
+    // U+3088 Hiragana Letter Yo
+    // U+30C4 Katakana Letter Tu
+    auto test_string = "\U000000A5\U00003088\U000030C4"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
+        return processed_bytes.try_append(byte);
+    }));
+    EXPECT(processed_bytes.size() == 5);
+    EXPECT(processed_bytes[0] == 0x5C);
+    EXPECT(processed_bytes[1] == 0x82);
+    EXPECT(processed_bytes[2] == 0xE6);
+    EXPECT(processed_bytes[3] == 0x83);
+    EXPECT(processed_bytes[4] == 0x63);
+}
+
 TEST_CASE(test_euc_kr_encoder)
 {
     TextCodec::EUCKREncoder encoder;

--- a/Tests/LibTextCodec/TestTextEncoders.cpp
+++ b/Tests/LibTextCodec/TestTextEncoders.cpp
@@ -14,9 +14,10 @@ TEST_CASE(test_utf8_encode)
     auto test_string = "\U0001F600"sv;
 
     Vector<u8> processed_bytes;
-    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
-        return processed_bytes.try_append(byte);
-    }));
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
     EXPECT(processed_bytes.size() == 4);
     EXPECT(processed_bytes[0] == 0xF0);
     EXPECT(processed_bytes[1] == 0x9F);
@@ -33,15 +34,46 @@ TEST_CASE(test_euc_jp_encoder)
     auto test_string = "\U000000A5\U00003088\U000030C4"sv;
 
     Vector<u8> processed_bytes;
-    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
-        return processed_bytes.try_append(byte);
-    }));
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
     EXPECT(processed_bytes.size() == 5);
     EXPECT(processed_bytes[0] == 0x5C);
     EXPECT(processed_bytes[1] == 0xA4);
     EXPECT(processed_bytes[2] == 0xE8);
     EXPECT(processed_bytes[3] == 0xA5);
     EXPECT(processed_bytes[4] == 0xC4);
+}
+
+TEST_CASE(test_iso_2022_jp_encoder)
+{
+    TextCodec::ISO2022JPEncoder encoder;
+    // U+A5 Yen Sign
+    // U+3088 Hiragana Letter Yo
+    // U+30C4 Katakana Letter Tu
+    auto test_string = "\U000000A5\U00003088\U000030C4"sv;
+
+    Vector<u8> processed_bytes;
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
+    EXPECT(processed_bytes.size() == 14);
+    EXPECT(processed_bytes[0] == 0x1B);
+    EXPECT(processed_bytes[1] == 0x28);
+    EXPECT(processed_bytes[2] == 0x4A);
+    EXPECT(processed_bytes[3] == 0x5C);
+    EXPECT(processed_bytes[4] == 0x1B);
+    EXPECT(processed_bytes[5] == 0x24);
+    EXPECT(processed_bytes[6] == 0x42);
+    EXPECT(processed_bytes[7] == 0x24);
+    EXPECT(processed_bytes[8] == 0x68);
+    EXPECT(processed_bytes[9] == 0x25);
+    EXPECT(processed_bytes[10] == 0x44);
+    EXPECT(processed_bytes[11] == 0x1B);
+    EXPECT(processed_bytes[12] == 0x28);
+    EXPECT(processed_bytes[13] == 0x42);
 }
 
 TEST_CASE(test_shift_jis_encoder)
@@ -53,9 +85,10 @@ TEST_CASE(test_shift_jis_encoder)
     auto test_string = "\U000000A5\U00003088\U000030C4"sv;
 
     Vector<u8> processed_bytes;
-    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
-        return processed_bytes.try_append(byte);
-    }));
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
     EXPECT(processed_bytes.size() == 5);
     EXPECT(processed_bytes[0] == 0x5C);
     EXPECT(processed_bytes[1] == 0x82);
@@ -72,9 +105,10 @@ TEST_CASE(test_euc_kr_encoder)
     auto test_string = "\U0000B29F\U00007C97"sv;
 
     Vector<u8> processed_bytes;
-    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
-        return processed_bytes.try_append(byte);
-    }));
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
     EXPECT(processed_bytes.size() == 4);
     EXPECT(processed_bytes[0] == 0x88);
     EXPECT(processed_bytes[1] == 0x6B);
@@ -90,9 +124,10 @@ TEST_CASE(test_big5_encoder)
     auto test_string = "\U000000A7\U000070D7"sv;
 
     Vector<u8> processed_bytes;
-    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
-        return processed_bytes.try_append(byte);
-    }));
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
     EXPECT(processed_bytes.size() == 4);
     EXPECT(processed_bytes[0] == 0xA1);
     EXPECT(processed_bytes[1] == 0xB1);
@@ -108,10 +143,10 @@ TEST_CASE(test_gb18030_encoder)
     auto test_string = "\U000020AC\U0000E4C5"sv;
 
     Vector<u8> processed_bytes;
-    MUST(encoder.process(Utf8View(test_string), [&](u8 byte) {
-        return processed_bytes.try_append(byte);
-    }));
-
+    MUST(encoder.process(
+        Utf8View(test_string),
+        [&](u8 byte) { return processed_bytes.try_append(byte); },
+        [&](u32) -> ErrorOr<void> { EXPECT(false); return {}; }));
     EXPECT(processed_bytes.size() == 4);
     EXPECT(processed_bytes[0] == 0xA2);
     EXPECT(processed_bytes[1] == 0xE3);

--- a/Userland/Libraries/LibTextCodec/CMakeLists.txt
+++ b/Userland/Libraries/LibTextCodec/CMakeLists.txt
@@ -2,6 +2,7 @@ include(libtextcodec_generators)
 
 set(SOURCES
     Decoder.cpp
+    Encoder.cpp
 )
 
 generate_encoding_indexes()

--- a/Userland/Libraries/LibTextCodec/Encoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Encoder.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Ben Jilks <benjyjilks@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/Utf8View.h>
+#include <LibTextCodec/Decoder.h>
+#include <LibTextCodec/Encoder.h>
+#include <LibTextCodec/LookupTables.h>
+
+namespace TextCodec {
+
+namespace {
+UTF8Encoder s_utf8_encoder;
+EUCJPEncoder s_euc_jp_encoder;
+}
+
+Optional<Encoder&> encoder_for_exact_name(StringView encoding)
+{
+    if (encoding.equals_ignoring_ascii_case("utf-8"sv))
+        return s_utf8_encoder;
+    if (encoding.equals_ignoring_ascii_case("euc-jp"sv))
+        return s_euc_jp_encoder;
+    dbgln("TextCodec: No encoder implemented for encoding '{}'", encoding);
+    return {};
+}
+
+Optional<Encoder&> encoder_for(StringView label)
+{
+    auto encoding = get_standardized_encoding(label);
+    return encoding.has_value() ? encoder_for_exact_name(encoding.value()) : Optional<Encoder&> {};
+}
+
+// https://encoding.spec.whatwg.org/#utf-8-encoder
+ErrorOr<void> UTF8Encoder::process(Utf8View input, Function<ErrorOr<void>(u8)> on_byte)
+{
+    ReadonlyBytes bytes { input.bytes(), input.byte_length() };
+    for (auto byte : bytes)
+        TRY(on_byte(byte));
+    return {};
+}
+
+// https://encoding.spec.whatwg.org/#euc-jp-encoder
+ErrorOr<void> EUCJPEncoder::process(Utf8View input, Function<ErrorOr<void>(u8)> on_byte)
+{
+    for (auto item : input) {
+        // 1. If code point is end-of-queue, return finished.
+
+        // 2. If code point is an ASCII code point, return a byte whose value is code point.
+        if (is_ascii(item)) {
+            TRY(on_byte(static_cast<u8>(item)));
+            continue;
+        }
+
+        // 3. If code point is U+00A5, return byte 0x5C.
+        if (item == 0x00A5) {
+            TRY(on_byte(static_cast<u8>(0x5C)));
+            continue;
+        }
+
+        // 4. If code point is U+203E, return byte 0x7E.
+        if (item == 0x203E) {
+            TRY(on_byte(static_cast<u8>(0x7E)));
+            continue;
+        }
+
+        // 5. If code point is in the range U+FF61 to U+FF9F, inclusive, return two bytes whose values are 0x8E and code point − 0xFF61 + 0xA1.
+        if (item >= 0xFF61 && item <= 0xFF9F) {
+            TRY(on_byte(0x8E));
+            TRY(on_byte(static_cast<u8>(item - 0xFF61 + 0xA1)));
+            continue;
+        }
+
+        // 6. If code point is U+2212, set it to U+FF0D.
+        if (item == 0x2212)
+            item = 0xFF0D;
+
+        // 7. Let pointer be the index pointer for code point in index jis0208.
+        auto pointer = code_point_jis0208_index(item);
+
+        // 8. If pointer is null, return error with code point.
+        if (!pointer.has_value()) {
+            // TODO: Report error.
+            continue;
+        }
+
+        // 9. Let lead be pointer / 94 + 0xA1.
+        auto lead = *pointer / 94 + 0xA1;
+
+        // 10. Let trail be pointer % 94 + 0xA1.
+        auto trail = *pointer % 94 + 0xA1;
+
+        // 11. Return two bytes whose values are lead and trail.
+        TRY(on_byte(static_cast<u8>(lead)));
+        TRY(on_byte(static_cast<u8>(trail)));
+    }
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibTextCodec/Encoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Encoder.cpp
@@ -14,6 +14,7 @@ namespace TextCodec {
 
 namespace {
 UTF8Encoder s_utf8_encoder;
+Big5Encoder s_big5_encoder;
 EUCJPEncoder s_euc_jp_encoder;
 EUCKREncoder s_euc_kr_encoder;
 }
@@ -22,6 +23,8 @@ Optional<Encoder&> encoder_for_exact_name(StringView encoding)
 {
     if (encoding.equals_ignoring_ascii_case("utf-8"sv))
         return s_utf8_encoder;
+    if (encoding.equals_ignoring_ascii_case("big5"sv))
+        return s_big5_encoder;
     if (encoding.equals_ignoring_ascii_case("euc-jp"sv))
         return s_euc_jp_encoder;
     if (encoding.equals_ignoring_ascii_case("euc-kr"sv))
@@ -133,6 +136,72 @@ ErrorOr<void> EUCKREncoder::process(Utf8View input, Function<ErrorOr<void>(u8)> 
         // 7. Return two bytes whose values are lead and trail.
         TRY(on_byte(static_cast<u8>(lead)));
         TRY(on_byte(static_cast<u8>(trail)));
+    }
+
+    return {};
+}
+
+// https://encoding.spec.whatwg.org/#index-big5-pointer
+static Optional<u32> index_big5_pointer(u32 code_point)
+{
+    // 1. Let index be index Big5 excluding all entries whose pointer is less than (0xA1 - 0x81) × 157.
+    auto start_index = (0xA1 - 0x81) * 157 - s_big5_index_first_pointer;
+
+    // 2. If code point is U+2550, U+255E, U+2561, U+256A, U+5341, or U+5345, return the last pointer
+    //    corresponding to code point in index.
+    if (Array<u32, 6> { 0x2550, 0x255E, 0x2561, 0x256A, 0x5341, 0x5345 }.contains_slow(code_point)) {
+        for (u32 i = s_big5_index.size() - 1; i >= start_index; --i) {
+            if (s_big5_index[i] == code_point) {
+                return s_big5_index_first_pointer + i;
+            }
+        }
+        return {};
+    }
+
+    // 3. Return the index pointer for code point in index.
+    for (u32 i = start_index; i < s_big5_index.size(); ++i) {
+        if (s_big5_index[i] == code_point) {
+            return s_big5_index_first_pointer + i;
+        }
+    }
+    return {};
+}
+
+// https://encoding.spec.whatwg.org/#big5-encoder
+ErrorOr<void> Big5Encoder::process(Utf8View input, Function<ErrorOr<void>(u8)> on_byte)
+{
+    for (u32 item : input) {
+        // 1. If code point is end-of-queue, return finished.
+
+        // 2. If code point is an ASCII code point, return a byte whose value is code point.
+        if (is_ascii(item)) {
+            TRY(on_byte(static_cast<u8>(item)));
+            continue;
+        }
+
+        // 3. Let pointer be the index Big5 pointer for code point.
+        auto pointer = index_big5_pointer(item);
+
+        // 4. If pointer is null, return error with code point.
+        if (!pointer.has_value()) {
+            // TODO: Report error.
+            continue;
+        }
+
+        // 5. Let lead be pointer / 157 + 0x81.
+        auto lead = *pointer / 157 + 0x81;
+
+        // 6. Let trail be pointer % 157.
+        auto trail = *pointer % 157;
+
+        // 7. Let offset be 0x40 if trail is less than 0x3F, otherwise 0x62.
+        auto offset = 0x62;
+        if (trail < 0x3f)
+            offset = 0x40;
+
+        // 8. Return two bytes whose values are lead and trail + offset.
+        TRY(on_byte(static_cast<u8>(lead)));
+        TRY(on_byte(static_cast<u8>(trail + offset)));
     }
 
     return {};

--- a/Userland/Libraries/LibTextCodec/Encoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Encoder.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/BinarySearch.h>
 #include <AK/Error.h>
 #include <AK/Utf8View.h>
 #include <LibTextCodec/Decoder.h>
@@ -14,6 +15,8 @@ namespace TextCodec {
 
 namespace {
 UTF8Encoder s_utf8_encoder;
+GB18030Encoder s_gb18030_encoder;
+GB18030Encoder s_gbk_encoder(GB18030Encoder::IsGBK::Yes);
 Big5Encoder s_big5_encoder;
 EUCJPEncoder s_euc_jp_encoder;
 EUCKREncoder s_euc_kr_encoder;
@@ -29,6 +32,10 @@ Optional<Encoder&> encoder_for_exact_name(StringView encoding)
         return s_euc_jp_encoder;
     if (encoding.equals_ignoring_ascii_case("euc-kr"sv))
         return s_euc_kr_encoder;
+    if (encoding.equals_ignoring_ascii_case("gb18030"sv))
+        return s_gb18030_encoder;
+    if (encoding.equals_ignoring_ascii_case("gbk"sv))
+        return s_gbk_encoder;
     dbgln("TextCodec: No encoder implemented for encoding '{}'", encoding);
     return {};
 }
@@ -202,6 +209,116 @@ ErrorOr<void> Big5Encoder::process(Utf8View input, Function<ErrorOr<void>(u8)> o
         // 8. Return two bytes whose values are lead and trail + offset.
         TRY(on_byte(static_cast<u8>(lead)));
         TRY(on_byte(static_cast<u8>(trail + offset)));
+    }
+
+    return {};
+}
+
+// https://encoding.spec.whatwg.org/#index-gb18030-ranges-pointer
+static u32 index_gb18030_ranges_pointer(u32 code_point)
+{
+    // 1. If code point is U+E7C7, return pointer 7457.
+    if (code_point == 0xe7c7)
+        return 7457;
+
+    // 2. Let offset be the last code point in index gb18030 ranges that is less than
+    //    or equal to code point and let pointer offset be its corresponding pointer.
+    size_t last_index;
+    binary_search(s_gb18030_ranges, code_point, &last_index, [](auto const code_point, auto const& entry) {
+        return code_point - entry.code_point;
+    });
+    auto offset = s_gb18030_ranges[last_index].code_point;
+    auto pointer_offset = s_gb18030_ranges[last_index].pointer;
+
+    // 3. Return a pointer whose value is pointer offset + code point − offset.
+    return pointer_offset + code_point - offset;
+}
+
+GB18030Encoder::GB18030Encoder(IsGBK is_gbk)
+    : m_is_gbk(is_gbk)
+{
+}
+
+// https://encoding.spec.whatwg.org/#gb18030-encoder
+ErrorOr<void> GB18030Encoder::process(Utf8View input, Function<ErrorOr<void>(u8)> on_byte)
+{
+    bool gbk = (m_is_gbk == IsGBK::Yes);
+
+    for (u32 item : input) {
+        // 1. If code point is end-of-queue, return finished.
+
+        // 2. If code point is an ASCII code point, return a byte whose value is code point.
+        if (is_ascii(item)) {
+            TRY(on_byte(static_cast<u8>(item)));
+            continue;
+        }
+
+        // 3. If code point is U+E5E5, return error with code point.
+        if (item == 0xE5E5) {
+            // TODO: Report error.
+            continue;
+        }
+
+        // 4. If is GBK is true and code point is U+20AC, return byte 0x80.
+        if (gbk && item == 0x20AC) {
+            TRY(on_byte(0x80));
+            continue;
+        }
+
+        // 5. Let pointer be the index pointer for code point in index gb18030.
+        auto pointer = code_point_gb18030_index(item);
+
+        // 6. If pointer is non-null, then:
+        if (pointer.has_value()) {
+            // 1. Let lead be pointer / 190 + 0x81.
+            auto lead = *pointer / 190 + 0x81;
+
+            // 2. Let trail be pointer % 190.
+            auto trail = *pointer % 190;
+
+            // 3. Let offset be 0x40 if trail is less than 0x3F, otherwise 0x41.
+            auto offset = 0x41;
+            if (trail < 0x3f)
+                offset = 0x40;
+
+            // 4. Return two bytes whose values are lead and trail + offset.
+            TRY(on_byte(static_cast<u8>(lead)));
+            TRY(on_byte(static_cast<u8>(trail + offset)));
+            continue;
+        }
+
+        // 7. If is GBK is true, return error with code point.
+        if (gbk) {
+            // TODO: Report error.
+            continue;
+        }
+
+        // 8. Set pointer to the index gb18030 ranges pointer for code point.
+        pointer = index_gb18030_ranges_pointer(item);
+
+        // 9. Let byte1 be pointer / (10 × 126 × 10).
+        auto byte1 = *pointer / (10 * 126 * 10);
+
+        // 10. Set pointer to pointer % (10 × 126 × 10).
+        pointer = *pointer % (10 * 126 * 10);
+
+        // 11. Let byte2 be pointer / (10 × 126).
+        auto byte2 = *pointer / (10 * 126);
+
+        // 12. Set pointer to pointer % (10 × 126).
+        pointer = *pointer % (10 * 126);
+
+        // 13. Let byte3 be pointer / 10.
+        auto byte3 = *pointer / 10;
+
+        // 14. Let byte4 be pointer % 10.
+        auto byte4 = *pointer % 10;
+
+        // 15. Return four bytes whose values are byte1 + 0x81, byte2 + 0x30, byte3 + 0x81, byte4 + 0x30.
+        TRY(on_byte(static_cast<u8>(byte1 + 0x81)));
+        TRY(on_byte(static_cast<u8>(byte2 + 0x30)));
+        TRY(on_byte(static_cast<u8>(byte3 + 0x81)));
+        TRY(on_byte(static_cast<u8>(byte4 + 0x30)));
     }
 
     return {};

--- a/Userland/Libraries/LibTextCodec/Encoder.h
+++ b/Userland/Libraries/LibTextCodec/Encoder.h
@@ -29,6 +29,11 @@ public:
     virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
 };
 
+class ShiftJISEncoder final : public Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+};
+
 class EUCKREncoder final : public Encoder {
 public:
     virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;

--- a/Userland/Libraries/LibTextCodec/Encoder.h
+++ b/Userland/Libraries/LibTextCodec/Encoder.h
@@ -39,6 +39,21 @@ public:
     virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
 };
 
+class GB18030Encoder final : public Encoder {
+public:
+    enum class IsGBK {
+        Yes,
+        No,
+    };
+
+    GB18030Encoder(IsGBK is_gbk = IsGBK::No);
+
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+
+private:
+    IsGBK m_is_gbk { IsGBK::No };
+};
+
 Optional<Encoder&> encoder_for_exact_name(StringView encoding);
 Optional<Encoder&> encoder_for(StringView label);
 

--- a/Userland/Libraries/LibTextCodec/Encoder.h
+++ b/Userland/Libraries/LibTextCodec/Encoder.h
@@ -29,6 +29,11 @@ public:
     virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
 };
 
+class EUCKREncoder final : public Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+};
+
 Optional<Encoder&> encoder_for_exact_name(StringView encoding);
 Optional<Encoder&> encoder_for(StringView label);
 

--- a/Userland/Libraries/LibTextCodec/Encoder.h
+++ b/Userland/Libraries/LibTextCodec/Encoder.h
@@ -34,6 +34,11 @@ public:
     virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
 };
 
+class Big5Encoder final : public Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+};
+
 Optional<Encoder&> encoder_for_exact_name(StringView encoding);
 Optional<Encoder&> encoder_for(StringView label);
 

--- a/Userland/Libraries/LibTextCodec/Encoder.h
+++ b/Userland/Libraries/LibTextCodec/Encoder.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Ben Jilks <benjyjilks@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/Function.h>
+
+namespace TextCodec {
+
+class Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) = 0;
+
+protected:
+    virtual ~Encoder() = default;
+};
+
+class UTF8Encoder final : public Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+};
+
+class EUCJPEncoder final : public Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+};
+
+Optional<Encoder&> encoder_for_exact_name(StringView encoding);
+Optional<Encoder&> encoder_for(StringView label);
+
+}

--- a/Userland/Libraries/LibTextCodec/Encoder.h
+++ b/Userland/Libraries/LibTextCodec/Encoder.h
@@ -13,7 +13,7 @@ namespace TextCodec {
 
 class Encoder {
 public:
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) = 0;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) = 0;
 
 protected:
     virtual ~Encoder() = default;
@@ -21,27 +21,41 @@ protected:
 
 class UTF8Encoder final : public Encoder {
 public:
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
 };
 
 class EUCJPEncoder final : public Encoder {
 public:
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
+};
+
+class ISO2022JPEncoder final : public Encoder {
+public:
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
+
+private:
+    enum class State {
+        ASCII,
+        Roman,
+        jis0208,
+    };
+
+    ErrorOr<State> process_item(u32 item, State, Function<ErrorOr<void>(u8)>& on_byte, Function<ErrorOr<void>(u32)>& on_error);
 };
 
 class ShiftJISEncoder final : public Encoder {
 public:
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
 };
 
 class EUCKREncoder final : public Encoder {
 public:
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
 };
 
 class Big5Encoder final : public Encoder {
 public:
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
 };
 
 class GB18030Encoder final : public Encoder {
@@ -53,7 +67,7 @@ public:
 
     GB18030Encoder(IsGBK is_gbk = IsGBK::No);
 
-    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte) override;
+    virtual ErrorOr<void> process(Utf8View, Function<ErrorOr<void>(u8)> on_byte, Function<ErrorOr<void>(u32)> on_error) override;
 
 private:
     IsGBK m_is_gbk { IsGBK::No };

--- a/Userland/Libraries/LibURL/CMakeLists.txt
+++ b/Userland/Libraries/LibURL/CMakeLists.txt
@@ -4,4 +4,4 @@ set(SOURCES
 )
 
 serenity_lib(LibURL url)
-target_link_libraries(LibURL PRIVATE LibUnicode)
+target_link_libraries(LibURL PRIVATE LibUnicode LibTextCodec)

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -14,6 +14,8 @@
 #include <AK/StringBuilder.h>
 #include <AK/StringUtils.h>
 #include <AK/Utf8View.h>
+#include <LibTextCodec/Decoder.h>
+#include <LibTextCodec/Encoder.h>
 #include <LibURL/Parser.h>
 #include <LibUnicode/IDNA.h>
 
@@ -755,18 +757,17 @@ void Parser::shorten_urls_path(URL& url)
 }
 
 // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
-ErrorOr<String> Parser::percent_encode_after_encoding(StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus)
+ErrorOr<String> Parser::percent_encode_after_encoding(TextCodec::Encoder& encoder, StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus)
 {
-    // NOTE: This is written somewhat ad-hoc since we don't yet implement the Encoding spec.
-
+    // 1. Let encodeOutput be an empty I/O queue.
     StringBuilder output;
 
     // 3. For each byte of encodeOutput converted to a byte sequence:
-    for (u8 byte : input) {
+    TRY(encoder.process(Utf8View(input), [&](u8 byte) -> ErrorOr<void> {
         // 1. If spaceAsPlus is true and byte is 0x20 (SP), then append U+002B (+) to output and continue.
         if (space_as_plus && byte == ' ') {
             output.append('+');
-            continue;
+            return {};
         }
 
         // 2. Let isomorph be a code point whose value is byte’s value.
@@ -783,7 +784,9 @@ ErrorOr<String> Parser::percent_encode_after_encoding(StringView input, PercentE
         else {
             output.appendff("%{:02X}", byte);
         }
-    }
+
+        return {};
+    }));
 
     // 6. Return output.
     return output.to_string();
@@ -840,7 +843,9 @@ URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Opt
     // 4. Let state be state override if given, or scheme start state otherwise.
     State state = state_override.value_or(State::SchemeStart);
 
-    // FIXME: 5. Set encoding to the result of getting an output encoding from encoding.
+    // 5. Set encoding to the result of getting an output encoding from encoding.
+    auto encoder = TextCodec::encoder_for("utf-8"sv);
+    VERIFY(encoder.has_value());
 
     // 6. Let buffer be the empty string.
     StringBuilder buffer;
@@ -1673,7 +1678,7 @@ URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Opt
                 auto query_percent_encode_set = url->is_special() ? PercentEncodeSet::SpecialQuery : PercentEncodeSet::Query;
 
                 // 2. Percent-encode after encoding, with encoding, buffer, and queryPercentEncodeSet, and append the result to url’s query.
-                url->m_data->query = percent_encode_after_encoding(buffer.string_view(), query_percent_encode_set).release_value_but_fixme_should_propagate_errors();
+                url->m_data->query = percent_encode_after_encoding(*encoder, buffer.string_view(), query_percent_encode_set).release_value_but_fixme_should_propagate_errors();
 
                 // 3. Set buffer to the empty string.
                 buffer.clear();
@@ -1715,7 +1720,7 @@ URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Opt
                 // NOTE: The percent-encode is done on EOF on the entire buffer.
                 buffer.append_code_point(code_point);
             } else {
-                url->m_data->fragment = percent_encode_after_encoding(buffer.string_view(), PercentEncodeSet::Fragment).release_value_but_fixme_should_propagate_errors();
+                url->m_data->fragment = percent_encode_after_encoding(*encoder, buffer.string_view(), PercentEncodeSet::Fragment).release_value_but_fixme_should_propagate_errors();
                 buffer.clear();
             }
             break;

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -762,31 +762,42 @@ ErrorOr<String> Parser::percent_encode_after_encoding(TextCodec::Encoder& encode
     // 1. Let encodeOutput be an empty I/O queue.
     StringBuilder output;
 
-    // 3. For each byte of encodeOutput converted to a byte sequence:
-    TRY(encoder.process(Utf8View(input), [&](u8 byte) -> ErrorOr<void> {
-        // 1. If spaceAsPlus is true and byte is 0x20 (SP), then append U+002B (+) to output and continue.
-        if (space_as_plus && byte == ' ') {
-            output.append('+');
+    // 2. Set potentialError to the result of running encode or fail with inputQueue, encoder, and encodeOutput.
+    TRY(encoder.process(
+        Utf8View(input),
+
+        // 3. For each byte of encodeOutput converted to a byte sequence:
+        [&](u8 byte) -> ErrorOr<void> {
+            // 1. If spaceAsPlus is true and byte is 0x20 (SP), then append U+002B (+) to output and continue.
+            if (space_as_plus && byte == ' ') {
+                output.append('+');
+                return {};
+            }
+
+            // 2. Let isomorph be a code point whose value is byte’s value.
+            u32 isomorph = byte;
+
+            // 3. Assert: percentEncodeSet includes all non-ASCII code points.
+
+            // 4. If isomorphic is not in percentEncodeSet, then append isomorph to output.
+            if (!code_point_is_in_percent_encode_set(isomorph, percent_encode_set)) {
+                output.append_code_point(isomorph);
+            }
+
+            // 5. Otherwise, percent-encode byte and append the result to output.
+            else {
+                output.appendff("%{:02X}", byte);
+            }
+
             return {};
-        }
+        },
 
-        // 2. Let isomorph be a code point whose value is byte’s value.
-        u32 isomorph = byte;
-
-        // 3. Assert: percentEncodeSet includes all non-ASCII code points.
-
-        // 4. If isomorphic is not in percentEncodeSet, then append isomorph to output.
-        if (!code_point_is_in_percent_encode_set(isomorph, percent_encode_set)) {
-            output.append_code_point(isomorph);
-        }
-
-        // 5. Otherwise, percent-encode byte and append the result to output.
-        else {
-            output.appendff("%{:02X}", byte);
-        }
-
-        return {};
-    }));
+        // 4. If potentialError is non-null, then append "%26%23", followed by the shortest sequence of ASCII digits
+        //    representing potentialError in base ten, followed by "%3B", to output.
+        [&](u32 error) -> ErrorOr<void> {
+            output.appendff("%26%23{}%3B", error);
+            return {};
+        }));
 
     // 6. Return output.
     return output.to_string();

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -793,8 +793,7 @@ ErrorOr<String> Parser::percent_encode_after_encoding(TextCodec::Encoder& encode
 }
 
 // https://url.spec.whatwg.org/#concept-basic-url-parser
-// NOTE: This parser assumes a UTF-8 encoding.
-URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Optional<URL> url, Optional<State> state_override)
+URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Optional<URL> url, Optional<State> state_override, Optional<StringView> encoding)
 {
     dbgln_if(URL_PARSER_DEBUG, "URL::Parser::parse: Parsing '{}'", raw_input);
     if (raw_input.is_empty())
@@ -844,7 +843,11 @@ URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Opt
     State state = state_override.value_or(State::SchemeStart);
 
     // 5. Set encoding to the result of getting an output encoding from encoding.
-    auto encoder = TextCodec::encoder_for("utf-8"sv);
+    Optional<TextCodec::Encoder&> encoder = {};
+    if (encoding.has_value())
+        encoder = TextCodec::encoder_for(TextCodec::get_output_encoding(*encoding));
+    if (!encoder.has_value())
+        encoder = TextCodec::encoder_for("utf-8"sv);
     VERIFY(encoder.has_value());
 
     // 6. Let buffer be the empty string.

--- a/Userland/Libraries/LibURL/Parser.h
+++ b/Userland/Libraries/LibURL/Parser.h
@@ -9,6 +9,7 @@
 
 #include <AK/Optional.h>
 #include <AK/StringView.h>
+#include <LibTextCodec/Encoder.h>
 #include <LibURL/URL.h>
 
 namespace URL {
@@ -60,7 +61,7 @@ public:
     static URL basic_parse(StringView input, Optional<URL> const& base_url = {}, Optional<URL> url = {}, Optional<State> state_override = {});
 
     // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
-    static ErrorOr<String> percent_encode_after_encoding(StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus = false);
+    static ErrorOr<String> percent_encode_after_encoding(TextCodec::Encoder&, StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus = false);
 
     // https://url.spec.whatwg.org/#concept-host-serializer
     static ErrorOr<String> serialize_host(Host const&);

--- a/Userland/Libraries/LibURL/Parser.h
+++ b/Userland/Libraries/LibURL/Parser.h
@@ -58,7 +58,7 @@ public:
     }
 
     // https://url.spec.whatwg.org/#concept-basic-url-parser
-    static URL basic_parse(StringView input, Optional<URL> const& base_url = {}, Optional<URL> url = {}, Optional<State> state_override = {});
+    static URL basic_parse(StringView input, Optional<URL> const& base_url = {}, Optional<URL> url = {}, Optional<State> state_override = {}, Optional<StringView> encoding = {});
 
     // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
     static ErrorOr<String> percent_encode_after_encoding(TextCodec::Encoder&, StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus = false);

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1034,7 +1034,7 @@ URL::URL Document::parse_url(StringView url) const
     auto base_url = this->base_url();
 
     // 2. Return the result of applying the URL parser to url, with baseURL.
-    return DOMURL::parse(url, base_url);
+    return DOMURL::parse(url, base_url, Optional<StringView> { m_encoding });
 }
 
 void Document::set_needs_layout()

--- a/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -585,12 +585,12 @@ void strip_trailing_spaces_from_an_opaque_path(DOMURL& url)
 }
 
 // https://url.spec.whatwg.org/#concept-url-parser
-URL::URL parse(StringView input, Optional<URL::URL> const& base_url)
+URL::URL parse(StringView input, Optional<URL::URL> const& base_url, Optional<StringView> encoding)
 {
     // FIXME: We should probably have an extended version of URL::URL for LibWeb instead of standalone functions like this.
 
     // 1. Let url be the result of running the basic URL parser on input with base and encoding.
-    auto url = URL::Parser::basic_parse(input, base_url);
+    auto url = URL::Parser::basic_parse(input, base_url, {}, {}, encoding);
 
     // 2. If url is failure, return failure.
     if (!url.is_valid())

--- a/Userland/Libraries/LibWeb/DOMURL/DOMURL.h
+++ b/Userland/Libraries/LibWeb/DOMURL/DOMURL.h
@@ -99,6 +99,6 @@ bool host_is_domain(URL::Host const&);
 void strip_trailing_spaces_from_an_opaque_path(DOMURL& url);
 
 // https://url.spec.whatwg.org/#concept-url-parser
-URL::URL parse(StringView input, Optional<URL::URL> const& base_url = {});
+URL::URL parse(StringView input, Optional<URL::URL> const& base_url = {}, Optional<StringView> encoding = {});
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -160,10 +160,6 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(JS::NonnullGCPtr<HTMLElem
 
     // 6. Let encoding be the result of picking an encoding for the form.
     auto encoding = TRY_OR_THROW_OOM(vm, pick_an_encoding());
-    if (encoding != "UTF-8"sv) {
-        dbgln("FIXME: Support encodings other than UTF-8 in form submission. Returning from form submission.");
-        return {};
-    }
 
     // 7. Let entry list be the result of constructing the entry list with form, submitter, and encoding.
     auto entry_list_or_null = TRY(construct_entry_list(realm, *this, submitter, encoding));


### PR DESCRIPTION
This pull request adresses the issue https://github.com/LadybirdBrowser/ladybird/issues/824

- [x] EUC-JP encoder
- [x] EUC-KR encoder
- [x] Big5 encoder
- [x] GBK encoder
- [x] GB18030 encoder
- [x] ISO-2022-JP encoder
- [x] SHIFT_JIS encoder
- [x] Tests

This passes most of the WPT encoding/legacy-mb-* tests, but it’s still not 100%.

It’s also pretty slow, doing a linear search of the lookup tables. It would be much better if we had some kind of sorted reverse lookup table, that we could then binary search. But I don't know if that's really necessary for the moment.