### PR TITLE
LibWeb: Fix crash when setting innerHTML inside iframe srcdoc document

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/set-innerHTML-inside-iframe-srcdoc-document.txt
+++ b/Tests/LibWeb/Text/expected/HTML/set-innerHTML-inside-iframe-srcdoc-document.txt
@@ -1,0 +1,1 @@
+   PASS (Didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/set-innerHTML-inside-iframe-srcdoc-document.html
+++ b/Tests/LibWeb/Text/input/HTML/set-innerHTML-inside-iframe-srcdoc-document.html
@@ -1,0 +1,14 @@
+<iframe id="ifr" srcdoc=""></iframe>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        ifr.contentDocument.body.innerHTML = "<a href='foo.html'>foo</a>";
+        let href = ifr.contentDocument.body.querySelector("a").href;
+        if (href.endsWith("foo.html")) {
+            println("PASS (Didn't crash)");
+        } else {
+            println("FAIL");
+        }
+        ifr.remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4273,6 +4273,10 @@ Vector<JS::Handle<DOM::Node>> HTMLParser::parse_html_fragment(DOM::Element& cont
     auto temp_document = DOM::Document::create_for_fragment_parsing(context_element.realm());
     temp_document->set_document_type(DOM::Document::Type::HTML);
 
+    // AD-HOC: We set the about base URL of the document to the same as the context element's document.
+    //         This is required for Document::parse_url() to work inside iframe srcdoc documents.
+    temp_document->set_about_base_url(context_element.document().about_base_url());
+
     // 2. If the node document of the context element is in quirks mode, then let the Document be in quirks mode.
     //    Otherwise, the node document of the context element is in limited-quirks mode, then let the Document be in limited-quirks mode.
     //    Otherwise, leave the Document in no-quirks mode.


### PR DESCRIPTION
In particular, there was an assertion failure due to the temporary parser document's "about base URL" being empty when trying to "parse a URL" during parsing.

We fix this by copying the context element's document's about base URL to the temporary parsing document while parsing a fragment.

This fixes a crash when loading search results on https://amazon.com/