### PR TITLE
AK+Meta: Update simdutf to version 5.3.4, make use of new Base64URL option

### DIFF
--- a/Toolchain/BuildVcpkg.sh
+++ b/Toolchain/BuildVcpkg.sh
@@ -21,7 +21,7 @@ if [ "$ci" -eq 0 ]; then
 fi
 
 GIT_REPO="https://github.com/microsoft/vcpkg.git"
-GIT_REV="f7423ee180c4b7f40d43402c2feb3859161ef625" # 2024.06.15
+GIT_REV="3508985146f1b1d248c67ead13f8f54be5b4f5da" # 2024.08.23
 PREFIX_DIR="$DIR/Local/vcpkg"
 
 mkdir -p "$DIR/Tarballs"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "f7423ee180c4b7f40d43402c2feb3859161ef625",
+  "builtin-baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da",
   "dependencies": [
     {
       "name": "fontconfig",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -91,7 +91,7 @@
     },
     {
       "name": "simdutf",
-      "version": "5.2.5#0"
+      "version": "5.3.4#0"
     },
     {
       "name": "skia",


### PR DESCRIPTION
The main goal here is to now hopefully be able to fully implement the Uint8Array base64 proposal.