### PR TITLE
LibWeb: Use keepalive maximum size in NavigatorBeacon

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1670,7 +1670,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
             }
 
             // 5. If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a network error.
-            if ((content_length.value() + inflight_keep_alive_bytes) > 65536)
+            if ((content_length.value() + inflight_keep_alive_bytes) > keepalive_maximum_size)
                 return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Keepalive request exceeded maximum allowed size of 64 KiB"sv));
 
             // NOTE: The above limit ensures that requests that are allowed to outlive the environment settings object

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.h
@@ -18,6 +18,10 @@ namespace Web::Fetch::Fetching {
 // The document `Accept` header value is `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`.
 constexpr auto document_accept_header_value = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"sv;
 
+// https://fetch.spec.whatwg.org/#http-network-or-cache-fetch
+// If the sum of contentLength and inflightKeepaliveBytes is greater than 64 kibibytes, then return a network error.
+constexpr auto keepalive_maximum_size = 64 * KiB;
+
 #define ENUMERATE_BOOL_PARAMS                     \
     __ENUMERATE_BOOL_PARAM(IncludeCredentials)    \
     __ENUMERATE_BOOL_PARAM(IsAuthenticationFetch) \

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Bodies.h>
 #include <LibWeb/HTML/Navigator.h>
 #include <LibWeb/HTML/NavigatorBeacon.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
@@ -50,7 +51,8 @@ WebIDL::ExceptionOr<bool> NavigatorBeaconMixin::send_beacon(String const& url, O
         auto& content_type = body_with_type.type;
 
         // 6.2 If the amount of data that can be queued to be sent by keepalive enabled requests is exceeded by the size of transmittedData (as defined in HTTP-network-or-cache fetch), set the return value to false and terminate these steps.
-        // FIXME: We don't have a size limit in Fetching::fetch
+        if (transmitted_data->length().has_value() && transmitted_data->length().value() > Fetch::Fetching::keepalive_maximum_size)
+            return false;
 
         // 6.3 If contentType is not null:
         if (content_type.has_value()) {


### PR DESCRIPTION
This is defined as 64 KiB in the fetch spec.

See:
 - https://wpt.live/beacon/beacon-basic.https.window.html