### PR TITLE
LibWeb: Fix getBoundingClientRect() for elements with "position: sticky"

### DIFF
--- a/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-of-sticky.txt
+++ b/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-of-sticky.txt
@@ -1,0 +1,1 @@
+  Sticky Element      Bounding Client Rect: top=50, left=10, width=500, height=57

--- a/Tests/LibWeb/Text/input/element-get-bounding-client-rect-of-sticky.html
+++ b/Tests/LibWeb/Text/input/element-get-bounding-client-rect-of-sticky.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<style>
+    body {
+        margin: 0;
+    }
+
+    #scrollable {
+        width: 300px;
+        height: 200px;
+        overflow: auto;
+        position: relative;
+    }
+
+    #inner-content {
+        width: 500px;
+        height: 800px;
+        padding: 10px;
+        background-color: #f06;
+    }
+
+    #sticky-element {
+        position: sticky;
+        top: 50px;
+        padding: 20px;
+        background-color: #4caf50;
+        color: white;
+        font-weight: bold;
+        text-align: center;
+    }
+</style>
+<div id="scrollable">
+    <div id="inner-content">
+        <div id="sticky-element">Sticky Element</div>
+        <div style="height: 600px"></div>
+    </div>
+</div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const stickyElement = document.getElementById("sticky-element");
+        const boundingRect = stickyElement.getBoundingClientRect();
+
+        const result = document.createElement("p");
+        result.textContent = `Bounding Client Rect: top=${boundingRect.top}, left=${boundingRect.left}, width=${boundingRect.width}, height=${boundingRect.height}`;
+        document.body.appendChild(result);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1291,11 +1291,16 @@ void Document::update_animated_style_if_needed()
 
 void Document::update_paint_and_hit_testing_properties_if_needed()
 {
+    if (auto* paintable = this->paintable()) {
+        paintable->refresh_scroll_state();
+    }
+
     if (!m_needs_to_resolve_paint_only_properties)
         return;
     m_needs_to_resolve_paint_only_properties = false;
-    if (auto* paintable = this->paintable())
+    if (auto* paintable = this->paintable()) {
         paintable->resolve_paint_only_properties();
+    }
 }
 
 void Document::set_normal_link_color(Color color)


### PR DESCRIPTION
Use offset from ScrollFrame which is an actual value a box is shifted by while painting.

Also change `update_paint_and_hit_testing_properties_if_needed()` to refresh scroll frames state, because `getBoundingClientRect()` now depends on them.

Fixes wrong file tree sidebar location and excessive layout invalidations caused by some miscalculation on JS-side when wrong bounding client rect is provided on Github PR pages like https://github.com/LadybirdBrowser/ladybird/pull/1232/files