### PR TITLE
LibWeb: Make CSS :hover selector match shadow-inclusive ancestors

### DIFF
--- a/Tests/LibWeb/Text/expected/ShadowDOM/css-hover-shadow-dom.txt
+++ b/Tests/LibWeb/Text/expected/ShadowDOM/css-hover-shadow-dom.txt
@@ -1,0 +1,1 @@
+   hovered bg: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/ShadowDOM/css-hover-shadow-dom.html
+++ b/Tests/LibWeb/Text/input/ShadowDOM/css-hover-shadow-dom.html
@@ -1,0 +1,23 @@
+<style>
+#myShadowHost:hover {
+    background: green;
+}
+#myShadowHost {
+    position: absolute;
+    width: 100px;
+    height: 100px;
+}
+</style>
+<body><div id="myShadowHost"><template shadowrootmode="open"><div>hover me</div></template></div></body>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        if (window.internals && window.internals.movePointerTo)
+            internals.movePointerTo(50, 50);
+
+        let s = getComputedStyle(myShadowHost);
+        println("hovered bg: " + s.backgroundColor);
+
+        myShadowHost.remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -147,7 +147,7 @@ static inline bool matches_hover_pseudo_class(DOM::Element const& element)
         return false;
     if (&element == hovered_node)
         return true;
-    return element.is_ancestor_of(*hovered_node);
+    return element.is_shadow_including_ancestor_of(*hovered_node);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics-other.html#selector-checked


### PR DESCRIPTION
Before this change, :hover wouldn't match anything outside the shadow boundary when hovering elements inside a shadow tree. This was most noticeable when hovering the text inside an input element and hover styles disappearing from the hosting input element itself.