### PR TITLE
LibWeb: Use nearest-neighbor scaling for ScalingMode::SmoothPixels

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -317,9 +317,9 @@ static SkSamplingOptions to_skia_sampling_options(Gfx::ScalingMode scaling_mode)
 {
     switch (scaling_mode) {
     case Gfx::ScalingMode::NearestNeighbor:
+    case Gfx::ScalingMode::SmoothPixels:
         return SkSamplingOptions(SkFilterMode::kNearest);
     case Gfx::ScalingMode::BilinearBlend:
-    case Gfx::ScalingMode::SmoothPixels:
         return SkSamplingOptions(SkFilterMode::kLinear);
     case Gfx::ScalingMode::BoxSampling:
         return SkSamplingOptions(SkCubicResampler::Mitchell());


### PR DESCRIPTION
Adjust the translation from Gfx::ScalingMode to Skia SkFilterMode, so
that CSS::ImageRendering::Pixelated will result in
SkFilterMode::kNearest.

Before:
ScalingMode::SmoothPixels -> kLinear

After:
ScalingMode::SmoothPixels -> kNearest

Fixes #1170

Supersedes https://github.com/LadybirdBrowser/ladybird/pull/1171

Idea given by @gmta in https://github.com/LadybirdBrowser/ladybird/pull/1171#pullrequestreview-2262653188