### PR TITLE
LibJS: Implement the Uint8Array to/from base64 proposal

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -54,14 +54,22 @@ ErrorOr<ByteBuffer> decode_base64url(StringView input)
     return decode_base64_impl(input, simdutf::base64_url);
 }
 
-ErrorOr<String> encode_base64(ReadonlyBytes input)
+ErrorOr<String> encode_base64(ReadonlyBytes input, OmitPadding omit_padding)
 {
-    return encode_base64_impl(input, simdutf::base64_default);
+    auto options = omit_padding == OmitPadding::Yes
+        ? simdutf::base64_default_no_padding
+        : simdutf::base64_default;
+
+    return encode_base64_impl(input, options);
 }
 
-ErrorOr<String> encode_base64url(ReadonlyBytes input)
+ErrorOr<String> encode_base64url(ReadonlyBytes input, OmitPadding omit_padding)
 {
-    return encode_base64_impl(input, simdutf::base64_url_with_padding);
+    auto options = omit_padding == OmitPadding::Yes
+        ? simdutf::base64_url
+        : simdutf::base64_url_with_padding;
+
+    return encode_base64_impl(input, options);
 }
 
 }

--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -12,10 +12,15 @@
 
 namespace AK {
 
+size_t size_required_to_decode_base64(StringView input)
+{
+    return simdutf::maximal_binary_length_from_base64(input.characters_without_null_termination(), input.length());
+}
+
 static ErrorOr<ByteBuffer> decode_base64_impl(StringView input, simdutf::base64_options options)
 {
     ByteBuffer output;
-    TRY(output.try_resize(simdutf::maximal_binary_length_from_base64(input.characters_without_null_termination(), input.length())));
+    TRY(output.try_resize(size_required_to_decode_base64(input)));
 
     auto result = simdutf::base64_to_binary(
         input.characters_without_null_termination(),

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -16,8 +16,13 @@ namespace AK {
 ErrorOr<ByteBuffer> decode_base64(StringView);
 ErrorOr<ByteBuffer> decode_base64url(StringView);
 
-ErrorOr<String> encode_base64(ReadonlyBytes);
-ErrorOr<String> encode_base64url(ReadonlyBytes);
+enum class OmitPadding {
+    No,
+    Yes,
+};
+
+ErrorOr<String> encode_base64(ReadonlyBytes, OmitPadding = OmitPadding::No);
+ErrorOr<String> encode_base64url(ReadonlyBytes, OmitPadding = OmitPadding::No);
 
 }
 

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -18,6 +18,16 @@ size_t size_required_to_decode_base64(StringView);
 ErrorOr<ByteBuffer> decode_base64(StringView);
 ErrorOr<ByteBuffer> decode_base64url(StringView);
 
+struct InvalidBase64 {
+    Error error;
+    size_t valid_input_bytes { 0 };
+};
+
+// On success, these return the number of input bytes that were decoded. This might be less than the
+// string length if the output buffer was not large enough.
+ErrorOr<size_t, InvalidBase64> decode_base64_into(StringView, ByteBuffer&);
+ErrorOr<size_t, InvalidBase64> decode_base64url_into(StringView, ByteBuffer&);
+
 enum class OmitPadding {
     No,
     Yes,

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -13,6 +13,8 @@
 
 namespace AK {
 
+size_t size_required_to_decode_base64(StringView);
+
 ErrorOr<ByteBuffer> decode_base64(StringView);
 ErrorOr<ByteBuffer> decode_base64url(StringView);
 

--- a/Tests/AK/TestBase64.cpp
+++ b/Tests/AK/TestBase64.cpp
@@ -73,6 +73,22 @@ TEST_CASE(test_encode)
     encode_equal("foobar"sv, "Zm9vYmFy"sv);
 }
 
+TEST_CASE(test_encode_omit_padding)
+{
+    auto encode_equal = [&](StringView input, StringView expected) {
+        auto encoded = MUST(encode_base64(input.bytes(), AK::OmitPadding::Yes));
+        EXPECT_EQ(encoded, expected);
+    };
+
+    encode_equal(""sv, ""sv);
+    encode_equal("f"sv, "Zg"sv);
+    encode_equal("fo"sv, "Zm8"sv);
+    encode_equal("foo"sv, "Zm9v"sv);
+    encode_equal("foob"sv, "Zm9vYg"sv);
+    encode_equal("fooba"sv, "Zm9vYmE"sv);
+    encode_equal("foobar"sv, "Zm9vYmFy"sv);
+}
+
 TEST_CASE(test_urldecode)
 {
     auto decode_equal = [&](StringView input, StringView expected) {
@@ -111,6 +127,27 @@ TEST_CASE(test_urlencode)
 
     encode_equal("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."sv, "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEu"sv);
     encode_equal("hello?world"sv, "aGVsbG8_d29ybGQ="sv);
+
+    encode_equal("hello!!world"sv, "aGVsbG8hIXdvcmxk"sv);
+}
+
+TEST_CASE(test_urlencode_omit_padding)
+{
+    auto encode_equal = [&](StringView input, StringView expected) {
+        auto encoded = MUST(encode_base64url(input.bytes(), AK::OmitPadding::Yes));
+        EXPECT_EQ(encoded, expected);
+    };
+
+    encode_equal(""sv, ""sv);
+    encode_equal("f"sv, "Zg"sv);
+    encode_equal("fo"sv, "Zm8"sv);
+    encode_equal("foo"sv, "Zm9v"sv);
+    encode_equal("foob"sv, "Zm9vYg"sv);
+    encode_equal("fooba"sv, "Zm9vYmE"sv);
+    encode_equal("foobar"sv, "Zm9vYmFy"sv);
+
+    encode_equal("Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."sv, "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdCwgc2VkIGRvIGVpdXNtb2QgdGVtcG9yIGluY2lkaWR1bnQgdXQgbGFib3JlIGV0IGRvbG9yZSBtYWduYSBhbGlxdWEu"sv);
+    encode_equal("hello?world"sv, "aGVsbG8_d29ybGQ"sv);
 
     encode_equal("hello!!world"sv, "aGVsbG8hIXdvcmxk"sv);
 }

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -5,8 +5,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Enumerate.h>
 #include <LibCore/Environment.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/TypedArray.h>
 #include <LibTest/JavaScriptTestRunner.h>
 #include <LibUnicode/TimeZone.h>
 #include <stdlib.h>
@@ -111,6 +113,19 @@ TESTJS_GLOBAL_FUNCTION(set_time_zone, setTimeZone)
     tzset();
 
     return current_time_zone;
+}
+
+TESTJS_GLOBAL_FUNCTION(to_utf8_bytes, toUTF8Bytes)
+{
+    auto& realm = *vm.current_realm();
+
+    auto string = TRY(vm.argument(0).to_string(vm));
+    auto typed_array = TRY(JS::Uint8Array::create(realm, string.bytes().size()));
+
+    for (auto [i, byte] : enumerate(string.bytes()))
+        typed_array->set_value_in_buffer(i, JS::Value { byte }, JS::ArrayBuffer::Order::SeqCst);
+
+    return typed_array;
 }
 
 TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::ExecutionContext&)

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -249,6 +249,7 @@ set(SOURCES
     Runtime/TypedArray.cpp
     Runtime/TypedArrayConstructor.cpp
     Runtime/TypedArrayPrototype.cpp
+    Runtime/Uint8Array.cpp
     Runtime/Utf16String.cpp
     Runtime/Value.cpp
     Runtime/VM.cpp

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -464,6 +464,7 @@ namespace JS {
     P(setFloat32)                            \
     P(setFloat64)                            \
     P(setFromBase64)                         \
+    P(setFromHex)                            \
     P(setFullYear)                           \
     P(setHours)                              \
     P(setInt8)                               \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -427,6 +427,7 @@ namespace JS {
     P(race)                                  \
     P(random)                                \
     P(raw)                                   \
+    P(read)                                  \
     P(reason)                                \
     P(reduce)                                \
     P(reduceRight)                           \
@@ -461,6 +462,7 @@ namespace JS {
     P(setDate)                               \
     P(setFloat32)                            \
     P(setFloat64)                            \
+    P(setFromBase64)                         \
     P(setFullYear)                           \
     P(setHours)                              \
     P(setInt8)                               \
@@ -604,6 +606,7 @@ namespace JS {
     P(withResolvers)                         \
     P(withTimeZone)                          \
     P(writable)                              \
+    P(written)                               \
     P(year)                                  \
     P(yearMonthFromFields)                   \
     P(yearOfWeek)                            \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -220,6 +220,7 @@ namespace JS {
     P(fromEpochMilliseconds)                 \
     P(fromEpochNanoseconds)                  \
     P(fromEpochSeconds)                      \
+    P(fromHex)                               \
     P(fround)                                \
     P(gc)                                    \
     P(get)                                   \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -68,6 +68,7 @@ namespace JS {
     P(adopt)                                 \
     P(all)                                   \
     P(allSettled)                            \
+    P(alphabet)                              \
     P(anchor)                                \
     P(any)                                   \
     P(apply)                                 \
@@ -398,6 +399,7 @@ namespace JS {
     P(of)                                    \
     P(offset)                                \
     P(offsetNanoseconds)                     \
+    P(omitPadding)                           \
     P(overflow)                              \
     P(ownKeys)                               \
     P(padEnd)                                \
@@ -526,6 +528,7 @@ namespace JS {
     P(timeZone)                              \
     P(timeZoneName)                          \
     P(toArray)                               \
+    P(toBase64)                              \
     P(toDateString)                          \
     P(toExponential)                         \
     P(toFixed)                               \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -533,6 +533,7 @@ namespace JS {
     P(toExponential)                         \
     P(toFixed)                               \
     P(toGMTString)                           \
+    P(toHex)                                 \
     P(toInstant)                             \
     P(toISOString)                           \
     P(toJSON)                                \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -212,6 +212,7 @@ namespace JS {
     P(freeze)                                \
     P(from)                                  \
     P(fromAsync)                             \
+    P(fromBase64)                            \
     P(fromCharCode)                          \
     P(fromCodePoint)                         \
     P(fromEntries)                           \
@@ -338,6 +339,7 @@ namespace JS {
     P(language)                              \
     P(languageDisplay)                       \
     P(largestUnit)                           \
+    P(lastChunkHandling)                     \
     P(lastIndex)                             \
     P(lastIndexOf)                           \
     P(length)                                \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -527,6 +527,9 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         define_direct_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                    \
                                                                                                                             \
         define_direct_property(vm.names.length, Value(3), Attribute::Configurable);                                         \
+                                                                                                                            \
+        if constexpr (IsSame<ConstructorName, Uint8ArrayConstructor>)                                                       \
+            Uint8ArrayConstructorHelpers::initialize(realm, *this);                                                         \
     }                                                                                                                       \
                                                                                                                             \
     /* 23.2.5.1 TypedArray ( ...args ), https://tc39.es/ecma262/#sec-typedarray */                                          \

--- a/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArray.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/Iterator.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibJS/Runtime/TypedArrayConstructor.h>
+#include <LibJS/Runtime/Uint8Array.h>
 #include <LibJS/Runtime/ValueInlines.h>
 
 namespace JS {
@@ -500,6 +501,9 @@ void TypedArrayBase::visit_edges(Visitor& visitor)
         auto& vm = this->vm();                                                                                              \
         Base::initialize(realm);                                                                                            \
         define_direct_property(vm.names.BYTES_PER_ELEMENT, Value((i32)sizeof(Type)), 0);                                    \
+                                                                                                                            \
+        if constexpr (IsSame<PrototypeName, Uint8ArrayPrototype>)                                                           \
+            Uint8ArrayPrototypeHelpers::initialize(realm, *this);                                                           \
     }                                                                                                                       \
                                                                                                                             \
     ConstructorName::ConstructorName(Realm& realm, Object& prototype)                                                       \

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.cpp
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Base64.h>
+#include <LibJS/Runtime/Temporal/AbstractOperations.h>
+#include <LibJS/Runtime/TypedArray.h>
+#include <LibJS/Runtime/Uint8Array.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibJS/Runtime/ValueInlines.h>
+
+namespace JS {
+
+void Uint8ArrayPrototypeHelpers::initialize(Realm& realm, Object& prototype)
+{
+    auto& vm = prototype.vm();
+
+    static constexpr u8 attr = Attribute::Writable | Attribute::Configurable;
+    prototype.define_native_function(realm, vm.names.toBase64, to_base64, 0, attr);
+}
+
+static ThrowCompletionOr<Alphabet> parse_alphabet(VM& vm, Object& options)
+{
+    // Let alphabet be ? Get(opts, "alphabet").
+    auto alphabet = TRY(options.get(vm.names.alphabet));
+
+    // If alphabet is undefined, set alphabet to "base64".
+    if (alphabet.is_undefined())
+        return Alphabet::Base64;
+
+    // If alphabet is neither "base64" nor "base64url", throw a TypeError exception.
+    if (alphabet.is_string()) {
+        if (alphabet.as_string().utf8_string_view() == "base64"sv)
+            return Alphabet::Base64;
+        if (alphabet.as_string().utf8_string_view() == "base64url"sv)
+            return Alphabet::Base64URL;
+    }
+
+    return vm.throw_completion<TypeError>(ErrorType::OptionIsNotValidValue, alphabet, "alphabet"sv);
+}
+
+// 1 Uint8Array.prototype.toBase64 ( [ options ] ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tobase64
+JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayPrototypeHelpers::to_base64)
+{
+    auto options_value = vm.argument(0);
+
+    // 1. Let O be the this value.
+    // 2. Perform ? ValidateUint8Array(O).
+    auto typed_array = TRY(validate_uint8_array(vm));
+
+    // 3. Let opts be ? GetOptionsObject(options).
+    auto* options = TRY(Temporal::get_options_object(vm, options_value));
+
+    // 4. Let alphabet be ? Get(opts, "alphabet").
+    // 5. If alphabet is undefined, set alphabet to "base64".
+    // 6. If alphabet is neither "base64" nor "base64url", throw a TypeError exception.
+    auto alphabet = TRY(parse_alphabet(vm, *options));
+
+    // 7. Let omitPadding be ToBoolean(? Get(opts, "omitPadding")).
+    auto omit_padding_value = TRY(options->get(vm.names.omitPadding)).to_boolean();
+    auto omit_padding = omit_padding_value ? AK::OmitPadding::Yes : AK::OmitPadding::No;
+
+    // 8. Let toEncode be ? GetUint8ArrayBytes(O).
+    auto to_encode = TRY(get_uint8_array_bytes(vm, typed_array));
+
+    String out_ascii;
+
+    // 9. If alphabet is "base64", then
+    if (alphabet == Alphabet::Base64) {
+        // a. Let outAscii be the sequence of code points which results from encoding toEncode according to the base64
+        //    encoding specified in section 4 of RFC 4648. Padding is included if and only if omitPadding is false.
+        out_ascii = MUST(encode_base64(to_encode, omit_padding));
+    }
+    // 10. Else,
+    else {
+        // a. Assert: alphabet is "base64url".
+        // b. Let outAscii be the sequence of code points which results from encoding toEncode according to the base64url
+        //    encoding specified in section 5 of RFC 4648. Padding is included if and only if omitPadding is false.
+        out_ascii = MUST(encode_base64url(to_encode, omit_padding));
+    }
+
+    // 11. Return CodePointsToString(outAscii).
+    return PrimitiveString::create(vm, move(out_ascii));
+}
+
+// 7 ValidateUint8Array ( ta ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-validateuint8array
+ThrowCompletionOr<NonnullGCPtr<TypedArrayBase>> validate_uint8_array(VM& vm)
+{
+    auto this_object = TRY(vm.this_value().to_object(vm));
+
+    // 1. Perform ? RequireInternalSlot(ta, [[TypedArrayName]]).
+    if (!this_object->is_typed_array())
+        return vm.throw_completion<TypeError>(ErrorType::NotAnObjectOfType, "Uint8Array");
+
+    auto& typed_array = static_cast<TypedArrayBase&>(*this_object.ptr());
+
+    // 2. If ta.[[TypedArrayName]] is not "Uint8Array", throw a TypeError exception.
+    if (typed_array.kind() != TypedArrayBase::Kind::Uint8Array)
+        return vm.throw_completion<TypeError>(ErrorType::NotAnObjectOfType, "Uint8Array");
+
+    // 3. Return UNUSED.
+    return typed_array;
+}
+
+// 8 GetUint8ArrayBytes ( ta ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-getuint8arraybytes
+ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM& vm, TypedArrayBase const& typed_array)
+{
+    // 1. Let buffer be ta.[[ViewedArrayBuffer]].
+    // 2. Let taRecord be MakeTypedArrayWithBufferWitnessRecord(ta, SEQ-CST).
+    auto typed_array_record = make_typed_array_with_buffer_witness_record(typed_array, ArrayBuffer::Order::SeqCst);
+
+    // 3. If IsTypedArrayOutOfBounds(taRecord) is true, throw a TypeError exception.
+    if (is_typed_array_out_of_bounds(typed_array_record))
+        return vm.throw_completion<TypeError>(ErrorType::BufferOutOfBounds, "TypedArray"sv);
+
+    // 4. Let len be TypedArrayLength(taRecord).
+    auto length = typed_array_length(typed_array_record);
+
+    // 5. Let byteOffset be ta.[[ByteOffset]].
+    auto byte_offset = typed_array.byte_offset();
+
+    // 6. Let bytes be a new empty List.
+    ByteBuffer bytes;
+
+    // 7. Let index be 0.
+    // 8. Repeat, while index < len,
+    for (u32 index = 0; index < length; ++index) {
+        // a. Let byteIndex be byteOffset + index.
+        auto byte_index = byte_offset + index;
+
+        // b. Let byte be ℝ(GetValueFromBuffer(buffer, byteIndex, UINT8, true, UNORDERED)).
+        auto byte = typed_array.get_value_from_buffer(byte_index, ArrayBuffer::Order::Unordered);
+
+        // c. Append byte to bytes.
+        bytes.append(MUST(byte.to_u8(vm)));
+
+        // d. Set index to index + 1.
+    }
+
+    // 9. Return bytes.
+    return bytes;
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.cpp
@@ -14,6 +14,14 @@
 
 namespace JS {
 
+void Uint8ArrayConstructorHelpers::initialize(Realm& realm, Object& constructor)
+{
+    auto& vm = constructor.vm();
+
+    static constexpr u8 attr = Attribute::Writable | Attribute::Configurable;
+    constructor.define_native_function(realm, vm.names.fromBase64, from_base64, 1, attr);
+}
+
 void Uint8ArrayPrototypeHelpers::initialize(Realm& realm, Object& prototype)
 {
     auto& vm = prototype.vm();
@@ -41,6 +49,28 @@ static ThrowCompletionOr<Alphabet> parse_alphabet(VM& vm, Object& options)
     }
 
     return vm.throw_completion<TypeError>(ErrorType::OptionIsNotValidValue, alphabet, "alphabet"sv);
+}
+
+static ThrowCompletionOr<LastChunkHandling> parse_last_chunk_handling(VM& vm, Object& options)
+{
+    // Let lastChunkHandling be ? Get(opts, "lastChunkHandling").
+    auto last_chunk_handling = TRY(options.get(vm.names.lastChunkHandling));
+
+    // If lastChunkHandling is undefined, set lastChunkHandling to "loose".
+    if (last_chunk_handling.is_undefined())
+        return LastChunkHandling::Loose;
+
+    // If lastChunkHandling is not one of "loose", "strict", or "stop-before-partial", throw a TypeError exception.
+    if (last_chunk_handling.is_string()) {
+        if (last_chunk_handling.as_string().utf8_string_view() == "loose"sv)
+            return LastChunkHandling::Loose;
+        if (last_chunk_handling.as_string().utf8_string_view() == "strict"sv)
+            return LastChunkHandling::Strict;
+        if (last_chunk_handling.as_string().utf8_string_view() == "stop-before-partial"sv)
+            return LastChunkHandling::StopBeforePartial;
+    }
+
+    return vm.throw_completion<TypeError>(ErrorType::OptionIsNotValidValue, last_chunk_handling, "lastChunkHandling"sv);
 }
 
 // 1 Uint8Array.prototype.toBase64 ( [ options ] ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.prototype.tobase64
@@ -112,6 +142,57 @@ JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayPrototypeHelpers::to_hex)
     return PrimitiveString::create(vm, MUST(out.to_string()));
 }
 
+// 3 Uint8Array.fromBase64 ( string [ , options ] ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-uint8array.frombase64
+JS_DEFINE_NATIVE_FUNCTION(Uint8ArrayConstructorHelpers::from_base64)
+{
+    auto& realm = *vm.current_realm();
+
+    auto string_value = vm.argument(0);
+    auto options_value = vm.argument(1);
+
+    // 1. If string is not a String, throw a TypeError exception.
+    if (!string_value.is_string())
+        return vm.throw_completion<TypeError>(ErrorType::NotAString, string_value);
+
+    // 2. Let opts be ? GetOptionsObject(options).
+    auto* options = TRY(Temporal::get_options_object(vm, options_value));
+
+    // 3. Let alphabet be ? Get(opts, "alphabet").
+    // 4. If alphabet is undefined, set alphabet to "base64".
+    // 5. If alphabet is neither "base64" nor "base64url", throw a TypeError exception.
+    auto alphabet = TRY(parse_alphabet(vm, *options));
+
+    // 6. Let lastChunkHandling be ? Get(opts, "lastChunkHandling").
+    // 7. If lastChunkHandling is undefined, set lastChunkHandling to "loose".
+    // 8. If lastChunkHandling is not one of "loose", "strict", or "stop-before-partial", throw a TypeError exception.
+    auto last_chunk_handling = TRY(parse_last_chunk_handling(vm, *options));
+
+    // 9. Let result be FromBase64(string, alphabet, lastChunkHandling).
+    auto result = JS::from_base64(vm, string_value.as_string().utf8_string_view(), alphabet, last_chunk_handling);
+
+    // 10. If result.[[Error]] is not none, then
+    if (result.error.has_value()) {
+        // a. Throw result.[[Error]].
+        return result.error.release_value();
+    }
+
+    // 11. Let resultLength be the length of result.[[Bytes]].
+    auto result_length = result.bytes.size();
+
+    // 12. Let ta be ? AllocateTypedArray("Uint8Array", %Uint8Array%, "%Uint8Array.prototype%", resultLength).
+    auto typed_array = TRY(Uint8Array::create(realm, result_length));
+
+    // 13. Set the value at each index of ta.[[ViewedArrayBuffer]].[[ArrayBufferData]] to the value at the corresponding
+    //     index of result.[[Bytes]].
+    auto& array_buffer_data = typed_array->viewed_array_buffer()->buffer();
+
+    for (size_t index = 0; index < result_length; ++index)
+        array_buffer_data[index] = result.bytes[index];
+
+    // 14. Return ta.
+    return typed_array;
+}
+
 // 7 ValidateUint8Array ( ta ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-validateuint8array
 ThrowCompletionOr<NonnullGCPtr<TypedArrayBase>> validate_uint8_array(VM& vm)
 {
@@ -168,6 +249,339 @@ ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM& vm, TypedArrayBase const
 
     // 9. Return bytes.
     return bytes;
+}
+
+// 10.1 SkipAsciiWhitespace ( string, index ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-skipasciiwhitespace
+static size_t skip_ascii_whitespace(StringView string, size_t index)
+{
+    // 1. Let length be the length of string.
+    auto length = string.length();
+
+    // 2. Repeat, while index < length,
+    while (index < length) {
+        // a. Let char be the code unit at index index of string.
+        auto ch = string[index];
+
+        // b. If char is neither 0x0009 (TAB), 0x000A (LF), 0x000C (FF), 0x000D (CR), nor 0x0020 (SPACE), then
+        if (ch != '\t' && ch != '\n' && ch != '\f' && ch != '\r' && ch != ' ') {
+            // i. Return index.
+            return index;
+        }
+
+        // c. Set index to index + 1.
+        ++index;
+    }
+
+    // 3. Return index.
+    return index;
+}
+
+// 10.2 DecodeBase64Chunk ( chunk [ , throwOnExtraBits ] ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
+static ThrowCompletionOr<ByteBuffer> decode_base64_chunk(VM& vm, StringBuilder& chunk, Optional<bool> throw_on_extra_bits = {})
+{
+    // 1. Let chunkLength be the length of chunk.
+    auto chunk_length = chunk.length();
+
+    // 2. If chunkLength is 2, then
+    if (chunk_length == 2) {
+        // a. Set chunk to the string-concatenation of chunk and "AA".
+        chunk.append("AA"sv);
+    }
+    // 3. Else if chunkLength is 3, then
+    else if (chunk_length == 3) {
+        // a. Set chunk to the string-concatenation of chunk and "A".
+        chunk.append("A"sv);
+    }
+    // 4. Else,
+    else {
+        // a. Assert: chunkLength is 4.
+        VERIFY(chunk_length == 4);
+    }
+
+    // 5. Let byteSequence be the unique sequence of 3 bytes resulting from decoding chunk as base64 (such that applying
+    //    the base64 encoding specified in section 4 of RFC 4648 to byteSequence would produce chunk).
+    // 6. Let bytes be a List whose elements are the elements of byteSequence, in order.
+    auto bytes = MUST(decode_base64(chunk.string_view()));
+
+    // 7. If chunkLength is 2, then
+    if (chunk_length == 2) {
+        // a. Assert: throwOnExtraBits is present.
+        VERIFY(throw_on_extra_bits.has_value());
+
+        // b. If throwOnExtraBits is true and bytes[1] ≠ 0, then
+        if (*throw_on_extra_bits && bytes[1] != 0) {
+            // i. Throw a SyntaxError exception.
+            return vm.throw_completion<SyntaxError>("Extra bits found at end of chunk"sv);
+        }
+
+        // c. Return « bytes[0] ».
+        return MUST(bytes.slice(0, 1));
+    }
+
+    // 8. Else if chunkLength is 3, then
+    if (chunk_length == 3) {
+        // a. Assert: throwOnExtraBits is present.
+        VERIFY(throw_on_extra_bits.has_value());
+
+        // b. If throwOnExtraBits is true and bytes[2] ≠ 0, then
+        if (*throw_on_extra_bits && bytes[2] != 0) {
+            // i. Throw a SyntaxError exception.
+            return vm.throw_completion<SyntaxError>("Extra bits found at end of chunk"sv);
+        }
+
+        // c. Return « bytes[0], bytes[1] ».
+        return MUST(bytes.slice(0, 2));
+    }
+
+    // 9. Else,
+    //     a. Return bytes.
+    return bytes;
+}
+
+// 10.3 FromBase64 ( string, alphabet, lastChunkHandling [ , maxLength ] ), https://tc39.es/proposal-arraybuffer-base64/spec/#sec-frombase64
+DecodeResult from_base64(VM& vm, StringView string, Alphabet alphabet, LastChunkHandling last_chunk_handling, Optional<size_t> max_length)
+{
+    // FIXME: We can only use simdutf when the last-chunk-handling parameter is "loose". Upstream is planning to implement
+    //        the remaining options. When that is complete, we should be able to remove the slow implementation below. See:
+    //        https://github.com/simdutf/simdutf/issues/440
+    if (last_chunk_handling == LastChunkHandling::Loose) {
+        auto output = MUST(ByteBuffer::create_uninitialized(max_length.value_or_lazy_evaluated([&]() {
+            return AK::size_required_to_decode_base64(string);
+        })));
+
+        auto result = alphabet == Alphabet::Base64
+            ? AK::decode_base64_into(string, output)
+            : AK::decode_base64url_into(string, output);
+
+        if (result.is_error()) {
+            auto error = vm.throw_completion<SyntaxError>(result.error().error.string_literal());
+            return { .read = result.error().valid_input_bytes, .bytes = move(output), .error = move(error) };
+        }
+
+        return { .read = result.value(), .bytes = move(output), .error = {} };
+    }
+
+    // 1. If maxLength is not present, then
+    if (!max_length.has_value()) {
+        // a. Let maxLength be 2**53 - 1.
+        max_length = MAX_ARRAY_LIKE_INDEX;
+
+        // b. NOTE: Because the input is a string, the length of strings is limited to 2**53 - 1 characters, and the
+        //    output requires no more bytes than the input has characters, this limit can never be reached. However, it
+        //    is editorially convenient to use a finite value here.
+    }
+
+    // 2. NOTE: The order of validation and decoding in the algorithm below is not observable. Implementations are
+    //    encouraged to perform them in whatever order is most efficient, possibly interleaving validation with decoding,
+    //    as long as the behaviour is observably equivalent.
+
+    // 3. If maxLength is 0, then
+    if (max_length == 0uz) {
+        // a. Return the Record { [[Read]]: 0, [[Bytes]]: « », [[Error]]: none }.
+        return { .read = 0, .bytes = {}, .error = {} };
+    }
+
+    // 4. Let read be 0.
+    size_t read = 0;
+
+    // 5. Let bytes be « ».
+    ByteBuffer bytes;
+
+    // 6. Let chunk be the empty String.
+    StringBuilder chunk;
+
+    // 7. Let chunkLength be 0.
+    size_t chunk_length = 0;
+
+    // 8. Let index be 0.
+    size_t index = 0;
+
+    // 9. Let length be the length of string.
+    auto length = string.length();
+
+    // 10. Repeat,
+    while (true) {
+        // a. Set index to SkipAsciiWhitespace(string, index).
+        index = skip_ascii_whitespace(string, index);
+
+        // b. If index = length, then
+        if (index == length) {
+            // i. If chunkLength > 0, then
+            if (chunk_length > 0) {
+                // 1. If lastChunkHandling is "stop-before-partial", then
+                if (last_chunk_handling == LastChunkHandling::StopBeforePartial) {
+                    // a. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: none }.
+                    return { .read = read, .bytes = move(bytes), .error = {} };
+                }
+                // 2. Else if lastChunkHandling is "loose", then
+                else if (last_chunk_handling == LastChunkHandling::Loose) {
+                    VERIFY_NOT_REACHED();
+                }
+                // 3. Else,
+                else {
+                    // a. Assert: lastChunkHandling is "strict".
+                    VERIFY(last_chunk_handling == LastChunkHandling::Strict);
+
+                    // b. Let error be a new SyntaxError exception.
+                    auto error = vm.throw_completion<SyntaxError>("Invalid trailing data"sv);
+
+                    // c. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+                    return { .read = read, .bytes = move(bytes), .error = move(error) };
+                }
+            }
+
+            // ii. Return the Record { [[Read]]: length, [[Bytes]]: bytes, [[Error]]: none }.
+            return { .read = length, .bytes = move(bytes), .error = {} };
+        }
+
+        // c. Let char be the substring of string from index to index + 1.
+        auto ch = string[index];
+
+        // d. Set index to index + 1.
+        ++index;
+
+        // e. If char is "=", then
+        if (ch == '=') {
+            // i. If chunkLength < 2, then
+            if (chunk_length < 2) {
+                // 1. Let error be a new SyntaxError exception.
+                auto error = vm.throw_completion<SyntaxError>("Unexpected padding character"sv);
+
+                // 2. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+                return { .read = read, .bytes = move(bytes), .error = move(error) };
+            }
+
+            // ii. Set index to SkipAsciiWhitespace(string, index).
+            index = skip_ascii_whitespace(string, index);
+
+            // iii. If chunkLength = 2, then
+            if (chunk_length == 2) {
+                // 1. If index = length, then
+                if (index == length) {
+                    // a. If lastChunkHandling is "stop-before-partial", then
+                    if (last_chunk_handling == LastChunkHandling::StopBeforePartial) {
+                        // i. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: none }.
+                        return { .read = read, .bytes = move(bytes), .error = {} };
+                    }
+
+                    // b. Let error be a new SyntaxError exception.
+                    auto error = vm.throw_completion<SyntaxError>("Incomplete number of padding characters"sv);
+
+                    // c. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+                    return { .read = read, .bytes = move(bytes), .error = move(error) };
+                }
+
+                // 2. Set char to the substring of string from index to index + 1.
+                ch = string[index];
+
+                // 3. If char is "=", then
+                if (ch == '=') {
+                    // a. Set index to SkipAsciiWhitespace(string, index + 1).
+                    index = skip_ascii_whitespace(string, index + 1);
+                }
+            }
+
+            // iv. If index < length, then
+            if (index < length) {
+                // 1. Let error be a new SyntaxError exception.
+                auto error = vm.throw_completion<SyntaxError>("Unexpected padding character"sv);
+
+                // 2. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+                return { .read = read, .bytes = move(bytes), .error = move(error) };
+            }
+
+            // v. If lastChunkHandling is "strict", let throwOnExtraBits be true.
+            // vi. Else, let throwOnExtraBits be false.
+            auto throw_on_extra_bits = last_chunk_handling == LastChunkHandling::Strict;
+
+            // vii. Let decodeResult be Completion(DecodeBase64Chunk(chunk, throwOnExtraBits)).
+            auto decode_result = decode_base64_chunk(vm, chunk, throw_on_extra_bits);
+
+            // viii. If decodeResult is an abrupt completion, then
+            if (decode_result.is_error()) {
+                // 1. Let error be decodeResult.[[Value]].
+                auto error = decode_result.release_error();
+
+                // 2. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+                return { .read = read, .bytes = move(bytes), .error = move(error) };
+            }
+
+            // ix. Set bytes to the list-concatenation of bytes and ! decodeResult.
+            bytes.append(decode_result.release_value());
+
+            // x. Return the Record { [[Read]]: length, [[Bytes]]: bytes, [[Error]]: none }.
+            return { .read = length, .bytes = move(bytes), .error = {} };
+        }
+
+        // f. If alphabet is "base64url", then
+        if (alphabet == Alphabet::Base64URL) {
+            // i. If char is either "+" or "/", then
+            if (ch == '+' || ch == '/') {
+                // 1. Let error be a new SyntaxError exception.
+                auto error = vm.throw_completion<SyntaxError>(MUST(String::formatted("Invalid character '{}'"sv, ch)));
+
+                // 2. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+                return { .read = read, .bytes = move(bytes), .error = move(error) };
+            }
+            // ii. Else if char is "-", then
+            else if (ch == '-') {
+                // 1. Set char to "+".
+                ch = '+';
+            }
+            // iii. Else if char is "_", then
+            else if (ch == '-') {
+                // 1. Set char to "/".
+                ch = '/';
+            }
+        }
+
+        // g. If the sole code unit of char is not an element of the standard base64 alphabet, then
+        static constexpr auto standard_base64_alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"sv;
+
+        if (!standard_base64_alphabet.contains(ch)) {
+            // i. Let error be a new SyntaxError exception.
+            auto error = vm.throw_completion<SyntaxError>(MUST(String::formatted("Invalid character '{}'"sv, ch)));
+
+            // ii. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: error }.
+            return { .read = read, .bytes = move(bytes), .error = move(error) };
+        }
+
+        // h. Let remaining be maxLength - the length of bytes.
+        auto remaining = *max_length - bytes.size();
+
+        // i. If remaining = 1 and chunkLength = 2, or if remaining = 2 and chunkLength = 3, then
+        if ((remaining == 1 && chunk_length == 2) || (remaining == 2 && chunk_length == 3)) {
+            // i. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: none }.
+            return { .read = read, .bytes = move(bytes), .error = {} };
+        }
+
+        // j. Set chunk to the string-concatenation of chunk and char.
+        chunk.append(ch);
+
+        // k. Set chunkLength to the length of chunk.
+        chunk_length = chunk.length();
+
+        // l. If chunkLength = 4, then
+        if (chunk_length == 4) {
+            // i. Set bytes to the list-concatenation of bytes and ! DecodeBase64Chunk(chunk).
+            bytes.append(MUST(decode_base64_chunk(vm, chunk)));
+
+            // ii. Set chunk to the empty String.
+            chunk.clear();
+
+            // iii. Set chunkLength to 0.
+            chunk_length = 0;
+
+            // iv. Set read to index.
+            read = index;
+
+            // v. If the length of bytes = maxLength, then
+            if (bytes.size() == max_length) {
+                // 1. Return the Record { [[Read]]: read, [[Bytes]]: bytes, [[Error]]: none }.
+                return { .read = read, .bytes = move(bytes), .error = {} };
+            }
+        }
+    }
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
+
+namespace JS {
+
+class Uint8ArrayPrototypeHelpers {
+public:
+    static void initialize(Realm&, Object& prototype);
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(to_base64);
+};
+
+enum class Alphabet {
+    Base64,
+    Base64URL,
+};
+
+ThrowCompletionOr<NonnullGCPtr<TypedArrayBase>> validate_uint8_array(VM&);
+ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM&, TypedArrayBase const&);
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.h
@@ -31,6 +31,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(to_base64);
     JS_DECLARE_NATIVE_FUNCTION(to_hex);
+    JS_DECLARE_NATIVE_FUNCTION(set_from_base64);
 };
 
 enum class Alphabet {
@@ -52,6 +53,7 @@ struct DecodeResult {
 
 ThrowCompletionOr<NonnullGCPtr<TypedArrayBase>> validate_uint8_array(VM&);
 ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM&, TypedArrayBase const&);
+void set_uint8_array_bytes(TypedArrayBase&, ReadonlyBytes);
 DecodeResult from_base64(VM&, StringView string, Alphabet alphabet, LastChunkHandling last_chunk_handling, Optional<size_t> max_length = {});
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.h
@@ -6,10 +6,23 @@
 
 #pragma once
 
+#include <AK/ByteBuffer.h>
+#include <AK/Optional.h>
+#include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/Value.h>
 
 namespace JS {
+
+class Uint8ArrayConstructorHelpers {
+public:
+    static void initialize(Realm&, Object& constructor);
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(from_base64);
+};
 
 class Uint8ArrayPrototypeHelpers {
 public:
@@ -25,7 +38,20 @@ enum class Alphabet {
     Base64URL,
 };
 
+enum class LastChunkHandling {
+    Loose,
+    Strict,
+    StopBeforePartial,
+};
+
+struct DecodeResult {
+    size_t read { 0 };          // [[Read]]
+    ByteBuffer bytes;           // [[Bytes]]
+    Optional<Completion> error; // [[Error]]
+};
+
 ThrowCompletionOr<NonnullGCPtr<TypedArrayBase>> validate_uint8_array(VM&);
 ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM&, TypedArrayBase const&);
+DecodeResult from_base64(VM&, StringView string, Alphabet alphabet, LastChunkHandling last_chunk_handling, Optional<size_t> max_length = {});
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.h
@@ -17,6 +17,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(to_base64);
+    JS_DECLARE_NATIVE_FUNCTION(to_hex);
 };
 
 enum class Alphabet {

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.h
@@ -33,6 +33,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(to_base64);
     JS_DECLARE_NATIVE_FUNCTION(to_hex);
     JS_DECLARE_NATIVE_FUNCTION(set_from_base64);
+    JS_DECLARE_NATIVE_FUNCTION(set_from_hex);
 };
 
 enum class Alphabet {

--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.h
@@ -22,6 +22,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(from_base64);
+    JS_DECLARE_NATIVE_FUNCTION(from_hex);
 };
 
 class Uint8ArrayPrototypeHelpers {
@@ -55,5 +56,6 @@ ThrowCompletionOr<NonnullGCPtr<TypedArrayBase>> validate_uint8_array(VM&);
 ThrowCompletionOr<ByteBuffer> get_uint8_array_bytes(VM&, TypedArrayBase const&);
 void set_uint8_array_bytes(TypedArrayBase&, ReadonlyBytes);
 DecodeResult from_base64(VM&, StringView string, Alphabet alphabet, LastChunkHandling last_chunk_handling, Optional<size_t> max_length = {});
+DecodeResult from_hex(VM&, StringView string, Optional<size_t> max_length = {});
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
@@ -1,0 +1,120 @@
+describe("errors", () => {
+    test("invalid string", () => {
+        expect(() => {
+            Uint8Array.fromBase64(3.14);
+        }).toThrowWithMessage(TypeError, "3.14 is not a string");
+    });
+
+    test("invalid options object", () => {
+        expect(() => {
+            Uint8Array.fromBase64("", 3.14);
+        }).toThrowWithMessage(TypeError, "Options is not an object");
+    });
+
+    test("invalid alphabet option", () => {
+        expect(() => {
+            Uint8Array.fromBase64("", { alphabet: 3.14 });
+        }).toThrowWithMessage(TypeError, "3.14 is not a valid value for option alphabet");
+
+        expect(() => {
+            Uint8Array.fromBase64("", { alphabet: "foo" });
+        }).toThrowWithMessage(TypeError, "foo is not a valid value for option alphabet");
+    });
+
+    test("invalid lastChunkHandling option", () => {
+        expect(() => {
+            Uint8Array.fromBase64("", { lastChunkHandling: 3.14 });
+        }).toThrowWithMessage(TypeError, "3.14 is not a valid value for option lastChunkHandling");
+
+        expect(() => {
+            Uint8Array.fromBase64("", { lastChunkHandling: "foo" });
+        }).toThrowWithMessage(TypeError, "foo is not a valid value for option lastChunkHandling");
+    });
+
+    test("strict mode with trailing data", () => {
+        expect(() => {
+            Uint8Array.fromBase64("Zm9va", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+    });
+
+    test("invalid padding", () => {
+        expect(() => {
+            Uint8Array.fromBase64("Zm9v=", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+
+        expect(() => {
+            Uint8Array.fromBase64("Zm9vaa=", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Incomplete number of padding characters");
+
+        expect(() => {
+            Uint8Array.fromBase64("Zm9vaa=a", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+    });
+
+    test("invalid alphabet", () => {
+        expect(() => {
+            Uint8Array.fromBase64("-", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Invalid character '-'");
+
+        expect(() => {
+            Uint8Array.fromBase64("+", { alphabet: "base64url", lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Invalid character '+'");
+    });
+
+    test("overlong chunk", () => {
+        expect(() => {
+            Uint8Array.fromBase64("Zh==", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Extra bits found at end of chunk");
+
+        expect(() => {
+            Uint8Array.fromBase64("Zm9=", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Extra bits found at end of chunk");
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Uint8Array.fromBase64).toHaveLength(1);
+    });
+
+    const decodeEqual = (input, expected, options) => {
+        const decoded = Uint8Array.fromBase64(input, options);
+        expect(decoded).toEqual(toUTF8Bytes(expected));
+    };
+
+    test("basic functionality", () => {
+        decodeEqual("", "");
+        decodeEqual("Zg==", "f");
+        decodeEqual("Zm8=", "fo");
+        decodeEqual("Zm9v", "foo");
+        decodeEqual("Zm9vYg==", "foob");
+        decodeEqual("Zm9vYmE=", "fooba");
+        decodeEqual("Zm9vYmFy", "foobar");
+
+        decodeEqual("8J+kkw==", "🤓");
+        decodeEqual("8J+kk2Zvb/CflpY=", "🤓foo🖖");
+    });
+
+    test("base64url alphabet", () => {
+        const options = { alphabet: "base64url" };
+
+        decodeEqual("", "", options);
+        decodeEqual("Zg==", "f", options);
+        decodeEqual("Zm8=", "fo", options);
+        decodeEqual("Zm9v", "foo", options);
+        decodeEqual("Zm9vYg==", "foob", options);
+        decodeEqual("Zm9vYmE=", "fooba", options);
+        decodeEqual("Zm9vYmFy", "foobar", options);
+
+        decodeEqual("8J-kkw==", "🤓", options);
+        decodeEqual("8J-kk2Zvb_CflpY=", "🤓foo🖖", options);
+    });
+
+    test("stop-before-partial lastChunkHandling", () => {
+        const options = { lastChunkHandling: "stop-before-partial" };
+
+        decodeEqual("Zm9v", "foo", options);
+        decodeEqual("Zm9va", "foo", options);
+        decodeEqual("Zm9vaa", "foo", options);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromHex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromHex.js
@@ -1,0 +1,38 @@
+describe("errors", () => {
+    test("invalid string", () => {
+        expect(() => {
+            Uint8Array.fromHex(3.14);
+        }).toThrowWithMessage(TypeError, "3.14 is not a string");
+    });
+
+    test("odd number of characters", () => {
+        expect(() => {
+            Uint8Array.fromHex("a");
+        }).toThrowWithMessage(SyntaxError, "Hex string must have an even length");
+    });
+
+    test("invalid alphabet", () => {
+        expect(() => {
+            Uint8Array.fromHex("qq");
+        }).toThrowWithMessage(SyntaxError, "Hex string must only contain hex characters");
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Uint8Array.fromHex).toHaveLength(1);
+    });
+
+    const decodeEqual = (input, expected, options) => {
+        const decoded = Uint8Array.fromHex(input, options);
+        expect(decoded).toEqual(toUTF8Bytes(expected));
+    };
+
+    test("basic functionality", () => {
+        decodeEqual("", "");
+        decodeEqual("61", "a");
+        decodeEqual("616263646566303132333435", "abcdef012345");
+        decodeEqual("f09fa493", "🤓");
+        decodeEqual("f09fa493666f6ff09f9696", "🤓foo🖖");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromBase64.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromBase64.js
@@ -1,0 +1,169 @@
+describe("errors", () => {
+    test("called on non-Uint8Array object", () => {
+        expect(() => {
+            Uint8Array.prototype.setFromBase64.call("");
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+
+        expect(() => {
+            Uint8Array.prototype.setFromBase64.call(new Uint16Array());
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+    });
+
+    test("detached ArrayBuffer", () => {
+        let arrayBuffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        detachArrayBuffer(arrayBuffer);
+
+        expect(() => {
+            typedArray.setFromBase64("");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+
+    test("ArrayBuffer out of bounds", () => {
+        let arrayBuffer = new ArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: Uint8Array.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        arrayBuffer.resize(Uint8Array.BYTES_PER_ELEMENT);
+
+        expect(() => {
+            typedArray.setFromBase64("");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+
+    test("invalid string", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64(3.14);
+        }).toThrowWithMessage(TypeError, "3.14 is not a string");
+    });
+
+    test("invalid options object", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("", 3.14);
+        }).toThrowWithMessage(TypeError, "Options is not an object");
+    });
+
+    test("invalid alphabet option", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("", { alphabet: 3.14 });
+        }).toThrowWithMessage(TypeError, "3.14 is not a valid value for option alphabet");
+
+        expect(() => {
+            new Uint8Array(10).setFromBase64("", { alphabet: "foo" });
+        }).toThrowWithMessage(TypeError, "foo is not a valid value for option alphabet");
+    });
+
+    test("invalid lastChunkHandling option", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("", { lastChunkHandling: 3.14 });
+        }).toThrowWithMessage(TypeError, "3.14 is not a valid value for option lastChunkHandling");
+
+        expect(() => {
+            new Uint8Array(10).setFromBase64("", { lastChunkHandling: "foo" });
+        }).toThrowWithMessage(TypeError, "foo is not a valid value for option lastChunkHandling");
+    });
+
+    test("strict mode with trailing data", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("Zm9va", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Invalid trailing data");
+    });
+
+    test("invalid padding", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("Zm9v=", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+
+        expect(() => {
+            new Uint8Array(10).setFromBase64("Zm9vaa=", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Incomplete number of padding characters");
+
+        expect(() => {
+            new Uint8Array(10).setFromBase64("Zm9vaa=a", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Unexpected padding character");
+    });
+
+    test("invalid alphabet", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("-", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Invalid character '-'");
+
+        expect(() => {
+            new Uint8Array(10).setFromBase64("+", {
+                alphabet: "base64url",
+                lastChunkHandling: "strict",
+            });
+        }).toThrowWithMessage(SyntaxError, "Invalid character '+'");
+    });
+
+    test("overlong chunk", () => {
+        expect(() => {
+            new Uint8Array(10).setFromBase64("Zh==", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Extra bits found at end of chunk");
+
+        expect(() => {
+            new Uint8Array(10).setFromBase64("Zm9=", { lastChunkHandling: "strict" });
+        }).toThrowWithMessage(SyntaxError, "Extra bits found at end of chunk");
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Uint8Array.prototype.setFromBase64).toHaveLength(1);
+    });
+
+    const decodeEqual = (input, expected, options, expectedInputBytesRead) => {
+        expected = toUTF8Bytes(expected);
+
+        let array = new Uint8Array(expected.length);
+        let result = array.setFromBase64(input, options);
+
+        expect(result.read).toBe(expectedInputBytesRead || input.length);
+        expect(result.written).toBe(expected.length);
+
+        expect(array).toEqual(expected);
+    };
+
+    test("basic functionality", () => {
+        decodeEqual("", "");
+        decodeEqual("Zg==", "f");
+        decodeEqual("Zm8=", "fo");
+        decodeEqual("Zm9v", "foo");
+        decodeEqual("Zm9vYg==", "foob");
+        decodeEqual("Zm9vYmE=", "fooba");
+        decodeEqual("Zm9vYmFy", "foobar");
+
+        decodeEqual("8J+kkw==", "🤓");
+        decodeEqual("8J+kk2Zvb/CflpY=", "🤓foo🖖");
+    });
+
+    test("base64url alphabet", () => {
+        const options = { alphabet: "base64url" };
+
+        decodeEqual("", "", options);
+        decodeEqual("Zg==", "f", options);
+        decodeEqual("Zm8=", "fo", options);
+        decodeEqual("Zm9v", "foo", options);
+        decodeEqual("Zm9vYg==", "foob", options);
+        decodeEqual("Zm9vYmE=", "fooba", options);
+        decodeEqual("Zm9vYmFy", "foobar", options);
+
+        decodeEqual("8J-kkw==", "🤓", options);
+        decodeEqual("8J-kk2Zvb_CflpY=", "🤓foo🖖", options);
+    });
+
+    test("stop-before-partial lastChunkHandling", () => {
+        const options = { lastChunkHandling: "stop-before-partial" };
+
+        decodeEqual("Zm9v", "foo", options, 4);
+        decodeEqual("Zm9va", "foo", options, 4);
+        decodeEqual("Zm9vaa", "foo", options, 4);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromHex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.setFromHex.js
@@ -1,0 +1,84 @@
+describe("errors", () => {
+    test("called on non-Uint8Array object", () => {
+        expect(() => {
+            Uint8Array.prototype.setFromHex.call("");
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+
+        expect(() => {
+            Uint8Array.prototype.setFromHex.call(new Uint16Array());
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+    });
+
+    test("detached ArrayBuffer", () => {
+        let arrayBuffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        detachArrayBuffer(arrayBuffer);
+
+        expect(() => {
+            typedArray.setFromHex("");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+
+    test("ArrayBuffer out of bounds", () => {
+        let arrayBuffer = new ArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: Uint8Array.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        arrayBuffer.resize(Uint8Array.BYTES_PER_ELEMENT);
+
+        expect(() => {
+            typedArray.setFromHex("");
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+
+    test("invalid string", () => {
+        expect(() => {
+            new Uint8Array(10).setFromHex(3.14);
+        }).toThrowWithMessage(TypeError, "3.14 is not a string");
+    });
+
+    test("odd number of characters", () => {
+        expect(() => {
+            new Uint8Array(10).setFromHex("a");
+        }).toThrowWithMessage(SyntaxError, "Hex string must have an even length");
+    });
+
+    test("invalid alphabet", () => {
+        expect(() => {
+            new Uint8Array(10).setFromHex("qq");
+        }).toThrowWithMessage(SyntaxError, "Hex string must only contain hex characters");
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Uint8Array.prototype.setFromHex).toHaveLength(1);
+    });
+
+    const decodeEqual = (input, expected) => {
+        expected = toUTF8Bytes(expected);
+
+        let array = new Uint8Array(expected.length);
+        let result = array.setFromHex(input);
+
+        expect(result.read).toBe(input.length);
+        expect(result.written).toBe(expected.length);
+
+        expect(array).toEqual(expected);
+    };
+
+    test("basic functionality", () => {
+        decodeEqual("", "");
+        decodeEqual("61", "a");
+        decodeEqual("616263646566303132333435", "abcdef012345");
+        decodeEqual("f09fa493", "🤓");
+        decodeEqual("f09fa493666f6ff09f9696", "🤓foo🖖");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.toBase64.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.toBase64.js
@@ -1,0 +1,110 @@
+describe("errors", () => {
+    test("called on non-Uint8Array object", () => {
+        expect(() => {
+            Uint8Array.prototype.toBase64.call(1);
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+
+        expect(() => {
+            Uint8Array.prototype.toBase64.call(new Uint16Array());
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+    });
+
+    test("invalid options object", () => {
+        expect(() => {
+            new Uint8Array().toBase64(3.14);
+        }).toThrowWithMessage(TypeError, "Options is not an object");
+    });
+
+    test("invalid alphabet option", () => {
+        expect(() => {
+            new Uint8Array().toBase64({ alphabet: 3.14 });
+        }).toThrowWithMessage(TypeError, "3.14 is not a valid value for option alphabet");
+
+        expect(() => {
+            new Uint8Array().toBase64({ alphabet: "foo" });
+        }).toThrowWithMessage(TypeError, "foo is not a valid value for option alphabet");
+    });
+
+    test("detached ArrayBuffer", () => {
+        let arrayBuffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        detachArrayBuffer(arrayBuffer);
+
+        expect(() => {
+            typedArray.toBase64();
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+
+    test("ArrayBuffer out of bounds", () => {
+        let arrayBuffer = new ArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: Uint8Array.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        arrayBuffer.resize(Uint8Array.BYTES_PER_ELEMENT);
+
+        expect(() => {
+            typedArray.toBase64();
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Uint8Array.prototype.toBase64).toHaveLength(0);
+    });
+
+    const encodeEqual = (input, expected, options) => {
+        const encoded = toUTF8Bytes(input).toBase64(options);
+        expect(encoded).toBe(expected);
+    };
+
+    test("basic functionality", () => {
+        encodeEqual("", "");
+        encodeEqual("f", "Zg==");
+        encodeEqual("fo", "Zm8=");
+        encodeEqual("foo", "Zm9v");
+        encodeEqual("foob", "Zm9vYg==");
+        encodeEqual("fooba", "Zm9vYmE=");
+        encodeEqual("foobar", "Zm9vYmFy");
+
+        encodeEqual("🤓", "8J+kkw==");
+        encodeEqual("🤓foo🖖", "8J+kk2Zvb/CflpY=");
+    });
+
+    test("omit padding", () => {
+        const options = { omitPadding: true };
+
+        encodeEqual("", "", options);
+        encodeEqual("f", "Zg", options);
+        encodeEqual("fo", "Zm8", options);
+        encodeEqual("foo", "Zm9v", options);
+        encodeEqual("foob", "Zm9vYg", options);
+        encodeEqual("fooba", "Zm9vYmE", options);
+        encodeEqual("foobar", "Zm9vYmFy", options);
+
+        encodeEqual("🤓", "8J+kkw", options);
+        encodeEqual("🤓foo🖖", "8J+kk2Zvb/CflpY", options);
+    });
+
+    test("base64url alphabet", () => {
+        const options = { alphabet: "base64url" };
+
+        encodeEqual("", "", options);
+        encodeEqual("f", "Zg==", options);
+        encodeEqual("fo", "Zm8=", options);
+        encodeEqual("foo", "Zm9v", options);
+        encodeEqual("foob", "Zm9vYg==", options);
+        encodeEqual("fooba", "Zm9vYmE=", options);
+        encodeEqual("foobar", "Zm9vYmFy", options);
+
+        encodeEqual("🤓", "8J-kkw==", options);
+        encodeEqual("🤓foo🖖", "8J-kk2Zvb_CflpY=", options);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.toHex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.prototype.toHex.js
@@ -1,0 +1,59 @@
+describe("errors", () => {
+    test("called on non-Uint8Array object", () => {
+        expect(() => {
+            Uint8Array.prototype.toHex.call(1);
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+
+        expect(() => {
+            Uint8Array.prototype.toHex.call(new Uint16Array());
+        }).toThrowWithMessage(TypeError, "Not an object of type Uint8Array");
+    });
+
+    test("detached ArrayBuffer", () => {
+        let arrayBuffer = new ArrayBuffer(5, { maxByteLength: 10 });
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        detachArrayBuffer(arrayBuffer);
+
+        expect(() => {
+            typedArray.toHex();
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+
+    test("ArrayBuffer out of bounds", () => {
+        let arrayBuffer = new ArrayBuffer(Uint8Array.BYTES_PER_ELEMENT * 2, {
+            maxByteLength: Uint8Array.BYTES_PER_ELEMENT * 4,
+        });
+
+        let typedArray = new Uint8Array(arrayBuffer, Uint8Array.BYTES_PER_ELEMENT, 1);
+        arrayBuffer.resize(Uint8Array.BYTES_PER_ELEMENT);
+
+        expect(() => {
+            typedArray.toHex();
+        }).toThrowWithMessage(
+            TypeError,
+            "TypedArray contains a property which references a value at an index not contained within its buffer's bounds"
+        );
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Uint8Array.prototype.toHex).toHaveLength(0);
+    });
+
+    const encodeEqual = (input, expected) => {
+        const encoded = toUTF8Bytes(input).toHex();
+        expect(encoded).toBe(expected);
+    };
+
+    test("basic functionality", () => {
+        encodeEqual("", "");
+        encodeEqual("a", "61");
+        encodeEqual("abcdef012345", "616263646566303132333435");
+        encodeEqual("🤓", "f09fa493");
+        encodeEqual("🤓foo🖖", "f09fa493666f6ff09f9696");
+    });
+});


### PR DESCRIPTION
test262 diff (we pass all of the `Uint8Array` tests):
```
Diff Tests:
    +56 ✅    -56 ❌

Diff Tests:
    test/built-ins/Uint8Array/fromBase64/alphabet.js                         ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/descriptor.js                       ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/ignores-receiver.js                 ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/illegal-characters.js               ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/last-chunk-handling.js              ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/length.js                           ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/name.js                             ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/nonconstructor.js                   ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/option-coercion.js                  ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/results.js                          ❌ -> ✅
    test/built-ins/Uint8Array/fromBase64/whitespace.js                       ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/descriptor.js                          ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/ignores-receiver.js                    ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/illegal-characters.js                  ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/length.js                              ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/name.js                                ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/nonconstructor.js                      ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/odd-length-input.js                    ❌ -> ✅
    test/built-ins/Uint8Array/fromHex/results.js                             ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/alphabet.js            ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/descriptor.js          ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/detached-buffer.js     ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/illegal-characters.js  ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/last-chunk-handling.js ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/length.js              ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/name.js                ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/nonconstructor.js      ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/option-coercion.js     ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/results.js             ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/subarray.js            ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/target-size.js         ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/whitespace.js          ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromBase64/writes-up-to-error.js  ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/descriptor.js             ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/illegal-characters.js     ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/length.js                 ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/name.js                   ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/nonconstructor.js         ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/results.js                ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/subarray.js               ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/target-size.js            ❌ -> ✅
    test/built-ins/Uint8Array/prototype/setFromHex/writes-up-to-error.js     ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/alphabet.js                 ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/descriptor.js               ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/detached-buffer.js          ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/length.js                   ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/name.js                     ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/nonconstructor.js           ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/omit-padding.js             ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/option-coercion.js          ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toBase64/results.js                  ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toHex/descriptor.js                  ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toHex/length.js                      ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toHex/name.js                        ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toHex/nonconstructor.js              ❌ -> ✅
    test/built-ins/Uint8Array/prototype/toHex/results.js                     ❌ -> ✅
```