### PR TITLE
LibWeb: Add URL reflection to obsolete HTMLImageElement lowsrc property

### DIFF
--- a/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
+++ b/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
@@ -5,6 +5,8 @@ frame.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 iframe.longDesc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 iframe.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 img.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+img.longDesc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+img.lowsrc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 link.href final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 object.codeBase final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 object.data final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD

--- a/Tests/LibWeb/Text/input/usvstring-url-reflection.html
+++ b/Tests/LibWeb/Text/input/usvstring-url-reflection.html
@@ -10,6 +10,8 @@
             { "iframe": "longDesc" },
             { "iframe": "src" },
             { "img": "src" },
+            { "img": "longDesc" },
+            { "img": "lowsrc" },
             { "link": "href" },
             { "object": "codeBase" },
             { "object": "data" },

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -30,7 +30,7 @@ interface HTMLImageElement : HTMLElement {
 
     // Obsolete
     [CEReactions, Reflect] attribute DOMString name;
-    [CEReactions, Reflect] attribute USVString lowsrc;
+    [CEReactions, Reflect, URL] attribute USVString lowsrc;
     [CEReactions, Reflect] attribute DOMString align;
     [CEReactions, Reflect] attribute unsigned long hspace;
     [CEReactions, Reflect] attribute unsigned long vspace;


### PR DESCRIPTION
I noticed that #1059 didn't add URL reflection to the `HTMLImageElement.lowsrc` property (https://html.spec.whatwg.org/multipage/obsolete.html#dom-img-lowsrc)

I found it strange that the [WPT idlharness](https://wpt.live/html/dom/idlharness.https.html?include=HTMLImage.*) already passes but it is in the HTML obsolete spec