### PR TITLE
LibWeb: Begin support for `direction` property

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-dir-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-dir-selector.txt
@@ -18,9 +18,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (200,212) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,213) content-size 100x100 children: inline
-        frag 0 from TextNode start: 0, length: 11, rect: [401,213 79.96875x17] baseline: 13.296875
+        frag 0 from TextNode start: 0, length: 11, rect: [421,213 79.96875x17] baseline: 13.296875
             "Well, hello"
-        frag 1 from TextNode start: 12, length: 8, rect: [401,230 59.21875x17] baseline: 13.296875
+        frag 1 from TextNode start: 12, length: 8, rect: [442,230 59.21875x17] baseline: 13.296875
             "friends!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,314) content-size 592x0 children: inline
@@ -50,17 +50,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (200,620) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,621) content-size 100x100 children: inline
-        frag 0 from TextNode start: 0, length: 26, rect: [401,621 86.125x17] baseline: 13.296875
+        frag 0 from TextNode start: 0, length: 26, rect: [415,621 86.125x17] baseline: 13.296875
             "حسنًا ، مرحباً"
-        frag 1 from TextNode start: 27, length: 25, rect: [401,638 78.125x17] baseline: 13.296875
+        frag 1 from TextNode start: 27, length: 25, rect: [423,638 78.125x17] baseline: 13.296875
             "أيها الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,722) content-size 592x0 children: inline
         TextNode <#text>
       BlockContainer <div> at (401,723) content-size 100x100 children: inline
-        frag 0 from TextNode start: 0, length: 26, rect: [401,723 86.125x17] baseline: 13.296875
+        frag 0 from TextNode start: 0, length: 26, rect: [415,723 86.125x17] baseline: 13.296875
             "حسنًا ، مرحباً"
-        frag 1 from TextNode start: 27, length: 25, rect: [401,740 78.125x17] baseline: 13.296875
+        frag 1 from TextNode start: 27, length: 25, rect: [423,740 78.125x17] baseline: 13.296875
             "أيها الأصدقاء"
         TextNode <#text>
       BlockContainer <(anonymous)> at (200,824) content-size 592x0 children: inline
@@ -75,7 +75,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x832]
       PaintableWithLines (BlockContainer<DIV>) [300,110 102x102]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [200,212 592x0]
-      PaintableWithLines (BlockContainer<DIV>) [400,212 102x102]
+      PaintableWithLines (BlockContainer<DIV>) [400,212 102x102] overflow: [401,213 100.21875x100]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [200,314 592x0]
       PaintableWithLines (BlockContainer<DIV>) [300,314 102x102]
@@ -87,9 +87,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x832]
       PaintableWithLines (BlockContainer<DIV>) [300,518 102x102]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [200,620 592x0]
-      PaintableWithLines (BlockContainer<DIV>) [400,620 102x102]
+      PaintableWithLines (BlockContainer<DIV>) [400,620 102x102] overflow: [401,621 100.125x100]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [200,722 592x0]
-      PaintableWithLines (BlockContainer<DIV>) [400,722 102x102]
+      PaintableWithLines (BlockContainer<DIV>) [400,722 102x102] overflow: [401,723 100.125x100]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [200,824 592x0]

--- a/Tests/LibWeb/Layout/expected/writing-modes-direction-flex.txt
+++ b/Tests/LibWeb/Layout/expected/writing-modes-direction-flex.txt
@@ -1,0 +1,53 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x50 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
+      Box <div> at (8,8) content-size 784x17 flex-container(row) [FFC] children: not-inline
+        BlockContainer <div> at (763.96875,8) content-size 28.03125x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [763.96875,8 28.03125x17] baseline: 13.296875
+              "aaa"
+          TextNode <#text>
+        BlockContainer <div> at (735.5625,8) content-size 28.40625x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [735.5625,8 28.40625x17] baseline: 13.296875
+              "bbb"
+          TextNode <#text>
+        BlockContainer <div> at (708.890625,8) content-size 26.671875x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [708.890625,8 26.671875x17] baseline: 13.296875
+              "ccc"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div> at (8,25) content-size 784x17 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <div> at (8,25) content-size 28.03125x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,25 28.03125x17] baseline: 13.296875
+              "aaa"
+          TextNode <#text>
+        BlockContainer <div> at (36.03125,25) content-size 28.40625x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [36.03125,25 28.40625x17] baseline: 13.296875
+              "bbb"
+          TextNode <#text>
+        BlockContainer <div> at (64.4375,25) content-size 26.671875x17 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [64.4375,25 26.671875x17] baseline: 13.296875
+              "ccc"
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x50]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
+      PaintableBox (Box<DIV>) [8,8 784x17]
+        PaintableWithLines (BlockContainer<DIV>) [763.96875,8 28.03125x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [735.5625,8 28.40625x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [708.890625,8 26.671875x17]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
+      PaintableBox (Box<DIV>) [8,25 784x17]
+        PaintableWithLines (BlockContainer<DIV>) [8,25 28.03125x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [36.03125,25 28.40625x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>) [64.4375,25 26.671875x17]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]

--- a/Tests/LibWeb/Layout/expected/writing-modes-direction-inline.txt
+++ b/Tests/LibWeb/Layout/expected/writing-modes-direction-inline.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 1, rect: [737,8 8x17] baseline: 13.296875
+          " "
+      InlineNode <span>
+        frag 0 from TextNode start: 0, length: 5, rect: [690,8 46.71875x17] baseline: 13.296875
+            "aaaaa"
+        TextNode <#text>
+      TextNode <#text>
+      InlineNode <span>
+        frag 0 from TextNode start: 0, length: 5, rect: [745,8 47.34375x17] baseline: 13.296875
+            "bbbbb"
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784.34375x17]
+      InlinePaintable (InlineNode<SPAN>)
+        TextPaintable (TextNode<#text>)
+      TextPaintable (TextNode<#text>)
+      InlinePaintable (InlineNode<SPAN>)
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/writing-modes-direction-inline.txt
+++ b/Tests/LibWeb/Layout/expected/writing-modes-direction-inline.txt
@@ -1,24 +1,29 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
-      frag 0 from TextNode start: 0, length: 1, rect: [737,8 8x17] baseline: 13.296875
-          " "
-      InlineNode <span>
-        frag 0 from TextNode start: 0, length: 5, rect: [690,8 46.71875x17] baseline: 13.296875
-            "aaaaa"
+      frag 0 from BlockContainer start: 0, length: 0, rect: [622,8 51.5625x17] baseline: 13.296875
+      frag 1 from BlockContainer start: 0, length: 0, rect: [674,8 46.71875x17] baseline: 13.296875
+      frag 2 from BlockContainer start: 0, length: 0, rect: [721,8 71.328125x17] baseline: 13.296875
+      BlockContainer <div> at (721,8) content-size 71.328125x17 inline-block [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [721,8 71.328125x17] baseline: 13.296875
+            "AAAAA"
         TextNode <#text>
-      TextNode <#text>
-      InlineNode <span>
-        frag 0 from TextNode start: 0, length: 5, rect: [745,8 47.34375x17] baseline: 13.296875
-            "bbbbb"
+      BlockContainer <div> at (674,8) content-size 46.71875x17 inline-block [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [674,8 46.71875x17] baseline: 13.296875
+            "BBBBB"
+        TextNode <#text>
+      BlockContainer <div> at (622,8) content-size 51.5625x17 inline-block [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [622,8 51.5625x17] baseline: 13.296875
+            "CCCCC"
         TextNode <#text>
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784.34375x17]
-      InlinePaintable (InlineNode<SPAN>)
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17] overflow: [8,8 784.328125x17]
+      PaintableWithLines (BlockContainer<DIV>) [721,8 71.328125x17]
         TextPaintable (TextNode<#text>)
-      TextPaintable (TextNode<#text>)
-      InlinePaintable (InlineNode<SPAN>)
+      PaintableWithLines (BlockContainer<DIV>) [674,8 46.71875x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [622,8 51.5625x17]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/writing-modes-direction-flex.html
+++ b/Tests/LibWeb/Layout/input/writing-modes-direction-flex.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html dir="rtl">
+    <div style="display: flex; flex-direction: row"><div>aaa</div><div>bbb</div><div>ccc</div></div>
+    <div style="display: flex; flex-direction: row-reverse"><div>aaa</div><div>bbb</div><div>ccc</div></div>
+</html>

--- a/Tests/LibWeb/Layout/input/writing-modes-direction-inline.html
+++ b/Tests/LibWeb/Layout/input/writing-modes-direction-inline.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<html dir="rtl">
+<span>aaaaa</span>
+<span>bbbbb</span>

--- a/Tests/LibWeb/Layout/input/writing-modes-direction-inline.html
+++ b/Tests/LibWeb/Layout/input/writing-modes-direction-inline.html
@@ -1,4 +1,8 @@
 <!DOCTYPE html>
 <html dir="rtl">
-<span>aaaaa</span>
-<span>bbbbb</span>
+<style>
+div {
+    display: inline-block;
+}
+</style>
+<div>AAAAA</div><div>BBBBB</div><div>CCCCC</div>

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -192,7 +192,7 @@ stroke: none
 stroke-opacity: 1
 stroke-width: 1px
 table-layout: auto
-text-align: left
+text-align: start
 text-anchor: start
 text-decoration-color: rgb(0, 0, 0)
 text-decoration-line: none

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -178,6 +178,7 @@ public:
     static CSS::TableLayout table_layout() { return CSS::TableLayout::Auto; }
     static QuotesData quotes() { return QuotesData { .type = QuotesData::Type::Auto }; }
     static CSS::TransformBox transform_box() { return CSS::TransformBox::ViewBox; }
+    static CSS::Direction direction() { return CSS::Direction::Ltr; }
 
     // https://www.w3.org/TR/SVG/geometry.html
     static LengthPercentage cx() { return CSS::Length::make_px(0); }
@@ -422,6 +423,7 @@ public:
     Vector<Vector<String>> const& grid_template_areas() const { return m_noninherited.grid_template_areas; }
     CSS::ObjectFit object_fit() const { return m_noninherited.object_fit; }
     CSS::ObjectPosition object_position() const { return m_noninherited.object_position; }
+    CSS::Direction direction() const { return m_inherited.direction; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -531,6 +533,7 @@ protected:
         CSS::ListStylePosition list_style_position { InitialValues::list_style_position() };
         CSS::Visibility visibility { InitialValues::visibility() };
         CSS::QuotesData quotes { InitialValues::quotes() };
+        CSS::Direction direction { InitialValues::direction() };
 
         Optional<SVGPaint> fill;
         CSS::FillRule fill_rule { InitialValues::fill_rule() };
@@ -756,6 +759,7 @@ public:
     void set_quotes(CSS::QuotesData value) { m_inherited.quotes = value; }
     void set_object_fit(CSS::ObjectFit value) { m_noninherited.object_fit = value; }
     void set_object_position(CSS::ObjectPosition value) { m_noninherited.object_position = value; }
+    void set_direction(CSS::Direction value) { m_inherited.direction = value; }
 
     void set_fill(SVGPaint value) { m_inherited.fill = value; }
     void set_stroke(SVGPaint value) { m_inherited.stroke = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -104,7 +104,7 @@ public:
     static CSS::ContentVisibility content_visibility() { return CSS::ContentVisibility::Visible; }
     static CSS::Cursor cursor() { return CSS::Cursor::Auto; }
     static CSS::WhiteSpace white_space() { return CSS::WhiteSpace::Normal; }
-    static CSS::TextAlign text_align() { return CSS::TextAlign::Left; }
+    static CSS::TextAlign text_align() { return CSS::TextAlign::Start; }
     static CSS::TextJustify text_justify() { return CSS::TextJustify::Auto; }
     static CSS::Positioning position() { return CSS::Positioning::Static; }
     static CSS::TextDecorationLine text_decoration_line() { return CSS::TextDecorationLine::None; }

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -144,6 +144,10 @@
     "zoom-in",
     "zoom-out"
   ],
+  "direction": [
+    "ltr",
+    "rtl"
+  ],
   "display-box": [
     "contents",
     "none"

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -390,6 +390,8 @@
   "text-align": [
     "center",
     "justify",
+    "start",
+    "end",
     "left",
     "right",
     "-libweb-center",

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -2471,7 +2471,7 @@
   "text-align": {
     "animation-type": "discrete",
     "inherited": true,
-    "initial": "left",
+    "initial": "start",
     "valid-types": [
       "text-align"
     ]

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -1085,6 +1085,12 @@ Optional<CSS::TableLayout> StyleProperties::table_layout() const
     return value_id_to_table_layout(value->to_identifier());
 }
 
+Optional<CSS::Direction> StyleProperties::direction() const
+{
+    auto value = property(CSS::PropertyID::Direction);
+    return value_id_to_direction(value->to_identifier());
+}
+
 Optional<CSS::MaskType> StyleProperties::mask_type() const
 {
     auto value = property(CSS::PropertyID::MaskType);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -130,6 +130,7 @@ public:
     Optional<CSS::ObjectFit> object_fit() const;
     CSS::ObjectPosition object_position() const;
     Optional<CSS::TableLayout> table_layout() const;
+    Optional<CSS::Direction> direction() const;
 
     static Vector<CSS::Transformation> transformations_for_style_value(StyleValue const& value);
     Vector<CSS::Transformation> transformations() const;

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -194,6 +194,19 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
     });
 }
 
+// https://www.w3.org/TR/css-flexbox-1/#flex-direction-property
+bool FlexFormattingContext::is_direction_reverse() const
+{
+    switch (flex_container().computed_values().direction()) {
+    case CSS::Direction::Ltr:
+        return m_flex_direction == CSS::FlexDirection::ColumnReverse || m_flex_direction == CSS::FlexDirection::RowReverse;
+    case CSS::Direction::Rtl:
+        return m_flex_direction == CSS::FlexDirection::ColumnReverse || m_flex_direction == CSS::FlexDirection::Row;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::FlexDirection flex_direction) const
 {
     auto width_of_containing_block = m_flex_container_state.content_width();

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -195,7 +195,7 @@ private:
 
     bool is_row_layout() const { return m_flex_direction == CSS::FlexDirection::Row || m_flex_direction == CSS::FlexDirection::RowReverse; }
     bool is_single_line() const { return flex_container().computed_values().flex_wrap() == CSS::FlexWrap::Nowrap; }
-    bool is_direction_reverse() const { return m_flex_direction == CSS::FlexDirection::ColumnReverse || m_flex_direction == CSS::FlexDirection::RowReverse; }
+    bool is_direction_reverse() const;
     void populate_specified_margins(FlexItem&, CSS::FlexDirection) const;
 
     void determine_intrinsic_size_of_flex_container();

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -249,7 +249,18 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
     auto& line_boxes = m_containing_block_used_values.line_boxes;
     line_boxes.clear_with_capacity();
 
-    InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, layout_mode);
+    auto iterator_direction = [&]() {
+        switch (m_context_box->computed_values().direction()) {
+        case CSS::Direction::Ltr:
+            return InlineLevelIterator::Direction::Forward;
+        case CSS::Direction::Rtl:
+            return InlineLevelIterator::Direction::Reverse;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }();
+
+    InlineLevelIterator iterator(*this, m_state, containing_block(), m_containing_block_used_values, layout_mode, iterator_direction);
     LineBuilder line_builder(*this, m_state, m_containing_block_used_values);
 
     // NOTE: When we ignore collapsible whitespace chunks at the start of a line,

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.h
@@ -50,7 +50,12 @@ public:
         }
     };
 
-    InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutMode);
+    enum class Direction {
+        Forward,
+        Reverse,
+    };
+
+    InlineLevelIterator(Layout::InlineFormattingContext&, LayoutState&, Layout::BlockContainer const& containing_block, LayoutState::UsedValues const& containing_block_used_values, LayoutMode, Direction);
 
     Optional<Item> next();
     CSSPixels next_non_whitespace_sequence_width();
@@ -100,6 +105,7 @@ private:
 
     Vector<JS::NonnullGCPtr<NodeWithStyleAndBoxModelMetrics const>> m_box_model_node_stack;
     Queue<InlineLevelIterator::Item> m_lookahead_items;
+    Direction m_direction;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -163,6 +163,7 @@ void LineBuilder::update_last_line()
     auto& line_box = line_boxes.last();
 
     auto text_align = m_context.containing_block().computed_values().text_align();
+    auto direction = m_context.containing_block().computed_values().direction();
 
     auto current_line_height = max(m_max_height_on_current_line, m_context.containing_block().computed_values().line_height());
     CSSPixels x_offset_top = m_context.leftmost_x_offset_at(m_current_y);
@@ -178,6 +179,14 @@ void LineBuilder::update_last_line()
         case CSS::TextAlign::Center:
         case CSS::TextAlign::LibwebCenter:
             x_offset += excess_horizontal_space / 2;
+            break;
+        case CSS::TextAlign::Start:
+            if (direction == CSS::Direction::Rtl)
+                x_offset += excess_horizontal_space;
+            break;
+        case CSS::TextAlign::End:
+            if (direction == CSS::Direction::Ltr)
+                x_offset += excess_horizontal_space;
             break;
         case CSS::TextAlign::Right:
         case CSS::TextAlign::LibwebRight:

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -872,6 +872,9 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
 
     computed_values.set_object_position(computed_style.object_position());
 
+    if (auto direction = computed_style.direction(); direction.has_value())
+        computed_values.set_direction(direction.value());
+
     if (auto scrollbar_width = computed_style.scrollbar_width(); scrollbar_width.has_value())
         computed_values.set_scrollbar_width(scrollbar_width.value());
 


### PR DESCRIPTION
This makes a start on issue https://github.com/LadybirdBrowser/ladybird/issues/862, it now renders the nav bar in the correct order.