### PR TITLE
LibWeb/HTML: MathML's <ms> is a special tag

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1654,6 +1654,7 @@ bool HTMLParser::is_special_tag(FlyString const& tag_name, Optional<FlyString> c
             MathML::TagNames::mi,
             MathML::TagNames::mo,
             MathML::TagNames::mn,
+            MathML::TagNames::ms,
             MathML::TagNames::mtext,
             MathML::TagNames::annotation_xml);
     }


### PR DESCRIPTION
This is an omission I noticed while browsing some code :^)

See:
 - https://html.spec.whatwg.org/multipage/parsing.html#special