### PR TITLE
Fix `<a target="name">` not always opening in `<iframe name="name">`

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3660,7 +3660,9 @@ void Document::make_active()
         m_visibility_state = navigable()->traversable_navigable()->system_visibility_state();
     }
 
-    // 4. Set window's relevant settings object's execution ready flag.
+    // TODO: 4. Queue a new VisibilityStateEntry whose visibility state is document's visibility state and whose timestamp is zero.
+
+    // 5. Set window's relevant settings object's execution ready flag.
     HTML::relevant_settings_object(window).execution_ready = true;
 
     if (m_needs_to_call_page_did_load) {

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -45,7 +45,6 @@ public:
 
     JS::NonnullGCPtr<HTML::TraversableNavigable> top_level_traversable() const;
 
-    JS::GCPtr<BrowsingContext> parent() const { return m_parent; }
     JS::GCPtr<BrowsingContext> first_child() const;
     JS::GCPtr<BrowsingContext> next_sibling() const;
 
@@ -112,6 +111,8 @@ public:
     Page& page() { return m_page; }
     Page const& page() const { return m_page; }
 
+    u64 virtual_browsing_context_group_id() const { return m_virtual_browsing_context_group_id; }
+
     JS::GCPtr<BrowsingContext> top_level_browsing_context() const;
 
     BrowsingContextGroup* group();
@@ -161,7 +162,6 @@ private:
     // https://html.spec.whatwg.org/multipage/browsers.html#tlbc-group
     JS::GCPtr<BrowsingContextGroup> m_group;
 
-    JS::GCPtr<BrowsingContext> m_parent;
     JS::GCPtr<BrowsingContext> m_first_child;
     JS::GCPtr<BrowsingContext> m_last_child;
     JS::GCPtr<BrowsingContext> m_next_sibling;

--- a/Userland/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/MixedContent/AbstractOperations.cpp
@@ -80,7 +80,8 @@ Fetch::Infrastructure::RequestOrResponseBlocking should_fetching_request_be_bloc
         || false
 
         // 4. request’s destination is "document", and request’s target browsing context has no parent browsing context.
-        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && !(request.client()->target_browsing_context && request.client()->target_browsing_context->parent()))) {
+        // TODO: "parent browsing context" doesn't exist anymore and is a spec bug, seems like it should be `is_top_level`
+        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && request.client()->target_browsing_context && request.client()->target_browsing_context->is_top_level())) {
         return Fetch::Infrastructure::RequestOrResponseBlocking::Allowed;
     }
 
@@ -104,7 +105,8 @@ Web::Fetch::Infrastructure::RequestOrResponseBlocking should_response_to_request
         || false
 
         // 4. request’s destination is "document", and request’s target browsing context has no parent browsing context.
-        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && !(request.client()->target_browsing_context && request.client()->target_browsing_context->parent()))) {
+        // TODO: "parent browsing context" doesn't exist anymore and is a spec bug, seems like it should be `is_top_level`
+        || (request.destination() == Fetch::Infrastructure::Request::Destination::Document && request.client()->target_browsing_context && request.client()->target_browsing_context->is_top_level())) {
         return Fetch::Infrastructure::RequestOrResponseBlocking::Allowed;
     }
 


### PR DESCRIPTION
I made these changes a week ago and stopped after trying to figure out issues caused by `BrowsingContext::is_top_level` for hours, but I figured it's better to just put a FIXME as the scope these changes already got a bit large. I don't think (but don't remember) if the `coop-check-access-report` commit is necessary for the main changes.

`BrowsingContext::m_parent` has been removed from the spec, and previously `m_parent` was always null.

`BrowsingContext::is_top_level` was already always returning true before because of that, and the updated spec algorithm causes assertions to fail.

This fixes the following example:
```html
<a href="https://ladybird.org" target="test">a
<iframe name="test">
```
clicking the link twice no longer causes it to open in a new tab.

Edit: Retested on master without this pr, `about:blank` already works, `https://ladybird.org` doesn't (I tried to reduce the example as much as possible), I don't want to force push to change the commit message because it'll retrigger CI...