### PR TITLE
AK+LibWeb: Don't verify_cast where input and output types are the same 

### DIFF
--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Concepts.h>
 #include <AK/Forward.h>
 #include <AK/Platform.h>
 
@@ -15,6 +16,7 @@ namespace AK {
 template<typename OutputType, typename InputType>
 ALWAYS_INLINE bool is(InputType& input)
 {
+    static_assert(!SameAs<OutputType, InputType>);
     if constexpr (requires { input.template fast_is<OutputType>(); }) {
         return input.template fast_is<OutputType>();
     }

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -74,9 +74,10 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(StringView value)
 
     // 2. Let context be this's host.
     auto context = this->host();
+    VERIFY(context);
 
     // 3. Let fragment be the result of invoking the fragment parsing algorithm steps with context and compliantString. FIXME: Use compliantString instead of markup.
-    auto fragment = TRY(verify_cast<Element>(*context).parse_fragment(value));
+    auto fragment = TRY(context->parse_fragment(value));
 
     // 4. Replace all with fragment within this.
     this->replace_all(fragment);

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -229,7 +229,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Se
         auto text_node = document.heap().allocate_without_realm<Layout::TextNode>(document, *text);
         text_node->set_generated_for(generated_for, element);
 
-        push_parent(verify_cast<NodeWithStyle>(*pseudo_element_node));
+        push_parent(*pseudo_element_node);
         insert_node_into_inline_or_block_ancestor(*text_node, text_node->display(), AppendOrPrepend::Append);
         pop_parent();
     } else {


### PR DESCRIPTION
This fixes a compilation failure with GCC 13.2.0 and later.