### PR TITLE
LibWeb: Skip trim trailing whitespace if user is typing

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBox.cpp
@@ -50,6 +50,9 @@ void LineBox::trim_trailing_whitespace()
             return;
         // last_fragment cannot be null from here on down, as m_fragments is not empty.
         last_fragment = &m_fragments.last();
+        auto dom_node = last_fragment->layout_node().dom_node();
+        if (dom_node && dom_node->is_editable() && dom_node->document().cursor_position())
+            return;
         if (!should_trim(last_fragment))
             return;
         if (last_fragment->is_justifiable_whitespace()) {


### PR DESCRIPTION
This PR stops the cursor from disappearing while typing trailing spaces in a text input box.

Before:

[before.webm](https://github.com/user-attachments/assets/92be5acb-3c39-4957-9c6f-49d1622ea3f5)

After:

[after.webm](https://github.com/user-attachments/assets/f634fba4-f0db-4fb5-b67b-e032de98745f)

