### PR TITLE
LibWeb: Change IDL attribute type to USVString where applicable

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3636,6 +3636,41 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
         }
     }
 )~~~");
+            }
+
+            // If a reflected IDL attribute has the type USVString:
+            else if (attribute.type->name() == "USVString") {
+                // The getter steps are:
+                // 1. Let element be the result of running this's get the element.
+                // NOTE: this is "impl" above
+                // 2. Let contentAttributeValue be the result of running this's get the content attribute.
+                attribute_generator.append(R"~~~(
+    auto content_attribute_value = impl->attribute(HTML::AttributeNames::@attribute.reflect_name@);
+)~~~");
+                // 3. Let attributeDefinition be the attribute definition of element's content attribute whose namespace is null and local name is the reflected content attribute name.
+                // NOTE: this is "attribute" above
+
+                // 4. If attributeDefinition indicates it contains a URL:
+                if (attribute.extended_attributes.contains("URL")) {
+                    // 1. If contentAttributeValue is null, then return the empty string.
+                    // 2. Let urlString be the result of encoding-parsing-and-serializing a URL given contentAttributeValue, relative to element's node document.
+                    // 3. If urlString is not failure, then return urlString.
+                    attribute_generator.append(R"~~~(
+    if (!content_attribute_value.has_value())
+        return JS::PrimitiveString::create(vm, String {});
+
+    auto url_string = impl->document().parse_url(*content_attribute_value);
+    if (url_string.is_valid())
+        return JS::PrimitiveString::create(vm, MUST(url_string.to_string()));
+)~~~");
+                }
+
+                // 5. Return contentAttributeValue, converted to a scalar value string.
+                attribute_generator.append(R"~~~(
+    String retval;
+    if (content_attribute_value.has_value())
+        retval = MUST(Infra::convert_to_scalar_value_string(*content_attribute_value));
+)~~~");
             } else {
                 attribute_generator.append(R"~~~(
     auto retval = impl->get_attribute_value(HTML::AttributeNames::@attribute.reflect_name@);
@@ -4614,6 +4649,7 @@ void generate_prototype_implementation(IDL::Interface const& interface, StringBu
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowProxy.h>
+#include <LibWeb/Infra/Strings.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 #include <LibWeb/WebIDL/Buffers.h>
 #include <LibWeb/WebIDL/Tracing.h>

--- a/Tests/LibWeb/Text/expected/input-image.txt
+++ b/Tests/LibWeb/Text/expected/input-image.txt
@@ -1,2 +1,2 @@
-../../Layout/input/120.png loaded
+120.png loaded
 file:///i-do-no-exist-i-swear.png failed

--- a/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
+++ b/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
@@ -1,0 +1,14 @@
+audio.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+embed.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+frame.longDesc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+frame.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+iframe.longDesc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+iframe.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+img.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+link.href final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+object.codeBase final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+object.data final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+script.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+source.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+track.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+video.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD

--- a/Tests/LibWeb/Text/expected/video-canceled-load.txt
+++ b/Tests/LibWeb/Text/expected/video-canceled-load.txt
@@ -1,1 +1,1 @@
- wfh
+ file:///example/file/location/wfh

--- a/Tests/LibWeb/Text/expected/video-failed-load.txt
+++ b/Tests/LibWeb/Text/expected/video-failed-load.txt
@@ -1,3 +1,3 @@
 failed to load: "data:"
 failed to load: "file:///i-do-no-exist-i-swear"
-failed to load: "https://i-do-no-exist-i-swear.net.uk"
+failed to load: "https://i-do-no-exist-i-swear.net.uk/"

--- a/Tests/LibWeb/Text/input/input-image.html
+++ b/Tests/LibWeb/Text/input/input-image.html
@@ -9,7 +9,8 @@
 
         return new Promise((resolve, reject) => {
             input.addEventListener("load", () => {
-                resolve(`${input.src} loaded`);
+                const filename = input.src.split('/').pop();
+                resolve(`${filename} loaded`);
             });
             input.addEventListener("error", () => {
                 resolve(`${input.src} failed`);

--- a/Tests/LibWeb/Text/input/usvstring-url-reflection.html
+++ b/Tests/LibWeb/Text/input/usvstring-url-reflection.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        let elementList = [
+            { "audio": "src" },
+            { "embed": "src" },
+            { "frame": "longDesc" },
+            { "frame": "src" },
+            { "iframe": "longDesc" },
+            { "iframe": "src" },
+            { "img": "src" },
+            { "link": "href" },
+            { "object": "codeBase" },
+            { "object": "data" },
+            { "script": "src" },
+            { "source": "src" },
+            { "track": "src" },
+            { "video": "src" },
+        ];
+        for (const elementDescriptor of elementList) {
+            [elementName, propertyName] = Object.entries(elementDescriptor)[0];
+            const element = document.createElement(elementName);
+            element[propertyName] = "\udddda\uddddb\udddd";
+            println(`${elementName}.${propertyName} final URL path segment: ${element[propertyName].split("/").pop()}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/video-canceled-load.html
+++ b/Tests/LibWeb/Text/input/video-canceled-load.html
@@ -1,7 +1,7 @@
 <script src="include.js"></script>
 <script type="text/javascript">
     function updateSrc() {
-        video.src = "wfh";
+        video.src = "file:///example/file/location/wfh";
     }
 
     test(() => {

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.idl
@@ -10,7 +10,7 @@ interface HTMLAnchorElement : HTMLElement {
 
     [CEReactions, Reflect] attribute DOMString target;
     [CEReactions, Reflect] attribute DOMString download;
-    [CEReactions, Reflect] attribute DOMString ping;
+    [CEReactions, Reflect] attribute USVString ping;
     [CEReactions, Reflect] attribute DOMString rel;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
     [CEReactions, Reflect] attribute DOMString hreflang;

--- a/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLEmbedElement.idl
@@ -6,7 +6,7 @@ interface HTMLEmbedElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString type;
     [CEReactions, Reflect] attribute DOMString width;
     [CEReactions, Reflect] attribute DOMString height;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.idl
@@ -8,9 +8,9 @@ interface HTMLFrameElement : HTMLElement {
 
     [CEReactions, Reflect] attribute DOMString name;
     [CEReactions, Reflect] attribute DOMString scrolling;
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect=frameborder] attribute DOMString frameBorder;
-    [CEReactions, Reflect=longdesc] attribute DOMString longDesc;
+    [CEReactions, Reflect=longdesc, URL] attribute USVString longDesc;
     [CEReactions, Reflect=noresize] attribute boolean noResize;
     [FIXME] readonly attribute Document? contentDocument;
     [FIXME] readonly attribute WindowProxy? contentWindow;

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.idl
@@ -8,7 +8,7 @@ interface HTMLIFrameElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString srcdoc;
     [CEReactions, Reflect] attribute DOMString name;
     [FIXME, SameObject, PutForwards=value] readonly attribute DOMTokenList sandbox;
@@ -26,7 +26,7 @@ interface HTMLIFrameElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString align;
     [CEReactions, Reflect] attribute DOMString scrolling;
     [CEReactions, Reflect=frameborder] attribute DOMString frameBorder;
-    [CEReactions, Reflect=longdesc] attribute USVString longDesc;
+    [CEReactions, Reflect=longdesc, URL] attribute USVString longDesc;
 
     [CEReactions, LegacyNullToEmptyString, Reflect=marginheight] attribute DOMString marginHeight;
     [CEReactions, LegacyNullToEmptyString, Reflect=marginwidth] attribute DOMString marginWidth;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -9,7 +9,7 @@ interface HTMLImageElement : HTMLElement {
     [HTMLConstructor] constructor();
 
     [CEReactions, Reflect] attribute DOMString alt;
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString srcset;
     [CEReactions, Reflect] attribute DOMString sizes;
     [CEReactions, Enumerated=CORSSettingsAttribute, Reflect=crossorigin] attribute DOMString? crossOrigin;
@@ -34,7 +34,7 @@ interface HTMLImageElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString align;
     [CEReactions, Reflect] attribute unsigned long hspace;
     [CEReactions, Reflect] attribute unsigned long vspace;
-    [CEReactions, Reflect=longdesc] attribute USVString longDesc;
+    [CEReactions, Reflect=longdesc, URL] attribute USVString longDesc;
 
     [CEReactions, LegacyNullToEmptyString, Reflect] attribute DOMString border;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -36,7 +36,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect=readonly] attribute boolean readOnly;
     [CEReactions, Reflect] attribute boolean required;
     [CEReactions] attribute unsigned long size;
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString step;
     [CEReactions] attribute DOMString type;
     [CEReactions, Reflect=value] attribute DOMString defaultValue;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -9,7 +9,7 @@ interface HTMLLinkElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString href;
+    [CEReactions, Reflect, URL] attribute USVString href;
     [CEReactions, Reflect=crossorigin, Enumerated=CORSSettingsAttribute] attribute DOMString? crossOrigin;
     [CEReactions, Reflect] attribute DOMString rel;
     [CEReactions] attribute DOMString as;
@@ -19,7 +19,7 @@ interface HTMLLinkElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString hreflang;
     [CEReactions, Reflect] attribute DOMString type;
     [FIXME, SameObject, PutForwards=value] readonly attribute DOMTokenList sizes;
-    [CEReactions, Reflect=imagesrcset] attribute DOMString imageSrcset;
+    [CEReactions, Reflect=imagesrcset] attribute USVString imageSrcset;
     [CEReactions, Reflect=imagesizes] attribute DOMString imageSizes;
     [CEReactions, Reflect=referrerpolicy, Enumerated=ReferrerPolicy] attribute DOMString referrerPolicy;
     [FIXME, SameObject, PutForwards=value] readonly attribute DOMTokenList blocking;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -30,7 +30,7 @@ interface HTMLMediaElement : HTMLElement {
     readonly attribute MediaError? error;
 
     // network state
-    [Reflect, CEReactions] attribute DOMString src;
+    [Reflect, CEReactions, URL] attribute USVString src;
     [FIXME] attribute MediaProvider? srcObject;
     readonly attribute USVString currentSrc;
     [Reflect=crossorigin, CEReactions, Enumerated=CORSSettingsAttribute] attribute DOMString? crossOrigin;

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.idl
@@ -7,7 +7,7 @@ interface HTMLObjectElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions] attribute DOMString data;
+    [CEReactions, URL] attribute USVString data;
     [CEReactions, Reflect] attribute DOMString type;
     [CEReactions, Reflect] attribute DOMString name;
     readonly attribute HTMLFormElement? form;
@@ -32,7 +32,7 @@ interface HTMLObjectElement : HTMLElement {
     [CEReactions, Reflect] attribute unsigned long hspace;
     [CEReactions, Reflect] attribute DOMString standby;
     [CEReactions, Reflect] attribute unsigned long vspace;
-    [CEReactions, Reflect=codebase] attribute DOMString codeBase;
+    [CEReactions, Reflect=codebase, URL] attribute USVString codeBase;
     [CEReactions, Reflect=codetype] attribute DOMString codeType;
     [CEReactions, Reflect=usemap] attribute DOMString useMap;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.idl
@@ -8,7 +8,7 @@ interface HTMLScriptElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString type;
     [CEReactions, Reflect=nomodule] attribute boolean noModule;
     [CEReactions] attribute boolean async;

--- a/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSourceElement.idl
@@ -6,9 +6,9 @@ interface HTMLSourceElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString type;
-    [CEReactions, Reflect] attribute DOMString srcset;
+    [CEReactions, Reflect] attribute USVString srcset;
     [CEReactions, Reflect] attribute DOMString sizes;
     [CEReactions, Reflect] attribute DOMString media;
     [CEReactions, Reflect] attribute unsigned long width;

--- a/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTrackElement.idl
@@ -17,7 +17,7 @@ interface HTMLTrackElement : HTMLElement {
     [HTMLConstructor] constructor();
 
     [CEReactions, Enumerated=TrackKindAttribute, Reflect] attribute DOMString kind;
-    [CEReactions, Reflect] attribute DOMString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString srclang;
     [CEReactions, Reflect] attribute DOMString label;
     [CEReactions, Reflect] attribute boolean default;


### PR DESCRIPTION
This PR changes some IDL attribute return types to USVString, where the specification says that's what should be used and updates the bindings generator to ensure that reflected USVString attributes behave correctly.

USVString attributes that represent a URL are now explicitly marked with the `URL` extended attribute, as the specification says that they are supposed to behave differently to attributes that don't represent a URL.

Fixes 5 subtests on: http://wpt.live/html/dom/usvstring-reflection.https.html