### PR TITLE
LibWeb: Reuse display list across repaints

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -48,7 +48,7 @@ void ImageStyleValue::load_any_resources(DOM::Document& document)
                 m_document->set_needs_to_resolve_paint_only_properties();
 
                 // FIXME: Do less than a full repaint if possible?
-                navigable->set_needs_display();
+                m_document->set_needs_display();
             }
 
             auto image_data = m_resource_request->image_data();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -699,6 +699,18 @@ public:
     JS::GCPtr<HTML::Navigable> cached_navigable();
     void set_cached_navigable(JS::GCPtr<HTML::Navigable>);
 
+    [[nodiscard]] bool needs_repaint() const { return m_needs_repaint; }
+    void set_needs_display();
+    void set_needs_display(CSSPixelRect const&);
+
+    struct PaintConfig {
+        bool paint_overlay { false };
+        bool should_show_line_box_borders { false };
+        bool has_focus { false };
+        Optional<Gfx::IntRect> canvas_fill_rect {};
+    };
+    RefPtr<Painting::DisplayList> record_display_list(PaintConfig);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -972,6 +984,8 @@ private:
 
     // NOTE: This is WeakPtr, not GCPtr, on purpose. We don't want the document to keep some old detached navigable alive.
     WeakPtr<HTML::Navigable> m_cached_navigable;
+
+    bool m_needs_repaint { false };
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -708,8 +708,12 @@ public:
         bool should_show_line_box_borders { false };
         bool has_focus { false };
         Optional<Gfx::IntRect> canvas_fill_rect {};
+
+        bool operator==(PaintConfig const& other) const = default;
     };
     RefPtr<Painting::DisplayList> record_display_list(PaintConfig);
+
+    void invalidate_display_list();
 
 protected:
     virtual void initialize(JS::Realm&) override;
@@ -986,6 +990,9 @@ private:
     WeakPtr<HTML::Navigable> m_cached_navigable;
 
     bool m_needs_repaint { false };
+
+    Optional<PaintConfig> m_cached_display_list_paint_config;
+    RefPtr<Painting::DisplayList> m_cached_display_list;
 };
 
 template<>

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -98,6 +98,7 @@ void Range::update_associated_selection()
 {
     if (auto* viewport = m_start_container->document().paintable()) {
         viewport->recompute_selection_states();
+        m_start_container->document().invalidate_display_list();
         viewport->set_needs_display();
     }
 

--- a/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -31,7 +31,7 @@ AudioTrack::AudioTrack(JS::Realm& realm, JS::NonnullGCPtr<HTMLMediaElement> medi
     , m_audio_plugin(Platform::AudioCodecPlugin::create(move(loader)).release_value_but_fixme_should_propagate_errors())
 {
     m_audio_plugin->on_playback_position_updated = [this](auto position) {
-        if (auto const* paintable = m_media_element->paintable())
+        if (auto* paintable = m_media_element->paintable())
             paintable->set_needs_display();
 
         auto playback_position = static_cast<double>(position.to_milliseconds()) / 1000.0;

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -186,6 +186,7 @@ Gfx::Painter* CanvasRenderingContext2D::painter()
     if (!canvas_element().bitmap()) {
         if (!canvas_element().create_bitmap())
             return nullptr;
+        canvas_element().document().invalidate_display_list();
         m_painter = make<Gfx::Painter>(*canvas_element().bitmap());
     }
     return m_painter.ptr();

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -209,7 +209,7 @@ void EventLoop::process()
     //         loop processing.
     for_each_fully_active_document_in_docs([&](DOM::Document& document) {
         auto navigable = document.navigable();
-        if (navigable && !navigable->has_a_rendering_opportunity() && navigable->needs_repaint())
+        if (navigable && !navigable->has_a_rendering_opportunity() && document.needs_repaint())
             schedule();
         if (navigable && navigable->has_a_rendering_opportunity())
             return;
@@ -328,7 +328,7 @@ void EventLoop::process()
     // 16. For each fully active Document in docs, update the rendering or user interface of that Document and its browsing context to reflect the current state.
     for_each_fully_active_document_in_docs([&](DOM::Document& document) {
         auto navigable = document.navigable();
-        if (navigable && navigable->needs_repaint()) {
+        if (navigable && document.needs_repaint()) {
             auto* browsing_context = document.browsing_context();
             auto& page = browsing_context->page();
             if (navigable->is_traversable()) {
@@ -341,7 +341,7 @@ void EventLoop::process()
     // FIXME: Not in the spec: If there is a screenshot request queued, process it now.
     //        This prevents tests deadlocking on screenshot requests on macOS.
     for (auto& document : docs) {
-        if (document->page().top_level_traversable()->needs_repaint())
+        if (document->needs_repaint())
             document->page().client().process_screenshot_requests();
     }
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2128,13 +2128,15 @@ RefPtr<Painting::DisplayList> Navigable::record_display_list(PaintConfig config)
 
     viewport_paintable.paint_all_phases(context);
 
-    Vector<Gfx::IntPoint> scroll_offsets_by_frame_id;
-    scroll_offsets_by_frame_id.resize(viewport_paintable.scroll_state.size());
-    for (auto [_, scrollable_frame] : viewport_paintable.scroll_state) {
-        auto scroll_offset = context.rounded_device_point(scrollable_frame->cumulative_offset).to_type<int>();
-        scroll_offsets_by_frame_id[scrollable_frame->id] = scroll_offset;
+    display_list->set_device_pixels_per_css_pixel(page.client().device_pixels_per_css_pixel());
+
+    Vector<RefPtr<Painting::ScrollFrame>> scroll_state;
+    scroll_state.resize(viewport_paintable.scroll_state.size());
+    for (auto& [_, scrollable_frame] : viewport_paintable.scroll_state) {
+        scroll_state[scrollable_frame->id] = scrollable_frame;
     }
-    display_list_recorder.display_list().apply_scroll_offsets(scroll_offsets_by_frame_id);
+
+    display_list->set_scroll_state(move(scroll_state));
 
     m_needs_repaint = false;
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2131,7 +2131,7 @@ RefPtr<Painting::DisplayList> Navigable::record_display_list(PaintConfig config)
     Vector<Gfx::IntPoint> scroll_offsets_by_frame_id;
     scroll_offsets_by_frame_id.resize(viewport_paintable.scroll_state.size());
     for (auto [_, scrollable_frame] : viewport_paintable.scroll_state) {
-        auto scroll_offset = context.rounded_device_point(scrollable_frame->offset).to_type<int>();
+        auto scroll_offset = context.rounded_device_point(scrollable_frame->cumulative_offset).to_type<int>();
         scroll_offsets_by_frame_id[scrollable_frame->id] = scroll_offset;
     }
     display_list_recorder.display_list().apply_scroll_offsets(scroll_offsets_by_frame_id);

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
 #include <LibWeb/Page/EventHandler.h>
+#include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/XHR/FormDataEntry.h>
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -170,7 +170,6 @@ public:
     void perform_scroll_of_viewport(CSSPixelPoint position);
 
     void set_needs_display();
-    void set_needs_display(CSSPixelRect const&);
 
     void set_is_popup(TokenizedFeature::Popup is_popup) { m_is_popup = is_popup; }
 
@@ -178,16 +177,6 @@ public:
     [[nodiscard]] bool has_a_rendering_opportunity() const;
 
     [[nodiscard]] TargetSnapshotParams snapshot_target_snapshot_params();
-
-    [[nodiscard]] bool needs_repaint() const { return m_needs_repaint; }
-
-    struct PaintConfig {
-        bool paint_overlay { false };
-        bool should_show_line_box_borders { false };
-        bool has_focus { false };
-        Optional<Gfx::IntRect> canvas_fill_rect {};
-    };
-    RefPtr<Painting::DisplayList> record_display_list(PaintConfig);
 
     Page& page() { return m_page; }
     Page const& page() const { return m_page; }
@@ -244,8 +233,6 @@ private:
 
     CSSPixelSize m_size;
     CSSPixelPoint m_viewport_scroll_offset;
-
-    bool m_needs_repaint { false };
 
     Web::EventHandler m_event_handler;
 };

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 
 namespace Web::HTML {
@@ -1192,6 +1193,12 @@ void TraversableNavigable::paint(DevicePixelRect const& content_rect, Painting::
     auto document = active_document();
     if (!document)
         return;
+
+    for (auto& navigable : all_navigables()) {
+        if (auto active_document = navigable->active_document(); active_document && active_document->paintable()) {
+            active_document->paintable()->refresh_scroll_state();
+        }
+    }
 
     DOM::Document::PaintConfig paint_config;
     paint_config.paint_overlay = paint_options.paint_overlay == PaintOptions::PaintOverlay::Yes;

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1189,12 +1189,16 @@ JS::GCPtr<DOM::Node> TraversableNavigable::currently_focused_area()
 
 void TraversableNavigable::paint(DevicePixelRect const& content_rect, Painting::BackingStore& target, PaintOptions paint_options)
 {
-    HTML::Navigable::PaintConfig paint_config;
+    auto document = active_document();
+    if (!document)
+        return;
+
+    DOM::Document::PaintConfig paint_config;
     paint_config.paint_overlay = paint_options.paint_overlay == PaintOptions::PaintOverlay::Yes;
     paint_config.should_show_line_box_borders = paint_options.should_show_line_box_borders;
     paint_config.has_focus = paint_options.has_focus;
     paint_config.canvas_fill_rect = Gfx::IntRect { {}, content_rect.size() };
-    auto display_list = record_display_list(paint_config);
+    auto display_list = document->record_display_list(paint_config);
     if (!display_list) {
         return;
     }

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -582,7 +582,7 @@ bool EventHandler::handle_mousemove(CSSPixelPoint viewport_position, CSSPixelPoi
                 if (should_set_cursor_position)
                     document.set_cursor_position(DOM::Position::create(realm, *hit->dom_node(), *start_index));
 
-                document.navigable()->set_needs_display();
+                document.set_needs_display();
             }
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/ClipFrame.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClipFrame.cpp
@@ -24,12 +24,12 @@ CSSPixelRect ClipFrame::clip_rect_for_hit_testing() const
     VERIFY(!m_clip_rects.is_empty());
     auto rect = m_clip_rects[0].rect;
     if (m_clip_rects[0].enclosing_scroll_frame) {
-        rect.translate_by(m_clip_rects[0].enclosing_scroll_frame->offset);
+        rect.translate_by(m_clip_rects[0].enclosing_scroll_frame->cumulative_offset);
     }
     for (size_t i = 1; i < m_clip_rects.size(); ++i) {
         auto clip_rect = m_clip_rects[i].rect;
         if (m_clip_rects[i].enclosing_scroll_frame) {
-            clip_rect.translate_by(m_clip_rects[i].enclosing_scroll_frame->offset);
+            clip_rect.translate_by(m_clip_rects[i].enclosing_scroll_frame->cumulative_offset);
         }
         rect.intersect(clip_rect);
     }

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -23,10 +23,10 @@ Optional<int> ClippableAndScrollable::scroll_frame_id() const
     return {};
 }
 
-CSSPixelPoint ClippableAndScrollable::enclosing_scroll_frame_offset() const
+CSSPixelPoint ClippableAndScrollable::cumulative_offset_of_enclosing_scroll_frame() const
 {
     if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->offset;
+        return m_enclosing_scroll_frame->cumulative_offset;
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -20,7 +20,7 @@ public:
 
     [[nodiscard]] RefPtr<ScrollFrame const> enclosing_scroll_frame() const { return m_enclosing_scroll_frame; }
     [[nodiscard]] Optional<int> scroll_frame_id() const;
-    [[nodiscard]] CSSPixelPoint enclosing_scroll_frame_offset() const;
+    [[nodiscard]] CSSPixelPoint cumulative_offset_of_enclosing_scroll_frame() const;
     [[nodiscard]] Optional<CSSPixelRect> clip_rect_for_hit_testing() const;
 
     [[nodiscard]] Optional<int> own_scroll_frame_id() const;

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -24,6 +24,12 @@ public:
     [[nodiscard]] Optional<CSSPixelRect> clip_rect_for_hit_testing() const;
 
     [[nodiscard]] Optional<int> own_scroll_frame_id() const;
+    [[nodiscard]] CSSPixelPoint own_scroll_frame_offset() const
+    {
+        if (m_own_scroll_frame)
+            return m_own_scroll_frame->own_offset;
+        return {};
+    }
     void set_own_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_own_scroll_frame = scroll_frame; }
 
     void apply_clip(PaintContext&) const;

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -374,6 +374,18 @@ struct PaintNestedDisplayList {
     }
 };
 
+struct PaintScrollBar {
+    int scroll_frame_id;
+    Gfx::IntRect rect;
+    CSSPixelFraction scroll_size;
+    bool vertical;
+
+    void translate_by(Gfx::IntPoint const& offset)
+    {
+        rect.translate_by(offset);
+    }
+};
+
 using Command = Variant<
     DrawGlyphRun,
     FillRect,
@@ -404,6 +416,7 @@ using Command = Variant<
     DrawTriangleWave,
     AddRoundedRectClip,
     AddMask,
-    PaintNestedDisplayList>;
+    PaintNestedDisplayList,
+    PaintScrollBar>;
 
 }

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -72,6 +72,7 @@ private:
     virtual void add_rounded_rect_clip(AddRoundedRectClip const&) = 0;
     virtual void add_mask(AddMask const&) = 0;
     virtual void paint_nested_display_list(PaintNestedDisplayList const&) = 0;
+    virtual void paint_scrollbar(PaintScrollBar const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
 };
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -29,6 +29,7 @@
 #include <LibWeb/Painting/Command.h>
 #include <LibWeb/Painting/GradientData.h>
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
+#include <LibWeb/Painting/ScrollFrame.h>
 
 namespace Web::Painting {
 
@@ -83,8 +84,6 @@ public:
 
     void append(Command&& command, Optional<i32> scroll_frame_id);
 
-    void apply_scroll_offsets(Vector<Gfx::IntPoint> const& offsets_by_frame_id);
-
     struct CommandListItem {
         Optional<i32> scroll_frame_id;
         Command command;
@@ -92,10 +91,19 @@ public:
 
     AK::SegmentedVector<CommandListItem, 512> const& commands() const { return m_commands; }
 
+    void set_scroll_state(Vector<RefPtr<ScrollFrame>> scroll_state) { m_scroll_state = move(scroll_state); }
+
+    Vector<RefPtr<ScrollFrame>> const& scroll_state() const { return m_scroll_state; }
+
+    void set_device_pixels_per_css_pixel(double device_pixels_per_css_pixel) { m_device_pixels_per_css_pixel = device_pixels_per_css_pixel; }
+    double device_pixels_per_css_pixel() const { return m_device_pixels_per_css_pixel; }
+
 private:
     DisplayList() = default;
 
     AK::SegmentedVector<CommandListItem, 512> m_commands;
+    Vector<RefPtr<ScrollFrame>> m_scroll_state;
+    double m_device_pixels_per_css_pixel;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1304,6 +1304,27 @@ void DisplayListPlayerSkia::paint_nested_display_list(PaintNestedDisplayList con
     execute(*command.display_list);
 }
 
+void DisplayListPlayerSkia::paint_scrollbar(PaintScrollBar const& command)
+{
+    auto rect = to_skia_rect(command.rect);
+    auto radius = rect.width() / 2;
+    auto rrect = SkRRect::MakeRectXY(rect, radius, radius);
+
+    auto& canvas = surface().canvas();
+
+    auto fill_color = Color(Color::NamedColor::DarkGray).with_alpha(128);
+    SkPaint fill_paint;
+    fill_paint.setColor(to_skia_color(fill_color));
+    canvas.drawRRect(rrect, fill_paint);
+
+    auto stroke_color = Color(Color::NamedColor::LightGray).with_alpha(128);
+    SkPaint stroke_paint;
+    stroke_paint.setStroke(true);
+    stroke_paint.setStrokeWidth(1);
+    stroke_paint.setColor(to_skia_color(stroke_color));
+    canvas.drawRRect(rrect, stroke_paint);
+}
+
 bool DisplayListPlayerSkia::would_be_fully_clipped_by_painter(Gfx::IntRect rect) const
 {
     return surface().canvas().quickReject(to_skia_rect(rect));

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -77,6 +77,7 @@ private:
     void draw_triangle_wave(DrawTriangleWave const&) override;
     void add_rounded_rect_clip(AddRoundedRectClip const&) override;
     void add_mask(AddMask const&) override;
+    void paint_scrollbar(PaintScrollBar const&) override;
     void paint_nested_display_list(PaintNestedDisplayList const&) override;
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -408,4 +408,13 @@ void DisplayListRecorder::draw_triangle_wave(Gfx::IntPoint a_p1, Gfx::IntPoint a
         .thickness = thickness });
 }
 
+void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect rect, CSSPixelFraction scroll_size, bool vertical)
+{
+    append(PaintScrollBar {
+        .scroll_frame_id = scroll_frame_id,
+        .rect = rect,
+        .scroll_size = scroll_size,
+        .vertical = vertical });
+}
+
 }

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -143,6 +143,8 @@ public:
 
     void draw_triangle_wave(Gfx::IntPoint a_p1, Gfx::IntPoint a_p2, Color color, int amplitude, int thickness);
 
+    void paint_scrollbar(int scroll_frame_id, Gfx::IntRect, CSSPixelFraction scroll_size, bool vertical);
+
     DisplayListRecorder(DisplayList&);
     ~DisplayListRecorder();
 

--- a/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/InlinePaintable.cpp
@@ -191,7 +191,7 @@ TraversalDecision InlinePaintable::hit_test(CSSPixelPoint position, HitTestType 
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;
-    position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset());
+    position_adjusted_by_scroll_offset.translate_by(-cumulative_offset_of_enclosing_scroll_frame());
 
     for (auto const& fragment : m_fragments) {
         if (fragment.paintable().stacking_context())

--- a/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/NestedBrowsingContextPaintable.cpp
@@ -54,11 +54,11 @@ void NestedBrowsingContextPaintable::paint(PaintContext& context, PaintPhase pha
 
         context.display_list_recorder().add_clip_rect(clip_rect.to_type<int>());
 
-        HTML::Navigable::PaintConfig paint_config;
+        DOM::Document::PaintConfig paint_config;
         paint_config.paint_overlay = context.should_paint_overlay();
         paint_config.should_show_line_box_borders = context.should_show_line_box_borders();
         paint_config.has_focus = context.has_focus();
-        auto display_list = const_cast<DOM::Document*>(hosted_document)->navigable()->record_display_list(paint_config);
+        auto display_list = const_cast<DOM::Document*>(hosted_document)->record_display_list(paint_config);
         context.display_list_recorder().paint_nested_display_list(display_list, context.enclosing_device_rect(absolute_rect).to_type<int>());
 
         context.display_list_recorder().restore();

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -127,25 +127,24 @@ void Paintable::invalidate_stacking_context()
     m_stacking_context = nullptr;
 }
 
-void Paintable::set_needs_display() const
+void Paintable::set_needs_display()
 {
     auto* containing_block = this->containing_block();
     if (!containing_block)
         return;
-    auto navigable = this->navigable();
-    if (!navigable)
-        return;
+
+    auto& document = const_cast<DOM::Document&>(this->document());
 
     if (is<Painting::InlinePaintable>(*this)) {
         auto const& fragments = static_cast<Painting::InlinePaintable const*>(this)->fragments();
         for (auto const& fragment : fragments)
-            navigable->set_needs_display(fragment.absolute_rect());
+            document.set_needs_display(fragment.absolute_rect());
     }
 
     if (!is<Painting::PaintableWithLines>(*containing_block))
         return;
     static_cast<Painting::PaintableWithLines const&>(*containing_block).for_each_fragment([&](auto& fragment) {
-        navigable->set_needs_display(fragment.absolute_rect());
+        document.set_needs_display(fragment.absolute_rect());
         return IterationDecision::Continue;
     });
 }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -198,7 +198,7 @@ public:
 
     JS::GCPtr<HTML::Navigable> navigable() const;
 
-    virtual void set_needs_display() const;
+    virtual void set_needs_display();
 
     PaintableBox* containing_block() const
     {

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -806,7 +806,7 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;
-    position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset());
+    position_adjusted_by_scroll_offset.translate_by(-cumulative_offset_of_enclosing_scroll_frame());
 
     if (!is_visible())
         return TraversalDecision::Continue;
@@ -858,7 +858,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
         return TraversalDecision::Continue;
 
     auto position_adjusted_by_scroll_offset = position;
-    position_adjusted_by_scroll_offset.translate_by(-enclosing_scroll_frame_offset());
+    position_adjusted_by_scroll_offset.translate_by(-cumulative_offset_of_enclosing_scroll_frame());
 
     if (!layout_box().children_are_inline() || m_fragments.is_empty()) {
         return PaintableBox::hit_test(position, type, callback);

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -907,10 +907,9 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
     return TraversalDecision::Continue;
 }
 
-void PaintableBox::set_needs_display() const
+void PaintableBox::set_needs_display()
 {
-    if (auto navigable = this->navigable())
-        navigable->set_needs_display(absolute_rect());
+    document().set_needs_display(absolute_rect());
 }
 
 Optional<CSSPixelRect> PaintableBox::get_masking_area() const

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -221,10 +221,15 @@ protected:
     virtual CSSPixelRect compute_absolute_rect() const;
     virtual CSSPixelRect compute_absolute_paint_rect() const;
 
+    struct ScrollbarData {
+        CSSPixelRect thumb_rect;
+        CSSPixelFraction scroll_length;
+    };
     enum class ScrollDirection {
         Horizontal,
         Vertical,
     };
+    Optional<ScrollbarData> compute_scrollbar_data(ScrollDirection) const;
     [[nodiscard]] Optional<CSSPixelRect> scroll_thumb_rect(ScrollDirection) const;
     [[nodiscard]] bool is_scrollable(ScrollDirection) const;
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -128,7 +128,7 @@ public:
     DOM::Node const* dom_node() const { return layout_box().dom_node(); }
     DOM::Node* dom_node() { return layout_box().dom_node(); }
 
-    virtual void set_needs_display() const override;
+    virtual void set_needs_display() override;
 
     virtual void apply_scroll_offset(PaintContext&, PaintPhase) const override;
     virtual void reset_scroll_offset(PaintContext&, PaintPhase) const override;

--- a/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -13,6 +13,7 @@ namespace Web::Painting {
 struct ScrollFrame : public RefCounted<ScrollFrame> {
     i32 id { -1 };
     CSSPixelPoint cumulative_offset;
+    CSSPixelPoint own_offset;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -12,7 +12,7 @@ namespace Web::Painting {
 
 struct ScrollFrame : public RefCounted<ScrollFrame> {
     i32 id { -1 };
-    CSSPixelPoint offset;
+    CSSPixelPoint cumulative_offset;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -412,10 +412,10 @@ TraversalDecision StackingContext::hit_test(CSSPixelPoint position, HitTestType 
     CSSPixelPoint enclosing_scroll_offset;
     if (is<PaintableBox>(paintable())) {
         auto const& paintable_box = static_cast<PaintableBox const&>(paintable());
-        enclosing_scroll_offset = paintable_box.enclosing_scroll_frame_offset();
+        enclosing_scroll_offset = paintable_box.cumulative_offset_of_enclosing_scroll_frame();
     } else if (is<InlinePaintable>(paintable())) {
         auto const& inline_paintable = static_cast<InlinePaintable const&>(paintable());
-        enclosing_scroll_offset = inline_paintable.enclosing_scroll_frame_offset();
+        enclosing_scroll_offset = inline_paintable.cumulative_offset_of_enclosing_scroll_frame();
     }
 
     auto position_adjusted_by_scroll_offset = transformed_position;

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -162,14 +162,14 @@ void ViewportPaintable::refresh_scroll_state()
     for (auto& it : scroll_state) {
         auto const& paintable_box = *it.key;
         auto& scroll_frame = *it.value;
-        CSSPixelPoint offset;
+        CSSPixelPoint cumulative_offset;
         for (auto const* block = &paintable_box.layout_box(); block; block = block->containing_block()) {
             auto const& block_paintable_box = *block->paintable_box();
-            offset.translate_by(block_paintable_box.scroll_offset());
+            cumulative_offset.translate_by(block_paintable_box.scroll_offset());
             if (block->is_fixed_position())
                 break;
         }
-        scroll_frame.offset = -offset;
+        scroll_frame.cumulative_offset = -cumulative_offset;
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -66,13 +66,9 @@ void ViewportPaintable::paint_all_phases(PaintContext& context)
 
 void ViewportPaintable::assign_scroll_frames()
 {
-    auto viewport_scroll_frame = adopt_ref(*new ScrollFrame());
-    viewport_scroll_frame->id = 0;
-    scroll_state.set(this, move(viewport_scroll_frame));
-
-    int next_id = 1;
-    for_each_in_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
-        if (paintable_box.has_scrollable_overflow()) {
+    int next_id = 0;
+    for_each_in_inclusive_subtree_of_type<PaintableBox>([&](auto& paintable_box) {
+        if (paintable_box.has_scrollable_overflow() || is<ViewportPaintable>(paintable_box)) {
             auto scroll_frame = adopt_ref(*new ScrollFrame());
             scroll_frame->id = next_id++;
             paintable_box.set_own_scroll_frame(scroll_frame);

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -170,6 +170,7 @@ void ViewportPaintable::refresh_scroll_state()
                 break;
         }
         scroll_frame.cumulative_offset = -cumulative_offset;
+        scroll_frame.own_offset = -paintable_box.scroll_offset();
     }
 }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -92,7 +92,7 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
     m_document->navigable()->set_viewport_size(size.to_type<CSSPixels>());
     m_document->update_layout();
 
-    auto display_list = m_document->navigable()->record_display_list({});
+    auto display_list = m_document->record_display_list({});
     if (!display_list)
         return {};
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -359,7 +359,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
     if (request == "set-line-box-borders") {
         bool state = argument == "on";
         page->set_should_show_line_box_borders(state);
-        page->page().top_level_traversable()->set_needs_display(page->page().top_level_traversable()->viewport_rect());
+        page->page().top_level_traversable()->set_needs_display();
         return;
     }
 


### PR DESCRIPTION
...if only the scroll offset is updated.

Currently, on any document with a large amount of content, the process
of building a display list is often more expensive than its
rasterization. This is because the amount of work required to build a
display list is proportional to the size of the paintable tree, whereas
rasterization only occurs for the portion visible in the viewport.

This change is the first step toward improving this process by caching
the display list across repaints when neither style nor layout requires
invalidation. This means that repainting while scrolling becomes
significantly less expensive, as we only need to reapply the scroll
offsets to the existing display list.

The performance improvement is especially visible on pages like
https://ziglang.org/documentation/master/ or
https://www.w3.org/TR/css-grid-2/