### PR TITLE
LibWeb: Account for intrinsic width or height in flex base size

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-item-on-row-with-intrinsic-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-on-row-with-intrinsic-size.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x8 children: not-inline
+      Box <div> at (8,8) content-size 784x8 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        ImageBox <img> at (8,8) content-size 8x8 flex-item children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x8]
+      PaintableBox (Box<DIV>) [8,8 784x8]
+        ImagePaintable (ImageBox<IMG>) [8,8 8x8]

--- a/Tests/LibWeb/Layout/input/flex/flex-item-on-row-with-intrinsic-size.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-item-on-row-with-intrinsic-size.html
@@ -1,0 +1,2 @@
+<div style="display:flex">
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAgAAAAIAQMAAAD+wSzIAAAABlBMVEX///+/v7+jQ3Y5AAAADklEQVQI12P4AIX8EAgALgAD/aNpbtEAAAAASUVORK5CYII">

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -6,7 +6,6 @@
  */
 
 #include "InlineFormattingContext.h"
-#include <AK/Function.h>
 #include <AK/QuickSort.h>
 #include <AK/StdLibExtras.h>
 #include <LibWeb/Layout/BlockContainer.h>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -621,19 +621,19 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
         //       in the various helpers that calculate the intrinsic sizes of a flex item,
         //       e.g. calculate_min_content_main_size().
 
-        if (item.used_flex_basis->has<CSS::FlexBasisContent>()) {
+        if (item.used_flex_basis->has<CSS::FlexBasisContent>())
             return calculate_max_content_main_size(item);
-        }
 
         return calculate_fit_content_main_size(item);
     }();
 
-    // AD-HOC: This is not mentioned in the spec, but if the item has an aspect ratio,
-    //         we may need to adjust the main size in these ways:
-    //         - using stretch-fit main size if the flex basis is indefinite and there is no cross size to resolve the ratio against.
+    // AD-HOC: This is not mentioned in the spec, but if the item has an aspect ratio, we may need
+    //         to adjust the main size in these ways:
+    //         - using stretch-fit main size if the flex basis is indefinite, there is no
+    //           intrinsic size and no cross size to resolve the ratio against.
     //         - in response to cross size min/max constraints.
     if (item.box->has_natural_aspect_ratio()) {
-        if (!item.used_flex_basis_is_definite && !has_definite_cross_size(item)) {
+        if (!item.used_flex_basis_is_definite && !item.box->has_natural_width() && !item.box->has_natural_height() && !has_definite_cross_size(item)) {
             item.flex_base_size = inner_main_size(m_flex_container_state);
         }
         item.flex_base_size = adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(child_box, item.flex_base_size, computed_cross_min_size(child_box), computed_cross_max_size(child_box));

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1019,7 +1019,7 @@ void FlexFormattingContext::resolve_flexible_lengths()
     }
 }
 
-// https://drafts.csswg.org/css-flexbox-1/#algo-cross-item
+// https://www.w3.org/TR/css-flexbox-1/#hypothetical-cross-size
 void FlexFormattingContext::determine_hypothetical_cross_size_of_item(FlexItem& item, bool resolve_percentage_min_max_sizes)
 {
     // Determine the hypothetical cross size of each item by performing layout
@@ -1149,7 +1149,7 @@ void FlexFormattingContext::calculate_cross_size_of_each_flex_line()
     }
 }
 
-// https://www.w3.org/TR/css-flexbox-1/#algo-stretch
+// https://www.w3.org/TR/css-flexbox-1/#cross-sizing
 void FlexFormattingContext::determine_used_cross_size_of_each_flex_item()
 {
     for (auto& flex_line : m_flex_lines) {

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -6,7 +6,6 @@
 
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/DecodedImageData.h>
-#include <LibWeb/HTML/ImageRequest.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/ImageProvider.h>
 #include <LibWeb/Painting/ImagePaintable.h>


### PR DESCRIPTION
We were stretching flex items with an intrinsic aspect ratio, even if we had an intrinsic width or height available. This fixes the icons in the footer of Ladybird.org.

Ladybird.org before | Ladybird.org after
:---: | :---:
![Screenshot_20240808_171259](https://github.com/user-attachments/assets/f0764868-7218-428f-acc0-973022123543) | ![Screenshot_20240808_171233](https://github.com/user-attachments/assets/b6fc8e27-a8dd-4a69-a6c5-b03fc293cc11)


