### PR TITLE
Implement getComputedStyle() for pseudo-elements

### DIFF
--- a/Base/res/html/misc/pseudo-elements.html
+++ b/Base/res/html/misc/pseudo-elements.html
@@ -71,8 +71,9 @@
         <li>Markers</li>
     </ul>
 
-    <h2>FIXME: These do not work yet</h2>
     <p class="quote">This should have chonky quotation marks.</p>
+
+    <h2>FIXME: These do not work yet</h2>
     <p>
         This is some text. Each <a href="#" class="heart">link</a> should have a little <a href="#" class="page">icon</a> before it, <a href="#" class="face">and this one has a tooltip too.</a>
     </p>

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-pseudo-element.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-pseudo-element.txt
@@ -1,0 +1,6 @@
+hi  #foo:
+  color: rgb(128, 128, 128)
+  background-color: rgb(255, 255, 0)
+#foo::before:
+  color: rgb(128, 128, 128)
+  background-color: rgb(0, 255, 255)

--- a/Tests/LibWeb/Text/input/css/getComputedStyle-pseudo-element.html
+++ b/Tests/LibWeb/Text/input/css/getComputedStyle-pseudo-element.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #foo {
+        color: grey;
+        background-color: yellow;
+    }
+    #foo::before {
+        content: "hi";
+        background-color: cyan;
+    }
+</style>
+<div id="foo"></div>
+<script>
+    test(() => {
+        const foo = document.getElementById("foo");
+        const style = getComputedStyle(foo);
+        const beforeStyle = getComputedStyle(foo, "::before");
+        const propertyValues = [
+            "color",
+            "background-color",
+        ];
+        println("#foo:");
+        for (const property of propertyValues) {
+            println(`  ${property}: ${style.getPropertyValue(property)}`);
+        }
+        println("#foo::before:");
+        for (const property of propertyValues) {
+            println(`  ${property}: ${beforeStyle.getPropertyValue(property)}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2023, the SerenityOS developers.
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  *
@@ -47,6 +47,11 @@ CSS::CSSRule* parse_css_rule(CSS::Parser::ParsingContext const& context, StringV
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingContext const& context, StringView selector_text)
 {
     return CSS::Parser::Parser::create(context, selector_text).parse_as_selector();
+}
+
+Optional<CSS::Selector::PseudoElement> parse_pseudo_element_selector(CSS::Parser::ParsingContext const& context, StringView selector_text)
+{
+    return CSS::Parser::Parser::create(context, selector_text).parse_as_pseudo_element_selector();
 }
 
 RefPtr<CSS::MediaQuery> parse_media_query(CSS::Parser::ParsingContext const& context, StringView string)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -60,6 +60,8 @@ public:
     Optional<SelectorList> parse_as_selector(SelectorParsingMode = SelectorParsingMode::Standard);
     Optional<SelectorList> parse_as_relative_selector(SelectorParsingMode = SelectorParsingMode::Standard);
 
+    Optional<Selector::PseudoElement> parse_as_pseudo_element_selector();
+
     Vector<NonnullRefPtr<MediaQuery>> parse_as_media_query_list();
     RefPtr<MediaQuery> parse_as_media_query();
 
@@ -412,6 +414,7 @@ CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const&, Str
 CSS::ElementInlineCSSStyleDeclaration* parse_css_style_attribute(CSS::Parser::ParsingContext const&, StringView, DOM::Element&);
 RefPtr<CSS::StyleValue> parse_css_value(CSS::Parser::ParsingContext const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
 Optional<CSS::SelectorList> parse_selector(CSS::Parser::ParsingContext const&, StringView);
+Optional<CSS::Selector::PseudoElement> parse_pseudo_element_selector(CSS::Parser::ParsingContext const&, StringView);
 CSS::CSSRule* parse_css_rule(CSS::Parser::ParsingContext const&, StringView);
 RefPtr<CSS::MediaQuery> parse_media_query(CSS::Parser::ParsingContext const&, StringView);
 Vector<NonnullRefPtr<CSS::MediaQuery>> parse_media_query_list(CSS::Parser::ParsingContext const&, StringView);

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -32,6 +32,34 @@ Optional<SelectorList> Parser::parse_as_relative_selector(SelectorParsingMode pa
     return {};
 }
 
+Optional<Selector::PseudoElement> Parser::parse_as_pseudo_element_selector()
+{
+    // FIXME: This is quite janky. Selector parsing is not at all designed to allow parsing just a single part of a selector.
+    //        So, this code parses a whole selector, then rejects it if it's not a single pseudo-element simple selector.
+    //        Come back and fix this, future Sam!
+    auto maybe_selector_list = parse_a_selector_list(m_token_stream, SelectorType::Standalone, SelectorParsingMode::Standard);
+    if (maybe_selector_list.is_error())
+        return {};
+    auto& selector_list = maybe_selector_list.value();
+
+    if (selector_list.size() != 1)
+        return {};
+    auto& selector = selector_list.first();
+
+    if (selector->compound_selectors().size() != 1)
+        return {};
+    auto& first_compound_selector = selector->compound_selectors().first();
+
+    if (first_compound_selector.simple_selectors.size() != 1)
+        return {};
+    auto& simple_selector = first_compound_selector.simple_selectors.first();
+
+    if (simple_selector.type != Selector::SimpleSelector::Type::PseudoElement)
+        return {};
+
+    return simple_selector.pseudo_element();
+}
+
 template<typename T>
 Parser::ParseErrorOr<SelectorList> Parser::parse_a_selector_list(TokenStream<T>& tokens, SelectorType mode, SelectorParsingMode parsing_mode)
 {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
+#include <LibWeb/CSS/Selector.h>
 
 namespace Web::CSS {
 
@@ -15,7 +16,7 @@ class ResolvedCSSStyleDeclaration final : public CSSStyleDeclaration {
     JS_DECLARE_ALLOCATOR(ResolvedCSSStyleDeclaration);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<ResolvedCSSStyleDeclaration> create(DOM::Element&);
+    [[nodiscard]] static JS::NonnullGCPtr<ResolvedCSSStyleDeclaration> create(DOM::Element&, Optional<Selector::PseudoElement::Type> = {});
 
     virtual ~ResolvedCSSStyleDeclaration() override = default;
 
@@ -32,13 +33,14 @@ public:
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
 private:
-    explicit ResolvedCSSStyleDeclaration(DOM::Element&);
+    explicit ResolvedCSSStyleDeclaration(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
     RefPtr<StyleValue const> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;
 
     JS::NonnullGCPtr<DOM::Element> m_element;
+    Optional<CSS::Selector::PseudoElement::Type> m_pseudo_element;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1141,6 +1141,17 @@ JS::GCPtr<Layout::NodeWithStyle> Element::get_pseudo_element_node(CSS::Selector:
     return nullptr;
 }
 
+bool Element::has_pseudo_elements() const
+{
+    if (m_pseudo_element_data) {
+        for (auto& pseudo_element : *m_pseudo_element_data) {
+            if (pseudo_element.layout_node)
+                return true;
+        }
+    }
+    return false;
+}
+
 void Element::clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>)
 {
     if (m_pseudo_element_data) {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -607,9 +607,9 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
     return invalidation;
 }
 
-NonnullRefPtr<CSS::StyleProperties> Element::resolved_css_values()
+NonnullRefPtr<CSS::StyleProperties> Element::resolved_css_values(Optional<CSS::Selector::PseudoElement::Type> type)
 {
-    auto element_computed_style = CSS::ResolvedCSSStyleDeclaration::create(*this);
+    auto element_computed_style = CSS::ResolvedCSSStyleDeclaration::create(*this, type);
     auto properties = CSS::StyleProperties::create();
 
     for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -395,7 +395,7 @@ JS::GCPtr<Layout::Node> Element::create_layout_node(NonnullRefPtr<CSS::StyleProp
     return create_layout_node_for_display_type(document(), display, move(style), this);
 }
 
-JS::GCPtr<Layout::Node> Element::create_layout_node_for_display_type(DOM::Document& document, CSS::Display const& display, NonnullRefPtr<CSS::StyleProperties> style, Element* element)
+JS::GCPtr<Layout::NodeWithStyle> Element::create_layout_node_for_display_type(DOM::Document& document, CSS::Display const& display, NonnullRefPtr<CSS::StyleProperties> style, Element* element)
 {
     if (display.is_table_inside() || display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group() || display.is_table_row())
         return document.heap().allocate_without_realm<Layout::Box>(document, element, move(style));
@@ -1125,7 +1125,7 @@ void Element::children_changed()
     set_needs_style_update(true);
 }
 
-void Element::set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type pseudo_element, JS::GCPtr<Layout::Node> pseudo_element_node)
+void Element::set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type pseudo_element, JS::GCPtr<Layout::NodeWithStyle> pseudo_element_node)
 {
     auto existing_pseudo_element = get_pseudo_element(pseudo_element);
     if (!existing_pseudo_element.has_value() && !pseudo_element_node)
@@ -1134,7 +1134,7 @@ void Element::set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector:
     ensure_pseudo_element(pseudo_element).layout_node = move(pseudo_element_node);
 }
 
-JS::GCPtr<Layout::Node> Element::get_pseudo_element_node(CSS::Selector::PseudoElement::Type pseudo_element) const
+JS::GCPtr<Layout::NodeWithStyle> Element::get_pseudo_element_node(CSS::Selector::PseudoElement::Type pseudo_element) const
 {
     if (auto element_data = get_pseudo_element(pseudo_element); element_data.has_value())
         return element_data->layout_node;

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -245,6 +245,7 @@ public:
 
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, JS::GCPtr<Layout::NodeWithStyle>);
     JS::GCPtr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
+    bool has_pseudo_elements() const;
     void clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>);
     void serialize_pseudo_elements_as_json(JsonArraySerializer<StringBuilder>& children_array) const;
 

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -186,7 +186,7 @@ public:
     CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
     CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }
     void set_computed_css_values(RefPtr<CSS::StyleProperties>);
-    NonnullRefPtr<CSS::StyleProperties> resolved_css_values();
+    NonnullRefPtr<CSS::StyleProperties> resolved_css_values(Optional<CSS::Selector::PseudoElement::Type> = {});
 
     void set_pseudo_element_computed_css_values(CSS::Selector::PseudoElement::Type, RefPtr<CSS::StyleProperties>);
     RefPtr<CSS::StyleProperties> pseudo_element_computed_css_values(CSS::Selector::PseudoElement::Type);

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -241,10 +241,10 @@ public:
     virtual void did_receive_focus() { }
     virtual void did_lose_focus() { }
 
-    static JS::GCPtr<Layout::Node> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, NonnullRefPtr<CSS::StyleProperties>, Element*);
+    static JS::GCPtr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, NonnullRefPtr<CSS::StyleProperties>, Element*);
 
-    void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, JS::GCPtr<Layout::Node>);
-    JS::GCPtr<Layout::Node> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
+    void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, JS::GCPtr<Layout::NodeWithStyle>);
+    JS::GCPtr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
     void clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>);
     void serialize_pseudo_elements_as_json(JsonArraySerializer<StringBuilder>& children_array) const;
 
@@ -453,7 +453,7 @@ private:
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
 
     struct PseudoElement {
-        JS::GCPtr<Layout::Node> layout_node;
+        JS::GCPtr<Layout::NodeWithStyle> layout_node;
         RefPtr<CSS::StyleProperties> computed_css_values;
         HashMap<FlyString, CSS::StyleProperty> custom_properties;
     };

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1362,7 +1362,10 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
 
     MUST((object.add("visible"sv, !!layout_node())));
 
-    if (has_child_nodes() || (is_element() && static_cast<DOM::Element const*>(this)->is_shadow_host())) {
+    auto const* element = is_element() ? static_cast<DOM::Element const*>(this) : nullptr;
+
+    if (has_child_nodes()
+        || (element && (element->is_shadow_host() || element->has_pseudo_elements()))) {
         auto children = MUST(object.add_array("children"sv));
         auto add_child = [&children](DOM::Node const& child) {
             if (child.is_uninteresting_whitespace_node())
@@ -1374,9 +1377,7 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
         };
         for_each_child(add_child);
 
-        if (is_element()) {
-            auto const* element = static_cast<DOM::Element const*>(this);
-
+        if (element) {
             // Pseudo-elements don't have DOM nodes,so we have to add them separately.
             element->serialize_pseudo_elements_as_json(children);
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1136,9 +1136,51 @@ Variant<JS::Handle<DOM::Event>, JS::Value> Window::event() const
 // https://w3c.github.io/csswg-drafts/cssom/#dom-window-getcomputedstyle
 JS::NonnullGCPtr<CSS::CSSStyleDeclaration> Window::get_computed_style(DOM::Element& element, Optional<String> const& pseudo_element) const
 {
-    // FIXME: Make this fully spec compliant.
-    (void)pseudo_element;
-    return heap().allocate<CSS::ResolvedCSSStyleDeclaration>(realm(), element);
+    // 1. Let doc be elt’s node document.
+
+    // 2. Let obj be elt.
+    Optional<CSS::Selector::PseudoElement::Type> obj_pseudo;
+
+    // 3. If pseudoElt is provided, is not the empty string, and starts with a colon, then:
+    if (pseudo_element.has_value() && pseudo_element.value().starts_with(':')) {
+        // 1. Parse pseudoElt as a <pseudo-element-selector>, and let type be the result.
+        auto type = parse_pseudo_element_selector(CSS::Parser::ParsingContext(associated_document()), pseudo_element.value());
+
+        // 2. If type is failure, or is an ::slotted() or ::part() pseudo-element, let obj be null.
+        // FIXME: We can't pass a null element to ResolvedCSSStyleDeclaration
+        if (!type.has_value()) {
+        }
+        // 3. Otherwise let obj be the given pseudo-element of elt.
+        else {
+            // TODO: Keep the function arguments of the pseudo-element if there are any.
+            obj_pseudo = type.value().type();
+        }
+    }
+
+    // AD-HOC: Just return a ResolvedCSSStyleDeclaration because that's what we have for now.
+    // FIXME: Implement CSSStyleProperties, and then follow the rest of these steps instead.
+    return heap().allocate<CSS::ResolvedCSSStyleDeclaration>(realm(), element, obj_pseudo);
+
+    // 4. Let decls be an empty list of CSS declarations.
+
+    // 5. If obj is not null, and elt is connected, part of the flat tree, and its shadow-including root
+    //    has a browsing context which either doesn’t have a browsing context container, or whose browsing
+    //    context container is being rendered, set decls to a list of all longhand properties that are
+    //    supported CSS properties, in lexicographical order, with the value being the resolved value
+    //    computed for obj using the style rules associated with doc. Additionally, append to decls all
+    //    the custom properties whose computed value for obj is not the guaranteed-invalid value.
+
+    // 6. Return a live CSSStyleProperties object with the following properties:
+    //    computed flag
+    //        Set.
+    //    readonly flag
+    //        Set.
+    //    declarations
+    //        decls.
+    //    parent CSS rule
+    //        Null.
+    //    owner node
+    //        obj.
 }
 
 // https://w3c.github.io/csswg-drafts/cssom-view/#dom-window-matchmedia

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -553,12 +553,9 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, i32 node_id, Optional<W
                 return;
             }
 
-            // FIXME: Pseudo-elements only exist as Layout::Nodes, which don't have style information
-            //        in a format we can use. So, we run the StyleComputer again to get the specified
-            //        values, and have to ignore the computed values and custom properties.
-            auto pseudo_element_style = page->page().focused_navigable().active_document()->style_computer().compute_style(element, pseudo_element);
-            ByteString computed_values = serialize_json(pseudo_element_style);
-            ByteString resolved_values = "{}";
+            auto pseudo_element_style = element.pseudo_element_computed_css_values(pseudo_element.value());
+            ByteString computed_values = serialize_json(*pseudo_element_style);
+            ByteString resolved_values = serialize_json(*element.resolved_css_values(pseudo_element.value()));
             ByteString custom_properties_json = serialize_custom_properties_json(element, pseudo_element);
             ByteString node_box_sizing_json = serialize_node_box_sizing_json(pseudo_element_node.ptr());
 


### PR DESCRIPTION
At some point `getComputedStyle()` gained a second parameter for the name of a pseudo-element to get style for. We previously ignored that completely, but now we don't! :tada:

As a side feature, the resolved style now also shows up in the inspector.

As a side-side feature, I fixed a bug where the inspector wouldn't show pseudo-elements at all if their parent had no other children.

Several parts of this are hacky and temporary, just because I didn't want to get too sidetracked. :sweat_smile: Our `CSSStyleDeclaration` classes need some reworking to match the spec.

## WPT Progress:

I'm bad at figuring out what WPT is doing, but this test in particular got some points:

`css/cssom/getComputedStyle-pseudo.html`
Before: 2 Pass. 15 Fail. 9 Optional Feature Unsupported
After: 12 Pass. 5 Fail. 9 Optional Feature Unsupported

The failures seem to all be related to fixmes now.