### PR TITLE
LibCore+LibTimeZone+LibWebView: Create a system time zone cache

### DIFF
--- a/Tests/LibCore/TestLibCoreDateTime.cpp
+++ b/Tests/LibCore/TestLibCoreDateTime.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/DateTime.h>
 #include <LibCore/Environment.h>
 #include <LibTest/TestCase.h>
+#include <LibUnicode/TimeZone.h>
 #include <time.h>
 
 class TimeZoneGuard {
@@ -29,12 +30,14 @@ public:
         else
             TRY_OR_FAIL(Core::Environment::unset("TZ"sv));
 
+        Unicode::clear_system_time_zone_cache();
         tzset();
     }
 
     void update(StringView time_zone)
     {
         TRY_OR_FAIL(Core::Environment::set("TZ"sv, time_zone, Core::Environment::Overwrite::Yes));
+        Unicode::clear_system_time_zone_cache();
         tzset();
     }
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/Environment.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibTest/JavaScriptTestRunner.h>
+#include <LibUnicode/TimeZone.h>
 #include <stdlib.h>
 #include <time.h>
 
@@ -106,6 +107,7 @@ TESTJS_GLOBAL_FUNCTION(set_time_zone, setTimeZone)
             return vm.throw_completion<JS::InternalError>(MUST(String::formatted("Could not set time zone: {}", result.error())));
     }
 
+    Unicode::clear_system_time_zone_cache();
     tzset();
 
     return current_time_zone;

--- a/Tests/LibUnicode/TestTimeZone.cpp
+++ b/Tests/LibUnicode/TestTimeZone.cpp
@@ -16,6 +16,7 @@ public:
         : m_time_zone(Core::Environment::get("TZ"sv))
     {
         MUST(Core::Environment::set("TZ"sv, time_zone, Core::Environment::Overwrite::Yes));
+        Unicode::clear_system_time_zone_cache();
     }
 
     ~TimeZoneGuard()
@@ -24,6 +25,7 @@ public:
             MUST(Core::Environment::set("TZ"sv, *m_time_zone, Core::Environment::Overwrite::Yes));
         else
             MUST(Core::Environment::unset("TZ"sv));
+        Unicode::clear_system_time_zone_cache();
     }
 
 private:

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -63,21 +63,24 @@ if (NOT WIN32 AND NOT EMSCRIPTEN)
     list(APPEND SOURCES LocalServer.cpp)
 endif()
 
-# FIXME: Implement Core::FileWatcher for *BSD and Windows.
+# FIXME: Implement these for other systems.
 if (LINUX AND NOT EMSCRIPTEN)
     list(APPEND SOURCES
         FileWatcherLinux.cpp
         Platform/ProcessStatisticsLinux.cpp
+        TimeZoneWatcherLinux.cpp
     )
 elseif (APPLE AND NOT IOS)
     list(APPEND SOURCES
         FileWatcherMacOS.mm
         Platform/ProcessStatisticsMach.cpp
+        TimeZoneWatcherMacOS.mm
     )
 else()
     list(APPEND SOURCES
         FileWatcherUnimplemented.cpp
         Platform/ProcessStatisticsUnimplemented.cpp
+        TimeZoneWatcherUnimplemented.cpp
     )
 endif()
 

--- a/Userland/Libraries/LibCore/FileWatcher.h
+++ b/Userland/Libraries/LibCore/FileWatcher.h
@@ -25,6 +25,7 @@ struct FileWatcherEvent {
         Deleted = 1 << 2,
         ChildCreated = 1 << 3,
         ChildDeleted = 1 << 4,
+        DoNotFollowLink = 1 << 5,
     };
     Type type { Type::Invalid };
     ByteString event_path;

--- a/Userland/Libraries/LibCore/FileWatcherLinux.cpp
+++ b/Userland/Libraries/LibCore/FileWatcherLinux.cpp
@@ -145,6 +145,8 @@ ErrorOr<bool> FileWatcherBase::add_watch(ByteString path, FileWatcherEvent::Type
         inotify_mask |= IN_MODIFY;
     if (has_flag(event_mask, FileWatcherEvent::Type::MetadataModified))
         inotify_mask |= IN_ATTRIB;
+    if (has_flag(event_mask, FileWatcherEvent::Type::DoNotFollowLink))
+        inotify_mask |= IN_DONT_FOLLOW;
 
     int watch_descriptor = ::inotify_add_watch(m_watcher_fd, path.characters(), inotify_mask);
     if (watch_descriptor < 0)

--- a/Userland/Libraries/LibCore/FileWatcherLinux.cpp
+++ b/Userland/Libraries/LibCore/FileWatcherLinux.cpp
@@ -74,6 +74,8 @@ static Optional<FileWatcherEvent> get_event_from_fd(int fd, HashMap<unsigned, By
         result.type |= FileWatcherEvent::Type::ContentModified;
     if ((event->mask & IN_ATTRIB) != 0)
         result.type |= FileWatcherEvent::Type::MetadataModified;
+    if ((event->mask & IN_IGNORED) != 0)
+        return {};
 
     if (result.type == FileWatcherEvent::Type::Invalid) {
         warnln("Unknown event type {:x} returned by the watch_file descriptor for {}", event->mask, path);

--- a/Userland/Libraries/LibCore/FileWatcherLinux.cpp
+++ b/Userland/Libraries/LibCore/FileWatcherLinux.cpp
@@ -164,11 +164,11 @@ ErrorOr<bool> FileWatcherBase::remove_watch(ByteString path)
         return false;
     }
 
-    if (::inotify_rm_watch(m_watcher_fd, it->value) < 0)
-        return Error::from_errno(errno);
-
     m_path_to_wd.remove(it);
     m_wd_to_path.remove(it->value);
+
+    if (::inotify_rm_watch(m_watcher_fd, it->value) < 0)
+        return Error::from_errno(errno);
 
     dbgln_if(FILE_WATCHER_DEBUG, "remove_watch: stopped watching path '{}' on InodeWatcher {}", path, m_watcher_fd);
     return true;

--- a/Userland/Libraries/LibCore/FileWatcherLinux.cpp
+++ b/Userland/Libraries/LibCore/FileWatcherLinux.cpp
@@ -111,7 +111,6 @@ FileWatcher::FileWatcher(int watcher_fd, NonnullRefPtr<Notifier> notifier)
         auto maybe_event = get_event_from_fd(m_notifier->fd(), m_wd_to_path);
         if (maybe_event.has_value()) {
             auto event = maybe_event.value();
-            on_change(event);
 
             if (has_flag(event.type, FileWatcherEvent::Type::Deleted)) {
                 auto result = remove_watch(event.event_path);
@@ -119,6 +118,8 @@ FileWatcher::FileWatcher(int watcher_fd, NonnullRefPtr<Notifier> notifier)
                     dbgln_if(FILE_WATCHER_DEBUG, "on_ready_to_read: {}", result.error());
                 }
             }
+
+            on_change(event);
         }
     };
 }

--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -45,6 +45,7 @@ class TCPServer;
 class TCPSocket;
 class Timer;
 class TimerEvent;
+class TimeZoneWatcher;
 class UDPServer;
 class UDPSocket;
 

--- a/Userland/Libraries/LibCore/TimeZoneWatcher.h
+++ b/Userland/Libraries/LibCore/TimeZoneWatcher.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/Noncopyable.h>
+#include <AK/NonnullOwnPtr.h>
+
+namespace Core {
+
+class TimeZoneWatcher {
+    AK_MAKE_NONCOPYABLE(TimeZoneWatcher);
+
+public:
+    static ErrorOr<NonnullOwnPtr<TimeZoneWatcher>> create();
+    virtual ~TimeZoneWatcher() = default;
+
+    Function<void()> on_time_zone_changed;
+
+protected:
+    TimeZoneWatcher() = default;
+};
+
+}

--- a/Userland/Libraries/LibCore/TimeZoneWatcherLinux.cpp
+++ b/Userland/Libraries/LibCore/TimeZoneWatcherLinux.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+#include <LibCore/FileWatcher.h>
+#include <LibCore/TimeZoneWatcher.h>
+
+#if !defined(AK_OS_LINUX)
+static_assert(false, "This file must only be used for Linux");
+#endif
+
+namespace Core {
+
+static constexpr auto time_zone_files = Array {
+    "/etc/localtime"sv,
+    "/etc/timezone"sv,
+    "/etc/TZ"sv,
+};
+
+static constexpr auto time_zone_mask = FileWatcherEvent::Type::ContentModified
+    | FileWatcherEvent::Type::Deleted
+    | FileWatcherEvent::Type::DoNotFollowLink;
+
+class TimeZoneWatcherImpl final : public TimeZoneWatcher {
+public:
+    static ErrorOr<NonnullOwnPtr<TimeZoneWatcherImpl>> create()
+    {
+        auto file_watcher = TRY(FileWatcher::create());
+
+        for (auto time_zone_file : time_zone_files) {
+            if (auto result = file_watcher->add_watch(time_zone_file, time_zone_mask); !result.is_error())
+                break;
+        }
+
+        return adopt_own(*new TimeZoneWatcherImpl(move(file_watcher)));
+    }
+
+private:
+    explicit TimeZoneWatcherImpl(NonnullRefPtr<FileWatcher> file_watcher)
+        : m_file_watcher(move(file_watcher))
+    {
+        m_file_watcher->on_change = [this](Core::FileWatcherEvent const& event) {
+            if (on_time_zone_changed)
+                on_time_zone_changed();
+
+            if (has_flag(event.type, FileWatcherEvent::Type::Deleted))
+                (void)m_file_watcher->add_watch(event.event_path, time_zone_mask);
+        };
+    }
+
+    NonnullRefPtr<FileWatcher> m_file_watcher;
+};
+
+ErrorOr<NonnullOwnPtr<TimeZoneWatcher>> TimeZoneWatcher::create()
+{
+    return TimeZoneWatcherImpl::create();
+}
+
+}

--- a/Userland/Libraries/LibCore/TimeZoneWatcherMacOS.mm
+++ b/Userland/Libraries/LibCore/TimeZoneWatcherMacOS.mm
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Platform.h>
+#include <LibCore/TimeZoneWatcher.h>
+
+#if !defined(AK_OS_MACOS)
+static_assert(false, "This file must only be used for macOS");
+#endif
+
+#include <CoreFoundation/CoreFoundation.h>
+
+namespace Core {
+
+class TimeZoneWatcherImpl final : public TimeZoneWatcher {
+public:
+    static ErrorOr<NonnullOwnPtr<TimeZoneWatcherImpl>> create()
+    {
+        return adopt_own(*new TimeZoneWatcherImpl());
+    }
+
+    virtual ~TimeZoneWatcherImpl() override
+    {
+        CFNotificationCenterRemoveObserver(
+            CFNotificationCenterGetLocalCenter(),
+            this,
+            kCFTimeZoneSystemTimeZoneDidChangeNotification,
+            nullptr);
+    }
+
+private:
+    explicit TimeZoneWatcherImpl()
+    {
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetLocalCenter(),
+            this,
+            time_zone_changed,
+            kCFTimeZoneSystemTimeZoneDidChangeNotification,
+            nullptr,
+            CFNotificationSuspensionBehaviorDeliverImmediately);
+    }
+
+    static void time_zone_changed(CFNotificationCenterRef, void* observer, CFStringRef, void const*, CFDictionaryRef)
+    {
+        auto const& time_zone_watcher = *reinterpret_cast<TimeZoneWatcherImpl*>(observer);
+
+        if (time_zone_watcher.on_time_zone_changed)
+            time_zone_watcher.on_time_zone_changed();
+    }
+};
+
+ErrorOr<NonnullOwnPtr<TimeZoneWatcher>> TimeZoneWatcher::create()
+{
+    return TimeZoneWatcherImpl::create();
+}
+
+}

--- a/Userland/Libraries/LibCore/TimeZoneWatcherUnimplemented.cpp
+++ b/Userland/Libraries/LibCore/TimeZoneWatcherUnimplemented.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/TimeZoneWatcher.h>
+
+namespace Core {
+
+ErrorOr<NonnullOwnPtr<TimeZoneWatcher>> TimeZoneWatcher::create()
+{
+    return Error::from_errno(ENOTSUP);
+}
+
+}

--- a/Userland/Libraries/LibUnicode/TimeZone.cpp
+++ b/Userland/Libraries/LibUnicode/TimeZone.cpp
@@ -15,8 +15,13 @@
 
 namespace Unicode {
 
-String current_time_zone()
+static Optional<String> cached_system_time_zone;
+
+String current_time_zone(UseTimeZoneCache)
 {
+    if (cached_system_time_zone.has_value())
+        return *cached_system_time_zone;
+
     UErrorCode status = U_ZERO_ERROR;
 
     auto time_zone = adopt_own_if_nonnull(icu::TimeZone::detectHostTimeZone());
@@ -32,7 +37,13 @@ String current_time_zone()
     if (icu_failure(status))
         return "UTC"_string;
 
-    return icu_string_to_string(time_zone_name);
+    cached_system_time_zone = icu_string_to_string(time_zone_name);
+    return *cached_system_time_zone;
+}
+
+void clear_system_time_zone_cache()
+{
+    cached_system_time_zone.clear();
 }
 
 // https://github.com/unicode-org/icu/blob/main/icu4c/source/tools/tzcode/icuzones

--- a/Userland/Libraries/LibUnicode/TimeZone.h
+++ b/Userland/Libraries/LibUnicode/TimeZone.h
@@ -23,7 +23,13 @@ struct TimeZoneOffset {
     InDST in_dst { InDST::No };
 };
 
-String current_time_zone();
+enum class UseTimeZoneCache {
+    No,
+    Yes,
+};
+
+String current_time_zone(UseTimeZoneCache = UseTimeZoneCache::Yes);
+void clear_system_time_zone_cache();
 Vector<String> const& available_time_zones();
 Vector<String> available_time_zones_in_region(StringView region);
 Optional<String> resolve_primary_time_zone(StringView time_zone);

--- a/Userland/Libraries/LibWebView/Application.h
+++ b/Userland/Libraries/LibWebView/Application.h
@@ -9,6 +9,7 @@
 #include <AK/Badge.h>
 #include <AK/Swift.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/Forward.h>
 #include <LibMain/Main.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Options.h>
@@ -68,6 +69,8 @@ private:
 
     ChromeOptions m_chrome_options;
     WebContentOptions m_web_content_options;
+
+    OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 
     Core::EventLoop m_event_loop;
     ProcessManager m_process_manager;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -16,6 +16,7 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/ConsoleObject.h>
+#include <LibUnicode/TimeZone.h>
 #include <LibWeb/ARIA/RoleType.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/CSS/StyleComputer.h>
@@ -1167,6 +1168,11 @@ void ConnectionFromClient::set_user_style(u64 page_id, String const& source)
 void ConnectionFromClient::enable_inspector_prototype(u64)
 {
     Web::HTML::Window::set_inspector_object_exposed(true);
+}
+
+void ConnectionFromClient::system_time_zone_changed()
+{
+    Unicode::clear_system_time_zone_cache();
 }
 
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -145,6 +145,8 @@ private:
 
     virtual void paste(u64 page_id, String const& text) override;
 
+    virtual void system_time_zone_changed() override;
+
     void report_finished_handling_input_event(u64 page_id, bool event_was_handled);
 
     NonnullOwnPtr<PageHost> m_page_host;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -115,4 +115,6 @@ endpoint WebContentServer
     set_user_style(u64 page_id, String source) =|
 
     enable_inspector_prototype(u64 page_id) =|
+
+    system_time_zone_changed() =|
 }


### PR DESCRIPTION
Getting the system time zone from disk can be expensive when it is hammered frequently by web pages. We can instead cache the time zone, and only go to disk after we detect a system time zone change.

This contains a handful of fixes to `Core::FileWatcher` to be able to monitor symbolic links (/etc/localtime is usually a link). Then creates a platform-dependent time zone watcher to monitor for time zone changes from the OS, and IPC to propagate that notification over to WebContent.

The following benchmark previously took ~0.8s on Linux and ~2.5s on macOS, and now takes 0ms on both:
```c++
BENCHMARK_CASE(bench_current_time_zone)
{
    for (size_t i = 0; i < 100'000; ++i)
        (void)Unicode::current_time_zone();
}
```

And a small demo showing we respond to time zone changes:

https://github.com/user-attachments/assets/1776ca07-8d65-43bc-ab74-a096cca1f24e



