### PR TITLE
LibWeb: Add an HTML tokenizer re-implementation in swift 

### DIFF
--- a/AK/AK+Swift.swift
+++ b/AK/AK+Swift.swift
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import AK
+import Foundation
+
+public extension Foundation.Data {
+    init(_ string: AK.StringView) {
+        let bytes = string.bytes()
+        self.init(bytesNoCopy: UnsafeMutableRawPointer(mutating: bytes.data()), count: bytes.size(), deallocator: .none)
+    }
+}
+
+public extension Swift.String {
+    init?(_ string: AK.String) {
+        self.init(data: Foundation.Data(string.__bytes_as_string_viewUnsafe()), encoding: .utf8)
+    }
+
+    init?(_ string: AK.StringView) {
+        self.init(data: Foundation.Data(string), encoding: .utf8)
+    }
+}

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -68,4 +68,8 @@ if (ENABLE_SWIFT)
         "${CMAKE_CURRENT_BINARY_DIR}/Backtrace.h"
         "${CMAKE_CURRENT_BINARY_DIR}/Debug.h"
     )
+
+    target_compile_features(AK PUBLIC cxx_std_23)
+    set_target_properties(AK PROPERTIES Swift_MODULE_NAME SwiftAK)
+    target_sources(AK PRIVATE AK+Swift.swift)
 endif()

--- a/Meta/CMake/Swift/GenerateSwiftHeader.cmake
+++ b/Meta/CMake/Swift/GenerateSwiftHeader.cmake
@@ -36,10 +36,12 @@ function(_swift_generate_cxx_header target header)
 
   if(APPLE)
     set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
+    list(APPEND SDK_FLAGS "-target" "${CMAKE_Swift_COMPILER_TARGET}")
   elseif(WIN32)
     set(SDK_FLAGS "-sdk" "$ENV{SDKROOT}")
   elseif(DEFINED ${CMAKE_SYSROOT})
     set(SDK_FLAGS "-sdk" "${CMAKE_SYSROOT}")
+    list(APPEND SDK_FLAGS "-target" "${CMAKE_Swift_COMPILER_TARGET}")
   endif()
 
   cmake_path(APPEND CMAKE_CURRENT_BINARY_DIR include

--- a/Meta/CMake/collections.cmake
+++ b/Meta/CMake/collections.cmake
@@ -1,0 +1,20 @@
+include_guard(GLOBAL)
+
+include(FetchContent)
+
+set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE OPT_IN)
+FetchContent_Declare(SwiftCollections
+    GIT_REPOSITORY https://github.com/apple/swift-collections.git
+    GIT_TAG 1.1.2
+    PATCH_COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_LIST_DIR}/patches/git-patch.cmake"
+                  "${CMAKE_CURRENT_LIST_DIR}/patches/swift-collections/0001-CMake-Remove-top-level-binary-module-locations.patch"
+    OVERRIDE_FIND_PACKAGE
+)
+
+set(BUILD_TESTING_SAVE ${BUILD_TESTING})
+set(BUILD_TESTING OFF)
+set(BUILD_EXAMPLES OFF)
+
+FetchContent_MakeAvailable(SwiftCollections)
+
+set(BUILD_TESTING ${BUILD_TESTING_SAVE})

--- a/Meta/CMake/lagom_install_options.cmake
+++ b/Meta/CMake/lagom_install_options.cmake
@@ -15,6 +15,10 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${IN_BUILD_PREFIX}${CMAK
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${IN_BUILD_PREFIX}${CMAKE_INSTALL_LIBDIR}")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${IN_BUILD_PREFIX}${CMAKE_INSTALL_LIBDIR}")
 
+# FIXME: Stop setting this when we have a good way to retrieve the directory that has the swift module
+#        file for use by the swift frontend's header generator
+set(CMAKE_Swift_MODULE_DIRECTORY  "${CMAKE_BINARY_DIR}/${IN_BUILD_PREFIX}swift")
+
 set(CMAKE_SKIP_BUILD_RPATH FALSE)
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 # See slide 100 of the following ppt :^)

--- a/Meta/CMake/patches/git-patch.cmake
+++ b/Meta/CMake/patches/git-patch.cmake
@@ -1,0 +1,14 @@
+# A script to apply a Git patch unless it was already applied
+find_package(Git REQUIRED QUIET)
+
+execute_process(
+  ERROR_VARIABLE discarded RESULT_VARIABLE patch_not_yet_applied
+  COMMAND ${GIT_EXECUTABLE} apply --reverse --check ${CMAKE_ARGV3})
+
+if(patch_not_yet_applied)
+  execute_process(
+    ERROR_VARIABLE discarded
+    COMMAND ${GIT_EXECUTABLE} apply  ${CMAKE_ARGV3} COMMAND_ERROR_IS_FATAL LAST
+  )
+endif()
+

--- a/Meta/CMake/patches/swift-collections/0001-CMake-Remove-top-level-binary-module-locations.patch
+++ b/Meta/CMake/patches/swift-collections/0001-CMake-Remove-top-level-binary-module-locations.patch
@@ -1,0 +1,170 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <andrew@ladybird.org>
+Date: Thu, 22 Aug 2024 20:51:38 -0600
+Subject: [PATCH] CMake: Remove top-level binary/module locations
+
+---
+ CMakeLists.txt                                      | 13 +++++--------
+ Sources/BitCollections/CMakeLists.txt               |  2 --
+ Sources/CMakeLists.txt                              |  2 --
+ Sources/Collections/CMakeLists.txt                  |  4 ++--
+ Sources/DequeModule/CMakeLists.txt                  |  2 --
+ Sources/HashTreeCollections/CMakeLists.txt          |  2 --
+ Sources/HeapModule/CMakeLists.txt                   |  2 --
+ Sources/InternalCollectionsUtilities/CMakeLists.txt |  2 --
+ Sources/OrderedCollections/CMakeLists.txt           |  2 --
+ Sources/RopeModule/CMakeLists.txt                   |  2 --
+ 10 files changed, 7 insertions(+), 26 deletions(-)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 939a29e48ee386c0dac32350c6f6dfb4c4279170..2692814e02971e1469fc236a89c825a5c1547932 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,22 +11,19 @@ if(POLICY CMP0091)
+   cmake_policy(SET CMP0091 NEW)
+ endif()
+ 
++if(POLICY CMP0157)
++  cmake_policy(SET CMP0157 OLD)
++endif()
++
++
+ cmake_minimum_required(VERSION 3.16)
+ project(SwiftCollections
+   LANGUAGES C Swift)
+ 
+ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
+ 
+-set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+ set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+ 
+-set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+-set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+-
+-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+-
+ set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+ 
+ if(CMAKE_SYSTEM_NAME STREQUAL Windows OR CMAKE_SYSTEM_NAME STREQUAL Darwin)
+diff --git a/Sources/BitCollections/CMakeLists.txt b/Sources/BitCollections/CMakeLists.txt
+index c5becdeec08a91978aa8b00dc2fc272299ca16b0..3f52e47220362de9c47e3e2527a2b78260d6f45e 100644
+--- a/Sources/BitCollections/CMakeLists.txt
++++ b/Sources/BitCollections/CMakeLists.txt
+@@ -15,8 +15,6 @@ else()
+     ${COLLECTIONS_BIT_SOURCES})
+   target_link_libraries(BitCollections PRIVATE
+     InternalCollectionsUtilities)
+-  set_target_properties(BitCollections PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(BitCollections)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS BitCollections)
+diff --git a/Sources/CMakeLists.txt b/Sources/CMakeLists.txt
+index ad39dd9be70a3d3fd7f3176e9a607c6fa1413d82..a54e494c81a552282735bd926a05cb3d9527b169 100644
+--- a/Sources/CMakeLists.txt
++++ b/Sources/CMakeLists.txt
+@@ -24,8 +24,6 @@ if(COLLECTIONS_SINGLE_MODULE)
+   endif()
+ 
+   target_compile_definitions(${COLLECTIONS_MODULE_NAME} PRIVATE COLLECTIONS_SINGLE_MODULE)
+-  set_target_properties(${COLLECTIONS_MODULE_NAME} PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   if(COLLECTIONS_FOUNDATION_TOOLCHAIN_MODULE)
+     get_swift_host_os(swift_os)
+diff --git a/Sources/Collections/CMakeLists.txt b/Sources/Collections/CMakeLists.txt
+index 9f534a46c80475e2ef39ba39d386be00d25b7c30..6be24ce21145f14718e90d67247d2ea56c21ffd4 100644
+--- a/Sources/Collections/CMakeLists.txt
++++ b/Sources/Collections/CMakeLists.txt
+@@ -15,9 +15,9 @@ target_link_libraries(Collections PRIVATE
+   HeapModule
+   OrderedCollections
+   HashTreeCollections
++  InternalCollectionsUtilities
+   )
+-set_target_properties(Collections PROPERTIES
+-  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+ _install_target(Collections)
+ set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS Collections)
++
+diff --git a/Sources/DequeModule/CMakeLists.txt b/Sources/DequeModule/CMakeLists.txt
+index 07364b66e32257c098edfbfdd3204206dee56709..da1a79becc36893a90d797bee610b973c3c12853 100644
+--- a/Sources/DequeModule/CMakeLists.txt
++++ b/Sources/DequeModule/CMakeLists.txt
+@@ -15,8 +15,6 @@ else()
+     ${COLLECTIONS_DEQUE_SOURCES})
+   target_link_libraries(DequeModule PRIVATE
+     InternalCollectionsUtilities)
+-  set_target_properties(DequeModule PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(DequeModule)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS DequeModule)
+diff --git a/Sources/HashTreeCollections/CMakeLists.txt b/Sources/HashTreeCollections/CMakeLists.txt
+index 0329fe664fd103348f55ce34dee71da9f437dfd6..56566f36a63c834f0c7d40f787504adede820808 100644
+--- a/Sources/HashTreeCollections/CMakeLists.txt
++++ b/Sources/HashTreeCollections/CMakeLists.txt
+@@ -15,8 +15,6 @@ else()
+     ${COLLECTIONS_HASHTREE_SOURCES})
+   target_link_libraries(HashTreeCollections PRIVATE
+     InternalCollectionsUtilities)
+-  set_target_properties(HashTreeCollections PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(HashTreeCollections)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS HashTreeCollections)
+diff --git a/Sources/HeapModule/CMakeLists.txt b/Sources/HeapModule/CMakeLists.txt
+index a1cc57a63b5bcd140ea207298fbd0c6d48f784de..6bf9edeed5bfdeb9120869dfdbaed21a2376e3c3 100644
+--- a/Sources/HeapModule/CMakeLists.txt
++++ b/Sources/HeapModule/CMakeLists.txt
+@@ -15,8 +15,6 @@ else()
+     ${COLLECTIONS_HEAP_SOURCES})
+   target_link_libraries(HeapModule PRIVATE
+     InternalCollectionsUtilities)
+-  set_target_properties(HeapModule PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(HeapModule)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS HeapModule)
+diff --git a/Sources/InternalCollectionsUtilities/CMakeLists.txt b/Sources/InternalCollectionsUtilities/CMakeLists.txt
+index 808e36c2eb43f26f8009d4982e5cd095c3a3639d..f25f3da067e8d6ce540ba911a3df43d6e3b5b561 100644
+--- a/Sources/InternalCollectionsUtilities/CMakeLists.txt
++++ b/Sources/InternalCollectionsUtilities/CMakeLists.txt
+@@ -13,8 +13,6 @@ else()
+   set(module_name InternalCollectionsUtilities)
+   add_library(InternalCollectionsUtilities
+     ${COLLECTIONS_UTILITIES_SOURCES})
+-  set_target_properties(InternalCollectionsUtilities PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(InternalCollectionsUtilities)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS InternalCollectionsUtilities)
+diff --git a/Sources/OrderedCollections/CMakeLists.txt b/Sources/OrderedCollections/CMakeLists.txt
+index 017113861101c5acfb3f77a8feca86f1b9a6fd50..16e63aec3d0e317191b59637ef02aba9b0e76a76 100644
+--- a/Sources/OrderedCollections/CMakeLists.txt
++++ b/Sources/OrderedCollections/CMakeLists.txt
+@@ -15,8 +15,6 @@ else()
+     ${COLLECTIONS_ORDERED_SOURCES})
+   target_link_libraries(OrderedCollections PRIVATE
+     InternalCollectionsUtilities)
+-  set_target_properties(OrderedCollections PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(OrderedCollections)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS OrderedCollections)
+diff --git a/Sources/RopeModule/CMakeLists.txt b/Sources/RopeModule/CMakeLists.txt
+index d33fac9213f939fcfccb1f702039b421814d3dfd..19e08d235a14348dac983cb4bf1972a039ea3fbb 100644
+--- a/Sources/RopeModule/CMakeLists.txt
++++ b/Sources/RopeModule/CMakeLists.txt
+@@ -15,8 +15,6 @@ else()
+     ${COLLECTIONS_ROPE_SOURCES})
+   target_link_libraries(_RopeModule PRIVATE
+     InternalCollectionsUtilities)
+-  set_target_properties(_RopeModule PROPERTIES
+-    INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+ 
+   _install_target(_RopeModule)
+   set_property(GLOBAL APPEND PROPERTY SWIFT_COLLECTIONS_EXPORTS _RopeModule)

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -123,6 +123,7 @@ if (ENABLE_SWIFT)
         Color.swift
     )
     target_compile_definitions(LibGfx PRIVATE LIBGFX_USE_SWIFT)
+    target_link_libraries(LibGfx PRIVATE AK)
     set_target_properties(LibGfx PROPERTIES Swift_MODULE_NAME "SwiftLibGfx")
 
     # FIXME: These should be pulled automatically from interface compile options for the target
@@ -131,6 +132,7 @@ if (ENABLE_SWIFT)
         -Xcc -ivfsoverlay${Lagom_BINARY_DIR}/AK/vfs_overlay.yaml
     )
     get_target_property(LIBGFX_NATIVE_DIRS LibGfx INCLUDE_DIRECTORIES)
+    list(APPEND LIBGFX_NATIVE_DIRS ${CMAKE_Swift_MODULE_DIRECTORY})
     _swift_generate_cxx_header(LibGfx "LibGfx-Swift.h"
         SEARCH_PATHS ${LIBGFX_NATIVE_DIRS}
         COMPILE_OPTIONS ${VFS_OVERLAY_OPTIONS}

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -268,14 +268,9 @@ Optional<Color> Color::from_named_css_color_string(StringView string)
 }
 
 #if defined(LIBGFX_USE_SWIFT)
-static swift::String to_swift_string(StringView string)
-{
-    return swift::String(std::string(string.characters_without_null_termination(), string.length()));
-}
-
 static Optional<Color> hex_string_to_color(StringView string)
 {
-    auto color = SwiftLibGfx::parseHexString(to_swift_string(string));
+    auto color = SwiftLibGfx::parseHexString(string);
     if (color.getCount() == 0)
         return {};
     return color[0];

--- a/Userland/Libraries/LibGfx/Color.swift
+++ b/Userland/Libraries/LibGfx/Color.swift
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import AK
+import SwiftAK
 import LibGfx
 
 // FIXME: Do this without extending String with an index operation that was explicitly deleted :^)
@@ -32,7 +32,11 @@ private func hexNibblesToUInt8(_ nib1: Character, _ nib2: Character) -> UInt8? {
 }
 
 // FIXME: Return Gfx.Color? When swift ABI bug is fixed
-public func parseHexString(_ string: Swift.String) -> [Gfx.Color] {
+public func parseHexString(_ rawString: AK.StringView) -> [Gfx.Color] {
+    guard let string = Swift.String(rawString) else {
+        return []
+    }
+
     assert(string.hasPrefix("#"))
 
     switch string.count {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -788,6 +788,8 @@ target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibI
 generate_js_bindings(LibWeb)
 
 if (ENABLE_SWIFT)
+    include(collections)
+
     set(generated_headers ${GENERATED_SOURCES})
     list(FILTER generated_headers INCLUDE REGEX "\\.h$")
     list(TRANSFORM generated_headers PREPEND "${CMAKE_CURRENT_BINARY_DIR}/")
@@ -799,9 +801,13 @@ if (ENABLE_SWIFT)
 
     target_sources(LibWeb PRIVATE
         HTML/Parser/HTMLToken.swift
+        HTML/Parser/HTMLTokenizer.swift
+        HTML/Parser/HTMLTokenizerHelpers.cpp
     )
     target_compile_definitions(LibWeb PRIVATE LIBWEB_USE_SWIFT)
     set_target_properties(LibWeb PROPERTIES Swift_MODULE_NAME "SwiftLibWeb")
+
+    target_link_libraries(LibWeb PRIVATE AK Collections)
 
     # FIXME: These should be pulled automatically from interface compile options for the target
     set(VFS_OVERLAY_OPTIONS
@@ -810,6 +816,8 @@ if (ENABLE_SWIFT)
         -Xcc -ivfsoverlay${Lagom_BINARY_DIR}/AK/vfs_overlay.yaml
     )
     get_target_property(LIBWEB_NATIVE_DIRS LibWeb INCLUDE_DIRECTORIES)
+    list(APPEND LIBWEB_NATIVE_DIRS ${CMAKE_Swift_MODULE_DIRECTORY})
+
     _swift_generate_cxx_header(LibWeb "LibWeb-Swift.h"
         SEARCH_PATHS ${LIBWEB_NATIVE_DIRS}
         COMPILE_OPTIONS ${VFS_OVERLAY_OPTIONS}

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.swift
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.swift
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import Collections
+import Foundation
+import LibWeb
+import SwiftAK
+
+extension Swift.String {
+    public init?(decoding: AK.StringView, as: AK.StringView) {
+        let maybe_decoded = Web.HTML.decode_to_utf8(decoding, `as`)
+        if maybe_decoded.hasValue {
+            self.init(maybe_decoded.value!)
+        } else {
+            return nil
+        }
+    }
+}
+
+class HTMLTokenizer {
+
+    enum State {
+        case Data
+        case RCDATA
+        case RAWTEXT
+        case ScriptData
+        case PLAINTEXT
+        case TagOpen
+        case EndTagOpen
+        case TagName
+        case RCDATALessThanSign
+        case RCDATAEndTagOpen
+        case RCDATAEndTagName
+        case RAWTEXTLessThanSign
+        case RAWTEXTEndTagOpen
+        case RAWTEXTEndTagName
+        case ScriptDataLessThanSign
+        case ScriptDataEndTagOpen
+        case ScriptDataEndTagName
+        case ScriptDataEscapeStart
+        case ScriptDataEscapeStartDash
+        case ScriptDataEscaped
+        case ScriptDataEscapedDash
+        case ScriptDataEscapedDashDash
+        case ScriptDataEscapedLessThanSign
+        case ScriptDataEscapedEndTagOpen
+        case ScriptDataEscapedEndTagName
+        case ScriptDataDoubleEscapeStart
+        case ScriptDataDoubleEscaped
+        case ScriptDataDoubleEscapedDash
+        case ScriptDataDoubleEscapedDashDash
+        case ScriptDataDoubleEscapedLessThanSign
+        case ScriptDataDoubleEscapeEnd
+        case BeforeAttributeName
+        case AttributeName
+        case AfterAttributeName
+        case BeforeAttributeValue
+        case AttributeValueDoubleQuoted
+        case AttributeValueSingleQuoted
+        case AttributeValueUnquoted
+        case AfterAttributeValueQuoted
+        case SelfClosingStartTag
+        case BogusComment
+        case MarkupDeclarationOpen
+        case CommentStart
+        case CommentStartDash
+        case Comment
+        case CommentLessThanSign
+        case CommentLessThanSignBang
+        case CommentLessThanSignBangDash
+        case CommentLessThanSignBangDashDash
+        case CommentEndDash
+        case CommentEnd
+        case CommentEndBang
+        case DOCTYPE
+        case BeforeDOCTYPEName
+        case DOCTYPEName
+        case AfterDOCTYPEName
+        case AfterDOCTYPEPublicKeyword
+        case BeforeDOCTYPEPublicIdentifier
+        case DOCTYPEPublicIdentifierDoubleQuoted
+        case DOCTYPEPublicIdentifierSingleQuoted
+        case AfterDOCTYPEPublicIdentifier
+        case BetweenDOCTYPEPublicAndSystemIdentifiers
+        case AfterDOCTYPESystemKeyword
+        case BeforeDOCTYPESystemIdentifier
+        case DOCTYPESystemIdentifierDoubleQuoted
+        case DOCTYPESystemIdentifierSingleQuoted
+        case AfterDOCTYPESystemIdentifier
+        case BogusDOCTYPE
+        case CDATASection
+        case CDATASectionBracket
+        case CDATASectionEnd
+        case CharacterReference
+        case NamedCharacterReference
+        case AmbiguousAmpersand
+        case NumericCharacterReference
+        case HexadecimalCharacterReferenceStart
+        case DecimalCharacterReferenceStart
+        case HexadecimalCharacterReference
+        case DecimalCharacterReference
+        case NumericCharacterReferenceEnd
+    }
+
+    var input = Swift.String()
+    var state = State.Data
+    var returnState = State.Data
+
+    var currentToken = HTMLToken()
+    var queuedTokens = Deque<HTMLToken>()
+
+    public init() {}
+    public init?(input: AK.StringView, encoding: AK.StringView) {
+        if let string = Swift.String(decoding: input, as: encoding) {
+            self.input = string
+        } else {
+            return nil
+        }
+    }
+
+    public func nextToken(stopAtInsertionPoint: Bool = false) -> HTMLToken? {
+
+        while !queuedTokens.isEmpty {
+            return queuedTokens.popFirst()
+        }
+
+        return nil
+    }
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizerHelpers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizerHelpers.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTextCodec/Decoder.h>
+#include <LibWeb/HTML/Parser/HTMLTokenizerHelpers.h>
+
+namespace Web::HTML {
+
+OptionalString decode_to_utf8(StringView text, StringView encoding)
+{
+    auto decoder = TextCodec::decoder_for(encoding);
+    if (!decoder.has_value())
+        return std::nullopt;
+    auto decoded_or_error = decoder.value().to_utf8(text);
+    if (decoded_or_error.is_error())
+        return std::nullopt;
+    return decoded_or_error.release_value();
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizerHelpers.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizerHelpers.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <optional>
+
+namespace Web::HTML {
+
+// Swift-friendly wrapper for TextCodec::Decoder::to_utf8
+using OptionalString = std::optional<String>;
+OptionalString decode_to_utf8(StringView text, StringView encoding);
+
+}


### PR DESCRIPTION
It doesn't do much yet, the fun part was the scaffolding.


We can now more naturally construct Swift.String from AK.StringView and AK.String
The swift-collections library is added as a dependency we can use, via FetchContent.


Depends on #1130