### PR TITLE
LibWebView: Properly handle new lines inside styled view-source elements

### DIFF
--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -79,27 +79,36 @@ String highlight_source(URL::URL const& url, StringView source)
 
         auto segment = source.substring_view(previous_position, end_position - previous_position);
 
-        if (class_name.has_value())
-            builder.appendff("<span class=\"{}\">"sv, *class_name);
+        auto append_class_start = [&]() {
+            if (class_name.has_value())
+                builder.appendff("<span class=\"{}\">"sv, *class_name);
+        };
+        auto append_class_end = [&]() {
+            if (class_name.has_value())
+                builder.append("</span>"sv);
+        };
+
+        append_class_start();
 
         for (auto code_point : Utf8View { segment }) {
-            if (code_point == '&')
+            if (code_point == '&') {
                 builder.append("&amp;"sv);
-            else if (code_point == 0xA0)
+            } else if (code_point == 0xA0) {
                 builder.append("&nbsp;"sv);
-            else if (code_point == '<')
+            } else if (code_point == '<') {
                 builder.append("&lt;"sv);
-            else if (code_point == '>')
+            } else if (code_point == '>') {
                 builder.append("&gt;"sv);
-            else if (code_point == '\n')
+            } else if (code_point == '\n') {
+                append_class_end();
                 builder.append("</span>\n<span class=\"line\">"sv);
-            else
+                append_class_start();
+            } else {
                 builder.append_code_point(code_point);
+            }
         }
 
-        if (class_name.has_value())
-            builder.append("</span>"sv);
-
+        append_class_end();
         previous_position = end_position;
     };
 


### PR DESCRIPTION
When we want to inject a CSS counter for a line, we need to be sure to handle if we had previously opened a styled span for the current source substring. For example, if we see a new line in the middle of a comment, we will have previously opened the following tag:

    <span class="comment">

So when injecting a new line and the <span class="line"> element (for CSS counters), we need to close the previous span and insert a newly opened tag to continue using the style.

Before:
![before](https://github.com/user-attachments/assets/d186819c-0144-4661-9482-43181be317cc)

After:
![after](https://github.com/user-attachments/assets/c80f114e-e4ce-444b-bc5f-8ac80a8c8321)

Fixes #1243