### PR TITLE
LibWeb: Handle cases with <template> on the HTML parsing stack

### DIFF
--- a/Tests/LibWeb/Layout/expected/crash-tests/html-with-only-a-template-tag.txt
+++ b/Tests/LibWeb/Layout/expected/crash-tests/html-with-only-a-template-tag.txt
@@ -1,0 +1,7 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]

--- a/Tests/LibWeb/Layout/input/crash-tests/html-with-only-a-template-tag.html
+++ b/Tests/LibWeb/Layout/input/crash-tests/html-with-only-a-template-tag.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<template><body>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1748,11 +1748,11 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         log_parse_error();
 
         // If the stack of open elements has only one node on it, if the second element on the stack of open elements is not a body element,
-        // or if there is a template element on the stack of open elements, then ignore the token. (fragment case)
+        // or if there is a template element on the stack of open elements, then ignore the token.
+        // (fragment case or there is a template element on the stack)
         if (m_stack_of_open_elements.elements().size() == 1
             || m_stack_of_open_elements.elements().at(1)->local_name() != HTML::TagNames::body
             || m_stack_of_open_elements.contains(HTML::TagNames::template_)) {
-            VERIFY(m_parsing_fragment);
             return;
         }
 


### PR DESCRIPTION
This appears to have been a bug in the spec which was later corrected - so to fix the crash we can simply remove this assertion.

Fixes: #868