### PR TITLE
LibJS: Set configurable toStringTag property for console

### DIFF
--- a/Tests/LibWeb/Text/expected/console/console-to-string-tag.txt
+++ b/Tests/LibWeb/Text/expected/console/console-to-string-tag.txt
@@ -1,0 +1,2 @@
+console
+[object console]

--- a/Tests/LibWeb/Text/input/console/console-to-string-tag.html
+++ b/Tests/LibWeb/Text/input/console/console-to-string-tag.html
@@ -1,0 +1,7 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(console[Symbol.toStringTag])
+        println(console.toString())
+    });
+</script>

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -50,6 +50,8 @@ void ConsoleObject::initialize(Realm& realm)
     define_native_function(realm, vm.names.time, time, 0, attr);
     define_native_function(realm, vm.names.timeLog, time_log, 0, attr);
     define_native_function(realm, vm.names.timeEnd, time_end, 0, attr);
+
+    define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "console"_string), Attribute::Configurable);
 }
 
 // 1.1.1. assert(condition, ...data), https://console.spec.whatwg.org/#assert


### PR DESCRIPTION
## Description

Added configurable `Symbol.toStringTag` property to `console` whose value is "console"

## Affected WPT Tests Suites

- https://staging.wpt.fyi/results/console/console-namespace-object-class-string.any.html?product=ladybird
- https://staging.wpt.fyi/results/console/console-namespace-object-class-string.any.worker.html?product=ladybird