### PR TITLE
LibJS+LibUnicode: Fully implement Intl.Collator with ICU

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,83 +16,6 @@ Collator::Collator(Object& prototype)
 {
 }
 
-void Collator::set_usage(StringView type)
-{
-    if (type == "sort"sv)
-        m_usage = Usage::Sort;
-    else if (type == "search"sv)
-        m_usage = Usage::Search;
-    else
-        VERIFY_NOT_REACHED();
-}
-
-StringView Collator::usage_string() const
-{
-    switch (m_usage) {
-    case Usage::Sort:
-        return "sort"sv;
-    case Usage::Search:
-        return "search"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-void Collator::set_sensitivity(StringView type)
-{
-    if (type == "base"sv)
-        m_sensitivity = Sensitivity::Base;
-    else if (type == "accent"sv)
-        m_sensitivity = Sensitivity::Accent;
-    else if (type == "case"sv)
-        m_sensitivity = Sensitivity::Case;
-    else if (type == "variant"sv)
-        m_sensitivity = Sensitivity::Variant;
-    else
-        VERIFY_NOT_REACHED();
-}
-
-StringView Collator::sensitivity_string() const
-{
-    switch (m_sensitivity) {
-    case Sensitivity::Base:
-        return "base"sv;
-    case Sensitivity::Accent:
-        return "accent"sv;
-    case Sensitivity::Case:
-        return "case"sv;
-    case Sensitivity::Variant:
-        return "variant"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-void Collator::set_case_first(StringView case_first)
-{
-    if (case_first == "upper"sv)
-        m_case_first = CaseFirst::Upper;
-    else if (case_first == "lower"sv)
-        m_case_first = CaseFirst::Lower;
-    else if (case_first == "false"sv)
-        m_case_first = CaseFirst::False;
-    else
-        VERIFY_NOT_REACHED();
-}
-
-StringView Collator::case_first_string() const
-{
-    switch (m_case_first) {
-    case CaseFirst::Upper:
-        return "upper"sv;
-    case CaseFirst::Lower:
-        return "lower"sv;
-    case CaseFirst::False:
-        return "false"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
 void Collator::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -37,7 +37,7 @@ public:
     StringView usage_string() const { return Unicode::usage_to_string(m_usage); }
 
     Unicode::Sensitivity sensitivity() const { return m_sensitivity; }
-    void set_sensitivity(StringView sensitivity) { m_sensitivity = Unicode::sensitivity_from_string(sensitivity); }
+    void set_sensitivity(Unicode::Sensitivity sensitivity) { m_sensitivity = sensitivity; }
     StringView sensitivity_string() const { return Unicode::sensitivity_to_string(m_sensitivity); }
 
     Unicode::CaseFirst case_first() const { return m_case_first; }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
@@ -30,6 +30,6 @@ private:
     NonnullGCPtr<Collator> m_collator; // [[Collator]]
 };
 
-double compare_strings(Collator&, Utf8View const& x, Utf8View const& y);
+int compare_strings(Collator const&, StringView x, StringView y);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -16,141 +16,6 @@ namespace JS::Intl {
 
 JS_DEFINE_ALLOCATOR(CollatorConstructor);
 
-// 10.1.2 InitializeCollator ( collator, locales, options ), https://tc39.es/ecma402/#sec-initializecollator
-static ThrowCompletionOr<NonnullGCPtr<Collator>> initialize_collator(VM& vm, Collator& collator, Value locales_value, Value options_value)
-{
-    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
-    auto requested_locales = TRY(canonicalize_locale_list(vm, locales_value));
-
-    // 2. Set options to ? CoerceOptionsToObject(options).
-    auto* options = TRY(coerce_options_to_object(vm, options_value));
-
-    // 3. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
-    auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
-
-    // 4. Set collator.[[Usage]] to usage.
-    collator.set_usage(usage.as_string().utf8_string_view());
-
-    // 5. If usage is "sort", then
-    //     a. Let localeData be %Collator%.[[SortLocaleData]].
-    // 6. Else,
-    //     a. Let localeData be %Collator%.[[SearchLocaleData]].
-
-    // 7. Let opt be a new Record.
-    LocaleOptions opt {};
-
-    // 8. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
-    auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
-
-    // 9. Set opt.[[localeMatcher]] to matcher.
-    opt.locale_matcher = matcher;
-
-    // 10. Let collation be ? GetOption(options, "collation", string, empty, undefined).
-    auto collation = TRY(get_option(vm, *options, vm.names.collation, OptionType::String, {}, Empty {}));
-
-    // 11. If collation is not undefined, then
-    if (!collation.is_undefined()) {
-        // a. If collation does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!Unicode::is_type_identifier(collation.as_string().utf8_string_view()))
-            return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, collation, "collation"sv);
-
-        // 12. Set opt.[[co]] to collation.
-        opt.co = collation.as_string().utf8_string();
-    }
-
-    // 13. Let numeric be ? GetOption(options, "numeric", boolean, empty, undefined).
-    auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
-
-    // 14. If numeric is not undefined, then
-    if (!numeric.is_undefined()) {
-        // a. Let numeric be ! ToString(numeric).
-        numeric = PrimitiveString::create(vm, MUST(numeric.to_string(vm)));
-    }
-
-    // 15. Set opt.[[kn]] to numeric.
-    opt.kn = locale_key_from_value(numeric);
-
-    // 16. Let caseFirst be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
-    auto case_first = TRY(get_option(vm, *options, vm.names.caseFirst, OptionType::String, { "upper"sv, "lower"sv, "false"sv }, Empty {}));
-
-    // 17. Set opt.[[kf]] to caseFirst.
-    opt.kf = locale_key_from_value(case_first);
-
-    // 18. Let relevantExtensionKeys be %Collator%.[[RelevantExtensionKeys]].
-    auto relevant_extension_keys = Collator::relevant_extension_keys();
-
-    // 19. Let r be ResolveLocale(%Collator%.[[AvailableLocales]], requestedLocales, opt, relevantExtensionKeys, localeData).
-    auto result = resolve_locale(requested_locales, opt, relevant_extension_keys);
-
-    // 20. Set collator.[[Locale]] to r.[[locale]].
-    collator.set_locale(move(result.locale));
-
-    // 21. Let collation be r.[[co]].
-    auto& collation_value = result.co;
-
-    // 22. If collation is null, let collation be "default".
-    if (collation_value.has<Empty>())
-        collation_value = "default"_string;
-
-    // 23. Set collator.[[Collation]] to collation.
-    collator.set_collation(move(collation_value.get<String>()));
-
-    // 24. If relevantExtensionKeys contains "kn", then
-    if (relevant_extension_keys.span().contains_slow("kn"sv)) {
-        // a. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
-        collator.set_numeric(result.kn == "true"_string);
-    }
-
-    // 25. If relevantExtensionKeys contains "kf", then
-    if (relevant_extension_keys.span().contains_slow("kf"sv)) {
-        // a. Set collator.[[CaseFirst]] to r.[[kf]].
-        if (auto* resolved_case_first = result.kf.get_pointer<String>())
-            collator.set_case_first(*resolved_case_first);
-    }
-
-    // 26. Let sensitivity be ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », undefined).
-    auto sensitivity = TRY(get_option(vm, *options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, Empty {}));
-
-    // 27. If sensitivity is undefined, then
-    if (sensitivity.is_undefined()) {
-        // a. If usage is "sort", then
-        if (collator.usage() == Unicode::Usage::Sort) {
-            // i. Let sensitivity be "variant".
-            sensitivity = PrimitiveString::create(vm, "variant"_string);
-        }
-        // b. Else,
-        else {
-            // i. Let dataLocale be r.[[dataLocale]].
-            // ii. Let dataLocaleData be localeData.[[<dataLocale>]].
-            // iii. Let sensitivity be dataLocaleData.[[sensitivity]].
-            sensitivity = PrimitiveString::create(vm, "base"_string);
-        }
-    }
-
-    // 28. Set collator.[[Sensitivity]] to sensitivity.
-    collator.set_sensitivity(sensitivity.as_string().utf8_string_view());
-
-    // 29. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", boolean, empty, false).
-    auto ignore_punctuation = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, false));
-
-    // 30. Set collator.[[IgnorePunctuation]] to ignorePunctuation.
-    collator.set_ignore_punctuation(ignore_punctuation.as_bool());
-
-    // Non-standard, create an ICU collator for this Intl object.
-    auto icu_collator = Unicode::Collator::create(
-        collator.locale(),
-        collator.usage(),
-        collator.collation(),
-        collator.sensitivity(),
-        collator.case_first(),
-        collator.numeric(),
-        collator.ignore_punctuation());
-    collator.set_collator(move(icu_collator));
-
-    // 31. Return collator.
-    return collator;
-}
-
 // 10.1 The Intl.Collator Constructor, https://tc39.es/ecma402/#sec-the-intl-collator-constructor
 CollatorConstructor::CollatorConstructor(Realm& realm)
     : NativeFunction(realm.vm().names.Collator.as_string(), realm.intrinsics().function_prototype())
@@ -183,20 +48,151 @@ ThrowCompletionOr<NonnullGCPtr<Object>> CollatorConstructor::construct(FunctionO
 {
     auto& vm = this->vm();
 
-    auto locales = vm.argument(0);
-    auto options = vm.argument(1);
+    auto locales_value = vm.argument(0);
+    auto options_value = vm.argument(1);
 
     // 2. Let internalSlotsList be « [[InitializedCollator]], [[Locale]], [[Usage]], [[Sensitivity]], [[IgnorePunctuation]], [[Collation]], [[BoundCompare]] ».
-    // 3. If %Collator%.[[RelevantExtensionKeys]] contains "kn", then
-    //     a. Append [[Numeric]] as the last element of internalSlotsList.
-    // 4. If %Collator%.[[RelevantExtensionKeys]] contains "kf", then
-    //     a. Append [[CaseFirst]] as the last element of internalSlotsList.
+    // 3. If %Intl.Collator%.[[RelevantExtensionKeys]] contains "kn", then
+    //     a. Append [[Numeric]] to internalSlotsList.
+    // 4. If %Intl.Collator%.[[RelevantExtensionKeys]] contains "kf", then
+    //     a. Append [[CaseFirst]] to internalSlotsList.
 
-    // 5. Let collator be ? OrdinaryCreateFromConstructor(newTarget, "%Collator.prototype%", internalSlotsList).
+    // 5. Let collator be ? OrdinaryCreateFromConstructor(newTarget, "%Intl.Collator.prototype%", internalSlotsList).
     auto collator = TRY(ordinary_create_from_constructor<Collator>(vm, new_target, &Intrinsics::intl_collator_prototype));
 
-    // 6. Return ? InitializeCollator(collator, locales, options).
-    return TRY(initialize_collator(vm, collator, locales, options));
+    // 6. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(vm, locales_value));
+
+    // 7. Set options to ? CoerceOptionsToObject(options).
+    auto* options = TRY(coerce_options_to_object(vm, options_value));
+
+    // 8. Let usage be ? GetOption(options, "usage", string, « "sort", "search" », "sort").
+    auto usage = TRY(get_option(vm, *options, vm.names.usage, OptionType::String, { "sort"sv, "search"sv }, "sort"sv));
+
+    // 9. Set collator.[[Usage]] to usage.
+    collator->set_usage(usage.as_string().utf8_string_view());
+
+    // 10. If usage is "sort", then
+    //     a. Let localeData be %Intl.Collator%.[[SortLocaleData]].
+    // 11. Else,
+    //     a. Let localeData be %Intl.Collator%.[[SearchLocaleData]].
+
+    // 12. Let opt be a new Record.
+    LocaleOptions opt {};
+
+    // 13. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 14. Set opt.[[localeMatcher]] to matcher.
+    opt.locale_matcher = matcher;
+
+    // 15. Let collation be ? GetOption(options, "collation", string, empty, undefined).
+    auto collation = TRY(get_option(vm, *options, vm.names.collation, OptionType::String, {}, Empty {}));
+
+    // 16. If collation is not undefined, then
+    if (!collation.is_undefined()) {
+        // a. If collation cannot be matched by the type Unicode locale nonterminal, throw a RangeError exception.
+        if (!Unicode::is_type_identifier(collation.as_string().utf8_string_view()))
+            return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, collation, "collation"sv);
+    }
+
+    // 17. Set opt.[[co]] to collation.
+    opt.co = locale_key_from_value(collation);
+
+    // 18. Let numeric be ? GetOption(options, "numeric", boolean, empty, undefined).
+    auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::Boolean, {}, Empty {}));
+
+    // 19. If numeric is not undefined, then
+    if (!numeric.is_undefined()) {
+        // a. Set numeric to ! ToString(numeric).
+        numeric = PrimitiveString::create(vm, MUST(numeric.to_string(vm)));
+    }
+
+    // 20. Set opt.[[kn]] to numeric.
+    opt.kn = locale_key_from_value(numeric);
+
+    // 21. Let caseFirst be ? GetOption(options, "caseFirst", string, « "upper", "lower", "false" », undefined).
+    auto case_first = TRY(get_option(vm, *options, vm.names.caseFirst, OptionType::String, { "upper"sv, "lower"sv, "false"sv }, Empty {}));
+
+    // 22. Set opt.[[kf]] to caseFirst.
+    opt.kf = locale_key_from_value(case_first);
+
+    // 23. Let relevantExtensionKeys be %Intl.Collator%.[[RelevantExtensionKeys]].
+    auto relevant_extension_keys = Collator::relevant_extension_keys();
+
+    // 24. Let r be ResolveLocale(%Intl.Collator%.[[AvailableLocales]], requestedLocales, opt, relevantExtensionKeys, localeData).
+    auto result = resolve_locale(requested_locales, opt, relevant_extension_keys);
+
+    // 25. Set collator.[[Locale]] to r.[[Locale]].
+    collator->set_locale(move(result.locale));
+
+    // 26. Set collation to r.[[co]].
+    auto collation_value = move(result.co);
+
+    // 27. If collation is null, set collation to "default".
+    if (collation_value.has<Empty>())
+        collation_value = "default"_string;
+
+    // 28. Set collator.[[Collation]] to collation.
+    collator->set_collation(move(collation_value.get<String>()));
+
+    // 29. If relevantExtensionKeys contains "kn", then
+    if (relevant_extension_keys.span().contains_slow("kn"sv)) {
+        // a. Set collator.[[Numeric]] to SameValue(r.[[kn]], "true").
+        collator->set_numeric(result.kn == "true"_string);
+    }
+
+    // 30. If relevantExtensionKeys contains "kf", then
+    if (relevant_extension_keys.span().contains_slow("kf"sv)) {
+        // a. Set collator.[[CaseFirst]] to r.[[kf]].
+        if (auto* resolved_case_first = result.kf.get_pointer<String>())
+            collator->set_case_first(*resolved_case_first);
+    }
+
+    // 31. Let resolvedLocaleData be r.[[LocaleData]].
+
+    // 32. Let sensitivity be ? GetOption(options, "sensitivity", string, « "base", "accent", "case", "variant" », undefined).
+    auto sensitivity = TRY(get_option(vm, *options, vm.names.sensitivity, OptionType::String, { "base"sv, "accent"sv, "case"sv, "variant"sv }, Empty {}));
+
+    // 33. If sensitivity is undefined, then
+    if (sensitivity.is_undefined()) {
+        // a. If usage is "sort", then
+        if (collator->usage() == Unicode::Usage::Sort) {
+            // i. Set sensitivity to "variant".
+            sensitivity = PrimitiveString::create(vm, "variant"_string);
+        }
+        // b. Else,
+        else {
+            // FIXME: i. Set sensitivity to resolvedLocaleData.[[sensitivity]].
+            sensitivity = PrimitiveString::create(vm, "base"_string);
+        }
+    }
+
+    // 34. Set collator.[[Sensitivity]] to sensitivity.
+    collator->set_sensitivity(sensitivity.as_string().utf8_string_view());
+
+    // FIXME: 35. Let defaultIgnorePunctuation be resolvedLocaleData.[[ignorePunctuation]].
+    auto default_ignore_punctuation = false;
+
+    // 36. Let ignorePunctuation be ? GetOption(options, "ignorePunctuation", boolean, empty, defaultIgnorePunctuation).
+    auto ignore_punctuation = TRY(get_option(vm, *options, vm.names.ignorePunctuation, OptionType::Boolean, {}, default_ignore_punctuation));
+
+    // 37. Set collator.[[IgnorePunctuation]] to ignorePunctuation.
+    collator->set_ignore_punctuation(ignore_punctuation.as_bool());
+
+    // Non-standard, create an ICU collator for this Intl object.
+    auto icu_collator = Unicode::Collator::create(
+        collator->locale(),
+        collator->usage(),
+        collator->collation(),
+        collator->sensitivity(),
+        collator->case_first(),
+        collator->numeric(),
+        collator->ignore_punctuation());
+    collator->set_collator(move(icu_collator));
+
+    // 38. Return collator.
+    return collator;
 }
 
 // 10.2.2 Intl.Collator.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.collator.supportedlocalesof

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -114,7 +114,7 @@ static ThrowCompletionOr<NonnullGCPtr<Collator>> initialize_collator(VM& vm, Col
     // 27. If sensitivity is undefined, then
     if (sensitivity.is_undefined()) {
         // a. If usage is "sort", then
-        if (collator.usage() == Collator::Usage::Sort) {
+        if (collator.usage() == Unicode::Usage::Sort) {
             // i. Let sensitivity be "variant".
             sensitivity = PrimitiveString::create(vm, "variant"_string);
         }
@@ -135,6 +135,17 @@ static ThrowCompletionOr<NonnullGCPtr<Collator>> initialize_collator(VM& vm, Col
 
     // 30. Set collator.[[IgnorePunctuation]] to ignorePunctuation.
     collator.set_ignore_punctuation(ignore_punctuation.as_bool());
+
+    // Non-standard, create an ICU collator for this Intl object.
+    auto icu_collator = Unicode::Collator::create(
+        collator.locale(),
+        collator.usage(),
+        collator.collation(),
+        collator.sensitivity(),
+        collator.case_first(),
+        collator.numeric(),
+        collator.ignore_punctuation());
+    collator.set_collator(move(icu_collator));
 
     // 31. Return collator.
     return collator;

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -566,7 +566,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::locale_compare)
     auto collator = TRY(construct(vm, realm.intrinsics().intl_collator_constructor(), vm.argument(1), vm.argument(2)));
 
     // 5. Return CompareStrings(collator, S, thatValue).
-    return Intl::compare_strings(static_cast<Intl::Collator&>(*collator), string.code_points(), that_value.code_points());
+    return Intl::compare_strings(static_cast<Intl::Collator const&>(*collator), string, that_value);
 }
 
 // 22.1.3.13 String.prototype.match ( regexp ), https://tc39.es/ecma262/#sec-string.prototype.match

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.compare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.compare.js
@@ -17,13 +17,13 @@ describe("correct behavior", () => {
             const aTob = collator.compare(a, b);
             const bToa = collator.compare(b, a);
 
-            expect(aTob > 0).toBeTrue();
-            expect(aTob).toBe(-bToa);
+            expect(aTob).toBe(1);
+            expect(bToa).toBe(-1);
         }
 
         compareBoth("a", "");
         compareBoth("1", "");
-        compareBoth("a", "A");
+        compareBoth("A", "a");
         compareBoth("7", "3");
         compareBoth("0000", "0");
 
@@ -31,8 +31,65 @@ describe("correct behavior", () => {
         expect(collator.compare("undefined", undefined)).toBe(0);
 
         expect(collator.compare("null", null)).toBe(0);
-        expect(collator.compare("null", undefined)).not.toBe(0);
-        expect(collator.compare("null") < 0).toBeTrue();
+        expect(collator.compare("null", undefined)).toBe(-1);
+        expect(collator.compare("null")).toBe(-1);
+    });
+
+    test("canonically equivalent strings", () => {
+        var tests = [
+            ["ä\u0306", "a\u0308\u0306"],
+            ["ă\u0308", "a\u0306\u0308"],
+            ["ạ\u0308", "a\u0323\u0308"],
+            ["a\u0308\u0323", "a\u0323\u0308"],
+            ["ä\u0323", "a\u0323\u0308"],
+            ["Å", "Å"],
+            ["Å", "A\u030A"],
+            ["Ç", "C\u0327"],
+            ["ḋ\u0323", "ḍ\u0307"],
+            ["ḋ\u0323", "d\u0323\u0307"],
+            ["ô", "o\u0302"],
+            ["ö", "o\u0308"],
+            ["q\u0307\u0323", "q\u0323\u0307"],
+            ["ṩ", "s\u0323\u0307"],
+            ["ự", "ụ\u031B"],
+            ["ự", "u\u031B\u0323"],
+            ["ự", "ư\u0323"],
+            ["ự", "u\u0323\u031B"],
+            ["Ω", "Ω"],
+            ["x\u031B\u0323", "x\u0323\u031B"],
+            ["퓛", "\u1111\u1171\u11B6"],
+            ["北", "\uD87E\uDC2B"],
+            ["가", "\u1100\u1161"],
+            ["\uD834\uDD5E", "\uD834\uDD57\uD834\uDD65"],
+        ];
+
+        const en = new Intl.Collator("en");
+        const ja = new Intl.Collator("ja");
+        const th = new Intl.Collator("th");
+
+        tests.forEach(test => {
+            expect(en.compare(test[0], test[1])).toBe(0);
+            expect(ja.compare(test[0], test[1])).toBe(0);
+            expect(th.compare(test[0], test[1])).toBe(0);
+        });
+    });
+
+    test("ignorePunctuation", () => {
+        [undefined, true, false].forEach(ignorePunctuation => {
+            let expected = false;
+
+            const en = new Intl.Collator("en", { ignorePunctuation });
+            expect(en.compare("", " ")).toBe(en.resolvedOptions().ignorePunctuation ? 0 : -1);
+            expect(en.compare("", ",")).toBe(en.resolvedOptions().ignorePunctuation ? 0 : -1);
+
+            const ja = new Intl.Collator("ja", { ignorePunctuation });
+            expect(ja.compare("", " ")).toBe(ja.resolvedOptions().ignorePunctuation ? 0 : -1);
+            expect(ja.compare("", ",")).toBe(ja.resolvedOptions().ignorePunctuation ? 0 : -1);
+
+            const th = new Intl.Collator("th", { ignorePunctuation });
+            expect(th.compare("", " ")).toBe(th.resolvedOptions().ignorePunctuation ? 0 : -1);
+            expect(th.compare("", ",")).toBe(th.resolvedOptions().ignorePunctuation ? 0 : -1);
+        });
     });
 
     test("UTF-16", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.resolvedOptions.js
@@ -28,9 +28,12 @@ describe("correct behavior", () => {
         const en1 = new Intl.Collator("en");
         expect(en1.resolvedOptions().sensitivity).toBe("variant");
 
+        const en2 = new Intl.Collator("en", { usage: "search" });
+        expect(en2.resolvedOptions().sensitivity).toBe("variant");
+
         ["base", "accent", "case", "variant"].forEach(sensitivity => {
-            const en2 = new Intl.Collator("en", { sensitivity: sensitivity });
-            expect(en2.resolvedOptions().sensitivity).toBe(sensitivity);
+            const en3 = new Intl.Collator("en", { sensitivity: sensitivity });
+            expect(en3.resolvedOptions().sensitivity).toBe(sensitivity);
         });
     });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.resolvedOptions.js
@@ -38,9 +38,15 @@ describe("correct behavior", () => {
         const en1 = new Intl.Collator("en");
         expect(en1.resolvedOptions().ignorePunctuation).toBeFalse();
 
+        const th1 = new Intl.Collator("th");
+        expect(th1.resolvedOptions().ignorePunctuation).toBeTrue();
+
         [true, false].forEach(ignorePunctuation => {
             const en2 = new Intl.Collator("en", { ignorePunctuation: ignorePunctuation });
             expect(en2.resolvedOptions().ignorePunctuation).toBe(ignorePunctuation);
+
+            const th2 = new Intl.Collator("th", { ignorePunctuation: ignorePunctuation });
+            expect(th2.resolvedOptions().ignorePunctuation).toBe(ignorePunctuation);
         });
     });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.localeCompare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.localeCompare.js
@@ -15,7 +15,7 @@ test("basic functionality", () => {
 
     compareBoth("a", "");
     compareBoth("1", "");
-    compareBoth("a", "A");
+    compareBoth("A", "a");
     compareBoth("7", "3");
     compareBoth("0000", "0");
 

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -2,6 +2,7 @@ include(${SerenityOS_SOURCE_DIR}/Meta/CMake/unicode_data.cmake)
 
 set(SOURCES
     CharacterTypes.cpp
+    Collator.cpp
     CurrencyCode.cpp
     DateTimeFormat.cpp
     DisplayNames.cpp

--- a/Userland/Libraries/LibUnicode/Collator.cpp
+++ b/Userland/Libraries/LibUnicode/Collator.cpp
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibUnicode/Collator.h>
+#include <LibUnicode/ICU.h>
+
+#include <unicode/coll.h>
+
+namespace Unicode {
+
+Usage usage_from_string(StringView usage)
+{
+    if (usage == "sort"sv)
+        return Usage::Sort;
+    if (usage == "search"sv)
+        return Usage::Search;
+    VERIFY_NOT_REACHED();
+}
+
+StringView usage_to_string(Usage usage)
+{
+    switch (usage) {
+    case Usage::Sort:
+        return "sort"sv;
+    case Usage::Search:
+        return "search"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static NonnullOwnPtr<icu::Locale> apply_usage_to_locale(icu::Locale const& locale, Usage usage, StringView collation)
+{
+    auto result = adopt_own(*locale.clone());
+    UErrorCode status = U_ZERO_ERROR;
+
+    switch (usage) {
+    case Usage::Sort:
+        result->setUnicodeKeywordValue("co", icu_string_piece(collation), status);
+        break;
+    case Usage::Search:
+        result->setUnicodeKeywordValue("co", "search", status);
+        break;
+    }
+
+    VERIFY(icu_success(status));
+    return result;
+}
+
+Sensitivity sensitivity_from_string(StringView sensitivity)
+{
+    if (sensitivity == "base"sv)
+        return Sensitivity::Base;
+    if (sensitivity == "accent"sv)
+        return Sensitivity::Accent;
+    if (sensitivity == "case"sv)
+        return Sensitivity::Case;
+    if (sensitivity == "variant"sv)
+        return Sensitivity::Variant;
+    VERIFY_NOT_REACHED();
+}
+
+StringView sensitivity_to_string(Sensitivity sensitivity)
+{
+    switch (sensitivity) {
+    case Sensitivity::Base:
+        return "base"sv;
+    case Sensitivity::Accent:
+        return "accent"sv;
+    case Sensitivity::Case:
+        return "case"sv;
+    case Sensitivity::Variant:
+        return "variant"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static constexpr UColAttributeValue icu_sensitivity(Sensitivity sensitivity)
+{
+    switch (sensitivity) {
+    case Sensitivity::Base:
+        return UCOL_PRIMARY;
+    case Sensitivity::Accent:
+        return UCOL_SECONDARY;
+    case Sensitivity::Case:
+        return UCOL_PRIMARY;
+    case Sensitivity::Variant:
+        return UCOL_TERTIARY;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+CaseFirst case_first_from_string(StringView case_first)
+{
+    if (case_first == "upper"sv)
+        return CaseFirst::Upper;
+    if (case_first == "lower"sv)
+        return CaseFirst::Lower;
+    if (case_first == "false"sv)
+        return CaseFirst::False;
+    VERIFY_NOT_REACHED();
+}
+
+StringView case_first_to_string(CaseFirst case_first)
+{
+    switch (case_first) {
+    case CaseFirst::Upper:
+        return "upper"sv;
+    case CaseFirst::Lower:
+        return "lower"sv;
+    case CaseFirst::False:
+        return "false"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static constexpr UColAttributeValue icu_case_first(CaseFirst case_first)
+{
+    switch (case_first) {
+    case CaseFirst::Upper:
+        return UCOL_UPPER_FIRST;
+    case CaseFirst::Lower:
+        return UCOL_LOWER_FIRST;
+    case CaseFirst::False:
+        return UCOL_OFF;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+class CollatorImpl : public Collator {
+public:
+    explicit CollatorImpl(NonnullOwnPtr<icu::Collator> collator)
+        : m_collator(move(collator))
+    {
+    }
+
+    virtual Collator::Order compare(StringView lhs, StringView rhs) const override
+    {
+        UErrorCode status = U_ZERO_ERROR;
+
+        auto result = m_collator->compareUTF8(icu_string_piece(lhs), icu_string_piece(rhs), status);
+        VERIFY(icu_success(status));
+
+        switch (result) {
+        case UCOL_LESS:
+            return Order::Before;
+        case UCOL_EQUAL:
+            return Order::Equal;
+        case UCOL_GREATER:
+            return Order::After;
+        }
+
+        VERIFY_NOT_REACHED();
+    }
+
+private:
+    NonnullOwnPtr<icu::Collator> m_collator;
+};
+
+NonnullOwnPtr<Collator> Collator::create(
+    StringView locale,
+    Usage usage,
+    StringView collation,
+    Sensitivity sensitivity,
+    CaseFirst case_first,
+    bool numeric,
+    bool ignore_punctuation)
+{
+    UErrorCode status = U_ZERO_ERROR;
+
+    auto locale_data = LocaleData::for_locale(locale);
+    VERIFY(locale_data.has_value());
+
+    auto locale_with_usage = apply_usage_to_locale(locale_data->locale(), usage, collation);
+
+    auto collator = adopt_own(*icu::Collator::createInstance(*locale_with_usage, status));
+    VERIFY(icu_success(status));
+
+    auto set_attribute = [&](UColAttribute attribute, UColAttributeValue value) {
+        collator->setAttribute(attribute, value, status);
+        VERIFY(icu_success(status));
+    };
+
+    set_attribute(UCOL_STRENGTH, icu_sensitivity(sensitivity));
+    set_attribute(UCOL_CASE_LEVEL, sensitivity == Sensitivity::Case ? UCOL_ON : UCOL_OFF);
+    set_attribute(UCOL_CASE_FIRST, icu_case_first(case_first));
+    set_attribute(UCOL_NUMERIC_COLLATION, numeric ? UCOL_ON : UCOL_OFF);
+    set_attribute(UCOL_ALTERNATE_HANDLING, ignore_punctuation ? UCOL_SHIFTED : UCOL_NON_IGNORABLE);
+    set_attribute(UCOL_NORMALIZATION_MODE, UCOL_ON);
+
+    return adopt_own(*new CollatorImpl(move(collator)));
+}
+
+}

--- a/Userland/Libraries/LibUnicode/Collator.h
+++ b/Userland/Libraries/LibUnicode/Collator.h
@@ -41,7 +41,7 @@ public:
         StringView locale,
         Usage,
         StringView collation,
-        Sensitivity,
+        Optional<Sensitivity>,
         CaseFirst,
         bool numeric,
         Optional<bool> ignore_punctuation);
@@ -55,6 +55,7 @@ public:
     };
     virtual Order compare(StringView, StringView) const = 0;
 
+    virtual Sensitivity sensitivity() const = 0;
     virtual bool ignore_punctuation() const = 0;
 
 protected:

--- a/Userland/Libraries/LibUnicode/Collator.h
+++ b/Userland/Libraries/LibUnicode/Collator.h
@@ -44,7 +44,7 @@ public:
         Sensitivity,
         CaseFirst,
         bool numeric,
-        bool ignore_punctuation);
+        Optional<bool> ignore_punctuation);
 
     virtual ~Collator() = default;
 
@@ -54,6 +54,8 @@ public:
         After,
     };
     virtual Order compare(StringView, StringView) const = 0;
+
+    virtual bool ignore_punctuation() const = 0;
 
 protected:
     Collator() = default;

--- a/Userland/Libraries/LibUnicode/Collator.h
+++ b/Userland/Libraries/LibUnicode/Collator.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullOwnPtr.h>
+#include <AK/StringView.h>
+
+namespace Unicode {
+
+enum class Usage {
+    Sort,
+    Search,
+};
+Usage usage_from_string(StringView);
+StringView usage_to_string(Usage);
+
+enum class Sensitivity {
+    Base,
+    Accent,
+    Case,
+    Variant,
+};
+Sensitivity sensitivity_from_string(StringView);
+StringView sensitivity_to_string(Sensitivity);
+
+enum class CaseFirst {
+    Upper,
+    Lower,
+    False,
+};
+CaseFirst case_first_from_string(StringView);
+StringView case_first_to_string(CaseFirst);
+
+class Collator {
+public:
+    static NonnullOwnPtr<Collator> create(
+        StringView locale,
+        Usage,
+        StringView collation,
+        Sensitivity,
+        CaseFirst,
+        bool numeric,
+        bool ignore_punctuation);
+
+    virtual ~Collator() = default;
+
+    enum class Order {
+        Before,
+        Equal,
+        After,
+    };
+    virtual Order compare(StringView, StringView) const = 0;
+
+protected:
+    Collator() = default;
+};
+
+}


### PR DESCRIPTION
We were never able to implement anything other than a basic, locale-unaware collator with the JSON export of the CLDR as it did not have collation data. We can now use ICU to implement collation.

test262 diff:
```
Diff Tests:
    +8 ✅    -8 ❌

    test/built-ins/String/prototype/localeCompare/15.5.4.9_CE.js                    ❌ -> ✅
    test/intl402/Collator/prototype/compare/canonically-equivalent-strings.js       ❌ -> ✅
    test/intl402/Collator/prototype/compare/ignorePunctuation.js                    ❌ -> ✅
    test/intl402/Collator/prototype/compare/non-normative-basic.js                  ❌ -> ✅
    test/intl402/Collator/prototype/compare/non-normative-sensitivity.js            ❌ -> ✅
    test/intl402/Collator/prototype/resolvedOptions/ignorePunctuation-default.js    ❌ -> ✅
    test/intl402/Collator/usage-de.js                                               ❌ -> ✅
    test/intl402/String/prototype/localeCompare/default-options-object-prototype.js ❌ -> ✅
```

(We now pass all of `test/intl402/Collator`, `test/intl402/String`, and `test/built-ins/String/prototype/localeCompare`)