### PR TITLE
LibGfx: Set opacity for BGRx8888 bitmaps in BMPLoader

### DIFF
--- a/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/BMPLoader.cpp
@@ -1372,7 +1372,9 @@ static ErrorOr<void> decode_bmp_pixel_data(BMPLoadingContext& context)
             case 24: {
                 if (!streamer.has_u24())
                     return Error::from_string_literal("Cannot read 24 bits");
-                context.bitmap->scanline(row)[column++] = streamer.read_u24();
+                auto color = streamer.read_u24();
+                color |= 0xff000000; // Set the alpha value to opaque (255), to be compatible to BitmapFormat::BGRA8888.
+                context.bitmap->scanline(row)[column++] = color;
                 break;
             }
             case 32:


### PR DESCRIPTION
<s>In case the original bitmap has no alpha channel
(BitmapFormat::BGRx8888), we need to set the alpha value of very pixel to opaque (255).</s>

Second solution:
Previously, when loading a 24 bit BMP image the alpha bytes were
uninitialized. This made the image look (mostly) transparent when it is
passed to Skia as BitmapFormat::BGRA8888.
Now, the alpha bytes are set to opaque (255) by BMPImageDecoderPlugin.

Fixes #1132