### PR TITLE
HTMLImageElement: Improve decoding stub

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1145,4 +1145,30 @@ void HTMLImageElement::animate()
         paintable()->set_needs_display();
 }
 
+StringView HTMLImageElement::decoding() const
+{
+    switch (m_decoding_hint) {
+    case ImageDecodingHint::Sync:
+        return "sync"sv;
+    case ImageDecodingHint::Async:
+        return "async"sv;
+    case ImageDecodingHint::Auto:
+        return "auto"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void HTMLImageElement::set_decoding(String decoding)
+{
+    if (decoding == "sync"sv) {
+        dbgln("FIXME: HTMLImageElement.decoding = 'sync' is not implemented yet");
+        m_decoding_hint = ImageDecodingHint::Sync;
+    } else if (decoding == "async"sv) {
+        dbgln("FIXME: HTMLImageElement.decoding = 'async' is not implemented yet");
+        m_decoding_hint = ImageDecodingHint::Async;
+    } else
+        m_decoding_hint = ImageDecodingHint::Auto;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -80,6 +80,10 @@ public:
     // https://html.spec.whatwg.org/multipage/images.html#select-an-image-source
     [[nodiscard]] Optional<ImageSourceAndPixelDensity> select_an_image_source();
 
+    StringView decoding() const;
+
+    void set_decoding(String);
+
     void set_source_set(SourceSet);
 
     ImageRequest& current_request() { return *m_current_request; }
@@ -147,6 +151,15 @@ private:
     SourceSet m_source_set;
 
     CSSPixelSize m_last_seen_viewport_size;
+
+    // https://html.spec.whatwg.org/multipage/images.html#image-decoding-hint
+    enum class ImageDecodingHint {
+        Auto,
+        Sync,
+        Async
+    };
+
+    ImageDecodingHint m_decoding_hint = ImageDecodingHint::Auto;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -22,7 +22,7 @@ interface HTMLImageElement : HTMLElement {
     readonly attribute boolean complete;
     readonly attribute USVString currentSrc;
     [CEReactions, Reflect=referrerpolicy, Enumerated=ReferrerPolicy] attribute DOMString referrerPolicy;
-    [FIXME, CEReactions] attribute DOMString decoding;
+    [CEReactions] attribute DOMString decoding;
     [CEReactions, Enumerated=LazyLoadingAttribute, Reflect] attribute DOMString loading;
     [CEReactions, Enumerated=FetchPriorityAttribute, Reflect=fetchpriority] attribute DOMString fetchPriority;
 


### PR DESCRIPTION
Add an enum and warn when setting to sync/async.

This is used by https://maps.google.com/

Making sure the decoding happen at the right time is a little bit beyond my current understanding, but happy to try implementing that if someone can point me in the right direction.