### PR TITLE
LibWeb+LibCore: Use OpenGL ES backend using EGL for Skia

### DIFF
--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -85,6 +85,10 @@ if (HAS_VULKAN)
     list(APPEND SOURCES VulkanContext.cpp)
 endif()
 
+if (NOT APPLE)
+    list(APPEND SOURCES EGLInterface.cpp)
+endif()
+
 if (APPLE OR CMAKE_SYSTEM_NAME STREQUAL "GNU")
     list(APPEND SOURCES MachPort.cpp)
 endif()
@@ -112,4 +116,8 @@ endif()
 
 if (HAS_VULKAN)
     target_link_libraries(LibCore PUBLIC Vulkan::Vulkan Vulkan::Headers)
+endif()
+
+if (NOT APPLE)
+    target_link_libraries(LibCore PRIVATE EGL)
 endif()

--- a/Userland/Libraries/LibCore/EGLInterface.cpp
+++ b/Userland/Libraries/LibCore/EGLInterface.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Olekoop <mlglol360xd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/Vector.h>
+#include <LibCore/EGLInterface.h>
+
+namespace Core {
+
+static bool s_has_been_created = false;
+
+ErrorOr<void> create_egl_interface()
+{
+    if (s_has_been_created)
+        return {};
+
+    EGLDisplay display;
+    EGLint num_configs;
+    EGLConfig config;
+
+    EGLint const config_attributes[] = {
+        EGL_SURFACE_TYPE, EGL_PBUFFER_BIT,
+        EGL_RED_SIZE, 8,
+        EGL_GREEN_SIZE, 8,
+        EGL_BLUE_SIZE, 8,
+        EGL_ALPHA_SIZE, 8,
+        EGL_RENDERABLE_TYPE, EGL_OPENGL_ES2_BIT,
+        EGL_NONE
+    };
+
+    EGLint const pbuffer_attributes[] = {
+        EGL_WIDTH, 1,
+        EGL_HEIGHT, 1,
+        EGL_TEXTURE_TARGET, EGL_NO_TEXTURE,
+        EGL_TEXTURE_FORMAT, EGL_NO_TEXTURE,
+        EGL_NONE
+    };
+
+    EGLint const context_atributes[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
+
+    if ((display = eglGetDisplay(EGL_DEFAULT_DISPLAY)) == EGL_NO_DISPLAY)
+        return Error::from_string_literal("eglGetDisplay() failed");
+
+    if (!eglInitialize(display, 0, 0))
+        return Error::from_string_literal("eglInitialize() failed");
+
+    if (!eglChooseConfig(display, config_attributes, &config, 1, &num_configs))
+        return Error::from_string_literal("eglChooseConfig() failed");
+
+    EGLContext context = eglCreateContext(display, config, nullptr, context_atributes);
+    if (context == EGL_NO_CONTEXT)
+        return Error::from_string_literal("eglCreateContext() failed");
+
+    EGLSurface surface = eglCreatePbufferSurface(display, config, pbuffer_attributes);
+    if (surface == EGL_NO_SURFACE)
+        return Error::from_errno(eglGetError());
+
+    if (!eglMakeCurrent(display, surface, surface, context))
+        return Error::from_string_literal("eglMakeCurrent() failed");
+
+    s_has_been_created = true;
+
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibCore/EGLInterface.h
+++ b/Userland/Libraries/LibCore/EGLInterface.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, Olekoop <mlglol360xd@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if defined(AK_OS_MACOS)
+static_assert(false, "This file cannot be used for macOS");
+#endif
+
+#include <AK/Forward.h>
+#include <AK/Function.h>
+#include <EGL/egl.h>
+
+namespace Core {
+
+ErrorOr<void> create_egl_interface();
+
+}

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -18,6 +18,10 @@
 #    include <LibCore/VulkanContext.h>
 #endif
 
+#ifndef AK_OS_MACOS
+#    include <LibCore/EGLInterface.h>
+#endif
+
 namespace Web::Painting {
 
 class SkiaBackendContext {
@@ -43,6 +47,13 @@ public:
 #ifdef AK_OS_MACOS
     static OwnPtr<SkiaBackendContext> create_metal_context(Core::MetalContext const&);
     DisplayListPlayerSkia(SkiaBackendContext&, Core::MetalTexture&);
+#endif
+
+#ifndef AK_OS_MACOS
+    static OwnPtr<SkiaBackendContext> create_egl_context();
+#    ifndef USE_VULKAN
+    DisplayListPlayerSkia(SkiaBackendContext&, Gfx::Bitmap&);
+#    endif
 #endif
 
     virtual ~DisplayListPlayerSkia() override;

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,10 @@
   "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
   "dependencies": [
     {
+      "name": "egl",
+      "platform": "!osx"
+    },
+    {
       "name": "fontconfig",
       "platform": "linux | freebsd | openbsd"
     },


### PR DESCRIPTION
This PR adds a OpenGL ES backend using EGL for Skia.
It has been tested on Linux and Android.