### PR TITLE
LibWebView: Add Kagi as a search engine to the list of selectable search engines

### DIFF
--- a/Userland/Libraries/LibWebView/SearchEngine.cpp
+++ b/Userland/Libraries/LibWebView/SearchEngine.cpp
@@ -17,6 +17,7 @@ static constexpr auto builtin_search_engines = Array {
     SearchEngine { "Ecosia"sv, "https://ecosia.org/search?q={}"sv },
     SearchEngine { "GitHub"sv, "https://github.com/search?q={}"sv },
     SearchEngine { "Google"sv, "https://www.google.com/search?q={}"sv },
+    SearchEngine { "Kagi"sv, "https://kagi.com/search?q={}"sv },
     SearchEngine { "Mojeek"sv, "https://www.mojeek.com/search?q={}"sv },
     SearchEngine { "Wikipedia"sv, "https://en.wikipedia.org/w/index.php?title=Special:Search&search={}"sv },
     SearchEngine { "Yahoo"sv, "https://search.yahoo.com/search?p={}"sv },


### PR DESCRIPTION
This pull request adds the Kagi search engine as a selectable option on the Settings > Search Engine menu.