### PR TITLE
LibWeb: Remove ViewportPaintable::refresh_clip_frames()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1157,6 +1157,9 @@ void Document::update_layout()
     set_needs_to_resolve_paint_only_properties();
 
     paintable()->assign_scroll_frames();
+
+    // assign_clip_frames() needs border-radius be resolved
+    update_paint_and_hit_testing_properties_if_needed();
     paintable()->assign_clip_frames();
 
     if (navigable->is_traversable()) {
@@ -5194,12 +5197,6 @@ void Document::process_top_layer_removals()
             element->set_in_top_layer(false);
         }
     }
-}
-
-void Document::set_needs_to_refresh_clip_state(bool b)
-{
-    if (auto* paintable = this->paintable())
-        paintable->set_needs_to_refresh_clip_state(b);
 }
 
 void Document::set_needs_to_refresh_scroll_state(bool b)

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -482,7 +482,6 @@ public:
     bool needs_full_style_update() const { return m_needs_full_style_update; }
     void set_needs_full_style_update(bool b) { m_needs_full_style_update = b; }
 
-    void set_needs_to_refresh_clip_state(bool b);
     void set_needs_to_refresh_scroll_state(bool b);
 
     bool has_active_favicon() const { return m_active_favicon; }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2014,7 +2014,6 @@ void Navigable::perform_scroll_of_viewport(CSSPixelPoint new_position)
 
         if (auto document = active_document()) {
             document->set_needs_to_refresh_scroll_state(true);
-            document->set_needs_to_refresh_clip_state(true);
             document->inform_all_viewport_clients_about_the_current_viewport_rect();
         }
     }
@@ -2121,7 +2120,6 @@ RefPtr<Painting::DisplayList> Navigable::record_display_list(PaintConfig config)
     auto& viewport_paintable = *document->paintable();
 
     viewport_paintable.refresh_scroll_state();
-    viewport_paintable.refresh_clip_state();
 
     viewport_paintable.paint_all_phases(context);
 

--- a/Userland/Libraries/LibWeb/Painting/ClipFrame.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClipFrame.cpp
@@ -19,11 +19,6 @@ void ClipFrame::add_clip_rect(CSSPixelRect rect, BorderRadiiData radii, RefPtr<S
     m_clip_rects.append({ rect, radii, move(enclosing_scroll_frame) });
 }
 
-void ClipFrame::clear_rects()
-{
-    m_clip_rects.clear_with_capacity();
-}
-
 CSSPixelRect ClipFrame::clip_rect_for_hit_testing() const
 {
     VERIFY(!m_clip_rects.is_empty());

--- a/Userland/Libraries/LibWeb/Painting/ClipFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ClipFrame.h
@@ -21,7 +21,6 @@ struct ClipRectWithScrollFrame {
 struct ClipFrame : public RefCounted<ClipFrame> {
     Vector<ClipRectWithScrollFrame> const& clip_rects() const { return m_clip_rects; }
     void add_clip_rect(CSSPixelRect rect, BorderRadiiData radii, RefPtr<ScrollFrame const> enclosing_scroll_frame);
-    void clear_rects();
 
     CSSPixelRect clip_rect_for_hit_testing() const;
 

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -9,6 +9,13 @@
 
 namespace Web::Painting {
 
+Optional<int> ClippableAndScrollable::own_scroll_frame_id() const
+{
+    if (m_own_scroll_frame)
+        return m_own_scroll_frame->id;
+    return {};
+}
+
 Optional<int> ClippableAndScrollable::scroll_frame_id() const
 {
     if (m_enclosing_scroll_frame)

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -23,6 +23,9 @@ public:
     [[nodiscard]] CSSPixelPoint enclosing_scroll_frame_offset() const;
     [[nodiscard]] Optional<CSSPixelRect> clip_rect_for_hit_testing() const;
 
+    [[nodiscard]] Optional<int> own_scroll_frame_id() const;
+    void set_own_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_own_scroll_frame = scroll_frame; }
+
     void apply_clip(PaintContext&) const;
     void restore_clip(PaintContext&) const;
 
@@ -31,6 +34,7 @@ public:
 
 private:
     RefPtr<ScrollFrame const> m_enclosing_scroll_frame;
+    RefPtr<ScrollFrame const> m_own_scroll_frame;
     RefPtr<ClipFrame const> m_enclosing_clip_frame;
 
     Gfx::AffineTransform m_combined_css_transform;

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -60,12 +60,36 @@ public:
     [[nodiscard]] CSS::Display display() const { return layout_node().display(); }
 
     template<typename U, typename Callback>
+    TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback)
+    {
+        if (is<U>(*this)) {
+            if (auto decision = callback(static_cast<U&>(*this)); decision != TraversalDecision::Continue)
+                return decision;
+        }
+        for (auto* child = first_child(); child; child = child->next_sibling()) {
+            if (child->template for_each_in_inclusive_subtree_of_type<U>(callback) == TraversalDecision::Break)
+                return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    }
+
+    template<typename U, typename Callback>
     TraversalDecision for_each_in_inclusive_subtree_of_type(Callback callback) const
     {
         if (is<U>(*this)) {
             if (auto decision = callback(static_cast<U const&>(*this)); decision != TraversalDecision::Continue)
                 return decision;
         }
+        for (auto* child = first_child(); child; child = child->next_sibling()) {
+            if (child->template for_each_in_inclusive_subtree_of_type<U>(callback) == TraversalDecision::Break)
+                return TraversalDecision::Break;
+        }
+        return TraversalDecision::Continue;
+    }
+
+    template<typename U, typename Callback>
+    TraversalDecision for_each_in_subtree_of_type(Callback callback)
+    {
         for (auto* child = first_child(); child; child = child->next_sibling()) {
             if (child->template for_each_in_inclusive_subtree_of_type<U>(callback) == TraversalDecision::Break)
                 return TraversalDecision::Break;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -81,7 +81,6 @@ void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
     if (!scrollable_overflow_rect.has_value())
         return;
 
-    document().set_needs_to_refresh_clip_state(true);
     document().set_needs_to_refresh_scroll_state(true);
 
     auto padding_rect = absolute_padding_box_rect();
@@ -820,7 +819,6 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
         viewport_paintable.build_stacking_context_tree_if_needed();
         viewport_paintable.document().update_paint_and_hit_testing_properties_if_needed();
         viewport_paintable.refresh_scroll_state();
-        viewport_paintable.refresh_clip_state();
         return stacking_context()->hit_test(position, type, callback);
     }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -680,9 +680,9 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
             context.display_list_recorder().add_rounded_rect_clip(corner_radii, context.rounded_device_rect(clip_box).to_type<int>(), CornerClip::Outside);
         }
 
-        context.display_list_recorder().save();
-        auto scroll_offset = context.rounded_device_point(this->scroll_offset());
-        context.display_list_recorder().translate(-scroll_offset.to_type<int>());
+        if (own_scroll_frame_id().has_value()) {
+            context.display_list_recorder().set_scroll_frame_id(own_scroll_frame_id().value());
+        }
     }
 
     // Text shadows
@@ -709,7 +709,6 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
     }
 
     if (should_clip_overflow) {
-        context.display_list_recorder().restore();
         context.display_list_recorder().restore();
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -33,7 +33,7 @@ void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase ph
         return;
     context.display_list_recorder().save();
     auto clip_rect = absolute_rect();
-    clip_rect.translate_by(enclosing_scroll_frame_offset());
+    context.display_list_recorder().set_scroll_frame_id(scroll_frame_id());
     context.display_list_recorder().add_clip_rect(context.enclosing_device_rect(clip_rect).to_type<int>());
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -135,6 +135,26 @@ void ViewportPaintable::assign_clip_frames()
         }
         return TraversalDecision::Continue;
     });
+
+    for (auto& it : clip_state) {
+        auto const& paintable_box = *it.key;
+        auto& clip_frame = *it.value;
+        for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
+            auto const& block_paintable_box = *block->paintable_box();
+            auto block_overflow_x = block_paintable_box.computed_values().overflow_x();
+            auto block_overflow_y = block_paintable_box.computed_values().overflow_y();
+            if (block_overflow_x != CSS::Overflow::Visible && block_overflow_y != CSS::Overflow::Visible) {
+                auto rect = block_paintable_box.absolute_padding_box_rect();
+                clip_frame.add_clip_rect(rect, block_paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes), block_paintable_box.enclosing_scroll_frame());
+            }
+            if (auto css_clip_property_rect = block->paintable_box()->get_clip_rect(); css_clip_property_rect.has_value()) {
+                clip_frame.add_clip_rect(css_clip_property_rect.value(), {}, block_paintable_box.enclosing_scroll_frame());
+            }
+            if (block->has_css_transform()) {
+                break;
+            }
+        }
+    }
 }
 
 void ViewportPaintable::refresh_scroll_state()
@@ -154,36 +174,6 @@ void ViewportPaintable::refresh_scroll_state()
                 break;
         }
         scroll_frame.offset = -offset;
-    }
-}
-
-void ViewportPaintable::refresh_clip_state()
-{
-    if (!m_needs_to_refresh_clip_state)
-        return;
-    m_needs_to_refresh_clip_state = false;
-
-    for (auto& it : clip_state) {
-        auto const& paintable_box = *it.key;
-        auto& clip_frame = *it.value;
-
-        clip_frame.clear_rects();
-
-        for (auto const* block = &paintable_box.layout_box(); !block->is_viewport(); block = block->containing_block()) {
-            auto const& block_paintable_box = *block->paintable_box();
-            auto block_overflow_x = block_paintable_box.computed_values().overflow_x();
-            auto block_overflow_y = block_paintable_box.computed_values().overflow_y();
-            if (block_overflow_x != CSS::Overflow::Visible && block_overflow_y != CSS::Overflow::Visible) {
-                auto rect = block_paintable_box.absolute_padding_box_rect();
-                clip_frame.add_clip_rect(rect, block_paintable_box.normalized_border_radii_data(ShrinkRadiiForBorders::Yes), block_paintable_box.enclosing_scroll_frame());
-            }
-            if (auto css_clip_property_rect = block->paintable_box()->get_clip_rect(); css_clip_property_rect.has_value()) {
-                clip_frame.add_clip_rect(css_clip_property_rect.value(), {}, block_paintable_box.enclosing_scroll_frame());
-            }
-            if (block->has_css_transform()) {
-                break;
-            }
-        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -71,10 +71,11 @@ void ViewportPaintable::assign_scroll_frames()
     scroll_state.set(this, move(viewport_scroll_frame));
 
     int next_id = 1;
-    for_each_in_subtree_of_type<PaintableBox>([&](auto const& paintable_box) {
+    for_each_in_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
         if (paintable_box.has_scrollable_overflow()) {
             auto scroll_frame = adopt_ref(*new ScrollFrame());
             scroll_frame->id = next_id++;
+            paintable_box.set_own_scroll_frame(scroll_frame);
             scroll_state.set(paintable_box, move(scroll_frame));
         }
         return TraversalDecision::Continue;

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -27,7 +27,6 @@ public:
 
     HashMap<JS::GCPtr<PaintableBox const>, RefPtr<ClipFrame>> clip_state;
     void assign_clip_frames();
-    void refresh_clip_state();
 
     void resolve_paint_only_properties();
 
@@ -36,7 +35,6 @@ public:
 
     bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y) override;
 
-    void set_needs_to_refresh_clip_state(bool value) { m_needs_to_refresh_clip_state = value; }
     void set_needs_to_refresh_scroll_state(bool value) { m_needs_to_refresh_scroll_state = value; }
 
 private:
@@ -46,7 +44,6 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    bool m_needs_to_refresh_clip_state { true };
     bool m_needs_to_refresh_scroll_state { true };
 };
 


### PR DESCRIPTION
After https://github.com/LadybirdBrowser/ladybird/commit/d0da377767a9ca1245e8b505a53ab8969aef8e64 clip frame state is no longer depends on scroll state, so it could be calculated only once for each layout invalidation.