### PR TITLE
Add “valid floating-point number” for HTMLInputElement.value

### DIFF
--- a/Tests/LibWeb/TestNumbers.cpp
+++ b/Tests/LibWeb/TestNumbers.cpp
@@ -103,4 +103,31 @@ TEST_CASE(parse_non_negative_integer)
 
     optional_value = Web::HTML::parse_non_negative_integer("-3"sv);
     EXPECT(!optional_value.has_value());
+
+    EXPECT(Web::HTML::is_valid_floating_point_number("11"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("11.12"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("-11111"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("-11111.123"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("1e2"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("1E2"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("1e+2"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("1d+2"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("foobar"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number(".1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("1."sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("-0"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("Infinity"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("-Infinity"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("NaN"sv));
+    EXPECT(Web::HTML::is_valid_floating_point_number("9007199254740993"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("1e"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("+1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("+"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("-"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("\t1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("\n1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("\f1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("\r1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number(" 1"sv));
+    EXPECT(!Web::HTML::is_valid_floating_point_number("1trailing junk"sv));
 }

--- a/Userland/Libraries/LibWeb/HTML/Numbers.h
+++ b/Userland/Libraries/LibWeb/HTML/Numbers.h
@@ -19,6 +19,8 @@ Optional<u32> parse_non_negative_integer(StringView string);
 
 Optional<double> parse_floating_point_number(StringView string);
 
+bool is_valid_floating_point_number(StringView string);
+
 WebIDL::ExceptionOr<String> convert_non_negative_integer_to_string(JS::Realm&, WebIDL::Long);
 
 }


### PR DESCRIPTION
This change adds checking for the following spec requirements:

- `<input type=number>`: [If the value of the element is not a valid floating-point number, then set it to the empty string](https://html.spec.whatwg.org/#number-state-(type=number):value-sanitization-algorithm)
- `<input type=range>`: [If the value of the element is not a valid floating-point number, then set it to the best representation, as a floating-point number, of the default value](https://html.spec.whatwg.org/#range-state-(type=range):value-sanitization-algorithm)

That is, it adds checking that `HTMLInputElement.value` is what the spec defines as a “valid floating-point number” when the `type` attribute for the `HTMLInputElement` is either `number` or `range`.

This change causes Ladybird to pass all the failing tests at https://wpt.fyi/results/html/semantics/forms/the-input-element/number.html?run_id=5080423051034624 and to match the relevant behavior in Webkit, Blink, and Gecko.

Otherwise, without this change, Ladybird fails those tests, and the relevant Ladybird behavior isn’t interoperable with other engines.