### PR TITLE
LibWeb: Implement `DataTransferItem.prototype.getAsFile()` and `DataTransferItem.prototype.getAsString()`

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -903,16 +903,16 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 
         // An ECMAScript value V is converted to an IDL callback function type value by running the following algorithm:
         // 1. If the result of calling IsCallable(V) is false and the conversion to an IDL value is not being performed due to V being assigned to an attribute whose type is a nullable callback function that is annotated with [LegacyTreatNonObjectAsNull], then throw a TypeError.
-        if (!callback_function.is_legacy_treat_non_object_as_null) {
+        if (!parameter.type->is_nullable() && !callback_function.is_legacy_treat_non_object_as_null) {
             callback_function_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_function())
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, @js_name@@js_suffix@.to_string_without_side_effects());
 )~~~");
         }
         // 2. Return the IDL callback function type value that represents a reference to the same object that V represents, with the incumbent settings object as the callback context.
-        if (callback_function.is_legacy_treat_non_object_as_null) {
+        if (parameter.type->is_nullable() || callback_function.is_legacy_treat_non_object_as_null) {
             callback_function_generator.append(R"~~~(
-    WebIDL::CallbackType* @cpp_name@ = nullptr;
+    JS::GCPtr<WebIDL::CallbackType> @cpp_name@;
     if (@js_name@@js_suffix@.is_object())
         @cpp_name@ = vm.heap().allocate_without_realm<WebIDL::CallbackType>(@js_name@@js_suffix@.as_object(), HTML::incumbent_settings_object(), @operation_returns_promise@);
 )~~~");

--- a/Tests/LibWeb/Text/expected/HTML/data-transfer.txt
+++ b/Tests/LibWeb/Text/expected/HTML/data-transfer.txt
@@ -5,3 +5,4 @@ stringItem: kind=string, type=custom-type
 length=1, types=custom-type
 fileItem: kind=file, type=text/plain
 length=2, types=custom-type,Files
+fileItemAsFile: name=file.txt, type=text/plain

--- a/Tests/LibWeb/Text/expected/HTML/data-transfer.txt
+++ b/Tests/LibWeb/Text/expected/HTML/data-transfer.txt
@@ -3,6 +3,7 @@ effectAllowed: none
 length=0, types=
 stringItem: kind=string, type=custom-type
 length=1, types=custom-type
+stringItemAsString: data=well hello friends
 fileItem: kind=file, type=text/plain
 length=2, types=custom-type,Files
 fileItemAsFile: name=file.txt, type=text/plain

--- a/Tests/LibWeb/Text/input/HTML/data-transfer.html
+++ b/Tests/LibWeb/Text/input/HTML/data-transfer.html
@@ -29,6 +29,9 @@
         println(`fileItem: kind=${fileItem.kind}, type=${fileItem.type}`);
         println(`length=${dataTransferItemList.length}, types=${dataTransfer.types}`);
 
+        let fileItemAsFile = fileItem.getAsFile();
+        println(`fileItemAsFile: name=${fileItemAsFile.name}, type=${fileItemAsFile.type}`);
+
         if (dataTransferItemList[1] !== fileItem) {
             println("FAILED");
         }

--- a/Tests/LibWeb/Text/input/HTML/data-transfer.html
+++ b/Tests/LibWeb/Text/input/HTML/data-transfer.html
@@ -1,6 +1,6 @@
 <script src="../include.js"></script>
 <script>
-    test(() => {
+    test(async () => {
         let dataTransfer = new DataTransfer();
         println(`dropEffect: ${dataTransfer.dropEffect}`);
         println(`effectAllowed: ${dataTransfer.effectAllowed}`);
@@ -15,6 +15,14 @@
         if (dataTransferItemList[0] !== stringItem) {
             println("FAILED");
         }
+
+        let promise = new Promise((resolve, reject) => {
+            stringItem.getAsString(data => {
+                println(`stringItemAsString: data=${data}`);
+                resolve();
+            });
+        });
+        await promise;
 
         try {
             dataTransferItemList.add("well hello friends", "custom-type");

--- a/Userland/Libraries/LibWeb/HTML/DataTransferItem.h
+++ b/Userland/Libraries/LibWeb/HTML/DataTransferItem.h
@@ -25,6 +25,7 @@ public:
     String kind() const;
     String type() const;
 
+    void get_as_string(JS::GCPtr<WebIDL::CallbackType>) const;
     JS::GCPtr<FileAPI::File> get_as_file() const;
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/DataTransferItem.h
+++ b/Userland/Libraries/LibWeb/HTML/DataTransferItem.h
@@ -25,6 +25,8 @@ public:
     String kind() const;
     String type() const;
 
+    JS::GCPtr<FileAPI::File> get_as_file() const;
+
 private:
     DataTransferItem(JS::Realm&, JS::NonnullGCPtr<DataTransfer>, size_t item_index);
 

--- a/Userland/Libraries/LibWeb/HTML/DataTransferItem.idl
+++ b/Userland/Libraries/LibWeb/HTML/DataTransferItem.idl
@@ -8,5 +8,5 @@ interface DataTransferItem {
     readonly attribute DOMString kind;
     readonly attribute DOMString type;
     [FIXME] undefined getAsString(FunctionStringCallback? _callback);
-    [FIXME] File? getAsFile();
+    File? getAsFile();
 };

--- a/Userland/Libraries/LibWeb/HTML/DataTransferItem.idl
+++ b/Userland/Libraries/LibWeb/HTML/DataTransferItem.idl
@@ -7,6 +7,6 @@ callback FunctionStringCallback = undefined (DOMString data);
 interface DataTransferItem {
     readonly attribute DOMString kind;
     readonly attribute DOMString type;
-    [FIXME] undefined getAsString(FunctionStringCallback? _callback);
+    undefined getAsString(FunctionStringCallback? _callback);
     File? getAsFile();
 };


### PR DESCRIPTION
`getAsFile` is used on imgur after drag-and-dropping an image onto its page. This PR also includes `getAsString` as it's closely related and was the last prototype left for `DataTransferItem`.

https://github.com/user-attachments/assets/3f0fbbf2-d117-4441-9fb7-0e134504b052

