### PR TITLE
UI/Qt: Enable basic IME keyboard input for WebContentView

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -36,7 +36,6 @@
 #include <QCursor>
 #include <QGuiApplication>
 #include <QIcon>
-#include <QLineEdit>
 #include <QMimeData>
 #include <QMouseEvent>
 #include <QPaintEvent>
@@ -60,6 +59,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     m_client_state.client = parent_client;
     m_client_state.page_index = page_index;
 
+    setAttribute(Qt::WA_InputMethodEnabled, true);
     setMouseTracking(true);
     setAcceptDrops(true);
 
@@ -344,6 +344,20 @@ void WebContentView::keyPressEvent(QKeyEvent* event)
 void WebContentView::keyReleaseEvent(QKeyEvent* event)
 {
     enqueue_native_event(Web::KeyEvent::Type::KeyUp, *event);
+}
+
+void WebContentView::inputMethodEvent(QInputMethodEvent* event)
+{
+    if (!event->commitString().isEmpty()) {
+        QKeyEvent keyEvent(QEvent::KeyPress, 0, Qt::NoModifier, event->commitString());
+        keyPressEvent(&keyEvent);
+    }
+    event->accept();
+}
+
+QVariant WebContentView::inputMethodQuery(Qt::InputMethodQuery) const
+{
+    return QVariant();
 }
 
 void WebContentView::mouseMoveEvent(QMouseEvent* event)

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -61,6 +61,8 @@ public:
     virtual void dropEvent(QDropEvent*) override;
     virtual void keyPressEvent(QKeyEvent* event) override;
     virtual void keyReleaseEvent(QKeyEvent* event) override;
+    virtual void inputMethodEvent(QInputMethodEvent*) override;
+    virtual QVariant inputMethodQuery(Qt::InputMethodQuery) const override;
     virtual void showEvent(QShowEvent*) override;
     virtual void hideEvent(QHideEvent*) override;
     virtual void focusInEvent(QFocusEvent*) override;


### PR DESCRIPTION
This makes dead keys work (e.g. typing ' and e results in é).