### PR TITLE
LibWeb: Fix clip for boxes nested into a stacking context with transform

### DIFF
--- a/Tests/LibWeb/Ref/clip-border-radius-with-css-transform.html
+++ b/Tests/LibWeb/Ref/clip-border-radius-with-css-transform.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<link rel="match" href="reference/clip-border-radius-with-css-transform-ref.html" />
+<style>
+  * {
+    margin: 0;
+  }
+  .outer {
+    position: absolute;
+    overflow: hidden;
+    border-radius: 9999px;
+    width: 300px;
+    height: 300px;
+    transform: translateX(-100px);
+    left: 100px;
+  }
+  .middle {
+    overflow: hidden;
+    top: 0px;
+    bottom: 0px;
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    background-color: transparent;
+  }
+  .inner {
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    width: 300px;
+    height: 300px;
+    background: mediumspringgreen;
+  }
+</style><body><div class="outer"><div class="middle"><div class="inner"></div>

--- a/Tests/LibWeb/Ref/reference/clip-border-radius-with-css-transform-ref.html
+++ b/Tests/LibWeb/Ref/reference/clip-border-radius-with-css-transform-ref.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<style>
+  * {
+    margin: 0;
+  }
+  .outer {
+    position: absolute;
+    overflow: hidden;
+    border-radius: 9999px;
+    width: 300px;
+    height: 300px;
+  }
+  .inner {
+    position: absolute;
+    top: 0px;
+    bottom: 0px;
+    width: 300px;
+    height: 300px;
+    background: mediumspringgreen;
+  }
+</style><body><div class="outer"><div class="inner"></div>

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -168,29 +168,19 @@ void ViewportPaintable::refresh_clip_state()
 
         clip_frame.clear_rects();
 
-        auto overflow_x = paintable_box.computed_values().overflow_x();
-        auto overflow_y = paintable_box.computed_values().overflow_y();
-        if (auto clip_rect = paintable_box.get_clip_rect(); clip_rect.has_value()) {
-            clip_frame.add_clip_rect(clip_rect.value(), {}, paintable_box.enclosing_scroll_frame());
-        }
-
-        if (overflow_x != CSS::Overflow::Visible && overflow_y != CSS::Overflow::Visible) {
-            auto overflow_clip_rect = paintable_box.absolute_padding_box_rect();
-            clip_frame.add_clip_rect(overflow_clip_rect, paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes), paintable_box.enclosing_scroll_frame());
-            for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
-                auto const& block_paintable_box = *block->paintable_box();
-                auto block_overflow_x = block_paintable_box.computed_values().overflow_x();
-                auto block_overflow_y = block_paintable_box.computed_values().overflow_y();
-                if (block_overflow_x != CSS::Overflow::Visible && block_overflow_y != CSS::Overflow::Visible) {
-                    auto rect = block_paintable_box.absolute_padding_box_rect();
-                    clip_frame.add_clip_rect(rect, block_paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes), block_paintable_box.enclosing_scroll_frame());
-                }
-                if (auto css_clip_property_rect = block->paintable_box()->get_clip_rect(); css_clip_property_rect.has_value()) {
-                    clip_frame.add_clip_rect(css_clip_property_rect.value(), {}, block_paintable_box.enclosing_scroll_frame());
-                }
-                if (block->has_css_transform()) {
-                    break;
-                }
+        for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
+            auto const& block_paintable_box = *block->paintable_box();
+            auto block_overflow_x = block_paintable_box.computed_values().overflow_x();
+            auto block_overflow_y = block_paintable_box.computed_values().overflow_y();
+            if (block_overflow_x != CSS::Overflow::Visible && block_overflow_y != CSS::Overflow::Visible) {
+                auto rect = block_paintable_box.absolute_padding_box_rect();
+                clip_frame.add_clip_rect(rect, block_paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes), block_paintable_box.enclosing_scroll_frame());
+            }
+            if (auto css_clip_property_rect = block->paintable_box()->get_clip_rect(); css_clip_property_rect.has_value()) {
+                clip_frame.add_clip_rect(css_clip_property_rect.value(), {}, block_paintable_box.enclosing_scroll_frame());
+            }
+            if (block->has_css_transform()) {
+                break;
             }
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -178,9 +178,6 @@ void ViewportPaintable::refresh_clip_state()
             auto overflow_clip_rect = paintable_box.absolute_padding_box_rect();
             clip_frame.add_clip_rect(overflow_clip_rect, paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes), paintable_box.enclosing_scroll_frame());
             for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
-                if (block->has_css_transform()) {
-                    break;
-                }
                 auto const& block_paintable_box = *block->paintable_box();
                 auto block_overflow_x = block_paintable_box.computed_values().overflow_x();
                 auto block_overflow_y = block_paintable_box.computed_values().overflow_y();
@@ -190,6 +187,9 @@ void ViewportPaintable::refresh_clip_state()
                 }
                 if (auto css_clip_property_rect = block->paintable_box()->get_clip_rect(); css_clip_property_rect.has_value()) {
                     clip_frame.add_clip_rect(css_clip_property_rect.value(), {}, block_paintable_box.enclosing_scroll_frame());
+                }
+                if (block->has_css_transform()) {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Modifies a loop that collects clip rectangles to stop once a box with a
CSS transform is encountered, as its clip still needs to be considered.