### PR TITLE
LibWeb: Remove unused image-rendering param for stacking context

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -114,7 +114,6 @@ struct PushStackingContext {
     Gfx::IntRect source_paintable_rect;
     // A translation to be applied after the stacking context has been transformed.
     Gfx::IntPoint post_transform_translation;
-    CSS::ImageRendering image_rendering;
     StackingContextTransform transform;
     Optional<StackingContextMask> mask = {};
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -304,7 +304,6 @@ void DisplayListRecorder::push_stacking_context(PushStackingContextParams params
         .post_transform_translation = params.is_fixed_position
             ? Gfx::IntPoint {}
             : state().translation.translation().to_rounded<int>(),
-        .image_rendering = params.image_rendering,
         .transform = {
             .origin = params.transform.origin,
             .matrix = params.transform.matrix,

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -115,7 +115,6 @@ public:
         float opacity;
         bool is_fixed_position;
         Gfx::IntRect source_paintable_rect;
-        CSS::ImageRendering image_rendering;
         StackingContextTransform transform;
         Optional<StackingContextMask> mask = {};
     };

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -293,7 +293,6 @@ void StackingContext::paint(PaintContext& context) const
         .opacity = opacity,
         .is_fixed_position = paintable().is_fixed_position(),
         .source_paintable_rect = source_paintable_rect,
-        .image_rendering = paintable().computed_values().image_rendering(),
         .transform = {
             .origin = transform_origin.scaled(to_device_pixels_scale),
             .matrix = matrix_with_scaled_translation(transform_matrix, to_device_pixels_scale),


### PR DESCRIPTION
Previously it was accounted for by LibGfx while applying scale transformation, but is no longer needed for Skia.