### PR TITLE
LibWeb: Fix grid min height not being computed correctly when a max width was set

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/min-height-from-text.txt
+++ b/Tests/LibWeb/Layout/expected/grid/min-height-from-text.txt
@@ -1,0 +1,29 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x50 flex-container(column) [FFC] children: not-inline
+      Box <div.content> at (8,8) content-size 784x51 flex-item [GFC] children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 784x51 [BFC] children: inline
+          frag 0 from TextNode start: 1, length: 87, rect: [8,8 705.625x17] baseline: 13.296875
+              "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dignissim elit eget arcu"
+          frag 1 from TextNode start: 89, length: 92, rect: [8,25 758x17] baseline: 13.296875
+              "accumsan imperdiet vulputate a justo. Phasellus tincidunt sem non tellus tristique hendrerit"
+          frag 2 from TextNode start: 182, length: 82, rect: [8,42 683.125x17] baseline: 13.296875
+              "quis eu eros. Morbi dolor erat, posuere ut feugiat rhoncus, vestibulum vel tortor."
+          TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+      BlockContainer <div.footer> at (8,59) content-size 784x17 flex-item [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 27, rect: [8,59 232.140625x17] baseline: 13.296875
+            "Lorem ipsum dolor sit amet."
+        TextNode <#text>
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66] overflow: [0,0 800x76]
+    PaintableBox (Box<BODY>) [8,8 784x50] overflow: [8,8 784x68]
+      PaintableBox (Box<DIV>.content) [8,8 784x51]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x51]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>.footer) [8,59 784x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/min-height-from-text.html
+++ b/Tests/LibWeb/Layout/input/grid/min-height-from-text.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+    body {
+        display: flex;
+        flex-direction: column;
+        height: 50px;
+    }
+
+    .content {
+        display: grid;
+        max-width: 100%;
+    }
+
+    .footer {
+        background: black;
+        color: white;
+    }
+</style>
+
+<div class="content">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam dignissim elit eget arcu accumsan imperdiet vulputate
+    a justo. Phasellus tincidunt sem non tellus tristique hendrerit quis eu eros. Morbi dolor erat, posuere ut feugiat
+    rhoncus, vestibulum vel tortor.
+</div>
+
+<div class="footer">Lorem ipsum dolor sit amet.</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2248,12 +2248,22 @@ CSSPixels GridFormattingContext::calculate_limited_min_content_contribution(Grid
     if (min_content_contribution < minimum_contribution)
         return minimum_contribution;
 
+    auto should_treat_max_size_as_none = [&]() {
+        switch (dimension) {
+        case GridDimension::Row:
+            return should_treat_max_height_as_none(grid_container(), m_available_space->height);
+        case GridDimension::Column:
+            return should_treat_max_width_as_none(grid_container(), m_available_space->width);
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }();
+
     // FIXME: limit by max track sizing function instead of grid container maximum size
-    auto const& available_size = dimension == GridDimension::Column ? m_available_space->width : m_available_space->height;
-    if (!should_treat_max_width_as_none(grid_container(), available_size)) {
-        auto max_width = calculate_grid_container_maximum_size(dimension);
-        if (min_content_contribution > max_width)
-            return max_width;
+    if (!should_treat_max_size_as_none) {
+        auto max_size = calculate_grid_container_maximum_size(dimension);
+        if (min_content_contribution > max_size)
+            return max_size;
     }
 
     return min_content_contribution;


### PR DESCRIPTION
This addresses issue https://github.com/LadybirdBrowser/ladybird/issues/1177

When computing the min size, `should_treat_max_width_as_none` was always being called regardless of the dimension. This PR uses the appropriate one for the dimension.
