### PR TITLE
LibWeb: Make “create an event” set the event’s isTrusted to true

### DIFF
--- a/Tests/LibWeb/Text/expected/synthetic-event-constructor-istrusted-check.txt
+++ b/Tests/LibWeb/Text/expected/synthetic-event-constructor-istrusted-check.txt
@@ -1,0 +1,1 @@
+new Event('x').isTrusted is false

--- a/Tests/LibWeb/Text/input/synthetic-event-constructor-istrusted-check.html
+++ b/Tests/LibWeb/Text/input/synthetic-event-constructor-istrusted-check.html
@@ -1,0 +1,6 @@
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println(`new Event('x').isTrusted is ${new Event('x').isTrusted}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Event.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Event.cpp
@@ -18,14 +18,18 @@ namespace Web::DOM {
 
 JS_DEFINE_ALLOCATOR(Event);
 
+// https://dom.spec.whatwg.org/#concept-event-create
 JS::NonnullGCPtr<Event> Event::create(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
-    return realm.heap().allocate<Event>(realm, realm, event_name, event_init);
+    auto event = realm.heap().allocate<Event>(realm, realm, event_name, event_init);
+    // 4. Initialize event’s isTrusted attribute to true.
+    event->m_is_trusted = true;
+    return event;
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Event::construct_impl(JS::Realm& realm, FlyString const& event_name, EventInit const& event_init)
 {
-    return create(realm, event_name, event_init);
+    return realm.heap().allocate<Event>(realm, realm, event_name, event_init);
 }
 
 // https://dom.spec.whatwg.org/#inner-event-creation-steps


### PR DESCRIPTION
This change ensures that when then the code corresponding to the “create an event” operation at https://dom.spec.whatwg.org/#concept-event-create is called, the event’s `isTrusted` is set to true — as the spec requires.

That causes the failures for the following WPT tests to pass:

- https://wpt.fyi/results/html/semantics/forms/the-input-element/checkbox.html?run_id=5080423051034624
- https://wpt.fyi/results/html/semantics/interactive-elements/the-dialog-element/dialog-close.html?run_id=5080423051034624

…and there are likely a number of similar WPT tests that hit this same code path which this commit will cause to be changed to passes.

Otherwise, without this change, the “create event” implementation doesn’t conform to the spec requirements – nor behave interoperably with other existing engines — and those WPT test would continue to fail.