### PR TITLE
Ladybird/AppKit: Use sRGB color space when blitting web content

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1523,6 +1523,8 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     auto* provider = CGDataProviderCreateWithData(nil, bitmap.scanline_u8(0), bitmap.size_in_bytes(), nil);
     auto image_rect = CGRectMake(rect.origin.x * device_pixel_ratio, rect.origin.y * device_pixel_ratio, bitmap_size.width(), bitmap_size.height());
 
+    static auto color_space = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
+
     // Ideally, this would be NSBitmapImageRep, but the equivalent factory initWithBitmapDataPlanes: does
     // not seem to actually respect endianness. We need NSBitmapFormatThirtyTwoBitLittleEndian, but the
     // resulting image is always big endian. CGImageCreate actually does respect the endianness.
@@ -1532,7 +1534,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         BITS_PER_COMPONENT,
         BITS_PER_PIXEL,
         bitmap.pitch(),
-        CGColorSpaceCreateDeviceRGB(),
+        color_space,
         kCGBitmapByteOrder32Little | kCGImageAlphaFirst,
         provider,
         nil,


### PR DESCRIPTION
Before this change, we were passing CGColorSpaceCreateDeviceRGB() to CGImageCreate(), causing the system to assume that the image data is in a device-specific RGB space without any color profile adjustments.

If your monitor is more vibrant than the assumed profile (for example, a wide-gamut display), colors may appear over-saturated as there's no correction applied for how the display actually renders those colors.

We now pass CGColorSpaceCreateWithName(kCGColorSpaceSRGB) instead, which makes colors look the same in Ladybird as in other browsers. :^)