### PR TITLE
LibWeb: Stub missing includes for CanvasRenderingContext2D and WebGLRenderingContext

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFilters.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasFilters.idl
@@ -1,0 +1,5 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvasfilters
+interface mixin CanvasFilters {
+    // filters
+    [FIXME] attribute DOMString filter; // (default "none")
+};

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasShadowStyles.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasShadowStyles.idl
@@ -1,0 +1,8 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvasshadowstyles
+interface mixin CanvasShadowStyles {
+    // shadows
+    [FIXME] attribute unrestricted double shadowOffsetX; // (default 0)
+    [FIXME] attribute unrestricted double shadowOffsetY; // (default 0)
+    [FIXME] attribute unrestricted double shadowBlur; // (default 0)
+    [FIXME] attribute DOMString shadowColor; // (default transparent black)
+};

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasUserInterface.idl
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasUserInterface.idl
@@ -1,0 +1,5 @@
+// https://html.spec.whatwg.org/multipage/canvas.html#canvasuserinterface
+interface mixin CanvasUserInterface {
+    [FIXME] undefined drawFocusIfNeeded(Element element);
+    [FIXME] undefined drawFocusIfNeeded(Path2D path, Element element);
+};

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -3,15 +3,27 @@
 #import <HTML/Canvas/CanvasDrawImage.idl>
 #import <HTML/Canvas/CanvasDrawPath.idl>
 #import <HTML/Canvas/CanvasFillStrokeStyles.idl>
+#import <HTML/Canvas/CanvasFilters.idl>
 #import <HTML/Canvas/CanvasImageData.idl>
 #import <HTML/Canvas/CanvasImageSmoothing.idl>
 #import <HTML/Canvas/CanvasPath.idl>
 #import <HTML/Canvas/CanvasPathDrawingStyles.idl>
 #import <HTML/Canvas/CanvasTextDrawingStyles.idl>
 #import <HTML/Canvas/CanvasRect.idl>
+#import <HTML/Canvas/CanvasShadowStyles.idl>
 #import <HTML/Canvas/CanvasState.idl>
 #import <HTML/Canvas/CanvasText.idl>
 #import <HTML/Canvas/CanvasTransform.idl>
+#import <HTML/Canvas/CanvasUserInterface.idl>
+
+enum PredefinedColorSpace { "srgb", "display-p3" };
+
+dictionary CanvasRenderingContext2DSettings {
+    boolean alpha = true;
+    boolean desynchronized = false;
+    PredefinedColorSpace colorSpace = "srgb";
+    boolean willReadFrequently = false;
+};
 
 enum ImageSmoothingQuality { "low", "medium", "high" };
 
@@ -23,6 +35,8 @@ enum CanvasTextBaseline { "top", "hanging", "middle", "alphabetic", "ideographic
 [Exposed=Window]
 interface CanvasRenderingContext2D {
     [ImplementedAs=canvas_for_binding] readonly attribute HTMLCanvasElement canvas;
+
+    [FIXME] CanvasRenderingContext2DSettings getContextAttributes();
 };
 
 CanvasRenderingContext2D includes CanvasState;
@@ -30,11 +44,11 @@ CanvasRenderingContext2D includes CanvasTransform;
 CanvasRenderingContext2D includes CanvasCompositing;
 CanvasRenderingContext2D includes CanvasImageSmoothing;
 CanvasRenderingContext2D includes CanvasFillStrokeStyles;
-// FIXME: CanvasRenderingContext2D includes CanvasShadowStyles;
-// FIXME: CanvasRenderingContext2D includes CanvasFilters;
+CanvasRenderingContext2D includes CanvasShadowStyles;
+CanvasRenderingContext2D includes CanvasFilters;
 CanvasRenderingContext2D includes CanvasRect;
 CanvasRenderingContext2D includes CanvasDrawPath;
-// FIXME: CanvasRenderingContext2D includes CanvasUserInterface;
+CanvasRenderingContext2D includes CanvasUserInterface;
 CanvasRenderingContext2D includes CanvasText;
 CanvasRenderingContext2D includes CanvasDrawImage;
 CanvasRenderingContext2D includes CanvasImageData;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.idl
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.idl
@@ -1,4 +1,5 @@
 #import <WebGL/WebGLRenderingContextBase.idl>
+#import <WebGL/WebGLRenderingContextOverloads.idl>
 
 // https://registry.khronos.org/webgl/specs/latest/1.0/#5.14
 [Exposed=(Window,Worker)]
@@ -6,3 +7,4 @@ interface WebGLRenderingContext {
 };
 
 WebGLRenderingContext includes WebGLRenderingContextBase;
+WebGLRenderingContext includes WebGLRenderingContextOverloads;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
@@ -22,7 +22,14 @@ interface mixin WebGLRenderingContextBase {
 
     // FIXME: The type should be (HTMLCanvasElement or OffscreenCanvas).
     [ImplementedAs=canvas_for_binding] readonly attribute HTMLCanvasElement canvas;
+    [FIXME] readonly attribute GLsizei drawingBufferWidth;
+    [FIXME] readonly attribute GLsizei drawingBufferHeight;
+    [FIXME] readonly attribute GLenum drawingBufferFormat;
 
+    [FIXME] attribute PredefinedColorSpace drawingBufferColorSpace;
+    [FIXME] attribute PredefinedColorSpace unpackColorSpace;
+
+    [FIXME] WebGLContextAttributes? getContextAttributes();
     boolean isContextLost();
 
     sequence<DOMString>? getSupportedExtensions();

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.idl
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextOverloads.idl
@@ -1,0 +1,31 @@
+// https://registry.khronos.org/webgl/specs/latest/1.0/#5.14
+interface mixin WebGLRenderingContextOverloads {
+    [FIXME] undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
+    [FIXME] undefined bufferData(GLenum target, AllowSharedBufferSource? data, GLenum usage);
+    [FIXME] undefined bufferSubData(GLenum target, GLintptr offset, AllowSharedBufferSource data);
+
+    [FIXME] undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, [AllowShared] ArrayBufferView data);
+    [FIXME] undefined compressedTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, [AllowShared] ArrayBufferView data);
+
+    [FIXME] undefined readPixels(GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
+
+    [FIXME] undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
+    [FIXME] undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLenum format, GLenum type, TexImageSource source); // May throw DOMException
+
+    [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
+    [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLenum format, GLenum type, TexImageSource source); // May throw DOMException
+
+    [FIXME] undefined uniform1fv(WebGLUniformLocation? location, Float32List v);
+    [FIXME] undefined uniform2fv(WebGLUniformLocation? location, Float32List v);
+    [FIXME] undefined uniform3fv(WebGLUniformLocation? location, Float32List v);
+    [FIXME] undefined uniform4fv(WebGLUniformLocation? location, Float32List v);
+
+    [FIXME] undefined uniform1iv(WebGLUniformLocation? location, Int32List v);
+    [FIXME] undefined uniform2iv(WebGLUniformLocation? location, Int32List v);
+    [FIXME] undefined uniform3iv(WebGLUniformLocation? location, Int32List v);
+    [FIXME] undefined uniform4iv(WebGLUniformLocation? location, Int32List v);
+
+    [FIXME] undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List value);
+    [FIXME] undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List value);
+    [FIXME] undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List value);
+};


### PR DESCRIPTION
More work towards [GH-24168](https://github.com/SerenityOS/serenity/issues/24168) (yet again 😅)

Knocks quite a bit from https://idl-compare.pages.dev/ :^)