### PR TITLE
LibUnicode: Remove unused time zone cache option

### DIFF
--- a/Userland/Libraries/LibUnicode/TimeZone.cpp
+++ b/Userland/Libraries/LibUnicode/TimeZone.cpp
@@ -17,7 +17,7 @@ namespace Unicode {
 
 static Optional<String> cached_system_time_zone;
 
-String current_time_zone(UseTimeZoneCache)
+String current_time_zone()
 {
     if (cached_system_time_zone.has_value())
         return *cached_system_time_zone;

--- a/Userland/Libraries/LibUnicode/TimeZone.h
+++ b/Userland/Libraries/LibUnicode/TimeZone.h
@@ -23,12 +23,7 @@ struct TimeZoneOffset {
     InDST in_dst { InDST::No };
 };
 
-enum class UseTimeZoneCache {
-    No,
-    Yes,
-};
-
-String current_time_zone(UseTimeZoneCache = UseTimeZoneCache::Yes);
+String current_time_zone();
 void clear_system_time_zone_cache();
 Vector<String> const& available_time_zones();
 Vector<String> available_time_zones_in_region(StringView region);


### PR DESCRIPTION
Added this during development while testing some callers, but forgot to remove it before opening a PR.