### PR TITLE
AK+LibGfx: Only generate clang module map if ENABLE_SWIFT

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -60,9 +60,11 @@ endif()
 find_package(simdutf REQUIRED)
 target_link_libraries(AK PRIVATE simdutf::simdutf)
 
-generate_clang_module_map(
-   AK
-   GENERATED_FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/Backtrace.h"
-    "${CMAKE_CURRENT_BINARY_DIR}/Debug.h"
-)
+if (ENABLE_SWIFT)
+    generate_clang_module_map(
+       AK
+       GENERATED_FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/Backtrace.h"
+        "${CMAKE_CURRENT_BINARY_DIR}/Debug.h"
+    )
+endif()

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -91,7 +91,6 @@ add_dependencies(LibGfx generate_tiff_files_handler)
 set(generated_headers ${generated_sources})
 list(FILTER generated_headers INCLUDE REGEX "\\.h$")
 list(TRANSFORM generated_headers PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
-generate_clang_module_map(LibGfx GENERATED_FILES ${generated_headers})
 
 if (ENABLE_INSTALL_HEADERS)
     list(TRANSFORM generated_sources PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
@@ -112,6 +111,8 @@ target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PkgConfig::Jxl 
             WebP::webpdemux WebP::libwebpmux)
 
 if (ENABLE_SWIFT)
+    generate_clang_module_map(LibGfx GENERATED_FILES ${generated_headers})
+
     target_compile_features(LibGfx PUBLIC cxx_std_23)
 
     target_sources(LibGfx PRIVATE


### PR DESCRIPTION
The script pulls in a dependency on the `yaml` python package. Instead of updating all the docs and CI jobs to account for this, let's guard calling the script behind our experimental flag instead.