### PR TITLE
LibWeb: Adjust stacking context position by scroll offset in hit-testing

### DIFF
--- a/Tests/LibWeb/Text/expected/hit_testing/stacking-context-inside-scrollable-box.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/stacking-context-inside-scrollable-box.txt
@@ -1,0 +1,1 @@
+  Establishes a stacking context.     <DIV id="scroll-space-filler" >

--- a/Tests/LibWeb/Text/input/hit_testing/stacking-context-inside-scrollable-box.html
+++ b/Tests/LibWeb/Text/input/hit_testing/stacking-context-inside-scrollable-box.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+  #scrollable-box {
+    width: 300px;
+    height: 300px;
+    border: 1px solid #000;
+    overflow: auto;
+    padding: 10px;
+  }
+  #inner-box {
+    width: 100px;
+    height: 100px;
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    position: relative;
+    z-index: 1;
+  }
+</style>
+<div id="scrollable-box">
+  <section id="inner-box">
+    <p>Establishes a stacking context.</p>
+  </section>
+  <div id="scroll-space-filler" style="height: 500px"></div>
+</div>
+<script>
+    const scrollbox = document.getElementById("scrollable-box");
+    scrollbox.scrollTop = 200;
+    test(() => {
+        printElement(internals.hitTest(50, 50).node);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -165,10 +165,10 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
     CSSPixelPoint enclosing_scroll_offset;
     if (is<PaintableBox>(layout_node.paintable())) {
         auto const& paintable_box = static_cast<PaintableBox const&>(*layout_node.paintable());
-        enclosing_scroll_offset = paintable_box.enclosing_scroll_frame_offset().value_or({});
+        enclosing_scroll_offset = paintable_box.enclosing_scroll_frame_offset();
     } else if (is<InlinePaintable>(layout_node.paintable())) {
         auto const& inline_paintable = static_cast<InlinePaintable const&>(*layout_node.paintable());
-        enclosing_scroll_offset = inline_paintable.enclosing_scroll_frame_offset().value_or({});
+        enclosing_scroll_offset = inline_paintable.enclosing_scroll_frame_offset();
     }
 
     // Note: Background layers are ordered front-to-back, so we paint them in reverse

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -15,7 +15,7 @@ Optional<int> ClippableAndScrollable::scroll_frame_id() const
     return {};
 }
 
-Optional<CSSPixelPoint> ClippableAndScrollable::enclosing_scroll_frame_offset() const
+CSSPixelPoint ClippableAndScrollable::enclosing_scroll_frame_offset() const
 {
     if (m_enclosing_scroll_frame)
         return m_enclosing_scroll_frame->offset;

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -23,7 +23,7 @@ public:
     void set_enclosing_clip_frame(RefPtr<ClipFrame> clip_frame) { m_enclosing_clip_frame = clip_frame; }
 
     [[nodiscard]] Optional<int> scroll_frame_id() const;
-    [[nodiscard]] Optional<CSSPixelPoint> enclosing_scroll_frame_offset() const;
+    [[nodiscard]] CSSPixelPoint enclosing_scroll_frame_offset() const;
     [[nodiscard]] Optional<CSSPixelRect> clip_rect() const;
     [[nodiscard]] Span<BorderRadiiClip const> border_radii_clips() const;
 

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -193,8 +193,7 @@ TraversalDecision InlinePaintable::hit_test(CSSPixelPoint position, HitTestType 
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;
-    if (enclosing_scroll_frame_offset().has_value())
-        position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset().value());
+    position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset());
 
     for (auto const& fragment : m_fragments) {
         if (fragment.paintable().stacking_context())

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -161,9 +161,7 @@ CSSPixelRect PaintableBox::compute_absolute_rect() const
 CSSPixelRect PaintableBox::compute_absolute_padding_rect_with_scroll_offset_applied() const
 {
     auto rect = absolute_rect();
-    auto scroll_offset = this->enclosing_scroll_frame_offset();
-    if (scroll_offset.has_value())
-        rect.translate_by(scroll_offset.value());
+    rect.translate_by(enclosing_scroll_frame_offset());
 
     CSSPixelRect padding_rect;
     padding_rect.set_x(rect.x() - box_model().padding.left);
@@ -700,8 +698,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
         context.display_list_recorder().save();
         // FIXME: Handle overflow-x and overflow-y being different values.
         auto clip_box_with_enclosing_scroll_frame_offset = clip_box;
-        if (enclosing_scroll_frame_offset().has_value())
-            clip_box_with_enclosing_scroll_frame_offset.translate_by(enclosing_scroll_frame_offset().value());
+        clip_box_with_enclosing_scroll_frame_offset.translate_by(enclosing_scroll_frame_offset());
         context.display_list_recorder().add_clip_rect(context.rounded_device_rect(clip_box_with_enclosing_scroll_frame_offset).to_type<int>());
 
         auto border_radii = normalized_border_radii_data(ShrinkRadiiForBorders::Yes);
@@ -850,8 +847,7 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;
-    if (enclosing_scroll_frame_offset().has_value())
-        position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset().value());
+    position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset());
 
     if (!is_visible())
         return TraversalDecision::Continue;
@@ -904,8 +900,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;
-    if (enclosing_scroll_frame_offset().has_value())
-        position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset().value());
+    position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset());
 
     if (!layout_box().children_are_inline() || m_fragments.is_empty()) {
         return PaintableBox::hit_test(position, type, callback);

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -33,7 +33,7 @@ void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase ph
         return;
     context.display_list_recorder().save();
     auto clip_rect = absolute_rect();
-    clip_rect.translate_by(enclosing_scroll_frame_offset().value_or({}));
+    clip_rect.translate_by(enclosing_scroll_frame_offset());
     context.display_list_recorder().add_clip_rect(context.enclosing_device_rect(clip_rect).to_type<int>());
 }
 


### PR DESCRIPTION
Fixes a bug when stacking contexts nested inside scrollable box are treated as fixed positioned during hit-testing.