### PR TITLE
LibWeb: Skip AddMask in display list player if destination rect is empty

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -353,6 +353,8 @@ struct AddMask {
     RefPtr<DisplayList> display_list;
     Gfx::IntRect rect;
 
+    [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
+
     void translate_by(Gfx::IntPoint const& offset)
     {
         rect.translate_by(offset);

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1280,6 +1280,9 @@ void DisplayListPlayerSkia::add_rounded_rect_clip(AddRoundedRectClip const& comm
 void DisplayListPlayerSkia::add_mask(AddMask const& command)
 {
     auto const& rect = command.rect;
+    if (rect.is_empty())
+        return;
+
     auto mask_surface = m_surface->make_surface(rect.width(), rect.height());
 
     auto previous_surface = move(m_surface);


### PR DESCRIPTION
once I decided https://github.com/LadybirdBrowser/ladybird/pull/988 is good to go I almost immediately found two little issues.