### PR TITLE
LibWeb: Check presence of `WWW-Authenticate` header in fetch response

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1987,7 +1987,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> http_network_or_cache_fet
         if (response->status() == 401
             && http_request->response_tainting() != Infrastructure::Request::ResponseTainting::CORS
             && include_credentials == IncludeCredentials::Yes
-            && request->window().has<JS::GCPtr<HTML::EnvironmentSettingsObject>>()) {
+            && request->window().has<JS::GCPtr<HTML::EnvironmentSettingsObject>>()
+            // AD-HOC: Require at least one WWW-Authenticate header to be set before automatically retrying an authenticated
+            //         request (see rule 1 below). See: https://github.com/whatwg/fetch/issues/1766
+            && request->header_list()->contains("WWW-Authenticate"sv.bytes())) {
             // 1. Needs testing: multiple `WWW-Authenticate` headers, missing, parsing issues.
             // (Red box in the spec, no-op)
 


### PR DESCRIPTION
If a HTTP 401 response we get does not contain a `WWW-Authenticate` header, we should not trigger the logic to ask the user for credentials and retry the request.

This part is hinted at in a TODO / 'Needs testing' remark in the spec but needs to be fleshed out. Raised an upstream issue to do so:

  https://github.com/whatwg/fetch/issues/1766

This fixes login forms triggering an infinite fetch loop when providing incorrect credentials.

PR #357 has a similar change but went stale-ish since last month, so this supersedes it. @vicr123 I'll gladly mention you as co-author if you'd like!