### PR TITLE
LibWeb: Fix behavior of reverse wrapping flex containers

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-column-reverse-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-reverse-constrained-wrap.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x252 children: not-inline
+      Box <div.container.column> at (9,9) content-size 250x250 flex-container(column-reverse) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,158) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,158 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,56) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,56 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (135,158) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [135,158 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x252]
+      PaintableBox (Box<DIV>.container.column) [8,8 252x252]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,157 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,55 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [134,157 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,260 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/flex-constrained-wrap-reverse.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-constrained-wrap-reverse.txt
@@ -1,0 +1,131 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x1024 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x1008 children: not-inline
+      Box <div.row> at (9,9) content-size 250x250 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,158) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,158 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (112,158) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [112,158 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,33) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,33 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,260) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.column> at (9,261) content-size 250x250 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (158,262) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [158,262 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (158,364) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [158,364 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (33,262) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [33,262 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,512) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.row.start> at (9,513) content-size 250x250 flex-container(row) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,639) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,639 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (112,639) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [112,639 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,514) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,514 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,764) content-size 784x0 children: inline
+        TextNode <#text>
+      Box <div.column.start> at (9,765) content-size 250x250 flex-container(column) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (135,766) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [135,766 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (135,868) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [135,868 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (10,766) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [10,766 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,1016) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x1024]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x1024]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x1008]
+      PaintableBox (Box<DIV>.row) [8,8 252x252]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,157 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [111,157 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,32 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,260 784x0]
+      PaintableBox (Box<DIV>.column) [8,260 252x252]
+        PaintableWithLines (BlockContainer<DIV>.box) [157,261 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [157,363 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [32,261 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,512 784x0]
+      PaintableBox (Box<DIV>.row.start) [8,512 252x252]
+        PaintableWithLines (BlockContainer<DIV>.box) [9,638 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [111,638 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,513 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,764 784x0]
+      PaintableBox (Box<DIV>.column.start) [8,764 252x252]
+        PaintableWithLines (BlockContainer<DIV>.box) [134,765 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [134,867 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [9,765 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,1016 784x0]

--- a/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-constrained-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-row-reverse-constrained-wrap.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x206 children: not-inline
+      Box <div.container> at (9,9) content-size 250x204 flex-container(row-reverse) [FFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (158,10) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [158,10 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (56,10) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [56,10 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.box> at (158,112) content-size 100x100 flex-item [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [158,112 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,214) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x206]
+      PaintableBox (Box<DIV>.container) [8,8 252x206]
+        PaintableWithLines (BlockContainer<DIV>.box) [157,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [55,9 102x102]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.box) [157,111 102x102]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,214 784x0]

--- a/Tests/LibWeb/Layout/input/flex/flex-column-reverse-constrained-wrap.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-column-reverse-constrained-wrap.html
@@ -1,0 +1,25 @@
+<style>
+    body {
+        font-family: 'SerenitySans';
+    }
+
+    .container {
+        display: flex;
+        border: 1px solid salmon;
+        flex-direction: column-reverse;
+        height: 250px;
+        width: 250px;
+        flex-wrap: wrap;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+</style>
+<div class="container column">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>

--- a/Tests/LibWeb/Layout/input/flex/flex-constrained-wrap-reverse.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-constrained-wrap-reverse.html
@@ -1,0 +1,47 @@
+<style>
+    .row, .column {
+        display: flex;
+        border: 1px solid salmon;
+        width: 250px;
+        height: 250px;
+        flex-wrap: wrap-reverse;
+    }
+
+    .column {
+        flex-direction: column;
+    }
+
+    .start {
+        align-items: start;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+</style>
+
+<div class="row">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>
+
+<div class="column">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>
+
+<div class="row start">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>
+
+<div class="column start">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>

--- a/Tests/LibWeb/Layout/input/flex/flex-row-reverse-constrained-wrap.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-row-reverse-constrained-wrap.html
@@ -1,0 +1,24 @@
+<style>
+    body {
+        font-family: 'SerenitySans';
+    }
+
+    .container {
+        display: flex;
+        border: 1px solid salmon;
+        width: 250px;
+        flex-direction: row-reverse;
+        flex-wrap: wrap;
+    }
+
+    .box {
+        width: 100px;
+        height: 100px;
+        border: 1px solid black;
+    }
+</style>
+<div class="container">
+    <div class="box">1</div>
+    <div class="box">2</div>
+    <div class="box">3</div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -295,14 +295,8 @@ void FlexFormattingContext::generate_anonymous_flex_items()
         auto order_bucket = order_item_bucket.get(key);
         if (order_bucket.has_value()) {
             auto& items = order_bucket.value();
-            if (is_direction_reverse()) {
-                for (auto item : items.in_reverse()) {
-                    m_flex_items.append(move(item));
-                }
-            } else {
-                for (auto item : items) {
-                    m_flex_items.append(move(item));
-                }
+            for (auto item : items) {
+                m_flex_items.append(move(item));
             }
         }
     }
@@ -776,7 +770,11 @@ void FlexFormattingContext::collect_flex_items_into_flex_lines()
     if (is_single_line()) {
         FlexLine line;
         for (auto& item : m_flex_items) {
-            line.items.append(item);
+            if (is_direction_reverse()) {
+                line.items.prepend(item);
+            } else {
+                line.items.append(item);
+            }
         }
         m_flex_lines.append(move(line));
         return;
@@ -800,7 +798,13 @@ void FlexFormattingContext::collect_flex_items_into_flex_lines()
             line = {};
             line_main_size = 0;
         }
-        line.items.append(item);
+
+        if (is_direction_reverse()) {
+            line.items.prepend(item);
+        } else {
+            line.items.append(item);
+        }
+
         line_main_size += outer_hypothetical_main_size;
         // CSS-FLEXBOX-2: Account for gap between flex items.
         line_main_size += main_gap();


### PR DESCRIPTION
When either `row-reverse` or `column-reverse` was set along with `flex-wrap: wrap`. The order of every item was being reversed, instead of just each line:
<img width="715" alt="reverse-wrap-wrong" src="https://github.com/user-attachments/assets/3e8ccfb8-d8de-43fb-a657-da30b82bda7c">

Now it only reverses the line:
<img width="715" alt="reverse-wrap-correct" src="https://github.com/user-attachments/assets/a37fa347-148e-456a-809c-c577147da7ce">

This PR also implements the `flex-wrap: wrap-reverse`. It reverses the order of flex lines, and swaps the cross-start and cross-end directions. (https://drafts.csswg.org/css-flexbox/#flex-wrap-property)