### PR TITLE
Revert "LibWeb: Change where content selection via mouse is allowed"

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -70,8 +70,6 @@ public:
     virtual bool has_activation_behavior() const override;
     virtual void activation_behavior(DOM::Event const&) override;
 
-    virtual bool is_child_node_selectable(DOM::Node const&) const override { return false; }
-
 private:
     virtual bool is_html_button_element() const override { return true; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -80,8 +80,6 @@ public:
     WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
     Optional<String> popover() const;
 
-    virtual bool is_child_node_selectable(DOM::Node const&) const { return true; }
-
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2380,9 +2380,4 @@ HTMLInputElement::ValueAttributeMode HTMLInputElement::value_attribute_mode() co
     VERIFY_NOT_REACHED();
 }
 
-bool HTMLInputElement::is_child_node_selectable(DOM::Node const& node) const
-{
-    return !is_button() && (!m_placeholder_element || !m_placeholder_element->is_inclusive_ancestor_of(node));
-}
-
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -206,8 +206,6 @@ public:
     WebIDL::ExceptionOr<void> set_selection_end_for_bindings(Optional<WebIDL::UnsignedLong> const&);
     Optional<WebIDL::UnsignedLong> selection_end_for_bindings() const;
 
-    virtual bool is_child_node_selectable(DOM::Node const&) const override;
-
 private:
     HTMLInputElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -449,19 +449,9 @@ bool EventHandler::handle_mousedown(CSSPixelPoint viewport_position, CSSPixelPoi
                         HTML::run_unfocusing_steps(focused_element);
                 }
 
-                // Ask the next non-shadow parent element whether the node at the mouse position is selectable.
-                auto& root_node = dom_node->root();
-                DOM::Element* non_shadow_parent_element;
-                if (root_node.is_shadow_root())
-                    non_shadow_parent_element = root_node.parent_or_shadow_host_element();
-                else
-                    non_shadow_parent_element = dom_node->parent_element();
-                bool is_selectable = true;
-                if (non_shadow_parent_element && non_shadow_parent_element->is_html_element())
-                    is_selectable = static_cast<HTML::HTMLElement*>(non_shadow_parent_element)->is_child_node_selectable(*dom_node);
-
-                // If it is selectable, place the document text cursor at the mouse position.
-                if (is_selectable) {
+                // If we didn't focus anything, place the document text cursor at the mouse position.
+                // FIXME: This is all rather strange. Find a better solution.
+                if (!did_focus_something || dom_node->is_editable()) {
                     auto& realm = document->realm();
                     document->set_cursor_position(DOM::Position::create(realm, *dom_node, result->index_in_node));
                     if (auto selection = document->get_selection()) {


### PR DESCRIPTION
This reverts commit 6c9adf3dbc641445a03da9cd1083f89c911504be.

This change breaks e.g. typing into the search box on google.com and comment boxes on github.com.