### PR TITLE
LibWeb: Don't paint text fragments with CSS visibility:hidden

### DIFF
--- a/Tests/LibWeb/Ref/inline-visibility-hidden.html
+++ b/Tests/LibWeb/Ref/inline-visibility-hidden.html
@@ -1,0 +1,2 @@
+<link rel="match" href="reference/inline-visibility-hidden-ref.html" />
+<span>hello friends<span style="visibility: hidden"> and enemies</span></span>

--- a/Tests/LibWeb/Ref/reference/inline-visibility-hidden-ref.html
+++ b/Tests/LibWeb/Ref/reference/inline-visibility-hidden-ref.html
@@ -1,0 +1,1 @@
+<span>hello friends</span>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -605,6 +605,9 @@ void paint_text_decoration(PaintContext& context, TextPaintable const& paintable
 
 void paint_text_fragment(PaintContext& context, TextPaintable const& paintable, PaintableFragment const& fragment, PaintPhase phase)
 {
+    if (!paintable.is_visible())
+        return;
+
     auto& painter = context.display_list_recorder();
 
     if (phase == PaintPhase::Foreground) {


### PR DESCRIPTION
We *could* even skip creating a paintable for hidden nodes, but that means that dynamic updates to the CSS visibility property would require mutating the paint tree, so let's keep it simple for now.