### PR TITLE
AK: Conform SimpleIterator to std requirements, interop test

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -149,7 +149,8 @@ jobs:
       - name: Enable the AppKit chrome with Swift files
         if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}
-        run: cmake -B Build -DENABLE_QT=OFF -DENABLE_SWIFT=ON
+        # FIXME: Don't force release build after https://github.com/LadybirdBrowser/ladybird/issues/1101 is fixed
+        run: cmake -B Build -DENABLE_QT=OFF -DENABLE_SWIFT=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build the AppKit chrome with Swift files
         if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -58,6 +58,7 @@ else()
 endif()
 
 find_package(simdutf REQUIRED)
+swizzle_target_properties_for_swift(simdutf::simdutf)
 target_link_libraries(AK PRIVATE simdutf::simdutf)
 
 if (ENABLE_SWIFT)

--- a/Meta/CMake/Swift/swift-settings.cmake
+++ b/Meta/CMake/Swift/swift-settings.cmake
@@ -22,3 +22,16 @@ add_compile_options("SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -std=c++23 -cxx-inte
 if (APPLE)
     set(CMAKE_Swift_COMPILER_TARGET "${CMAKE_SYSTEM_PROCESSOR}-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}")
 endif()
+
+# FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/26195
+# For now, we'll just manually massage the flags.
+function(swizzle_target_properties_for_swift target_name)
+    get_property(compile_options TARGET ${target_name} PROPERTY INTERFACE_COMPILE_OPTIONS)
+    set(munged_properties "")
+    foreach(property IN LISTS compile_options)
+        set(cxx_property "$<$<COMPILE_LANGUAGE:C,CXX,ASM>:${property}>")
+        set(swift_property "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc ${property}>")
+        list(APPEND munged_properties "${cxx_property}" "${swift_property}")
+    endforeach()
+    set_property(TARGET ${target_name} PROPERTY INTERFACE_COMPILE_OPTIONS ${munged_properties})
+endfunction()

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -252,3 +252,8 @@ function(add_lagom_library_install_rules target_name)
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
     )
 endfunction()
+
+if (NOT COMMAND swizzle_target_properties_for_swift)
+    function(swizzle_target_properties_for_swift target)
+    endfunction()
+endif()

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -91,3 +91,10 @@ foreach(source IN LISTS AK_TEST_SOURCES)
 endforeach()
 
 target_link_libraries(TestString PRIVATE LibUnicode)
+
+if (ENABLE_SWIFT)
+    add_executable(TestAKBindings TestAKBindings.swift)
+    target_link_libraries(TestAKBindings PRIVATE AK)
+    target_compile_options(TestAKBindings PRIVATE -parse-as-library)
+    add_test(NAME TestAKBindings COMMAND TestAKBindings)
+endif()

--- a/Tests/AK/TestAKBindings.swift
+++ b/Tests/AK/TestAKBindings.swift
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import AK
+import Foundation
+
+protocol ConformanceMarker {}
+enum CxxSequenceMarker<T: ~Copyable> {}
+extension CxxSequenceMarker: ConformanceMarker where T: CxxSequence {}
+private func isCxxSequenceType<T: ~Copyable>(_ type: borrowing T.Type) -> Bool {
+    return CxxSequenceMarker<T>.self is ConformanceMarker.Type
+}
+
+class StandardError: TextOutputStream {
+    func write(_ string: Swift.String) {
+        try! FileHandle.standardError.write(contentsOf: Data(string.utf8))
+    }
+}
+
+@main
+struct TestAKBindings {
+    static func testSequenceTypesAreBound() {
+        var standardError = StandardError()
+        print("Testing CxxSequence types...", to: &standardError)
+
+        precondition(isCxxSequenceType(AK.StringView.self))
+        precondition(isCxxSequenceType(AK.Bytes.self))
+        precondition(isCxxSequenceType(AK.ReadonlyBytes.self))
+        precondition(isCxxSequenceType(AK.Utf16Data.self))
+
+        precondition(!isCxxSequenceType(AK.Utf16View.self))
+        precondition(!isCxxSequenceType(AK.String.self))
+
+        precondition(!isCxxSequenceType(AK.Error.self))
+
+        print("CxxSequence types pass", to: &standardError)
+    }
+
+    static func main() {
+        var standardError = StandardError()
+        print("Starting test suite...", to: &standardError)
+        testSequenceTypesAreBound()
+
+        print("All tests pass", to: &standardError)
+    }
+}

--- a/Tests/AK/TestArray.cpp
+++ b/Tests/AK/TestArray.cpp
@@ -23,6 +23,12 @@ TEST_CASE(compile_time_constructible)
     static_assert(array.size() == 4);
 }
 
+TEST_CASE(conforms_to_iterator_protocol)
+{
+    static_assert(std::random_access_iterator<Array<int, 8>::Iterator>);
+    static_assert(std::random_access_iterator<Array<int, 8>::ConstIterator>);
+}
+
 TEST_CASE(compile_time_iterable)
 {
     constexpr Array<int, 8> array = { 0, 1, 2, 3, 4, 5, 6, 7 };

--- a/Tests/AK/TestFixedArray.cpp
+++ b/Tests/AK/TestFixedArray.cpp
@@ -27,6 +27,14 @@ TEST_CASE(ints)
     EXPECT_EQ(ints[2], 2);
 }
 
+TEST_CASE(conforms_to_iterator_procotol)
+{
+    static_assert(std::random_access_iterator<FixedArray<int>::Iterator>);
+    static_assert(std::random_access_iterator<FixedArray<int>::ConstIterator>);
+    static_assert(std::random_access_iterator<FixedArray<int const>::Iterator>);
+    static_assert(std::random_access_iterator<FixedArray<int const>::ConstIterator>);
+}
+
 TEST_CASE(swap)
 {
     FixedArray<int> first = FixedArray<int>::must_create_but_fixme_should_propagate_errors(4);

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -16,6 +16,19 @@ TEST_CASE(constexpr_default_constructor_is_empty)
     static_assert(span.is_empty(), "Default constructed span should be empty.");
 }
 
+TEST_CASE(conforms_to_iterator_protocol)
+{
+    static_assert(std::random_access_iterator<Span<int>::Iterator>);
+    static_assert(std::random_access_iterator<Span<int>::ConstIterator>);
+    static_assert(std::random_access_iterator<Span<int const>::Iterator>);
+    static_assert(std::random_access_iterator<Span<int const>::ConstIterator>);
+
+    static_assert(std::random_access_iterator<Bytes::Iterator>);
+    static_assert(std::random_access_iterator<Bytes::ConstIterator>);
+    static_assert(std::random_access_iterator<ReadonlyBytes::Iterator>);
+    static_assert(std::random_access_iterator<ReadonlyBytes::ConstIterator>);
+}
+
 TEST_CASE(implicit_conversion_to_const)
 {
     constexpr Bytes bytes0;

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -40,6 +40,11 @@ TEST_CASE(compare_views)
     EXPECT_EQ(view1, "foo");
 }
 
+TEST_CASE(conforms_to_iterator_protocol)
+{
+    static_assert(std::random_access_iterator<StringView::ConstIterator>);
+}
+
 TEST_CASE(string_view_literal_operator)
 {
     StringView literal_view = "foo"sv;

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -56,6 +56,19 @@ TEST_CASE(strings)
     EXPECT_EQ(loop_counter, 2);
 }
 
+TEST_CASE(conforms_to_iterator_protocol)
+{
+    static_assert(std::random_access_iterator<Vector<int>::Iterator>);
+    static_assert(std::random_access_iterator<Vector<int>::ConstIterator>);
+    static_assert(std::random_access_iterator<Vector<int const>::Iterator>);
+    static_assert(std::random_access_iterator<Vector<int const>::ConstIterator>);
+
+    static_assert(std::random_access_iterator<Vector<String>::Iterator>);
+    static_assert(std::random_access_iterator<Vector<String>::ConstIterator>);
+    static_assert(std::random_access_iterator<Vector<String const>::Iterator>);
+    static_assert(std::random_access_iterator<Vector<String const>::ConstIterator>);
+}
+
 TEST_CASE(strings_insert_ordered)
 {
     Vector<ByteString> strings;


### PR DESCRIPTION
Conform SimpleIterator to the random access iterator requirements by pulling in some of the STL. The result is that our iterator is now STL Approved ™️ and our containers can be auto-conformed to Swift protocols.

Also Add a test that swift interop properties are present for containers