### PR TITLE
LibWeb: Add "position: sticky" support

### DIFF
--- a/Tests/LibWeb/Ref/position-sticky-bottom.html
+++ b/Tests/LibWeb/Ref/position-sticky-bottom.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/position-sticky-bottom-ref.html" />
+<style>
+    .scrollable-container {
+        width: 300px;
+        height: 300px;
+        overflow-y: scroll;
+        border: 5px solid red;
+    }
+
+    .sticky-box {
+        position: sticky;
+        bottom: 50px;
+        width: 240px;
+        height: 80px;
+        background: #3498db;
+        color: white;
+    }
+
+    .box {
+        height: 500px;
+        background-color: orange;
+    }
+</style>
+
+<div class="scrollable-container" id="sticky-is-below-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-inside-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-above-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<script>
+    const stickyIsBelowScrollport = document.getElementById("sticky-is-below-scrollport");
+    stickyIsBelowScrollport.scrollTop = 0;
+
+    const stickyIsInsideScrollport = document.getElementById("sticky-is-inside-scrollport");
+    stickyIsInsideScrollport.scrollTop = 390;
+
+    const stickyIsAboveScrollport = document.getElementById("sticky-is-above-scrollport");
+    stickyIsAboveScrollport.scrollTop = 780;
+</script>

--- a/Tests/LibWeb/Ref/position-sticky-left.html
+++ b/Tests/LibWeb/Ref/position-sticky-left.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/position-sticky-left-ref.html" />
+<style>
+    * {
+        scrollbar-width: none;
+    }
+
+    .scroll-container {
+        width: 500px;
+        overflow-x: scroll;
+        white-space: nowrap;
+        background-color: #f0f0f0;
+        display: grid;
+        grid-template-columns: 1000px 300px 1000px;
+        border: 5px solid yellowgreen;
+    }
+
+    .section {
+        height: 200px;
+        background-color: orangered;
+    }
+
+    .sticky-element {
+        position: sticky;
+        left: 0;
+        background-color: blueviolet;
+        height: 200px;
+        line-height: 200px;
+        color: white;
+    }
+</style>
+<div class="scroll-container" id="a">
+    <div class="section"></div>
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>
+<div class="scroll-container" id="b">
+    <div class="section"></div>
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>
+<div class="scroll-container" id="c">
+    <div class="section"></div>
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>
+<script>
+    const a = document.getElementById("a");
+    a.scrollLeft = 0;
+
+    const b = document.getElementById("b");
+    b.scrollLeft = 900;
+
+    const c = document.getElementById("c");
+    c.scrollLeft = 1400;
+</script>

--- a/Tests/LibWeb/Ref/position-sticky-right.html
+++ b/Tests/LibWeb/Ref/position-sticky-right.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/position-sticky-right-ref.html" />
+<style>
+    * {
+        scrollbar-width: none;
+    }
+
+    .scroll-container {
+        width: 500px;
+        overflow-x: scroll;
+        white-space: nowrap;
+        background-color: #f0f0f0;
+        display: grid;
+        grid-template-columns: 1000px 300px 1000px;
+        border: 5px solid yellowgreen;
+    }
+
+    .section {
+        height: 200px;
+        background-color: orangered;
+    }
+
+    .sticky-element {
+        position: sticky;
+        right: 0;
+        background-color: blueviolet;
+        height: 200px;
+        line-height: 200px;
+        color: white;
+    }
+</style>
+<div class="scroll-container" id="a">
+    <div class="section"></div>
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>
+<div class="scroll-container" id="b">
+    <div class="section"></div>
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>
+<div class="scroll-container" id="c">
+    <div class="section"></div>
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>
+<script>
+    const a = document.getElementById("a");
+    a.scrollLeft = 0;
+
+    const b = document.getElementById("b");
+    b.scrollLeft = 900;
+
+    const c = document.getElementById("c");
+    c.scrollLeft = 1400;
+</script>

--- a/Tests/LibWeb/Ref/position-sticky-should-stay-within-containing-block.html
+++ b/Tests/LibWeb/Ref/position-sticky-should-stay-within-containing-block.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/position-sticky-should-stay-within-containing-block-ref.html" />
+<style>
+    .scrollable-container {
+        width: 300px;
+        height: 300px;
+        overflow-y: scroll;
+        border: 5px solid red;
+    }
+
+    .sticky-box {
+        position: sticky;
+        top: 0;
+        bottom: 0;
+        width: 240px;
+        height: 80px;
+        background: #3498db;
+        color: white;
+    }
+
+    .box {
+        height: 500px;
+        background-color: orange;
+    }
+</style>
+
+<div class="scrollable-container" id="sticky-is-below-scrollport">
+    <div class="box"></div>
+    <div>
+        <div class="sticky-box">I stick within this scrollable box!</div>
+    </div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-inside-scrollport">
+    <div class="box"></div>
+    <div>
+        <div class="sticky-box">I stick within this scrollable box!</div>
+    </div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-above-scrollport">
+    <div class="box"></div>
+    <div>
+        <div class="sticky-box">I stick within this scrollable box!</div>
+    </div>
+    <div class="box"></div>
+</div>
+
+<script>
+    const stickyIsBelowScrollport = document.getElementById("sticky-is-below-scrollport");
+    stickyIsBelowScrollport.scrollTop = 0;
+
+    const stickyIsInsideScrollport = document.getElementById("sticky-is-inside-scrollport");
+    stickyIsInsideScrollport.scrollTop = 390;
+
+    const stickyIsAboveScrollport = document.getElementById("sticky-is-above-scrollport");
+    stickyIsAboveScrollport.scrollTop = 780;
+</script>

--- a/Tests/LibWeb/Ref/position-sticky-top.html
+++ b/Tests/LibWeb/Ref/position-sticky-top.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/position-sticky-top-ref.html" />
+<style>
+    .scrollable-container {
+        width: 300px;
+        height: 300px;
+        overflow-y: scroll;
+        border: 5px solid red;
+    }
+
+    .sticky-box {
+        position: sticky;
+        top: 50px;
+        width: 240px;
+        height: 80px;
+        background: #3498db;
+        color: white;
+    }
+
+    .box {
+        height: 500px;
+        background-color: orange;
+    }
+</style>
+
+<div class="scrollable-container" id="sticky-is-below-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-inside-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-above-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<script>
+    const stickyIsBelowScrollport = document.getElementById("sticky-is-below-scrollport");
+    stickyIsBelowScrollport.scrollTop = 0;
+
+    const stickyIsInsideScrollport = document.getElementById("sticky-is-inside-scrollport");
+    stickyIsInsideScrollport.scrollTop = 390;
+
+    const stickyIsAboveScrollport = document.getElementById("sticky-is-above-scrollport");
+    stickyIsAboveScrollport.scrollTop = 780;
+</script>

--- a/Tests/LibWeb/Ref/reference/position-sticky-bottom-ref.html
+++ b/Tests/LibWeb/Ref/reference/position-sticky-bottom-ref.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<style>
+    .scrollable-container {
+        width: 300px;
+        height: 300px;
+        overflow-y: scroll;
+        border: 5px solid red;
+        position: relative;
+    }
+
+    .sticky-box {
+        width: 240px;
+        height: 80px;
+        background: #3498db;
+        color: white;
+    }
+
+    .box {
+        height: 500px;
+        background-color: orange;
+    }
+
+    .fill-abspos-box-space {
+        height: 80px;
+    }
+</style>
+
+<div class="scrollable-container" id="sticky-is-below-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box" style="position: absolute; bottom: 50px">
+        I stick within this scrollable box!
+    </div>
+    <div class="fill-abspos-box-space"></div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-inside-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-above-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<script>
+    const stickyIsBelowScrollport = document.getElementById("sticky-is-below-scrollport");
+    stickyIsBelowScrollport.scrollTop = 0;
+
+    const stickyIsInsideScrollport = document.getElementById("sticky-is-inside-scrollport");
+    stickyIsInsideScrollport.scrollTop = 390;
+
+    const stickyIsAboveScrollport = document.getElementById("sticky-is-above-scrollport");
+    stickyIsAboveScrollport.scrollTop = 780;
+</script>

--- a/Tests/LibWeb/Ref/reference/position-sticky-left-ref.html
+++ b/Tests/LibWeb/Ref/reference/position-sticky-left-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<style>
+    * {
+        scrollbar-width: none;
+    }
+
+    .scroll-container {
+        width: 500px;
+        overflow-x: scroll;
+        white-space: nowrap;
+        background-color: #f0f0f0;
+        display: flex;
+        border: 5px solid yellowgreen;
+    }
+
+    .section {
+        flex: 0 0 1000px;
+        height: 200px;
+        background-color: orangered;
+    }
+
+    .sticky-element {
+        position: sticky;
+        left: 0;
+        background-color: blueviolet;
+        flex: 0 0 300px;
+        height: 200px;
+        line-height: 200px;
+        color: white;
+    }
+</style>
+<div class="scroll-container" id="a">
+    <div class="section"></div>
+</div>
+<div class="scroll-container" id="b">
+    <div class="section" style="flex-basis: 100px"></div>
+    <div class="sticky-element"></div>
+    <div class="section" style="flex-basis: 100px"></div>
+</div>
+<div class="scroll-container" id="c">
+    <div class="sticky-element"></div>
+    <div class="section"></div>
+</div>

--- a/Tests/LibWeb/Ref/reference/position-sticky-right-ref.html
+++ b/Tests/LibWeb/Ref/reference/position-sticky-right-ref.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<style>
+    * {
+        scrollbar-width: none;
+    }
+
+    .scroll-container {
+        width: 500px;
+        overflow-x: scroll;
+        white-space: nowrap;
+        background-color: #f0f0f0;
+        display: flex;
+        border: 5px solid yellowgreen;
+    }
+
+    .section {
+        flex: 0 0 1000px;
+        height: 200px;
+        background-color: orangered;
+    }
+
+    .sticky-element {
+        position: sticky;
+        left: 0;
+        background-color: blueviolet;
+        flex: 0 0 300px;
+        height: 200px;
+        line-height: 200px;
+        color: white;
+    }
+</style>
+<div class="scroll-container" id="a">
+    <div class="section" style="flex-basis: 200px"></div>
+    <div class="sticky-element"></div>
+</div>
+<div class="scroll-container" id="b">
+    <div class="section" style="flex-basis: 100px"></div>
+    <div class="sticky-element"></div>
+    <div class="section" style="flex-basis: 100px"></div>
+</div>
+<div class="scroll-container" id="c">
+    <div class="section"></div>
+</div>

--- a/Tests/LibWeb/Ref/reference/position-sticky-should-stay-within-containing-block-ref.html
+++ b/Tests/LibWeb/Ref/reference/position-sticky-should-stay-within-containing-block-ref.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<style>
+    .scrollable-container {
+        width: 300px;
+        height: 300px;
+        overflow-y: scroll;
+        border: 5px solid red;
+        position: relative;
+    }
+
+    .sticky-box {
+        width: 240px;
+        height: 80px;
+        background: #3498db;
+        color: white;
+    }
+
+    .box {
+        height: 500px;
+        background-color: orange;
+    }
+</style>
+
+<div class="scrollable-container" id="sticky-is-below-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-inside-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-above-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<script>
+    const stickyIsBelowScrollport = document.getElementById("sticky-is-below-scrollport");
+    stickyIsBelowScrollport.scrollTop = 0;
+
+    const stickyIsInsideScrollport = document.getElementById("sticky-is-inside-scrollport");
+    stickyIsInsideScrollport.scrollTop = 390;
+
+    const stickyIsAboveScrollport = document.getElementById("sticky-is-above-scrollport");
+    stickyIsAboveScrollport.scrollTop = 780;
+</script>

--- a/Tests/LibWeb/Ref/reference/position-sticky-top-ref.html
+++ b/Tests/LibWeb/Ref/reference/position-sticky-top-ref.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<style>
+    .scrollable-container {
+        width: 300px;
+        height: 300px;
+        overflow-y: scroll;
+        border: 5px solid red;
+        position: relative;
+    }
+
+    .sticky-box {
+        width: 240px;
+        height: 80px;
+        background: #3498db;
+        color: white;
+    }
+
+    .box {
+        height: 500px;
+        background-color: orange;
+    }
+
+    .fill-abspos-box-space {
+        height: 80px;
+    }
+</style>
+
+<div class="scrollable-container" id="sticky-is-below-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-inside-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box">I stick within this scrollable box!</div>
+    <div class="box"></div>
+</div>
+
+<div class="scrollable-container" id="sticky-is-above-scrollport">
+    <div class="box"></div>
+    <div class="sticky-box" style="position: absolute; top: 830px">
+        I stick within this scrollable box!
+    </div>
+    <div class="fill-abspos-box-space"></div>
+    <div class="box"></div>
+</div>
+
+<script>
+    const stickyIsBelowScrollport = document.getElementById("sticky-is-below-scrollport");
+    stickyIsBelowScrollport.scrollTop = 0;
+
+    const stickyIsInsideScrollport = document.getElementById("sticky-is-inside-scrollport");
+    stickyIsInsideScrollport.scrollTop = 390;
+
+    const stickyIsAboveScrollport = document.getElementById("sticky-is-above-scrollport");
+    stickyIsAboveScrollport.scrollTop = 780;
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5454,8 +5454,11 @@ RefPtr<Painting::DisplayList> Document::record_display_list(PaintConfig config)
     display_list->set_device_pixels_per_css_pixel(page().client().device_pixels_per_css_pixel());
 
     Vector<RefPtr<Painting::ScrollFrame>> scroll_state;
-    scroll_state.resize(viewport_paintable.scroll_state.size());
+    scroll_state.resize(viewport_paintable.scroll_state.size() + viewport_paintable.sticky_state.size());
     for (auto& [_, scrollable_frame] : viewport_paintable.scroll_state) {
+        scroll_state[scrollable_frame->id] = scrollable_frame;
+    }
+    for (auto& [_, scrollable_frame] : viewport_paintable.sticky_state) {
         scroll_state[scrollable_frame->id] = scrollable_frame;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -376,6 +376,24 @@ void LayoutState::commit(Box& root)
         auto& paintable_box = const_cast<Painting::PaintableBox&>(*box.paintable_box());
         if (!paintable_box.scroll_offset().is_zero())
             paintable_box.set_scroll_offset(paintable_box.scroll_offset());
+
+        if (box.is_sticky_position()) {
+            auto sticky_insets = make<Painting::PaintableBox::StickyInsets>();
+            auto const& inset = box.computed_values().inset();
+            if (!inset.top().is_auto()) {
+                sticky_insets->top = inset.top().to_px(box, used_values.containing_block_used_values()->content_height());
+            }
+            if (!inset.right().is_auto()) {
+                sticky_insets->right = inset.right().to_px(box, used_values.containing_block_used_values()->content_width());
+            }
+            if (!inset.bottom().is_auto()) {
+                sticky_insets->bottom = inset.bottom().to_px(box, used_values.containing_block_used_values()->content_height());
+            }
+            if (!inset.left().is_auto()) {
+                sticky_insets->left = inset.left().to_px(box, used_values.containing_block_used_values()->content_width());
+            }
+            paintable_box.set_sticky_insets(move(sticky_insets));
+        }
     }
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -262,6 +262,14 @@ bool Node::is_fixed_position() const
     return position == CSS::Positioning::Fixed;
 }
 
+bool Node::is_sticky_position() const
+{
+    if (!has_style())
+        return false;
+    auto position = computed_values().position();
+    return position == CSS::Positioning::Sticky;
+}
+
 NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> computed_style)
     : Node(document, node)
     , m_computed_values(make<CSS::ComputedValues>())

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -122,6 +122,7 @@ public:
     bool is_positioned() const;
     bool is_absolutely_positioned() const;
     bool is_fixed_position() const;
+    bool is_sticky_position() const;
 
     bool is_flex_item() const { return m_is_flex_item; }
     void set_flex_item(bool b) { m_is_flex_item = b; }

--- a/Userland/Libraries/LibWeb/Painting/ClipFrame.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClipFrame.cpp
@@ -24,12 +24,12 @@ CSSPixelRect ClipFrame::clip_rect_for_hit_testing() const
     VERIFY(!m_clip_rects.is_empty());
     auto rect = m_clip_rects[0].rect;
     if (m_clip_rects[0].enclosing_scroll_frame) {
-        rect.translate_by(m_clip_rects[0].enclosing_scroll_frame->cumulative_offset);
+        rect.translate_by(m_clip_rects[0].enclosing_scroll_frame->cumulative_offset());
     }
     for (size_t i = 1; i < m_clip_rects.size(); ++i) {
         auto clip_rect = m_clip_rects[i].rect;
         if (m_clip_rects[i].enclosing_scroll_frame) {
-            clip_rect.translate_by(m_clip_rects[i].enclosing_scroll_frame->cumulative_offset);
+            clip_rect.translate_by(m_clip_rects[i].enclosing_scroll_frame->cumulative_offset());
         }
         rect.intersect(clip_rect);
     }

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -26,7 +26,7 @@ Optional<int> ClippableAndScrollable::scroll_frame_id() const
 CSSPixelPoint ClippableAndScrollable::cumulative_offset_of_enclosing_scroll_frame() const
 {
     if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->cumulative_offset;
+        return m_enclosing_scroll_frame->cumulative_offset();
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -23,6 +23,7 @@ public:
     [[nodiscard]] CSSPixelPoint cumulative_offset_of_enclosing_scroll_frame() const;
     [[nodiscard]] Optional<CSSPixelRect> clip_rect_for_hit_testing() const;
 
+    [[nodiscard]] RefPtr<ScrollFrame const> own_scroll_frame() const { return m_own_scroll_frame; }
     [[nodiscard]] Optional<int> own_scroll_frame_id() const;
     [[nodiscard]] CSSPixelPoint own_scroll_frame_offset() const
     {

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -48,7 +48,7 @@ void DisplayListPlayer::execute(DisplayList& display_list)
         }
 
         if (scroll_frame_id.has_value()) {
-            auto const& scroll_offset = scroll_state[scroll_frame_id.value()]->cumulative_offset.to_type<double>().scaled(device_pixels_per_css_pixel).to_type<int>();
+            auto const& scroll_offset = scroll_state[scroll_frame_id.value()]->cumulative_offset().to_type<double>().scaled(device_pixels_per_css_pixel).to_type<int>();
             command.visit(
                 [&](auto& command) {
                     if constexpr (requires { command.translate_by(scroll_offset); }) {

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -26,6 +26,7 @@ Paintable::Paintable(Layout::Node const& layout_node)
     }
 
     m_fixed_position = computed_values.position() == CSS::Positioning::Fixed;
+    m_sticky_position = computed_values.position() == CSS::Positioning::Sticky;
     m_absolutely_positioned = computed_values.position() == CSS::Positioning::Absolute;
     m_floating = layout_node.is_floating();
     m_inline = layout_node.is_inline();

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -54,6 +54,7 @@ public:
     [[nodiscard]] bool is_visible() const;
     [[nodiscard]] bool is_positioned() const { return m_positioned; }
     [[nodiscard]] bool is_fixed_position() const { return m_fixed_position; }
+    [[nodiscard]] bool is_sticky_position() const { return m_sticky_position; }
     [[nodiscard]] bool is_absolutely_positioned() const { return m_absolutely_positioned; }
     [[nodiscard]] bool is_floating() const { return m_floating; }
     [[nodiscard]] bool is_inline() const { return m_inline; }
@@ -258,6 +259,7 @@ private:
 
     bool m_positioned : 1 { false };
     bool m_fixed_position : 1 { false };
+    bool m_sticky_position : 1 { false };
     bool m_absolutely_positioned : 1 { false };
     bool m_floating : 1 { false };
     bool m_inline : 1 { false };

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1100,4 +1100,15 @@ void PaintableWithLines::resolve_paint_properties()
     }
 }
 
+RefPtr<ScrollFrame const> PaintableBox::nearest_scroll_frame() const
+{
+    auto const* paintable = this->containing_block();
+    while (paintable) {
+        if (paintable->own_scroll_frame())
+            return paintable->own_scroll_frame();
+        paintable = paintable->containing_block();
+    }
+    return nullptr;
+}
+
 }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -210,6 +210,8 @@ public:
 
     virtual void resolve_paint_properties() override;
 
+    RefPtr<ScrollFrame const> nearest_scroll_frame() const;
+
 protected:
     explicit PaintableBox(Layout::Box const&);
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -212,6 +212,20 @@ public:
 
     RefPtr<ScrollFrame const> nearest_scroll_frame() const;
 
+    CSSPixelRect padding_box_rect_relative_to_nearest_scrollable_ancestor() const;
+    PaintableBox const* nearest_scrollable_ancestor() const;
+
+    struct StickyInsets {
+        Optional<CSSPixels> top;
+        Optional<CSSPixels> right;
+        Optional<CSSPixels> bottom;
+        Optional<CSSPixels> left;
+    };
+    StickyInsets const& sticky_insets() const { return *m_sticky_insets; }
+    void set_sticky_insets(OwnPtr<StickyInsets> sticky_insets) { m_sticky_insets = move(sticky_insets); }
+
+    [[nodiscard]] bool is_scrollable() const;
+
 protected:
     explicit PaintableBox(Layout::Box const&);
 
@@ -270,6 +284,8 @@ private:
     Optional<ScrollDirection> m_scroll_thumb_dragging_direction;
 
     ResolvedBackground m_resolved_background;
+
+    OwnPtr<StickyInsets> m_sticky_insets;
 };
 
 class PaintableWithLines : public PaintableBox {

--- a/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -12,8 +12,15 @@ namespace Web::Painting {
 
 struct ScrollFrame : public RefCounted<ScrollFrame> {
     i32 id { -1 };
-    CSSPixelPoint cumulative_offset;
     CSSPixelPoint own_offset;
+    RefPtr<ScrollFrame const> parent;
+
+    CSSPixelPoint cumulative_offset() const
+    {
+        if (parent)
+            return parent->cumulative_offset() + own_offset;
+        return own_offset;
+    }
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -22,6 +22,7 @@ public:
     void build_stacking_context_tree_if_needed();
 
     HashMap<JS::GCPtr<PaintableBox const>, RefPtr<ScrollFrame>> scroll_state;
+    HashMap<JS::GCPtr<PaintableBox const>, RefPtr<ScrollFrame>> sticky_state;
     void assign_scroll_frames();
     void refresh_scroll_state();
 


### PR DESCRIPTION
Sticky positioning is implemented by modifying the algorithm for
assigning and refreshing scroll frames. Now, elements with
"position: sticky" are assigned their own scroll frame, and their
position is refreshed independently from regular scroll boxes.
Refreshing the scroll offsets for sticky boxes does not require display
list invalidation.

A separate hash map is used for the scroll frames of sticky boxes. This
is necessary because a single paintable box can have two scroll frames
if it 1) has "position: sticky" and 2) contains scrollable overflow.