### PR TITLE
LibJS: Set custom prototype for console object

### DIFF
--- a/Tests/LibWeb/Text/expected/console/console-prototype.txt
+++ b/Tests/LibWeb/Text/expected/console/console-prototype.txt
@@ -1,0 +1,2 @@
+0
+Prototype of console prototype is Object.prototype

--- a/Tests/LibWeb/Text/input/console/console-prototype.html
+++ b/Tests/LibWeb/Text/input/console/console-prototype.html
@@ -1,0 +1,15 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+       const p1 = Object.getPrototypeOf(console)
+       const p2 = Object.getPrototypeOf(p1)
+
+       println(Object.getOwnPropertyNames(p1).length)
+
+       if (p2 == Object.prototype) {
+        println("Prototype of console prototype is Object.prototype")
+       } else {
+        println("Prototype of console prototype is NOT Object.prototype")
+       }
+    });
+</script>

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SOURCES
     Runtime/BooleanPrototype.cpp
     Runtime/BoundFunction.cpp
     Runtime/Completion.cpp
+    Runtime/ConsoleObjectPrototype.cpp
     Runtime/ConsoleObject.cpp
     Runtime/DataView.cpp
     Runtime/DataViewConstructor.cpp

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -8,14 +8,20 @@
 
 #include <LibJS/Console.h>
 #include <LibJS/Runtime/ConsoleObject.h>
+#include <LibJS/Runtime/ConsoleObjectPrototype.h>
 #include <LibJS/Runtime/GlobalObject.h>
 
 namespace JS {
 
 JS_DEFINE_ALLOCATOR(ConsoleObject);
 
+static NonnullGCPtr<ConsoleObjectPrototype> create_console_prototype(Realm& realm)
+{
+    return realm.heap().allocate<ConsoleObjectPrototype>(realm, realm);
+}
+
 ConsoleObject::ConsoleObject(Realm& realm)
-    : Object(ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
+    : Object(ConstructWithPrototypeTag::Tag, create_console_prototype(realm))
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObjectPrototype.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Gasim Gasimzada <gasim@gasimzada.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ConsoleObjectPrototype.h"
+
+#include <AK/ByteString.h>
+#include <AK/Function.h>
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Accessor.h>
+#include <LibJS/Runtime/BooleanObject.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/Date.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/NumberObject.h>
+#include <LibJS/Runtime/ObjectPrototype.h>
+#include <LibJS/Runtime/RegExpObject.h>
+#include <LibJS/Runtime/StringObject.h>
+#include <LibJS/Runtime/Value.h>
+
+namespace JS {
+
+JS_DEFINE_ALLOCATOR(ConsoleObjectPrototype);
+
+ConsoleObjectPrototype::ConsoleObjectPrototype(JS::Realm& realm)
+    : Object(JS::Object::ConstructWithPrototypeTag::Tag, realm.intrinsics().object_prototype())
+{
+}
+
+void ConsoleObjectPrototype::initialize(JS::Realm& realm)
+{
+    Base::initialize(realm);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObjectPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObjectPrototype.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Gasim Gasimzada <gasim@gasimzada.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Object.h>
+
+namespace JS {
+
+class ConsoleObjectPrototype final : public Object {
+    JS_OBJECT(ConsoleObjectPrototype, Object);
+    JS_DECLARE_ALLOCATOR(ConsoleObjectPrototype);
+
+public:
+    virtual void initialize(JS::Realm&) override;
+    virtual ~ConsoleObjectPrototype() override = default;
+
+private:
+    explicit ConsoleObjectPrototype(JS::Realm&);
+};
+
+}


### PR DESCRIPTION
## Description

According to [W3C spec](https://console.spec.whatwg.org/#console-namespace), the global console object's prototype must be an empty object and the prototype's prototype must be `Object.prototype`

> For historical web-compatibility reasons, the [namespace object](https://webidl.spec.whatwg.org/#dfn-namespace-object) for [console](https://console.spec.whatwg.org/#namespacedef-console) must have as its [[Prototype]] an empty object, created as if by [ObjectCreate](https://tc39.github.io/ecma262/#sec-objectcreate)([%ObjectPrototype%](https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object)), instead of [%ObjectPrototype%](https://tc39.github.io/ecma262/#sec-properties-of-the-object-prototype-object).

So, I am creating a custom prototype for the console that is empty and setting the prototype's default prototype to `object_prototype`.

## Affected WPT Test Suites:

- https://staging.wpt.fyi/results/console/console-is-a-namespace.any.html?product=ladybird
- https://staging.wpt.fyi/results/console/console-is-a-namespace.any.worker.html?product=ladybird
- https://staging.wpt.fyi/results/console/idlharness.any.html?product=ladybird
- https://staging.wpt.fyi/results/console/idlharness.any.worker.html?product=ladybird
