### PR TITLE
WebContent: Actually start WebDriver timeout timers

### DIFF
--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1936,6 +1936,7 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::wait_for_navigation_to
     auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout, [&] {
         page_load_timeout_fired = true;
     });
+    timer->start();
 
     // 4. If there is an ongoing attempt to navigate the current browsing context that has not yet matured, wait for navigation to mature.
     Web::Platform::EventLoopPlugin::the().spin_until([&] {
@@ -1980,6 +1981,7 @@ void WebDriverConnection::restore_the_window()
     auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout, [&] {
         page_load_timeout_fired = true;
     });
+    timer->start();
 
     Web::Platform::EventLoopPlugin::the().spin_until([&]() {
         auto state = m_page_client->page().top_level_traversable()->system_visibility_state();
@@ -2009,6 +2011,7 @@ Gfx::IntRect WebDriverConnection::iconify_the_window()
     auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout, [&] {
         page_load_timeout_fired = true;
     });
+    timer->start();
 
     Web::Platform::EventLoopPlugin::the().spin_until([&]() {
         auto state = m_page_client->page().top_level_traversable()->system_visibility_state();


### PR DESCRIPTION
The timers added previously in #1021 had no effect, as they were never started.