### PR TITLE
LibWeb: Adjust flex item intrinsic contributions through aspect ratio

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-cross-size-contribution-with-main-size-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-cross-size-contribution-with-main-size-constraint.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x0 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 50x50 positioned flex-container(row) [FFC] children: not-inline
+      ImageBox <img> at (8,8) content-size 50x50 flex-item children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0] overflow: [8,8 50x50]
+    PaintableBox (Box<BODY>) [8,8 50x50]
+      ImagePaintable (ImageBox<IMG>) [8,8 50x50]

--- a/Tests/LibWeb/Layout/input/flex/intrinsic-cross-size-contribution-with-main-size-constraint.html
+++ b/Tests/LibWeb/Layout/input/flex/intrinsic-cross-size-contribution-with-main-size-constraint.html
@@ -1,0 +1,9 @@
+<!doctype html><style type="text/css">
+    * { outline: 1px solid black; }
+    body {
+        display: flex;
+        position: absolute;
+        left: 0px;
+    }
+    img { max-width: 50px; }
+</style><body><img src="../120.png">

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -34,6 +34,8 @@ private:
     [[nodiscard]] bool should_treat_cross_max_size_as_none(Box const&) const;
 
     [[nodiscard]] CSSPixels adjust_main_size_through_aspect_ratio_for_cross_size_min_max_constraints(Box const&, CSSPixels main_size, CSS::Size const& min_cross_size, CSS::Size const& max_cross_size) const;
+    [[nodiscard]] CSSPixels adjust_cross_size_through_aspect_ratio_for_main_size_min_max_constraints(Box const&, CSSPixels cross_size, CSS::Size const& min_main_size, CSS::Size const& max_main_size) const;
+
     [[nodiscard]] CSSPixels calculate_main_size_from_cross_size_and_aspect_ratio(CSSPixels cross_size, CSSPixelFraction aspect_ratio) const;
     [[nodiscard]] CSSPixels calculate_cross_size_from_main_size_and_aspect_ratio(CSSPixels main_size, CSSPixelFraction aspect_ratio) const;
 


### PR DESCRIPTION
When determining the intrinsic cross size contribution of a flex item with a preferred aspect ratio, we have to account for any min/max constraints in the main axis.