### PR TITLE
LibWeb: Use the correct base class in for SVGImageElement

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -17,7 +17,7 @@ class SVGImageElement
     : public SVGGraphicsElement
     , public SVGURIReferenceMixin<SupportsXLinkHref::Yes>
     , public Layout::ImageProvider {
-    WEB_PLATFORM_OBJECT(SVGImageElement, SVGElement);
+    WEB_PLATFORM_OBJECT(SVGImageElement, SVGGraphicsElement);
 
 public:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;


### PR DESCRIPTION
Fixes the clang plugin failure mentioned here: https://github.com/LadybirdBrowser/ladybird/pull/1198#issuecomment-2317126132