### PR TITLE
LibWeb: Return empty string if URL attribute is invalid

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/invalid-url-attribute-values.txt
+++ b/Tests/LibWeb/Text/expected/HTML/invalid-url-attribute-values.txt
@@ -1,0 +1,1 @@
+img.currentSrc default value: ''

--- a/Tests/LibWeb/Text/expected/HTML/invalid-url-attribute-values.txt
+++ b/Tests/LibWeb/Text/expected/HTML/invalid-url-attribute-values.txt
@@ -1,1 +1,2 @@
 img.currentSrc default value: ''
+object.data default value: ''

--- a/Tests/LibWeb/Text/input/HTML/invalid-url-attribute-values.html
+++ b/Tests/LibWeb/Text/input/HTML/invalid-url-attribute-values.html
@@ -4,6 +4,7 @@
     test(() => {
         const elementList = [
             { "img": "currentSrc" },
+            { "object": "data" },
         ];
         for (const elementDescriptor of elementList) {
             [elementName, propertyName] = Object.entries(elementDescriptor)[0];

--- a/Tests/LibWeb/Text/input/HTML/invalid-url-attribute-values.html
+++ b/Tests/LibWeb/Text/input/HTML/invalid-url-attribute-values.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const elementList = [
+            { "img": "currentSrc" },
+        ];
+        for (const elementDescriptor of elementList) {
+            [elementName, propertyName] = Object.entries(elementDescriptor)[0];
+            const element = document.createElement(elementName);
+            println(`${elementName}.${propertyName} default value: '${element[propertyName]}'`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -275,7 +275,10 @@ bool HTMLImageElement::complete() const
 String HTMLImageElement::current_src() const
 {
     // The currentSrc IDL attribute must return the img element's current request's current URL.
-    return MUST(m_current_request->current_url().to_string());
+    auto current_url = m_current_request->current_url();
+    if (!current_url.is_valid())
+        return {};
+    return MUST(current_url.to_string());
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -77,8 +77,11 @@ void HTMLObjectElement::form_associated_element_was_removed(DOM::Node*)
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-data
 String HTMLObjectElement::data() const
 {
-    auto data = get_attribute_value(HTML::AttributeNames::data);
-    return MUST(document().parse_url(data).to_string());
+    auto data = get_attribute(HTML::AttributeNames::data);
+    if (!data.has_value())
+        return {};
+
+    return MUST(document().parse_url(*data).to_string());
 }
 
 JS::GCPtr<Layout::Node> HTMLObjectElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)


### PR DESCRIPTION
This modifies `HTMLImageElement::current_src()` and `HTMLObjectElement::data()` so that they return the empty string if they are backed by a URL which is invalid.

There are probably other attributes where the same issue is still present.

Fixes 181 subtests in: https://wpt.live/html/semantics/embedded-content/the-img-element/srcset/parse-a-srcset-attribute.html