### PR TITLE
UI: Add a `--disable-scripting` option to disable scripting by default

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -197,6 +197,7 @@
     }
 
     [self.managed_tabs addObject:controller];
+    [controller onCreateNewTab];
     return controller;
 }
 

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -35,11 +35,14 @@ struct TabSettings {
 
 - (void)onTitleChange:(ByteString const&)title;
 
+- (void)onCreateNewTab;
+
 - (void)navigateBack:(id)sender;
 - (void)navigateForward:(id)sender;
 - (void)reload:(id)sender;
 - (void)clearHistory;
 
+- (void)setPopupBlocking:(BOOL)block_popups;
 - (void)debugRequest:(ByteString const&)request argument:(ByteString const&)argument;
 
 - (void)focusLocationToolbarItem;

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -43,6 +43,7 @@ struct TabSettings {
 - (void)clearHistory;
 
 - (void)setPopupBlocking:(BOOL)block_popups;
+- (void)setScripting:(BOOL)enabled;
 - (void)debugRequest:(ByteString const&)request argument:(ByteString const&)argument;
 
 - (void)focusLocationToolbarItem;

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -139,6 +139,11 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     m_title = title;
 }
 
+- (void)onCreateNewTab
+{
+    [self setPopupBlocking:m_settings.block_popups];
+}
+
 - (void)zoomIn:(id)sender
 {
     [[[self tab] web_view] zoomIn];
@@ -348,7 +353,12 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 - (void)togglePopupBlocking:(id)sender
 {
     m_settings.block_popups = !m_settings.block_popups;
-    [self debugRequest:"block-pop-ups" argument:m_settings.block_popups ? "on" : "off"];
+    [self setPopupBlocking:m_settings.block_popups];
+}
+
+- (void)setPopupBlocking:(BOOL)block_popups
+{
+    [self debugRequest:"block-pop-ups" argument:block_popups ? "on" : "off"];
 }
 
 - (void)toggleSameOriginPolicy:(id)sender

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -92,7 +92,10 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [self.toolbar setAllowsUserCustomization:NO];
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];
 
-        m_settings = { .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES };
+        m_settings = {
+            .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
+            .scripting_enabled = WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
+        };
 
         if (auto const& user_agent_preset = WebView::Application::web_content_options().user_agent_preset; user_agent_preset.has_value())
             m_settings.user_agent_name = *user_agent_preset;
@@ -142,6 +145,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 - (void)onCreateNewTab
 {
     [self setPopupBlocking:m_settings.block_popups];
+    [self setScripting:m_settings.scripting_enabled];
 }
 
 - (void)zoomIn:(id)sender
@@ -347,7 +351,12 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 - (void)toggleScripting:(id)sender
 {
     m_settings.scripting_enabled = !m_settings.scripting_enabled;
-    [self debugRequest:"scripting" argument:m_settings.scripting_enabled ? "on" : "off"];
+    [self setScripting:m_settings.scripting_enabled];
+}
+
+- (void)setScripting:(BOOL)enabled
+{
+    [self debugRequest:"scripting" argument:enabled ? "on" : "off"];
 }
 
 - (void)togglePopupBlocking:(id)sender

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -552,7 +552,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::Cook
 
     m_enable_scripting_action = new QAction("Enable Scripting", this);
     m_enable_scripting_action->setCheckable(true);
-    m_enable_scripting_action->setChecked(true);
+    m_enable_scripting_action->setChecked(WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::No);
     debug_menu->addAction(m_enable_scripting_action);
     QObject::connect(m_enable_scripting_action, &QAction::triggered, this, [this] {
         bool state = m_enable_scripting_action->isChecked();

--- a/Userland/Libraries/LibWebView/Application.cpp
+++ b/Userland/Libraries/LibWebView/Application.cpp
@@ -56,6 +56,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     bool new_window = false;
     bool force_new_process = false;
     bool allow_popups = false;
+    bool disable_scripting = false;
     bool disable_sql_database = false;
     Optional<StringView> debug_process;
     Optional<StringView> profile_process;
@@ -75,6 +76,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
     args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
     args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
+    args_parser.add_option(disable_scripting, "Disable scripting by default", "disable-scripting");
     args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");
     args_parser.add_option(debug_process, "Wait for a debugger to attach to the given process name (WebContent, RequestServer, etc.)", "debug-process", 0, "process-name");
     args_parser.add_option(profile_process, "Enable callgrind profiling of the given process name (WebContent, RequestServer, etc.)", "profile-process", 0, "process-name");
@@ -115,6 +117,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
         .new_window = new_window ? NewWindow::Yes : NewWindow::No,
         .force_new_process = force_new_process ? ForceNewProcess::Yes : ForceNewProcess::No,
         .allow_popups = allow_popups ? AllowPopups::Yes : AllowPopups::No,
+        .disable_scripting = disable_scripting ? DisableScripting::Yes : DisableScripting::No,
         .disable_sql_database = disable_sql_database ? DisableSQLDatabase::Yes : DisableSQLDatabase::No,
         .debug_helper_process = move(debug_process_type),
         .profile_helper_process = move(profile_process_type),

--- a/Userland/Libraries/LibWebView/Options.h
+++ b/Userland/Libraries/LibWebView/Options.h
@@ -30,6 +30,11 @@ enum class AllowPopups {
     Yes,
 };
 
+enum class DisableScripting {
+    No,
+    Yes,
+};
+
 enum class DisableSQLDatabase {
     No,
     Yes,
@@ -43,6 +48,7 @@ struct ChromeOptions {
     NewWindow new_window { NewWindow::No };
     ForceNewProcess force_new_process { ForceNewProcess::No };
     AllowPopups allow_popups { AllowPopups::No };
+    DisableScripting disable_scripting { DisableScripting::No };
     DisableSQLDatabase disable_sql_database { DisableSQLDatabase::No };
     Optional<ProcessType> debug_helper_process {};
     Optional<ProcessType> profile_helper_process {};


### PR DESCRIPTION
This makes the "Enable Scripting" checkbox in the Debug menu unchecked by default.