### PR TITLE
LibWeb: Actually run UTF-8 decode without BOM for URLSearchParams

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -20,6 +20,16 @@
 
 namespace AK {
 
+String String::from_utf8_with_replacement_character(StringView view)
+{
+    StringBuilder builder;
+
+    for (auto c : Utf8View { view })
+        builder.append_code_point(c);
+
+    return builder.to_string_without_validation();
+}
+
 String String::from_utf8_without_validation(ReadonlyBytes bytes)
 {
     String result;

--- a/AK/String.h
+++ b/AK/String.h
@@ -51,6 +51,9 @@ public:
     // Creates a new String from a sequence of UTF-8 encoded code points.
     static ErrorOr<String> from_utf8(StringView);
 
+    // Creates a new String using the replacement character for invalid bytes
+    [[nodiscard]] static String from_utf8_with_replacement_character(StringView);
+
     template<typename T>
     requires(IsOneOf<RemoveCVReference<T>, ByteString, DeprecatedFlyString, FlyString, String>)
     static ErrorOr<String> from_utf8(T&&) = delete;

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -173,6 +173,19 @@ TEST_CASE(invalid_utf8)
     EXPECT(string3.error().string_literal().contains("Input was not valid UTF-8"sv));
 }
 
+TEST_CASE(with_replacement_character)
+{
+    auto string1 = String::from_utf8_with_replacement_character("long string \xf4\x8f\xbf\xc0"sv); // U+110000
+    Array<u8, 24> string1_expected { 0x6c, 0x6f, 0x6e, 0x67, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67, 0x20, 0xef, 0xbf, 0xbd, 0xef, 0xbf, 0xbd, 0xef, 0xbf, 0xbd, 0xef, 0xbf, 0xbd };
+    EXPECT_EQ(string1.bytes(), string1_expected);
+
+    auto string3 = String::from_utf8_with_replacement_character("A valid string!"sv);
+    EXPECT_EQ(string3, "A valid string!"sv);
+
+    auto string4 = String::from_utf8_with_replacement_character(""sv);
+    EXPECT_EQ(string4, ""sv);
+}
+
 TEST_CASE(from_code_points)
 {
     for (u32 code_point = 0; code_point < 0x80; ++code_point) {

--- a/Tests/LibWeb/Text/expected/URL/search-params-with-invalid-utf8.txt
+++ b/Tests/LibWeb/Text/expected/URL/search-params-with-invalid-utf8.txt
@@ -1,0 +1,2 @@
+key equals   = true
+value equals = true

--- a/Tests/LibWeb/Text/expected/URL/search-params-with-plus-in-value.txt
+++ b/Tests/LibWeb/Text/expected/URL/search-params-with-plus-in-value.txt
@@ -1,0 +1,2 @@
+key 'key'
+value 'value1 value2'

--- a/Tests/LibWeb/Text/input/URL/search-params-with-invalid-utf8.html
+++ b/Tests/LibWeb/Text/input/URL/search-params-with-invalid-utf8.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const params = new URLSearchParams('%FE%FF');
+        for (const [key, value] of params) {
+            println(`key equals   = ${"\uFFFD\uFFFD" === key}`);
+            println(`value equals = ${"" === value}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/URL/search-params-with-plus-in-value.html
+++ b/Tests/LibWeb/Text/input/URL/search-params-with-plus-in-value.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const params = new URLSearchParams('key=value1+value2');
+        for (const [key, value] of params) {
+            println(`key '${key}'`);
+            println(`value '${value}'`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -75,7 +75,7 @@ static Optional<Host> parse_opaque_host(StringView input)
     //       currently report validation errors, they are only useful for debugging efforts in the URL parsing code.
 
     // 4. Return the result of running UTF-8 percent-encode on input using the C0 control percent-encode set.
-    return String::from_byte_string(percent_encode(input, PercentEncodeSet::C0Control)).release_value_but_fixme_should_propagate_errors();
+    return percent_encode(input, PercentEncodeSet::C0Control);
 }
 
 struct ParsedIPv4Number {

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -1237,7 +1237,7 @@ URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, Opt
                 || (url->is_special() && code_point == '\\')) {
                 // then:
 
-                // 1. If atSignSeen is true and buffer is the empty string, invalid-credentials validation error, return failure.
+                // 1. If atSignSeen is true and buffer is the empty string, host-missing validation error, return failure.
                 if (at_sign_seen && buffer.is_empty()) {
                     report_validation_error();
                     return {};

--- a/Userland/Libraries/LibURL/URL.cpp
+++ b/Userland/Libraries/LibURL/URL.cpp
@@ -59,21 +59,19 @@ void URL::set_scheme(String scheme)
 }
 
 // https://url.spec.whatwg.org/#set-the-username
-ErrorOr<void> URL::set_username(StringView username)
+void URL::set_username(StringView username)
 {
     // To set the username given a url and username, set url’s username to the result of running UTF-8 percent-encode on username using the userinfo percent-encode set.
-    m_data->username = TRY(String::from_byte_string(percent_encode(username, PercentEncodeSet::Userinfo)));
+    m_data->username = percent_encode(username, PercentEncodeSet::Userinfo);
     m_data->valid = compute_validity();
-    return {};
 }
 
 // https://url.spec.whatwg.org/#set-the-password
-ErrorOr<void> URL::set_password(StringView password)
+void URL::set_password(StringView password)
 {
     // To set the password given a url and password, set url’s password to the result of running UTF-8 percent-encode on password using the userinfo percent-encode set.
-    m_data->password = TRY(String::from_byte_string(percent_encode(password, PercentEncodeSet::Userinfo)));
+    m_data->password = percent_encode(password, PercentEncodeSet::Userinfo);
     m_data->valid = compute_validity();
-    return {};
 }
 
 void URL::set_host(Host host)
@@ -103,13 +101,13 @@ void URL::set_paths(Vector<ByteString> const& paths)
     m_data->paths.clear_with_capacity();
     m_data->paths.ensure_capacity(paths.size());
     for (auto const& segment : paths)
-        m_data->paths.unchecked_append(String::from_byte_string(percent_encode(segment, PercentEncodeSet::Path)).release_value_but_fixme_should_propagate_errors());
+        m_data->paths.unchecked_append(percent_encode(segment, PercentEncodeSet::Path));
     m_data->valid = compute_validity();
 }
 
 void URL::append_path(StringView path)
 {
-    m_data->paths.append(String::from_byte_string(percent_encode(path, PercentEncodeSet::Path)).release_value_but_fixme_should_propagate_errors());
+    m_data->paths.append(percent_encode(path, PercentEncodeSet::Path));
 }
 
 // https://url.spec.whatwg.org/#cannot-have-a-username-password-port
@@ -444,7 +442,7 @@ void append_percent_encoded_if_necessary(StringBuilder& builder, u32 code_point,
         builder.append_code_point(code_point);
 }
 
-ByteString percent_encode(StringView input, PercentEncodeSet set, SpaceAsPlus space_as_plus)
+String percent_encode(StringView input, PercentEncodeSet set, SpaceAsPlus space_as_plus)
 {
     StringBuilder builder;
     for (auto code_point : Utf8View(input)) {
@@ -453,7 +451,7 @@ ByteString percent_encode(StringView input, PercentEncodeSet set, SpaceAsPlus sp
         else
             append_percent_encoded_if_necessary(builder, code_point, set);
     }
-    return builder.to_byte_string();
+    return MUST(builder.to_string());
 }
 
 ByteString percent_decode(StringView input)

--- a/Userland/Libraries/LibURL/URL.h
+++ b/Userland/Libraries/LibURL/URL.h
@@ -70,7 +70,7 @@ enum class SpaceAsPlus {
     No,
     Yes,
 };
-ByteString percent_encode(StringView input, PercentEncodeSet set = PercentEncodeSet::Userinfo, SpaceAsPlus = SpaceAsPlus::No);
+String percent_encode(StringView input, PercentEncodeSet set = PercentEncodeSet::Userinfo, SpaceAsPlus = SpaceAsPlus::No);
 ByteString percent_decode(StringView input);
 
 template<typename T>
@@ -140,8 +140,8 @@ public:
     bool is_special() const { return is_special_scheme(m_data->scheme); }
 
     void set_scheme(String);
-    ErrorOr<void> set_username(StringView);
-    ErrorOr<void> set_password(StringView);
+    void set_username(StringView);
+    void set_password(StringView);
     void set_host(Host);
     void set_port(Optional<u16>);
     void set_paths(Vector<ByteString> const&);

--- a/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -260,7 +260,7 @@ void DOMURL::set_username(String const& username)
         return;
 
     // 2. Set the username given this’s URL and the given value.
-    MUST(m_url.set_username(username));
+    m_url.set_username(username);
 }
 
 // https://url.spec.whatwg.org/#dom-url-password
@@ -278,7 +278,7 @@ void DOMURL::set_password(String const& password)
         return;
 
     // 2. Set the password given this’s URL and the given value.
-    MUST(m_url.set_password(password));
+    m_url.set_password(password);
 }
 
 // https://url.spec.whatwg.org/#dom-url-host

--- a/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -115,8 +115,8 @@ ErrorOr<Vector<QueryParam>> url_decode(StringView input)
         auto space_decoded_name = name.replace("+"sv, " "sv, ReplaceMode::All);
 
         // 5. Let nameString and valueString be the result of running UTF-8 decode without BOM on the percent-decoding of name and value, respectively.
-        auto name_string = TRY(String::from_byte_string(URL::percent_decode(space_decoded_name)));
-        auto value_string = TRY(String::from_byte_string(URL::percent_decode(value)));
+        auto name_string = String::from_utf8_with_replacement_character(URL::percent_decode(space_decoded_name));
+        auto value_string = String::from_utf8_with_replacement_character(URL::percent_decode(value));
 
         TRY(output.try_empend(move(name_string), move(value_string)));
     }

--- a/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -113,10 +113,11 @@ ErrorOr<Vector<QueryParam>> url_decode(StringView input)
 
         // 4. Replace any 0x2B (+) in name and value with 0x20 (SP).
         auto space_decoded_name = name.replace("+"sv, " "sv, ReplaceMode::All);
+        auto space_decoded_value = value.replace("+"sv, " "sv, ReplaceMode::All);
 
         // 5. Let nameString and valueString be the result of running UTF-8 decode without BOM on the percent-decoding of name and value, respectively.
         auto name_string = String::from_utf8_with_replacement_character(URL::percent_decode(space_decoded_name));
-        auto value_string = String::from_utf8_with_replacement_character(URL::percent_decode(value));
+        auto value_string = String::from_utf8_with_replacement_character(URL::percent_decode(space_decoded_value));
 
         TRY(output.try_empend(move(name_string), move(value_string)));
     }

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2024,10 +2024,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
                 auto password = ByteString::empty();
 
                 // 3. Set the username given request’s current URL and username.
-                MUST(request->current_url().set_username(username));
+                request->current_url().set_username(username);
 
                 // 4. Set the password given request’s current URL and password.
-                MUST(request->current_url().set_password(password));
+                request->current_url().set_password(password);
             }
 
             // 4. Set response to the result of running HTTP-network-or-cache fetch given fetchParams and true.

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -845,8 +845,7 @@ ErrorOr<void> HTMLFormElement::mail_as_body(URL::URL parsed_action, Vector<XHR::
         // 2. Set body to the result of running UTF-8 percent-encode on body using the default encode set. [URL]
         // NOTE: body is already UTF-8 encoded due to using AK::String, so we only have to do the percent encoding.
         // NOTE: "default encode set" links to "path percent-encode-set": https://url.spec.whatwg.org/#default-encode-set
-        auto percent_encoded_body = URL::percent_encode(body, URL::PercentEncodeSet::Path);
-        body = TRY(String::from_utf8(percent_encoded_body.view()));
+        body = URL::percent_encode(body, URL::PercentEncodeSet::Path);
         break;
     }
     default:

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -114,7 +114,7 @@ void HTMLHyperlinkElementUtils::set_username(StringView username)
         return;
 
     // 4. Set the username given this’s URL and the given value.
-    MUST(url->set_username(username));
+    url->set_username(username);
 
     // 5. Update href.
     update_href();
@@ -151,7 +151,7 @@ void HTMLHyperlinkElementUtils::set_password(StringView password)
         return;
 
     // 4. Set the password, given url and the given value.
-    MUST(url->set_password(password));
+    url->set_password(password);
 
     // 5. Update href.
     update_href();

--- a/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/ReferrerPolicy/AbstractOperations.cpp
@@ -210,10 +210,10 @@ Optional<URL::URL> strip_url_for_use_as_referrer(Optional<URL::URL> url, OriginO
         return {};
 
     // 3. Set url’s username to the empty string.
-    MUST(url->set_username(""sv));
+    url->set_username(""sv);
 
     // 4. Set url’s password to the empty string.
-    MUST(url->set_password(""sv));
+    url->set_password(""sv);
 
     // 5. Set url’s fragment to null.
     url->set_fragment({});

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -495,10 +495,10 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     if (!parsed_url.host().has<Empty>()) {
         // 1. If the username argument is not null, set the username given parsedURL and username.
         if (username.has_value())
-            MUST(parsed_url.set_username(username.value()));
+            parsed_url.set_username(username.value());
         // 2. If the password argument is not null, set the password given parsedURL and password.
         if (password.has_value())
-            MUST(parsed_url.set_password(password.value()));
+            parsed_url.set_password(password.value());
     }
 
     // 9. If async is false, the current global object is a Window object, and either this’s timeout is


### PR DESCRIPTION
Fixes a crash running https://wpt.live/url/urlencoded-parser.any.html

Which, along with the fix cherry-picked here from https://github.com/LadybirdBrowser/ladybird/pull/878 that I just today noticed (important to also prevent conflicts), makes all of the tests from that link pass.