### PR TITLE
LibWeb: Various preparation commits to making LibWeb importable from swift.

### DIFF
--- a/AK/Swift.h
+++ b/AK/Swift.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#if __has_include(<swift/bridging>)
+#    include <swift/bridging>
+#else
+#    define SWIFT_SELF_CONTAINED
+#    define SWIFT_RETURNS_INDEPENDENT_VALUE
+#    define SWIFT_SHARED_REFERENCE(retain, release)
+#    define SWIFT_IMMORTAL_REFERENCE
+#    define SWIFT_UNSAFE_REFERENCE
+#    define SWIFT_NAME(name)
+#    define SWIFT_CONFORMS_TO_PROTOCOL(protocol)
+#    define SWIFT_COMPUTED_PROPERTY
+#    define SWIFT_MUTATING
+#endif

--- a/Ladybird/Android/src/main/cpp/WebContentService.cpp
+++ b/Ladybird/Android/src/main/cpp/WebContentService.cpp
@@ -19,7 +19,7 @@
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibJS/Bytecode/Interpreter.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/RequestClient.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Loader/ContentFilter.h>
@@ -32,9 +32,9 @@
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageHost.h>
 
-static ErrorOr<NonnullRefPtr<Protocol::RequestClient>> bind_request_server_service()
+static ErrorOr<NonnullRefPtr<Requests::RequestClient>> bind_request_server_service()
 {
-    return bind_service<Protocol::RequestClient>(&bind_request_server_java);
+    return bind_service<Requests::RequestClient>(&bind_request_server_java);
 }
 
 static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> bind_image_decoder_service()

--- a/Ladybird/AppKit/Application/ApplicationBridge.cpp
+++ b/Ladybird/AppKit/Application/ApplicationBridge.cpp
@@ -9,16 +9,17 @@
 #include <Ladybird/HelperProcess.h>
 #include <Ladybird/Utilities.h>
 #include <LibImageDecoderClient/Client.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/RequestClient.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace Ladybird {
 
+// FIXME: LibProtocol is renamed to LibRequests, remove this workaround
 // Unfortunately, the Protocol namespace conflicts hard with a @Protocol interface defined by Objective-C. And the #define
 // trick we use for e.g. Duration does not work for Protocol. So here, we make sure that any use of the Protocol namespace
 // is limited to .cpp files (i.e. not .h files that an Objective-C file can include).
 struct ApplicationBridgeImpl {
-    RefPtr<Protocol::RequestClient> request_server_client;
+    RefPtr<Requests::RequestClient> request_server_client;
     RefPtr<ImageDecoderClient::Client> image_decoder_client;
 };
 

--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -90,7 +90,7 @@ else()
     set(LADYBIRD_TARGET ladybird PRIVATE)
 endif()
 
-target_link_libraries(${LADYBIRD_TARGET} AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibProtocol LibURL)
+target_link_libraries(${LADYBIRD_TARGET} AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibRequests LibURL)
 
 target_include_directories(${LADYBIRD_TARGET} ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${LADYBIRD_TARGET} ${LADYBIRD_SOURCE_DIR}/Userland/)
@@ -118,7 +118,7 @@ add_executable(headless-browser
 
 target_include_directories(headless-browser PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(headless-browser PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
-target_link_libraries(headless-browser PRIVATE AK LibCore LibWeb LibWebView LibWebSocket LibCrypto LibFileSystem LibHTTP LibImageDecoderClient LibJS LibGfx LibMain LibTLS LibIPC LibDiff LibProtocol LibURL)
+target_link_libraries(headless-browser PRIVATE AK LibCore LibWeb LibWebView LibWebSocket LibCrypto LibFileSystem LibHTTP LibImageDecoderClient LibJS LibGfx LibMain LibTLS LibIPC LibDiff LibRequests LibURL)
 
 add_custom_target(run
     COMMAND "${CMAKE_COMMAND}" -E env "LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}" "$<TARGET_FILE:ladybird>" $ENV{LAGOM_ARGS}

--- a/Ladybird/HelperProcess.cpp
+++ b/Ladybird/HelperProcess.cpp
@@ -130,7 +130,7 @@ ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(
     return launch_server_process<ImageDecoderClient::Client>("ImageDecoder"sv, candidate_image_decoder_paths, arguments);
 }
 
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Protocol::RequestClient> request_client)
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Requests::RequestClient> request_client)
 {
     Vector<ByteString> arguments;
     if (request_client) {
@@ -144,7 +144,7 @@ ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(Rea
     return launch_server_process<Web::HTML::WebWorkerClient>("WebWorker"sv, candidate_web_worker_paths, move(arguments));
 }
 
-ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root)
+ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root)
 {
     Vector<ByteString> arguments;
 
@@ -161,10 +161,10 @@ ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(Re
         arguments.append(server.value());
     }
 
-    return launch_server_process<Protocol::RequestClient>("RequestServer"sv, candidate_request_server_paths, move(arguments));
+    return launch_server_process<Requests::RequestClient>("RequestServer"sv, candidate_request_server_paths, move(arguments));
 }
 
-ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient& client)
+ErrorOr<IPC::File> connect_new_request_server_client(Requests::RequestClient& client)
 {
     auto new_socket = client.send_sync_but_allow_failure<Messages::RequestServer::ConnectNewClient>();
     if (!new_socket)

--- a/Ladybird/HelperProcess.h
+++ b/Ladybird/HelperProcess.h
@@ -11,7 +11,7 @@
 #include <AK/Span.h>
 #include <AK/StringView.h>
 #include <LibImageDecoderClient/Client.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/RequestClient.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -23,8 +23,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     Optional<IPC::File> request_server_socket = {});
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths);
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Protocol::RequestClient>);
-ErrorOr<NonnullRefPtr<Protocol::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root);
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, RefPtr<Requests::RequestClient>);
+ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root);
 
-ErrorOr<IPC::File> connect_new_request_server_client(Protocol::RequestClient&);
+ErrorOr<IPC::File> connect_new_request_server_client(Requests::RequestClient&);
 ErrorOr<IPC::File> connect_new_image_decoder_client(ImageDecoderClient::Client&);

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -10,7 +10,7 @@
 #include <AK/HashTable.h>
 #include <Ladybird/Qt/BrowserWindow.h>
 #include <LibImageDecoderClient/Client.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/RequestClient.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Application.h>
 #include <QApplication>
@@ -29,7 +29,7 @@ public:
     virtual bool event(QEvent* event) override;
 
     Function<void(URL::URL)> on_open_file;
-    RefPtr<Protocol::RequestClient> request_server_client;
+    RefPtr<Requests::RequestClient> request_server_client;
 
     NonnullRefPtr<ImageDecoderClient::Client> image_decoder_client() const { return *m_image_decoder_client; }
     ErrorOr<void> initialize_image_decoder();

--- a/Ladybird/Qt/RequestManagerQt.cpp
+++ b/Ladybird/Qt/RequestManagerQt.cpp
@@ -105,12 +105,12 @@ RequestManagerQt::Request::Request(QNetworkReply& reply)
 
 RequestManagerQt::Request::~Request() = default;
 
-void RequestManagerQt::Request::set_buffered_request_finished_callback(Protocol::Request::BufferedRequestFinished on_buffered_request_finished)
+void RequestManagerQt::Request::set_buffered_request_finished_callback(Requests::Request::BufferedRequestFinished on_buffered_request_finished)
 {
     this->on_buffered_request_finish = move(on_buffered_request_finished);
 }
 
-void RequestManagerQt::Request::set_unbuffered_request_callbacks(Protocol::Request::HeadersReceived, Protocol::Request::DataReceived, Protocol::Request::RequestFinished on_request_finished)
+void RequestManagerQt::Request::set_unbuffered_request_callbacks(Requests::Request::HeadersReceived, Requests::Request::DataReceived, Requests::Request::RequestFinished on_request_finished)
 {
     dbgln("Unbuffered requests are not yet supported with Qt networking");
     on_request_finished(false, 0);

--- a/Ladybird/Qt/RequestManagerQt.h
+++ b/Ladybird/Qt/RequestManagerQt.h
@@ -43,8 +43,8 @@ private:
 
         virtual ~Request() override;
 
-        virtual void set_buffered_request_finished_callback(Protocol::Request::BufferedRequestFinished) override;
-        virtual void set_unbuffered_request_callbacks(Protocol::Request::HeadersReceived, Protocol::Request::DataReceived, Protocol::Request::RequestFinished) override;
+        virtual void set_buffered_request_finished_callback(Requests::Request::BufferedRequestFinished) override;
+        virtual void set_unbuffered_request_callbacks(Requests::Request::HeadersReceived, Requests::Request::DataReceived, Requests::Request::RequestFinished) override;
         virtual bool stop() override { return false; }
 
         void did_finish();
@@ -56,7 +56,7 @@ private:
 
         QNetworkReply& m_reply;
 
-        Protocol::Request::BufferedRequestFinished on_buffered_request_finish;
+        Requests::Request::BufferedRequestFinished on_buffered_request_finish;
     };
 
     HashMap<QNetworkReply*, NonnullRefPtr<Request>> m_pending;

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -131,7 +131,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     };
 
     on_request_worker_agent = [&]() {
-        RefPtr<Protocol::RequestClient> request_server_client {};
+        RefPtr<Requests::RequestClient> request_server_client {};
         if (WebView::Application::web_content_options().use_lagom_networking == WebView::UseLagomNetworking::Yes)
             request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
 

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -124,8 +124,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
     if (app->web_content_options().use_lagom_networking == WebView::UseLagomNetworking::Yes) {
         auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-        auto protocol_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root));
-        app->request_server_client = move(protocol_client);
+        auto requests_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root));
+        app->request_server_client = move(requests_client);
     }
 
     TRY(app->initialize_image_decoder());

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE
 target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/>)
 target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
-target_link_libraries(webcontent PUBLIC LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibProtocol LibWebView LibImageDecoderClient)
+target_link_libraries(webcontent PUBLIC LibAudio LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient)
 
 if (HAVE_PULSEAUDIO)
     target_compile_definitions(webcontent PUBLIC HAVE_PULSEAUDIO=1)

--- a/Ladybird/WebContent/main.cpp
+++ b/Ladybird/WebContent/main.cpp
@@ -18,7 +18,7 @@
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibMain/Main.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/RequestClient.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Loader/ContentFilter.h>
@@ -248,7 +248,7 @@ ErrorOr<void> initialize_lagom_networking(int request_server_socket)
     auto socket = TRY(Core::LocalSocket::adopt_fd(request_server_socket));
     TRY(socket->set_blocking(true));
 
-    auto new_client = TRY(try_make_ref_counted<Protocol::RequestClient>(move(socket)));
+    auto new_client = TRY(try_make_ref_counted<Requests::RequestClient>(move(socket)));
 
     Web::ResourceLoader::initialize(TRY(WebView::RequestServerAdapter::try_create(move(new_client))));
     return {};

--- a/Ladybird/WebWorker/CMakeLists.txt
+++ b/Ladybird/WebWorker/CMakeLists.txt
@@ -19,7 +19,7 @@ set_target_properties(webworker PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
 target_include_directories(webworker PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(webworker PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibProtocol LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL)
+target_link_libraries(webworker PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibRequests LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL)
 
 if (HAS_FONTCONFIG)
     target_link_libraries(webworker PRIVATE Fontconfig::Fontconfig)

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -86,7 +86,7 @@ static ErrorOr<void> initialize_lagom_networking(int request_server_socket)
     auto socket = TRY(Core::LocalSocket::adopt_fd(request_server_socket));
     TRY(socket->set_blocking(true));
 
-    auto new_client = TRY(try_make_ref_counted<Protocol::RequestClient>(move(socket)));
+    auto new_client = TRY(try_make_ref_counted<Requests::RequestClient>(move(socket)));
 
     Web::ResourceLoader::initialize(TRY(WebView::RequestServerAdapter::try_create(move(new_client))));
 

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -96,20 +96,21 @@ function (generate_css_implementation)
         NAMESPACE "Web::CSS"
     )
 
+    set(CSS_GENERATED_HEADERS
+       "CSS/Enums.h"
+       "CSS/Keyword.h"
+       "CSS/MathFunctions.h"
+       "CSS/MediaFeatureID.h"
+       "CSS/PropertyID.h"
+       "CSS/PseudoClass.h"
+       "CSS/TransformFunctions.h"
+    )
+    list(TRANSFORM CSS_GENERATED_HEADERS PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
     if (ENABLE_INSTALL_HEADERS)
-        set(CSS_GENERATED_TO_INSTALL
-            "CSS/Enums.h"
-            "CSS/Keyword.h"
-            "CSS/MathFunctions.h"
-            "CSS/MediaFeatureID.h"
-            "CSS/PropertyID.h"
-            "CSS/PseudoClass.h"
-            "CSS/TransformFunctions.h"
-        )
-        list(TRANSFORM CSS_GENERATED_TO_INSTALL PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
-        install(FILES ${CSS_GENERATED_TO_INSTALL} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/CSS")
+        install(FILES ${CSS_GENERATED_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/CSS")
     endif()
-
+    list(APPEND LIBWEB_ALL_GENERATED_HEADERS ${CSS_GENERATED_HEADERS})
+    set(LIBWEB_ALL_GENERATED_HEADERS ${LIBWEB_ALL_GENERATED_HEADERS} PARENT_SCOPE)
 endfunction()
 
 function (generate_js_bindings target)
@@ -175,11 +176,15 @@ function (generate_js_bindings target)
         add_dependencies(all_generated generate_${basename})
         add_dependencies(${target} generate_${basename})
 
+        set(BINDINGS_HEADERS ${BINDINGS_SOURCES})
+        list(FILTER BINDINGS_HEADERS INCLUDE REGEX "\.h$")
+
         if (ENABLE_INSTALL_HEADERS)
-            # install generated sources
-            list(FILTER BINDINGS_SOURCES INCLUDE REGEX "\.h$")
-            install(FILES ${BINDINGS_SOURCES} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/Bindings")
+            install(FILES ${BINDINGS_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/Bindings")
         endif()
+
+        list(APPEND LIBWEB_ALL_GENERATED_HEADERS ${BINDINGS_HEADERS})
+        set(LIBWEB_ALL_GENERATED_HEADERS ${LIBWEB_ALL_GENERATED_HEADERS} PARENT_SCOPE)
 
         list(APPEND LIBWEB_ALL_IDL_FILES "${LIBWEB_INPUT_FOLDER}/${class}.idl")
         set(LIBWEB_ALL_IDL_FILES ${LIBWEB_ALL_IDL_FILES} PARENT_SCOPE)
@@ -212,14 +217,20 @@ function (generate_js_bindings target)
         add_dependencies(all_generated generate_exposed_interfaces)
         add_dependencies(${target} generate_exposed_interfaces)
 
+        list(TRANSFORM exposed_interface_sources PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
+        set(exposed_interface_headers ${exposed_interface_sources})
+        list(FILTER exposed_interface_headers INCLUDE REGEX "\.h$")
+
         if (ENABLE_INSTALL_HEADERS)
-            list(FILTER exposed_interface_sources INCLUDE REGEX "\.h$")
-            list(TRANSFORM exposed_interface_sources PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
-            install(FILES ${exposed_interface_sources} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/Bindings")
+            install(FILES ${exposed_interface_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/LibWeb/Bindings")
         endif()
+
+        list(APPEND LIBWEB_ALL_GENERATED_HEADERS ${exposed_interface_headers})
+        set(LIBWEB_ALL_GENERATED_HEADERS ${LIBWEB_ALL_GENERATED_HEADERS} PARENT_SCOPE)
     endfunction()
 
     include("idl_files.cmake")
     generate_exposed_interface_files()
 
+    set(LIBWEB_ALL_GENERATED_HEADERS ${LIBWEB_ALL_GENERATED_HEADERS} PARENT_SCOPE)
 endfunction()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -390,8 +390,8 @@ set(lagom_standard_libraries
     IPC
     JS
     Line
-    Protocol
     Regex
+    Requests
     RIFF
     Syntax
     TextCodec

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -14,3 +14,10 @@ foreach(source IN LISTS TEST_SOURCES)
 endforeach()
 
 target_link_libraries(TestFetchURL PRIVATE LibURL)
+
+if (ENABLE_SWIFT)
+    add_executable(TestLibWebSwiftBindings TestLibWebSwiftBindings.swift)
+    target_link_libraries(TestLibWebSwiftBindings PRIVATE AK LibWeb)
+    target_compile_options(TestLibWebSwiftBindings PRIVATE -parse-as-library)
+    add_test(NAME TestLibWebSwiftBindings COMMAND TestLibWebSwiftBindings)
+endif()

--- a/Tests/LibWeb/TestLibWebSwiftBindings.swift
+++ b/Tests/LibWeb/TestLibWebSwiftBindings.swift
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import AK
+import LibWeb
+import Foundation
+
+class StandardError: TextOutputStream {
+    func write(_ string: Swift.String) {
+        try! FileHandle.standardError.write(contentsOf: Data(string.utf8))
+    }
+}
+
+@main
+struct TestLibWebSwiftBindings {
+
+    static func testEnumsAreBound() {
+        var standardError = StandardError()
+        print("Testing LibWeb enum types...", to: &standardError)
+
+        print("Web.DOM.NodeType.ELEMENT_NODE == \(Web.DOM.NodeType.ELEMENT_NODE)", to: &standardError)
+        precondition(Web.DOM.NodeType.ELEMENT_NODE.rawValue == 1)
+
+        print("Web.Bindings.NavigationType.Push == \(Web.Bindings.NavigationType.Push)", to: &standardError)
+        precondition(Web.Bindings.NavigationType.Push.rawValue == 0)
+
+        let end = Web.Bindings.idl_enum_to_string(Web.Bindings.ScrollLogicalPosition.End)
+        let end_view = end.__bytes_as_string_viewUnsafe().bytes();
+        let end_string = Swift.String(bytes: end_view, encoding: .utf8)!
+
+        print("Web.Bindings.idl_enum_to_string(Web.Bindings.ScrollLogicalPosition.End) == \(end_string)", to: &standardError)
+        precondition(end_string == "end")
+
+        print("LibWeb enum types pass", to: &standardError)
+    }
+
+    static func main() {
+        var standardError = StandardError()
+        print("Starting test suite...", to: &standardError)
+        testEnumsAreBound()
+
+        print("All tests pass", to: &standardError)
+    }
+}

--- a/Userland/Libraries/LibCore/MachPort.h
+++ b/Userland/Libraries/LibCore/MachPort.h
@@ -15,9 +15,13 @@
 #include <AK/Error.h>
 #include <AK/Noncopyable.h>
 
+#if defined(AK_OS_MACOS) || defined(AK_OS_IOS)
+#    include <mach/mach.h>
+#else
 extern "C" {
-#include <mach/mach.h>
+#    include <mach/mach.h>
 }
+#endif
 
 namespace Core {
 

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -9,6 +9,7 @@
 #include <AK/ByteString.h>
 #include <AK/FloatingPointStringConversions.h>
 #include <AK/Optional.h>
+#include <AK/Swift.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/SystemTheme.h>
@@ -18,7 +19,6 @@
 
 #ifdef LIBGFX_USE_SWIFT
 #    include <LibGfx-Swift.h>
-#    include <swift/bridging>
 #endif
 
 namespace Gfx {

--- a/Userland/Libraries/LibRequests/CMakeLists.txt
+++ b/Userland/Libraries/LibRequests/CMakeLists.txt
@@ -9,5 +9,5 @@ set(GENERATED_SOURCES
     ../../Services/RequestServer/RequestServerEndpoint.h
 )
 
-serenity_lib(LibProtocol protocol)
-target_link_libraries(LibProtocol PRIVATE LibCore LibIPC)
+serenity_lib(LibRequests requests)
+target_link_libraries(LibRequests PRIVATE LibCore LibIPC)

--- a/Userland/Libraries/LibRequests/Request.cpp
+++ b/Userland/Libraries/LibRequests/Request.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibProtocol/Request.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/Request.h>
+#include <LibRequests/RequestClient.h>
 
-namespace Protocol {
+namespace Requests {
 
 Request::Request(RequestClient& client, i32 request_id)
     : m_client(client)
@@ -29,7 +29,7 @@ bool Request::stop()
     return m_client->stop_request({}, *this);
 }
 
-void Request::set_request_fd(Badge<Protocol::RequestClient>, int fd)
+void Request::set_request_fd(Badge<Requests::RequestClient>, int fd)
 {
     VERIFY(m_fd == -1);
     m_fd = fd;

--- a/Userland/Libraries/LibRequests/Request.h
+++ b/Userland/Libraries/LibRequests/Request.h
@@ -17,7 +17,7 @@
 #include <LibHTTP/HeaderMap.h>
 #include <LibIPC/Forward.h>
 
-namespace Protocol {
+namespace Requests {
 
 class RequestClient;
 

--- a/Userland/Libraries/LibRequests/RequestClient.cpp
+++ b/Userland/Libraries/LibRequests/RequestClient.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibProtocol/Request.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/Request.h>
+#include <LibRequests/RequestClient.h>
 
-namespace Protocol {
+namespace Requests {
 
 RequestClient::RequestClient(NonnullOwnPtr<Core::LocalSocket> socket)
     : IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>(*this, move(socket))

--- a/Userland/Libraries/LibRequests/RequestClient.h
+++ b/Userland/Libraries/LibRequests/RequestClient.h
@@ -9,12 +9,12 @@
 #include <AK/HashMap.h>
 #include <LibHTTP/HeaderMap.h>
 #include <LibIPC/ConnectionToServer.h>
-#include <LibProtocol/WebSocket.h>
+#include <LibRequests/WebSocket.h>
 #include <LibWebSocket/WebSocket.h>
 #include <RequestServer/RequestClientEndpoint.h>
 #include <RequestServer/RequestServerEndpoint.h>
 
-namespace Protocol {
+namespace Requests {
 
 class Request;
 

--- a/Userland/Libraries/LibRequests/WebSocket.cpp
+++ b/Userland/Libraries/LibRequests/WebSocket.cpp
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibProtocol/RequestClient.h>
-#include <LibProtocol/WebSocket.h>
+#include <LibRequests/RequestClient.h>
+#include <LibRequests/WebSocket.h>
 
-namespace Protocol {
+namespace Requests {
 
 WebSocket::WebSocket(RequestClient& client, i32 connection_id)
     : m_client(client)

--- a/Userland/Libraries/LibRequests/WebSocket.h
+++ b/Userland/Libraries/LibRequests/WebSocket.h
@@ -15,7 +15,7 @@
 #include <LibCore/Notifier.h>
 #include <LibIPC/Forward.h>
 
-namespace Protocol {
+namespace Requests {
 
 class RequestClient;
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -777,5 +777,11 @@ target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibI
 
 generate_js_bindings(LibWeb)
 
-# Note: If you're looking for the calls to "libweb_js_bindings()",
-# they have been moved to "idl_files.cmake"
+if (ENABLE_SWIFT)
+    set(generated_headers ${GENERATED_SOURCES})
+    list(FILTER generated_headers INCLUDE REGEX "\\.h$")
+    list(TRANSFORM generated_headers PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
+    list(APPEND LIBWEB_ALL_GENERATED_HEADERS ${generated_headers})
+
+    generate_clang_module_map(LibWeb GENERATED_FILES ${LIBWEB_ALL_GENERATED_HEADERS})
+endif()

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -773,7 +773,7 @@ set(GENERATED_SOURCES
 
 serenity_lib(LibWeb web)
 
-target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibAudio LibMedia LibWasm LibXML LibIDL LibURL LibTLS ${SKIA_LIBRARIES})
+target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibAudio LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests ${SKIA_LIBRARIES})
 
 generate_js_bindings(LibWeb)
 

--- a/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorBeacon.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibWeb/Fetch/BodyInit.h>
-#include <LibWeb/HTML/Navigator.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -13,7 +13,7 @@
 #include <LibCore/EventReceiver.h>
 #include <LibCore/Proxy.h>
 #include <LibJS/SafeFunction.h>
-#include <LibProtocol/Request.h>
+#include <LibRequests/Request.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Loader/Resource.h>
 #include <LibWeb/Loader/UserAgent.h>
@@ -36,11 +36,11 @@ public:
 
     // Configure the request such that the entirety of the response data is buffered. The callback receives that data and
     // the response headers all at once. Using this method is mutually exclusive with `set_unbuffered_data_received_callback`.
-    virtual void set_buffered_request_finished_callback(Protocol::Request::BufferedRequestFinished) = 0;
+    virtual void set_buffered_request_finished_callback(Requests::Request::BufferedRequestFinished) = 0;
 
     // Configure the request such that the response data is provided unbuffered as it is received. Using this method is
     // mutually exclusive with `set_buffered_request_finished_callback`.
-    virtual void set_unbuffered_request_callbacks(Protocol::Request::HeadersReceived, Protocol::Request::DataReceived, Protocol::Request::RequestFinished) = 0;
+    virtual void set_unbuffered_request_callbacks(Requests::Request::HeadersReceived, Requests::Request::DataReceived, Requests::Request::RequestFinished) = 0;
 
     virtual bool stop() = 0;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -8,6 +8,7 @@
 
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/DecodedImageData.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web::SVG {
 

--- a/Userland/Libraries/LibWebView/Application.h
+++ b/Userland/Libraries/LibWebView/Application.h
@@ -7,18 +7,13 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/Swift.h>
 #include <LibCore/EventLoop.h>
 #include <LibMain/Main.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Options.h>
 #include <LibWebView/Process.h>
 #include <LibWebView/ProcessManager.h>
-
-#ifdef __swift__
-#    include <swift/bridging>
-#else
-#    define SWIFT_IMMORTAL_REFERENCE
-#endif
 
 namespace WebView {
 

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -48,7 +48,7 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibWebView webview)
-target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibProtocol LibJS LibWeb LibUnicode LibURL)
+target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL)
 target_compile_definitions(LibWebView PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENABLE_PUBLIC_SUFFIX_DOWNLOAD}>)
 
 # Third-party

--- a/Userland/Libraries/LibWebView/RequestServerAdapter.cpp
+++ b/Userland/Libraries/LibWebView/RequestServerAdapter.cpp
@@ -5,18 +5,18 @@
  */
 
 #include "WebSocketClientAdapter.h"
-#include <LibProtocol/Request.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/Request.h>
+#include <LibRequests/RequestClient.h>
 #include <LibWebView/RequestServerAdapter.h>
 
 namespace WebView {
 
-ErrorOr<NonnullRefPtr<RequestServerRequestAdapter>> RequestServerRequestAdapter::try_create(NonnullRefPtr<Protocol::Request> request)
+ErrorOr<NonnullRefPtr<RequestServerRequestAdapter>> RequestServerRequestAdapter::try_create(NonnullRefPtr<Requests::Request> request)
 {
     return adopt_nonnull_ref_or_enomem(new (nothrow) RequestServerRequestAdapter(move(request)));
 }
 
-RequestServerRequestAdapter::RequestServerRequestAdapter(NonnullRefPtr<Protocol::Request> request)
+RequestServerRequestAdapter::RequestServerRequestAdapter(NonnullRefPtr<Requests::Request> request)
     : m_request(request)
 {
     request->on_progress = [weak_this = make_weak_ptr()](Optional<u64> total_size, u64 downloaded_size) {
@@ -29,25 +29,25 @@ RequestServerRequestAdapter::RequestServerRequestAdapter(NonnullRefPtr<Protocol:
         if (auto strong_this = weak_this.strong_ref()) {
             if (strong_this->on_certificate_requested) {
                 auto certificate_and_key = strong_this->on_certificate_requested();
-                return Protocol::Request::CertificateAndKey {
+                return Requests::Request::CertificateAndKey {
                     .certificate = move(certificate_and_key.certificate),
                     .key = move(certificate_and_key.key),
                 };
             }
         }
 
-        return Protocol::Request::CertificateAndKey {};
+        return Requests::Request::CertificateAndKey {};
     };
 }
 
 RequestServerRequestAdapter::~RequestServerRequestAdapter() = default;
 
-void RequestServerRequestAdapter::set_buffered_request_finished_callback(Protocol::Request::BufferedRequestFinished on_buffered_request_finished)
+void RequestServerRequestAdapter::set_buffered_request_finished_callback(Requests::Request::BufferedRequestFinished on_buffered_request_finished)
 {
     m_request->set_buffered_request_finished_callback(move(on_buffered_request_finished));
 }
 
-void RequestServerRequestAdapter::set_unbuffered_request_callbacks(Protocol::Request::HeadersReceived on_headers_received, Protocol::Request::DataReceived on_data_received, Protocol::Request::RequestFinished on_finished)
+void RequestServerRequestAdapter::set_unbuffered_request_callbacks(Requests::Request::HeadersReceived on_headers_received, Requests::Request::DataReceived on_data_received, Requests::Request::RequestFinished on_finished)
 {
     m_request->set_unbuffered_request_callbacks(move(on_headers_received), move(on_data_received), move(on_finished));
 }
@@ -57,18 +57,18 @@ bool RequestServerRequestAdapter::stop()
     return m_request->stop();
 }
 
-ErrorOr<NonnullRefPtr<RequestServerAdapter>> RequestServerAdapter::try_create(NonnullRefPtr<Protocol::RequestClient> protocol_client)
+ErrorOr<NonnullRefPtr<RequestServerAdapter>> RequestServerAdapter::try_create(NonnullRefPtr<Requests::RequestClient> protocol_client)
 {
     return try_make_ref_counted<RequestServerAdapter>(move(protocol_client));
 }
 
 ErrorOr<NonnullRefPtr<RequestServerAdapter>> RequestServerAdapter::try_create()
 {
-    auto protocol_client = TRY(Protocol::RequestClient::try_create());
+    auto protocol_client = TRY(Requests::RequestClient::try_create());
     return try_make_ref_counted<RequestServerAdapter>(move(protocol_client));
 }
 
-RequestServerAdapter::RequestServerAdapter(NonnullRefPtr<Protocol::RequestClient> protocol_client)
+RequestServerAdapter::RequestServerAdapter(NonnullRefPtr<Requests::RequestClient> protocol_client)
     : m_protocol_client(protocol_client)
 {
 }

--- a/Userland/Libraries/LibWebView/RequestServerAdapter.h
+++ b/Userland/Libraries/LibWebView/RequestServerAdapter.h
@@ -11,7 +11,7 @@
 #include <LibWeb/Loader/ResourceLoader.h>
 #include <LibWeb/WebSockets/WebSocket.h>
 
-namespace Protocol {
+namespace Requests {
 class Request;
 class RequestClient;
 }
@@ -22,23 +22,23 @@ class RequestServerRequestAdapter
     : public Web::ResourceLoaderConnectorRequest
     , public Weakable<RequestServerRequestAdapter> {
 public:
-    static ErrorOr<NonnullRefPtr<RequestServerRequestAdapter>> try_create(NonnullRefPtr<Protocol::Request>);
+    static ErrorOr<NonnullRefPtr<RequestServerRequestAdapter>> try_create(NonnullRefPtr<Requests::Request>);
     virtual ~RequestServerRequestAdapter() override;
 
-    virtual void set_buffered_request_finished_callback(Protocol::Request::BufferedRequestFinished) override;
-    virtual void set_unbuffered_request_callbacks(Protocol::Request::HeadersReceived, Protocol::Request::DataReceived, Protocol::Request::RequestFinished) override;
+    virtual void set_buffered_request_finished_callback(Requests::Request::BufferedRequestFinished) override;
+    virtual void set_unbuffered_request_callbacks(Requests::Request::HeadersReceived, Requests::Request::DataReceived, Requests::Request::RequestFinished) override;
     virtual bool stop() override;
 
 private:
-    RequestServerRequestAdapter(NonnullRefPtr<Protocol::Request>);
-    NonnullRefPtr<Protocol::Request> m_request;
+    RequestServerRequestAdapter(NonnullRefPtr<Requests::Request>);
+    NonnullRefPtr<Requests::Request> m_request;
 };
 
 class RequestServerAdapter : public Web::ResourceLoaderConnector {
 public:
-    explicit RequestServerAdapter(NonnullRefPtr<Protocol::RequestClient> protocol_client);
+    explicit RequestServerAdapter(NonnullRefPtr<Requests::RequestClient> protocol_client);
 
-    static ErrorOr<NonnullRefPtr<RequestServerAdapter>> try_create(NonnullRefPtr<Protocol::RequestClient>);
+    static ErrorOr<NonnullRefPtr<RequestServerAdapter>> try_create(NonnullRefPtr<Requests::RequestClient>);
     static ErrorOr<NonnullRefPtr<RequestServerAdapter>> try_create();
     virtual ~RequestServerAdapter() override;
 
@@ -49,7 +49,7 @@ public:
     virtual RefPtr<Web::WebSockets::WebSocketClientSocket> websocket_connect(const URL::URL&, ByteString const& origin, Vector<ByteString> const& protocols) override;
 
 private:
-    RefPtr<Protocol::RequestClient> m_protocol_client;
+    RefPtr<Requests::RequestClient> m_protocol_client;
 };
 
 }

--- a/Userland/Libraries/LibWebView/WebSocketClientAdapter.cpp
+++ b/Userland/Libraries/LibWebView/WebSocketClientAdapter.cpp
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibProtocol/RequestClient.h>
-#include <LibProtocol/WebSocket.h>
+#include <LibRequests/RequestClient.h>
+#include <LibRequests/WebSocket.h>
 #include <LibWebView/WebSocketClientAdapter.h>
 
 namespace WebView {
 
-RefPtr<WebSocketClientSocketAdapter> WebSocketClientSocketAdapter::create(NonnullRefPtr<Protocol::WebSocket> websocket)
+RefPtr<WebSocketClientSocketAdapter> WebSocketClientSocketAdapter::create(NonnullRefPtr<Requests::WebSocket> websocket)
 {
     return adopt_ref(*new WebSocketClientSocketAdapter(move(websocket)));
 }
 
-WebSocketClientSocketAdapter::WebSocketClientSocketAdapter(NonnullRefPtr<Protocol::WebSocket> websocket)
+WebSocketClientSocketAdapter::WebSocketClientSocketAdapter(NonnullRefPtr<Requests::WebSocket> websocket)
     : m_websocket(move(websocket))
 {
     m_websocket->on_open = [weak_this = make_weak_ptr()] {
@@ -37,13 +37,13 @@ WebSocketClientSocketAdapter::WebSocketClientSocketAdapter(NonnullRefPtr<Protoco
         if (auto strong_this = weak_this.strong_ref()) {
             if (strong_this->on_error) {
                 switch (error) {
-                case Protocol::WebSocket::Error::CouldNotEstablishConnection:
+                case Requests::WebSocket::Error::CouldNotEstablishConnection:
                     strong_this->on_error(Web::WebSockets::WebSocketClientSocket::Error::CouldNotEstablishConnection);
                     return;
-                case Protocol::WebSocket::Error::ConnectionUpgradeFailed:
+                case Requests::WebSocket::Error::ConnectionUpgradeFailed:
                     strong_this->on_error(Web::WebSockets::WebSocketClientSocket::Error::ConnectionUpgradeFailed);
                     return;
-                case Protocol::WebSocket::Error::ServerClosedSocket:
+                case Requests::WebSocket::Error::ServerClosedSocket:
                     strong_this->on_error(Web::WebSockets::WebSocketClientSocket::Error::ServerClosedSocket);
                     return;
                 }
@@ -60,13 +60,13 @@ WebSocketClientSocketAdapter::WebSocketClientSocketAdapter(NonnullRefPtr<Protoco
         if (auto strong_this = weak_this.strong_ref()) {
             if (strong_this->on_certificate_requested) {
                 auto certificate_and_key = weak_this->on_certificate_requested();
-                return Protocol::WebSocket::CertificateAndKey {
+                return Requests::WebSocket::CertificateAndKey {
                     .certificate = move(certificate_and_key.certificate),
                     .key = move(certificate_and_key.key),
                 };
             }
         }
-        return Protocol::WebSocket::CertificateAndKey {};
+        return Requests::WebSocket::CertificateAndKey {};
     };
 }
 
@@ -75,13 +75,13 @@ WebSocketClientSocketAdapter::~WebSocketClientSocketAdapter() = default;
 Web::WebSockets::WebSocket::ReadyState WebSocketClientSocketAdapter::ready_state()
 {
     switch (m_websocket->ready_state()) {
-    case Protocol::WebSocket::ReadyState::Connecting:
+    case Requests::WebSocket::ReadyState::Connecting:
         return Web::WebSockets::WebSocket::ReadyState::Connecting;
-    case Protocol::WebSocket::ReadyState::Open:
+    case Requests::WebSocket::ReadyState::Open:
         return Web::WebSockets::WebSocket::ReadyState::Open;
-    case Protocol::WebSocket::ReadyState::Closing:
+    case Requests::WebSocket::ReadyState::Closing:
         return Web::WebSockets::WebSocket::ReadyState::Closing;
-    case Protocol::WebSocket::ReadyState::Closed:
+    case Requests::WebSocket::ReadyState::Closed:
         return Web::WebSockets::WebSocket::ReadyState::Closed;
     }
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWebView/WebSocketClientAdapter.h
+++ b/Userland/Libraries/LibWebView/WebSocketClientAdapter.h
@@ -11,7 +11,7 @@
 #include <AK/Weakable.h>
 #include <LibWeb/WebSockets/WebSocket.h>
 
-namespace Protocol {
+namespace Requests {
 class WebSocket;
 class RequestClient;
 };
@@ -22,7 +22,7 @@ class WebSocketClientSocketAdapter
     : public Web::WebSockets::WebSocketClientSocket
     , public Weakable<WebSocketClientSocketAdapter> {
 public:
-    static RefPtr<WebSocketClientSocketAdapter> create(NonnullRefPtr<Protocol::WebSocket>);
+    static RefPtr<WebSocketClientSocketAdapter> create(NonnullRefPtr<Requests::WebSocket>);
     virtual ~WebSocketClientSocketAdapter() override;
 
     virtual Web::WebSockets::WebSocket::ReadyState ready_state() override;
@@ -33,9 +33,9 @@ public:
     virtual void close(u16 code = 1005, ByteString reason = {}) override;
 
 private:
-    WebSocketClientSocketAdapter(NonnullRefPtr<Protocol::WebSocket>);
+    WebSocketClientSocketAdapter(NonnullRefPtr<Requests::WebSocket>);
 
-    NonnullRefPtr<Protocol::WebSocket> m_websocket;
+    NonnullRefPtr<Requests::WebSocket> m_websocket;
 };
 
 }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -43,7 +43,7 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibIPC/File.h>
 #include <LibImageDecoderClient/Client.h>
-#include <LibProtocol/RequestClient.h>
+#include <LibRequests/RequestClient.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
@@ -65,7 +65,7 @@ class HeadlessWebContentView final : public WebView::ViewImplementation {
 public:
     static ErrorOr<NonnullOwnPtr<HeadlessWebContentView>> create(Core::AnonymousBuffer theme, Gfx::IntSize const& window_size, StringView resources_folder)
     {
-        RefPtr<Protocol::RequestClient> request_client;
+        RefPtr<Requests::RequestClient> request_client;
         RefPtr<ImageDecoderClient::Client> image_decoder_client;
 
         auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
@@ -145,7 +145,7 @@ public:
     }
 
 private:
-    HeadlessWebContentView(NonnullRefPtr<WebView::Database> database, NonnullOwnPtr<WebView::CookieJar> cookie_jar, RefPtr<ImageDecoderClient::Client> image_decoder_client, RefPtr<Protocol::RequestClient> request_client)
+    HeadlessWebContentView(NonnullRefPtr<WebView::Database> database, NonnullOwnPtr<WebView::CookieJar> cookie_jar, RefPtr<ImageDecoderClient::Client> image_decoder_client, RefPtr<Requests::RequestClient> request_client)
         : m_database(move(database))
         , m_cookie_jar(move(cookie_jar))
         , m_request_client(move(request_client))
@@ -178,7 +178,7 @@ private:
 
     NonnullRefPtr<WebView::Database> m_database;
     NonnullOwnPtr<WebView::CookieJar> m_cookie_jar;
-    RefPtr<Protocol::RequestClient> m_request_client;
+    RefPtr<Requests::RequestClient> m_request_client;
     RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
 };
 


### PR DESCRIPTION
The most painful commit is the first, which renames an entire library.

The identifier "Protocol" is claimed by Objective-C and Swift for use
by the language's built-in protocol conformance feature, which is
similar to Rust traits or Java interfaces.

Rename LibProtocol -> LibRequests, and its namespace from Protocol to
Requests to accomodate this.

The rest are various errors encounter by trying to import the LibWeb library through clang modules, and a big CMake slurry to make all generated headers available in the module map file.