### PR TITLE
LibWeb: Set referrerPolicy when link type includes noreferrer keyword

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/HTML/HTMLAnchorElement.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
@@ -64,6 +65,12 @@ WebIDL::ExceptionOr<void> HTMLAnchorElement::set_hyperlink_element_utils_href(St
 Optional<String> HTMLAnchorElement::hyperlink_element_utils_referrerpolicy() const
 {
     return attribute(HTML::AttributeNames::referrerpolicy);
+}
+
+Vector<StringView> HTMLAnchorElement::hyperlink_element_utils_subject_link_types() const
+{
+    String rel = MUST(this->rel().to_lowercase());
+    return rel.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
 }
 
 bool HTMLAnchorElement::has_activation_behavior() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -53,6 +53,7 @@ private:
     virtual Optional<String> hyperlink_element_utils_href() const override;
     virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) override;
     virtual Optional<String> hyperlink_element_utils_referrerpolicy() const override;
+    virtual Vector<StringView> hyperlink_element_utils_subject_link_types() const override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const final { return true; }
     virtual bool hyperlink_element_utils_is_connected() const final { return is_connected(); }
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 
 namespace Web::HTML {
 
@@ -66,6 +67,12 @@ WebIDL::ExceptionOr<void> HTMLAreaElement::set_hyperlink_element_utils_href(Stri
 Optional<String> HTMLAreaElement::hyperlink_element_utils_referrerpolicy() const
 {
     return attribute(HTML::AttributeNames::referrerpolicy);
+}
+
+Vector<StringView> HTMLAreaElement::hyperlink_element_utils_subject_link_types() const
+{
+    String rel = MUST(this->rel().to_lowercase());
+    return rel.bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -20,6 +20,9 @@ class HTMLAreaElement final
 
 public:
     virtual ~HTMLAreaElement() override;
+
+    String rel() const { return get_attribute_value(HTML::AttributeNames::rel); }
+
     JS::NonnullGCPtr<DOM::DOMTokenList> rel_list();
 
 private:
@@ -37,6 +40,7 @@ private:
     virtual Optional<String> hyperlink_element_utils_href() const override;
     virtual WebIDL::ExceptionOr<void> set_hyperlink_element_utils_href(String) override;
     virtual Optional<String> hyperlink_element_utils_referrerpolicy() const override;
+    virtual Vector<StringView> hyperlink_element_utils_subject_link_types() const override;
     virtual bool hyperlink_element_utils_is_html_anchor_element() const override { return false; }
     virtual bool hyperlink_element_utils_is_connected() const override { return is_connected(); }
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHyperlinkElementUtils.h>
 #include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/Infra/CharacterTypes.h>
 
 namespace Web::HTML {
 
@@ -501,7 +502,9 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // 11. Let referrerPolicy be the current state of subject's referrerpolicy content attribute.
     auto referrer_policy = ReferrerPolicy::from_string(hyperlink_element_utils_referrerpolicy().value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
 
-    // FIXME: 12. If subject's link types includes the noreferrer keyword, then set referrerPolicy to "no-referrer".
+    // 12. If subject's link types includes the noreferrer keyword, then set referrerPolicy to "no-referrer".
+    if (hyperlink_element_utils_subject_link_types().contains_slow("noreferrer"sv))
+        referrer_policy = ReferrerPolicy::ReferrerPolicy::NoReferrer;
 
     // 13. Navigate targetNavigable to urlString using subject's node document, with referrerPolicy set to referrerPolicy and userInvolvement set to userInvolvement.
     MUST(target_navigable->navigate({ .url = url_string, .source_document = hyperlink_element_utils_document(), .referrer_policy = referrer_policy, .user_involvement = user_involvement }));

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -61,6 +61,7 @@ protected:
     virtual TokenizedFeature::NoOpener hyperlink_element_utils_get_an_elements_noopener(StringView target) const = 0;
 
     virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) = 0;
+    virtual Vector<StringView> hyperlink_element_utils_subject_link_types() const = 0;
 
     void set_the_url();
     void follow_the_hyperlink(Optional<String> hyperlink_suffix, UserNavigationInvolvement = UserNavigationInvolvement::None);


### PR DESCRIPTION
This PR checks if the subject's link types includes the noreferrer keyword and then sets the referrerPolicy to "no-referrer".
This also adds a rel attribute to HTMLAreaElement as in the [spec](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element). 