### PR TITLE
LibJS: Treat passing undefined as no argument for console labels

### DIFF
--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -203,7 +203,7 @@ ThrowCompletionOr<Value> Console::dir()
 
 static ThrowCompletionOr<String> label_or_fallback(VM& vm, StringView fallback)
 {
-    return vm.argument_count() > 0
+    return vm.argument_count() > 0 && !vm.argument(0).is_undefined()
         ? vm.argument(0).to_string(vm)
         : TRY_OR_THROW_OOM(vm, String::from_utf8(fallback));
 }


### PR DESCRIPTION
## Description

Fixes the discrepancy between calling `console.count()` and `console.count(undefined)`. I changed the common function that checks whether argument exists by also checking if the first argument is not `undefined`. So, this change affects:

- `console.time`, `console.timeEnd` and `console.timeLog`
- `console.count` and `console.countReset`

Now, in all of the functions above, `console.x()` yields the same result as `console.count(undefined)`

## Affected WPT Test Suites

- https://staging.wpt.fyi/results/console/console-count-logging.html?product=ladybird