### PR TITLE
LibWeb: Support animations in embedded SVG images

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -49,11 +49,16 @@ protected:
 
 private:
     virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    void animate();
 
     JS::GCPtr<SVG::SVGAnimatedLength> m_x;
     JS::GCPtr<SVG::SVGAnimatedLength> m_y;
     JS::GCPtr<SVG::SVGAnimatedLength> m_width;
     JS::GCPtr<SVG::SVGAnimatedLength> m_height;
+
+    RefPtr<Core::Timer> m_animation_timer;
+    size_t m_current_frame_index { 0 };
+    size_t m_loops_completed { 0 };
 
     URL::URL m_href;
 


### PR DESCRIPTION
This PR adds animation support to SVG `<image>` tags. The performance is currently not the best when many images are displayed. The code looks very similar to the animation code in `HTMLImageElement` - this code should probably be shared.

Example:


https://github.com/user-attachments/assets/51a57a6a-63a8-405a-be5f-2de01d829f80

