### PR TITLE
LibWeb: Implement the setter for `location.protocol`

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Location-protocol-setter.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Location-protocol-setter.txt
@@ -1,0 +1,1 @@
+Setting location.protocol to an invalid value throws SyntaxError

--- a/Tests/LibWeb/Text/input/HTML/Location-protocol-setter.html
+++ b/Tests/LibWeb/Text/input/HTML/Location-protocol-setter.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        try {
+            window.location.protocol = "\xff";
+        } catch (e) {
+            println(`Setting location.protocol to an invalid value throws ${e.name}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Unfortunately, I don't think it's possible to write a test for anything other than the error case, as a HTTP(S) protocol has to be used.

Fixes 47 subtests in: https://wpt.live/html/browsers/history/the-location-interface/location-protocol-setter.html