### PR TITLE
LibHTTP: Don't double percent encode path in HTTPRequst::to_raw_request

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -49,10 +49,9 @@ ErrorOr<ByteBuffer> HttpRequest::to_raw_request() const
     StringBuilder builder;
     TRY(builder.try_append(method_name()));
     TRY(builder.try_append(' '));
-    // NOTE: The percent_encode is so that e.g. spaces are properly encoded.
     auto path = m_url.serialize_path();
     VERIFY(!path.is_empty());
-    TRY(builder.try_append(URL::percent_encode(path, URL::PercentEncodeSet::EncodeURI)));
+    TRY(builder.try_append(path));
     if (m_url.query().has_value()) {
         TRY(builder.try_append('?'));
         TRY(builder.try_append(*m_url.query()));


### PR DESCRIPTION
This was a goof in cc557323326ba55514ef2a8a6e0efd7f09330f06 which resulted in the URL path getting double percent encoded. Since the path already comes out percent encoded following the rules in the URL spec - we don't need to percent encode again.

Fixes: #978