### PR TITLE
LibWeb: Create clip and scroll frame trees separately for each navigable

### DIFF
--- a/Tests/LibWeb/Ref/iframe-contains-scrollable-box.html
+++ b/Tests/LibWeb/Ref/iframe-contains-scrollable-box.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/iframe-contains-scrollable-box-ref.html" />
+<style>
+    iframe {
+        width: 300px;
+        height: 200px;
+        border: 1px solid #ccc;
+    }
+</style>
+<iframe
+    srcdoc="
+    <!DOCTYPE html>
+    <style>
+        * {
+            scrollbar-width: none;
+        }
+        body {
+            margin: 0;
+        }
+        #scrollable-box {
+            width: 300px;
+            height: 200px;
+            overflow-y: scroll;
+            border: 1px solid #ccc;
+            box-sizing: border-box;
+        }
+        #scroll-space-filler {
+            height: 300px;
+        }
+        #box {
+            width: 50px;
+            height: 50px;
+            background-color: magenta;
+        }
+    </style>
+    <div id='scrollable-box'>
+        <div id='scroll-space-filler'></div>
+        <div id='box'></div>
+        <div id='scroll-space-filler'></div>
+    </div>
+    <script>
+        const scrollable = document.getElementById('scrollable-box');
+        scrollable.scrollTop = 300;
+    </script>
+"
+></iframe>

--- a/Tests/LibWeb/Ref/reference/iframe-contains-scrollable-box-ref.html
+++ b/Tests/LibWeb/Ref/reference/iframe-contains-scrollable-box-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+    iframe {
+        width: 300px;
+        height: 200px;
+        border: 1px solid #ccc;
+    }
+</style>
+<iframe
+    srcdoc="
+    <!DOCTYPE html>
+    <style>
+        * {
+            scrollbar-width: none;
+        }
+        body {
+            margin: 0;
+        }
+        #scrollable-box {
+            width: 300px;
+            height: 200px;
+            overflow-y: scroll;
+            border: 1px solid #ccc;
+            box-sizing: border-box;
+        }
+        #box {
+            width: 50px;
+            height: 50px;
+            background-color: magenta;
+        }
+    </style>
+    <div id='scrollable-box'>
+        <div id='box'></div>
+    </div>
+"
+></iframe>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1156,12 +1156,10 @@ void Document::update_layout()
     navigable->set_needs_display();
     set_needs_to_resolve_paint_only_properties();
 
-    if (navigable->is_traversable()) {
-        // NOTE: The assignment of scroll frames only needs to occur for traversables because they take care of all
-        //       nested navigable documents.
-        paintable()->assign_scroll_frames();
-        paintable()->assign_clip_frames();
+    paintable()->assign_scroll_frames();
+    paintable()->assign_clip_frames();
 
+    if (navigable->is_traversable()) {
         page().client().page_did_layout();
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -185,8 +185,9 @@ public:
         bool paint_overlay { false };
         bool should_show_line_box_borders { false };
         bool has_focus { false };
+        Optional<Gfx::IntRect> canvas_fill_rect {};
     };
-    void record_display_list(Painting::DisplayListRecorder& display_list_recorder, PaintConfig);
+    RefPtr<Painting::DisplayList> record_display_list(PaintConfig);
 
     Page& page() { return m_page; }
     Page const& page() const { return m_page; }

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -360,6 +360,18 @@ struct AddMask {
     }
 };
 
+struct PaintNestedDisplayList {
+    RefPtr<DisplayList> display_list;
+    Gfx::IntRect rect;
+
+    [[nodiscard]] Gfx::IntRect bounding_rect() const { return rect; }
+
+    void translate_by(Gfx::IntPoint const& offset)
+    {
+        rect.translate_by(offset);
+    }
+};
+
 using Command = Variant<
     DrawGlyphRun,
     FillRect,
@@ -389,6 +401,7 @@ using Command = Variant<
     DrawRect,
     DrawTriangleWave,
     AddRoundedRectClip,
-    AddMask>;
+    AddMask,
+    PaintNestedDisplayList>;
 
 }

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -86,6 +86,7 @@ void DisplayListPlayer::execute(DisplayList& display_list)
         else HANDLE_COMMAND(DrawTriangleWave, draw_triangle_wave)
         else HANDLE_COMMAND(AddRoundedRectClip, add_rounded_rect_clip)
         else HANDLE_COMMAND(AddMask, add_mask)
+        else HANDLE_COMMAND(PaintNestedDisplayList, paint_nested_display_list)
         else VERIFY_NOT_REACHED();
         // clang-format on
     }

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -70,6 +70,7 @@ private:
     virtual void draw_triangle_wave(DrawTriangleWave const&) = 0;
     virtual void add_rounded_rect_clip(AddRoundedRectClip const&) = 0;
     virtual void add_mask(AddMask const&) = 0;
+    virtual void paint_nested_display_list(PaintNestedDisplayList const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1299,6 +1299,13 @@ void DisplayListPlayerSkia::add_mask(AddMask const& command)
     surface().canvas().clipShader(shader);
 }
 
+void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList const& command)
+{
+    auto& canvas = surface().canvas();
+    canvas.translate(command.rect.x(), command.rect.y());
+    execute(*command.display_list);
+}
+
 bool DisplayListPlayerSkia::would_be_fully_clipped_by_painter(Gfx::IntRect rect) const
 {
     return surface().canvas().quickReject(to_skia_rect(rect));

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -77,6 +77,7 @@ private:
     void draw_triangle_wave(DrawTriangleWave const&) override;
     void add_rounded_rect_clip(AddRoundedRectClip const&) override;
     void add_mask(AddMask const&) override;
+    void paint_nested_display_list(PaintNestedDisplayList const&) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -22,6 +22,13 @@ void DisplayListRecorder::append(Command&& command)
     m_command_list.append(move(command), state().scroll_frame_id);
 }
 
+void DisplayListRecorder::paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect)
+{
+    append(PaintNestedDisplayList {
+        .display_list = move(display_list),
+        .rect = state().translation.map(rect) });
+}
+
 void DisplayListRecorder::add_rounded_rect_clip(CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip)
 {
     append(AddRoundedRectClip {

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -121,6 +121,8 @@ public:
     void push_stacking_context(PushStackingContextParams params);
     void pop_stacking_context();
 
+    void paint_nested_display_list(RefPtr<DisplayList> display_list, Gfx::IntRect rect);
+
     void add_rounded_rect_clip(CornerRadii corner_radii, Gfx::IntRect border_rect, CornerClip corner_clip);
     void add_mask(RefPtr<DisplayList> display_list, Gfx::IntRect rect);
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -92,17 +92,16 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
     m_document->navigable()->set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout();
 
-    auto display_list = Painting::DisplayList::create();
-    Painting::DisplayListRecorder display_list_recorder(display_list);
-
-    m_document->navigable()->record_display_list(display_list_recorder, {});
+    auto display_list = m_document->navigable()->record_display_list({});
+    if (!display_list)
+        return {};
 
     auto painting_command_executor_type = m_page_client->display_list_player_type();
     switch (painting_command_executor_type) {
     case DisplayListPlayerType::SkiaGPUIfAvailable:
     case DisplayListPlayerType::SkiaCPU: {
         Painting::DisplayListPlayerSkia display_list_player { *bitmap };
-        display_list_player.execute(display_list);
+        display_list_player.execute(*display_list);
         break;
     }
     default:


### PR DESCRIPTION
While introducing clip and scroll frame trees, I made a mistake by assuming that the paintable tree includes boxes from nested navigables. Therefore, this comment in the code was incorrect, and clip/scroll frames were simply not assigned for iframes:
```
// NOTE: We only need to refresh the scroll state for traversables
//       because they are responsible for tracking the state of all
//       nested navigables.
```

As a result, anything with "overflow: scroll" is currently not scrollable inside an iframe

This change fixes that by ensuring clip and scroll frames are assigned and refreshed for each navigable. To achieve this, I had to modify the display list building process to record a separate display list for each navigable. This is necessary because scroll frame ids are local to a navigable, making it impossible to call
`DisplayList::apply_scroll_offsets()` on a display list that contains ids from multiple navigables.