### PR TITLE
LibWeb: Derive SVG root's natural size from width/height attributes

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/natural-width-from-svg-attributes.txt
+++ b/Tests/LibWeb/Layout/expected/svg/natural-width-from-svg-attributes.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x144 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 128x128 children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 64x64 [SVG] children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 64x64 children: not-inline
+      BlockContainer <(anonymous)> at (8,72) content-size 128x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x144]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 128x128]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 64x64]
+        SVGPathPaintable (SVGGeometryBox<rect>) [8,8 64x64]
+      PaintableWithLines (BlockContainer(anonymous)) [8,72 128x0]

--- a/Tests/LibWeb/Layout/input/svg/natural-width-from-svg-attributes.html
+++ b/Tests/LibWeb/Layout/input/svg/natural-width-from-svg-attributes.html
@@ -1,0 +1,14 @@
+<!doctype html><style>
+  * {
+    outline: 1px solid black;
+  }
+  body {
+    height: 128px;
+    width: 128px;
+  }
+  svg {
+    width: auto;
+    height: auto;
+    display: block;
+  }
+</style><body><svg width="64" height="64" viewBox="0 0 10 10" ><rect x="0" y="0" width="10" height="10" fill="green"></rect></svg>

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -77,8 +77,11 @@ public:
     {
         (void)suspend_handle_id;
     }
-    void unsuspend_redraw_all() const {};
-    void force_redraw() const {};
+    void unsuspend_redraw_all() const { }
+    void force_redraw() const { }
+
+    [[nodiscard]] RefPtr<CSS::CSSStyleValue> width_style_value_from_attribute() const;
+    [[nodiscard]] RefPtr<CSS::CSSStyleValue> height_style_value_from_attribute() const;
 
 private:
     SVGSVGElement(DOM::Document&, DOM::QualifiedName);


### PR DESCRIPTION
We were incorrectly looking at the CSS computed values for width and height to determine the natural size of <svg> root elements. This meant that elements where the attribute and computed value were different values would end up with incorrect natural size.

Visual progression on https://hemnet.se/

Before:
<img width="952" alt="Screenshot 2024-08-22 at 14 09 41" src="https://github.com/user-attachments/assets/38d5bc98-1d4c-4d4e-94d0-98a0879086d1">

After:
<img width="952" alt="Screenshot 2024-08-22 at 14 07 49" src="https://github.com/user-attachments/assets/3b235d8e-d876-4170-87aa-03cfeb52f6c6">
