### PR TITLE
LibWeb: Set document type to HTML for text and media documents

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -205,7 +205,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_text_document(H
     // To load a text document, given a navigation params navigationParams and a string type:
 
     // 1. Let document be the result of creating and initializing a Document object given "html", type, and navigationParams.
-    auto document = TRY(DOM::Document::create_and_initialize(DOM::Document::Type::XML, type.essence(), navigation_params));
+    auto document = TRY(DOM::Document::create_and_initialize(DOM::Document::Type::HTML, type.essence(), navigation_params));
 
     // FIXME: 2. Set document's parser cannot change the mode flag to true.
 
@@ -269,7 +269,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<DOM::Document>> load_media_document(
     // To load a media document, given navigationParams and a string type:
 
     // 1. Let document be the result of creating and initializing a Document object given "html", type, and navigationParams.
-    auto document = TRY(DOM::Document::create_and_initialize(DOM::Document::Type::XML, type.essence(), navigation_params));
+    auto document = TRY(DOM::Document::create_and_initialize(DOM::Document::Type::HTML, type.essence(), navigation_params));
 
     // 2. Set document's mode to "no-quirks".
     document->set_quirks_mode(DOM::QuirksMode::No);


### PR DESCRIPTION
This update resolves an issue with document classification during creation, aligning with the [HTML specifications for the document lifecycle](https://html.spec.whatwg.org/multipage/document-lifecycle.html).

> 7.5.4 Loading text documents:
> 1. Let document be the result of creating and initializing a Document object given "html", type, and navigationParams."

> 7.5.6 Loading media documents
> 1. Let document be the result of creating and initializing a Document object given "html", type, and navigationParams.

This change passes the following WPT tests and may also address other issues related to HTML tag case sensitivity:
- https://wpt.live/html/browsers/browsing-the-web/read-media/pageload-image.html
- https://wpt.live/html/browsers/browsing-the-web/read-media/pageload-video.html