### PR TITLE
LibJS+LibWeb: Port some functions from SafeFunction to HeapFunction

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/IteratorHelper.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorHelper.h
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include <LibJS/Heap/HeapFunction.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/GeneratorObject.h>
 #include <LibJS/Runtime/Iterator.h>
 #include <LibJS/Runtime/Object.h>
-#include <LibJS/SafeFunction.h>
 
 namespace JS {
 
@@ -19,10 +19,10 @@ class IteratorHelper final : public GeneratorObject {
     JS_DECLARE_ALLOCATOR(IteratorHelper);
 
 public:
-    using Closure = JS::SafeFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&)>;
-    using AbruptClosure = JS::SafeFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&, Completion const&)>;
+    using Closure = JS::HeapFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&)>;
+    using AbruptClosure = JS::HeapFunction<ThrowCompletionOr<Value>(VM&, IteratorHelper&, Completion const&)>;
 
-    static ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> create(Realm&, NonnullGCPtr<IteratorRecord>, Closure, Optional<AbruptClosure> = {});
+    static ThrowCompletionOr<NonnullGCPtr<IteratorHelper>> create(Realm&, NonnullGCPtr<IteratorRecord>, NonnullGCPtr<Closure>, GCPtr<AbruptClosure> = {});
 
     IteratorRecord const& underlying_iterator() const { return m_underlying_iterator; }
 
@@ -33,14 +33,14 @@ public:
     ThrowCompletionOr<Value> close_result(VM&, Completion);
 
 private:
-    IteratorHelper(Realm&, Object& prototype, NonnullGCPtr<IteratorRecord>, Closure, Optional<AbruptClosure>);
+    IteratorHelper(Realm&, Object& prototype, NonnullGCPtr<IteratorRecord>, NonnullGCPtr<Closure>, GCPtr<AbruptClosure>);
 
     virtual void visit_edges(Visitor&) override;
     virtual ThrowCompletionOr<Value> execute(VM&, JS::Completion const& completion) override;
 
     NonnullGCPtr<IteratorRecord> m_underlying_iterator; // [[UnderlyingIterator]]
-    Closure m_closure;
-    Optional<AbruptClosure> m_abrupt_closure;
+    NonnullGCPtr<Closure> m_closure;
+    GCPtr<AbruptClosure> m_abrupt_closure;
 
     size_t m_counter { 0 };
     bool m_done { false };

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -98,7 +98,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::map)
     auto iterated = TRY(get_iterator_direct(vm, object));
 
     // 5. Let closure be a new Abstract Closure with no parameters that captures iterated and mapper and performs the following steps when called:
-    IteratorHelper::Closure closure = [mapper = NonnullGCPtr { mapper.as_function() }](auto& vm, auto& iterator) -> ThrowCompletionOr<Value> {
+    auto closure = JS::create_heap_function(realm.heap(), [mapper = NonnullGCPtr { mapper.as_function() }](VM& vm, IteratorHelper& iterator) -> ThrowCompletionOr<Value> {
         auto const& iterated = iterator.underlying_iterator();
 
         // a. Let counter be 0.
@@ -128,7 +128,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::map)
         // vi. Let completion be Completion(Yield(mapped)).
         // vii. IfAbruptCloseIterator(completion, iterated).
         return iterator.result(mapped.release_value());
-    };
+    });
 
     // 6. Let result be CreateIteratorFromClosure(closure, "Iterator Helper", %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
     // 7. Set result.[[UnderlyingIterator]] to iterated.
@@ -157,7 +157,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::filter)
     auto iterated = TRY(get_iterator_direct(vm, object));
 
     // 5. Let closure be a new Abstract Closure with no parameters that captures iterated and predicate and performs the following steps when called:
-    IteratorHelper::Closure closure = [predicate = NonnullGCPtr { predicate.as_function() }](auto& vm, auto& iterator) -> ThrowCompletionOr<Value> {
+    auto closure = JS::create_heap_function(realm.heap(), [predicate = NonnullGCPtr { predicate.as_function() }](VM& vm, IteratorHelper& iterator) -> ThrowCompletionOr<Value> {
         auto const& iterated = iterator.underlying_iterator();
 
         // a. Let counter be 0.
@@ -192,7 +192,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::filter)
                 return iterator.result(value);
             }
         }
-    };
+    });
 
     // 6. Let result be CreateIteratorFromClosure(closure, "Iterator Helper", %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
     // 7. Set result.[[UnderlyingIterator]] to iterated.
@@ -231,7 +231,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::take)
     auto iterated = TRY(get_iterator_direct(vm, object));
 
     // 8. Let closure be a new Abstract Closure with no parameters that captures iterated and integerLimit and performs the following steps when called:
-    IteratorHelper::Closure closure = [integer_limit](auto& vm, auto& iterator) -> ThrowCompletionOr<Value> {
+    auto closure = JS::create_heap_function(realm.heap(), [integer_limit](VM& vm, IteratorHelper& iterator) -> ThrowCompletionOr<Value> {
         auto const& iterated = iterator.underlying_iterator();
 
         // a. Let remaining be integerLimit.
@@ -257,7 +257,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::take)
         // v. Let completion be Completion(Yield(? IteratorValue(next))).
         // vi. IfAbruptCloseIterator(completion, iterated).
         return iterator.result(TRY(iterator_value(vm, *next)));
-    };
+    });
 
     // 9. Let result be CreateIteratorFromClosure(closure, "Iterator Helper", %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
     // 10. Set result.[[UnderlyingIterator]] to iterated.
@@ -296,7 +296,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::drop)
     auto iterated = TRY(get_iterator_direct(vm, object));
 
     // 8. Let closure be a new Abstract Closure with no parameters that captures iterated and integerLimit and performs the following steps when called:
-    IteratorHelper::Closure closure = [integer_limit](auto& vm, auto& iterator) -> ThrowCompletionOr<Value> {
+    auto closure = JS::create_heap_function(realm.heap(), [integer_limit](VM& vm, IteratorHelper& iterator) -> ThrowCompletionOr<Value> {
         auto const& iterated = iterator.underlying_iterator();
 
         // a. Let remaining be integerLimit.
@@ -326,7 +326,7 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::drop)
         // iii. Let completion be Completion(Yield(? IteratorValue(next))).
         // iv. IfAbruptCloseIterator(completion, iterated).
         return iterator.result(TRY(iterator_value(vm, *next)));
-    };
+    });
 
     // 9. Let result be CreateIteratorFromClosure(closure, "Iterator Helper", %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
     // 10. Set result.[[UnderlyingIterator]] to iterated.
@@ -471,14 +471,14 @@ JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::flat_map)
     auto flat_map_iterator = vm.heap().allocate<FlatMapIterator>(realm);
 
     // 5. Let closure be a new Abstract Closure with no parameters that captures iterated and mapper and performs the following steps when called:
-    IteratorHelper::Closure closure = [flat_map_iterator, mapper = NonnullGCPtr { mapper.as_function() }](auto& vm, auto& iterator) mutable -> ThrowCompletionOr<Value> {
+    auto closure = JS::create_heap_function(realm.heap(), [flat_map_iterator, mapper = NonnullGCPtr { mapper.as_function() }](VM& vm, IteratorHelper& iterator) mutable -> ThrowCompletionOr<Value> {
         auto const& iterated = iterator.underlying_iterator();
         return flat_map_iterator->next(vm, iterated, iterator, *mapper);
-    };
+    });
 
-    IteratorHelper::AbruptClosure abrupt_closure = [flat_map_iterator](auto& vm, auto& iterator, auto const& completion) -> ThrowCompletionOr<Value> {
+    auto abrupt_closure = JS::create_heap_function(realm.heap(), [flat_map_iterator](VM& vm, IteratorHelper& iterator, Completion const& completion) -> ThrowCompletionOr<Value> {
         return flat_map_iterator->on_abrupt_completion(vm, iterator, completion);
-    };
+    });
 
     // 6. Let result be CreateIteratorFromClosure(closure, "Iterator Helper", %IteratorHelperPrototype%, « [[UnderlyingIterator]] »).
     // 7. Set result.[[UnderlyingIterator]] to iterated.

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -61,11 +61,11 @@ void HTMLIFrameElement::inserted()
     // When an iframe element element is inserted into a document whose browsing context is non-null, the user agent must run these steps:
     if (in_a_document_tree() && document().browsing_context()) {
         // 1. Create a new child navigable for element.
-        MUST(create_new_child_navigable([this] {
+        MUST(create_new_child_navigable(JS::create_heap_function(realm().heap(), [this] {
             // 3. Process the iframe attributes for element, with initialInsertion set to true.
             process_the_iframe_attributes(true);
             set_content_navigable_initialized();
-        }));
+        })));
 
         // FIXME: 2. If element has a sandbox attribute, then parse the sandboxing directive given the attribute's value and element's iframe sandboxing flag set.
     }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1032,7 +1032,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
     Navigable::NavigationParamsVariant navigation_params,
     CSPNavigationType csp_navigation_type,
     bool allow_POST,
-    JS::SafeFunction<void()> completion_steps)
+    JS::GCPtr<JS::HeapFunction<void()>> completion_steps)
 {
     // FIXME: 1. Assert: this is running in parallel.
 
@@ -1086,14 +1086,15 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
         return {};
 
     // 6. Queue a global task on the navigation and traversal task source, given navigable's active window, to run these steps:
-    queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), JS::create_heap_function(heap(), [this, entry, navigation_params = move(navigation_params), navigation_id, completion_steps = move(completion_steps)]() mutable {
+    queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), JS::create_heap_function(heap(), [this, entry, navigation_params = move(navigation_params), navigation_id, completion_steps]() mutable {
         // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
         if (has_been_destroyed())
             return;
 
         // 1. If navigable's ongoing navigation no longer equals navigationId, then run completionSteps and return.
         if (navigation_id.has_value() && (!ongoing_navigation().has<String>() || ongoing_navigation().get<String>() != *navigation_id)) {
-            completion_steps();
+            if (completion_steps)
+                completion_steps->function()();
             return;
         }
 
@@ -1109,7 +1110,8 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
             if (entry->document()) {
                 entry->document_state()->set_ever_populated(true);
             }
-            completion_steps();
+            if (completion_steps)
+                completion_steps->function()();
             return;
         }
 
@@ -1153,7 +1155,8 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
         // FIXME: 9. Otherwise, if navigationParams's response's status is 204 or 205, then:
         else if (navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->response->status() == 204 || navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->response->status() == 205) {
             // 1. Run completionSteps.
-            completion_steps();
+            if (completion_steps)
+                completion_steps->function()();
 
             // 2. Return.
             return;
@@ -1168,7 +1171,8 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
 
             // 2. If document is null, then run completionSteps and return.
             if (!document) {
-                completion_steps();
+                if (completion_steps)
+                    completion_steps->function()();
                 return;
             }
 
@@ -1189,7 +1193,8 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
         }
 
         // 14. Run completionSteps.
-        completion_steps();
+        if (completion_steps)
+            completion_steps->function()();
     }));
 
     return {};
@@ -1428,7 +1433,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         //     for historyEntry, given navigable, "navigate", sourceSnapshotParams,
         //     targetSnapshotParams, navigationId, navigationParams, cspNavigationType, with allowPOST
         //     set to true and completionSteps set to the following step:
-        populate_session_history_entry_document(history_entry, source_snapshot_params, target_snapshot_params, navigation_id, navigation_params, csp_navigation_type, true, [this, history_entry, history_handling, navigation_id] {
+        populate_session_history_entry_document(history_entry, source_snapshot_params, target_snapshot_params, navigation_id, navigation_params, csp_navigation_type, true, JS::create_heap_function(heap(), [this, history_entry, history_handling, navigation_id] {
             // 1.     Append session history traversal steps to navigable's traversable to finalize a cross-document navigation given navigable, historyHandling, and historyEntry.
             traversable_navigable()->append_session_history_traversal_steps([this, history_entry, history_handling, navigation_id] {
                 if (this->has_been_destroyed()) {
@@ -1443,7 +1448,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
                 }
                 finalize_a_cross_document_navigation(*this, to_history_handling_behavior(history_handling), history_entry);
             });
-        }).release_value_but_fixme_should_propagate_errors();
+        })).release_value_but_fixme_should_propagate_errors();
     });
 
     return {};

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1435,7 +1435,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         //     set to true and completionSteps set to the following step:
         populate_session_history_entry_document(history_entry, source_snapshot_params, target_snapshot_params, navigation_id, navigation_params, csp_navigation_type, true, JS::create_heap_function(heap(), [this, history_entry, history_handling, navigation_id] {
             // 1.     Append session history traversal steps to navigable's traversable to finalize a cross-document navigation given navigable, historyHandling, and historyEntry.
-            traversable_navigable()->append_session_history_traversal_steps([this, history_entry, history_handling, navigation_id] {
+            traversable_navigable()->append_session_history_traversal_steps(JS::create_heap_function(heap(), [this, history_entry, history_handling, navigation_id] {
                 if (this->has_been_destroyed()) {
                     // NOTE: This check is not in the spec but we should not continue navigation if navigable has been destroyed.
                     set_delaying_load_events(false);
@@ -1447,7 +1447,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
                     return;
                 }
                 finalize_a_cross_document_navigation(*this, to_history_handling_behavior(history_handling), history_entry);
-            });
+            }));
         })).release_value_but_fixme_should_propagate_errors();
     });
 
@@ -1529,14 +1529,14 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(URL::URL const& url,
     auto traversable = traversable_navigable();
 
     // 17. Append the following session history synchronous navigation steps involving navigable to traversable:
-    traversable->append_session_history_synchronous_navigation_steps(*this, [this, traversable, history_entry, entry_to_replace, navigation_id, history_handling] {
+    traversable->append_session_history_synchronous_navigation_steps(*this, JS::create_heap_function(heap(), [this, traversable, history_entry, entry_to_replace, navigation_id, history_handling] {
         // 1. Finalize a same-document navigation given traversable, navigable, historyEntry, and entryToReplace.
         finalize_a_same_document_navigation(*traversable, *this, history_entry, entry_to_replace, history_handling);
 
         // FIXME: 2. Invoke WebDriver BiDi fragment navigated with navigable's active browsing context and a new WebDriver BiDi
         //            navigation status whose id is navigationId, url is url, and status is "complete".
         (void)navigation_id;
-    });
+    }));
 
     return {};
 }
@@ -1710,9 +1710,9 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(URL::URL const
     history_entry->set_document_state(document_state);
 
     // 13. Append session history traversal steps to targetNavigable's traversable to finalize a cross-document navigation with targetNavigable, historyHandling, and historyEntry.
-    traversable_navigable()->append_session_history_traversal_steps([this, history_entry, history_handling, navigation_id] {
+    traversable_navigable()->append_session_history_traversal_steps(JS::create_heap_function(heap(), [this, history_entry, history_handling, navigation_id] {
         finalize_a_cross_document_navigation(*this, history_handling, history_entry);
-    });
+    }));
 
     return {};
 }
@@ -1727,10 +1727,10 @@ void Navigable::reload()
     auto traversable = traversable_navigable();
 
     // 3. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps([traversable] {
+    traversable->append_session_history_traversal_steps(JS::create_heap_function(heap(), [traversable] {
         // 1. Apply the reload history step to traversable.
         traversable->apply_the_reload_history_step();
-    });
+    }));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#the-navigation-must-be-a-replace
@@ -1942,10 +1942,10 @@ void perform_url_and_history_update_steps(DOM::Document& document, URL::URL new_
     auto traversable = navigable->traversable_navigable();
 
     // 13. Append the following session history synchronous navigation steps involving navigable to traversable:
-    traversable->append_session_history_synchronous_navigation_steps(*navigable, [traversable, navigable, new_entry, entry_to_replace, history_handling] {
+    traversable->append_session_history_synchronous_navigation_steps(*navigable, JS::create_heap_function(document.realm().heap(), [traversable, navigable, new_entry, entry_to_replace, history_handling] {
         // 1. Finalize a same-document navigation given traversable, navigable, newEntry, and entryToReplace.
         finalize_a_same_document_navigation(*traversable, *navigable, new_entry, entry_to_replace, history_handling);
-    });
+    }));
 }
 
 void Navigable::scroll_offset_did_change()

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -129,7 +129,7 @@ public:
         NavigationParamsVariant navigation_params = Empty {},
         CSPNavigationType csp_navigation_type = CSPNavigationType::Other,
         bool allow_POST = false,
-        JS::SafeFunction<void()> completion_steps = [] {});
+        JS::GCPtr<JS::HeapFunction<void()>> completion_steps = {});
 
     struct NavigateParams {
         URL::URL const& url;

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -59,7 +59,7 @@ JS::GCPtr<NavigableContainer> NavigableContainer::navigable_container_with_conte
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#create-a-new-child-navigable
-WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::Handle<JS::HeapFunction<void()>> after_session_history_update)
+WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::GCPtr<JS::HeapFunction<void()>> after_session_history_update)
 {
     // 1. Let parentNavigable be element's node navigable.
     auto parent_navigable = navigable();
@@ -110,7 +110,7 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::Han
     auto traversable = parent_navigable->traversable_navigable();
 
     // 12. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps([traversable, navigable, parent_navigable, history_entry, after_session_history_update = move(after_session_history_update)] {
+    traversable->append_session_history_traversal_steps(JS::create_heap_function(heap(), [traversable, navigable, parent_navigable, history_entry, after_session_history_update] {
         // 1. Let parentDocState be parentNavigable's active session history entry's document state.
         auto parent_doc_state = parent_navigable->active_session_history_entry()->document_state();
 
@@ -140,7 +140,7 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::Han
         if (after_session_history_update) {
             after_session_history_update->function()();
         }
-    });
+    }));
 
     return {};
 }
@@ -294,10 +294,10 @@ void NavigableContainer::destroy_the_child_navigable()
         auto traversable = this->navigable()->traversable_navigable();
 
         // 9. Append the following session history traversal steps to traversable:
-        traversable->append_session_history_traversal_steps([traversable] {
+        traversable->append_session_history_traversal_steps(JS::create_heap_function(heap(), [traversable] {
             // 1. Update for navigable creation/destruction given traversable.
             traversable->update_for_navigable_creation_or_destruction();
-        });
+        }));
     }));
 }
 

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -59,7 +59,7 @@ JS::GCPtr<NavigableContainer> NavigableContainer::navigable_container_with_conte
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#create-a-new-child-navigable
-WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::SafeFunction<void()> afterSessionHistoryUpdate)
+WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::Handle<JS::HeapFunction<void()>> after_session_history_update)
 {
     // 1. Let parentNavigable be element's node navigable.
     auto parent_navigable = navigable();
@@ -110,7 +110,7 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::Saf
     auto traversable = parent_navigable->traversable_navigable();
 
     // 12. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps([traversable, navigable, parent_navigable, history_entry, afterSessionHistoryUpdate = move(afterSessionHistoryUpdate)] {
+    traversable->append_session_history_traversal_steps([traversable, navigable, parent_navigable, history_entry, after_session_history_update = move(after_session_history_update)] {
         // 1. Let parentDocState be parentNavigable's active session history entry's document state.
         auto parent_doc_state = parent_navigable->active_session_history_entry()->document_state();
 
@@ -137,8 +137,8 @@ WebIDL::ExceptionOr<void> NavigableContainer::create_new_child_navigable(JS::Saf
         // 7. Update for navigable creation/destruction given traversable
         traversable->update_for_navigable_creation_or_destruction();
 
-        if (afterSessionHistoryUpdate) {
-            afterSessionHistoryUpdate();
+        if (after_session_history_update) {
+            after_session_history_update->function()();
         }
     });
 

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.h
@@ -64,7 +64,7 @@ protected:
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame
     void navigate_an_iframe_or_frame(URL::URL url, ReferrerPolicy::ReferrerPolicy referrer_policy, Optional<String> srcdoc_string = {});
 
-    WebIDL::ExceptionOr<void> create_new_child_navigable(JS::SafeFunction<void()> afterSessionHistoryUpdate = {});
+    WebIDL::ExceptionOr<void> create_new_child_navigable(JS::Handle<JS::HeapFunction<void()>> after_session_history_update = {});
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#content-navigable
     JS::GCPtr<Navigable> m_content_navigable { nullptr };

--- a/Userland/Libraries/LibWeb/HTML/NavigableContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigableContainer.h
@@ -64,7 +64,7 @@ protected:
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#navigate-an-iframe-or-frame
     void navigate_an_iframe_or_frame(URL::URL url, ReferrerPolicy::ReferrerPolicy referrer_policy, Optional<String> srcdoc_string = {});
 
-    WebIDL::ExceptionOr<void> create_new_child_navigable(JS::Handle<JS::HeapFunction<void()>> after_session_history_update = {});
+    WebIDL::ExceptionOr<void> create_new_child_navigable(JS::GCPtr<JS::HeapFunction<void()>> after_session_history_update = {});
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#content-navigable
     JS::GCPtr<Navigable> m_content_navigable { nullptr };

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -665,7 +665,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
     auto source_snapshot_params = document.snapshot_source_snapshot_params();
 
     // 12. Append the following session history traversal steps to traversable:
-    traversable->append_session_history_traversal_steps([key, api_method_tracker, navigable, source_snapshot_params, traversable, this] {
+    traversable->append_session_history_traversal_steps(JS::create_heap_function(heap(), [key, api_method_tracker, navigable, source_snapshot_params, traversable, this] {
         // 1. Let navigableSHEs be the result of getting session history entries given navigable.
         auto navigable_shes = navigable->get_session_history_entries();
 
@@ -727,7 +727,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
                 reject_the_finished_promise(api_method_tracker, WebIDL::SecurityError::create(realm, "Navigation disallowed from this origin"_fly_string));
             }));
         }
-    });
+    }));
 
     // 13. Return a navigation API method tracker-derived result for apiMethodTracker.
     return navigation_api_method_tracker_derived_result(api_method_tracker);

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.cpp
@@ -12,9 +12,9 @@ namespace Web::HTML {
 JS_DEFINE_ALLOCATOR(SessionHistoryTraversalQueue);
 JS_DEFINE_ALLOCATOR(SessionHistoryTraversalQueueEntry);
 
-JS::NonnullGCPtr<SessionHistoryTraversalQueueEntry> SessionHistoryTraversalQueueEntry::create(JS::VM& vm, Function<void()> steps, JS::GCPtr<HTML::Navigable> target_navigable)
+JS::NonnullGCPtr<SessionHistoryTraversalQueueEntry> SessionHistoryTraversalQueueEntry::create(JS::VM& vm, JS::NonnullGCPtr<JS::HeapFunction<void()>> steps, JS::GCPtr<HTML::Navigable> target_navigable)
 {
-    return vm.heap().allocate_without_realm<SessionHistoryTraversalQueueEntry>(JS::create_heap_function(vm.heap(), move(steps)), target_navigable);
+    return vm.heap().allocate_without_realm<SessionHistoryTraversalQueueEntry>(steps, target_navigable);
 }
 
 void SessionHistoryTraversalQueueEntry::visit_edges(JS::Cell::Visitor& visitor)
@@ -46,17 +46,17 @@ void SessionHistoryTraversalQueue::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_queue);
 }
 
-void SessionHistoryTraversalQueue::append(Function<void()> steps)
+void SessionHistoryTraversalQueue::append(JS::NonnullGCPtr<JS::HeapFunction<void()>> steps)
 {
-    m_queue.append(SessionHistoryTraversalQueueEntry::create(vm(), move(steps), nullptr));
+    m_queue.append(SessionHistoryTraversalQueueEntry::create(vm(), steps, nullptr));
     if (!m_timer->is_active()) {
         m_timer->start();
     }
 }
 
-void SessionHistoryTraversalQueue::append_sync(Function<void()> steps, JS::GCPtr<Navigable> target_navigable)
+void SessionHistoryTraversalQueue::append_sync(JS::NonnullGCPtr<JS::HeapFunction<void()>> steps, JS::GCPtr<Navigable> target_navigable)
 {
-    m_queue.append(SessionHistoryTraversalQueueEntry::create(vm(), move(steps), target_navigable));
+    m_queue.append(SessionHistoryTraversalQueueEntry::create(vm(), steps, target_navigable));
     if (!m_timer->is_active()) {
         m_timer->start();
     }

--- a/Userland/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
+++ b/Userland/Libraries/LibWeb/HTML/SessionHistoryTraversalQueue.h
@@ -23,7 +23,7 @@ struct SessionHistoryTraversalQueueEntry : public JS::Cell {
     JS_DECLARE_ALLOCATOR(SessionHistoryTraversalQueueEntry);
 
 public:
-    static JS::NonnullGCPtr<SessionHistoryTraversalQueueEntry> create(JS::VM& vm, Function<void()> steps, JS::GCPtr<HTML::Navigable> target_navigable);
+    static JS::NonnullGCPtr<SessionHistoryTraversalQueueEntry> create(JS::VM& vm, JS::NonnullGCPtr<JS::HeapFunction<void()>> steps, JS::GCPtr<HTML::Navigable> target_navigable);
 
     JS::GCPtr<HTML::Navigable> target_navigable() const { return m_target_navigable; }
     void execute_steps() const { m_steps->function()(); }
@@ -49,8 +49,8 @@ class SessionHistoryTraversalQueue : public JS::Cell {
 public:
     SessionHistoryTraversalQueue();
 
-    void append(Function<void()> steps);
-    void append_sync(Function<void()> steps, JS::GCPtr<Navigable> target_navigable);
+    void append(JS::NonnullGCPtr<JS::HeapFunction<void()>> steps);
+    void append_sync(JS::NonnullGCPtr<JS::HeapFunction<void()>> steps, JS::GCPtr<Navigable> target_navigable);
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#sync-navigations-jump-queue
     JS::GCPtr<SessionHistoryTraversalQueueEntry> first_synchronous_navigation_steps_with_target_navigable_not_contained_in(HashTable<JS::NonnullGCPtr<Navigable>> const&);

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -619,11 +619,11 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
                 //    targetSnapshotParams, with allowPOST set to allowPOST and completionSteps set to queue a global task on the navigation and traversal task source given
                 //    navigable's active window to run afterDocumentPopulated.
                 Platform::EventLoopPlugin::the().deferred_invoke([populated_target_entry, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated = JS::create_heap_function(this->heap(), move(after_document_populated))] {
-                    navigable->populate_session_history_entry_document(populated_target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, {}, Empty {}, CSPNavigationType::Other, allow_POST, [this, after_document_populated, populated_target_entry]() mutable {
+                    navigable->populate_session_history_entry_document(populated_target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, {}, Empty {}, CSPNavigationType::Other, allow_POST, JS::create_heap_function(this->heap(), [this, after_document_populated, populated_target_entry]() mutable {
                                  queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), JS::create_heap_function(this->heap(), [after_document_populated, populated_target_entry]() mutable {
                                      after_document_populated->function()(true, populated_target_entry);
                                  }));
-                             })
+                             }))
                         .release_value_but_fixme_should_propagate_errors();
                 });
             }

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -971,7 +971,7 @@ void TraversableNavigable::traverse_the_history_by_delta(int delta, Optional<DOM
     }
 
     // 4. Append the following session history traversal steps to traversable:
-    append_session_history_traversal_steps([this, delta, source_snapshot_params = move(source_snapshot_params), initiator_to_check, user_involvement] {
+    append_session_history_traversal_steps(JS::create_heap_function(heap(), [this, delta, source_snapshot_params = move(source_snapshot_params), initiator_to_check, user_involvement] {
         // 1. Let allSteps be the result of getting all used history steps for traversable.
         auto all_steps = get_all_used_history_steps();
 
@@ -989,7 +989,7 @@ void TraversableNavigable::traverse_the_history_by_delta(int delta, Optional<DOM
         // 5. Apply the traverse history step allSteps[targetStepIndex] to traversable, given sourceSnapshotParams,
         //    initiatorToCheck, and userInvolvement.
         apply_the_traverse_history_step(all_steps[target_step_index], source_snapshot_params, initiator_to_check, user_involvement);
-    });
+    }));
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#update-for-navigable-creation/destruction

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -80,14 +80,14 @@ public:
     void close_top_level_traversable();
     void destroy_top_level_traversable();
 
-    void append_session_history_traversal_steps(ESCAPING Function<void()> steps)
+    void append_session_history_traversal_steps(JS::NonnullGCPtr<JS::HeapFunction<void()>> steps)
     {
-        m_session_history_traversal_queue->append(move(steps));
+        m_session_history_traversal_queue->append(steps);
     }
 
-    void append_session_history_synchronous_navigation_steps(JS::NonnullGCPtr<Navigable> target_navigable, ESCAPING Function<void()> steps)
+    void append_session_history_synchronous_navigation_steps(JS::NonnullGCPtr<Navigable> target_navigable, JS::NonnullGCPtr<JS::HeapFunction<void()>> steps)
     {
-        m_session_history_traversal_queue->append_sync(move(steps), target_navigable);
+        m_session_history_traversal_queue->append_sync(steps, target_navigable);
     }
 
     String window_handle() const { return m_window_handle; }

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -307,29 +307,29 @@ JS::NonnullGCPtr<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source
 
     // FIXME: Currently a naive implementation that uses ReadableStreamDefaultReader::read_all_chunks() to read all chunks
     //        from the source and then through the callback success_steps writes those chunks to the destination.
-    auto chunk_steps = [&realm, writer](ByteBuffer buffer) {
+    auto chunk_steps = JS::create_heap_function(realm.heap(), [&realm, writer](ByteBuffer buffer) {
         auto array_buffer = JS::ArrayBuffer::create(realm, move(buffer));
         auto chunk = JS::Uint8Array::create(realm, array_buffer->byte_length(), *array_buffer);
 
         auto promise = writable_stream_default_writer_write(writer, chunk);
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
-    };
+    });
 
-    auto success_steps = [promise, &realm, writer](ByteBuffer) {
+    auto success_steps = JS::create_heap_function(realm.heap(), [promise, &realm, writer](ByteBuffer) {
         // Make sure we close the acquired writer.
         WebIDL::resolve_promise(realm, writable_stream_default_writer_close(*writer), JS::js_undefined());
 
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
-    };
+    });
 
-    auto failure_steps = [promise, &realm, writer](JS::Value error) {
+    auto failure_steps = JS::create_heap_function(realm.heap(), [promise, &realm, writer](JS::Value error) {
         // Make sure we close the acquired writer.
         WebIDL::resolve_promise(realm, writable_stream_default_writer_close(*writer), JS::js_undefined());
 
         WebIDL::reject_promise(realm, promise, error);
-    };
+    });
 
-    reader->read_all_chunks(move(chunk_steps), move(success_steps), move(failure_steps));
+    reader->read_all_chunks(chunk_steps, success_steps, failure_steps);
 
     // 16. Return promise.
     return promise;

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -37,15 +37,15 @@ class ReadLoopReadRequest final : public ReadRequest {
 
 public:
     // successSteps, which is an algorithm accepting a byte sequence
-    using SuccessSteps = JS::SafeFunction<void(ByteBuffer)>;
+    using SuccessSteps = JS::HeapFunction<void(ByteBuffer)>;
 
     // failureSteps, which is an algorithm accepting a JavaScript value
-    using FailureSteps = JS::SafeFunction<void(JS::Value error)>;
+    using FailureSteps = JS::HeapFunction<void(JS::Value error)>;
 
     // AD-HOC: callback triggered on every chunk received from the stream.
-    using ChunkSteps = JS::SafeFunction<void(ByteBuffer)>;
+    using ChunkSteps = JS::HeapFunction<void(ByteBuffer)>;
 
-    ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, SuccessSteps success_steps, FailureSteps failure_steps, ChunkSteps chunk_steps = {});
+    ReadLoopReadRequest(JS::VM& vm, JS::Realm& realm, ReadableStreamDefaultReader& reader, JS::NonnullGCPtr<SuccessSteps> success_steps, JS::NonnullGCPtr<FailureSteps> failure_steps, JS::GCPtr<ChunkSteps> chunk_steps = {});
 
     virtual void on_chunk(JS::Value chunk) override;
 
@@ -60,9 +60,9 @@ private:
     JS::NonnullGCPtr<JS::Realm> m_realm;
     JS::NonnullGCPtr<ReadableStreamDefaultReader> m_reader;
     ByteBuffer m_bytes;
-    SuccessSteps m_success_steps;
-    FailureSteps m_failure_steps;
-    ChunkSteps m_chunk_steps;
+    JS::NonnullGCPtr<SuccessSteps> m_success_steps;
+    JS::NonnullGCPtr<FailureSteps> m_failure_steps;
+    JS::GCPtr<ChunkSteps> m_chunk_steps;
 };
 
 // https://streams.spec.whatwg.org/#readablestreamdefaultreader
@@ -80,8 +80,8 @@ public:
     JS::NonnullGCPtr<JS::Promise> read();
 
     void read_a_chunk(Fetch::Infrastructure::IncrementalReadLoopReadRequest& read_request);
-    void read_all_bytes(ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
-    void read_all_chunks(ReadLoopReadRequest::ChunkSteps, ReadLoopReadRequest::SuccessSteps, ReadLoopReadRequest::FailureSteps);
+    void read_all_bytes(JS::NonnullGCPtr<ReadLoopReadRequest::SuccessSteps>, JS::NonnullGCPtr<ReadLoopReadRequest::FailureSteps>);
+    void read_all_chunks(JS::NonnullGCPtr<ReadLoopReadRequest::ChunkSteps>, JS::NonnullGCPtr<ReadLoopReadRequest::SuccessSteps>, JS::NonnullGCPtr<ReadLoopReadRequest::FailureSteps>);
     JS::NonnullGCPtr<WebIDL::Promise> read_all_bytes_deprecated();
 
     void release_lock();


### PR DESCRIPTION
Further removing our usage of SafeFunction - the remaining use cases being left _mostly_ in ResourceLoader / EventLoop / Timers.