### PR TITLE
RequestServer: Stop crash if too many HTTP requests are processed at once

### DIFF
--- a/AK/AtomicOwnPtr.h
+++ b/AK/AtomicOwnPtr.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2024, Ben Jilks <benjyjilks@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Atomic.h>
+#include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+
+namespace AK {
+
+template<typename T, typename TDeleter>
+class [[nodiscard]] AtomicOwnPtr {
+public:
+    AtomicOwnPtr() = default;
+
+    AtomicOwnPtr(decltype(nullptr))
+        : m_ptr(nullptr)
+    {
+    }
+
+    AtomicOwnPtr(AtomicOwnPtr&& other)
+        : m_ptr(other.leak_ptr())
+    {
+    }
+
+    template<typename U>
+    AtomicOwnPtr(NonnullOwnPtr<U>&& other)
+        : m_ptr(other.leak_ptr())
+    {
+    }
+    template<typename U>
+    AtomicOwnPtr(AtomicOwnPtr<U>&& other)
+        : m_ptr(other.leak_ptr())
+    {
+    }
+    ~AtomicOwnPtr()
+    {
+        clear();
+#ifdef SANITIZE_PTRS
+        m_ptr = (T*)(explode_byte(OWNPTR_SCRUB_BYTE));
+#endif
+    }
+
+    AtomicOwnPtr(AtomicOwnPtr const&) = delete;
+    template<typename U>
+    AtomicOwnPtr(AtomicOwnPtr<U> const&) = delete;
+    AtomicOwnPtr& operator=(AtomicOwnPtr const&) = delete;
+    template<typename U>
+    AtomicOwnPtr& operator=(AtomicOwnPtr<U> const&) = delete;
+
+    template<typename U>
+    AtomicOwnPtr(NonnullOwnPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr& operator=(NonnullOwnPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr(RefPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr(NonnullRefPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr(WeakPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr& operator=(RefPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr& operator=(NonnullRefPtr<U> const&) = delete;
+    template<typename U>
+    AtomicOwnPtr& operator=(WeakPtr<U> const&) = delete;
+
+    AtomicOwnPtr& operator=(AtomicOwnPtr&& other)
+    {
+        m_ptr.store(other.leak_ptr());
+        return *this;
+    }
+
+    template<typename U>
+    AtomicOwnPtr& operator=(AtomicOwnPtr<U>&& other)
+    {
+        m_ptr.store(other.leak_ptr());
+        return *this;
+    }
+
+    template<typename U>
+    AtomicOwnPtr& operator=(OwnPtr<U>&& other)
+    {
+        m_ptr.store(other.leak_ptr());
+        return *this;
+    }
+
+    template<typename U>
+    AtomicOwnPtr& operator=(NonnullOwnPtr<U>&& other)
+    {
+        m_ptr.store(other.leak_ptr());
+        VERIFY(m_ptr.load());
+        return *this;
+    }
+
+    AtomicOwnPtr& operator=(T* ptr) = delete;
+
+    AtomicOwnPtr& operator=(nullptr_t)
+    {
+        clear();
+        return *this;
+    }
+
+    void clear()
+    {
+        auto* ptr = m_ptr.load();
+        m_ptr.store(nullptr);
+        TDeleter {}(ptr);
+    }
+
+    bool operator!() const { return !m_ptr.load(); }
+
+    [[nodiscard]] T* leak_ptr()
+    {
+        T* leaked_ptr = m_ptr.load();
+        m_ptr.store(nullptr);
+        return leaked_ptr;
+    }
+
+    NonnullOwnPtr<T> release_nonnull()
+    {
+        VERIFY(m_ptr);
+        return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *leak_ptr());
+    }
+
+    template<typename U>
+    NonnullOwnPtr<U> release_nonnull()
+    {
+        VERIFY(m_ptr);
+        return NonnullOwnPtr<U>(NonnullOwnPtr<U>::Adopt, static_cast<U&>(*leak_ptr()));
+    }
+
+    T* ptr() const { return m_ptr.load(); }
+
+    T* operator->() const
+    {
+        VERIFY(m_ptr);
+        return m_ptr.load();
+    }
+
+    T& operator*() const
+    {
+        VERIFY(m_ptr);
+        return *m_ptr.load();
+    }
+
+    operator T*() const { return m_ptr.load(); }
+
+    operator bool() { return !!m_ptr.load(); }
+
+    void swap(AtomicOwnPtr& other)
+    {
+        m_ptr.exchange(other.m_ptr);
+    }
+
+    template<typename U>
+    void swap(AtomicOwnPtr<U>& other)
+    {
+        m_ptr.exchange(other.m_ptr);
+    }
+
+    static AtomicOwnPtr lift(T* ptr)
+    {
+        return AtomicOwnPtr { ptr };
+    }
+
+protected:
+    explicit AtomicOwnPtr(T* ptr)
+        : m_ptr(ptr)
+    {
+        static_assert(
+            requires { requires typename T::AllowOwnPtr()(); } || !requires { requires !typename T::AllowOwnPtr()(); declval<T>().ref(); declval<T>().unref(); }, "Use RefPtr<> for RefCounted types");
+    }
+
+private:
+    Atomic<T*> m_ptr { nullptr };
+};
+
+template<typename T, typename U>
+inline void swap(AtomicOwnPtr<T>& a, AtomicOwnPtr<U>& b)
+{
+    a.swap(b);
+}
+
+template<typename T>
+inline AtomicOwnPtr<T> adopt_atomic_own_if_nonnull(T* object)
+{
+    if (object)
+        return AtomicOwnPtr<T>::lift(object);
+    return {};
+}
+
+template<typename T>
+struct Traits<AtomicOwnPtr<T>> : public DefaultTraits<AtomicOwnPtr<T>> {
+    using PeekType = T*;
+    using ConstPeekType = T const*;
+    static unsigned hash(AtomicOwnPtr<T> const& p) { return ptr_hash(p.ptr()); }
+    static bool equals(AtomicOwnPtr<T> const& a, AtomicOwnPtr<T> const& b) { return a.ptr() == b.ptr(); }
+};
+
+template<typename T>
+struct Formatter<AtomicOwnPtr<T>> : Formatter<T*> {
+    ErrorOr<void> format(FormatBuilder& builder, AtomicOwnPtr<T> const& value)
+    {
+        return Formatter<T*>::format(builder, value.ptr());
+    }
+};
+}
+
+#if USING_AK_GLOBALLY
+using AK::adopt_atomic_own_if_nonnull;
+using AK::AtomicOwnPtr;
+#endif

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -77,6 +77,9 @@ using Bytes = Span<u8>;
 template<typename T, AK::MemoryOrder DefaultMemoryOrder>
 class Atomic;
 
+template<typename T, typename TDeleter = DefaultDelete<T>>
+class AtomicOwnPtr;
+
 template<typename T, typename TSizeCalculationPolicy = DefaultSizeCalculationPolicy>
 class SinglyLinkedList;
 

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -106,6 +106,11 @@ public:
     NonnullRefPtr& operator=(OwnPtr<U> const&) = delete;
 
     template<typename U>
+    NonnullRefPtr(AtomicOwnPtr<U> const&) = delete;
+    template<typename U>
+    NonnullRefPtr& operator=(AtomicOwnPtr<U> const&) = delete;
+
+    template<typename U>
     NonnullRefPtr(RefPtr<U> const&) = delete;
     template<typename U>
     NonnullRefPtr& operator=(RefPtr<U> const&) = delete;

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -36,6 +36,11 @@ public:
     {
     }
     template<typename U>
+    OwnPtr(AtomicOwnPtr<U>&& other)
+        : m_ptr(other.leak_ptr())
+    {
+    }
+    template<typename U>
     OwnPtr(OwnPtr<U>&& other)
         : m_ptr(other.leak_ptr())
     {
@@ -81,6 +86,14 @@ public:
 
     template<typename U>
     OwnPtr& operator=(OwnPtr<U>&& other)
+    {
+        OwnPtr ptr(move(other));
+        swap(ptr);
+        return *this;
+    }
+
+    template<typename U>
+    OwnPtr& operator=(AtomicOwnPtr<U>&& other)
     {
         OwnPtr ptr(move(other));
         swap(ptr);

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -111,6 +111,11 @@ public:
     template<typename U>
     RefPtr& operator=(OwnPtr<U> const&) = delete;
 
+    template<typename U>
+    RefPtr(AtomicOwnPtr<U> const&) = delete;
+    template<typename U>
+    RefPtr& operator=(AtomicOwnPtr<U> const&) = delete;
+
     void swap(RefPtr& other)
     {
         AK::swap(m_ptr, other.m_ptr);

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -3,6 +3,7 @@ set(AK_TEST_SOURCES
     TestAnyOf.cpp
     TestArray.cpp
     TestAtomic.cpp
+    TestAtomicOwnPtr.cpp
     TestBadge.cpp
     TestBase64.cpp
     TestBinaryHeap.cpp

--- a/Tests/AK/TestAtomicOwnPtr.cpp
+++ b/Tests/AK/TestAtomicOwnPtr.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/AtomicOwnPtr.h>
+
+static u64 deleter_call_count = 0;
+
+TEST_CASE(should_call_custom_deleter)
+{
+    auto deleter = [](auto* p) { if (p) ++deleter_call_count; };
+    auto ptr = AtomicOwnPtr<u64, decltype(deleter)> {};
+    ptr.clear();
+    EXPECT_EQ(0u, deleter_call_count);
+    ptr = adopt_atomic_own_if_nonnull(&deleter_call_count);
+    EXPECT_EQ(0u, deleter_call_count);
+    ptr.clear();
+    EXPECT_EQ(1u, deleter_call_count);
+}
+
+TEST_CASE(destroy_self_owning_object)
+{
+    struct SelfOwning {
+        AtomicOwnPtr<SelfOwning> self;
+    };
+    AtomicOwnPtr<SelfOwning> object = make<SelfOwning>();
+    auto* object_ptr = object.ptr();
+    object->self = move(object);
+    object = nullptr;
+    object_ptr->self = nullptr;
+}

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/AtomicOwnPtr.h>
 #include <AK/Debug.h>
 #include <AK/HashMap.h>
 #include <AK/Vector.h>
@@ -134,7 +135,7 @@ struct Connection {
     using SocketType = Socket;
     using StorageType = SocketStorageType;
 
-    OwnPtr<Core::BufferedSocket<SocketStorageType>> socket;
+    AtomicOwnPtr<Core::BufferedSocket<SocketStorageType>> socket;
     Threading::RWLockProtected<QueueType> request_queue;
     NonnullRefPtr<Core::Timer> removal_timer;
     Atomic<bool> is_being_started { false };


### PR DESCRIPTION
If you try to perform lots of HTTP request at once, the request server would sometimes crash. Below is an example page that would cause this crash to happen most of the time.

```html
<!DOCTYPE html>
<script>
for (let i = 0; i < 1000; ++i) {
    fetch('http://127.0.0.1:5000') // Or any http server
        .then(async response => {
            const text = await response.text();
            console.log(`Got response of size ${ text.length } bytes`);
        });
}
</script>
```

The issue seems to be that the socket's memory was getting corrupted, causing vtable lookups to fail. Wrapping the socket in RWLockProtected stops the crash from happening in the above code.

A lot of the legacy encoding tests send a large number of requests, so hopefully this helps reduce the number of timeouts.