### PR TITLE
CMake: fix Makefile build on case-insensitive file system

### DIFF
--- a/Ladybird/ImageDecoder/CMakeLists.txt
+++ b/Ladybird/ImageDecoder/CMakeLists.txt
@@ -9,19 +9,19 @@ set(IMAGE_DECODER_SOURCES
 )
 
 if (ANDROID)
-    add_library(imagedecoder SHARED
+    add_library(imagedecoderservice SHARED
             ${IMAGE_DECODER_SOURCES}
             ../Android/src/main/cpp/ImageDecoderService.cpp
             ../Android/src/main/cpp/LadybirdServiceBaseJNI.cpp
             ../Utilities.cpp
             )
 else()
-    add_library(imagedecoder STATIC ${IMAGE_DECODER_SOURCES})
+    add_library(imagedecoderservice STATIC ${IMAGE_DECODER_SOURCES})
 endif()
 
 add_executable(ImageDecoder main.cpp)
-target_link_libraries(ImageDecoder PRIVATE imagedecoder LibCore LibMain)
+target_link_libraries(ImageDecoder PRIVATE imagedecoderservice LibCore LibMain)
 
-target_include_directories(imagedecoder PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
-target_include_directories(imagedecoder PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(imagedecoder PRIVATE LibCore LibGfx LibIPC LibImageDecoderClient LibMain LibThreading)
+target_include_directories(imagedecoderservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
+target_include_directories(imagedecoderservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+target_link_libraries(imagedecoderservice PRIVATE LibCore LibGfx LibIPC LibImageDecoderClient LibMain LibThreading)

--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -9,28 +9,28 @@ set(REQUESTSERVER_SOURCES
 )
 
 if (ANDROID)
-    add_library(requestserver SHARED
+    add_library(requestserverservice SHARED
         ${REQUESTSERVER_SOURCES}
         ../Android/src/main/cpp/RequestServerService.cpp
         ../Android/src/main/cpp/LadybirdServiceBaseJNI.cpp
         ../Utilities.cpp
     )
 else()
-    add_library(requestserver STATIC ${REQUESTSERVER_SOURCES})
+    add_library(requestserverservice STATIC ${REQUESTSERVER_SOURCES})
 endif()
 
 find_package(PkgConfig)
 find_package(CURL REQUIRED)
 
 add_executable(RequestServer main.cpp)
-target_link_libraries(RequestServer PRIVATE requestserver)
+target_link_libraries(RequestServer PRIVATE requestserverservice)
 
-target_include_directories(requestserver PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
-target_include_directories(requestserver PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(requestserver PUBLIC LibCore LibMain LibCrypto LibFileSystem LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading CURL::libcurl)
+target_include_directories(requestserverservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
+target_include_directories(requestserverservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+target_link_libraries(requestserverservice PUBLIC LibCore LibMain LibCrypto LibFileSystem LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading CURL::libcurl)
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
-    target_link_libraries(requestserver PUBLIC nsl socket)
+    target_link_libraries(requestserverservice PUBLIC nsl socket)
 endif()
 if (HAIKU)
     # Haiku has networking related functions in the network library

--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -17,31 +17,31 @@ set(WEBCONTENT_SOURCES
 )
 
 if (ANDROID)
-    add_library(webcontent SHARED
+    add_library(webcontentservice SHARED
         ${WEBCONTENT_SOURCES}
         ../Android/src/main/cpp/WebContentService.cpp
         ../Android/src/main/cpp/WebContentServiceJNI.cpp
         ../Android/src/main/cpp/LadybirdServiceBaseJNI.cpp
         ../Android/src/main/cpp/JNIHelpers.cpp
     )
-    target_link_libraries(webcontent PRIVATE android)
+    target_link_libraries(webcontentservice PRIVATE android)
 else()
-    add_library(webcontent STATIC ${WEBCONTENT_SOURCES})
-    set_target_properties(webcontent PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
+    add_library(webcontentservice STATIC ${WEBCONTENT_SOURCES})
+    set_target_properties(webcontentservice PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 endif()
 
-target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/Services/>)
-target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/>)
-target_include_directories(webcontent PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
+target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/Services/>)
+target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Userland/>)
+target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
-target_link_libraries(webcontent PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibMedia LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient)
+target_link_libraries(webcontentservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibMedia LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient)
 
 if (HAVE_PULSEAUDIO)
-    target_compile_definitions(webcontent PUBLIC HAVE_PULSEAUDIO=1)
+    target_compile_definitions(webcontentservice PUBLIC HAVE_PULSEAUDIO=1)
 endif()
 
 if (HAS_FONTCONFIG)
-    target_link_libraries(webcontent PRIVATE Fontconfig::Fontconfig)
+    target_link_libraries(webcontentservice PRIVATE Fontconfig::Fontconfig)
 endif()
 
 if (ENABLE_QT)
@@ -72,14 +72,14 @@ else()
     add_executable(WebContent main.cpp)
 endif()
 
-target_link_libraries(WebContent PRIVATE webcontent LibURL)
+target_link_libraries(WebContent PRIVATE webcontentservice LibURL)
 
-target_sources(webcontent PUBLIC FILE_SET ladybird TYPE HEADERS
+target_sources(webcontentservice PUBLIC FILE_SET ladybird TYPE HEADERS
     BASE_DIRS ${LADYBIRD_SOURCE_DIR}
     FILES ../FontPlugin.h
           ../ImageCodecPlugin.h
 )
-target_sources(webcontent PUBLIC FILE_SET server TYPE HEADERS
+target_sources(webcontentservice PUBLIC FILE_SET server TYPE HEADERS
     BASE_DIRS ${LADYBIRD_SOURCE_DIR}/Userland/Services
     FILES ${WEBCONTENT_SOURCE_DIR}/ConnectionFromClient.h
           ${WEBCONTENT_SOURCE_DIR}/ConsoleGlobalEnvironmentExtensions.h

--- a/Ladybird/WebWorker/CMakeLists.txt
+++ b/Ladybird/WebWorker/CMakeLists.txt
@@ -13,16 +13,16 @@ set(WEBWORKER_SOURCES
 
 # FIXME: Add Android service
 
-add_library(webworker STATIC ${WEBWORKER_SOURCES})
-set_target_properties(webworker PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
+add_library(webworkerservice STATIC ${WEBWORKER_SOURCES})
+set_target_properties(webworkerservice PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 
-target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
-target_include_directories(webworker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
-target_include_directories(webworker PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(webworker PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibRequests LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL)
+target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
+target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
+target_include_directories(webworkerservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
+target_link_libraries(webworkerservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibRequests LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL)
 
 if (HAS_FONTCONFIG)
-    target_link_libraries(webworker PRIVATE Fontconfig::Fontconfig)
+    target_link_libraries(webworkerservice PRIVATE Fontconfig::Fontconfig)
 endif()
 
 if (ENABLE_QT)
@@ -36,7 +36,7 @@ if (ENABLE_QT)
             main.cpp
     )
     target_link_libraries(WebWorker PRIVATE Qt::Core Qt::Network)
-    target_link_libraries(WebWorker PRIVATE webworker LibWebSocket)
+    target_link_libraries(WebWorker PRIVATE webworkerservice LibWebSocket)
     target_compile_definitions(WebWorker PRIVATE HAVE_QT=1)
 
 else()
@@ -44,4 +44,4 @@ else()
 endif()
 
 target_include_directories(WebWorker PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/)
-target_link_libraries(WebWorker PRIVATE webworker)
+target_link_libraries(WebWorker PRIVATE webworkerservice)


### PR DESCRIPTION
Ladybird build scripts uses CMake Ninja generator. These changes will help to build Ladybird using different CMake generators (e.g. Makefile)