### PR TITLE
LibWebView+UI: Request users for a download directory if `~/Downloads` does not exist

### DIFF
--- a/Ladybird/AppKit/Application/Application.mm
+++ b/Ladybird/AppKit/Application/Application.mm
@@ -13,6 +13,7 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/LadybirdWebViewBridge.h>
+#include <Utilities/Conversions.h>
 
 #import <Application/Application.h>
 
@@ -24,6 +25,21 @@ namespace Ladybird {
 
 class ApplicationBridge : public WebView::Application {
     WEB_VIEW_APPLICATION(ApplicationBridge)
+
+private:
+    virtual Optional<ByteString> ask_user_for_download_folder() const override
+    {
+        auto* panel = [NSOpenPanel openPanel];
+        [panel setAllowsMultipleSelection:NO];
+        [panel setCanChooseDirectories:YES];
+        [panel setCanChooseFiles:NO];
+        [panel setMessage:@"Select download directory"];
+
+        if ([panel runModal] != NSModalResponseOK)
+            return {};
+
+        return Ladybird::ns_string_to_byte_string([[panel URL] path]);
+    }
 };
 
 ApplicationBridge::ApplicationBridge(Badge<WebView::Application>, Main::Arguments&)

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1201,6 +1201,9 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
                            }];
         })
         .when_rejected([self](auto const& error) {
+            if (error.is_errno() && error.code() == ECANCELED)
+                return;
+
             auto error_message = MUST(String::formatted("{}", error));
 
             auto* dialog = [[NSAlert alloc] init];

--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -12,6 +12,7 @@
 #include <Ladybird/Utilities.h>
 #include <LibCore/ArgsParser.h>
 #include <LibWebView/URL.h>
+#include <QFileDialog>
 #include <QFileOpenEvent>
 
 namespace Ladybird {
@@ -124,6 +125,15 @@ BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, Web
     window->activateWindow();
     window->raise();
     return *window;
+}
+
+Optional<ByteString> Application::ask_user_for_download_folder() const
+{
+    auto path = QFileDialog::getExistingDirectory(nullptr, "Select download directory", QDir::homePath());
+    if (path.isNull())
+        return {};
+
+    return ak_byte_string_from_qstring(path);
 }
 
 }

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -46,6 +46,8 @@ private:
     virtual void create_platform_arguments(Core::ArgsParser&) override;
     virtual void create_platform_options(WebView::ChromeOptions&, WebView::WebContentOptions&) override;
 
+    virtual Optional<ByteString> ask_user_for_download_folder() const override;
+
     bool m_enable_qt_networking { false };
 
     TaskManagerWindow* m_task_manager_window { nullptr };

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -481,6 +481,9 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
                 }
             })
             .when_rejected([this](auto const& error) {
+                if (error.is_errno() && error.code() == ECANCELED)
+                    return;
+
                 auto error_message = MUST(String::formatted("{}", error));
                 QMessageBox::warning(this, "Ladybird", qstring_from_ak_string(error_message));
             });

--- a/Userland/Libraries/LibWebView/Application.h
+++ b/Userland/Libraries/LibWebView/Application.h
@@ -7,6 +7,9 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/ByteString.h>
+#include <AK/LexicalPath.h>
+#include <AK/Optional.h>
 #include <AK/Swift.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Forward.h>
@@ -45,6 +48,8 @@ public:
     void update_process_statistics();
     String generate_process_statistics_html();
 
+    ErrorOr<LexicalPath> path_for_downloaded_file(StringView file) const;
+
 protected:
     template<DerivedFrom<Application> ApplicationType>
     static NonnullOwnPtr<ApplicationType> create(Main::Arguments& arguments, URL::URL new_tab_page_url)
@@ -61,6 +66,8 @@ protected:
 
     virtual void create_platform_arguments(Core::ArgsParser&) { }
     virtual void create_platform_options(ChromeOptions&, WebContentOptions&) { }
+
+    virtual Optional<ByteString> ask_user_for_download_folder() const { return {}; }
 
 private:
     void initialize(Main::Arguments const& arguments, URL::URL new_tab_page_url);

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/Timer.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/ViewImplementation.h>
 
 #ifdef AK_OS_MACOS
@@ -510,8 +511,8 @@ static ErrorOr<LexicalPath> save_screenshot(Gfx::ShareableBitmap const& bitmap)
     if (!bitmap.is_valid())
         return Error::from_string_view("Failed to take a screenshot"sv);
 
-    LexicalPath path { Core::StandardPaths::downloads_directory() };
-    path = path.append(TRY(Core::DateTime::now().to_string("screenshot-%Y-%m-%d-%H-%M-%S.png"sv)));
+    auto file = Core::DateTime::now().to_byte_string("screenshot-%Y-%m-%d-%H-%M-%S.png"sv);
+    auto path = TRY(Application::the().path_for_downloaded_file(file));
 
     auto encoded = TRY(Gfx::PNGWriter::encode(*bitmap.bitmap()));
 


### PR DESCRIPTION
If the Downloads directory exists, we will use it (note that this will respect the `XDG_DOWNLOAD_DIR` environment variable).

Otherwise, we will ask the UI layer to retrieve a download directory from the user. This directory is not saved, so it will be re-prompted every time. Once a proper settings UI is complete, we will of course integrate with that for persistent settings.

![Screenshot_20240828_152105](https://github.com/user-attachments/assets/d4ea2a5d-6caf-4e65-aa0f-95a696c0788a)

![Screenshot_20240828_152124](https://github.com/user-attachments/assets/453cc5b7-df2c-4800-ad83-65935979617f)


Fixes #780, fixes #854 