### PR TITLE
UI/Qt: Fix hover_label hiding URLs

### DIFF
--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -62,10 +62,14 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     m_toolbar = new QToolBar(this);
     m_location_edit = new LocationEdit(this);
 
-    m_hover_label = new QLabel(this);
+    m_hover_label = new HyperlinkLabel(this);
     m_hover_label->hide();
     m_hover_label->setFrameShape(QFrame::Shape::Box);
     m_hover_label->setAutoFillBackground(true);
+
+    QObject::connect(m_hover_label, &HyperlinkLabel::mouse_entered, [this] {
+        update_hover_label();
+    });
 
     auto* focus_location_editor_action = new QAction("Edit Location", this);
     focus_location_editor_action->setShortcut(QKeySequence("Ctrl+L"));
@@ -853,12 +857,18 @@ void Tab::resizeEvent(QResizeEvent* event)
 
 void Tab::update_hover_label()
 {
+    m_hover_label->setText(QFontMetrics(m_hover_label->font()).elidedText(m_hover_label->text(), Qt::ElideRight, width() / 2 - 10));
     m_hover_label->resize(QFontMetrics(m_hover_label->font()).boundingRect(m_hover_label->text()).adjusted(-4, -2, 4, 2).size());
-    auto hover_label_height = height() - m_hover_label->height() - 8;
-    if (m_find_in_page->isVisible())
-        hover_label_height -= m_find_in_page->height() - 4;
 
-    m_hover_label->move(6, hover_label_height);
+    auto hover_label_height = height() - m_hover_label->height();
+    if (m_find_in_page->isVisible())
+        hover_label_height -= m_find_in_page->height();
+
+    if (m_hover_label->underMouse() && m_hover_label->x() == 0)
+        m_hover_label->move(width() / 2 + (width() / 2 - m_hover_label->width()), hover_label_height);
+    else
+        m_hover_label->move(0, hover_label_height);
+
     m_hover_label->raise();
 }
 

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -26,6 +26,25 @@ namespace Ladybird {
 class BrowserWindow;
 class InspectorWidget;
 
+class HyperlinkLabel final : public QLabel {
+    Q_OBJECT
+
+public:
+    explicit HyperlinkLabel(QWidget* parent = nullptr)
+        : QLabel(parent)
+    {
+        setMouseTracking(true);
+    }
+
+    virtual void enterEvent(QEnterEvent* event) override
+    {
+        emit mouse_entered(event);
+    }
+
+signals:
+    void mouse_entered(QEnterEvent*);
+};
+
 class Tab final : public QWidget {
     Q_OBJECT
 
@@ -117,7 +136,7 @@ private:
     FindInPageWidget* m_find_in_page { nullptr };
     BrowserWindow* m_window { nullptr };
     QString m_title;
-    QLabel* m_hover_label { nullptr };
+    HyperlinkLabel* m_hover_label { nullptr };
     QIcon m_favicon;
 
     QMenu* m_context_menu { nullptr };

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -403,6 +403,7 @@ void WebContentView::mouseMoveEvent(QMouseEvent* event)
     }
 
     enqueue_native_event(Web::MouseEvent::Type::MouseMove, *event);
+    QWidget::mouseMoveEvent(event);
 }
 
 void WebContentView::mousePressEvent(QMouseEvent* event)


### PR DESCRIPTION
`m_hover_label` did not have checks if the mouse is in the same location which caused clickable URLs to be hidden.

![image](https://github.com/user-attachments/assets/83467fa6-bddb-49e8-b011-87a9005e75e4)

Set max length for the `hover_label` text to be `50%` of the window width and added a check for mouse position. If there's a chance they might overlap - `hover_label` is moved to the opposite side of the window.
`Ladybird/Qt/WebContentView.cpp` fix provided by @tcl3 

https://github.com/user-attachments/assets/c0947ae8-93c2-4dc0-800a-2d23d498849a

_Moved the `hover_label` up by additional 4px if `find in page` is visible after recording the video_