### PR TITLE
UI/Qt: Fix long URLs showing the end instead of domain

### DIFF
--- a/Ladybird/Qt/LocationEdit.cpp
+++ b/Ladybird/Qt/LocationEdit.cpp
@@ -73,6 +73,7 @@ void LocationEdit::focusOutEvent(QFocusEvent* event)
         if (text().isEmpty())
             setText(qstring_from_ak_string(m_url.serialize()));
     }
+    setCursorPosition(0);
     highlight_location();
 }
 
@@ -134,6 +135,7 @@ void LocationEdit::set_url(URL::URL const& url)
         clear();
     } else {
         setText(qstring_from_ak_string(url.serialize()));
+        setCursorPosition(0);
     }
 }
 


### PR DESCRIPTION
Cursor in `LocationEdit` (Address bar) did not return to front after loading - because of that long URLs would hide the domain (location).

Before:  
![image](https://github.com/user-attachments/assets/07ccbcf4-600e-43c9-9f39-594d59efd6f7)

`SetCursorPosition()` needed two calls as with only one in `highlight_location` block it would still default to the end after load. 

After:  

https://github.com/user-attachments/assets/02bb89b1-ae87-4fbd-88fb-c346ca7a9574

