### PR TITLE
Ladybird/Qt: Don't change to new tab with 'Open in New Tab'

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -852,7 +852,7 @@ void Tab::open_link(URL::URL const& url)
 
 void Tab::open_link_in_new_tab(URL::URL const& url)
 {
-    view().on_link_click(url, "_blank", 0);
+    view().on_link_click(url, "_blank", Web::UIEvents::Mod_Ctrl);
 }
 
 void Tab::copy_link_url(URL::URL const& url)


### PR DESCRIPTION
It now just opens a new tab, without changing the current tab.