### PR TITLE
CMake: Fix invalid target when using system skia

### DIFF
--- a/Meta/CMake/skia.cmake
+++ b/Meta/CMake/skia.cmake
@@ -17,6 +17,6 @@ else()
     endforeach()
 
     pkg_check_modules(SKIA skia=${SKIA_REQUIRED_VERSION} REQUIRED)
-    target_include_directories(LibWeb PRIVATE ${SKIA_INCLUDE_DIRS})
-    target_link_directories(LibWeb PRIVATE ${SKIA_LIBRARY_DIRS})
+    include_directories(${SKIA_INCLUDE_DIRS})
+    link_directories(${SKIA_LIBRARY_DIRS})
 endif()


### PR DESCRIPTION
Commit 35392d4d28bd129ae936bdf470e7d58807a4b10c (#845) moved the `target_*_directories()` calls (or rather their `include()`) before the target declaration, so they fail because of the undefined target. We can fix the problem by using global `*_directories()` instead.