### PR TITLE
Documentation: Fixed spelling mistakes and formatting of .md files.

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -8,28 +8,29 @@ The `Meta/ladybird.sh` script provides an abstraction over the build targets whi
 following build targets cannot be accessed through the script and have to be used directly by changing the current
 directory to `Build/ladybird` and then running `ninja <target>`:
 
-- `ninja check-style`: Runs the same linters the CI does to verify project style on changed files
-- `ninja lint-shell-scripts`: Checks style of shell scripts in the source tree with shellcheck
-- `ninja all_generated`: Builds all generated code. Useful for running analysis tools that can use compile_commands.json without a full system build
+-   `ninja check-style`: Runs the same linters the CI does to verify project style on changed files
+-   `ninja lint-shell-scripts`: Checks style of shell scripts in the source tree with shellcheck
+-   `ninja all_generated`: Builds all generated code. Useful for running analysis tools that can use compile_commands.json without a full system build
 
 ## CMake build options
 
 There are some optional features that can be enabled during compilation that are intended to help with specific types of development work or introduce experimental features. Currently, the following build options are available:
-- `ENABLE_ADDRESS_SANITIZER`: builds in runtime checks for memory corruption bugs (like buffer overflows and memory leaks) in Lagom test cases.
-- `ENABLE_MEMORY_SANITIZER`: enables runtime checks for uninitialized memory accesses in Lagom test cases.
-- `ENABLE_UNDEFINED_SANITIZER`: builds in runtime checks for [undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) (like null pointer dereferences and signed integer overflows) in Lagom and the SerenityOS userland.
-- `UNDEFINED_BEHAVIOR_IS_FATAL`: makes all undefined behavior sanitizer errors non-recoverable. This option reduces the performance overhead of `ENABLE_UNDEFINED_SANITIZER`.
-- `ENABLE_COMPILER_EXPLORER_BUILD`: Skip building non-library entities in Lagom (this only applies to Lagom).
-- `ENABLE_FUZZERS`: builds [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
-- `ENABLE_FUZZERS_LIBFUZZER`: builds Clang libFuzzer-based [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
-- `ENABLE_FUZZERS_OSSFUZZ`: builds OSS-Fuzz compatible [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
-- `ENABLE_ALL_THE_DEBUG_MACROS`: used for checking whether debug code compiles on CI. This should not be set normally, as it clutters the console output and makes the system run very slowly. Instead, enable only the needed debug macros, as described below.
-- `ENABLE_COMPILETIME_FORMAT_CHECK`: checks for the validity of `std::format`-style format string during compilation. Enabled by default.
-- `LAGOM_TOOLS_ONLY`: Skips building libraries, utiltis and tests for [Lagom](../Meta/Lagom/ReadMe.md). Mostly only useful for cross-compilation.
-- `INCLUDE_WASM_SPEC_TESTS`: downloads and includes the WebAssembly spec testsuite tests. In order to use this option, you will need to install `prettier` and `wabt`. wabt version 1.0.35 or higher is required to pre-process the WebAssembly spec testsuite.
-- `INCLUDE_FLAC_SPEC_TESTS`: downloads and includes the xiph.org FLAC test suite.
-- `SERENITY_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set manually unless managing a distribution package.
-- `ENABLE_NETWORK_DOWNLOADS`: allows downloading files from the internet during the build. Default on, turning off enables offline builds. For offline builds, the structure of the SERENITY_CACHE_DIR must be set up the way that the build expects.
+
+-   `ENABLE_ADDRESS_SANITIZER`: builds in runtime checks for memory corruption bugs (like buffer overflows and memory leaks) in Lagom test cases.
+-   `ENABLE_MEMORY_SANITIZER`: enables runtime checks for uninitialized memory accesses in Lagom test cases.
+-   `ENABLE_UNDEFINED_SANITIZER`: builds in runtime checks for [undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) (like null pointer dereferences and signed integer overflows) in Lagom and the SerenityOS userland.
+-   `UNDEFINED_BEHAVIOR_IS_FATAL`: makes all undefined behavior sanitizer errors non-recoverable. This option reduces the performance overhead of `ENABLE_UNDEFINED_SANITIZER`.
+-   `ENABLE_COMPILER_EXPLORER_BUILD`: Skip building non-library entities in Lagom (this only applies to Lagom).
+-   `ENABLE_FUZZERS`: builds [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
+-   `ENABLE_FUZZERS_LIBFUZZER`: builds Clang libFuzzer-based [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
+-   `ENABLE_FUZZERS_OSSFUZZ`: builds OSS-Fuzz compatible [fuzzers](../Meta/Lagom/ReadMe.md#fuzzing) for various parts of the system.
+-   `ENABLE_ALL_THE_DEBUG_MACROS`: used for checking whether debug code compiles on CI. This should not be set normally, as it clutters the console output and makes the system run very slowly. Instead, enable only the needed debug macros, as described below.
+-   `ENABLE_COMPILETIME_FORMAT_CHECK`: checks for the validity of `std::format`-style format string during compilation. Enabled by default.
+-   `LAGOM_TOOLS_ONLY`: Skips building libraries, utiltis and tests for [Lagom](../Meta/Lagom/ReadMe.md). Mostly only useful for cross-compilation.
+-   `INCLUDE_WASM_SPEC_TESTS`: downloads and includes the WebAssembly spec testsuite tests. In order to use this option, you will need to install `prettier` and `wabt`. wabt version 1.0.35 or higher is required to pre-process the WebAssembly spec testsuite.
+-   `INCLUDE_FLAC_SPEC_TESTS`: downloads and includes the xiph.org FLAC test suite.
+-   `SERENITY_CACHE_DIR`: sets the location of a shared cache of downloaded files. Should not need to be set manually unless managing a distribution package.
+-   `ENABLE_NETWORK_DOWNLOADS`: allows downloading files from the internet during the build. Default on, turning off enables offline builds. For offline builds, the structure of the SERENITY_CACHE_DIR must be set up the way that the build expects.
 
 Many parts of the codebase have debug functionality, mostly consisting of additional messages printed to the debug console. This is done via the `<component_name>_DEBUG` macros, which can be enabled individually at build time. They are listed in [this file](../Meta/CMake/all_the_debug_macros.cmake).
 
@@ -40,9 +41,10 @@ To toggle or change a build option, see the [CMake Cache Manipulation](#cmake-ca
 CMake caches variables and options in the binary directory. This allows a developer to tailor variables that are `set()` within the persistent configuration cache.
 
 There are three main ways to manipulate the cache:
-- `cmake path/to/binary/dir -DVAR_NAME=Value`
-- `ccmake` (TUI interface)
-- `cmake-gui`
+
+-   `cmake path/to/binary/dir -DVAR_NAME=Value`
+-   `ccmake` (TUI interface)
+-   `cmake-gui`
 
 Options can be set via the initial `cmake` invocation that creates the binary directory to set the initial cache for the binary directory.
 Once the binary directory exists, any of the three options above can be used to change the value of cache variables.
@@ -65,8 +67,8 @@ For information on running host and target tests, see [Running Tests](RunningTes
 
 Some OS distributions don't ship bleeding-edge clang-format binaries. Below are 2 options to acquire an updated clang-format tool, in order of preference:
 
-1) If you have a Debian-based (apt-based) distribution, use the [LLVM apt repositories](https://apt.llvm.org) to install the latest release of clang-format.
-2) Compile LLVM from source as described in the LLVM documentation [here](https://llvm.org/docs/GettingStarted.html#compiling-the-llvm-suite-source-code).
+1. If you have a Debian-based (apt-based) distribution, use the [LLVM apt repositories](https://apt.llvm.org) to install the latest release of clang-format.
+2. Compile LLVM from source as described in the LLVM documentation [here](https://llvm.org/docs/GettingStarted.html#compiling-the-llvm-suite-source-code).
 
 ## Clangd Configuration
 
@@ -76,7 +78,7 @@ edited. The Ladybird source code repository has a top-level `.clangd`
 configuration file in the root directory. One of the configuration
 stanzas in that file specifies the location for a compilation database.
 Depending on your build configuration (e.g., Debug, default, Sanitizer,
-etc), the path to the compilation database in that file may not be
+etc.), the path to the compilation database in that file may not be
 correct. The result is that clangd will have a difficult time
 understanding all your include directories. To resolve the problem, you
 can use the `Meta/configure-clangd.sh` script.

--- a/Documentation/AndroidStudioConfiguration.md
+++ b/Documentation/AndroidStudioConfiguration.md
@@ -6,28 +6,28 @@ The Android port of Ladybird has straightforward integration with the Android St
 
 Ensure that your system has the following tools available:
 
-- Android Studio Jellyfish 2023.3.1 or later
-- CMake 3.23 or higher as the default CMake executable
-- 20G or more storage space for SDKs + Emulator images + Gradle dependencies + build artifacts
+-   Android Studio Jellyfish 2023.3.1 or later
+-   CMake 3.23 or higher as the default CMake executable
+-   20G or more storage space for SDKs + Emulator images + Gradle dependencies + build artifacts
 
 ## Opening the project
 
-After opening the ``ladybird`` directory in Android Studio (NOT the Ladybird/Android directory!)
+After opening the `ladybird` directory in Android Studio (NOT the Ladybird/Android directory!)
 there should be a pop-up in the bottom left indicating that an Android Gradle project was detected
-in ``Ladybird/Android``.
+in `Ladybird/Android`.
 
-In the top left of the screen in the Project view, navigate to ``Ladybird/Android``. Or, click the
-highlighted text in the notification for that path. Open the ``settings.gradle.kts`` file. At the
-top of the file should be a banner that says ``Code Insight unavailable (related Gradle project not
-linked).`` Click the ``Link Gradle project`` text on the right side of the banner. After the IDE
+In the top left of the screen in the Project view, navigate to `Ladybird/Android`. Or, click the
+highlighted text in the notification for that path. Open the `settings.gradle.kts` file. At the
+top of the file should be a banner that says `Code Insight unavailable (related Gradle project not
+linked).` Click the `Link Gradle project` text on the right side of the banner. After the IDE
 loads the Gradle view to the right of the code window, go back to the banner at the top of the
-``settings.gradle.kts`` file and click ``Load Script Configurations`` to finish loading the Gradle
+`settings.gradle.kts` file and click `Load Script Configurations` to finish loading the Gradle
 project.
 
 Gradle will index the project, and download all the required plugins. If it complains about no NDK,
 follow the instructions in Android Studio to install an appropriate NDK version. If it still
-complains about the NDK version, open ``File->Invalidate Caches...`` and click  ``Invalidate and
-Restart``.
+complains about the NDK version, open `File->Invalidate Caches...` and click `Invalidate and
+Restart`.
 
 ## Getting the most out of the IDE
 

--- a/Documentation/Browser/BrowsingContextsAndNavigables.md
+++ b/Documentation/Browser/BrowsingContextsAndNavigables.md
@@ -6,9 +6,9 @@
 
 Before we can dive into how LibWeb and Ladybird implement the HTML web page navigation operations,
 we need to dive into some fundamental specification concepts. Starting with, how does code actually
-execute in a  (possibly virtual) machine? Next we'll look at what that means for the ECMAScript
+execute in a (possibly virtual) machine? Next we'll look at what that means for the ECMAScript
 Specification (JavaScript), and finally how the ECMAScript code execution model ties into the
-HTML specification to model how to display web content into a browser tab. 
+HTML specification to model how to display web content into a browser tab.
 
 ### Native Code Execution: A Primer
 
@@ -34,10 +34,10 @@ symbol table contained within the object file format. Normally local variable an
 names and locations are lost in the compile+link steps, but the compiler can be configured to
 emit extra debug information to allow debuggers to access and modify them at runtime. In order
 to support something like the dynamic imports of interpreted languages, the programmer has to
-call a platform-specific function to load the new module (e.g. ``dlopen`` or ``LoadLibrary``).
+call a platform-specific function to load the new module (e.g. `dlopen` or `LoadLibrary`).
 But after the module is opened, in order to actually refer to any exported symbols from that module the
 programmer has to retrieve the address of each symbol through another platform specific function
-(e.g. ``dlsym`` or ``GetProcAddress``), once per symbol.
+(e.g. `dlsym` or `GetProcAddress`), once per symbol.
 
 ### ECMAScript Execution Model: Realms and Agents
 
@@ -47,17 +47,17 @@ The ECMAScript specification has analogs for almost all of these concepts in the
 Working in the other direction from the native code explanation, ECMAScript describes the accessibility
 and scopes of functions, variables, and arguments in terms of [*Environment Records*](https://tc39.es/ecma262/#sec-environment-records).
 Note that these Environment Records are not actually visible to executing code, and are simply a mechanism
-used by the specification authors to model the language.  Every function and module has a type
+used by the specification authors to model the language. Every function and module has a type
 of Environment Record that contains the variables, functions, catch clause bindings, and other
 language constructs that affect which names are visible at any location in the code. These Environment Records
 are nested, in a tree-like structure that somewhat matches the Abstract Syntax Tree (AST).
 
 The root of the tree of Environment Records is the Global Environment Record, which corresponds to the
-Global Object and its properties. In JavaScript, there is always a ``this`` value representing the current
+Global Object and its properties. In JavaScript, there is always a `this` value representing the current
 object context. At global scope, the Global Object normally takes that responsibility. In a REPL, that might
 be some REPL specific global object that has global functions to call for doing things like loading
-from the filesystem, or even be as complex as Node or Bun. In a Browser context, the Global object is
-normally the Window, unless there's a Worker involved. For historical reasons the global ``this`` binding for
+from the file system, or even be as complex as Node or Bun. In a Browser context, the Global object is
+normally the Window, unless there's a Worker involved. For historical reasons the global `this` binding for
 Window contexts is actually a WindowProxy that wraps the Window. This concept is quite different from a native
 executable, where there's no actual object representing the global scope, simply symbols that the
 linker and loader make available to each module.
@@ -94,7 +94,7 @@ However, the HTML specification opts to remove the default execution context fro
 at creation, and instead manually pushes and pops execution contexts for script, module, and callback execution.
 The relationship between Realms and Agents is not 1-1, but N-1. In the ECMAScript specification, this manifests
 as a part of the [*Shadow Realm proposal*](https://tc39.es/proposal-shadowrealm/), while the Web platform
-requires multiple Realms per Agent to specify the historical behavior of ``<iframe>`` and related elements.
+requires multiple Realms per Agent to specify the historical behavior of `<iframe>` and related elements.
 
 An Agent holds a stack of Execution Contexts, with the topmost entry being the running execution context.
 Each Execution Context holds a Realm and a specific script's context, including the current function and
@@ -140,17 +140,15 @@ TODO: Finish this section
 
 ## HTML Navigation: Juggling Origins
 
-
-
 ### Global Scopes, Browsing Contexts, Browsing Context Groups, Navigables, and Traversable Navigables
 
 TODO:
 
-- Agents defined by the HTML Spec
-- Global Objects (Global Scopes) defined by the HTML Spec
-- Agents and Browsing Context Groups
-- Navigables and their relationship to Browsing Contexts
-- Walk through construction of a browser tab, its traversable navigable, and its navigation both same and
-  cross-origin
-- Walk through construction of a browser tab with a nested browsing context and what happens when the
-  nested context within its navigable container navigates on its own
+-   Agents defined by the HTML Spec
+-   Global Objects (Global Scopes) defined by the HTML Spec
+-   Agents and Browsing Context Groups
+-   Navigables and their relationship to Browsing Contexts
+-   Walk through construction of a browser tab, its traversable navigable, and its navigation both same and
+    cross-origin
+-   Walk through construction of a browser tab with a nested browsing context and what happens when the
+    nested context within its navigable container navigates on its own

--- a/Documentation/Browser/LibWebFromLoadingToPainting.md
+++ b/Documentation/Browser/LibWebFromLoadingToPainting.md
@@ -20,16 +20,16 @@ Due to the `document.write()` API, the parser also allows programmatic injection
 
 ### CSS parsing
 
-* CSS parser
-* Builds the CSSOM
-* Values with variables can't be resolved until cascade, kept as "unresolved" values
+-   CSS parser
+-   Builds the CSSOM
+-   Values with variables can't be resolved until cascade, kept as "unresolved" values
 
 ### JS parsing & execution
 
-* JS parser
-* Builds JavaScript AST
-* Interpreter runs AST
-* Garbage collector (basic stop-the-world mark&sweep)
+-   JS parser
+-   Builds JavaScript AST
+-   Interpreter runs AST
+-   Garbage collector (basic stop-the-world mark & sweep)
 
 ### Style computation
 
@@ -69,10 +69,10 @@ The main optimization is a cache in StyleComputer that divides style rules into 
 
 The C in CSS is for "cascading" and "the cascade" refers to the process where all the CSS declarations that should apply to a DOM element are evaluated in order. The order is determined by a number of factors, such as selector specificity, rule order within the style sheet. There's also per-property consideration of the `!important` annotation, which allows authors to override the normal cascade order.
 
-* To compute the "computed style" for an element...
-* Perform the CSS cascade to determine final property values
-* Interpolate variables
-* Absolutize, etc
+-   To compute the "computed style" for an element...
+-   Perform the CSS cascade to determine final property values
+-   Interpolate variables
+-   Absolutize, etc
 
 We separate CSS rules by their cascade origin. The two origins we're concerned with are "user-agent" and "author". If we supported custom user style sheets (we don't), they'd need a separate cascade origin as well.
 
@@ -95,9 +95,9 @@ There isn't a 1:1 mapping between DOM nodes and layout nodes. Elements with `dis
 
 A number of tree fix-ups are also performed:
 
-- To maintain the invariant that block containers only have all block-level children or all inline-level children, inline-level boxes with block-level siblings are wrapped in anonymous wrapper boxes.
-- If an individual table component box is found outside the context of a full table, a set of anonymous table boxes are generated to compensate and ensure that there's always a fully-formed table. (FIXME: This is currently buggy..)
-- For list item boxes (`display: list-item`), a box representing the marker is inserted if needed.
+-   To maintain the invariant that block containers only have all block-level children or all inline-level children, inline-level boxes with block-level siblings are wrapped in anonymous wrapper boxes.
+-   If an individual table component box is found outside the context of a full table, a set of anonymous table boxes are generated to compensate and ensure that there's always a fully-formed table. (FIXME: This is currently buggy..)
+-   For list item boxes (`display: list-item`), a box representing the marker is inserted if needed.
 
 ### Layout
 
@@ -105,10 +105,11 @@ Layout starts at the ICB (initial containing block), which is the layout node th
 CSS says that the ICB should be the size of the viewport, so the very first thing layout does is assign these dimensions.
 
 Layout works through a mechanism call formatting contexts. CSS defines a number of different formatting contexts:
-- Block Formatting Context (BFC)
-- Inline Formatting Context (IFC)
-- Table Formatting Context (TFC)
-- Flex Formatting Context (FFC)
+
+-   Block Formatting Context (BFC)
+-   Inline Formatting Context (IFC)
+-   Table Formatting Context (TFC)
+-   Flex Formatting Context (FFC)
 
 In LibWeb, to simplify the layout model, we also define our own SVGFormattingContext for embedded SVG content. This isn't part of the SVG specification, but simplifies the implementation.
 
@@ -128,9 +129,9 @@ The job of IFC is to generate line boxes. Line boxes are essentially a sequence 
 
 There are three main classes involved in inline-level layout:
 
-- InlineFormattingContext (IFC)
-- LineBuilder
-- InlineLevelIterator
+-   InlineFormattingContext (IFC)
+-   LineBuilder
+-   InlineLevelIterator
 
 IFC drives the high-level loop by creating a LineBuilder and an InlineLevelIterator. It then traverses the inline-level content within the IFC containing block, one item at a time, by calling InlineLevelIterator::next().
 
@@ -165,5 +166,5 @@ The stacking context tree is rooted at the ICB, and can have zero or more descen
 
 Painting follows the order specified in the CSS2 appendix E. The rules are quite involved, but two main things to know about:
 
-- Painting is driven through stacking contexts, which are painted back-to-front (stacking context tree order)
-- Painting is performed in *phases*. For each stacking context, we paint in order: backgrounds & borders, floats, backgrounds & borders for inline and replaced content, foreground (text), focus outlines and overlays.
+-   Painting is driven through stacking contexts, which are painted back-to-front (stacking context tree order)
+-   Painting is performed in *phases*. For each stacking context, we paint in order: backgrounds & borders, floats, backgrounds & borders for inline and replaced content, foreground (text), focus outlines and overlays.

--- a/Documentation/Browser/Patterns.md
+++ b/Documentation/Browser/Patterns.md
@@ -14,7 +14,7 @@ If necessary, code can also be grouped into sub-subdirectories (for example `HTM
 
 Sometimes a spec document affects several areas of the web platform. An example of this is CSSOM,
 which of course contains features belonging in `LibWeb/CSS/` / `Web::CSS`, but at the same time
-implements additions to `Window` from the HTML spec. Use best judgement in those cases.
+implements additions to `Window` from the HTML spec. Use your best judgement in those cases.
 
 ## Error Handling
 
@@ -138,7 +138,7 @@ namespace, e.g. `Fetch::Request` vs `Fetch::Infrastructure::Request`.
 ### File placement
 
 The `.cpp`, `.h`, and `.idl` files for a given interface should all be in the same directory, unless
-the implementation is hand-written when it cannot be generated from IDL. In those cases, no IDL file
+the implementation is handwritten when it cannot be generated from IDL. In those cases, no IDL file
 is present and code should be placed in `Bindings/`.
 
 ## Testing

--- a/Documentation/Browser/ProcessArchitecture.md
+++ b/Documentation/Browser/ProcessArchitecture.md
@@ -2,7 +2,7 @@
 
 *NOTE: This document is partly aspirational, in that the state of the code does not yet fully reflect what's described here. Implementation is underway.*
 
-The SerenityOS web browser (**"Browser"**) uses a multi-process architecture to improve stability and security in the face of arbitrary (and possibly hostile) web content.
+The SerenityOS web browser (**"Browser"**) uses a multiprocess architecture to improve stability and security in the face of arbitrary (and possibly hostile) web content.
 
 ## Process overview
 

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -19,7 +19,7 @@ sudo apt install autoconf autoconf-archive automake build-essential ccache cmake
 
 #### CMake 3.25 or newer:
 
-- Recommendation: Install `CMake 3.25` or newer from [Kitware's apt repository](https://apt.kitware.com/):
+-   Recommendation: Install `CMake 3.25` or newer from [Kitware's apt repository](https://apt.kitware.com/):
 
 > [!NOTE]
 > This repository is Ubuntu-only
@@ -39,7 +39,7 @@ sudo apt update -y && sudo apt install cmake -y
 
 #### C++23-capable compiler:
 
-- Recommendation: Install `clang-17` or newer from [LLVM's apt repository](https://apt.llvm.org/):
+-   Recommendation: Install `clang-17` or newer from [LLVM's apt repository](https://apt.llvm.org/):
 
 ```bash
 # Add LLVM GPG signing key
@@ -54,7 +54,7 @@ echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] https://apt.llvm
 sudo apt update -y && sudo apt install clang-18 clangd-18 clang-format-18 clang-tidy-18 lld-18 -y
 ```
 
-- Alternative: Install gcc-13 or newer from [Ubuntu Toolchain PPA](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test):
+-   Alternative: Install gcc-13 or newer from [Ubuntu Toolchain PPA](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test):
 
 ```bash
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -63,13 +63,13 @@ sudo apt update && sudo apt install g++-13 libstdc++-13-dev
 
 #### Audio support:
 
-- Recommendation: Install PulseAudio development package:
+-   Recommendation: Install PulseAudio development package:
 
 ```bash
 sudo apt install libpulse-dev
 ```
 
-- Alternative: Install Qt6's multimedia package:
+-   Alternative: Install Qt6's multimedia package:
 
 ```bash
 sudo apt install qt6-multimedia-dev
@@ -82,14 +82,17 @@ sudo pacman -S --needed autoconf-archive automake base-devel ccache cmake curl f
 ```
 
 ### Fedora or derivatives:
+
 ```
 sudo dnf install autoconf-archive automake ccache cmake curl libavcodec-free-devel liberation-sans-fonts libglvnd-devel nasm ninja-build qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
 ```
 
 ### openSUSE:
+
 ```
 sudo zypper install autoconf-archive automake ccache cmake curl ffmpeg-7-libavcodec-devel gcc13 gcc13-c++ liberation-fonts libglvnd-devel nasm ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel tar unzip zip
 ```
+
 The build process requires at least python3.7; openSUSE Leap only features Python 3.6 as default, so it is recommendable to install package python311 and create a virtual environment (venv) in this case.
 
 ### NixOS or with Nix:
@@ -97,7 +100,6 @@ The build process requires at least python3.7; openSUSE Leap only features Pytho
 > [!NOTE]
 > These steps are out of date, as vcpkg does not work with Nix.
 > Please refer to the nixpkgs package for the most up-to-date build instructions.
->
 
 ```console
 nix develop
@@ -107,6 +109,7 @@ nix develop --command bash
 ```
 
 On NixOS or with Nix using your host `nixpkgs` and the legacy `nix-shell` tool:
+
 ```console
 nix-shell Ladybird
 
@@ -124,20 +127,22 @@ brew install autoconf autoconf-archive automake ccache cmake ffmpeg nasm ninja p
 ```
 
 If you wish to use clang from homebrew instead:
+
 ```
 brew install llvm
 ```
 
 If you also plan to use the Qt chrome on macOS:
+
 ```
 brew install qt
 ```
 
 ### Windows:
 
-- Create a WSL2 environment using one of the Linux distros listed above. Ubuntu or Fedora is recommended.
+-   Create a WSL2 environment using one of the Linux distros listed above. Ubuntu or Fedora is recommended.
 
-- Install the required packages for the selected Linux distro in the WSL2 environment.
+-   Install the required packages for the selected Linux distro in the WSL2 environment.
 
 WSL1 is known to have issues. If you run into problems, please use WSL2.
 
@@ -154,6 +159,7 @@ pfexec pkg install clang-17 cmake libglvnd ninja qt6
 ```
 
 ### Haiku:
+
 ```
 pkgman install cmake cmd:python3 ninja openal_devel qt6_base_devel qt6_multimedia_devel qt6_tools_devel
 ```
@@ -161,7 +167,7 @@ pkgman install cmake cmd:python3 ninja openal_devel qt6_base_devel qt6_multimedi
 ### Android:
 
 On a Unix-like platform, install the prerequisites for that platform and then see the [Android Studio guide](AndroidStudioConfiguration.md).
-Or, download a version of Gradle >= 8.0.0, and run the ``gradlew`` program in ``Ladybird/Android``
+Or, download a version of Gradle >= 8.0.0, and run the `gradlew` program in `Ladybird/Android`
 
 ## Build steps
 
@@ -175,11 +181,13 @@ The simplest way to build and run ladybird is via the ladybird.sh script:
 ```
 
 On macOS, to build using clang from homebrew:
+
 ```bash
 CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ ./Meta/ladybird.sh run
 ```
 
 You may also choose to start it in `gdb` using:
+
 ```bash
 ./Meta/ladybird.sh gdb ladybird
 ```
@@ -196,9 +204,10 @@ Note that debug symbols are available in both Release and Debug builds.
 ### The chromes
 
 Ladybird will be built with one of the following browser chromes (graphical frontends), depending on the platform:
-* [AppKit](https://developer.apple.com/documentation/appkit?language=objc) - The native chrome on macOS.
-* [Qt](https://doc.qt.io/qt-6/) - The chrome used on all other platforms.
-* [Android UI](https://developer.android.com/develop/ui) - The native chrome on Android.
+
+-   [AppKit](https://developer.apple.com/documentation/appkit?language=objc) - The native chrome on macOS.
+-   [Qt](https://doc.qt.io/qt-6/) - The chrome used on all other platforms.
+-   [Android UI](https://developer.android.com/develop/ui) - The native chrome on Android.
 
 The Qt chrome is available on platforms where it is not the default as well (except on Android). To build the
 Qt chrome, install the Qt dependencies for your platform, and enable the Qt chrome via CMake:
@@ -218,7 +227,7 @@ The section lists out some particular error messages you may run into, and expla
 
 Solution to try: If you do in fact already have Ninja installed, then first try reinstalling Ninja.
 
-Details: If you see the message *“Unable to find a build program corresponding to "Ninja"”*, it’s likely not an indication that the build tooling can’t actually find Ninja, but instead an indication that the tooling found Ninja but it failed to run successfully.
+Details: If you see the message *“Unable to find a build program corresponding to "Ninja"”*, it’s likely not an indication that the build tooling can’t actually find Ninja, but instead an indication that the tooling found Ninja, but it failed to run successfully.
 
 So, when you do run into that error message, the way to start figuring out what’s actually wrong is to try invoking Ninja manually, like this:
 
@@ -243,7 +252,7 @@ The script Meta/ladybird.sh and the default preset in CMakePresets.json both def
 CMake build directory.
 
 The install rules in Ladybird/cmake/InstallRules.cmake define which binaries and libraries will be
-installed into the configured CMAKE_PREFIX_PATH or path passed to ``cmake --install``.
+installed into the configured CMAKE_PREFIX_PATH or path passed to `cmake --install`.
 
 Note that when using a custom build directory rather than Meta/ladybird.sh, the user may need to provide
 a suitable C++ compiler (g++ >= 13, clang >= 14, Apple Clang >= 14.3) via the CMAKE_CXX_COMPILER and
@@ -262,16 +271,19 @@ The Meta/ladybird.sh script will execute the `run-ladybird` and `debug-ladybird`
 If you don't want to use the ladybird.sh script to run the application, you can run the following commands:
 
 To automatically run in gdb:
+
 ```
 ninja -C Build/ladybird debug-ladybird
 ```
 
 To run without ninja rule on non-macOS systems:
+
 ```
 ./Build/ladybird/bin/Ladybird
 ```
 
 To run without ninja rule on macOS:
+
 ```
 open -W --stdout $(tty) --stderr $(tty) ./Build/ladybird/bin/Ladybird.app
 

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -8,14 +8,13 @@ This document describes the coding style used for C++ code in the Ladybird Brows
 
 We'll definitely be tweaking and amending this over time, so let's consider it a living document. :)
 
-
 ### Names
 
-A combination of CamelCase, snake\_case, and SCREAMING\_CASE:
+A combination of CamelCase, snake_case, and SCREAMING_CASE:
 
-- Use CamelCase (Capitalize the first letter, including all letters in an acronym) in a class, struct, or namespace name
-- Use snake\_case (all lowercase, with underscores separating words) for variable and function names
-- Use SCREAMING\_CASE for constants (both global and static member variables)
+-   Use CamelCase (Capitalize the first letter, including all letters in an acronym) in a class, struct, or namespace name
+-   Use snake_case (all lowercase, with underscores separating words) for variable and function names
+-   Use SCREAMING_CASE for constants (both global and static member variables)
 
 ###### Right:
 
@@ -94,7 +93,7 @@ void set_count(int); // Sets m_the_count.
 int get_count() const; // Returns m_the_count.
 ```
 
-Precede getters that return values through out arguments with the word "get".
+Precede getters that return values throughout arguments with the word "get".
 
 ###### Right:
 
@@ -138,7 +137,7 @@ Inode& inode();
 Inode* ensure_inode();
 ```
 
-Leave meaningless variable names out of function declarations. A good rule of thumb is if the parameter type name contains the parameter name (without trailing numbers or pluralization), then the parameter name isn't needed. Usually, there should be a parameter name for bools, strings, and numerical types.
+Leave meaningless variable names out of function declarations. A good rule of thumb is if the parameter type name contains the parameter name (without trailing numbers or pluralization), then the parameter name isn't needed. Usually, there should be a parameter name for booleans, strings, and numerical types.
 
 ###### Right:
 
@@ -156,7 +155,7 @@ void set_count(int count);
 void do_something(Context* context);
 ```
 
-Prefer enums to bools on function parameters if callers are likely to be passing constants, since named constants are easier to read at the call site. An exception to this rule is a setter function, where the name of the function already makes clear what the boolean is.
+Prefer enums to booleans on function parameters if callers are likely to be passing constants, since named constants are easier to read at the call site. An exception to this rule is a setter function, where the name of the function already makes clear what the boolean is.
 
 ###### Right:
 
@@ -247,7 +246,6 @@ Prefer index or range-for over iterators in Vector iterations for terse, easier-
 for (auto& child : children)
     child->do_child_thing();
 ```
-
 
 #### OK:
 
@@ -386,8 +384,8 @@ signed int c; // Doesn't omit "signed".
 
 For types with methods, prefer `class` over `struct`.
 
-* For classes, make public getters and setters, keep members private with `m_` prefix.
-* For structs, let everything be public and skip the `m_` prefix.
+-   For classes, make public getters and setters, keep members private with `m_` prefix.
+-   For structs, let everything be public and skip the `m_` prefix.
 
 ###### Right:
 
@@ -646,16 +644,17 @@ const Salt& m_salt;
 
 Before you consider a cast, please see if your problem can be solved another way that avoids the visual clutter.
 
-- Integer constants can be specified to have (some) specific sizes with postfixes like `u, l, ul` etc. The same goes for single-precision floating-point constants with `f`.
-- Working with smaller-size integers in arithmetic expressions is hard because of [implicit promotion](https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules). Generally, it is fine to use `int` and other "large" types in local variables, and possibly cast at the end.
-- If you `const_cast`, _really_ consider whether your APIs need to be adjusted in terms of their constness. Does the member function you're writing actually make sense to be `const`?
-- If you do checked casts between base and derived types, also consider your APIs. For example: Does the function being called actually need to receive the more general type or is it fine with the more specialized type?
+-   Integer constants can be specified to have (some) specific sizes with postfixes like `u, l, ul` etc. The same goes for single-precision floating-point constants with `f`.
+-   Working with smaller-size integers in arithmetic expressions is hard because of [implicit promotion](https://wiki.sei.cmu.edu/confluence/display/c/INT02-C.+Understand+integer+conversion+rules). Generally, it is fine to use `int` and other "large" types in local variables, and possibly cast at the end.
+-   If you `const_cast`, _really_ consider whether your APIs need to be adjusted in terms of their constness. Does the member function you're writing actually make sense to be `const`?
+-   If you do checked casts between base and derived types, also consider your APIs. For example: Does the function being called actually need to receive the more general type or is it fine with the more specialized type?
 
 If you _do_ need to cast: **Don't use C-style casts**. The C-style cast has [complex behavior](https://en.cppreference.com/w/c/language/cast) that is undesired in many instances. Be aware of what sort of type conversion the code is trying to achieve, and use the appropriate (!) C++ cast operator, like `static_cast`, `reinterpret_cast`, `bit_cast`, `dynamic_cast` etc.
 
 There is a single exception to this rule: marking a function parameter as used with `(void)parameter;`.
 
 ###### Right:
+
 ```cpp
 MyParentClass& object = get_object();
 // Verify the type...
@@ -678,6 +677,7 @@ return const_cast<SeekableStream*>(this)->seek(0, SeekMode::FromCurrentPosition)
 ```
 
 ###### Wrong:
+
 ```cpp
 // These should be static_cast.
 size_t mask_length = (size_t)((u8)-1) + 1;
@@ -695,6 +695,7 @@ Curly braces may only be omitted from `if`/`else`/`for`/`while`/etc. statement b
 Additionally, if any body of a connected if/else statement requires curly braces according to this rule, all of them do.
 
 ###### Right:
+
 ```cpp
 if (condition)
     foo();

--- a/Documentation/GettingStartedContributing.md
+++ b/Documentation/GettingStartedContributing.md
@@ -1,63 +1,75 @@
 # Getting started contributing to Ladybird
+
 Welcome to the Ladybird web browser project!
 
 This document aims to be a beginner-friendly guide to your first Ladybird contribution; remember to read the linked documentation for more information.
 
 ## Getting familiar with the project
+
 Ladybird is a large project making use of many homegrown and third-party libraries, written primarily in C++.
 
 It is recommended you read the README and FAQs in case they already answer any questions you have:
 
-* [README](/README.md)
-* [FAQ](FAQ.md)
-* [FAQ on the Ladybird website](https://ladybird.org/#faq)
+-   [README](/README.md)
+-   [FAQ](FAQ.md)
+-   [FAQ on the Ladybird website](https://ladybird.org/#faq)
 
 The [Discord server](https://discord.gg/nvfjVJ4Svh) is the preferred way to get in contact with the maintainers and community.
 
 ## Building the code
+
 Ladybird must be built from source during this pre-alpha stage of development, and currently natively supports Linux and macOS; running it on Windows requires WSL.
 
 Carefully follow the steps outlined in the [build instructions](BuildInstructionsLadybird.md). If you are facing issues, consult the [troubleshooting guide](Troubleshooting.md) and the #build-problems channel on Discord.
 
 ## Finding bugs and other issues
+
 Here are some of the ways you can find an issue in Ladybird:
 
-* By checking the [issue tracker](https://github.com/LadybirdBrowser/ladybird/issues).
-* Manually, by using the browser as you normally would.
-* By finding failing WPT tests on [WPT.fyi](https://wpt.fyi/results/?label=master&product=ladybird). Note that while fixes are welcome, you don't need to submit issue reports for individual tests.
+-   By checking the [issue tracker](https://github.com/LadybirdBrowser/ladybird/issues).
+-   Manually, by using the browser as you normally would.
+-   By finding failing WPT tests on [WPT.fyi](https://wpt.fyi/results/?label=master&product=ladybird). Note that while fixes are welcome, you don't need to submit issue reports for individual tests.
 
 There currently isn't a list of beginner-friendly issues, nor a strict roadmap of ones to address first. It is ultimately up to you to choose a task that you feel comfortable working on.
 
 ## Submitting an issue
+
 If you have found an issue that is not already in the [issue tracker](https://github.com/LadybirdBrowser/ladybird/issues), you may submit it. Do not submit general questions about the project, please use the Discord server instead.
 
-Read the [full contribution guidelines](/CONTRIBUTING.md), in particular the Issue policy and Human language policy. It is recommended you reduce the website to the most minimal amount of HTML/CSS/JS which still results in the error (if applicable), and provide the result expected from other browsers vs Ladybird. Read the [detailed issue-reporting guidelines](/ISSUES.md) for the exact steps to do so.
+Read the [full contribution guidelines](/CONTRIBUTING.md), in particular the Issue policy and Human language policy. It is recommended you reduce the website to the most minimal amount of HTML/CSS/JS which still results in the error (if applicable), and provide the result expected from other browsers vs Ladybird. Read the [detailed issue-reporting guidelines](/ISSUES.md) for the exact steps to take.
 
 ## Submitting your code
+
 ### Getting familiar with C++
+
 Ladybird requires at least a basic knowledge of C++, consult a tutorial website like [Learn C++](https://www.learncpp.com/) and online references if you need help. Start small before attempting to make large changes, as they require more in-depth C++ knowledge.
 
 ### Getting familiar with the codebase
+
 Ladybird makes use of the included AK library instead of the C++ STL, and employs a specific coding style based around it. Unfortunately most AK and internal library facilities are not documented; you may need to look for the header files, and examples of usage in existing code.
 
 Developer documentation:
 
-* [Coding patterns](Patterns.md)
-* [Smart pointers](SmartPointers.md)
-* [String formatting](StringFormatting.md)
+-   [Coding patterns](Patterns.md)
+-   [Smart pointers](SmartPointers.md)
+-   [String formatting](StringFormatting.md)
 
 ### Using `git`
+
 The recommended way to work on Ladybird is by cloning the main repository locally, then forking it on GitHub and adding your repository as a Git remote:
+
 ```sh
 git remote add myfork git@github.com:MyUsername/ladybird.git
 ```
 
 You can then create a new branch and start making changes to the code:
+
 ```sh
 git checkout -b mybranch
 ```
 
 And finally push the commits to your fork:
+
 ```sh
 # ONLY run this the first time you push
 git push --set-upstream myfork mybranch
@@ -66,6 +78,7 @@ git push
 ```
 
 If your pull request is showing conflicts with the master branch, resolve them locally with:
+
 ```sh
 # On mybranch
 git fetch origin
@@ -75,8 +88,9 @@ git rebase master
 You may be asked to perform actions like squashing, rewording, or editing commits. See the [Rewriting history in Git](https://www.youtube.com/watch?v=ElRzTuYln0M) YouTube tutorial for more information.
 
 ### Creating a pull request
+
 Make sure your code meets the requirements in the [full contribution guidelines](/CONTRIBUTING.md) and [coding style](CodingStyle.md). Additionally:
 
-* Make correctly formatted, atomic commits (building the project at every commit should succeed).
-* Discuss and resolve any reviews you receive.
-* Fix CI failures by editing your commits.
+-   Make correctly formatted, atomic commits (building the project at every commit should succeed).
+-   Discuss and resolve any reviews you receive.
+-   Fix CI failures by editing your commits.

--- a/Documentation/NvimConfiguration.md
+++ b/Documentation/NvimConfiguration.md
@@ -6,26 +6,27 @@ project:
 1. With [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) (assumes existing setup)
 2. With [coc.nvim](https://github.com/neoclide/coc.nvim) (from scratch, potentially out of date)
 
-For both setups, make sure you ran `./Meta/ladybird.sh run ladybird` at least 
+For both setups, make sure you ran `./Meta/ladybird.sh run ladybird` at least
 once.
 
 ## With nvim-lspconfig
 
-> Note: This guide assumes Lua is being used, but can easily be adapted to 
+> Note: This guide assumes Lua is being used, but can easily be adapted to
 > VimScript.
 
 If you have an [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), setup
 already, registering clangd is similar to other LSPs:
+
 ```lua
 require('lspconfig').clangd.setup {
-  -- If you have an on_attach function, this is where you'd put it. If not, 
+  -- If you have an on_attach function, this is where you'd put it. If not,
   -- you can delete this line.
   -- on_attach = ...,
 
   -- This is where you'd put capabilities (i.e. if you're useing nvim-cmp)
   -- capabilities = ...,
 
-  -- If you have another clangd installation, put it here. Note that we use 
+  -- If you have another clangd installation, put it here. Note that we use
   -- clangd version 18 for the Ladybird project.
   -- cmd = { '/path/to/clangd' },
 }
@@ -80,7 +81,7 @@ This will install a separate version of clangd just for neovim.
 Use the following settings to ensure that coc-clangd works out of the box.
 
 > **Note**: You might want to adjust the `clangd.fallbackFlags` depending on your build
-system and customize the `inlayHints.sep` based on your preference.
+> system and customize the `inlayHints.sep` based on your preference.
 
 ```json
 {
@@ -96,22 +97,27 @@ To change the coc-settings.json go to the file `~/.config/nvim/coc-settings.json
 or type `:CocConfig` in the command line.
 
 > **Note**: In case you already had another c++ language server configured in the
-`coc-settings.json` you might want to nuke it first and
-work towards your desired config by adding the other parts back in to avoid
-conflicts.
+> `coc-settings.json` you might want to nuke it first and
+> work towards your desired config by adding the other parts back in to avoid
+> conflicts.
 
 > **Note**: If you have configured `clangd` as a languageServer in
-`coc-settings.json`, you should remove it to avoid running clangd twice!
+> `coc-settings.json`, you should remove it to avoid running clangd twice!
 
 > **Note**: `clangd.inlayHints.sep` breaks on `clangd 15.0.6`.
 
 ### Formatting
+
 For code formatting the formatter plugin can be used.
+
 ```vim
 Plug 'mhartington/formatter.nvim'
 ```
+
 #### Configuration
+
 To use the formatter plugin one needs to opt-in to specific formatters. An example lua configuration which uses clang-format for cpp files:
+
 ```lua
 require("formatter").setup{
     filetype = {

--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -4,17 +4,17 @@
 
 Over time numerous reoccurring patterns have emerged from or were adopted by
 the Ladybird code base. This document aims to track and describe them, so they
-can be propagated further and the code base can be kept consistent. 
+can be propagated further and the code base can be kept consistent.
 
 ## `TRY(...)` Error Handling
 
 The `TRY(..)` macro is used for error propagation in the Ladybird code base.
-The goal being to reduce the amount of boiler plate error code required to
-properly handle and propagate errors throughout the code base. 
+The goal being to reduce the amount of boilerplate error code required to
+properly handle and propagate errors throughout the code base.
 
 Any code surrounded by `TRY(..)` will attempt to be executed, and any error
 will immediately be returned from the function. If no error occurs then the
-result of the contents of the TRY will be the result of the macro's execution. 
+result of the contents of the TRY will be the result of the macro's execution.
 
 ### Examples:
 
@@ -144,7 +144,7 @@ Instead, `serenity_main(..)` is defined like this:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    return 0; 
+    return 0;
 }
 ```
 
@@ -171,7 +171,7 @@ It's a universal pattern to use `static_assert` to validate the size of a
 type matches the author's expectations. Unfortunately when these assertions
 fail they don't give you the values that actually caused the failure. This
 forces one to go investigate by printing out the size, or checking it in a
-debugger, etc. 
+debugger, etc.
 
 For this reason `AK::AssertSize` was added. It exploits the fact that the
 compiler will emit template argument values for compiler errors to provide
@@ -201,10 +201,11 @@ static_assert(AssertSize<Empty, 1>());
 ```
 
 This allows `AK::StringView` to be constructed from string literals with no runtime
-cost to find the string length, and the data the `AK::StringView` points to will 
+cost to find the string length, and the data the `AK::StringView` points to will
 reside in the data section of the binary.
 
 Example Usage:
+
 ```cpp
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -223,7 +224,7 @@ TEST_CASE(string_view_literal_operator)
 ## Source Location
 
 C++20 added std::source_location, which lets you capture the
-callers __FILE__ / __LINE__ / __FUNCTION__ etc as a default
+callers `__FILE__` / `__LINE__` / `__FUNCTION__` etc. as a default
 argument to functions.
 See: https://en.cppreference.com/w/cpp/utility/source_location
 
@@ -237,6 +238,7 @@ to any function, using `AK::SourceLocation::current()` to initialize the
 default argument.
 
 Example Usage:
+
 ```cpp
 #include <AK/SourceLocation.h>
 #include <AK/StringView.h>
@@ -253,7 +255,7 @@ int main(int, char**)
 ```
 
 If you only want to only capture `AK::SourceLocation` data with a certain debug macro enabled, avoid
-adding `#ifdef`'s to all functions which have the  `AK::SourceLocation` argument. Since SourceLocation
+adding `#ifdef`'s to all functions which have the `AK::SourceLocation` argument. Since SourceLocation
 is just a simple struct, you can just declare an empty class which can be optimized away by the
 compiler, and alias both to the same name.
 
@@ -281,9 +283,9 @@ private:
 
 There are four "contiguous list" / array-like types, including C-style arrays themselves. They share a lot of their API, but their use cases are all slightly different, mostly relating to how they allocate their data.
 
-Note that `Span<type>` differs from all of these types in that it provides a *view* on data owned by somebody else. The four types mentioned above all own their data, but they can provide `Span`'s which view all or part of their data. For APIs that aren't specific to the kind of list and don't need to handle resizing in any way, `Span` is a good choice.
+Note that `Span<type>` differs from all of these types in that it provides a _view_ on data owned by somebody else. The four types mentioned above all own their data, but they can provide `Span`'s which view all or part of their data. For APIs that aren't specific to the kind of list and don't need to handle resizing in any way, `Span` is a good choice.
 
-* C-style arrays are generally discouraged (and this also holds for pointer+size-style arrays when passing them around). They are only used for the implementation of other collections or in specific circumstances.
-* `Array` is a thin wrapper around C-style arrays similar to `std::array`, where the template arguments include the size of the array. It allocates its data inline, just as arrays do, and never does any dynamic allocations.
-* `Vector` is similar to `std::vector` and represents a dynamic resizable array. For most basic use cases of lists, this is the go-to collection. It has an optional inline capacity (the second template argument) which will allocate inline as the name suggests, but this is not always used. If the contents outgrow the inline capacity, Vector will automatically switch to the standard out-of-line storage. This is allocated on the heap, and the space is automatically resized and moved when more (or less) space is needed.
-* `FixedArray` is essentially a runtime-sized `Array`. It can't resize like `Vector`, but it's ideal for circumstances where the size is not known at compile time but doesn't need to change once the collection is initialized. `FixedArray` guarantees to not allocate or deallocate except for its constructor and destructor.
+-   C-style arrays are generally discouraged (and this also holds for pointer+size-style arrays when passing them around). They are only used for the implementation of other collections or in specific circumstances.
+-   `Array` is a thin wrapper around C-style arrays similar to `std::array`, where the template arguments include the size of the array. It allocates its data inline, just as arrays do, and never does any dynamic allocations.
+-   `Vector` is similar to `std::vector` and represents a dynamic resizable array. For most basic use cases of lists, this is the go-to collection. It has an optional inline capacity (the second template argument) which will allocate inline as the name suggests, but this is not always used. If the contents outgrow the inline capacity, Vector will automatically switch to the standard out-of-line storage. This is allocated on the heap, and the space is automatically resized and moved when more (or less) space is needed.
+-   `FixedArray` is essentially a runtime-sized `Array`. It can't resize like `Vector`, but it's ideal for circumstances where the size is not known at compile time but doesn't need to change once the collection is initialized. `FixedArray` guarantees to not allocate or deallocate except for its constructor and destructor.

--- a/Documentation/QtCreatorConfiguration.md
+++ b/Documentation/QtCreatorConfiguration.md
@@ -4,22 +4,22 @@
 
 First, make sure you have a working toolchain and can build and run Ladybird. Go [here](BuildInstructionsLadybird.md) for instructions for setting that up.
 
-* Install [Qt Creator](https://www.qt.io/offline-installers). You don't need the entire Qt setup, just click 'Qt Creator' on the left side, and install that.
-* Open Qt Creator, select `File -> New File or Project...`
-* Select `Import Existing Project`
-* Give it a name (some tools assume lower-case `ladybird`), and navigate to the root of your Ladybird project checkout. Click Next.
-* Wait for the file list to generate. This can take a minute or two!
-* Ignore the file list, we will overwrite it later. Click Next.
-* Set `Add to version control` to `<None>`. Click Finish.
-* In your shell, go to your Ladybird project directory, and invoke the `Meta/refresh-ladybird-qtcreator.sh` script to regenerate the `ladybird.files` file. You will also have to do this every time you delete or add a new file to the project.
-* Edit the `ladybird.config` file (In Qt Creator, hit ^K or CMD+K on a Mac to open the search dialog, type the name of the file and hit return to open it)
-* Add the following `#define`s to the file:
+-   Install [Qt Creator](https://www.qt.io/offline-installers). You don't need the entire Qt setup, just click 'Qt Creator' on the left side, and install that.
+-   Open Qt Creator, select `File -> New File or Project...`
+-   Select `Import Existing Project`
+-   Give it a name (some tools assume lower-case `ladybird`), and navigate to the root of your Ladybird project checkout. Click Next.
+-   Wait for the file list to generate. This can take a minute or two!
+-   Ignore the file list, we will overwrite it later. Click Next.
+-   Set `Add to version control` to `<None>`. Click Finish.
+-   In your shell, go to your Ladybird project directory, and invoke the `Meta/refresh-ladybird-qtcreator.sh` script to regenerate the `ladybird.files` file. You will also have to do this every time you delete or add a new file to the project.
+-   Edit the `ladybird.config` file (In Qt Creator, hit ^K or CMD+K on a Mac to open the search dialog, type the name of the file and hit return to open it)
+-   Add the following `#define`s to the file:
     ```
     #define ENABLE_COMPILETIME_FORMAT_CHECK
     #define SANITIZE_PTRS 1
     ```
-* Edit the `ladybird.cxxflags` file to say `-std=c++23 -fsigned-char -fconcepts -fno-exceptions -fno-semantic-interposition -fPIC`
-* Edit the `ladybird.includes` file to list the following lines:
+-   Edit the `ladybird.cxxflags` file to say `-std=c++23 -fsigned-char -fconcepts -fno-exceptions -fno-semantic-interposition -fPIC`
+-   Edit the `ladybird.includes` file to list the following lines:
     ```
     ./
     Userland/
@@ -40,16 +40,16 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 18, as some OSes will ship older clang-format versions by default.
 
-- In QtCreator, go to "Help > About Plugins…"
-- Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)
-- Put a checkmark into the box
-- Restart QtCreator if it asks you
-- In QtCreator, go to "Tools > Options…"
-- Type "beau" in the search box, go to "Beautifier > Clang Format"
-- Select the "customized" style, click "edit"
-- Paste the entire content of the file `.clang-format` into the "value" box, and click "OK"
-- In the "Beautifier > General" tab, check "Enable auto format on file save"
-- Select the tool "ClangFormat" if not already selected, and click "OK"
+-   In QtCreator, go to "Help > About Plugins…"
+-   Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)
+-   Put a checkmark into the box
+-   Restart QtCreator if it asks you
+-   In QtCreator, go to "Tools > Options…"
+-   Type "beau" in the search box, go to "Beautifier > Clang Format"
+-   Select the "customized" style, click "edit"
+-   Paste the entire content of the file `.clang-format` into the "value" box, and click "OK"
+-   In the "Beautifier > General" tab, check "Enable auto format on file save"
+-   Select the tool "ClangFormat" if not already selected, and click "OK"
 
 Note that not the entire project is clang-format-clean (yet), so sometimes you will see large diffs.
 Use your own judgement whether you want to include such changes. Generally speaking, if it's a few lines then it's a good idea; if it's the entire file then maybe there's a better way to do it, like doing a separate commit, or just ignoring the clang-format changes.
@@ -57,12 +57,13 @@ Use your own judgement whether you want to include such changes. Generally speak
 You may want to read up what `git add -p` does (or `git checkout -p`, to undo).
 
 QtCreator tends to interpret IPC definitions as C++ headers, and then tries to format them. This is not useful. One way to avoid that is telling QtCreator that IPC definitions are not C++ headers.
-- In QtCreator, go to "Tools > Options…"
-- Type "beau" in the search box, go to "Environment > MIME Types"
-- In the little search box, type "plain", and select "text/plain"
-- In the "details" section, you should now see the list of Patterns, something like `*.txt;*.asc;*,v`. Extend it in the following way: `*.txt;*.asc;*,v;*.ipc;*.gml`
-- Click "OK" to close the dialog.
-- Maybe you need to close and open again the IPC files. You can check what QtCreator is doing by right-clicking the filename in the editor tab, and clicking "Properties...". In the third line, you should see `MIME type: text/plain`.
+
+-   In QtCreator, go to "Tools > Options…"
+-   Type "beau" in the search box, go to "Environment > MIME Types"
+-   In the little search box, type "plain", and select "text/plain"
+-   In the "details" section, you should now see the list of Patterns, something like `*.txt;*.asc;*,v`. Extend it in the following way: `*.txt;*.asc;*,v;*.ipc;*.gml`
+-   Click "OK" to close the dialog.
+-   Maybe you need to close and open again the IPC files. You can check what QtCreator is doing by right-clicking the filename in the editor tab, and clicking "Properties...". In the third line, you should see `MIME type: text/plain`.
 
 ## License template
 

--- a/Documentation/RunningTests.md
+++ b/Documentation/RunningTests.md
@@ -2,7 +2,7 @@
 
 To reproduce a CI failure, see the section on [Running with Sanitizers](#running-with-sanitizers).
 
-The simplest way to run tests locally is to use the `default` preset from ``CMakePresets.json``:
+The simplest way to run tests locally is to use the `default` preset from `CMakePresets.json`:
 
 ```sh
 cmake --preset default
@@ -70,10 +70,10 @@ CTEST_OUTPUT_ON_FAILURE=1 LADYBIRD_SOURCE_DIR=${PWD}/../.. ninja test
 
 # Running the Web Platform Tests
 
-The Web Platform Tests can be run with the `WPT.sh` script. This script can also be used to compare the results of two 
+The Web Platform Tests can be run with the `WPT.sh` script. This script can also be used to compare the results of two
 test runs.
 
-Enabling the Qt chrome is recommended when running the Web Platform Tests on MacOS. This can be done by running the 
+Enabling the Qt chrome is recommended when running the Web Platform Tests on macOS. This can be done by running the
 following command:
 
 ```sh
@@ -93,5 +93,5 @@ git checkout my-css-change
 # Pull the latest changes from the upstream WPT repository
 ./Meta/WPT.sh update
 # Run all of the Web Platform Tests, outputting the results to results.log
-./Meta/WPT.sh run --log results.log 
+./Meta/WPT.sh run --log results.log
 ```

--- a/Documentation/SmartPointers.md
+++ b/Documentation/SmartPointers.md
@@ -16,7 +16,7 @@ These pointers cannot be copied. Transferring ownership is done by moving the po
 
 `NonnullOwnPtr` is a special variant of `OwnPtr` with one additional property: it cannot be null. `NonnullOwnPtr` is suitable as a return type from functions that are guaranteed to never return null, and as an argument type where ownership is transferred, and the argument may not be null. In other words, if `OwnPtr` is "\*", then `NonnullOwnPtr` is "&".
 
-Note: A `NonnullOwnPtr` can be assigned to an `OwnPtr` but not vice versa. To transform an known-non-null `OwnPtr` into a `NonnullOwnPtr`, use `OwnPtr::release_nonnull()`.
+Note: A `NonnullOwnPtr` can be assigned to an `OwnPtr` but not vice versa. To transform a known-non-null `OwnPtr` into a `NonnullOwnPtr`, use `OwnPtr::release_nonnull()`.
 
 ### Construction using helper functions
 
@@ -83,7 +83,7 @@ class Bar : public RefCounted<Bar> {
 };
 ```
 
-Note: A `NonnullRefPtr` can be assigned to a `RefPtr` but not vice versa. To transform an known-non-null `RefPtr` into a `NonnullRefPtr`, either use `RefPtr::release_nonnull()` or simply dereference the `RefPtr` using its `operator*`.
+Note: A `NonnullRefPtr` can be assigned to a `RefPtr` but not vice versa. To transform a known-non-null `RefPtr` into a `NonnullRefPtr`, either use `RefPtr::release_nonnull()` or simply dereference the `RefPtr` using its `operator*`.
 
 ### Construction using helper functions
 
@@ -93,7 +93,6 @@ There is a `make_ref_counted<T>()` global helper function that constructs a new 
 NonnullRefPtr<Bar> our_object = make_ref_counted<Bar>();
 NonnullRefPtr<Bar> another_owner = our_object;
 ```
-
 
 The `try_make_ref_counted<T>()` function constructs an object wrapped in `ErrorOr<NonnullRefPtr<T>>` which may be an error if the allocation does not succeed. This allows the calling code to handle allocation failure as it wishes. All arguments passed to it are forwarded to `T`'s constructor.
 
@@ -120,11 +119,12 @@ NonnullRefPtr<Bar> our_object = adopt_ref(*new Bar);
 
 Note: It is safe to immediately dereference this raw pointer, as the normal `new` expression cannot return a null pointer.
 
-Any (possibly null) pointer to a reference-counted object can can be turned into a `RefPtr` by the global `adopt_ref_if_nonnull()` function.
+Any (possibly null) pointer to a reference-counted object can be turned into a `RefPtr` by the global `adopt_ref_if_nonnull()` function.
 
 ```cpp
 RefPtr<Bar> our_object = adopt_ref_if_nonnull(new (nothrow) Bar);
 ```
+
 In this case, the *non-throwing* `new` should be used to construct the raw pointer, which returns null if the allocation fails, instead of aborting the program.
 
 **Note:** Always prefer the helper functions to manual construction.

--- a/Documentation/StringFormatting.md
+++ b/Documentation/StringFormatting.md
@@ -1,7 +1,6 @@
 # String Formatting
 
-Many places in Ladybird allow you to format strings, similar to `printf()`, for example `ByteString::formatted()`
-, `StringBuilder::appendff()`, or `dbgln()`. These are checked at compile time to ensure the format string matches the
+Many places in Ladybird allow you to format strings, similar to `printf()`, for example `ByteString::formatted()`, `StringBuilder::appendff()`, or `dbgln()`. These are checked at compile time to ensure the format string matches the
 number of parameters. The syntax is largely based on
 the [C++ `std::formatter` syntax](https://en.cppreference.com/w/cpp/utility/format/formatter#Standard_format_specification)
 but there are some differences.
@@ -37,13 +36,13 @@ ByteString::formatted("{0:.4}", "cool dude") == "cool";
 
 In order, the format can contain:
 
-- Fill character and alignment
-- Sign
-- `#` Hash
-- `0` Zero
-- Width
-- Precision
-- Type specifier
+-   Fill character and alignment
+-   Sign
+-   `#` Hash
+-   `0` Zero
+-   Width
+-   Precision
+-   Type specifier
 
 Each of these is optional. You can include any combination of them, but they must be in this order.
 
@@ -55,15 +54,15 @@ space. (` `)
 
 The alignment characters are:
 
-- `<`: Align left.
-- `>`: Align right.
-- `^`: Align centered.
+-   `<`: Align left.
+-   `>`: Align right.
+-   `^`: Align centered.
 
 ### Sign
 
-- `+`: Always display a sign before the number.
-- `-`: Display a sign for negative numbers only.
-- (space): Display a sign for negative numbers, and a leading space for other numbers.
+-   `+`: Always display a sign before the number.
+-   `-`: Display a sign for negative numbers only.
+-   (space): Display a sign for negative numbers, and a leading space for other numbers.
 
 ### Hash
 
@@ -71,9 +70,9 @@ The alignment characters are:
 
 For integer types, this adds the number-base prefix after the sign:
 
-- `0b` for binary.
-- `0` for octal.
-- `0x` for hexadecimal.
+-   `0b` for binary.
+-   `0` for octal.
+-   `0x` for hexadecimal.
 
 ### Zero
 
@@ -90,7 +89,7 @@ allows you to use an integer argument instead of a hard-coded number.
 ### Type specifiers
 
 | Type      | Effect                | Example output           |
-|-----------|-----------------------|--------------------------|
+|-----------| --------------------- | ------------------------ |
 | *nothing* | default format        | Anything! :^)            |
 | b         | binary                | `110`, `0b000110`        |
 | B         | binary uppercase      | `110`, `0B000110`        |


### PR DESCRIPTION
I saw that there were a few spelling mistakes in the Documentation directory markdown files.
I have now fixed these.

There were also a few documents where the formatting was incorrect, so with the help of ltex, a markdown plugin for neovim, I have hopefully fixed that as well.