### PR TITLE
Tests: Convert Swift tests to use Testing module where possible

### DIFF
--- a/Meta/CMake/FindSwiftTesting.cmake
+++ b/Meta/CMake/FindSwiftTesting.cmake
@@ -1,0 +1,45 @@
+# Finds the swift-testing library
+# On Apple platforms, this is a framework included in the Xcode release
+
+# FIXME: Using Xcode's library actually doesn't work for rpath reasons
+#        When swift-testing ships better toolchain CMake support, we'll need to revisit this
+
+include(FetchContent)
+
+# Allow the Ninja generators to output messages as they happen by assigning
+# these jobs to the 'console' job pool
+set(console_access "")
+if(CMAKE_GENERATOR MATCHES "^Ninja")
+    set(console_access
+        USES_TERMINAL_CONFIGURE YES
+        USES_TERMINAL_BUILD YES
+        USES_TERMINAL_INSTALL YES
+    )
+endif()
+
+set(FETCHCONTENT_TRY_FIND_PACKAGE_MODE OPT_IN)
+FetchContent_Declare(SwiftTesting
+    GIT_REPOSITORY https://github.com/swiftlang/swift-testing.git
+    GIT_TAG d00d46920f9bb35342ad29398ea4740a2bbf3d38
+    PATCH_COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_LIST_DIR}/patches/git-patch.cmake"
+                  "${CMAKE_CURRENT_LIST_DIR}/patches/swift-testing//0001-CMake-Allow-ExternalProjects-to-use-console-with-Nin.patch"
+    OVERRIDE_FIND_PACKAGE
+    SYSTEM
+    ${console_access}
+)
+
+block()
+    add_cxx_compile_options(-Wno-error)
+    set(SwiftTesting_MACRO "<auto>")
+    FetchContent_MakeAvailable(SwiftTesting)
+    add_cxx_compile_options(-Werror)
+endblock()
+
+if (NOT TARGET SwiftTesting::SwiftTesting)
+    # FIXME: This should be an interface property on the target itself, if the maintainers intend
+    #        for the repository to be fetch-content-able
+    set_property(TARGET Testing APPEND PROPERTY INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-load-plugin-executable ${CMAKE_BINARY_DIR}/bin/TestingMacros#TestingMacros>")
+    add_library(SwiftTesting::SwiftTesting ALIAS Testing)
+    set(SwiftTesting_LIBRARIES SwiftTesting::SwiftTesting)
+endif()
+set(SwiftTesting_FOUND TRUE)

--- a/Meta/CMake/Swift/swift-settings.cmake
+++ b/Meta/CMake/Swift/swift-settings.cmake
@@ -16,8 +16,6 @@ endif()
 include(${CMAKE_CURRENT_LIST_DIR}/InitializeSwift.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/GenerateSwiftHeader.cmake)
 
-add_compile_options("SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -std=c++23 -cxx-interoperability-mode=default>")
-
 # FIXME: https://gitlab.kitware.com/cmake/cmake/-/issues/26174
 if (APPLE)
     set(CMAKE_Swift_COMPILER_TARGET "${CMAKE_SYSTEM_PROCESSOR}-apple-macosx${CMAKE_OSX_DEPLOYMENT_TARGET}")
@@ -42,6 +40,7 @@ function(add_swift_target_properties target_name)
     cmake_parse_arguments(PARSE_ARGV 1 SWIFT_TARGET "" "" "LAGOM_LIBRARIES")
 
     target_compile_features(${target_name} PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+    target_compile_options(${target_name} PUBLIC "SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -std=c++23 -cxx-interoperability-mode=default>")
 
     string(REPLACE "Lib" "" module_name ${target_name})
 

--- a/Meta/CMake/patches/swift-testing/0001-CMake-Allow-ExternalProjects-to-use-console-with-Nin.patch
+++ b/Meta/CMake/patches/swift-testing/0001-CMake-Allow-ExternalProjects-to-use-console-with-Nin.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Kaster <andrew@ladybird.org>
+Date: Mon, 26 Aug 2024 21:35:45 -0600
+Subject: [PATCH] [CMake] Allow ExternalProjects to use console with Ninja
+ generator
+
+Also stop forcing the SwiftMacros project to build every rebuild.
+---
+ Sources/CMakeLists.txt               | 13 ++++++++++++-
+ Sources/TestingMacros/CMakeLists.txt | 14 +++++++++++++-
+ 2 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/Sources/CMakeLists.txt b/Sources/CMakeLists.txt
+index 83a9a2b2330c9847ebac89e273c6ade9bf398a25..d917509ba47c2ddaf6b7a2d7d17de2afaabc68fd 100644
+--- a/Sources/CMakeLists.txt
++++ b/Sources/CMakeLists.txt
+@@ -43,10 +43,21 @@ if(SwiftTesting_MACRO STREQUAL "<auto>")
+   # Build and install the plugin into the current build directry.
+   set(SwiftTesting_MACRO_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
+ 
++  # Allow the Ninja generators to output messages as they happen by assigning
++  # these jobs to the 'console' job pool
++  set(SwiftTesting_ConsoleAccess "")
++  if(CMAKE_GENERATOR MATCHES "^Ninja")
++    set(SwiftTesting_ConsoleAccess
++      USES_TERMINAL_CONFIGURE YES
++      USES_TERMINAL_BUILD YES
++      USES_TERMINAL_INSTALL YES)
++  endif()
++
+   ExternalProject_Add(TestingMacros
+     PREFIX "tm"
+     SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/TestingMacros"
+-    BUILD_ALWAYS ON
++    BUILD_ALWAYS OFF
++    ${SwiftTesting_ConsoleAccess}
+     CMAKE_ARGS
+       -DCMAKE_MAKE_PROGRAM=${SwiftTesting_MACRO_MAKE_PROGRAM}
+       -DCMAKE_Swift_COMPILER=${SwiftTesting_MACRO_Swift_COMPILER}
+diff --git a/Sources/TestingMacros/CMakeLists.txt b/Sources/TestingMacros/CMakeLists.txt
+index a45663025a43adf39d17f0d94d692c9bf6092194..aa9939079ff18dee00288bf7fb0c92c124438228 100644
+--- a/Sources/TestingMacros/CMakeLists.txt
++++ b/Sources/TestingMacros/CMakeLists.txt
+@@ -28,11 +28,23 @@ if(SwiftTesting_BuildMacrosAsExecutables)
+   # When building the macro plugin as an executable, clone and build
+   # swift-syntax.
+   include(FetchContent)
++
++  # Allow the Ninja generators to output messages as they happen by assigning
++  # these jobs to the 'console' job pool
++  set(SwiftTesting_ConsoleAccess "")
++  if(CMAKE_GENERATOR MATCHES "^Ninja")
++    set(SwiftTesting_ConsoleAccess
++      USES_TERMINAL_CONFIGURE YES
++      USES_TERMINAL_BUILD YES
++      USES_TERMINAL_INSTALL YES)
++  endif()
++
+   set(FETCHCONTENT_BASE_DIR ${CMAKE_BINARY_DIR}/_d)
+   # TODO: Update GIT_TAG to the 6.0 release tag once it is available.
+   FetchContent_Declare(SwiftSyntax
+     GIT_REPOSITORY https://github.com/swiftlang/swift-syntax
+-    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837)
++    GIT_TAG 27b74edd5de625d0e399869a5af08f1501af8837
++    ${SwiftTesting_ConsoleAccess})
+   FetchContent_MakeAvailable(SwiftSyntax)
+ endif()
+ 

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -93,6 +93,8 @@ endforeach()
 target_link_libraries(TestString PRIVATE LibUnicode)
 
 if (ENABLE_SWIFT)
+
+    # FIXME: Convert to use swift-testing after resolving https://github.com/LadybirdBrowser/ladybird/issues/1201
     add_executable(TestAKBindings TestAKBindings.swift)
     target_link_libraries(TestAKBindings PRIVATE AK)
     target_compile_options(TestAKBindings PRIVATE -parse-as-library)

--- a/Tests/LibWeb/CMakeLists.txt
+++ b/Tests/LibWeb/CMakeLists.txt
@@ -16,13 +16,17 @@ endforeach()
 target_link_libraries(TestFetchURL PRIVATE LibURL)
 
 if (ENABLE_SWIFT)
-    add_executable(TestLibWebSwiftBindings TestLibWebSwiftBindings.swift)
-    target_link_libraries(TestLibWebSwiftBindings PRIVATE AK LibWeb)
-    target_compile_options(TestLibWebSwiftBindings PRIVATE -parse-as-library)
-    add_test(NAME TestLibWebSwiftBindings COMMAND TestLibWebSwiftBindings)
+    find_package(SwiftTesting REQUIRED)
 
-    add_executable(TestHTMLTokenizerSwift TestHTMLTokenizerSwift.swift)
-    target_link_libraries(TestHTMLTokenizerSwift PRIVATE AK LibWeb)
-    target_compile_options(TestHTMLTokenizerSwift PRIVATE -parse-as-library)
-    add_test(NAME TestHTMLTokenizerSwift COMMAND TestHTMLTokenizerSwift)
+    add_executable(TestLibWebSwift
+        TestLibWebSwiftBindings.swift
+        TestHTMLTokenizerSwift.swift
+    )
+
+    # FIXME: Swift doesn't seem to like object libraries for @main
+    target_sources(TestLibWebSwift PRIVATE ../Resources/SwiftTestMain.swift)
+
+    set_target_properties(TestLibWebSwift PROPERTIES SUFFIX .swift-testing)
+    target_link_libraries(TestLibWebSwift PRIVATE AK LibWeb SwiftTesting::SwiftTesting)
+    add_test(NAME TestLibWebSwift COMMAND TestLibWebSwift)
 endif()

--- a/Tests/LibWeb/TestHTMLTokenizerSwift.swift
+++ b/Tests/LibWeb/TestHTMLTokenizerSwift.swift
@@ -6,54 +6,28 @@
 
 import AK
 import Web
-import Foundation
+import Testing
 
-class StandardError: TextOutputStream {
-    func write(_ string: Swift.String) {
-        try! FileHandle.standardError.write(contentsOf: Data(string.utf8))
-    }
-}
-
-@main
+@Suite
 struct TestHTMLTokenizerSwift {
 
-    static func testTokenTypes() {
-        var standardError = StandardError()
-        print("Testing HTMLToken types...", to: &standardError)
-
+    @Test func tokenTypes() {
         let default_token = HTMLToken()
         default_token.type = .Character(codePoint: "a")
-        precondition(default_token.isCharacter())
+        #expect(default_token.isCharacter())
 
-        print("\(default_token)", to: &standardError)
-
-        print("HTMLToken types pass", to: &standardError)
+        #expect("\(default_token)" == "HTMLToken(type: Character(codePoint: a))")
     }
 
-    static func testParserWhitespace() {
-        var standardError = StandardError()
-        print("Testing HTMLToken parser whitespace...", to: &standardError)
-
+    @Test func parserWhitespace() {
         for codePoint: Character in ["\t", "\n", "\r", "\u{000C}", " "] {
             let token = HTMLToken(type: .Character(codePoint: codePoint))
-            precondition(token.isParserWhitespace())
+            #expect(token.isParserWhitespace())
         }
 
         for codePoint: Character in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"] {
             let token = HTMLToken(type: .Character(codePoint: codePoint))
-            precondition(!token.isParserWhitespace())
+            #expect(!token.isParserWhitespace())
         }
-
-        print("HTMLToken parser whitespace pass", to: &standardError)
-    }
-
-    static func main() {
-        var standardError = StandardError()
-        print("Starting test suite...", to: &standardError)
-
-        testTokenTypes()
-        testParserWhitespace()
-
-        print("All tests pass", to: &standardError)
     }
 }

--- a/Tests/LibWeb/TestLibWebSwiftBindings.swift
+++ b/Tests/LibWeb/TestLibWebSwiftBindings.swift
@@ -6,42 +6,20 @@
 
 import AK
 import Web
-import Foundation
+import Testing
 
-class StandardError: TextOutputStream {
-    func write(_ string: Swift.String) {
-        try! FileHandle.standardError.write(contentsOf: Data(string.utf8))
-    }
-}
-
-@main
+@Suite
 struct TestLibWebSwiftBindings {
 
-    static func testEnumsAreBound() {
-        var standardError = StandardError()
-        print("Testing LibWeb enum types...", to: &standardError)
+    @Test func enumsAreBound() {
+        #expect(Web.DOM.NodeType.ELEMENT_NODE.rawValue == 1)
 
-        print("Web.DOM.NodeType.ELEMENT_NODE == \(Web.DOM.NodeType.ELEMENT_NODE)", to: &standardError)
-        precondition(Web.DOM.NodeType.ELEMENT_NODE.rawValue == 1)
-
-        print("Web.Bindings.NavigationType.Push == \(Web.Bindings.NavigationType.Push)", to: &standardError)
-        precondition(Web.Bindings.NavigationType.Push.rawValue == 0)
+        #expect(Web.Bindings.NavigationType.Push.rawValue == 0)
 
         let end = Web.Bindings.idl_enum_to_string(Web.Bindings.ScrollLogicalPosition.End)
         let end_view = end.__bytes_as_string_viewUnsafe().bytes();
         let end_string = Swift.String(bytes: end_view, encoding: .utf8)!
 
-        print("Web.Bindings.idl_enum_to_string(Web.Bindings.ScrollLogicalPosition.End) == \(end_string)", to: &standardError)
-        precondition(end_string == "end")
-
-        print("LibWeb enum types pass", to: &standardError)
-    }
-
-    static func main() {
-        var standardError = StandardError()
-        print("Starting test suite...", to: &standardError)
-        testEnumsAreBound()
-
-        print("All tests pass", to: &standardError)
+        #expect(end_string == "end")
     }
 }

--- a/Tests/Resources/SwiftTestMain.swift
+++ b/Tests/Resources/SwiftTestMain.swift
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+// FIXME: This file is intended to become redundant as swift-testing stabilizes
+//        See https://github.com/swiftlang/swift-testing/blob/133e30231c4583b02ab3ea2a7f678f3d7f4f8a3d/Documentation/CMake.md#add-an-entry-point
+
+import Testing
+
+@main struct Runner {
+    static func main() async {
+        await Testing.__swiftPMEntryPoint() as Never
+    }
+}


### PR DESCRIPTION
Add the upcoming standard swift-testing library as a dependency.

In theory, this library will be included in the swift toolchain. Until that plan is finalized and stabilized for both Linux and macOS, pull it from GitHub using FetchContent.

The Testing.framework shipped with Xcode 16 Beta 5 links against libraries in /usr/lib/swift that only exist in the Developer/ and toolchain sections of the Xcode app, and not on my macOS installation. It also doesn't seem to be added to the rpath of our applications, as it lives in the Xcode Developer directories instead of in the system path. As such, we'll keep building it for macOS from source until the swift-testing maintainers come up with a good way to use the library from CMake, as the current focus is the Swift Package Manager.

The Xcode-shipped Testing.framework *can* be used if the developer sets USE_XCODE_TESTING_LIBRARY to ON in FindSwiftTesting.cmake and calls our test module like so: 

```
env DYLD_FALLBACK_FRAMEWORK_PATH="/Applications/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks" \
DYLD_LIBRARY_PATH="/Applications/Xcode-beta.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib" \
./Build/ladybird/bin/TestLibWebSwift.swift-testing
```