### PR TITLE
LibWeb: Invalidate the display list when calling `set_needs_display()`

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -384,7 +384,6 @@ Document::Document(JS::Realm& realm, const URL::URL& url, TemporaryDocumentForFr
         if (!navigable || !navigable->is_focused())
             return;
 
-        node->document().invalidate_display_list();
         node->document().update_layout();
 
         if (node->paintable()) {
@@ -5378,17 +5377,21 @@ void Document::set_cached_navigable(JS::GCPtr<HTML::Navigable> navigable)
     m_cached_navigable = navigable.ptr();
 }
 
-void Document::set_needs_display()
+void Document::set_needs_display(InvalidateDisplayList should_invalidate_display_list)
 {
-    set_needs_display(viewport_rect());
+    set_needs_display(viewport_rect(), should_invalidate_display_list);
 }
 
-void Document::set_needs_display(CSSPixelRect const&)
+void Document::set_needs_display(CSSPixelRect const&, InvalidateDisplayList should_invalidate_display_list)
 {
     // FIXME: Ignore updates outside the visible viewport rect.
     //        This requires accounting for fixed-position elements in the input rect, which we don't do yet.
 
     m_needs_repaint = true;
+
+    if (should_invalidate_display_list == InvalidateDisplayList::Yes) {
+        invalidate_display_list();
+    }
 
     auto navigable = this->navigable();
     if (!navigable)
@@ -5399,8 +5402,8 @@ void Document::set_needs_display(CSSPixelRect const&)
         return;
     }
 
-    if (navigable->container()) {
-        navigable->container()->document().set_needs_display();
+    if (auto container = navigable->container()) {
+        container->document().set_needs_display(should_invalidate_display_list);
     }
 }
 
@@ -5412,8 +5415,8 @@ void Document::invalidate_display_list()
     if (!navigable)
         return;
 
-    if (navigable->container()) {
-        navigable->container()->document().invalidate_display_list();
+    if (auto container = navigable->container()) {
+        container->document().invalidate_display_list();
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -35,6 +35,7 @@
 #include <LibWeb/HTML/SandboxingFlagSet.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/VisibilityState.h>
+#include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/ObservableArray.h>
 
@@ -700,8 +701,8 @@ public:
     void set_cached_navigable(JS::GCPtr<HTML::Navigable>);
 
     [[nodiscard]] bool needs_repaint() const { return m_needs_repaint; }
-    void set_needs_display();
-    void set_needs_display(CSSPixelRect const&);
+    void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes);
+    void set_needs_display(CSSPixelRect const&, InvalidateDisplayList = InvalidateDisplayList::Yes);
 
     struct PaintConfig {
         bool paint_overlay { false };

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -98,7 +98,6 @@ void Range::update_associated_selection()
 {
     if (auto* viewport = m_start_container->document().paintable()) {
         viewport->recompute_selection_states();
-        m_start_container->document().invalidate_display_list();
         viewport->set_needs_display();
     }
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -14,6 +14,7 @@ namespace Web {
 class DragAndDropEventHandler;
 class EditEventHandler;
 class EventHandler;
+enum class InvalidateDisplayList;
 class LoadRequest;
 class Page;
 class PageClient;

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -174,7 +174,7 @@ void CanvasRenderingContext2D::did_draw(Gfx::FloatRect const&)
     // FIXME: Make use of the rect to reduce the invalidated area when possible.
     if (!canvas_element().paintable())
         return;
-    canvas_element().paintable()->set_needs_display();
+    canvas_element().paintable()->set_needs_display(InvalidateDisplayList::No);
 }
 
 Gfx::Painter* CanvasRenderingContext2D::painter()

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -2012,7 +2012,7 @@ void Navigable::set_viewport_size(CSSPixelSize size)
     }
 
     if (auto document = active_document()) {
-        document->set_needs_display();
+        document->set_needs_display(InvalidateDisplayList::No);
 
         document->inform_all_viewport_clients_about_the_current_viewport_rect();
 
@@ -2028,7 +2028,7 @@ void Navigable::perform_scroll_of_viewport(CSSPixelPoint new_position)
         scroll_offset_did_change();
 
         if (auto document = active_document()) {
-            document->set_needs_display();
+            document->set_needs_display(InvalidateDisplayList::No);
             document->set_needs_to_refresh_scroll_state(true);
             document->inform_all_viewport_clients_about_the_current_viewport_rect();
         }
@@ -2038,10 +2038,10 @@ void Navigable::perform_scroll_of_viewport(CSSPixelPoint new_position)
     HTML::main_thread_event_loop().schedule();
 }
 
-void Navigable::set_needs_display()
+void Navigable::set_needs_display(InvalidateDisplayList should_invalidate_display_list)
 {
     if (auto document = active_document(); document) {
-        document->set_needs_display();
+        document->set_needs_display(should_invalidate_display_list);
     }
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -21,6 +21,7 @@
 #include <LibWeb/HTML/SourceSnapshotParams.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/TokenizedFeatures.h>
+#include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/PixelUnits.h>
@@ -170,7 +171,7 @@ public:
     void set_viewport_size(CSSPixelSize);
     void perform_scroll_of_viewport(CSSPixelPoint position);
 
-    void set_needs_display();
+    void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes);
 
     void set_is_popup(TokenizedFeature::Popup is_popup) { m_is_popup = is_popup; }
 

--- a/Userland/Libraries/LibWeb/InvalidateDisplayList.h
+++ b/Userland/Libraries/LibWeb/InvalidateDisplayList.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Web {
+
+enum class InvalidateDisplayList {
+    Yes,
+    No,
+};
+
+}

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/NonnullOwnPtr.h>
+#include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/LineBox.h>
 #include <LibWeb/Layout/TextNode.h>
@@ -199,7 +200,7 @@ public:
 
     JS::GCPtr<HTML::Navigable> navigable() const;
 
-    virtual void set_needs_display();
+    virtual void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes);
 
     PaintableBox* containing_block() const
     {

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -125,7 +125,7 @@ void PaintableBox::set_scroll_offset(CSSPixelPoint offset)
     // 4. Append the element to doc’s pending scroll event targets.
     document.pending_scroll_event_targets().append(*layout_box().dom_node());
 
-    set_needs_display();
+    set_needs_display(InvalidateDisplayList::No);
 }
 
 void PaintableBox::scroll_by(int delta_x, int delta_y)
@@ -915,9 +915,9 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
     return TraversalDecision::Continue;
 }
 
-void PaintableBox::set_needs_display()
+void PaintableBox::set_needs_display(InvalidateDisplayList should_invalidate_display_list)
 {
-    document().set_needs_display(absolute_rect());
+    document().set_needs_display(absolute_rect(), should_invalidate_display_list);
 }
 
 Optional<CSSPixelRect> PaintableBox::get_masking_area() const

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -128,7 +128,7 @@ public:
     DOM::Node const* dom_node() const { return layout_box().dom_node(); }
     DOM::Node* dom_node() { return layout_box().dom_node(); }
 
-    virtual void set_needs_display() override;
+    virtual void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes) override;
 
     virtual void apply_scroll_offset(PaintContext&, PaintPhase) const override;
     virtual void reset_scroll_offset(PaintContext&, PaintPhase) const override;


### PR DESCRIPTION
Previously, content wasn't always redrawn when a repaint was necessary. This PR fixes the following issues

* The media now repainted when its state changes
* The cursor is redrawn when moved
* Animated images are repainted when their animation state changes

Example from: https://en.wikipedia.org/wiki/File:United_States_Navy_Band_-_Amhr%C3%A1n_na_bhFiann.ogg
NOTE: I had to disable scripts to get this page to work correctly.

Before:

https://github.com/user-attachments/assets/e532c8c0-5737-42a0-8792-1bc8c0e25fb3

After:


https://github.com/user-attachments/assets/bd9fc5ea-7153-46f4-9323-51c4f94b5dea

Fixes: #1256
