### PR TITLE
LibWeb: Implement HTMLTrackElement.readyState

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLTrackElement-readyState-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLTrackElement-readyState-attribute.txt
@@ -1,0 +1,1 @@
+track.readyState == NONE: true

--- a/Tests/LibWeb/Text/input/HTML/HTMLTrackElement-readyState-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLTrackElement-readyState-attribute.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const track = document.createElement('track');
+        println(`track.readyState == NONE: ${track.readyState === HTMLTrackElement.NONE}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -56,4 +56,30 @@ void HTMLTrackElement::attribute_changed(FlyString const& name, Optional<String>
     }
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#dom-track-readystate
+WebIDL::UnsignedShort HTMLTrackElement::ready_state()
+{
+    // The readyState attribute must return the numeric value corresponding to the text track readiness state of the track element's text track, as defined by the following list:
+    switch (m_track->readiness_state()) {
+    case TextTrack::ReadinessState::NotLoaded:
+        // NONE (numeric value 0)
+        //    The text track not loaded state.
+        return 0;
+    case TextTrack::ReadinessState::Loading:
+        // LOADING (numeric value 1)
+        //    The text track loading state.
+        return 1;
+    case TextTrack::ReadinessState::Loaded:
+        // LOADED (numeric value 2)
+        //    The text track loaded state.
+        return 2;
+    case TextTrack::ReadinessState::FailedToLoad:
+        // ERROR (numeric value 3)
+        //    The text track failed to load state.
+        return 3;
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.h
@@ -19,6 +19,8 @@ class HTMLTrackElement final : public HTMLElement {
 public:
     virtual ~HTMLTrackElement() override;
 
+    WebIDL::UnsignedShort ready_state();
+
     JS::Handle<TextTrack> track() { return m_track; }
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
@@ -26,7 +26,7 @@ interface HTMLTrackElement : HTMLElement {
     const unsigned short LOADING = 1;
     const unsigned short LOADED = 2;
     const unsigned short ERROR = 3;
-    [FIXME] readonly attribute unsigned short readyState;
+    readonly attribute unsigned short readyState;
 
     readonly attribute TextTrack track;
 


### PR DESCRIPTION
Follow-up to https://github.com/LadybirdBrowser/ladybird/commit/ff08c2f735e938c8280089eca690fd5e65d017c1, as I realised I missed it :)