### PR TITLE
LibWeb: Add `scope` attribute to HTMLTableCellElement

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableCellElement.idl
@@ -1,5 +1,13 @@
 #import <HTML/HTMLElement.idl>
 
+// https://html.spec.whatwg.org/multipage/tables.html#attr-th-scope
+enum ScopeAttribute {
+    "row",
+    "col",
+    "rowgroup",
+    "colgroup"
+};
+
 // https://html.spec.whatwg.org/multipage/tables.html#htmltablecellelement
 [Exposed=Window]
 interface HTMLTableCellElement : HTMLElement {
@@ -11,7 +19,7 @@ interface HTMLTableCellElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString headers;
     readonly attribute long cellIndex;
 
-    [FIXME, CEReactions] attribute DOMString scope; // only conforming for th elements
+    [CEReactions, Enumerated=ScopeAttribute, Reflect] attribute DOMString scope; // only conforming for th elements
     [CEReactions, Reflect] attribute DOMString abbr;  // only conforming for th elements
 
     // Obsolete


### PR DESCRIPTION
This small update fixes a number of tests in https://wpt.live/html/dom/reflection-tabular.html, increasing the number of passing tests from 5930 to 6086/6116.