### PR TITLE
Meta: Make `WPT.sh` script compatible with MacOS

### DIFF
--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -73,6 +73,13 @@ CTEST_OUTPUT_ON_FAILURE=1 LADYBIRD_SOURCE_DIR=${PWD}/../.. ninja test
 The Web Platform Tests can be run with the `WPT.sh` script. This script can also be used to compare the results of two 
 test runs.
 
+Enabling the Qt chrome is recommended when running the Web Platform Tests on MacOS. This can be done by running the 
+following command:
+
+```sh
+cmake -GNinja Build/ladybird -DENABLE_QT=ON
+```
+
 Example usage:
 
 ```sh

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -86,6 +86,12 @@ ensure_wpt_repository() {
         if [ ! -d .git ]; then
             git clone --depth 1 "${WPT_REPOSITORY_URL}" "${WPT_SOURCE_DIR}"
         fi
+
+        # Update hosts file if needed
+        if [ "$(comm -13 <(sort -u /etc/hosts) <(./wpt make-hosts-file | sort -u) | wc -l)" -gt 0 ]; then
+            echo "Enter superuser password to append wpt hosts to /etc/hosts"
+            ./wpt make-hosts-file | sudo tee -a /etc/hosts
+        fi
     popd > /dev/null
 }
 

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -11,8 +11,15 @@ WPT_REPOSITORY_URL=${WPT_REPOSITORY_URL:-"https://github.com/web-platform-tests/
 # shellcheck source=/dev/null
 . "${DIR}/shell_include.sh"
 
-LADYBIRD_BINARY=${LADYBIRD_BINARY:-"${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/Ladybird"}
-WEBDRIVER_BINARY=${WEBDRIVER_BINARY:-"${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/WebDriver"}
+default_binary_path() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        echo "${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/Ladybird.app/Contents/MacOS/"
+    else
+        echo "${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/"
+    fi
+}
+LADYBIRD_BINARY=${LADYBIRD_BINARY:-"$(default_binary_path)/Ladybird"}
+WEBDRIVER_BINARY=${WEBDRIVER_BINARY:-"$(default_binary_path)/WebDriver"}
 WPT_PROCESSES=${WPT_PROCESSES:-$(get_number_of_processing_units)}
 WPT_CERTIFICATES=(
   "tools/certs/cacert.pem"

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -121,7 +121,7 @@ execute_wpt() {
             fi
             WPT_ARGS+=( "--webdriver-arg=--certificate=${certificate_path}" )
         done
-        QT_QPA_PLATFORM="minimal" ./wpt run "${WPT_ARGS[@]}" ladybird "${TEST_LIST[@]}"
+        QT_QPA_PLATFORM="offscreen" ./wpt run "${WPT_ARGS[@]}" ladybird "${TEST_LIST[@]}"
     popd > /dev/null
 }
 

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -8,10 +8,12 @@ LADYBIRD_SOURCE_DIR="$(realpath "${DIR}"/..)"
 WPT_SOURCE_DIR=${WPT_SOURCE_DIR:-"${LADYBIRD_SOURCE_DIR}/Tests/LibWeb/WPT/wpt"}
 WPT_REPOSITORY_URL=${WPT_REPOSITORY_URL:-"https://github.com/web-platform-tests/wpt.git"}
 
+# shellcheck source=/dev/null
+. "${DIR}/shell_include.sh"
+
 LADYBIRD_BINARY=${LADYBIRD_BINARY:-"${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/Ladybird"}
 WEBDRIVER_BINARY=${WEBDRIVER_BINARY:-"${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/WebDriver"}
-
-WPT_PROCESSES=${WPT_PROCESSES:-$(nproc)}
+WPT_PROCESSES=${WPT_PROCESSES:-$(get_number_of_processing_units)}
 WPT_CERTIFICATES=(
   "tools/certs/cacert.pem"
   "${LADYBIRD_SOURCE_DIR}/Build/ladybird/Lagom/cacert.pem"
@@ -74,9 +76,6 @@ if [ "$ARG" = "--log" ]; then
     WPT_ARGS+=( "--log-raw=${LOG_NAME}" )
 fi
 TEST_LIST=( "$@" )
-
-# shellcheck source=/dev/null
-. "${DIR}/shell_include.sh"
 
 exit_if_running_as_root "Do not run WPT.sh as root"
 


### PR DESCRIPTION
This PR makes the necessary changes to allow the `WPT.sh` to run on MacOS. 

I've also added a check to ensure the necessary hostnames are present in `/etc/hosts`, as this wasn't checked previously.

See individual commits for details.