### PR TITLE
LibWeb: Match attribute selectors case insensitively in XML documents 

### DIFF
--- a/Tests/LibWeb/Text/expected/css/attribute-selector-case-sensitivity.txt
+++ b/Tests/LibWeb/Text/expected/css/attribute-selector-case-sensitivity.txt
@@ -1,0 +1,4 @@
+The accept attribute is matched case insensitively in HTML documents true
+The accept attribute is matched case insensitively in XML documents false
+The accesskey attribute is matched case insensitively in HTML documents false
+The accesskey attribute is matched case insensitively in XML documents false

--- a/Tests/LibWeb/Text/input/css/attribute-selector-case-sensitivity.html
+++ b/Tests/LibWeb/Text/input/css/attribute-selector-case-sensitivity.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const elementName = "a";
+        const attributeNames = ["accept", "accesskey"];
+        for (const attributeName of attributeNames) {
+            const htmlElement = document.createElement(elementName);
+            htmlElement.setAttribute(attributeName, "TeSt");
+            println(`The ${attributeName} attribute is matched case insensitively in HTML documents ${htmlElement.matches(`[${attributeName}^=test]`)}`);
+
+            const xmlDocument = new Document();
+            const xmlElement = xmlDocument.createElementNS("http://www.w3.org/1999/xhtml", elementName);
+            xmlElement.setAttribute(attributeName, "TeSt");
+            println(`The ${attributeName} attribute is matched case insensitively in XML documents ${xmlElement.matches(`[${attributeName}^=test]`)}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -77,56 +77,6 @@ public:
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();
 
-    // https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
-    static constexpr Array case_insensitive_html_attributes = {
-        "accept"sv,
-        "accept-charset"sv,
-        "align"sv,
-        "alink"sv,
-        "axis"sv,
-        "bgcolor"sv,
-        "charset"sv,
-        "checked"sv,
-        "clear"sv,
-        "codetype"sv,
-        "color"sv,
-        "compact"sv,
-        "declare"sv,
-        "defer"sv,
-        "dir"sv,
-        "direction"sv,
-        "disabled"sv,
-        "enctype"sv,
-        "face"sv,
-        "frame"sv,
-        "hreflang"sv,
-        "http-equiv"sv,
-        "lang"sv,
-        "language"sv,
-        "link"sv,
-        "media"sv,
-        "method"sv,
-        "multiple"sv,
-        "nohref"sv,
-        "noresize"sv,
-        "noshade"sv,
-        "nowrap"sv,
-        "readonly"sv,
-        "rel"sv,
-        "rev"sv,
-        "rules"sv,
-        "scope"sv,
-        "scrolling"sv,
-        "selected"sv,
-        "shape"sv,
-        "target"sv,
-        "text"sv,
-        "type"sv,
-        "valign"sv,
-        "valuetype"sv,
-        "vlink"sv,
-    };
-
 private:
     Parser(ParsingContext const&, Vector<Token>);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -260,15 +260,8 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_attribute_simple_se
         .type = Selector::SimpleSelector::Type::Attribute,
         .value = Selector::SimpleSelector::Attribute {
             .match_type = Selector::SimpleSelector::Attribute::MatchType::HasAttribute,
-            // FIXME: Case-sensitivity is defined by the document language.
-            // HTML is insensitive with attribute names, and our code generally assumes
-            // they are converted to lowercase, so we do that here too. If we want to be
-            // correct with XML later, we'll need to keep the original case and then do
-            // a case-insensitive compare later.
             .qualified_name = qualified_name,
-            .case_type = case_insensitive_html_attributes.contains_slow(qualified_name.name.lowercase_name)
-                ? Selector::SimpleSelector::Attribute::CaseType::CaseInsensitiveMatch
-                : Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
+            .case_type = Selector::SimpleSelector::Attribute::CaseType::DefaultMatch,
         }
     };
 

--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -227,6 +227,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(rowspan)                    \
     __ENUMERATE_HTML_ATTRIBUTE(rules)                      \
     __ENUMERATE_HTML_ATTRIBUTE(scheme)                     \
+    __ENUMERATE_HTML_ATTRIBUTE(scope)                      \
     __ENUMERATE_HTML_ATTRIBUTE(scrollamount)               \
     __ENUMERATE_HTML_ATTRIBUTE(scrolldelay)                \
     __ENUMERATE_HTML_ATTRIBUTE(scrolling)                  \


### PR DESCRIPTION
The values of attribute selectors are now compared case insensitively by default if the attribute's document is not a HTML document, or the element is not in the HTML namespace.

Fixes: https://wpt.live/html/semantics/selectors/case-sensitivity/values.window.html