### PR TITLE
LibWeb: Avoid division by zero in SourceSet width descriptor calculation

### DIFF
--- a/Tests/LibWeb/Layout/expected/srcset-sizes-crash.txt
+++ b/Tests/LibWeb/Layout/expected/srcset-sizes-crash.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,20 1x1] baseline: 1
+      frag 1 from TextNode start: 0, length: 19, rect: [9,8 162.109375x17] baseline: 13.296875
+          "PASS (didn't crash)"
+      ImageBox <img> at (8,20) content-size 1x1 children: not-inline
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      ImagePaintable (ImageBox<IMG>) [8,20 1x1]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/srcset-sizes-crash.html
+++ b/Tests/LibWeb/Layout/input/srcset-sizes-crash.html
@@ -1,0 +1,1 @@
+<img sizes="0" srcset="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIW2NgaGD4DwAChAGAZM0bBgAAAABJRU5ErkJggg== 100w"/>PASS (didn't crash)


### PR DESCRIPTION
Fixes 4 crashing tests in: https://wpt.live/html/semantics/embedded-content/the-img-element/sizes, meaning we now pass 672 more subtests.