### PR TITLE
LibJS: Use the system native page size as the HeapBlock::block_size

### DIFF
--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
@@ -22,9 +22,6 @@
 
 namespace JS {
 
-// NOTE: If this changes, we need to update the mmap() code to ensure correct alignment.
-static_assert(HeapBlock::block_size == 4096);
-
 BlockAllocator::~BlockAllocator()
 {
     for (auto* block : m_blocks) {

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,6 +17,8 @@
 #endif
 
 namespace JS {
+
+size_t HeapBlockBase::block_size = PAGE_SIZE;
 
 NonnullOwnPtr<HeapBlock> HeapBlock::create_with_cell_size(Heap& heap, CellAllocator& cell_allocator, size_t cell_size, [[maybe_unused]] char const* class_name)
 {

--- a/Userland/Libraries/LibJS/Heap/Internals.h
+++ b/Userland/Libraries/LibJS/Heap/Internals.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2020-2023, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -33,7 +33,7 @@ class HeapBlockBase {
     AK_MAKE_NONCOPYABLE(HeapBlockBase);
 
 public:
-    static constexpr auto block_size = 4 * KiB;
+    static size_t block_size;
     static HeapBlockBase* from_cell(Cell const* cell)
     {
         return reinterpret_cast<HeapBlockBase*>(bit_cast<FlatPtr>(cell) & ~(HeapBlockBase::block_size - 1));


### PR DESCRIPTION
Before this change, we were hard-coding 4 KiB. This meant that systems with a 16 KiB native page size were wasting 12 KiB per HeapBlock on nothing, leading to worse locality and more mmap/madvise churn.

We now query the system page size on startup and use that as the HeapBlock size.

The only downside here is that some of the pointer math for finding the base of a HeapBlock now has to use a runtime computed value instead of a compile time constant. But that's a small price to pay for what we get.