### PR TITLE
LibWeb/FileAPI: Blob.slice fix & spec update

### DIFF
--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -67,6 +67,8 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
 
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> slice_blob(Optional<i64> start = {}, Optional<i64> end = {}, Optional<String> const& content_type = {});
+
     ByteBuffer m_byte_buffer {};
     String m_type {};
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.idl
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.idl
@@ -9,7 +9,7 @@ interface Blob {
     readonly attribute DOMString type;
 
     // slice Blob into byte-ranged chunks
-    Blob slice(optional long long start, optional long long end, optional DOMString contentType);
+    Blob slice(optional [Clamp] long long start, optional [Clamp] long long end, optional DOMString contentType);
 
     // read from the Blob.
     [NewObject] ReadableStream stream();


### PR DESCRIPTION
This pull requests updates Blob.slice to follow the new spec steps, and adds the `[Clamp]` extended attribute to it's arguments to fix http://wpt.live/FileAPI/blob/Blob-slice-overflow.any.html.