### PR TITLE
LibWeb: Implement `vertical-align: middle` correctly for atomic inlines

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-vertical-align-middle.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-block-vertical-align-middle.txt
@@ -1,0 +1,16 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: inline
+      InlineNode <span>
+        frag 0 from TextNode start: 0, length: 4, rect: [8,49 35.15625x17] baseline: 13.296875
+            "foo "
+        frag 1 from BlockContainer start: 0, length: 0, rect: [43,8 100x100] baseline: 54.296875
+        TextNode <#text>
+        BlockContainer <span.thing> at (43,8) content-size 100x100 inline-block [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      InlinePaintable (InlineNode<SPAN>)
+        TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<SPAN>.thing) [43,8 100x100]

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-block-vertical-align-middle.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-block-vertical-align-middle.html
@@ -1,0 +1,9 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    .thing {
+        display: inline-block;
+        vertical-align: middle;
+        width: 100px;
+        height: 100px;
+    }
+</style><body><span>foo <span class="thing"></span>


### PR DESCRIPTION
This makes inline icons pop into the right place on https://ahrefs.com/

Before:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/228729b3-a2ce-40d2-aec1-136c3aa61a71">

After:
<img width="1211" alt="image" src="https://github.com/user-attachments/assets/1cdd5f09-3307-4378-9804-928eb4040a32">
