### PR TITLE
LibJS: A collection of Intl.DurationFormat and related areas spec updates

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -608,21 +608,21 @@ bool is_time_zone_offset_string(StringView offset_string)
 // 21.4.1.33.2 ParseTimeZoneOffsetString ( offsetString ), https://tc39.es/ecma262/#sec-parsetimezoneoffsetstring
 double parse_time_zone_offset_string(StringView offset_string)
 {
-    // 1. Let parseResult be ParseText(StringToCodePoints(offsetString), UTCOffset).
+    // 1. Let parseResult be ParseText(offsetString, UTCOffset).
     auto parse_result = Temporal::parse_iso8601(Temporal::Production::TimeZoneNumericUTCOffset, offset_string);
 
     // 2. Assert: parseResult is not a List of errors.
     VERIFY(parse_result.has_value());
 
-    // 3. Assert: parseResult contains a TemporalSign Parse Node.
+    // 3. Assert: parseResult contains a ASCIISign Parse Node.
     VERIFY(parse_result->time_zone_utc_offset_sign.has_value());
 
-    // 4. Let parsedSign be the source text matched by the TemporalSign Parse Node contained within parseResult.
+    // 4. Let parsedSign be the source text matched by the ASCIISign Parse Node contained within parseResult.
     auto parsed_sign = *parse_result->time_zone_utc_offset_sign;
     i8 sign { 0 };
 
-    // 5. If parsedSign is the single code point U+002D (HYPHEN-MINUS) or U+2212 (MINUS SIGN), then
-    if (parsed_sign.is_one_of("-"sv, "\xE2\x88\x92"sv)) {
+    // 5. If parsedSign is the single code point U+002D (HYPHEN-MINUS), then
+    if (parsed_sign == "-"sv) {
         // a. Let sign be -1.
         sign = -1;
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -615,7 +615,7 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
     return result;
 }
 
-// 1.1.12 FormatNumericUnits ( durationFormat, duration, firstNumericUnit, signDisplayed )
+// 1.1.12 FormatNumericUnits ( durationFormat, duration, firstNumericUnit, signDisplayed ), https://tc39.es/proposal-intl-duration-format/#sec-formatnumericunits
 Vector<DurationFormatPart> format_numeric_units(VM& vm, DurationFormat const& duration_format, Temporal::DurationRecord const& duration, StringView first_numeric_unit, bool sign_displayed)
 {
     // 1. Assert: firstNumericUnit is "hours", "minutes", or "seconds".
@@ -685,20 +685,38 @@ Vector<DurationFormatPart> format_numeric_units(VM& vm, DurationFormat const& du
 
     // 16. If hoursFormatted is true, then
     if (hours_formatted) {
-        // a. Append FormatNumericHours(durationFormat, hoursValue, signDisplayed) to numericPartsList.
+        // a. If signDisplayed is true, then
+        if (sign_displayed) {
+            // i. If hoursValue is 0 and DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]) is -1, then
+            if (hours_value == 0 && Temporal::duration_sign(duration.years, duration.months, duration.weeks, duration.days, duration.hours, duration.minutes, duration.seconds, duration.milliseconds, duration.microseconds, duration.nanoseconds) == -1) {
+                // 1. Set hoursValue to negative-zero.
+                hours_value = -0.0;
+            }
+        }
+
+        // b. Append FormatNumericHours(durationFormat, hoursValue, signDisplayed) to numericPartsList.
         numeric_parts_list.extend(format_numeric_hours(vm, duration_format, hours_value, sign_displayed));
 
-        // b. Set signDisplayed to false.
-        sign_displayed = hours_value < 0;
+        // c. Set signDisplayed to false.
+        sign_displayed = false;
     }
 
     // 17. If minutesFormatted is true, then
     if (minutes_formatted) {
-        // a. Append FormatNumericMinutes(durationFormat, minutesValue, hoursFormatted, signDisplayed) to numericPartsList.
+        // a. If signDisplayed is true, then
+        if (sign_displayed) {
+            // i. If minutesValue is 0 and DurationSign(duration.[[Years]], duration.[[Months]], duration.[[Weeks]], duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]]) is -1, then
+            if (minutes_value == 0 && Temporal::duration_sign(duration.years, duration.months, duration.weeks, duration.days, duration.hours, duration.minutes, duration.seconds, duration.milliseconds, duration.microseconds, duration.nanoseconds) == -1) {
+                // 1. Set minutesValue to negative-zero.
+                minutes_value = -0.0;
+            }
+        }
+
+        // b. Append FormatNumericMinutes(durationFormat, minutesValue, hoursFormatted, signDisplayed) to numericPartsList.
         numeric_parts_list.extend(format_numeric_minutes(vm, duration_format, minutes_value, hours_formatted, sign_displayed));
 
-        // b. Set signDisplayed to false.
-        sign_displayed = minutes_value < 0;
+        // c. Set signDisplayed to false.
+        sign_displayed = false;
     }
 
     // 18. If secondsFormatted is true, then
@@ -707,7 +725,7 @@ Vector<DurationFormatPart> format_numeric_units(VM& vm, DurationFormat const& du
         numeric_parts_list.extend(format_numeric_seconds(vm, duration_format, seconds_value, minutes_formatted, sign_displayed));
 
         // b. Set signDisplayed to false.
-        sign_displayed = seconds_value < 0;
+        sign_displayed = false;
     }
 
     // 19. Return numericPartsList.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DurationFormat.cpp
@@ -442,13 +442,16 @@ Vector<DurationFormatPart> format_numeric_hours(VM& vm, DurationFormat const& du
         MUST(number_format_options->create_data_property_or_throw(vm.names.signDisplay, PrimitiveString::create(vm, "never"sv)));
     }
 
-    // 9. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
+    // 9. Perform ! CreateDataPropertyOrThrow(nfOpts, "useGrouping", false).
+    MUST(number_format_options->create_data_property_or_throw(vm.names.useGrouping, Value { false }));
+
+    // 10. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
     auto number_format = construct_number_format(vm, duration_format, number_format_options);
 
-    // 10. Let hoursParts be ! PartitionNumberPattern(nf, hoursValue).
+    // 11. Let hoursParts be ! PartitionNumberPattern(nf, hoursValue).
     auto hours_parts = partition_number_pattern(number_format, MathematicalValue { hours_value });
 
-    // 11. For each Record { [[Type]], [[Value]] } part of hoursParts, do
+    // 12. For each Record { [[Type]], [[Value]] } part of hoursParts, do
     result.ensure_capacity(hours_parts.size());
 
     for (auto& part : hours_parts) {
@@ -456,7 +459,7 @@ Vector<DurationFormatPart> format_numeric_hours(VM& vm, DurationFormat const& du
         result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "hour"sv });
     }
 
-    // 12. Return result.
+    // 13. Return result.
     return result;
 }
 
@@ -504,13 +507,16 @@ Vector<DurationFormatPart> format_numeric_minutes(VM& vm, DurationFormat const& 
         MUST(number_format_options->create_data_property_or_throw(vm.names.signDisplay, PrimitiveString::create(vm, "never"sv)));
     }
 
-    // 10. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
+    // 10. Perform ! CreateDataPropertyOrThrow(nfOpts, "useGrouping", false).
+    MUST(number_format_options->create_data_property_or_throw(vm.names.useGrouping, Value { false }));
+
+    // 11. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
     auto number_format = construct_number_format(vm, duration_format, number_format_options);
 
-    // 11. Let minutesParts be ! PartitionNumberPattern(nf, minutesValue).
+    // 12. Let minutesParts be ! PartitionNumberPattern(nf, minutesValue).
     auto minutes_parts = partition_number_pattern(number_format, MathematicalValue { minutes_value });
 
-    // 12. For each Record { [[Type]], [[Value]] } part of minutesParts, do
+    // 13. For each Record { [[Type]], [[Value]] } part of minutesParts, do
     result.ensure_capacity(result.size() + minutes_parts.size());
 
     for (auto& part : minutes_parts) {
@@ -518,7 +524,7 @@ Vector<DurationFormatPart> format_numeric_minutes(VM& vm, DurationFormat const& 
         result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "minute"sv });
     }
 
-    // 13. Return result.
+    // 14. Return result.
     return result;
 }
 
@@ -566,10 +572,13 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
         MUST(number_format_options->create_data_property_or_throw(vm.names.signDisplay, PrimitiveString::create(vm, "never"sv)));
     }
 
+    // 10. Perform ! CreateDataPropertyOrThrow(nfOpts, "useGrouping", false).
+    MUST(number_format_options->create_data_property_or_throw(vm.names.useGrouping, Value { false }));
+
     u8 maximum_fraction_digits = 0;
     u8 minimum_fraction_digits = 0;
 
-    // 11. If durationFormat.[[FractionalDigits]] is undefined, then
+    // 12. If durationFormat.[[FractionalDigits]] is undefined, then
     if (!duration_format.has_fractional_digits()) {
         // a. Let maximumFractionDigits be 9𝔽.
         maximum_fraction_digits = 9;
@@ -577,7 +586,7 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
         // b. Let minimumFractionDigits be +0𝔽.
         minimum_fraction_digits = 0;
     }
-    // 12. Else,
+    // 13. Else,
     else {
         // a. Let maximumFractionDigits be durationFormat.[[FractionalDigits]].
         maximum_fraction_digits = duration_format.fractional_digits();
@@ -586,24 +595,24 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
         minimum_fraction_digits = duration_format.fractional_digits();
     }
 
-    // 13. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", maximumFractionDigits).
+    // 14. Perform ! CreateDataPropertyOrThrow(nfOpts, "maximumFractionDigits", maximumFractionDigits).
     MUST(number_format_options->create_data_property_or_throw(vm.names.maximumFractionDigits, Value { maximum_fraction_digits }));
 
-    // 14. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", minimumFractionDigits).
+    // 15. Perform ! CreateDataPropertyOrThrow(nfOpts, "minimumFractionDigits", minimumFractionDigits).
     MUST(number_format_options->create_data_property_or_throw(vm.names.minimumFractionDigits, Value { minimum_fraction_digits }));
 
-    // 15. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").
+    // 16. Perform ! CreateDataPropertyOrThrow(nfOpts, "roundingMode", "trunc").
     MUST(number_format_options->create_data_property_or_throw(vm.names.roundingMode, PrimitiveString::create(vm, "trunc"sv)));
 
     // FIXME: We obviously have to create the NumberFormat object after its options are fully initialized.
     //        https://github.com/tc39/proposal-intl-duration-format/pull/203
-    // 10. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
+    // 11. Let nf be ! Construct(%NumberFormat%, « durationFormat.[[Locale]], nfOpts »).
     auto number_format = construct_number_format(vm, duration_format, number_format_options);
 
-    // 16. Let secondsParts be ! PartitionNumberPattern(nf, secondsValue).
+    // 17. Let secondsParts be ! PartitionNumberPattern(nf, secondsValue).
     auto seconds_parts = partition_number_pattern(number_format, MathematicalValue { seconds_value });
 
-    // 17. For each Record { [[Type]], [[Value]] } part of secondsParts, do
+    // 18. For each Record { [[Type]], [[Value]] } part of secondsParts, do
     result.ensure_capacity(result.size() + seconds_parts.size());
 
     for (auto& part : seconds_parts) {
@@ -611,7 +620,7 @@ Vector<DurationFormatPart> format_numeric_seconds(VM& vm, DurationFormat const& 
         result.unchecked_append({ .type = part.type, .value = move(part.value), .unit = "second"sv });
     }
 
-    // 18. Return result.
+    // 19. Return result.
     return result;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
@@ -64,11 +64,8 @@ bool ISO8601Parser::parse_sign()
 {
     // Sign :
     //     ASCIISign
-    //     U+2212
     StateTransaction transaction { *this };
-    auto success = parse_ascii_sign()
-        || m_state.lexer.consume_specific("\xE2\x88\x92"sv);
-    if (!success)
+    if (!parse_ascii_sign())
         return false;
     m_state.parse_result.sign = transaction.parsed_string_view();
     transaction.commit();

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
@@ -110,6 +110,27 @@ describe("correct behavior", () => {
         const lt = new Intl.DurationFormat("lt", { style: "digital" });
         expect(lt.format(duration)).toBe("01:02:03");
     });
+
+    test("negative duration fields", () => {
+        const duration = {
+            years: -1,
+            months: -2,
+            weeks: -3,
+            days: -4,
+            hours: -5,
+            minutes: -6,
+            seconds: -7,
+            milliseconds: -8,
+            microseconds: -9,
+            nanoseconds: -11,
+        };
+
+        const en = new Intl.DurationFormat("en", { style: "digital" });
+        expect(en.format(duration)).toBe("-1 yr, 2 mths, 3 wks, 4 days, 5:06:07.008009011");
+
+        const de = new Intl.DurationFormat("de", { style: "digital" });
+        expect(de.format(duration)).toBe("-1 J, 2 Mon., 3 Wo., 4 Tg. und 5:06:07,008009011");
+    });
 });
 
 describe("errors", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
@@ -131,6 +131,20 @@ describe("correct behavior", () => {
         const de = new Intl.DurationFormat("de", { style: "digital" });
         expect(de.format(duration)).toBe("-1 J, 2 Mon., 3 Wo., 4 Tg. und 5:06:07,008009011");
     });
+
+    test("formatted fields do not have grouping separators", () => {
+        const duration = {
+            hours: 123456,
+            minutes: 456789,
+            seconds: 789123,
+        };
+
+        const en = new Intl.DurationFormat("en", { style: "digital" });
+        expect(en.format(duration)).toBe("123456:456789:789123");
+
+        const de = new Intl.DurationFormat("de", { style: "digital" });
+        expect(de.format(duration)).toBe("123456:456789:789123");
+    });
 });
 
 describe("errors", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.from.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.from.js
@@ -108,4 +108,26 @@ describe("errors", () => {
             );
         }
     });
+
+    test("invalid duration string: exceed duration limits", () => {
+        const values = [
+            "P4294967296Y", // abs(years) >= 2**32
+            "P4294967296M", // abs(months) >= 2**32
+            "P4294967296W", // abs(weeks) >= 2**32
+            "P104249991375D", // days >= 2*53 seconds
+            "PT2501999792984H", // hours >= 2*53 seconds
+            "PT150119987579017M", // minutes >= 2*53 seconds
+            "PT9007199254740992S", // seconds >= 2*53 seconds
+        ];
+
+        for (const value of values) {
+            expect(() => {
+                Temporal.Duration.from(value);
+            }).toThrowWithMessage(RangeError, `Invalid duration`);
+
+            expect(() => {
+                Temporal.Duration.from("-" + value);
+            }).toThrowWithMessage(RangeError, `Invalid duration`);
+        }
+    });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.js
@@ -16,9 +16,14 @@ describe("errors", () => {
         expect(() => {
             new Temporal.TimeZone("0123456");
         }).toThrowWithMessage(RangeError, "Invalid time zone name '0123456'");
+
         expect(() => {
             new Temporal.TimeZone("23:59:59.9999999999");
         }).toThrowWithMessage(RangeError, "Invalid time zone name '23:59:59.9999999999'");
+
+        expect(() => {
+            new Temporal.TimeZone("\u221201");
+        }).toThrowWithMessage(RangeError, "Invalid time zone name '\u221201'");
     });
 });
 
@@ -58,7 +63,6 @@ describe("normal behavior", () => {
         const signs = [
             ["+", "+"],
             ["-", "-"],
-            ["\u2212", "-"],
         ];
         const values = [
             ["01", "01:00"],


### PR DESCRIPTION
test262 diff:
```
Diff Tests:
    +57 ✅    -57 ❌

    test/built-ins/Temporal/Duration/compare/argument-duration-out-of-range.js                                                  ❌ -> ✅
    test/built-ins/Temporal/Duration/compare/duration-out-of-range-added-to-relativeto.js                                       ❌ -> ✅
    test/built-ins/Temporal/Duration/from/argument-duration-max.js                                                              ✅ -> ❌
    test/built-ins/Temporal/Duration/from/argument-duration-out-of-range.js                                                     ❌ -> ✅
    test/built-ins/Temporal/Duration/max.js                                                                                     ✅ -> ❌
    test/built-ins/Temporal/Duration/out-of-range.js                                                                            ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/add/argument-duration-max.js                                                     ✅ -> ❌
    test/built-ins/Temporal/Duration/prototype/add/argument-duration-out-of-range.js                                            ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/add/argument-duration-precision-exact-numerical-values.js                        ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/add/result-out-of-range-1.js                                                     ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/add/result-out-of-range-2.js                                                     ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/round/duration-out-of-range-added-to-relativeto.js                               ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/round/out-of-range-when-converting-from-normalized-duration.js                   ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/round/result-out-of-range.js                                                     ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/subtract/argument-duration-max.js                                                ✅ -> ❌
    test/built-ins/Temporal/Duration/prototype/subtract/argument-duration-out-of-range.js                                       ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/subtract/argument-duration-precision-exact-numerical-values.js                   ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/subtract/result-out-of-range-1.js                                                ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/subtract/result-out-of-range-2.js                                                ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/toString/throws-when-rounded-duration-is-invalid.js                              ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/total/duration-out-of-range-added-to-relativeto.js                               ❌ -> ✅
    test/built-ins/Temporal/Duration/prototype/total/relativeto-plaindate-add24hourdaystonormalizedtimeduration-out-of-range.js ❌ -> ✅
    test/built-ins/Temporal/Instant/compare/argument-string-minus-sign.js                                                       ❌ -> ✅
    test/built-ins/Temporal/Instant/from/argument-string-minus-sign.js                                                          ❌ -> ✅
    test/built-ins/Temporal/Instant/prototype/equals/argument-string-minus-sign.js                                              ❌ -> ✅
    test/built-ins/Temporal/Instant/prototype/since/argument-string-minus-sign.js                                               ❌ -> ✅
    test/built-ins/Temporal/Instant/prototype/until/argument-string-minus-sign.js                                               ❌ -> ✅
    test/built-ins/Temporal/PlainDate/compare/argument-string-minus-sign.js                                                     ❌ -> ✅
    test/built-ins/Temporal/PlainDate/from/argument-string-minus-sign.js                                                        ❌ -> ✅
    test/built-ins/Temporal/PlainDate/prototype/equals/argument-string-minus-sign.js                                            ❌ -> ✅
    test/built-ins/Temporal/PlainDate/prototype/since/argument-string-minus-sign.js                                             ❌ -> ✅
    test/built-ins/Temporal/PlainDate/prototype/toPlainDateTime/argument-string-minus-sign.js                                   ❌ -> ✅
    test/built-ins/Temporal/PlainDate/prototype/toZonedDateTime/argument-string-minus-sign.js                                   ❌ -> ✅
    test/built-ins/Temporal/PlainDate/prototype/until/argument-string-minus-sign.js                                             ❌ -> ✅
    test/built-ins/Temporal/PlainDateTime/compare/argument-string-minus-sign.js                                                 ❌ -> ✅
    test/built-ins/Temporal/PlainDateTime/from/argument-string-minus-sign.js                                                    ❌ -> ✅
    test/built-ins/Temporal/PlainDateTime/prototype/equals/argument-string-minus-sign.js                                        ❌ -> ✅
    test/built-ins/Temporal/PlainDateTime/prototype/since/argument-string-minus-sign.js                                         ❌ -> ✅
    test/built-ins/Temporal/PlainDateTime/prototype/until/argument-string-minus-sign.js                                         ❌ -> ✅
    test/built-ins/Temporal/PlainDateTime/prototype/withPlainTime/argument-string-minus-sign.js                                 ❌ -> ✅
    test/built-ins/Temporal/PlainMonthDay/from/argument-string-minus-sign.js                                                    ❌ -> ✅
    test/built-ins/Temporal/PlainMonthDay/prototype/equals/argument-string-minus-sign.js                                        ❌ -> ✅
    test/built-ins/Temporal/PlainTime/compare/argument-string-minus-sign.js                                                     ❌ -> ✅
    test/built-ins/Temporal/PlainTime/from/argument-string-minus-sign.js                                                        ❌ -> ✅
    test/built-ins/Temporal/PlainTime/prototype/add/argument-duration-out-of-range.js                                           ❌ -> ✅
    test/built-ins/Temporal/PlainTime/prototype/equals/argument-string-minus-sign.js                                            ❌ -> ✅
    test/built-ins/Temporal/PlainTime/prototype/since/argument-string-minus-sign.js                                             ❌ -> ✅
    test/built-ins/Temporal/PlainTime/prototype/subtract/argument-duration-out-of-range.js                                      ❌ -> ✅
    test/built-ins/Temporal/PlainTime/prototype/until/argument-string-minus-sign.js                                             ❌ -> ✅
    test/built-ins/Temporal/PlainYearMonth/compare/argument-string-minus-sign.js                                                ❌ -> ✅
    test/built-ins/Temporal/PlainYearMonth/from/argument-string-minus-sign.js                                                   ❌ -> ✅
    test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-minus-sign.js                                       ❌ -> ✅
    test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-minus-sign.js                                        ❌ -> ✅
    test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-minus-sign.js                                        ❌ -> ✅
    test/built-ins/Temporal/ZonedDateTime/compare/argument-string-minus-sign.js                                                 ❌ -> ✅
    test/built-ins/Temporal/ZonedDateTime/from/argument-string-minus-sign.js                                                    ❌ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/equals/argument-string-minus-sign.js                                        ❌ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/since/argument-string-minus-sign.js                                         ❌ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/until/argument-string-minus-sign.js                                         ❌ -> ✅
    test/built-ins/Temporal/ZonedDateTime/prototype/withPlainTime/argument-string-minus-sign.js                                 ❌ -> ✅
    test/intl402/DateTimeFormat/offset-timezone-no-unicode-minus-sign.js                                                        ❌ -> ✅
    test/intl402/DurationFormat/prototype/format/negative-duration-with-leading-zero-style-digital-en.js                        ❌ -> ✅
    test/intl402/DurationFormat/prototype/format/negative-durationstyle-digital-en.js                                           ❌ -> ✅
    test/intl402/DurationFormat/prototype/formatToParts/negative-duration-formatToParts-style-digital-en.js                     ❌ -> ✅
    test/intl402/DurationFormat/prototype/formatToParts/negative-duration-with-leading-zero-style-digital-en.js                 ❌ -> ✅
```

The new failures are unfortunate, but I tracked them down to imprecise floating point handling in our implementation of AOs that no longer even exist in the upstream Temporal spec. So, not worth fixing here.