### PR TITLE
LibWeb: Update stylesheet media value when changing link media attribute

### DIFF
--- a/Tests/LibWeb/Text/expected/link-element-media-change-off.txt
+++ b/Tests/LibWeb/Text/expected/link-element-media-change-off.txt
@@ -1,0 +1,1 @@
+   document background: rgba(0, 0, 0, 0)

--- a/Tests/LibWeb/Text/expected/link-element-media-change.txt
+++ b/Tests/LibWeb/Text/expected/link-element-media-change.txt
@@ -1,0 +1,1 @@
+   document background: rgb(255, 0, 0)

--- a/Tests/LibWeb/Text/input/link-element-media-change-off.html
+++ b/Tests/LibWeb/Text/input/link-element-media-change-off.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="body-background-color-red.css" media="all" onload="this.media='none'">
+    </head>
+    <body>
+        <script src="include.js"></script>
+        <script>
+            test(() => {
+                window.onload = function () {
+                    println("document background: " + getComputedStyle(document.body).backgroundColor);
+                };
+            });
+        </script>
+    </body>
+</html>

--- a/Tests/LibWeb/Text/input/link-element-media-change.html
+++ b/Tests/LibWeb/Text/input/link-element-media-change.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <link rel="stylesheet" href="body-background-color-red.css" media="print" onload="this.media='all'">
+    </head>
+    <body>
+        <script src="include.js"></script>
+        <script>
+            test(() => {
+                window.onload = function () {
+                    println("document background: " + getComputedStyle(document.body).backgroundColor);
+                };
+            });
+        </script>
+    </body>
+</html>

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -308,12 +308,13 @@ bool CSSStyleSheet::evaluate_media_queries(HTML::Window const& window)
 {
     bool any_media_queries_changed_match_state = false;
 
-    bool did_match = m_media->matches();
     bool now_matches = m_media->evaluate(window);
-    if (did_match != now_matches)
+    if (!m_did_match.has_value() || m_did_match.value() != now_matches)
         any_media_queries_changed_match_state = true;
     if (now_matches && m_rules->evaluate_media_queries(window))
         any_media_queries_changed_match_state = true;
+
+    m_did_match = now_matches;
 
     return any_media_queries_changed_match_state;
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -100,6 +100,7 @@ private:
     JS::GCPtr<DOM::Document const> m_constructor_document;
     bool m_constructed { false };
     bool m_disallow_modification { false };
+    Optional<bool> m_did_match;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -187,6 +187,10 @@ void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> 
                 )) {
             fetch_and_process_linked_resource();
         }
+
+        if (name == HTML::AttributeNames::media && m_loaded_style_sheet) {
+            m_loaded_style_sheet->set_media(value.value_or(String {}));
+        }
     }
 }
 


### PR DESCRIPTION
Should fix #1032 

I'm not sure what the expected value is for `MediaList::matches` without first calling evaluate, but for now I've emulated the previous behaviour