### PR TITLE
LibWeb: Change where content selection via mouse is allowed

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -70,6 +70,8 @@ public:
     virtual bool has_activation_behavior() const override;
     virtual void activation_behavior(DOM::Event const&) override;
 
+    virtual bool is_child_node_selectable(DOM::Node const&) const override { return false; }
+
 private:
     virtual bool is_html_button_element() const override { return true; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -80,6 +80,8 @@ public:
     WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
     Optional<String> popover() const;
 
+    virtual bool is_child_node_selectable(DOM::Node const&) const { return true; }
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2368,4 +2368,9 @@ HTMLInputElement::ValueAttributeMode HTMLInputElement::value_attribute_mode() co
     VERIFY_NOT_REACHED();
 }
 
+bool HTMLInputElement::is_child_node_selectable(DOM::Node const& node) const
+{
+    return !is_button() && (!m_placeholder_element || !m_placeholder_element->is_inclusive_ancestor_of(node));
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -204,6 +204,8 @@ public:
     WebIDL::ExceptionOr<void> set_selection_end_for_bindings(Optional<WebIDL::UnsignedLong> const&);
     Optional<WebIDL::UnsignedLong> selection_end_for_bindings() const;
 
+    virtual bool is_child_node_selectable(DOM::Node const&) const override;
+
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -430,7 +430,8 @@ bool EventHandler::handle_mousedown(CSSPixelPoint viewport_position, CSSPixelPoi
     if (button == UIEvents::MouseButton::Primary) {
         if (auto result = paint_root()->hit_test(position, Painting::HitTestType::TextCursor); result.has_value()) {
             auto paintable = result->paintable;
-            if (paintable->dom_node()) {
+            auto dom_node = paintable->dom_node();
+            if (dom_node) {
                 // See if we want to focus something.
                 bool did_focus_something = false;
                 for (auto candidate = node; candidate; candidate = candidate->parent_or_shadow_host()) {
@@ -450,15 +451,15 @@ bool EventHandler::handle_mousedown(CSSPixelPoint viewport_position, CSSPixelPoi
 
                 // If we didn't focus anything, place the document text cursor at the mouse position.
                 // FIXME: This is all rather strange. Find a better solution.
-                if (!did_focus_something || paintable->dom_node()->is_editable()) {
+                if (!did_focus_something || dom_node->is_editable()) {
                     auto& realm = document->realm();
-                    document->set_cursor_position(DOM::Position::create(realm, *paintable->dom_node(), result->index_in_node));
+                    document->set_cursor_position(DOM::Position::create(realm, *dom_node, result->index_in_node));
                     if (auto selection = document->get_selection()) {
                         auto anchor_node = selection->anchor_node();
                         if (anchor_node && modifiers & UIEvents::KeyModifier::Mod_Shift) {
-                            (void)selection->set_base_and_extent(*anchor_node, selection->anchor_offset(), *paintable->dom_node(), result->index_in_node);
+                            (void)selection->set_base_and_extent(*anchor_node, selection->anchor_offset(), *dom_node, result->index_in_node);
                         } else {
-                            (void)selection->set_base_and_extent(*paintable->dom_node(), result->index_in_node, *paintable->dom_node(), result->index_in_node);
+                            (void)selection->set_base_and_extent(*dom_node, result->index_in_node, *dom_node, result->index_in_node);
                         }
                     }
                     m_in_mouse_selection = true;

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -449,9 +449,19 @@ bool EventHandler::handle_mousedown(CSSPixelPoint viewport_position, CSSPixelPoi
                         HTML::run_unfocusing_steps(focused_element);
                 }
 
-                // If we didn't focus anything, place the document text cursor at the mouse position.
-                // FIXME: This is all rather strange. Find a better solution.
-                if (!did_focus_something || dom_node->is_editable()) {
+                // Ask the next non-shadow parent element whether the node at the mouse position is selectable.
+                auto& root_node = dom_node->root();
+                DOM::Element* non_shadow_parent_element;
+                if (root_node.is_shadow_root())
+                    non_shadow_parent_element = root_node.parent_or_shadow_host_element();
+                else
+                    non_shadow_parent_element = dom_node->parent_element();
+                bool is_selectable = true;
+                if (non_shadow_parent_element && non_shadow_parent_element->is_html_element())
+                    is_selectable = static_cast<HTML::HTMLElement*>(non_shadow_parent_element)->is_child_node_selectable(*dom_node);
+
+                // If it is selectable, place the document text cursor at the mouse position.
+                if (is_selectable) {
                     auto& realm = document->realm();
                     document->set_cursor_position(DOM::Position::create(realm, *dom_node, result->index_in_node));
                     if (auto selection = document->get_selection()) {


### PR DESCRIPTION
Previously, only DOM nodes with `is_editable()` allowed selection via the mouse. This had the unwanted consequence, that read-only input/textarea elements did not allow selection.

Now, `EventHandler::handle_mousedown()` asks the node's non-shadow parent element over the new virtual method `is_child_node_selectable()`, if selection of the node is allowed.
This method is overridden for `HTMLButtonElement` and `HTMLInputElement`, to disallow selection of buttons and placeholders.

Fixes #579

Superseeds https://github.com/LadybirdBrowser/ladybird/pull/604