### PR TITLE
WebDriver: Add boilerplate for endpoint 15.7 Perform Actions

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -97,6 +97,7 @@ static constexpr auto s_webdriver_endpoints = Array {
     ROUTE(POST, "/session/:session_id/cookie"sv, add_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie/:name"sv, delete_cookie),
     ROUTE(DELETE, "/session/:session_id/cookie"sv, delete_all_cookies),
+    ROUTE(POST, "/session/:session_id/actions"sv, perform_actions),
     ROUTE(DELETE, "/session/:session_id/actions"sv, release_actions),
     ROUTE(POST, "/session/:session_id/alert/dismiss"sv, dismiss_alert),
     ROUTE(POST, "/session/:session_id/alert/accept"sv, accept_alert),

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -96,6 +96,7 @@ public:
     virtual Response delete_all_cookies(Parameters parameters, JsonValue payload) = 0;
 
     // 15. Actions, https://w3c.github.io/webdriver/#actions
+    virtual Response perform_actions(Parameters parameters, JsonValue payload) = 0;
     virtual Response release_actions(Parameters parameters, JsonValue payload) = 0;
 
     // 16. User prompts, https://w3c.github.io/webdriver/#user-prompts

--- a/Userland/Services/WebContent/WebDriverClient.ipc
+++ b/Userland/Services/WebContent/WebDriverClient.ipc
@@ -52,6 +52,7 @@ endpoint WebDriverClient {
     add_cookie(JsonValue payload) => (Web::WebDriver::Response response)
     delete_cookie(String name) => (Web::WebDriver::Response response)
     delete_all_cookies() => (Web::WebDriver::Response response)
+    perform_actions() => (Web::WebDriver::Response response)
     release_actions() => (Web::WebDriver::Response response)
     dismiss_alert() => (Web::WebDriver::Response response)
     accept_alert() => (Web::WebDriver::Response response)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1672,6 +1672,25 @@ Messages::WebDriverClient::DeleteAllCookiesResponse WebDriverConnection::delete_
     return JsonValue {};
 }
 
+// 15.7 Perform Actions, https://w3c.github.io/webdriver/#perform-actions
+Messages::WebDriverClient::PerformActionsResponse WebDriverConnection::perform_actions()
+{
+    // FIXME: 1. Let input state be the result of get the input state with session and session's current top-level browsing context.
+
+    // FIXME: 2.Let actions options be a new actions options with the is element origin steps set to represents a web element, and the get element origin steps set to get a WebElement origin.
+
+    // FIXME: 3.Let actions by tick be the result of trying to extract an action sequence with input state, parameters, and actions options.
+
+    // FIXME: 4. If session's current browsing context is no longer open, return error with error code no such window.
+
+    // FIXME: 5. Try to handle any user prompts with session.
+
+    // FIXME: 6. Dispatch actions with input state, actions by tick, current browsing context, and actions options. If this results in an error return that error.
+
+    // 7. Return success with data null.
+    return JsonValue {};
+}
+
 // 15.8 Release Actions, https://w3c.github.io/webdriver/#release-actions
 Messages::WebDriverClient::ReleaseActionsResponse WebDriverConnection::release_actions()
 {

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -89,6 +89,7 @@ private:
     virtual Messages::WebDriverClient::AddCookieResponse add_cookie(JsonValue const& payload) override;
     virtual Messages::WebDriverClient::DeleteCookieResponse delete_cookie(String const& name) override;
     virtual Messages::WebDriverClient::DeleteAllCookiesResponse delete_all_cookies() override;
+    virtual Messages::WebDriverClient::PerformActionsResponse perform_actions() override;
     virtual Messages::WebDriverClient::ReleaseActionsResponse release_actions() override;
     virtual Messages::WebDriverClient::DismissAlertResponse dismiss_alert() override;
     virtual Messages::WebDriverClient::AcceptAlertResponse accept_alert() override;

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -641,6 +641,15 @@ Web::WebDriver::Response Client::delete_all_cookies(Web::WebDriver::Parameters p
     return session->web_content_connection().delete_all_cookies();
 }
 
+// 15.7 Perform Actions, https://w3c.github.io/webdriver/#perform-actions
+// POST /session/{session id}/actions
+Web::WebDriver::Response Client::perform_actions(Web::WebDriver::Parameters parameters, JsonValue)
+{
+    dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/actions");
+    auto session = TRY(find_session_with_id(parameters[0]));
+    return session->web_content_connection().perform_actions();
+}
+
 // 15.8 Release Actions, https://w3c.github.io/webdriver/#release-actions
 // DELETE /session/{session id}/actions
 Web::WebDriver::Response Client::release_actions(Web::WebDriver::Parameters parameters, JsonValue)

--- a/Userland/Services/WebDriver/Client.h
+++ b/Userland/Services/WebDriver/Client.h
@@ -86,6 +86,7 @@ private:
     virtual Web::WebDriver::Response add_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_cookie(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_all_cookies(Web::WebDriver::Parameters parameters, JsonValue payload) override;
+    virtual Web::WebDriver::Response perform_actions(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response release_actions(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response dismiss_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response accept_alert(Web::WebDriver::Parameters parameters, JsonValue payload) override;


### PR DESCRIPTION
For issue #1040
Following the structure of the ReleaseActions endpoints, define analogous classes and methods for PerformActions