### PR TITLE
Meta: Add swift-format linter script 

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -4,7 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: macos-14
     if: always() && github.repository == 'LadybirdBrowser/ladybird'
 
     steps:
@@ -15,23 +15,20 @@ jobs:
         run: |
           set -e
 
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+          brew install curl flake8 llvm@18 ninja shellcheck swift-format unzip
 
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-
-          sudo apt-get update
-          sudo apt-get install clang-format-18 generate-ninja
+          # Note: gn isn't available in homebrew :(
+          # Corresponds to https://gn.googlesource.com/gn/+/225e90c5025bf74f41dbee60d9cde4512c846fe7
+          curl -L -o gn-mac-arm64.zip "https://chrome-infra-packages.appspot.com/dl/gn/gn/mac-arm64/+/786UV5-XW0Bz6QnRFxKtnzTSVq0ta5AU1KXRJs-ZNwcC"
+          unzip gn-mac-arm64.zip -d ${{ github.workspace }}/bin
+          chmod +x ${{ github.workspace }}/bin/gn
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+          echo -n "gn version: "
+          ${{ github.workspace}}/bin/gn --version
 
       - name: Install JS Dependencies
         shell: bash
-        run: sudo npm install -g prettier@2.7.1
-
-      - name: Install Python Dependencies
-        shell: bash
-        run: |
-          python3 -m pip install --upgrade pip
-          pip3 install flake8
+        run: npm install -g prettier@2.7.1
 
       - name: Lint
         run: ${{ github.workspace }}/Meta/lint-ci.sh

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -43,10 +43,17 @@ else
     echo -e "[${GREEN}SKIP${NC}]: IPCMagicLinter (in Meta/lint-ci.sh)"
 fi
 
-if Meta/lint-clang-format.sh --overwrite-inplace "$@" && git diff --exit-code; then
+if Meta/lint-clang-format.sh --overwrite-inplace "$@" && git diff --exit-code -- ':*.cpp' ':*.h' ':*.mm'; then
     echo -e "[${GREEN}OK${NC}]: Meta/lint-clang-format.sh"
 else
     echo -e "[${RED}FAIL${NC}]: Meta/lint-clang-format.sh"
+    ((FAILURES+=1))
+fi
+
+if Meta/lint-swift.sh "$@" && git diff --exit-code -- ':*.swift'; then
+    echo -e "[${GREEN}OK${NC}]: Meta/lint-swift.sh"
+else
+    echo -e "[${RED}FAIL${NC}]: Meta/lint-swift.sh"
     ((FAILURES+=1))
 fi
 

--- a/Meta/lint-swift.sh
+++ b/Meta/lint-swift.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -e
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+cd "${script_path}/.." || exit 1
+
+if [ "$#" -eq "0" ]; then
+    files=()
+    while IFS= read -r file; do
+        files+=("$file")
+    done < <(
+        git ls-files '*.swift'
+    )
+else
+    files=()
+    for file in "$@"; do
+        if [[ "${file}" == *".swift" ]] ; then
+            files+=("${file}")
+        fi
+    done
+fi
+
+if (( ${#files[@]} )); then
+    if ! command -v swift-format >/dev/null 2>&1 ; then
+        echo "swift-format is not available, but Swift files need linting! Either skip this script, or install swift-format."
+        exit 1
+    fi
+    swift-format -i "${files[@]}"
+    echo "Maybe some files have changed. Sorry, but swift-format doesn't indicate what happened."
+else
+    echo "No .swift files to check."
+fi

--- a/Tests/LibWeb/TestLibWebSwiftBindings.swift
+++ b/Tests/LibWeb/TestLibWebSwiftBindings.swift
@@ -5,8 +5,8 @@
  */
 
 import AK
-import Web
 import Testing
+import Web
 
 @Suite
 struct TestLibWebSwiftBindings {
@@ -17,7 +17,7 @@ struct TestLibWebSwiftBindings {
         #expect(Web.Bindings.NavigationType.Push.rawValue == 0)
 
         let end = Web.Bindings.idl_enum_to_string(Web.Bindings.ScrollLogicalPosition.End)
-        let end_view = end.__bytes_as_string_viewUnsafe().bytes();
+        let end_view = end.__bytes_as_string_viewUnsafe().bytes()
         let end_string = Swift.String(bytes: end_view, encoding: .utf8)!
 
         #expect(end_string == "end")


### PR DESCRIPTION
swift-format is available in the Xcode 16 Beta and homebrew.
We will need some extra docs to tell Linux developers how to get it on
their distribution.

This also makes use of the fact that you can pass git diff a colon
delimited pattern to include ':*pattern' or exclude ':!*pattern'
matching files, which is pretty neat.