### PR TITLE
LibWeb: Use padding box to get background rect for inline paintable

### DIFF
--- a/Tests/LibWeb/Ref/inline-block-with-css-background.html
+++ b/Tests/LibWeb/Ref/inline-block-with-css-background.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/inline-block-with-css-background-ref.html" />
+<style type="text/css">
+    body {
+        margin: 0;
+    }
+    .box {
+        margin-top: 8px;
+        width: 200px;
+    }
+    .box span {
+        background: rgb(138, 100, 229);
+        border: 3px solid orange;
+        font-size: 16px;
+        color: rgb(255, 255, 255);
+        padding: 5px 13px;
+    }
+</style>
+<div class="box"><span>Text</span></div>

--- a/Tests/LibWeb/Ref/reference/inline-block-with-css-background-ref.html
+++ b/Tests/LibWeb/Ref/reference/inline-block-with-css-background-ref.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style type="text/css">
+    body {
+        margin: 0;
+    }
+    .box {
+        width: 200px;
+    }
+    .box span {
+        background: rgb(138, 100, 229);
+        border: 3px solid orange;
+        font-size: 16px;
+        color: rgb(255, 255, 255);
+        padding: 5px 13px;
+        display: block;
+        width: fit-content;
+    }
+</style>
+<div class="box"><span>Text</span></div>

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -278,6 +278,9 @@ void InlinePaintable::resolve_paint_properties()
             bottom_left_border_radius);
         fragment.set_border_radii_data(border_radii_data);
 
+        absolute_fragment_rect.translate_by(0, -box_model().padding.top);
+        absolute_fragment_rect.set_height(absolute_fragment_rect.height() + box_model().padding.top + box_model().padding.bottom);
+
         auto resolved_background = resolve_background_layers(computed_values.background_layers(), layout_node, computed_values.background_color(), absolute_fragment_rect, border_radii_data);
         fragment.set_resolved_background(move(resolved_background));
     }


### PR DESCRIPTION
Fixes regression introduced by f574e2b03ab3c9c55a74a86435efeab179a4caa9