### PR TITLE
Ladybird: Remove unnecessary copy of decoded images

### DIFF
--- a/Ladybird/ImageCodecPlugin.cpp
+++ b/Ladybird/ImageCodecPlugin.cpp
@@ -51,7 +51,7 @@ NonnullRefPtr<Core::Promise<Web::Platform::DecodedImage>> ImageCodecPlugin::deco
             Web::Platform::DecodedImage decoded_image;
             decoded_image.is_animated = result.is_animated;
             decoded_image.loop_count = result.loop_count;
-            for (auto const& frame : result.frames) {
+            for (auto& frame : result.frames) {
                 decoded_image.frames.empend(move(frame.bitmap), frame.duration);
             }
             promise->resolve(move(decoded_image));


### PR DESCRIPTION
This also eliminates the clang-tidy warning _“Std::move of the const expression has no effect”._