### PR TITLE
LibWeb: Implement cloning steps for `HTMLInputElement` and `HTMLTextAreaElement`

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-cloning-steps.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-cloning-steps.txt
@@ -1,0 +1,2 @@
+  Cloned checkbox checked: true
+Cloned text input value: PASS

--- a/Tests/LibWeb/Text/expected/HTML/HTMLTextAreaElement-cloning-steps.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLTextAreaElement-cloning-steps.txt
@@ -1,0 +1,1 @@
+  Cloned textarea value: PASS

--- a/Tests/LibWeb/Text/input/HTML/HTMLInputElement-cloning-steps.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLInputElement-cloning-steps.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<form>
+    <input id="checkedCheckbox" type="checkbox">
+    <input type="text" value="FAIL">
+</form>
+<script>
+    test(() => {
+        const form = document.forms[0];
+        const inputs = form.getElementsByTagName("input");
+        inputs[0].checked = true;
+        inputs[1].value = "PASS";
+
+        const clone = form.cloneNode(true);
+        document.body.appendChild(clone);
+
+        println(`Cloned checkbox checked: ${clone.querySelector("input[type=checkbox]").checked}`);
+        println(`Cloned text input value: ${clone.querySelector("input[type=text]").value}`);
+
+        form.remove();
+        clone.remove();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLTextAreaElement-cloning-steps.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLTextAreaElement-cloning-steps.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<form>
+    <textarea id="testTextArea" value="FAIL"></textarea>
+</form>
+<script>
+    test(() => {
+        const form = document.forms[0];
+        const textarea = form.querySelector("textarea");
+        textarea.value = "PASS";
+
+        const clone = form.cloneNode(true);
+        document.body.appendChild(clone);
+
+        println(`Cloned textarea value: ${clone.querySelector("textarea").value}`);
+
+        form.remove();
+        clone.remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1446,6 +1446,18 @@ void HTMLInputElement::form_associated_element_was_removed(DOM::Node*)
     set_shadow_root(nullptr);
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#the-input-element%3Aconcept-node-clone-ext
+WebIDL::ExceptionOr<void> HTMLInputElement::cloned(DOM::Node& copy, bool)
+{
+    // The cloning steps for input elements must propagate the value, dirty value flag, checkedness, and dirty checkedness flag from the node being cloned to the copy.
+    auto& input_clone = verify_cast<HTMLInputElement>(copy);
+    input_clone.m_value = m_value;
+    input_clone.m_dirty_value = m_dirty_value;
+    input_clone.m_checked = m_checked;
+    input_clone.m_dirty_checkedness = m_dirty_checkedness;
+    return {};
+}
+
 // https://html.spec.whatwg.org/multipage/input.html#radio-button-group
 static bool is_in_same_radio_button_group(HTML::HTMLInputElement const& a, HTML::HTMLInputElement const& b)
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -176,6 +176,8 @@ public:
     virtual void form_associated_element_was_removed(DOM::Node*) override;
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&) override;
 
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
+
     JS::NonnullGCPtr<ValidityState const> validity() const;
 
     // ^HTMLElement

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -116,6 +116,17 @@ void HTMLTextAreaElement::reset_algorithm()
     }
 }
 
+// https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-node-clone-ext
+WebIDL::ExceptionOr<void> HTMLTextAreaElement::cloned(DOM::Node& copy, bool)
+{
+    // The cloning steps for textarea elements must propagate the raw value and dirty value flag from the node being cloned to the copy.
+    auto& textarea_copy = verify_cast<HTMLTextAreaElement>(copy);
+    textarea_copy.m_raw_value = m_raw_value;
+    textarea_copy.m_dirty_value = m_dirty_value;
+
+    return {};
+}
+
 void HTMLTextAreaElement::form_associated_element_was_inserted()
 {
     create_shadow_tree_if_needed();

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -63,6 +63,8 @@ public:
 
     virtual void reset_algorithm() override;
 
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
+
     virtual void form_associated_element_was_inserted() override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&) override;


### PR DESCRIPTION
Fixes:
*  https://wpt.live/html/semantics/forms/the-input-element/clone.html
*  http://wpt.live/html/semantics/forms/the-textarea-element/cloning-steps.html    