### PR TITLE
LibWeb: Implement the "fire a focus event" spec

### DIFF
--- a/Tests/LibWeb/Text/expected/focus-events.txt
+++ b/Tests/LibWeb/Text/expected/focus-events.txt
@@ -1,6 +1,6 @@
-   focus target=<INPUT id="a">
-focusin target=<INPUT id="a">
-blur target=<INPUT id="a">
-focusout target=<INPUT id="a">
-focus target=<INPUT id="b">
-focusin target=<INPUT id="b">
+   focus target=<INPUT id="a"> bubbles=false composed=true
+focusin target=<INPUT id="a"> bubbles=true composed=true
+blur target=<INPUT id="a"> bubbles=false composed=true
+focusout target=<INPUT id="a"> bubbles=true composed=true
+focus target=<INPUT id="b"> bubbles=false composed=true
+focusin target=<INPUT id="b"> bubbles=true composed=true

--- a/Tests/LibWeb/Text/input/focus-events.html
+++ b/Tests/LibWeb/Text/input/focus-events.html
@@ -16,32 +16,21 @@
         return element_string;
     }
 
-    document.addEventListener("focusin", function (e) {
+    function printFocusEvent(e) {
         const target = elementToString(e.target);
-        println(`focusin target=${target}`);
-    });
-    document.addEventListener("focusout", function (e) {
-        const target = elementToString(e.target);
-        println(`focusout target=${target}`);
-    });
+        println(`${e.type} target=${target} bubbles=${e.bubbles} composed=${e.composed}`);
+    }
+
+    document.addEventListener('focusin', printFocusEvent);
+    document.addEventListener('focusout', printFocusEvent);
 
     const a = document.getElementById("a");
     const b = document.getElementById("b");
 
-    function onFocus(e) {
-        const target = elementToString(e.target);
-        println(`focus target=${target}`);
-    }
-
-    function onBlur(e) {
-        const target = elementToString(e.target);
-        println(`blur target=${target}`);
-    }
-
-    a.addEventListener("focus", onFocus);
-    a.addEventListener("blur", onBlur);
-    b.addEventListener("focus", onFocus);
-    b.addEventListener("blur", onBlur);
+    a.addEventListener('focus', printFocusEvent);
+    a.addEventListener('blur', printFocusEvent);
+    b.addEventListener('focus', printFocusEvent);
+    b.addEventListener('blur', printFocusEvent);
 
     asyncTest(async done => {
         a.focus();

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.cpp
@@ -12,9 +12,14 @@ namespace Web::UIEvents {
 
 JS_DEFINE_ALLOCATOR(FocusEvent);
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> FocusEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
+JS::NonnullGCPtr<FocusEvent> FocusEvent::create(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
 {
     return realm.heap().allocate<FocusEvent>(realm, realm, event_name, event_init);
+}
+
+WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> FocusEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)
+{
+    return create(realm, event_name, event_init);
 }
 
 FocusEvent::FocusEvent(JS::Realm& realm, FlyString const& event_name, FocusEventInit const& event_init)

--- a/Userland/Libraries/LibWeb/UIEvents/FocusEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/FocusEvent.h
@@ -20,6 +20,7 @@ class FocusEvent final : public UIEvent {
     JS_DECLARE_ALLOCATOR(FocusEvent);
 
 public:
+    [[nodiscard]] static JS::NonnullGCPtr<FocusEvent> create(JS::Realm&, FlyString const& event_name, FocusEventInit const& = {});
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<FocusEvent>> construct_impl(JS::Realm&, FlyString const& event_name, FocusEventInit const& event_init);
 
     virtual ~FocusEvent() override;


### PR DESCRIPTION
We weren't setting the focus event's composed flag and view field correctly.