### PR TITLE
LibWeb: Correctly test if WebDriver ExecuteScript timeout is reached

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -332,7 +332,7 @@ ExecuteScriptResultSerialized execute_async_script(Web::Page& page, ByteString c
     auto start = MonotonicTime::now();
 
     auto has_timed_out = [&] {
-        return timeout.has_value() && (MonotonicTime::now() - start) > AK::Duration::from_seconds(static_cast<i64>(*timeout));
+        return timeout.has_value() && (MonotonicTime::now() - start) > AK::Duration::from_milliseconds(static_cast<i64>(*timeout));
     };
 
     // AD-HOC: An execution context is required for Promise creation hooks.


### PR DESCRIPTION
Previously, the conversion assumed that the supplied timeout was in seconds rather than milliseconds.

I found this issue while investigating a timeout that occurs while waiting for `execute_async_script()`  to complete. Unfortunately, this doesn't solve that issue :^(