### PR TITLE
Add a style sheet inspector

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -1,3 +1,7 @@
+:root {
+    --code-font-family: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 @media (prefers-color-scheme: dark) {
     :root {
         --background: rgb(23, 23, 23);
@@ -174,6 +178,17 @@ body {
     overflow: auto scroll;
 }
 
+.tab-header {
+    position: sticky;
+    top: 2px; /* FIXME: Remove this when https://github.com/LadybirdBrowser/ladybird/issues/1245 is resolved. */
+    left: 0;
+    right: 0;
+    background-color: var(--tab-controls);
+    border-top: 2px solid var(--background);
+    display: flex;
+    padding: 0.5em;
+}
+
 details > :not(:first-child) {
     display: list-item;
     list-style: none inside;
@@ -204,7 +219,7 @@ details > :not(:first-child) {
 }
 
 .console {
-    font-family: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-family: var(--code-font-family);
     width: 100%;
     height: 100%;
 }
@@ -329,4 +344,15 @@ details > :not(:first-child) {
 .console-log-table td {
     padding: 4px;
     text-align: left;
+}
+
+#style-sheet-picker {
+    flex-grow: 1;
+}
+
+#style-sheet-source {
+    font-size: 10pt;
+    font-family: var(--code-font-family);
+    white-space: pre;
+    padding: 0.5em;
 }

--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -168,7 +168,6 @@ body {
     height: calc(100% - 40px);
 
     display: none;
-    border-radius: 0.5rem;
 
     padding: 8px 0px 0px 4px;
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -326,6 +326,10 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_window->new_tab_from_content(html, Web::HTML::ActivateTab::Yes);
     };
 
+    view().on_inspector_requested_style_sheet_source = [this](auto const& identifier) {
+        view().request_style_sheet_source(identifier);
+    };
+
     view().on_navigate_back = [this]() {
         back();
     };

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -319,47 +319,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         m_find_in_page->update_result_label(current_match_index, total_match_count);
     };
 
-    m_select_dropdown = new QMenu("Select Dropdown", this);
-    QObject::connect(m_select_dropdown, &QMenu::aboutToHide, this, [this]() {
-        if (!m_select_dropdown->activeAction())
-            view().select_dropdown_closed({});
-    });
-
-    view().on_request_select_dropdown = [this](Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) {
-        m_select_dropdown->clear();
-        m_select_dropdown->setMinimumWidth(minimum_width / view().device_pixel_ratio());
-
-        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
-            QAction* action = new QAction(qstring_from_ak_string(in_option_group ? MUST(String::formatted("    {}", item_option.label)) : item_option.label), this);
-            action->setCheckable(true);
-            action->setChecked(item_option.selected);
-            action->setDisabled(item_option.disabled);
-            action->setData(QVariant(static_cast<uint>(item_option.id)));
-            QObject::connect(action, &QAction::triggered, this, &Tab::select_dropdown_action);
-            m_select_dropdown->addAction(action);
-        };
-
-        for (auto const& item : items) {
-            if (item.has<Web::HTML::SelectItemOptionGroup>()) {
-                auto const& item_option_group = item.get<Web::HTML::SelectItemOptionGroup>();
-                QAction* subtitle = new QAction(qstring_from_ak_string(item_option_group.label), this);
-                subtitle->setDisabled(true);
-                m_select_dropdown->addAction(subtitle);
-
-                for (auto const& item_option : item_option_group.items)
-                    add_menu_item(item_option, true);
-            }
-
-            if (item.has<Web::HTML::SelectItemOption>())
-                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
-
-            if (item.has<Web::HTML::SelectItemSeparator>())
-                m_select_dropdown->addSeparator();
-        }
-
-        m_select_dropdown->exec(view().map_point_to_global_position(content_position));
-    };
-
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);
 
     view().on_received_source = [this](auto const& url, auto const& source) {
@@ -794,12 +753,6 @@ Tab::~Tab()
     // Delete the InspectorWidget explicitly to ensure it is deleted before the WebContentView. Otherwise, Qt
     // can destroy these objects in any order, which may cause use-after-free in InspectorWidget's destructor.
     delete m_inspector_widget;
-}
-
-void Tab::select_dropdown_action()
-{
-    QAction* action = qobject_cast<QAction*>(sender());
-    view().select_dropdown_closed(action->data().value<uint>());
 }
 
 void Tab::update_reset_zoom_button()

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -84,7 +84,6 @@ public:
 public slots:
     void focus_location_editor();
     void location_edit_return_pressed();
-    void select_dropdown_action();
 
 signals:
     void title_changed(int id, QString const&);

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -142,9 +142,56 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
         auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), request_server_client));
         return worker_client->dup_socket();
     };
+
+    m_select_dropdown = new QMenu("Select Dropdown", this);
+    QObject::connect(m_select_dropdown, &QMenu::aboutToHide, this, [this]() {
+        if (!m_select_dropdown->activeAction())
+            select_dropdown_closed({});
+    });
+
+    on_request_select_dropdown = [this](Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items) {
+        m_select_dropdown->clear();
+        m_select_dropdown->setMinimumWidth(minimum_width / device_pixel_ratio());
+
+        auto add_menu_item = [this](Web::HTML::SelectItemOption const& item_option, bool in_option_group) {
+            QAction* action = new QAction(qstring_from_ak_string(in_option_group ? MUST(String::formatted("    {}", item_option.label)) : item_option.label), this);
+            action->setCheckable(true);
+            action->setChecked(item_option.selected);
+            action->setDisabled(item_option.disabled);
+            action->setData(QVariant(static_cast<uint>(item_option.id)));
+            QObject::connect(action, &QAction::triggered, this, &WebContentView::select_dropdown_action);
+            m_select_dropdown->addAction(action);
+        };
+
+        for (auto const& item : items) {
+            if (item.has<Web::HTML::SelectItemOptionGroup>()) {
+                auto const& item_option_group = item.get<Web::HTML::SelectItemOptionGroup>();
+                QAction* subtitle = new QAction(qstring_from_ak_string(item_option_group.label), this);
+                subtitle->setDisabled(true);
+                m_select_dropdown->addAction(subtitle);
+
+                for (auto const& item_option : item_option_group.items)
+                    add_menu_item(item_option, true);
+            }
+
+            if (item.has<Web::HTML::SelectItemOption>())
+                add_menu_item(item.get<Web::HTML::SelectItemOption>(), false);
+
+            if (item.has<Web::HTML::SelectItemSeparator>())
+                m_select_dropdown->addSeparator();
+        }
+
+        m_select_dropdown->exec(map_point_to_global_position(content_position));
+    };
 }
 
 WebContentView::~WebContentView() = default;
+
+void WebContentView::select_dropdown_action()
+{
+    QAction* action = qobject_cast<QAction*>(sender());
+    select_dropdown_closed(action->data().value<uint>());
+}
 
 static Web::UIEvents::MouseButton get_button_from_qt_mouse_button(Qt::MouseButton button)
 {

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -22,6 +22,7 @@
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
 #include <QAbstractScrollArea>
+#include <QMenu>
 #include <QTimer>
 #include <QUrl>
 
@@ -88,6 +89,9 @@ public:
 
     QPoint map_point_to_global_position(Gfx::IntPoint) const;
 
+public slots:
+    void select_dropdown_action();
+
 signals:
     void urls_dropped(QList<QUrl> const&);
 
@@ -119,6 +123,8 @@ private:
     bool m_should_show_line_box_borders { false };
 
     Gfx::IntSize m_viewport_size;
+
+    QMenu* m_select_dropdown { nullptr };
 };
 
 }

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -2,7 +2,7 @@
 # Functions for generating sources using host tools
 #
 
-function(embed_as_string_view name source_file output source_variable_name)
+function(embed_as_string name source_file output source_variable_name)
     cmake_parse_arguments(PARSE_ARGV 4 EMBED_STRING_VIEW "" "NAMESPACE" "")
     set(namespace_arg "")
     if (EMBED_STRING_VIEW_NAMESPACE)
@@ -11,11 +11,11 @@ function(embed_as_string_view name source_file output source_variable_name)
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
     add_custom_command(
         OUTPUT "${output}"
-        COMMAND "${Python3_EXECUTABLE}" "${SerenityOS_SOURCE_DIR}/Meta/embed_as_string_view.py" "${source_file}" -o "${output}.tmp" -n "${source_variable_name}" ${namespace_arg}
+        COMMAND "${Python3_EXECUTABLE}" "${SerenityOS_SOURCE_DIR}/Meta/embed_as_string.py" "${source_file}" -o "${output}.tmp" -n "${source_variable_name}" ${namespace_arg}
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${output}.tmp" "${output}"
         COMMAND "${CMAKE_COMMAND}" -E remove "${output}.tmp"
         VERBATIM
-        DEPENDS "${SerenityOS_SOURCE_DIR}/Meta/embed_as_string_view.py"
+        DEPENDS "${SerenityOS_SOURCE_DIR}/Meta/embed_as_string.py"
         MAIN_DEPENDENCY "${source_file}"
     )
 
@@ -78,4 +78,3 @@ function(compile_ipc source output)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${output} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${current_source_dir_relative}" OPTIONAL)
     endif()
 endfunction()
-

--- a/Meta/CMake/libweb_generators.cmake
+++ b/Meta/CMake/libweb_generators.cmake
@@ -64,7 +64,7 @@ function (generate_css_implementation)
         arguments -j "${LIBWEB_INPUT_FOLDER}/CSS/Keywords.json"
     )
 
-    embed_as_string_view(
+    embed_as_string(
         "DefaultStyleSheetSource.cpp"
         "${LIBWEB_INPUT_FOLDER}/CSS/Default.css"
         "CSS/DefaultStyleSheetSource.cpp"
@@ -72,7 +72,7 @@ function (generate_css_implementation)
         NAMESPACE "Web::CSS"
     )
 
-    embed_as_string_view(
+    embed_as_string(
         "QuirksModeStyleSheetSource.cpp"
         "${LIBWEB_INPUT_FOLDER}/CSS/QuirksMode.css"
         "CSS/QuirksModeStyleSheetSource.cpp"
@@ -80,7 +80,7 @@ function (generate_css_implementation)
         NAMESPACE "Web::CSS"
     )
 
-    embed_as_string_view(
+    embed_as_string(
         "MathMLStyleSheetSource.cpp"
         "${LIBWEB_INPUT_FOLDER}/MathML/Default.css"
         "MathML/MathMLStyleSheetSource.cpp"
@@ -88,7 +88,7 @@ function (generate_css_implementation)
         NAMESPACE "Web::CSS"
     )
 
-    embed_as_string_view(
+    embed_as_string(
         "SVGStyleSheetSource.cpp"
         "${LIBWEB_INPUT_FOLDER}/SVG/Default.css"
         "SVG/SVGStyleSheetSource.cpp"

--- a/Meta/embed_as_string.py
+++ b/Meta/embed_as_string.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 r"""
-    Embeds a file into a StringView, a la #embed from C++23
+    Embeds a file into a String, a la #embed from C++23
 """
 
 import argparse
@@ -21,15 +21,15 @@ def main():
     args = parser.parse_args()
 
     with open(args.output, 'w') as f:
-        f.write("#include <AK/StringView.h>\n")
+        f.write("#include <AK/String.h>\n")
         if args.namespace:
             f.write(f"namespace {args.namespace} {{\n")
-        f.write(f"extern StringView {args.variable_name};\n")
-        f.write(f"StringView {args.variable_name} = R\"~~~(")
+        f.write(f"extern String {args.variable_name};\n")
+        f.write(f"String {args.variable_name} = R\"~~~(")
         with open(args.input, 'r') as input:
             for line in input.readlines():
                 f.write(f"{line}")
-        f.write(")~~~\"sv;\n")
+        f.write(")~~~\"_string;\n")
         if args.namespace:
             f.write("}\n")
 

--- a/Meta/gn/build/embed_as_string.gni
+++ b/Meta/gn/build/embed_as_string.gni
@@ -1,6 +1,6 @@
-# This file introduces a template for calling embed_as_string_view.py.
+# This file introduces a template for calling embed_as_string.py.
 #
-# embed_as_string_view behaves like C++23 #embed, converting an input file into
+# embed_as_string behaves like C++23 #embed, converting an input file into
 # an AK::StringView literal rather than a C-string literal. The literal will
 # be placed into a global variable, optionally with a namespace wrapping it.
 #
@@ -19,21 +19,21 @@
 #
 # Example use:
 #
-#   embed_as_string_view("embed_my_file") {
+#   embed_as_string("embed_my_file") {
 #     input = "MyFile.txt"
 #     output = "$root_gen_dir/MyDirectory/MyFile.cpp"
 #     variable_name = "my_file_contents"
 #     namespace = "My::NS"
 #   }
 
-template("embed_as_string_view") {
+template("embed_as_string") {
   assert(defined(invoker.input), "must set 'input' in $target_name")
   assert(defined(invoker.output), "must set 'output' in $target_name")
   assert(defined(invoker.variable_name),
          "must set 'variable_name' in $target_name")
 
   action(target_name) {
-    script = "//Meta/embed_as_string_view.py"
+    script = "//Meta/embed_as_string.py"
 
     sources = [ invoker.input ]
     outputs = [ invoker.output ]

--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/BUILD.gn
@@ -1,5 +1,5 @@
 import("//Meta/gn/build/compiled_action.gni")
-import("//Meta/gn/build/embed_as_string_view.gni")
+import("//Meta/gn/build/embed_as_string.gni")
 import("generate_idl_bindings.gni")
 import("idl_files.gni")
 
@@ -220,28 +220,28 @@ compiled_action("generate_css_keyword") {
   ]
 }
 
-embed_as_string_view("generate_default_stylesheet_source") {
+embed_as_string("generate_default_stylesheet_source") {
   input = "CSS/Default.css"
   output = "$target_gen_dir/CSS/DefaultStyleSheetSource.cpp"
   variable_name = "default_stylesheet_source"
   namespace = "Web::CSS"
 }
 
-embed_as_string_view("generate_mathml_stylesheet_source") {
+embed_as_string("generate_mathml_stylesheet_source") {
   input = "MathML/Default.css"
   output = "$target_gen_dir/MathML/MathMLStyleSheetSource.cpp"
   variable_name = "mathml_stylesheet_source"
   namespace = "Web::CSS"
 }
 
-embed_as_string_view("generate_svg_stylesheet_source") {
+embed_as_string("generate_svg_stylesheet_source") {
   input = "SVG/Default.css"
   output = "$target_gen_dir/SVG/SVGStyleSheetSource.cpp"
   variable_name = "svg_stylesheet_source"
   namespace = "Web::CSS"
 }
 
-embed_as_string_view("generate_quirks_mode_stylesheet_source") {
+embed_as_string("generate_quirks_mode_stylesheet_source") {
   input = "CSS/QuirksMode.css"
   output = "$target_gen_dir/CSS/QuirksModeStyleSheetSource.cpp"
   variable_name = "quirks_mode_stylesheet_source"

--- a/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWebView/BUILD.gn
@@ -1,7 +1,7 @@
 import("//Meta/gn/build/compiled_action.gni")
 import("//Meta/gn/build/download_cache.gni")
 import("//Meta/gn/build/download_file.gni")
-import("//Meta/gn/build/embed_as_string_view.gni")
+import("//Meta/gn/build/embed_as_string.gni")
 
 declare_args() {
   # If true, Download public suffix list from GitHub.
@@ -106,7 +106,7 @@ compiled_action("UIProcessServerEndpoint") {
   ]
 }
 
-embed_as_string_view("generate_native_stylesheet_source") {
+embed_as_string("generate_native_stylesheet_source") {
   input = "Native.css"
   output = "$target_gen_dir/NativeStyleSheetSource.cpp"
   variable_name = "native_stylesheet_source"

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -102,6 +102,7 @@ set(SOURCES
     CSS/StyleProperties.cpp
     CSS/StyleProperty.cpp
     CSS/StyleSheet.cpp
+    CSS/StyleSheetIdentifier.cpp
     CSS/StyleSheetList.cpp
     CSS/StyleValues/AngleStyleValue.cpp
     CSS/StyleValues/BackgroundRepeatStyleValue.cpp

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -104,6 +104,7 @@ void CSSImportRule::resource_did_load()
     }
 
     m_style_sheet = sheet;
+    m_style_sheet->set_owner_css_rule(this);
 
     m_document->style_computer().invalidate_rule_cache();
     m_document->style_computer().load_fonts_from_sheet(*m_style_sheet);

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -97,7 +97,7 @@ void CSSImportRule::resource_did_load()
         dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Resource did load, has encoded data. URL: {}", resource()->url());
     }
 
-    auto* sheet = parse_css_stylesheet(CSS::Parser::ParsingContext(*m_document, resource()->url()), resource()->encoded_data());
+    auto* sheet = parse_css_stylesheet(CSS::Parser::ParsingContext(*m_document, resource()->url()), resource()->encoded_data(), resource()->url());
     if (!sheet) {
         dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Failed to parse stylesheet: {}", resource()->url());
         return;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022-2024, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2024, Tim Ledbetter <timledbetter@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -7,6 +8,7 @@
 
 #include <LibWeb/Bindings/CSSStyleSheetPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
@@ -101,10 +103,10 @@ CSSStyleSheet::CSSStyleSheet(JS::Realm& realm, CSSRuleList& rules, MediaList& me
     for (auto& rule : *m_rules)
         rule->set_parent_style_sheet(this);
 
-    recalculate_namespaces();
+    recalculate_rule_caches();
 
     m_rules->on_change = [this]() {
-        recalculate_namespaces();
+        recalculate_rule_caches();
     };
 }
 
@@ -123,6 +125,7 @@ void CSSStyleSheet::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_default_namespace_rule);
     visitor.visit(m_constructor_document);
     visitor.visit(m_namespace_rules);
+    visitor.visit(m_import_rules);
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-insertrule
@@ -340,34 +343,43 @@ Optional<FlyString> CSSStyleSheet::namespace_uri(StringView namespace_prefix) co
         });
 }
 
-void CSSStyleSheet::recalculate_namespaces()
+void CSSStyleSheet::recalculate_rule_caches()
 {
     m_default_namespace_rule = nullptr;
     m_namespace_rules.clear();
+    m_import_rules.clear();
 
-    for (JS::NonnullGCPtr<CSSRule> rule : *m_rules) {
+    for (auto const& rule : *m_rules) {
+        // "Any @import rules must precede all other valid at-rules and style rules in a style sheet
+        // (ignoring @charset and @layer statement rules) and must not have any other valid at-rules
+        // or style rules between it and previous @import rules, or else the @import rule is invalid."
+        // https://drafts.csswg.org/css-cascade-5/#at-import
+        //
         // "Any @namespace rules must follow all @charset and @import rules and precede all other
         // non-ignored at-rules and style rules in a style sheet.
         // ...
         // A syntactically invalid @namespace rule (whether malformed or misplaced) must be ignored."
         // https://drafts.csswg.org/css-namespaces/#syntax
         switch (rule->type()) {
-        case CSSRule::Type::Import:
-            continue;
-
-        case CSSRule::Type::Namespace:
+        case CSSRule::Type::Import: {
+            // @import rules must appear before @namespace rules, so skip this if we've seen @namespace.
+            if (!m_namespace_rules.is_empty())
+                continue;
+            m_import_rules.append(verify_cast<CSSImportRule>(*rule));
             break;
+        }
+        case CSSRule::Type::Namespace: {
+            auto& namespace_rule = verify_cast<CSSNamespaceRule>(*rule);
+            if (!namespace_rule.namespace_uri().is_empty() && namespace_rule.prefix().is_empty())
+                m_default_namespace_rule = namespace_rule;
 
+            m_namespace_rules.set(namespace_rule.prefix(), namespace_rule);
+            break;
+        }
         default:
             // Any other types mean that further @namespace rules are invalid, so we can stop here.
             return;
         }
-
-        auto& namespace_rule = verify_cast<CSSNamespaceRule>(*rule);
-        if (!namespace_rule.namespace_uri().is_empty() && namespace_rule.prefix().is_empty())
-            m_default_namespace_rule = namespace_rule;
-
-        m_namespace_rules.set(namespace_rule.prefix(), namespace_rule);
     }
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -371,4 +371,14 @@ void CSSStyleSheet::recalculate_namespaces()
     }
 }
 
+void CSSStyleSheet::set_source_text(String source)
+{
+    m_source_text = move(source);
+}
+
+Optional<String> CSSStyleSheet::source_text(Badge<DOM::Document>) const
+{
+    return m_source_text;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -78,6 +78,9 @@ public:
 
     bool disallow_modification() const { return m_disallow_modification; }
 
+    void set_source_text(String);
+    Optional<String> source_text(Badge<DOM::Document>) const;
+
 private:
     CSSStyleSheet(JS::Realm&, CSSRuleList&, MediaList&, Optional<URL::URL> location);
 
@@ -88,6 +91,8 @@ private:
 
     void set_constructed(bool constructed) { m_constructed = constructed; }
     void set_disallow_modification(bool disallow_modification) { m_disallow_modification = disallow_modification; }
+
+    Optional<String> m_source_text;
 
     JS::GCPtr<CSSRuleList> m_rules;
     JS::GCPtr<CSSNamespaceRule> m_default_namespace_rule;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -68,6 +68,8 @@ public:
 
     Optional<FlyString> namespace_uri(StringView namespace_prefix) const;
 
+    Vector<JS::NonnullGCPtr<CSSImportRule>> const& import_rules() const { return m_import_rules; }
+
     Optional<URL::URL> base_url() const { return m_base_url; }
     void set_base_url(Optional<URL::URL> base_url) { m_base_url = move(base_url); }
 
@@ -87,7 +89,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    void recalculate_namespaces();
+    void recalculate_rule_caches();
 
     void set_constructed(bool constructed) { m_constructed = constructed; }
     void set_disallow_modification(bool disallow_modification) { m_disallow_modification = disallow_modification; }
@@ -97,6 +99,7 @@ private:
     JS::GCPtr<CSSRuleList> m_rules;
     JS::GCPtr<CSSNamespaceRule> m_default_namespace_rule;
     HashMap<FlyString, JS::GCPtr<CSSNamespaceRule>> m_namespace_rules;
+    Vector<JS::NonnullGCPtr<CSSImportRule>> m_import_rules;
 
     JS::GCPtr<StyleSheetList> m_style_sheet_list;
     JS::GCPtr<CSSRule> m_owner_css_rule;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Helpers.cpp
@@ -20,9 +20,14 @@ CSS::CSSStyleSheet* parse_css_stylesheet(CSS::Parser::ParsingContext const& cont
     if (css.is_empty()) {
         auto rule_list = CSS::CSSRuleList::create_empty(context.realm());
         auto media_list = CSS::MediaList::create(context.realm(), {});
-        return CSS::CSSStyleSheet::create(context.realm(), rule_list, media_list, location);
+        auto style_sheet = CSS::CSSStyleSheet::create(context.realm(), rule_list, media_list, location);
+        style_sheet->set_source_text({});
+        return style_sheet;
     }
-    return CSS::Parser::Parser::create(context, css).parse_as_css_stylesheet(location);
+    auto* style_sheet = CSS::Parser::Parser::create(context, css).parse_as_css_stylesheet(location);
+    // FIXME: Avoid this copy
+    style_sheet->set_source_text(MUST(String::from_utf8(css)));
+    return style_sheet;
 }
 
 CSS::ElementInlineCSSStyleDeclaration* parse_css_style_attribute(CSS::Parser::ParsingContext const& context, StringView css, DOM::Element& element)

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2024, Matthew Olsson <mattco@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -252,6 +252,24 @@ static CSSStyleSheet& svg_stylesheet(DOM::Document const& document)
         sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document), svg_stylesheet_source));
     }
     return *sheet;
+}
+
+Optional<String> StyleComputer::user_agent_style_sheet_source(StringView name)
+{
+    extern String default_stylesheet_source;
+    extern String quirks_mode_stylesheet_source;
+    extern String mathml_stylesheet_source;
+    extern String svg_stylesheet_source;
+
+    if (name == "CSS/Default.css"sv)
+        return default_stylesheet_source;
+    if (name == "CSS/QuirksMode.css"sv)
+        return quirks_mode_stylesheet_source;
+    if (name == "MathML/Default.css"sv)
+        return mathml_stylesheet_source;
+    if (name == "SVG/Default.css"sv)
+        return svg_stylesheet_source;
+    return {};
 }
 
 template<typename Callback>

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -218,7 +218,7 @@ static CSSStyleSheet& default_stylesheet(DOM::Document const& document)
 {
     static JS::Handle<CSSStyleSheet> sheet;
     if (!sheet.cell()) {
-        extern StringView default_stylesheet_source;
+        extern String default_stylesheet_source;
         sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document), default_stylesheet_source));
     }
     return *sheet;
@@ -228,7 +228,7 @@ static CSSStyleSheet& quirks_mode_stylesheet(DOM::Document const& document)
 {
     static JS::Handle<CSSStyleSheet> sheet;
     if (!sheet.cell()) {
-        extern StringView quirks_mode_stylesheet_source;
+        extern String quirks_mode_stylesheet_source;
         sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document), quirks_mode_stylesheet_source));
     }
     return *sheet;
@@ -238,7 +238,7 @@ static CSSStyleSheet& mathml_stylesheet(DOM::Document const& document)
 {
     static JS::Handle<CSSStyleSheet> sheet;
     if (!sheet.cell()) {
-        extern StringView mathml_stylesheet_source;
+        extern String mathml_stylesheet_source;
         sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document), mathml_stylesheet_source));
     }
     return *sheet;
@@ -248,7 +248,7 @@ static CSSStyleSheet& svg_stylesheet(DOM::Document const& document)
 {
     static JS::Handle<CSSStyleSheet> sheet;
     if (!sheet.cell()) {
-        extern StringView svg_stylesheet_source;
+        extern String svg_stylesheet_source;
         sheet = JS::make_handle(parse_css_stylesheet(CSS::Parser::ParsingContext(document), svg_stylesheet_source));
     }
     return *sheet;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -269,7 +269,7 @@ void StyleComputer::for_each_stylesheet(CascadeOrigin cascade_origin, Callback c
             callback(*m_user_style_sheet, {});
     }
     if (cascade_origin == CascadeOrigin::Author) {
-        document().for_each_css_style_sheet([&](CSSStyleSheet& sheet) {
+        document().for_each_active_css_style_sheet([&](CSSStyleSheet& sheet) {
             callback(sheet, {});
         });
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2024, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -115,6 +115,8 @@ public:
     static void for_each_property_expanding_shorthands(PropertyID, CSSStyleValue const&, AllowUnresolved, Function<void(PropertyID, CSSStyleValue const&)> const& set_longhand_property);
     static void set_property_expanding_shorthands(StyleProperties&, PropertyID, CSSStyleValue const&, CSS::CSSStyleDeclaration const*, StyleProperties const& style_for_revert, Important = Important::No);
     static NonnullRefPtr<CSSStyleValue const> get_inherit_value(JS::Realm& initial_value_context_realm, CSS::PropertyID, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type> = {});
+
+    static Optional<String> user_agent_style_sheet_source(StringView name);
 
     explicit StyleComputer(DOM::Document&);
     ~StyleComputer();

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetIdentifier.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetIdentifier.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "StyleSheetIdentifier.h"
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+
+namespace Web::CSS {
+
+StringView style_sheet_identifier_type_to_string(StyleSheetIdentifier::Type type)
+{
+    switch (type) {
+    case StyleSheetIdentifier::Type::StyleElement:
+        return "StyleElement"sv;
+    case StyleSheetIdentifier::Type::LinkElement:
+        return "LinkElement"sv;
+    case StyleSheetIdentifier::Type::ImportRule:
+        return "ImportRule"sv;
+    case StyleSheetIdentifier::Type::UserAgent:
+        return "UserAgent"sv;
+    case StyleSheetIdentifier::Type::UserStyle:
+        return "UserStyle"sv;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+Optional<StyleSheetIdentifier::Type> style_sheet_identifier_type_from_string(StringView string)
+{
+    if (string == "StyleElement"sv)
+        return StyleSheetIdentifier::Type::StyleElement;
+    if (string == "LinkElement"sv)
+        return StyleSheetIdentifier::Type::LinkElement;
+    if (string == "ImportRule"sv)
+        return StyleSheetIdentifier::Type::ImportRule;
+    if (string == "UserAgent"sv)
+        return StyleSheetIdentifier::Type::UserAgent;
+    if (string == "UserStyle"sv)
+        return StyleSheetIdentifier::Type::UserStyle;
+    return {};
+}
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder& encoder, Web::CSS::StyleSheetIdentifier const& style_sheet_source)
+{
+    TRY(encoder.encode(style_sheet_source.type));
+    TRY(encoder.encode(style_sheet_source.dom_element_unique_id));
+    TRY(encoder.encode(style_sheet_source.url));
+
+    return {};
+}
+
+template<>
+ErrorOr<Web::CSS::StyleSheetIdentifier> decode(Decoder& decoder)
+{
+    auto type = TRY(decoder.decode<Web::CSS::StyleSheetIdentifier::Type>());
+    auto dom_element_unique_id = TRY(decoder.decode<Optional<i32>>());
+    auto url = TRY(decoder.decode<Optional<String>>());
+
+    return Web::CSS::StyleSheetIdentifier {
+        .type = type,
+        .dom_element_unique_id = move(dom_element_unique_id),
+        .url = move(url),
+    };
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleSheetIdentifier.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibIPC/Forward.h>
+#include <LibURL/URL.h>
+
+namespace Web::CSS {
+
+struct StyleSheetIdentifier {
+    enum class Type : u8 {
+        StyleElement,
+        LinkElement,
+        ImportRule,
+        UserAgent,
+        UserStyle,
+    } type;
+    Optional<i32> dom_element_unique_id {};
+    Optional<String> url {};
+};
+
+StringView style_sheet_identifier_type_to_string(StyleSheetIdentifier::Type);
+Optional<StyleSheetIdentifier::Type> style_sheet_identifier_type_from_string(StringView);
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, Web::CSS::StyleSheetIdentifier const&);
+
+template<>
+ErrorOr<Web::CSS::StyleSheetIdentifier> decode(Decoder&);
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2018-2024, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021-2023, Luke Wilde <lukew@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2024, Matthew Olsson <mattco@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -26,10 +26,12 @@
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/AnimationEvent.h>
 #include <LibWeb/CSS/CSSAnimation.h>
+#include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/MediaQueryList.h>
 #include <LibWeb/CSS/MediaQueryListEvent.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/VisualViewport.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
@@ -84,6 +86,7 @@
 #include <LibWeb/HTML/HTMLLinkElement.h>
 #include <LibWeb/HTML/HTMLObjectElement.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
+#include <LibWeb/HTML/HTMLStyleElement.h>
 #include <LibWeb/HTML/HTMLTitleElement.h>
 #include <LibWeb/HTML/HashChangeEvent.h>
 #include <LibWeb/HTML/ListOfAvailableImages.h>
@@ -119,8 +122,8 @@
 #include <LibWeb/ResizeObserver/ResizeObserverEntry.h>
 #include <LibWeb/SVG/SVGDecodedImageData.h>
 #include <LibWeb/SVG/SVGElement.h>
+#include <LibWeb/SVG/SVGStyleElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
-#include <LibWeb/SVG/TagNames.h>
 #include <LibWeb/Selection/Selection.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/FocusEvent.h>
@@ -5119,6 +5122,75 @@ void Document::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&
                 callback(style_sheet);
         });
     }
+}
+
+static Optional<CSS::CSSStyleSheet&> find_style_sheet_with_url(String const& url, CSS::CSSStyleSheet& style_sheet)
+{
+    if (style_sheet.location() == url)
+        return style_sheet;
+
+    for (auto& import_rule : style_sheet.import_rules()) {
+        if (import_rule->loaded_style_sheet()) {
+            if (auto match = find_style_sheet_with_url(url, *import_rule->loaded_style_sheet()); match.has_value())
+                return match;
+        }
+    }
+
+    return {};
+}
+
+Optional<String> Document::get_style_sheet_source(CSS::StyleSheetIdentifier const& identifier) const
+{
+    switch (identifier.type) {
+    case CSS::StyleSheetIdentifier::Type::StyleElement:
+        if (identifier.dom_element_unique_id.has_value()) {
+            if (auto* node = Node::from_unique_id(*identifier.dom_element_unique_id)) {
+                if (node->is_html_style_element()) {
+                    if (auto* sheet = verify_cast<HTML::HTMLStyleElement>(*node).sheet())
+                        return sheet->source_text({});
+                }
+                if (node->is_svg_style_element()) {
+                    if (auto* sheet = verify_cast<SVG::SVGStyleElement>(*node).sheet())
+                        return sheet->source_text({});
+                }
+            }
+        }
+        return {};
+    case CSS::StyleSheetIdentifier::Type::LinkElement:
+    case CSS::StyleSheetIdentifier::Type::ImportRule: {
+        if (!identifier.url.has_value()) {
+            dbgln("Attempting to get link or imported style-sheet with no url; giving up");
+            return {};
+        }
+
+        if (m_style_sheets) {
+            for (auto& style_sheet : m_style_sheets->sheets()) {
+                if (auto match = find_style_sheet_with_url(identifier.url.value(), style_sheet); match.has_value())
+                    return match->source_text({});
+            }
+        }
+
+        if (m_adopted_style_sheets) {
+            Optional<String> result;
+            m_adopted_style_sheets->for_each<CSS::CSSStyleSheet>([&](auto& style_sheet) {
+                if (result.has_value())
+                    return;
+
+                if (auto match = find_style_sheet_with_url(identifier.url.value(), style_sheet); match.has_value())
+                    result = match->source_text({});
+            });
+            return result;
+        }
+
+        return {};
+    }
+    case CSS::StyleSheetIdentifier::Type::UserAgent:
+        return CSS::StyleComputer::user_agent_style_sheet_source(identifier.url.value());
+    case CSS::StyleSheetIdentifier::Type::UserStyle:
+        return page().user_style();
+    }
+
+    return {};
 }
 
 void Document::register_shadow_root(Badge<DOM::ShadowRoot>, DOM::ShadowRoot& shadow_root)

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2702,7 +2702,7 @@ void Document::evaluate_media_rules()
         return;
 
     bool any_media_queries_changed_match_state = false;
-    for_each_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
+    for_each_active_css_style_sheet([&](CSS::CSSStyleSheet& style_sheet) {
         if (style_sheet.evaluate_media_queries(*window))
             any_media_queries_changed_match_state = true;
     });
@@ -5104,7 +5104,7 @@ WebIDL::ExceptionOr<void> Document::set_adopted_style_sheets(JS::Value new_value
     return {};
 }
 
-void Document::for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const
+void Document::for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const
 {
     if (m_style_sheets) {
         for (auto& style_sheet : m_style_sheets->sheets()) {

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -164,6 +164,8 @@ public:
 
     CSS::StyleSheetList* style_sheets_for_bindings() { return &style_sheets(); }
 
+    Optional<String> get_style_sheet_source(CSS::StyleSheetIdentifier const&) const;
+
     virtual FlyString node_name() const override { return "#document"_fly_string; }
 
     void set_hovered_node(Node*);

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -160,7 +160,7 @@ public:
     CSS::StyleSheetList& style_sheets();
     CSS::StyleSheetList const& style_sheets() const;
 
-    void for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
+    void for_each_active_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
 
     CSS::StyleSheetList* style_sheets_for_bindings() { return &style_sheets(); }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -83,6 +83,7 @@ public:
     virtual bool is_svg_element() const { return false; }
     virtual bool is_svg_graphics_element() const { return false; }
     virtual bool is_svg_script_element() const { return false; }
+    virtual bool is_svg_style_element() const { return false; }
     virtual bool is_svg_svg_element() const { return false; }
     virtual bool is_svg_use_element() const { return false; }
 
@@ -100,8 +101,10 @@ public:
     virtual bool is_html_base_element() const { return false; }
     virtual bool is_html_body_element() const { return false; }
     virtual bool is_html_input_element() const { return false; }
+    virtual bool is_html_link_element() const { return false; }
     virtual bool is_html_progress_element() const { return false; }
     virtual bool is_html_script_element() const { return false; }
+    virtual bool is_html_style_element() const { return false; }
     virtual bool is_html_template_element() const { return false; }
     virtual bool is_html_table_element() const { return false; }
     virtual bool is_html_table_section_element() const { return false; }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -199,6 +199,7 @@ class StringStyleValue;
 class StyleComputer;
 class StyleProperties;
 class StyleSheet;
+struct StyleSheetIdentifier;
 class StyleSheetList;
 class StyleValueList;
 class Supports;

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -391,7 +391,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
         //        type
         //            text/css
         //        location
-        //            The resulting URL string determined during the fetch and process the linked resource algorithm.
+        //            response's URL list[0]
         //        owner node
         //            element
         //        media
@@ -438,6 +438,10 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                 m_loaded_style_sheet = parse_css_stylesheet(CSS::Parser::ParsingContext(document(), *response.url()), decoded_string);
 
                 if (m_loaded_style_sheet) {
+                    Optional<String> location;
+                    if (!response.url_list().is_empty())
+                        location = MUST(response.url_list().first().to_string());
+
                     document().style_sheets().create_a_css_style_sheet(
                         "text/css"_string,
                         this,
@@ -445,7 +449,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
                         in_a_document_tree() ? attribute(HTML::AttributeNames::title).value_or({}) : String {},
                         m_relationship & Relationship::Alternate && !m_explicitly_enabled,
                         true,
-                        {},
+                        move(location),
                         nullptr,
                         nullptr,
                         *m_loaded_style_sheet);

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -53,7 +53,10 @@ private:
     virtual void resource_did_fail() override;
     virtual void resource_did_load() override;
 
-    // ^ HTMLElement
+    // ^DOM::Node
+    virtual bool is_html_link_element() const override { return true; }
+
+    // ^HTMLElement
     virtual void visit_edges(Cell::Visitor&) override;
 
     struct LinkProcessingOptions {

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -32,6 +32,9 @@ public:
 private:
     HTMLStyleElement(DOM::Document&, DOM::QualifiedName);
 
+    // ^DOM::Node
+    virtual bool is_html_style_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -32,9 +32,14 @@ void Inspector::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Inspector);
 }
 
+PageClient& Inspector::inspector_page_client() const
+{
+    return global_object().browsing_context()->page().client();
+}
+
 void Inspector::inspector_loaded()
 {
-    global_object().browsing_context()->page().client().inspector_did_load();
+    inspector_page_client().inspector_did_load();
 }
 
 void Inspector::inspect_dom_node(i32 node_id, Optional<i32> const& pseudo_element)
@@ -48,37 +53,37 @@ void Inspector::inspect_dom_node(i32 node_id, Optional<i32> const& pseudo_elemen
 
 void Inspector::set_dom_node_text(i32 node_id, String const& text)
 {
-    global_object().browsing_context()->page().client().inspector_did_set_dom_node_text(node_id, text);
+    inspector_page_client().inspector_did_set_dom_node_text(node_id, text);
 }
 
 void Inspector::set_dom_node_tag(i32 node_id, String const& tag)
 {
-    global_object().browsing_context()->page().client().inspector_did_set_dom_node_tag(node_id, tag);
+    inspector_page_client().inspector_did_set_dom_node_tag(node_id, tag);
 }
 
 void Inspector::add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<DOM::NamedNodeMap> attributes)
 {
-    global_object().browsing_context()->page().client().inspector_did_add_dom_node_attributes(node_id, attributes);
+    inspector_page_client().inspector_did_add_dom_node_attributes(node_id, attributes);
 }
 
 void Inspector::replace_dom_node_attribute(i32 node_id, WebIDL::UnsignedLongLong attribute_index, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes)
 {
-    global_object().browsing_context()->page().client().inspector_did_replace_dom_node_attribute(node_id, static_cast<size_t>(attribute_index), replacement_attributes);
+    inspector_page_client().inspector_did_replace_dom_node_attribute(node_id, static_cast<size_t>(attribute_index), replacement_attributes);
 }
 
 void Inspector::request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index)
 {
-    global_object().browsing_context()->page().client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag, attribute_index.map([](auto index) { return static_cast<size_t>(index); }));
+    inspector_page_client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag, attribute_index.map([](auto index) { return static_cast<size_t>(index); }));
 }
 
 void Inspector::execute_console_script(String const& script)
 {
-    global_object().browsing_context()->page().client().inspector_did_execute_console_script(script);
+    inspector_page_client().inspector_did_execute_console_script(script);
 }
 
 void Inspector::export_inspector_html(String const& html)
 {
-    global_object().browsing_context()->page().client().inspector_did_export_inspector_html(html);
+    inspector_page_client().inspector_did_export_inspector_html(html);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Bindings/InspectorPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/Window.h>
@@ -74,6 +75,18 @@ void Inspector::replace_dom_node_attribute(i32 node_id, WebIDL::UnsignedLongLong
 void Inspector::request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index)
 {
     inspector_page_client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag, attribute_index.map([](auto index) { return static_cast<size_t>(index); }));
+}
+
+void Inspector::request_style_sheet_source(String const& type_string, Optional<i32> const& dom_node_unique_id, Optional<String> const& url)
+{
+    auto type = CSS::style_sheet_identifier_type_from_string(type_string);
+    VERIFY(type.has_value());
+
+    inspector_page_client().inspector_did_request_style_sheet_source({
+        .type = type.value(),
+        .dom_element_unique_id = dom_node_unique_id,
+        .url = url,
+    });
 }
 
 void Inspector::execute_console_script(String const& script)

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -36,6 +36,8 @@ public:
 private:
     explicit Inspector(JS::Realm&);
 
+    PageClient& inspector_page_client() const;
+
     virtual void initialize(JS::Realm&) override;
 };
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -29,6 +29,8 @@ public:
 
     void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index);
 
+    void request_style_sheet_source(String const& type, Optional<i32> const& dom_node_unique_id, Optional<String> const& url);
+
     void execute_console_script(String const& script);
 
     void export_inspector_html(String const& html);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -12,6 +12,8 @@
 
     undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tag, unsigned long long? attributeIndex);
 
+    undefined requestStyleSheetSource(DOMString type, long? domNodeID, DOMString? url);
+
     undefined executeConsoleScript(DOMString script);
 
     undefined exportInspectorHTML(DOMString html);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -29,6 +29,7 @@
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
@@ -376,6 +377,7 @@ public:
     virtual void inspector_did_add_dom_node_attributes([[maybe_unused]] i32 node_id, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> attributes) { }
     virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] size_t attribute_index, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }
     virtual void inspector_did_request_dom_tree_context_menu([[maybe_unused]] i32 node_id, [[maybe_unused]] CSSPixelPoint position, [[maybe_unused]] String const& type, [[maybe_unused]] Optional<String> const& tag, [[maybe_unused]] Optional<size_t> const& attribute_index) { }
+    virtual void inspector_did_request_style_sheet_source([[maybe_unused]] CSS::StyleSheetIdentifier const& identifier) { }
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
     virtual void inspector_did_export_inspector_html([[maybe_unused]] String const& html) { }
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -28,6 +28,9 @@ public:
 private:
     SVGStyleElement(DOM::Document&, DOM::QualifiedName);
 
+    // ^DOM::Node
+    virtual bool is_svg_style_element() const override { return true; }
+
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -23,7 +23,7 @@ set(SOURCES
 
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
 
-embed_as_string_view(
+embed_as_string(
     "NativeStyleSheetSource.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/Native.css"
     "NativeStyleSheetSource.cpp"

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -592,8 +592,8 @@ void ViewImplementation::set_user_style_sheet(String source)
 
 void ViewImplementation::use_native_user_style_sheet()
 {
-    extern StringView native_stylesheet_source;
-    set_user_style_sheet(MUST(String::from_utf8(native_stylesheet_source)));
+    extern String native_stylesheet_source;
+    set_user_style_sheet(native_stylesheet_source);
 }
 
 void ViewImplementation::enable_inspector_prototype()

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -305,6 +305,16 @@ void ViewImplementation::get_dom_node_html(i32 node_id)
     client().async_get_dom_node_html(page_id(), node_id);
 }
 
+void ViewImplementation::list_style_sheets()
+{
+    client().async_list_style_sheets(page_id());
+}
+
+void ViewImplementation::request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& identifier)
+{
+    client().async_request_style_sheet_source(page_id(), identifier);
+}
+
 void ViewImplementation::debug_request(ByteString const& request, ByteString const& argument)
 {
     client().async_debug_request(page_id(), request, argument);

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -97,6 +97,9 @@ public:
     void remove_dom_node(i32 node_id);
     void get_dom_node_html(i32 node_id);
 
+    void list_style_sheets();
+    void request_style_sheet_source(Web::CSS::StyleSheetIdentifier const&);
+
     void debug_request(ByteString const& request, ByteString const& argument = {});
 
     void run_javascript(StringView);
@@ -182,6 +185,9 @@ public:
     Function<void(ByteString const&)> on_received_dom_tree;
     Function<void(Optional<DOMNodeProperties>)> on_received_dom_node_properties;
     Function<void(ByteString const&)> on_received_accessibility_tree;
+    Function<void(Vector<Web::CSS::StyleSheetIdentifier>)> on_received_style_sheet_list;
+    Function<void(Web::CSS::StyleSheetIdentifier const&)> on_inspector_requested_style_sheet_source;
+    Function<void(Web::CSS::StyleSheetIdentifier const&, String const&)> on_received_style_sheet_source;
     Function<void(i32 node_id)> on_received_hovered_node_id;
     Function<void(Optional<i32> const& node_id)> on_finshed_editing_dom_node;
     Function<void(String const&)> on_received_dom_node_html;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -711,6 +711,30 @@ Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request
     return IPC::File {};
 }
 
+void WebContentClient::inspector_did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> const& stylesheets)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_received_style_sheet_list)
+            view->on_received_style_sheet_list(stylesheets);
+    }
+}
+
+void WebContentClient::inspector_did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_inspector_requested_style_sheet_source)
+            view->on_inspector_requested_style_sheet_source(identifier);
+    }
+}
+
+void WebContentClient::did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier, String const& source)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_received_style_sheet_source)
+            view->on_received_style_sheet_source(identifier, source);
+    }
+}
+
 Optional<ViewImplementation&> WebContentClient::view_for_page_id(u64 page_id, SourceLocation location)
 {
     if (auto view = m_views.get(page_id); view.has_value())

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -9,6 +9,7 @@
 #include <AK/HashMap.h>
 #include <AK/SourceLocation.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/SelectItem.h>
@@ -122,6 +123,9 @@ private:
     virtual void inspector_did_execute_console_script(u64 page_id, String const& script) override;
     virtual void inspector_did_export_inspector_html(u64 page_id, String const& html) override;
     virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent(u64 page_id) override;
+    virtual void inspector_did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> const& stylesheets) override;
+    virtual void inspector_did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier) override;
+    virtual void did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier, String const& source) override;
 
     Optional<ViewImplementation&> view_for_page_id(u64, SourceLocation = SourceLocation::current());
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
@@ -627,6 +627,28 @@ void ConnectionFromClient::get_hovered_node_id(u64 page_id)
     }
 
     async_did_get_hovered_node_id(page_id, node_id);
+}
+
+void ConnectionFromClient::list_style_sheets(u64 page_id)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    async_inspector_did_list_style_sheets(page_id, page->list_style_sheets());
+}
+
+void ConnectionFromClient::request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    if (auto* document = page->page().top_level_browsing_context().active_document()) {
+        auto stylesheet = document->get_style_sheet_source(identifier);
+        if (stylesheet.has_value())
+            async_did_request_style_sheet_source(page_id, identifier, stylesheet.value());
+    }
 }
 
 void ConnectionFromClient::set_dom_node_text(u64 page_id, i32 node_id, String const& text)

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -76,6 +76,9 @@ private:
     virtual void inspect_accessibility_tree(u64 page_id) override;
     virtual void get_hovered_node_id(u64 page_id) override;
 
+    virtual void list_style_sheets(u64 page_id) override;
+    virtual void request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier) override;
+
     virtual void set_dom_node_text(u64 page_id, i32 node_id, String const& text) override;
     virtual void set_dom_node_tag(u64 page_id, i32 node_id, String const& name) override;
     virtual void add_dom_node_attributes(u64 page_id, i32 node_id, Vector<WebView::Attribute> const& attributes) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -10,9 +10,12 @@
 #include <LibJS/Console.h>
 #include <LibJS/Runtime/ConsoleObject.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/NamedNodeMap.h>
+#include <LibWeb/HTML/HTMLLinkElement.h>
+#include <LibWeb/HTML/HTMLStyleElement.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -737,6 +740,88 @@ void PageClient::console_peer_did_misbehave(char const* reason)
 void PageClient::did_get_js_console_messages(i32 start_index, Vector<ByteString> message_types, Vector<ByteString> messages)
 {
     client().async_did_get_js_console_messages(m_id, start_index, move(message_types), move(messages));
+}
+
+static void gather_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>& results, Web::CSS::CSSStyleSheet& sheet)
+{
+    Web::CSS::StyleSheetIdentifier identifier {};
+
+    bool valid = true;
+
+    if (sheet.owner_rule()) {
+        identifier.type = Web::CSS::StyleSheetIdentifier::Type::ImportRule;
+    } else if (auto* node = sheet.owner_node()) {
+        if (node->is_html_style_element() || node->is_svg_style_element()) {
+            identifier.type = Web::CSS::StyleSheetIdentifier::Type::StyleElement;
+        } else if (is<Web::HTML::HTMLLinkElement>(node)) {
+            identifier.type = Web::CSS::StyleSheetIdentifier::Type::LinkElement;
+        } else {
+            dbgln("Can't identify where style sheet came from; owner node is {}", node->debug_description());
+            identifier.type = Web::CSS::StyleSheetIdentifier::Type::StyleElement;
+        }
+        identifier.dom_element_unique_id = node->unique_id();
+    } else {
+        dbgln("Style sheet has no owner rule or owner node; skipping");
+        valid = false;
+    }
+
+    if (valid) {
+        if (auto location = sheet.location(); location.has_value())
+            identifier.url = location.release_value();
+
+        results.append(move(identifier));
+    }
+
+    for (auto& import_rule : sheet.import_rules()) {
+        if (import_rule->loaded_style_sheet()) {
+            gather_style_sheets(results, *import_rule->loaded_style_sheet());
+        } else {
+            // We can gather this anyway, and hope it loads later
+            results.append({ .type = Web::CSS::StyleSheetIdentifier::Type::ImportRule,
+                .url = MUST(import_rule->url().to_string()) });
+        }
+    }
+}
+
+Vector<Web::CSS::StyleSheetIdentifier> PageClient::list_style_sheets() const
+{
+    Vector<Web::CSS::StyleSheetIdentifier> results;
+
+    auto const* document = page().top_level_browsing_context().active_document();
+    if (document) {
+        for (auto& sheet : document->style_sheets().sheets()) {
+            gather_style_sheets(results, sheet);
+        }
+    }
+
+    // User style
+    if (page().user_style().has_value()) {
+        results.append({
+            .type = Web::CSS::StyleSheetIdentifier::Type::UserStyle,
+        });
+    }
+
+    // User-agent
+    results.append({
+        .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
+        .url = "CSS/Default.css"_string,
+    });
+    if (document && document->in_quirks_mode()) {
+        results.append({
+            .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
+            .url = "CSS/QuirksMode.css"_string,
+        });
+    }
+    results.append({
+        .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
+        .url = "MathML/Default.css"_string,
+    });
+    results.append({
+        .type = Web::CSS::StyleSheetIdentifier::Type::UserAgent,
+        .url = "SVG/Default.css"_string,
+    });
+
+    return results;
 }
 
 Web::DisplayListPlayerType PageClient::display_list_player_type() const

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2020-2023, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2023, Andrew Kaster <akaster@serenityos.org>
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -655,6 +656,11 @@ void PageClient::inspector_did_replace_dom_node_attribute(i32 node_id, size_t at
 void PageClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index)
 {
     client().async_inspector_did_request_dom_tree_context_menu(m_id, node_id, page().css_to_device_point(position).to_type<int>(), type, tag, attribute_index);
+}
+
+void PageClient::inspector_did_request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& identifier)
+{
+    client().async_inspector_did_request_style_sheet_source(m_id, identifier);
 }
 
 void PageClient::inspector_did_execute_console_script(String const& script)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <LibGfx/Rect.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
@@ -82,6 +83,8 @@ public:
     void did_output_js_console_message(i32 message_index);
     void console_peer_did_misbehave(char const* reason);
     void did_get_js_console_messages(i32 start_index, Vector<ByteString> message_types, Vector<ByteString> messages);
+
+    Vector<Web::CSS::StyleSheetIdentifier> list_style_sheets() const;
 
     virtual double device_pixels_per_css_pixel() const override { return m_device_pixels_per_css_pixel; }
 

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -169,6 +169,7 @@ private:
     virtual void inspector_did_add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> attributes) override;
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, size_t attribute_index, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
     virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index) override;
+    virtual void inspector_did_request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& stylesheet_source) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
     virtual void inspector_did_export_inspector_html(String const& script) override;
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -5,6 +5,7 @@
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/AudioPlayState.h>
 #include <LibWeb/HTML/FileFilter.h>
@@ -53,6 +54,10 @@ endpoint WebContentClient
     did_get_hovered_node_id(u64 page_id, i32 node_id) =|
     did_finish_editing_dom_node(u64 page_id, Optional<i32> node_id) =|
     did_get_dom_node_html(u64 page_id, String html) =|
+
+    inspector_did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> style_sheets) =|
+    inspector_did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) =|
+    did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier, String source) =|
 
     did_take_screenshot(u64 page_id, Gfx::ShareableBitmap screenshot) =|
 

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -5,6 +5,7 @@
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/Page/InputEvent.h>
@@ -45,6 +46,8 @@ endpoint WebContentServer
     get_hovered_node_id(u64 page_id) =|
     js_console_input(u64 page_id, ByteString js_source) =|
     js_console_request_messages(u64 page_id, i32 start_index) =|
+    list_style_sheets(u64 page_id) =|
+    request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) =|
 
     set_dom_node_text(u64 page_id, i32 node_id, String text) =|
     set_dom_node_tag(u64 page_id, i32 node_id, String name) =|


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c1735da7-1564-4577-bbde-bad5af7cb542)

The first pass at a style sheet viewer. Lists all style sheets in use by the page, including `<style>` elements, any `@import`-ed style sheets, and the user-agent or user styles.