### PR TITLE
LibWeb: Limit `HTMLProgressElement.max` to positive values

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
@@ -2,6 +2,7 @@ value attribute initial value: 0
 max attribute initial value: 1
 value attribute after setting value attribute to -1: 0
 max attribute after setting max attribute to -1: 1
+max attribute after setting max attribute to 0: 1
 value attribute after setting value attribute to 50: 1
 value attribute after setting max attribute to 100: 50
 max attribute after setting max attribute to 100: 100

--- a/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-set-attributes.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-set-attributes.html
@@ -9,6 +9,8 @@
         println(`value attribute after setting value attribute to -1: ${progressElement.value}`);
         progressElement.max = -1;
         println(`max attribute after setting max attribute to -1: ${progressElement.max}`);
+        progressElement.max = 0;
+        println(`max attribute after setting max attribute to 0: ${progressElement.max}`);
         progressElement.value = 50;
         println(`value attribute after setting value attribute to 50: ${progressElement.value}`);
         progressElement.max = 100;

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -64,7 +64,8 @@ double HTMLProgressElement::max() const
 {
     if (auto max_string = get_attribute(HTML::AttributeNames::max); max_string.has_value()) {
         if (auto max = parse_floating_point_number(*max_string); max.has_value())
-            return AK::max(*max, 0);
+            if (*max > 0)
+                return *max;
     }
     return 1;
 }


### PR DESCRIPTION
Previously, 0 was returned if `HTMLProgressElement.max` was set to a negative value.

Fixes:  http://wpt.live/html/semantics/forms/the-progress-element/progress.html