### PR TITLE
LibWeb: Make aria-relevant and ariaRelevant reflect

### DIFF
--- a/Tests/LibWeb/Text/expected/aria-attribute-reflection.txt
+++ b/Tests/LibWeb/Text/expected/aria-attribute-reflection.txt
@@ -1,0 +1,231 @@
+                                             Element Reflection for ARIA properties
+Testing: role attribute reflects.
+    PASS: button is equal to button as expected.
+    PASS: checkbox is equal to checkbox as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-atomic attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-autocomplete attribute reflects.
+    PASS: list is equal to list as expected.
+    PASS: inline is equal to inline as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-braillelabel attribute reflects.
+    FAIL: undefined is not equal to x.
+    FAIL: x is not equal to y.
+    PASS: null is equal to null as expected.
+    FAIL: Expected false but got true.
+    PASS: undefined is equal to null as expected.
+    FAIL: Expected false but got true.
+Testing: aria-brailleroledescription attribute reflects.
+    FAIL: undefined is not equal to x.
+    FAIL: x is not equal to y.
+    PASS: null is equal to null as expected.
+    FAIL: Expected false but got true.
+    PASS: undefined is equal to null as expected.
+    FAIL: Expected false but got true.
+Testing: aria-busy attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-checked attribute reflects.
+    PASS: mixed is equal to mixed as expected.
+    PASS: true is equal to true as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-colcount attribute reflects.
+    PASS: 5 is equal to 5 as expected.
+    PASS: 6 is equal to 6 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-colindex attribute reflects.
+    PASS: 1 is equal to 1 as expected.
+    PASS: 2 is equal to 2 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-colindextext attribute reflects.
+    FAIL: undefined is not equal to x.
+    FAIL: x is not equal to y.
+    PASS: null is equal to null as expected.
+    FAIL: Expected false but got true.
+    PASS: undefined is equal to null as expected.
+    FAIL: Expected false but got true.
+Testing: aria-colspan attribute reflects.
+    PASS: 2 is equal to 2 as expected.
+    PASS: 3 is equal to 3 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-current attribute reflects.
+    PASS: page is equal to page as expected.
+    PASS: step is equal to step as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-description attribute reflects.
+    FAIL: undefined is not equal to cold as ice.
+    FAIL: cold as ice is not equal to hot as fire.
+    PASS: null is equal to null as expected.
+    FAIL: Expected false but got true.
+    PASS: undefined is equal to null as expected.
+    FAIL: Expected false but got true.
+Testing: aria-disabled attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-expanded attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-haspopup attribute reflects.
+    PASS: menu is equal to menu as expected.
+    PASS: listbox is equal to listbox as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-hidden attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-invalid attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: grammar is equal to grammar as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-keyshortcuts attribute reflects.
+    PASS: x is equal to x as expected.
+    PASS: y is equal to y as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-label attribute reflects.
+    PASS: x is equal to x as expected.
+    PASS: y is equal to y as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-level attribute reflects.
+    PASS: 1 is equal to 1 as expected.
+    PASS: 2 is equal to 2 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-live attribute reflects.
+    PASS: polite is equal to polite as expected.
+    PASS: assertive is equal to assertive as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-modal attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-multiline attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-multiselectable attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-orientation attribute reflects.
+    PASS: vertical is equal to vertical as expected.
+    PASS: horizontal is equal to horizontal as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-placeholder attribute reflects.
+    PASS: x is equal to x as expected.
+    PASS: y is equal to y as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-posinset attribute reflects.
+    PASS: 10 is equal to 10 as expected.
+    PASS: 11 is equal to 11 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-pressed attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-readonly attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-relevant attribute reflects.
+    PASS: text is equal to text as expected.
+    PASS: removals is equal to removals as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-required attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-roledescription attribute reflects.
+    PASS: x is equal to x as expected.
+    PASS: y is equal to y as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-rowcount attribute reflects.
+    PASS: 10 is equal to 10 as expected.
+    PASS: 11 is equal to 11 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-rowindex attribute reflects.
+    PASS: 1 is equal to 1 as expected.
+    PASS: 2 is equal to 2 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-rowindextext attribute reflects.
+    FAIL: undefined is not equal to x.
+    FAIL: x is not equal to y.
+    PASS: null is equal to null as expected.
+    FAIL: Expected false but got true.
+    PASS: undefined is equal to null as expected.
+    FAIL: Expected false but got true.
+Testing: aria-rowspan attribute reflects.
+    PASS: 2 is equal to 2 as expected.
+    PASS: 3 is equal to 3 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-selected attribute reflects.
+    PASS: true is equal to true as expected.
+    PASS: false is equal to false as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-setsize attribute reflects.
+    PASS: 10 is equal to 10 as expected.
+    PASS: 11 is equal to 11 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-sort attribute reflects.
+    PASS: descending is equal to descending as expected.
+    PASS: ascending is equal to ascending as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-valuemax attribute reflects.
+    PASS: 99 is equal to 99 as expected.
+    PASS: 100 is equal to 100 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-valuemin attribute reflects.
+    PASS: 3 is equal to 3 as expected.
+    PASS: 2 is equal to 2 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-valuenow attribute reflects.
+    PASS: 50 is equal to 50 as expected.
+    PASS: 51 is equal to 51 as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.
+Testing: aria-valuetext attribute reflects.
+    PASS: 50% is equal to 50% as expected.
+    PASS: 51% is equal to 51% as expected.
+    PASS: null is equal to null as expected.
+    PASS: null is equal to null as expected.

--- a/Tests/LibWeb/Text/input/aria-attribute-reflection.html
+++ b/Tests/LibWeb/Text/input/aria-attribute-reflection.html
@@ -1,0 +1,433 @@
+<!DOCTYPE html><meta charset=utf-8>
+<script src="include.js"></script>
+<script>
+    function run_test(callback, description) {
+        println(`Testing: ${description}`);
+        callback();
+    }
+    function assert_false(expression) {
+      if (expression) {
+          println("    FAIL: Expected false but got true.");
+      }
+    }
+    function assert_equals(a, b) {
+      if (a == b) {
+          println(`    PASS: ${a} is equal to ${b} as expected.`);
+      } else {
+          println(`    FAIL: ${a} is not equal to ${b}.`);
+      }
+    }
+    function testNullable(element, jsAttr, contentAttr) {
+        var originalValue = element[jsAttr];
+        assert_false(originalValue === null);
+        element[jsAttr] = null;
+        assert_equals(element[jsAttr], null);
+        assert_false(element.hasAttribute(contentAttr));
+        // Setting to undefined results in same state as setting to null.
+        element[jsAttr] = originalValue;
+        element[jsAttr] = undefined;
+        assert_equals(element[jsAttr], null);
+        assert_false(element.hasAttribute(contentAttr));
+    }
+</script>
+
+<div id="role" role="button"></div>
+<div id="atomic" aria-atomic="true"></div>
+<div id="autocomplete" aria-autocomplete="list"></div>
+<div id="braillelabel" aria-braillelabel="x"></div>
+<div id="brailleroledescription" aria-brailleroledescription="x"></div>
+<div id="busy" aria-busy="true"></div>
+<div id="checked" aria-checked="mixed"></div>
+<div id="colcount" aria-colcount="5"></div>
+<div id="colindex" aria-colindex="1"></div>
+<div id="colindextext" aria-colindextext="x"></div>
+<div id="colspan" aria-colspan="2"></div>
+<div id="current" aria-current="page"></div>
+<div id="description" aria-description="cold as ice"></div>
+<div id="disabled" aria-disabled="true"></div>
+<div id="expanded" aria-expanded="true"></div>
+<div id="haspopup" aria-haspopup="menu"></div>
+<div id="hidden" aria-hidden="true" tabindex="-1"></div>
+<div id="invalid" aria-invalid="true"></div>
+<div id="keyshortcuts" aria-keyshortcuts="x"></div>
+<div id="label" aria-label="x"></div>
+<div id="level" aria-level="1"></div>
+<div id="live" aria-live="polite"></div>
+<div id="modal" aria-modal="true"></div>
+<div id="multiline" aria-multiline="true"></div>
+<div id="multiselectable" aria-multiselectable="true"></div>
+<div id="orientation" aria-orientation="vertical"></div>
+<div id="placeholder" aria-placeholder="x"></div>
+<div id="posinset" aria-posinset="10"></div>
+<button id="pressed" aria-pressed="true" style="display: none"></button>
+<div id="readonly" aria-readonly="true"></div>
+<div id="relevant" aria-relevant="text"></div>
+<div id="required" aria-required="true"></div>
+<div id="roledescription" aria-roledescription="x"></div>
+<div id="rowcount" aria-rowcount="10"></div>
+<div id="rowindex" aria-rowindex="1"></div>
+<div id="rowindextext" aria-rowindextext="x"></div>
+<div id="rowspan" aria-rowspan="2"></div>
+<div id="selected" aria-selected="true"></div>
+<div id="setsize" aria-setsize="10"></div>
+<div id="sort" aria-sort="descending"></div>
+<div id="valuemax" aria-valuemax="99"></div>
+<div id="valuemin" aria-valuemin="3"></div>
+<div id="valuenow" aria-valuenow="50"></div>
+<div id="valuetext" aria-valuetext="50%"></div>
+<script>
+    test(() => {
+        println("Element Reflection for ARIA properties");
+        run_test(function(t) {
+            var element = document.getElementById("role");
+            assert_equals(element.role, "button");
+            element.role = "checkbox";
+            assert_equals(element.getAttribute("role"), "checkbox");
+            testNullable(element, "role", "role");
+        }, "role attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("atomic");
+            assert_equals(element.ariaAtomic, "true");
+            element.ariaAtomic = "false";
+            assert_equals(element.getAttribute("aria-atomic"), "false");
+            testNullable(element, "ariaAtomic", "aria-atomic");
+        }, "aria-atomic attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("autocomplete");
+            assert_equals(element.ariaAutoComplete, "list");
+            element.ariaAutoComplete = "inline";
+            assert_equals(element.getAttribute("aria-autocomplete"), "inline");
+            testNullable(element, "ariaAutoComplete", "aria-autocomplete");
+        }, "aria-autocomplete attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("braillelabel");
+            assert_equals(element.ariaBrailleLabel, "x");
+            element.ariaBrailleLabel = "y";
+            assert_equals(element.getAttribute("aria-braillelabel"), "y");
+            testNullable(element, "ariaBrailleLabel", "aria-braillelabel");
+        }, "aria-braillelabel attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("brailleroledescription");
+            assert_equals(element.ariaBrailleRoleDescription, "x");
+            element.ariaBrailleRoleDescription = "y";
+            assert_equals(element.getAttribute("aria-brailleroledescription"), "y");
+            testNullable(element, "ariaBrailleRoleDescription", "aria-brailleroledescription");
+        }, "aria-brailleroledescription attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("busy");
+            assert_equals(element.ariaBusy, "true");
+            element.ariaBusy = "false";
+            assert_equals(element.getAttribute("aria-busy"), "false");
+            testNullable(element, "ariaBusy", "aria-busy");
+        }, "aria-busy attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("checked");
+            assert_equals(element.ariaChecked, "mixed");
+            element.ariaChecked = "true";
+            assert_equals(element.getAttribute("aria-checked"), "true");
+            testNullable(element, "ariaChecked", "aria-checked");
+        }, "aria-checked attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("colcount");
+            assert_equals(element.ariaColCount, "5");
+            element.ariaColCount = "6";
+            assert_equals(element.getAttribute("aria-colcount"), "6");
+            testNullable(element, "ariaColCount", "aria-colcount");
+        }, "aria-colcount attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("colindex");
+            assert_equals(element.ariaColIndex, "1");
+            element.ariaColIndex = "2";
+            assert_equals(element.getAttribute("aria-colindex"), "2");
+            testNullable(element, "ariaColIndex", "aria-colindex");
+        }, "aria-colindex attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("colindextext");
+            assert_equals(element.ariaColIndexText, "x");
+            element.ariaColIndexText = "y";
+            assert_equals(element.getAttribute("aria-colindextext"), "y");
+            testNullable(element, "ariaColIndexText", "aria-colindextext");
+        }, "aria-colindextext attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("colspan");
+            assert_equals(element.ariaColSpan, "2");
+            element.ariaColSpan = "3";
+            assert_equals(element.getAttribute("aria-colspan"), "3");
+            testNullable(element, "ariaColSpan", "aria-colspan");
+        }, "aria-colspan attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("current");
+            assert_equals(element.ariaCurrent, "page");
+            element.ariaCurrent = "step";
+            assert_equals(element.getAttribute("aria-current"), "step");
+            testNullable(element, "ariaCurrent", "aria-current");
+        }, "aria-current attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("description");
+            assert_equals(element.ariaDescription, "cold as ice");
+            element.ariaDescription = "hot as fire";
+            assert_equals(element.getAttribute("aria-description"), "hot as fire");
+            testNullable(element, "ariaDescription", "aria-description");
+        }, "aria-description attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("disabled");
+            assert_equals(element.ariaDisabled, "true");
+            element.ariaDisabled = "false";
+            assert_equals(element.getAttribute("aria-disabled"), "false");
+            testNullable(element, "ariaDisabled", "aria-disabled");
+        }, "aria-disabled attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("expanded");
+            assert_equals(element.ariaExpanded, "true");
+            element.ariaExpanded = "false";
+            assert_equals(element.getAttribute("aria-expanded"), "false");
+            testNullable(element, "ariaExpanded", "aria-expanded");
+        }, "aria-expanded attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("haspopup");
+            assert_equals(element.ariaHasPopup, "menu");
+            element.ariaHasPopup = "listbox";
+            assert_equals(element.getAttribute("aria-haspopup"), "listbox");
+            testNullable(element, "ariaHasPopup", "aria-haspopup");
+        }, "aria-haspopup attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("hidden");
+            assert_equals(element.ariaHidden, "true");
+            element.ariaHidden = "false";
+            assert_equals(element.getAttribute("aria-hidden"), "false");
+            testNullable(element, "ariaHidden", "aria-hidden");
+        }, "aria-hidden attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("invalid");
+            assert_equals(element.ariaInvalid, "true");
+            element.ariaInvalid = "grammar";
+            assert_equals(element.getAttribute("aria-invalid"), "grammar");
+            testNullable(element, "ariaInvalid", "aria-invalid");
+        }, "aria-invalid attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("keyshortcuts");
+            assert_equals(element.ariaKeyShortcuts, "x");
+            element.ariaKeyShortcuts = "y";
+            assert_equals(element.getAttribute("aria-keyshortcuts"), "y");
+            testNullable(element, "ariaKeyShortcuts", "aria-keyshortcuts");
+        }, "aria-keyshortcuts attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("label");
+            assert_equals(element.ariaLabel, "x");
+            element.ariaLabel = "y";
+            assert_equals(element.getAttribute("aria-label"), "y");
+            testNullable(element, "ariaLabel", "aria-label");
+        }, "aria-label attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("level");
+            assert_equals(element.ariaLevel, "1");
+            element.ariaLevel = "2";
+            assert_equals(element.getAttribute("aria-level"), "2");
+            testNullable(element, "ariaLevel", "aria-level");
+        }, "aria-level attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("live");
+            assert_equals(element.ariaLive, "polite");
+            element.ariaLive = "assertive";
+            assert_equals(element.getAttribute("aria-live"), "assertive");
+            testNullable(element, "ariaLive", "aria-live");
+        }, "aria-live attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("modal");
+            assert_equals(element.ariaModal, "true");
+            element.ariaModal = "false";
+            assert_equals(element.getAttribute("aria-modal"), "false");
+            testNullable(element, "ariaModal", "aria-modal");
+        }, "aria-modal attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("multiline");
+            assert_equals(element.ariaMultiLine, "true");
+            element.ariaMultiLine = "false";
+            assert_equals(element.getAttribute("aria-multiline"), "false");
+            testNullable(element, "ariaMultiLine", "aria-multiline");
+        }, "aria-multiline attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("multiselectable");
+            assert_equals(element.ariaMultiSelectable, "true");
+            element.ariaMultiSelectable = "false";
+            assert_equals(element.getAttribute("aria-multiselectable"), "false");
+            testNullable(element, "ariaMultiSelectable", "aria-multiselectable");
+        }, "aria-multiselectable attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("orientation");
+            assert_equals(element.ariaOrientation, "vertical");
+            element.ariaOrientation = "horizontal";
+            assert_equals(element.getAttribute("aria-orientation"), "horizontal");
+            testNullable(element, "ariaOrientation", "aria-orientation");
+        }, "aria-orientation attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("placeholder");
+            assert_equals(element.ariaPlaceholder, "x");
+            element.ariaPlaceholder = "y";
+            assert_equals(element.getAttribute("aria-placeholder"), "y");
+            testNullable(element, "ariaPlaceholder", "aria-placeholder");
+        }, "aria-placeholder attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("posinset");
+            assert_equals(element.ariaPosInSet, "10");
+            element.ariaPosInSet = "11";
+            assert_equals(element.getAttribute("aria-posinset"), "11");
+            testNullable(element, "ariaPosInSet", "aria-posinset");
+        }, "aria-posinset attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("pressed");
+            assert_equals(element.ariaPressed, "true");
+            element.ariaPressed = "false";
+            assert_equals(element.getAttribute("aria-pressed"), "false");
+            testNullable(element, "ariaPressed", "aria-pressed");
+        }, "aria-pressed attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("readonly");
+            assert_equals(element.ariaReadOnly, "true");
+            element.ariaReadOnly = "false";
+            assert_equals(element.getAttribute("aria-readonly"), "false");
+            testNullable(element, "ariaReadOnly", "aria-readonly");
+        }, "aria-readonly attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("relevant");
+            assert_equals(element.ariaRelevant, "text");
+            element.ariaRelevant = "removals";
+            assert_equals(element.getAttribute("aria-relevant"), "removals");
+            testNullable(element, "ariaRelevant", "aria-relevant");
+        }, "aria-relevant attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("required");
+            assert_equals(element.ariaRequired, "true");
+            element.ariaRequired = "false";
+            assert_equals(element.getAttribute("aria-required"), "false");
+            testNullable(element, "ariaRequired", "aria-required");
+        }, "aria-required attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("roledescription");
+            assert_equals(element.ariaRoleDescription, "x");
+            element.ariaRoleDescription = "y";
+            assert_equals(element.getAttribute("aria-roledescription"), "y");
+            testNullable(element, "ariaRoleDescription", "aria-roledescription");
+        }, "aria-roledescription attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("rowcount");
+            assert_equals(element.ariaRowCount, "10");
+            element.ariaRowCount = "11";
+            assert_equals(element.getAttribute("aria-rowcount"), "11");
+            testNullable(element, "ariaRowCount", "aria-rowcount");
+        }, "aria-rowcount attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("rowindex");
+            assert_equals(element.ariaRowIndex, "1");
+            element.ariaRowIndex = "2";
+            assert_equals(element.getAttribute("aria-rowindex"), "2");
+            testNullable(element, "ariaRowIndex", "aria-rowindex");
+        }, "aria-rowindex attribute reflects.");
+
+            run_test(function(t) {
+                var element = document.getElementById("rowindextext");
+                assert_equals(element.ariaRowIndexText, "x");
+                element.ariaRowIndexText = "y";
+                assert_equals(element.getAttribute("aria-rowindextext"), "y");
+                testNullable(element, "ariaRowIndexText", "aria-rowindextext");
+            }, "aria-rowindextext attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("rowspan");
+            assert_equals(element.ariaRowSpan, "2");
+            element.ariaRowSpan = "3";
+            assert_equals(element.getAttribute("aria-rowspan"), "3");
+            testNullable(element, "ariaRowSpan", "aria-rowspan");
+        }, "aria-rowspan attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("selected");
+            assert_equals(element.ariaSelected, "true");
+            element.ariaSelected = "false";
+            assert_equals(element.getAttribute("aria-selected"), "false");
+            testNullable(element, "ariaSelected", "aria-selected");
+        }, "aria-selected attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("setsize");
+            assert_equals(element.ariaSetSize, "10");
+            element.ariaSetSize = "11";
+            assert_equals(element.getAttribute("aria-setsize"), "11");
+            testNullable(element, "ariaSetSize", "aria-setsize");
+        }, "aria-setsize attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("sort");
+            assert_equals(element.ariaSort, "descending");
+            element.ariaSort = "ascending";
+            assert_equals(element.getAttribute("aria-sort"), "ascending");
+            testNullable(element, "ariaSort", "aria-sort");
+        }, "aria-sort attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("valuemax");
+            assert_equals(element.ariaValueMax, "99");
+            element.ariaValueMax = "100";
+            assert_equals(element.getAttribute("aria-valuemax"), "100");
+            testNullable(element, "ariaValueMax", "aria-valuemax");
+        }, "aria-valuemax attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("valuemin");
+            assert_equals(element.ariaValueMin, "3");
+            element.ariaValueMin = "2";
+            assert_equals(element.getAttribute("aria-valuemin"), "2");
+            testNullable(element, "ariaValueMin", "aria-valuemin");
+        }, "aria-valuemin attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("valuenow");
+            assert_equals(element.ariaValueNow, "50");
+            element.ariaValueNow = "51";
+            assert_equals(element.getAttribute("aria-valuenow"), "51");
+            testNullable(element, "ariaValueNow", "aria-valuenow");
+        }, "aria-valuenow attribute reflects.");
+
+        run_test(function(t) {
+            var element = document.getElementById("valuetext");
+            assert_equals(element.ariaValueText, "50%");
+            element.ariaValueText = "51%";
+            assert_equals(element.getAttribute("aria-valuetext"), "51%");
+            testNullable(element, "ariaValueText", "aria-valuetext");
+        }, "aria-valuetext attribute reflects.");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/ARIA/ARIAMixin.idl
+++ b/Userland/Libraries/LibWeb/ARIA/ARIAMixin.idl
@@ -36,6 +36,7 @@ interface mixin ARIAMixin {
 	attribute DOMString? ariaPosInSet;
 	attribute DOMString? ariaPressed;
 	attribute DOMString? ariaReadOnly;
+	attribute DOMString? ariaRelevant;
 
 	attribute DOMString? ariaRequired;
 	attribute DOMString? ariaRoleDescription;


### PR DESCRIPTION
This change makes the `aria-relevant` content attribute and the `ariaRelevant` IDL/DOM attribute reflect — which makes the Ladybird behavior interoperable with the implemented behavior in other existing engines.

Otherwise, without this change, Ladybird fails the relevant test case in https://wpt.fyi/results/html/dom/aria-attribute-reflection.html — which other existing engines all pass.

Note that at https://w3c.github.io/aria/#ARIAMixin the `ARIAMixin` IDL definition in the current ARIA spec actually lacks the `ariaRelevant` attribute — but I’ve raised https://github.com/w3c/aria/pull/2326 to get that fixed.

And note that this change doesn’t actually add support for the `aria-relevant` — because we _already_ have support for it; the only thing that was missing was that it wasn’t in our `ARIAMixin` IDL.

Finally: This change also adds a related new in-tree test for ARIA attribute reflection (for all attributes in the current canonical ARIA spec at https://w3c.github.io/aria/). It’s just a port of https://wpt.fyi/results/html/dom/aria-attribute-reflection.html over to our in-tree test harness. Some of the tests currently fail — but that’s expected because we haven’t yet added support for them. But I can add them in a follow-up PR — and after that, all those tests will be green.