### PR TITLE
LibJS: A couple LocalTime optimizations

### DIFF
--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -8,6 +8,7 @@
 #include <AK/Enumerate.h>
 #include <LibCore/Environment.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibTest/JavaScriptTestRunner.h>
 #include <LibUnicode/TimeZone.h>
@@ -109,6 +110,7 @@ TESTJS_GLOBAL_FUNCTION(set_time_zone, setTimeZone)
             return vm.throw_completion<JS::InternalError>(MUST(String::formatted("Could not set time zone: {}", result.error())));
     }
 
+    JS::clear_system_time_zone_cache();
     Unicode::clear_system_time_zone_cache();
     tzset();
 

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -411,9 +411,15 @@ Unicode::TimeZoneOffset get_named_time_zone_offset_nanoseconds(StringView time_z
     return offset.release_value();
 }
 
+static Optional<String> cached_system_time_zone_identifier;
+
 // 21.4.1.24 SystemTimeZoneIdentifier ( ), https://tc39.es/ecma262/#sec-systemtimezoneidentifier
 String system_time_zone_identifier()
 {
+    // OPTIMIZATION: We cache the system time zone to avoid the expensive lookups below.
+    if (cached_system_time_zone_identifier.has_value())
+        return *cached_system_time_zone_identifier;
+
     // 1. If the implementation only supports the UTC time zone, return "UTC".
 
     // 2. Let systemTimeZoneString be the String representing the host environment's current time zone, either a primary
@@ -429,7 +435,13 @@ String system_time_zone_identifier()
     }
 
     // 3. Return systemTimeZoneString.
-    return system_time_zone_string;
+    cached_system_time_zone_identifier = move(system_time_zone_string);
+    return *cached_system_time_zone_identifier;
+}
+
+void clear_system_time_zone_cache()
+{
+    cached_system_time_zone_identifier.clear();
 }
 
 // 21.4.1.25 LocalTime ( t ), https://tc39.es/ecma262/#sec-localtime

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -77,6 +77,7 @@ Crypto::SignedBigInteger get_utc_epoch_nanoseconds(i32 year, u8 month, u8 day, u
 Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringView time_zone_identifier, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
 Unicode::TimeZoneOffset get_named_time_zone_offset_nanoseconds(StringView time_zone_identifier, Crypto::SignedBigInteger const& epoch_nanoseconds);
 String system_time_zone_identifier();
+void clear_system_time_zone_cache();
 double local_time(double time);
 double utc_time(double time);
 double make_time(double hour, double min, double sec, double ms);

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -76,6 +76,7 @@ u16 ms_from_time(double);
 Crypto::SignedBigInteger get_utc_epoch_nanoseconds(i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
 Vector<Crypto::SignedBigInteger> get_named_time_zone_epoch_nanoseconds(StringView time_zone_identifier, i32 year, u8 month, u8 day, u8 hour, u8 minute, u8 second, u16 millisecond, u16 microsecond, u16 nanosecond);
 Unicode::TimeZoneOffset get_named_time_zone_offset_nanoseconds(StringView time_zone_identifier, Crypto::SignedBigInteger const& epoch_nanoseconds);
+Unicode::TimeZoneOffset get_named_time_zone_offset_milliseconds(StringView time_zone_identifier, double epoch_milliseconds);
 String system_time_zone_identifier();
 void clear_system_time_zone_cache();
 double local_time(double time);

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -1123,8 +1123,7 @@ ByteString time_zone_string(double time)
     // 3. Else,
     else {
         // a. Let offsetNs be GetNamedTimeZoneOffsetNanoseconds(systemTimeZoneIdentifier, ℤ(ℝ(tv) × 10^6)).
-        auto time_bigint = Crypto::SignedBigInteger { time }.multiplied_by(Crypto::UnsignedBigInteger { 1'000'000 });
-        auto offset = get_named_time_zone_offset_nanoseconds(system_time_zone_identifier, time_bigint);
+        auto offset = get_named_time_zone_offset_milliseconds(system_time_zone_identifier, time);
 
         offset_nanoseconds = static_cast<double>(offset.offset.to_nanoseconds());
         in_dst = offset.in_dst;

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -622,9 +622,9 @@ static void apply_time_zone_to_formatter(icu::SimpleDateFormat& formatter, icu::
 {
     UErrorCode status = U_ZERO_ERROR;
 
-    auto* time_zone = icu::TimeZone::createTimeZone(icu_string(time_zone_identifier));
+    auto time_zone_data = TimeZoneData::for_time_zone(time_zone_identifier);
 
-    auto* calendar = icu::Calendar::createInstance(time_zone, locale, status);
+    auto* calendar = icu::Calendar::createInstance(time_zone_data->time_zone(), locale, status);
     VERIFY(icu_success(status));
 
     if (calendar->getDynamicClassID() == icu::GregorianCalendar::getStaticClassID()) {

--- a/Userland/Libraries/LibUnicode/ICU.h
+++ b/Userland/Libraries/LibUnicode/ICU.h
@@ -24,6 +24,7 @@ U_NAMESPACE_BEGIN
 class DateTimePatternGenerator;
 class LocaleDisplayNames;
 class NumberingSystem;
+class TimeZone;
 class TimeZoneNames;
 U_NAMESPACE_END
 
@@ -61,6 +62,18 @@ private:
     OwnPtr<icu::DateTimePatternGenerator> m_date_time_pattern_generator;
     OwnPtr<icu::TimeZoneNames> m_time_zone_names;
     Optional<DigitalFormat> m_digital_format;
+};
+
+class TimeZoneData {
+public:
+    static Optional<TimeZoneData&> for_time_zone(StringView time_zone);
+
+    ALWAYS_INLINE icu::TimeZone& time_zone() { return *m_time_zone; }
+
+private:
+    explicit TimeZoneData(NonnullOwnPtr<icu::TimeZone>);
+
+    NonnullOwnPtr<icu::TimeZone> m_time_zone;
 };
 
 constexpr bool icu_success(UErrorCode code)

--- a/Userland/Libraries/LibUnicode/TimeZone.cpp
+++ b/Userland/Libraries/LibUnicode/TimeZone.cpp
@@ -131,14 +131,14 @@ Optional<TimeZoneOffset> time_zone_offset(StringView time_zone, UnixDateTime tim
 {
     UErrorCode status = U_ZERO_ERROR;
 
-    auto icu_time_zone = adopt_own_if_nonnull(icu::TimeZone::createTimeZone(icu_string(time_zone)));
-    if (!icu_time_zone || *icu_time_zone == icu::TimeZone::getUnknown())
+    auto time_zone_data = TimeZoneData::for_time_zone(time_zone);
+    if (!time_zone_data.has_value())
         return {};
 
     i32 raw_offset = 0;
     i32 dst_offset = 0;
 
-    icu_time_zone->getOffset(static_cast<UDate>(time.milliseconds_since_epoch()), 0, raw_offset, dst_offset, status);
+    time_zone_data->time_zone().getOffset(static_cast<UDate>(time.milliseconds_since_epoch()), 0, raw_offset, dst_offset, status);
     if (icu_failure(status))
         return {};
 

--- a/Userland/Libraries/LibUnicode/TimeZone.h
+++ b/Userland/Libraries/LibUnicode/TimeZone.h
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#pragma once
+
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
-
-#pragma once
 
 namespace Unicode {
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -16,6 +16,7 @@
 #include <LibGfx/SystemTheme.h>
 #include <LibJS/Heap/Heap.h>
 #include <LibJS/Runtime/ConsoleObject.h>
+#include <LibJS/Runtime/Date.h>
 #include <LibUnicode/TimeZone.h>
 #include <LibWeb/ARIA/RoleType.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -1194,6 +1195,7 @@ void ConnectionFromClient::enable_inspector_prototype(u64)
 
 void ConnectionFromClient::system_time_zone_changed()
 {
+    JS::clear_system_time_zone_cache();
     Unicode::clear_system_time_zone_cache();
 }
 


### PR DESCRIPTION
* Cache the resolved system time zone identifier
* Avoid needless BigInt conversions

Using the following benchmark:
```c++
BENCHMARK_CASE(foo)
{
    for (size_t i = 0; i < 1'000'000; ++i)
        (void)JS::local_time(0);
}
```

These patches reduce the runtime from 2.5s to 1.2s on my machine. So, still room on the table for more improvements, but these are some low hanging fruit.

No test262 diff.