### PR TITLE
LibWeb: Implement HTMLTableCellElement.cellIndex

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLTableCellElement-cellIndex-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLTableCellElement-cellIndex-attribute.txt
@@ -1,0 +1,4 @@
+lone td.cellIndex = -1
+parented td.cellIndex = 0
+lone th.cellIndex = -1
+parented th.cellIndex = 0

--- a/Tests/LibWeb/Text/input/HTML/HTMLTableCellElement-cellIndex-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLTableCellElement-cellIndex-attribute.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const testElements = ["td", "th"];
+
+        for (const elementName of testElements) {
+            // Test a <td> / <th> element with no parent.
+            {
+                const element = document.createElement(elementName);
+                println(`lone ${elementName}.cellIndex = ${element.cellIndex}`);
+            }
+
+            // Test a <td> / <th> element with a parent <tr> element>.
+            {
+                const tr = document.createElement("tr");
+                const element = tr.appendChild(document.createElement(elementName));
+                println(`parented ${elementName}.cellIndex = ${element.cellIndex}`);
+            }
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,6 +14,7 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>
 #include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/Numbers.h>
@@ -148,6 +150,24 @@ unsigned int HTMLTableCellElement::row_span() const
 WebIDL::ExceptionOr<void> HTMLTableCellElement::set_row_span(unsigned int value)
 {
     return set_attribute(HTML::AttributeNames::rowspan, MUST(String::number(value)));
+}
+
+// https://html.spec.whatwg.org/multipage/tables.html#dom-tdth-cellindex
+WebIDL::Long HTMLTableCellElement::cell_index() const
+{
+    // The cellIndex IDL attribute must, if the element has a parent tr element, return the index of the cell's
+    // element in the parent element's cells collection. If there is no such parent element, then the attribute
+    // must return −1.
+    auto const* parent = first_ancestor_of_type<HTMLTableRowElement>();
+    if (!parent)
+        return -1;
+
+    auto rows = parent->cells()->collect_matching_elements();
+    for (size_t i = 0; i < rows.size(); ++i) {
+        if (rows[i] == this)
+            return i;
+    }
+    return -1;
 }
 
 Optional<ARIA::Role> HTMLTableCellElement::default_role() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
@@ -22,6 +23,8 @@ public:
 
     WebIDL::ExceptionOr<void> set_col_span(unsigned);
     WebIDL::ExceptionOr<void> set_row_span(unsigned);
+
+    WebIDL::Long cell_index() const;
 
     virtual Optional<ARIA::Role> default_role() const override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.idl
@@ -9,7 +9,7 @@ interface HTMLTableCellElement : HTMLElement {
     [CEReactions] attribute unsigned long colSpan;
     [CEReactions] attribute unsigned long rowSpan;
     [CEReactions, Reflect] attribute DOMString headers;
-    [FIXME] readonly attribute long cellIndex;
+    readonly attribute long cellIndex;
 
     [FIXME, CEReactions] attribute DOMString scope; // only conforming for th elements
     [CEReactions, Reflect] attribute DOMString abbr;  // only conforming for th elements


### PR DESCRIPTION
See:
 - http://wpt.live/html/semantics/tabular-data/attributes-common-to-td-and-th-elements/cellIndex.html