### PR TITLE
LibWeb: Actually perform "update the href steps"

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/a-element-set-protocol-on-href.txt
+++ b/Tests/LibWeb/Text/expected/HTML/a-element-set-protocol-on-href.txt
@@ -1,0 +1,2 @@
+   http:
+https:

--- a/Tests/LibWeb/Text/input/HTML/a-element-set-protocol-on-href.html
+++ b/Tests/LibWeb/Text/input/HTML/a-element-set-protocol-on-href.html
@@ -1,0 +1,10 @@
+<a id="a" href="http://serenityos.org"></a>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const aElement = document.getElementById("a");
+        println(a.protocol);
+        a.protocol = "https";
+        println(a.protocol);
+    })
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -449,6 +449,7 @@ WebIDL::ExceptionOr<void> HTMLHyperlinkElementUtils::set_href(String href)
 void HTMLHyperlinkElementUtils::update_href()
 {
     // To update href, set the element's href content attribute's value to the element's url, serialized.
+    MUST(set_hyperlink_element_utils_href(MUST(String::from_byte_string(m_url->serialize()))));
 }
 
 bool HTMLHyperlinkElementUtils::cannot_navigate() const


### PR DESCRIPTION
We completely missed this step, which made setters not actually do anything!

Fixes 336 test failures on:

https://wpt.live/url/url-setters-a-area.window.html