### PR TITLE
Meta: Check for CMake version in ladybird.sh

### DIFF
--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -88,6 +88,7 @@ get_top_dir() {
 }
 
 create_build_dir() {
+    check_program_version_at_least CMake cmake 3.25 || exit 1
     cmake --preset "$BUILD_PRESET" "${CMAKE_ARGS[@]}" -S "$LADYBIRD_SOURCE_DIR" -B "$BUILD_DIR"
 }
 

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -17,6 +17,24 @@ exit_if_running_as_root() {
     fi
 }
 
+# Usage: check_program_version_at_least <Display Name> <Program Name> <Version String>
+check_program_version_at_least()
+{
+    echo -n "Checking for $1 version at least $3... "
+    if ! command -v "$2" > /dev/null 2>&1; then
+        echo "ERROR: Cannot find $2 ($1)"
+        return 1
+    fi
+    v=$("$2" --version 2>&1 | grep -E -o '[0-9]+\.[0-9\.]+[a-z]*' | head -n1)
+    if printf '%s\n' "$3" "$v" | sort --version-sort --check &>/dev/null; then
+        echo "ok, found $v"
+        return 0;
+    else
+        echo "ERROR: found version $v, too old!"
+        return 1;
+    fi
+}
+
 find_executable() {
   paths=("/usr/sbin" "/sbin")
 


### PR DESCRIPTION
CMake reads CMakePresets.json, which is before it reads CMakeLists.txt. 
This causes CMake Error: Unrecognized "version" field #980. 
Fix is to check CMake version in ladybird.sh itself.