### PR TITLE
Meta+Libraries+AK: Append Cxx to imported library module names in swift 

### DIFF
--- a/AK/AK+Swift.swift
+++ b/AK/AK+Swift.swift
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import AK
+@_exported import AKCxx
 import Foundation
 
 public extension Foundation.Data {

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -62,14 +62,11 @@ swizzle_target_properties_for_swift(simdutf::simdutf)
 target_link_libraries(AK PRIVATE simdutf::simdutf)
 
 if (ENABLE_SWIFT)
-    generate_clang_module_map(
-       AK
+    generate_clang_module_map(AK
        GENERATED_FILES
         "${CMAKE_CURRENT_BINARY_DIR}/Backtrace.h"
         "${CMAKE_CURRENT_BINARY_DIR}/Debug.h"
     )
-
-    target_compile_features(AK PUBLIC cxx_std_23)
-    set_target_properties(AK PROPERTIES Swift_MODULE_NAME SwiftAK)
     target_sources(AK PRIVATE AK+Swift.swift)
+    add_swift_target_properties(AK)
 endif()

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -29,14 +29,22 @@ function(generate_clang_module_map target_name)
         set(MODULE_MAP_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
     endif()
 
+    string(REPLACE "Lib" "" module_name ${target_name})
+    set(module_name "${module_name}Cxx")
+
     set(module_map_file "${CMAKE_CURRENT_BINARY_DIR}/module/module.modulemap")
-    set(vfs_overlay_file "${CMAKE_CURRENT_BINARY_DIR}/vfs_overlay.yaml")
+    set(vfs_overlay_file "${VFS_OVERLAY_DIRECTORY}/${target_name}_vfs_overlay.yaml")
 
     find_package(Python3 REQUIRED COMPONENTS Interpreter)
     # FIXME: Make this depend on the public headers of the target
     add_custom_command(
         OUTPUT "${module_map_file}"
-        COMMAND "${Python3_EXECUTABLE}" "${SerenityOS_SOURCE_DIR}/Meta/generate_clang_module_map.py" "${MODULE_MAP_DIRECTORY}" --module-map "${module_map_file}" --vfs-map ${vfs_overlay_file} ${MODULE_MAP_GENERATED_FILES}
+        COMMAND "${Python3_EXECUTABLE}" "${SerenityOS_SOURCE_DIR}/Meta/generate_clang_module_map.py"
+                "${MODULE_MAP_DIRECTORY}"
+                --module-name "${module_name}"
+                --module-map "${module_map_file}"
+                --vfs-map ${vfs_overlay_file}
+                ${MODULE_MAP_GENERATED_FILES}
         VERBATIM
         DEPENDS "${SerenityOS_SOURCE_DIR}/Meta/generate_clang_module_map.py"
     )

--- a/Meta/CMake/skia.cmake
+++ b/Meta/CMake/skia.cmake
@@ -1,6 +1,8 @@
+include_guard()
+
 find_package(unofficial-skia CONFIG)
 if(unofficial-skia_FOUND)
-    set(SKIA_LIBRARIES unofficial::skia::skia)
+    set(SKIA_TARGET unofficial::skia::skia)
 else()
     find_package(PkgConfig)
 
@@ -16,7 +18,8 @@ else()
       endif()
     endforeach()
 
-    pkg_check_modules(SKIA skia=${SKIA_REQUIRED_VERSION} REQUIRED)
-    include_directories(${SKIA_INCLUDE_DIRS})
-    link_directories(${SKIA_LIBRARY_DIRS})
+    pkg_check_modules(skia skia=${SKIA_REQUIRED_VERSION} REQUIRED IMPORTED_TARGET skia)
+    set(SKIA_TARGET PkgConfig::skia)
 endif()
+swizzle_target_properties_for_swift(${SKIA_TARGET})
+add_library(skia ALIAS ${SKIA_TARGET})

--- a/Meta/generate_clang_module_map.py
+++ b/Meta/generate_clang_module_map.py
@@ -27,6 +27,7 @@ def main():
                  formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument('directory', help='source directory to generate module map for')
     parser.add_argument('generated_files', nargs='+', help='extra files to include in the module map')
+    parser.add_argument('-n', '--module-name', help='top-level module name')
     parser.add_argument('-m', '--module-map', required=True, help='output module map file')
     parser.add_argument('-v', '--vfs-map', required=True, help='output VFS map file')
     args = parser.parse_args()
@@ -36,9 +37,10 @@ def main():
         print(f"Error: {args.directory} is not a directory", file=sys.stderr)
         return 1
     pathlib.Path(args.module_map).parent.mkdir(parents=True, exist_ok=True)
+    pathlib.Path(args.vfs_map).parent.mkdir(parents=True, exist_ok=True)
 
     header_files = [f for f in root.rglob('**/*.h') if f.is_file()]
-    module_name = root.name
+    module_name = args.module_name if args.module_name else root.name
 
     module_map = f"module {module_name} {{\n"
     for header_file in header_files:

--- a/Tests/LibWeb/TestHTMLTokenizerSwift.swift
+++ b/Tests/LibWeb/TestHTMLTokenizerSwift.swift
@@ -5,8 +5,7 @@
  */
 
 import AK
-import LibWeb
-import SwiftLibWeb
+import Web
 import Foundation
 
 class StandardError: TextOutputStream {

--- a/Tests/LibWeb/TestLibWebSwiftBindings.swift
+++ b/Tests/LibWeb/TestLibWebSwiftBindings.swift
@@ -5,7 +5,7 @@
  */
 
 import AK
-import LibWeb
+import Web
 import Foundation
 
 class StandardError: TextOutputStream {

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -73,8 +73,7 @@ set(SOURCES
 
 serenity_lib(LibGfx gfx)
 
-find_package(harfbuzz REQUIRED)
-target_link_libraries(LibGfx PRIVATE LibCompress LibCore LibCrypto LibFileSystem LibRIFF LibTextCodec LibIPC LibUnicode LibURL ${SKIA_LIBRARIES} harfbuzz)
+target_link_libraries(LibGfx PRIVATE LibCompress LibCore LibCrypto LibFileSystem LibRIFF LibTextCodec LibIPC LibUnicode LibURL)
 
 set(generated_sources TIFFMetadata.h TIFFTagHandler.cpp)
 list(TRANSFORM generated_sources PREPEND "ImageFormats/")
@@ -110,9 +109,10 @@ find_package(PNG REQUIRED)
 find_package(LIBAVIF REQUIRED)
 find_package(WebP REQUIRED)
 pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl)
+find_package(harfbuzz REQUIRED)
 
 target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PkgConfig::Jxl PNG::PNG avif WebP::webp WebP::webpdecoder
-            WebP::webpdemux WebP::libwebpmux)
+            WebP::webpdemux WebP::libwebpmux skia harfbuzz)
 
 if (ENABLE_SWIFT)
     generate_clang_module_map(LibGfx GENERATED_FILES ${generated_headers})

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -116,32 +116,9 @@ target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PkgConfig::Jxl 
 
 if (ENABLE_SWIFT)
     generate_clang_module_map(LibGfx GENERATED_FILES ${generated_headers})
-
-    target_compile_features(LibGfx PUBLIC cxx_std_23)
-
     target_sources(LibGfx PRIVATE
         Color.swift
     )
-    target_compile_definitions(LibGfx PRIVATE LIBGFX_USE_SWIFT)
     target_link_libraries(LibGfx PRIVATE AK)
-    set_target_properties(LibGfx PROPERTIES Swift_MODULE_NAME "SwiftLibGfx")
-
-    # FIXME: These should be pulled automatically from interface compile options for the target
-    set(VFS_OVERLAY_OPTIONS
-        -Xcc -ivfsoverlay${CMAKE_CURRENT_BINARY_DIR}/vfs_overlay.yaml
-        -Xcc -ivfsoverlay${Lagom_BINARY_DIR}/AK/vfs_overlay.yaml
-    )
-    get_target_property(LIBGFX_NATIVE_DIRS LibGfx INCLUDE_DIRECTORIES)
-    list(APPEND LIBGFX_NATIVE_DIRS ${CMAKE_Swift_MODULE_DIRECTORY})
-    _swift_generate_cxx_header(LibGfx "LibGfx-Swift.h"
-        SEARCH_PATHS ${LIBGFX_NATIVE_DIRS}
-        COMPILE_OPTIONS ${VFS_OVERLAY_OPTIONS}
-    )
-
-    # FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/26175
-    if (APPLE)
-        add_custom_command(TARGET LibGfx POST_BUILD
-            COMMAND install_name_tool -id @rpath/liblagom-gfx.0.dylib "$<TARGET_FILE:LibGfx>"
-        )
-    endif()
+    add_swift_target_properties(LibGfx LAGOM_LIBRARIES AK)
 endif()

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -270,7 +270,7 @@ Optional<Color> Color::from_named_css_color_string(StringView string)
 #if defined(LIBGFX_USE_SWIFT)
 static Optional<Color> hex_string_to_color(StringView string)
 {
-    auto color = SwiftLibGfx::parseHexString(string);
+    auto color = parseHexString(string);
     if (color.getCount() == 0)
         return {};
     return color[0];

--- a/Userland/Libraries/LibGfx/Color.swift
+++ b/Userland/Libraries/LibGfx/Color.swift
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import SwiftAK
-import LibGfx
+import AK
+@_exported import GfxCxx
 
 // FIXME: Do this without extending String with an index operation that was explicitly deleted :^)
 extension Swift.String {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -786,7 +786,7 @@ set(GENERATED_SOURCES
 
 serenity_lib(LibWeb web)
 
-target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibAudio LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests ${SKIA_LIBRARIES})
+target_link_libraries(LibWeb PRIVATE LibCore LibCrypto LibJS LibHTTP LibGfx LibIPC LibRegex LibSyntax LibTextCodec LibUnicode LibAudio LibMedia LibWasm LibXML LibIDL LibURL LibTLS LibRequests skia)
 
 generate_js_bindings(LibWeb)
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -800,36 +800,11 @@ if (ENABLE_SWIFT)
 
     generate_clang_module_map(LibWeb GENERATED_FILES ${LIBWEB_ALL_GENERATED_HEADERS})
 
-    target_compile_features(LibWeb PUBLIC cxx_std_23)
-
     target_sources(LibWeb PRIVATE
         HTML/Parser/HTMLToken.swift
         HTML/Parser/HTMLTokenizer.swift
         HTML/Parser/HTMLTokenizerHelpers.cpp
     )
-    target_compile_definitions(LibWeb PRIVATE LIBWEB_USE_SWIFT)
-    set_target_properties(LibWeb PROPERTIES Swift_MODULE_NAME "SwiftLibWeb")
-
     target_link_libraries(LibWeb PRIVATE AK Collections)
-
-    # FIXME: These should be pulled automatically from interface compile options for the target
-    set(VFS_OVERLAY_OPTIONS
-        -Xcc -ivfsoverlay${CMAKE_CURRENT_BINARY_DIR}/vfs_overlay.yaml
-        -Xcc -ivfsoverlay${CMAKE_CURRENT_BINARY_DIR}/../LibGfx/vfs_overlay.yaml
-        -Xcc -ivfsoverlay${Lagom_BINARY_DIR}/AK/vfs_overlay.yaml
-    )
-    get_target_property(LIBWEB_NATIVE_DIRS LibWeb INCLUDE_DIRECTORIES)
-    list(APPEND LIBWEB_NATIVE_DIRS ${CMAKE_Swift_MODULE_DIRECTORY})
-
-    _swift_generate_cxx_header(LibWeb "LibWeb-Swift.h"
-        SEARCH_PATHS ${LIBWEB_NATIVE_DIRS}
-        COMPILE_OPTIONS ${VFS_OVERLAY_OPTIONS}
-    )
-
-    # FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/26175
-    if (APPLE)
-        add_custom_command(TARGET LibWeb POST_BUILD
-            COMMAND install_name_tool -id @rpath/liblagom-web.0.dylib "$<TARGET_FILE:LibWeb>"
-        )
-    endif()
+    add_swift_target_properties(LibWeb LAGOM_LIBRARIES AK LibGfx)
 endif()

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.swift
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLToken.swift
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+@_exported import WebCxx
+
 public class HTMLToken {
     public struct Position {
         var line = UInt()
@@ -12,10 +14,10 @@ public class HTMLToken {
     }
 
     public struct Attribute {
-        var prefix: String?
-        var localName: String
-        var namespace_: String?
-        var value: String
+        var prefix: Swift.String?
+        var localName: Swift.String
+        var namespace_: Swift.String?
+        var value: Swift.String
         var nameStartPosition: Position
         var nameEndPosition: Position
         var valueStartPosition: Position
@@ -25,21 +27,21 @@ public class HTMLToken {
     public enum TokenType {
         case Invalid
         case DOCTYPE(
-            name: String?,
-            publicIdentifier: String?,
-            systemIdentifier: String?,
+            name: Swift.String?,
+            publicIdentifier: Swift.String?,
+            systemIdentifier: Swift.String?,
             forceQuirksMode: Bool)
         case StartTag(
-            tagName: String,
+            tagName: Swift.String,
             selfClosing: Bool,
             selfClosingAcknowledged: Bool,
             attributes: [Attribute])
         case EndTag(
-            tagName: String,
+            tagName: Swift.String,
             selfClosing: Bool,
             selfClosingAcknowledged: Bool,
             attributes: [Attribute])
-        case Comment(data: String)
+        case Comment(data: Swift.String)
         case Character(codePoint: Character)
         case EndOfFile
     }
@@ -78,14 +80,14 @@ public class HTMLToken {
 }
 
 extension HTMLToken.Position: Equatable, CustomStringConvertible {
-    public var description: String {
+    public var description: Swift.String {
         return "\(self.line):\(self.column)"
     }
 }
 
 extension HTMLToken.TokenType: CustomStringConvertible {
     // FIXME: Print attributes for start/end tags
-    public var description: String {
+    public var description: Swift.String {
         switch self {
         case .Invalid:
             return "Invalid"
@@ -106,7 +108,7 @@ extension HTMLToken.TokenType: CustomStringConvertible {
 }
 
 extension HTMLToken: CustomStringConvertible {
-    public var description: String {
+    public var description: Swift.String {
         if (self.startPosition == Position()) {
             return "HTMLToken(type: \(self.type))"
         }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.swift
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.swift
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import AK
 import Collections
 import Foundation
-import LibWeb
-import SwiftAK
+@_exported import WebCxx
 
 extension Swift.String {
     public init?(decoding: AK.StringView, as: AK.StringView) {


### PR DESCRIPTION
At the same time, simplify CMakeLists magic for libraries that want to
include Swift code in the library. The Lib-less name of the library is
now always the module name for the library with any Swift additions,
extensions, etc. All vfs overlays now live in a common location to make
finding them easier from CMake functions. A new pattern is needed for
the Lib-less modules to re-export their Cxx counterparts.

Another commit simplifies the CMake magic required to link Skia.