### PR TITLE
LibWeb/CSS: Use TokenStream in more places

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -135,9 +135,12 @@ Optional<Vector<AngularColorStopListElement>> Parser::parse_angular_color_stop_l
         [](Dimension& dimension) { return dimension.angle_percentage(); });
 }
 
-RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_linear_gradient_function(TokenStream<ComponentValue>& outer_tokens)
 {
     using GradientType = LinearGradientStyleValue::GradientType;
+
+    auto transaction = outer_tokens.begin_transaction();
+    auto& component_value = outer_tokens.next_token();
 
     if (!component_value.is_function())
         return nullptr;
@@ -260,11 +263,15 @@ RefPtr<StyleValue> Parser::parse_linear_gradient_function(ComponentValue const& 
     if (!color_stops.has_value())
         return nullptr;
 
+    transaction.commit();
     return LinearGradientStyleValue::create(gradient_direction, move(*color_stops), gradient_type, repeating_gradient);
 }
 
-RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_conic_gradient_function(TokenStream<ComponentValue>& outer_tokens)
 {
+    auto transaction = outer_tokens.begin_transaction();
+    auto& component_value = outer_tokens.next_token();
+
     if (!component_value.is_function())
         return nullptr;
 
@@ -360,16 +367,20 @@ RefPtr<StyleValue> Parser::parse_conic_gradient_function(ComponentValue const& c
     if (!at_position)
         at_position = PositionStyleValue::create_center();
 
+    transaction.commit();
     return ConicGradientStyleValue::create(from_angle, at_position.release_nonnull(), move(*color_stops), repeating_gradient);
 }
 
-RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_radial_gradient_function(TokenStream<ComponentValue>& outer_tokens)
 {
     using EndingShape = RadialGradientStyleValue::EndingShape;
     using Extent = RadialGradientStyleValue::Extent;
     using CircleSize = RadialGradientStyleValue::CircleSize;
     using EllipseSize = RadialGradientStyleValue::EllipseSize;
     using Size = RadialGradientStyleValue::Size;
+
+    auto transaction = outer_tokens.begin_transaction();
+    auto& component_value = outer_tokens.next_token();
 
     if (!component_value.is_function())
         return nullptr;
@@ -511,6 +522,7 @@ RefPtr<StyleValue> Parser::parse_radial_gradient_function(ComponentValue const& 
     if (!at_position)
         at_position = PositionStyleValue::create_center();
 
+    transaction.commit();
     return RadialGradientStyleValue::create(ending_shape, size, at_position.release_nonnull(), move(*color_stops), repeating_gradient);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -614,18 +614,28 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     return {};
 }
 
-CSSMediaRule* Parser::convert_to_media_rule(NonnullRefPtr<Web::CSS::Parser::Rule> rule)
+JS::GCPtr<CSSMediaRule> Parser::convert_to_media_rule(Rule& rule)
 {
-    auto media_query_tokens = TokenStream { rule->prelude() };
+    if (rule.prelude().is_empty()) {
+        dbgln_if(CSS_PARSER_DEBUG, "Failed to parse @media rule: Empty prelude.");
+        return {};
+    }
+
+    if (!rule.block()) {
+        dbgln_if(CSS_PARSER_DEBUG, "Failed to parse @media rule: No block.");
+        return {};
+    }
+
+    auto media_query_tokens = TokenStream { rule.prelude() };
     auto media_query_list = parse_a_media_query_list(media_query_tokens);
-    if (media_query_list.is_empty() || !rule->block())
+    if (media_query_list.is_empty())
         return {};
 
-    auto child_tokens = TokenStream { rule->block()->values() };
+    auto child_tokens = TokenStream { rule.block()->values() };
     auto parser_rules = parse_a_list_of_rules(child_tokens);
     JS::MarkedVector<CSSRule*> child_rules(m_context.realm().heap());
     for (auto& raw_rule : parser_rules) {
-        if (auto* child_rule = convert_to_rule(raw_rule))
+        if (auto child_rule = convert_to_rule(raw_rule))
             child_rules.append(child_rule);
     }
     auto media_list = MediaList::create(m_context.realm(), move(media_query_list));

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1199,8 +1199,10 @@ RefPtr<StyleValue> Parser::parse_url_value(TokenStream<ComponentValue>& tokens)
     return URLStyleValue::create(*url);
 }
 
-RefPtr<StyleValue> Parser::parse_basic_shape_function(ComponentValue const& component_value)
+RefPtr<StyleValue> Parser::parse_basic_shape_value(TokenStream<ComponentValue>& tokens)
 {
+    auto transaction = tokens.begin_transaction();
+    auto& component_value = tokens.next_token();
     if (!component_value.is_function())
         return nullptr;
 
@@ -1236,16 +1238,8 @@ RefPtr<StyleValue> Parser::parse_basic_shape_function(ComponentValue const& comp
         points.append(Polygon::Point { *x_pos, *y_pos });
     }
 
+    transaction.commit();
     return BasicShapeStyleValue::create(Polygon { FillRule::Nonzero, move(points) });
-}
-
-RefPtr<StyleValue> Parser::parse_basic_shape_value(TokenStream<ComponentValue>& tokens)
-{
-    auto basic_shape = parse_basic_shape_function(tokens.peek_token());
-    if (!basic_shape)
-        return nullptr;
-    (void)tokens.next_token();
-    return basic_shape;
 }
 
 CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3199,26 +3199,18 @@ RefPtr<StyleValue> Parser::parse_string_value(TokenStream<ComponentValue>& token
 
 RefPtr<StyleValue> Parser::parse_image_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-
-    if (auto url = parse_url_function(tokens); url.has_value()) {
-        transaction.commit();
+    if (auto url = parse_url_function(tokens); url.has_value())
         return ImageStyleValue::create(url.value());
-    }
 
-    auto& token = tokens.next_token();
-    if (auto linear_gradient = parse_linear_gradient_function(token)) {
-        transaction.commit();
+    if (auto linear_gradient = parse_linear_gradient_function(tokens))
         return linear_gradient;
-    }
-    if (auto conic_gradient = parse_conic_gradient_function(token)) {
-        transaction.commit();
+
+    if (auto conic_gradient = parse_conic_gradient_function(tokens))
         return conic_gradient;
-    }
-    if (auto radial_gradient = parse_radial_gradient_function(token)) {
-        transaction.commit();
+
+    if (auto radial_gradient = parse_radial_gradient_function(tokens))
         return radial_gradient;
-    }
+
     return nullptr;
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -149,7 +149,7 @@ CSSStyleSheet* Parser::parse_as_css_stylesheet(Optional<URL::URL> location)
     // Interpret all of the resulting top-level qualified rules as style rules, defined below.
     JS::MarkedVector<CSSRule*> rules(m_context.realm().heap());
     for (auto& raw_rule : style_sheet.rules) {
-        auto* rule = convert_to_rule(raw_rule);
+        auto rule = convert_to_rule(raw_rule);
         // If any style rule is invalid, or any at-rule is not recognized or is invalid according to its grammar or context, it’s a parse error. Discard that rule.
         if (rule)
             rules.append(rule);
@@ -1244,7 +1244,7 @@ RefPtr<StyleValue> Parser::parse_basic_shape_value(TokenStream<ComponentValue>& 
     return BasicShapeStyleValue::create(Polygon { FillRule::Nonzero, move(points) });
 }
 
-CSSRule* Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
+JS::GCPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<Rule> rule)
 {
     if (rule->is_at_rule()) {
         if (has_ignored_vendor_prefix(rule->at_rule_name()))
@@ -1547,7 +1547,7 @@ JS::GCPtr<CSSSupportsRule> Parser::convert_to_supports_rule(Rule& rule)
     auto parser_rules = parse_a_list_of_rules(child_tokens);
     JS::MarkedVector<CSSRule*> child_rules { m_context.realm().heap() };
     for (auto& raw_rule : parser_rules) {
-        if (auto* child_rule = convert_to_rule(raw_rule))
+        if (auto child_rule = convert_to_rule(raw_rule))
             child_rules.append(child_rule);
     }
 
@@ -5126,7 +5126,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(TokenStream<ComponentValue>& 
     return StyleValueList::create(move(font_families), StyleValueList::Separator::Comma);
 }
 
-CSSRule* Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
+JS::GCPtr<CSSFontFaceRule> Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens)
 {
     auto declarations_and_at_rules = parse_a_list_of_declarations(tokens);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -224,6 +224,7 @@ private:
     CSSMediaRule* convert_to_media_rule(NonnullRefPtr<Rule>);
     JS::GCPtr<CSSImportRule> convert_to_import_rule(Rule&);
     JS::GCPtr<CSSNamespaceRule> convert_to_namespace_rule(Rule&);
+    JS::GCPtr<CSSSupportsRule> convert_to_supports_rule(Rule&);
 
     PropertyOwningCSSStyleDeclaration* convert_to_style_declaration(Vector<DeclarationOrAtRule> const& declarations);
     Optional<StyleProperty> convert_to_style_property(Declaration const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -245,7 +245,7 @@ private:
     Optional<Color> parse_hwb_color(Vector<ComponentValue> const&);
     Optional<Color> parse_oklab_color(Vector<ComponentValue> const&);
     Optional<Color> parse_oklch_color(Vector<ComponentValue> const&);
-    Optional<Color> parse_color(ComponentValue const&);
+    Optional<Color> parse_color(TokenStream<ComponentValue>&);
     Optional<LengthOrCalculated> parse_source_size_value(TokenStream<ComponentValue>&);
     Optional<Ratio> parse_ratio(TokenStream<ComponentValue>&);
     Optional<Gfx::UnicodeRange> parse_unicode_range(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -261,7 +261,7 @@ private:
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
 
-    Optional<URL::URL> parse_url_function(ComponentValue const&);
+    Optional<URL::URL> parse_url_function(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_url_value(TokenStream<ComponentValue>&);
 
     RefPtr<StyleValue> parse_basic_shape_value(TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -215,13 +215,13 @@ private:
 
     Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<ComponentValue>&);
 
-    CSSRule* parse_font_face_rule(TokenStream<ComponentValue>&);
+    JS::GCPtr<CSSFontFaceRule> parse_font_face_rule(TokenStream<ComponentValue>&);
 
     template<typename T>
     Vector<ParsedFontFace::Source> parse_font_face_src(TokenStream<T>&);
 
-    CSSRule* convert_to_rule(NonnullRefPtr<Rule>);
-    CSSMediaRule* convert_to_media_rule(NonnullRefPtr<Rule>);
+    JS::GCPtr<CSSRule> convert_to_rule(NonnullRefPtr<Rule>);
+    JS::GCPtr<CSSMediaRule> convert_to_media_rule(Rule&);
     JS::GCPtr<CSSKeyframesRule> convert_to_keyframes_rule(Rule&);
     JS::GCPtr<CSSImportRule> convert_to_import_rule(Rule&);
     JS::GCPtr<CSSNamespaceRule> convert_to_namespace_rule(Rule&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -222,6 +222,7 @@ private:
 
     CSSRule* convert_to_rule(NonnullRefPtr<Rule>);
     CSSMediaRule* convert_to_media_rule(NonnullRefPtr<Rule>);
+    JS::GCPtr<CSSImportRule> convert_to_import_rule(Rule&);
 
     PropertyOwningCSSStyleDeclaration* convert_to_style_declaration(Vector<DeclarationOrAtRule> const& declarations);
     Optional<StyleProperty> convert_to_style_property(Declaration const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -271,9 +271,9 @@ private:
     Optional<Vector<LinearColorStopListElement>> parse_linear_color_stop_list(TokenStream<ComponentValue>&);
     Optional<Vector<AngularColorStopListElement>> parse_angular_color_stop_list(TokenStream<ComponentValue>&);
 
-    RefPtr<StyleValue> parse_linear_gradient_function(ComponentValue const&);
-    RefPtr<StyleValue> parse_conic_gradient_function(ComponentValue const&);
-    RefPtr<StyleValue> parse_radial_gradient_function(ComponentValue const&);
+    RefPtr<StyleValue> parse_linear_gradient_function(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_conic_gradient_function(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_radial_gradient_function(TokenStream<ComponentValue>&);
 
     ParseErrorOr<NonnullRefPtr<StyleValue>> parse_css_value(PropertyID, TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_css_value_for_property(PropertyID, TokenStream<ComponentValue>&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -278,7 +278,7 @@ private:
         RefPtr<StyleValue> style_value;
     };
     Optional<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
-    RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_builtin_value(TokenStream<ComponentValue>&);
     RefPtr<CalculatedStyleValue> parse_calculated_value(ComponentValue const&);
     RefPtr<CustomIdentStyleValue> parse_custom_ident_value(TokenStream<ComponentValue>&, std::initializer_list<StringView> blacklist);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -222,6 +222,7 @@ private:
 
     CSSRule* convert_to_rule(NonnullRefPtr<Rule>);
     CSSMediaRule* convert_to_media_rule(NonnullRefPtr<Rule>);
+    JS::GCPtr<CSSKeyframesRule> convert_to_keyframes_rule(Rule&);
     JS::GCPtr<CSSImportRule> convert_to_import_rule(Rule&);
     JS::GCPtr<CSSNamespaceRule> convert_to_namespace_rule(Rule&);
     JS::GCPtr<CSSSupportsRule> convert_to_supports_rule(Rule&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -223,6 +223,7 @@ private:
     CSSRule* convert_to_rule(NonnullRefPtr<Rule>);
     CSSMediaRule* convert_to_media_rule(NonnullRefPtr<Rule>);
     JS::GCPtr<CSSImportRule> convert_to_import_rule(Rule&);
+    JS::GCPtr<CSSNamespaceRule> convert_to_namespace_rule(Rule&);
 
     PropertyOwningCSSStyleDeclaration* convert_to_style_declaration(Vector<DeclarationOrAtRule> const& declarations);
     Optional<StyleProperty> convert_to_style_property(Declaration const&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -260,7 +260,6 @@ private:
     Optional<URL::URL> parse_url_function(ComponentValue const&);
     RefPtr<StyleValue> parse_url_value(TokenStream<ComponentValue>&);
 
-    RefPtr<StyleValue> parse_basic_shape_function(ComponentValue const&);
     RefPtr<StyleValue> parse_basic_shape_value(TokenStream<ComponentValue>&);
 
     template<typename TElement>


### PR DESCRIPTION
The end goal is to consistently use TokenStream everywhere, so that mistakes are harder to make and easier to spot. (Such as not consuming all tokens, or skipping one accidentally.) The ones here aren't that exciting, but there are some harder ones left and my brain wasn't up to those today. :sweat_smile: 

And as a tangent, split up the unwieldy `convert_to_rule()` function into one per rule, and add some documentation to them.