### PR TITLE
LibWebView: Remove early exit in `InspectorClient::inspect()`

### DIFF
--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -194,8 +194,6 @@ void InspectorClient::inspect()
 {
     if (!m_inspector_loaded)
         return;
-    if (m_dom_tree_loaded)
-        return;
 
     m_content_web_view.inspect_dom_tree();
     m_content_web_view.inspect_accessibility_tree();


### PR DESCRIPTION
This early exit prevents to show the current DOM in the inspector, when the inspector was already opened.

Fixes #990