### PR TITLE
LibWeb: Use transform-box for resolving percentage transform values

### DIFF
--- a/Tests/LibWeb/Ref/reference/transform-box-ref.html
+++ b/Tests/LibWeb/Ref/reference/transform-box-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<style>
+.a {
+    border: 20px solid crimson;
+    transform: translateY(0px);
+}
+.b {
+    border: 20px solid crimson;
+    transform: translateY(40px);
+}
+</style>
+<div class="a"></div>
+<div class="b"></div>

--- a/Tests/LibWeb/Ref/transform-box.html
+++ b/Tests/LibWeb/Ref/transform-box.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<link rel="match" href="reference/transform-box-ref.html" />
+<style>
+div {
+    border: 20px solid crimson;
+    transform: translateY(100%);
+}
+</style>
+<div style="transform-box: fill-box"></div>
+<div></div>

--- a/Userland/Libraries/LibWeb/CSS/Transformation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Transformation.cpp
@@ -47,7 +47,7 @@ ErrorOr<Gfx::FloatMatrix4x4> Transformation::to_matrix(Optional<Painting::Painta
     CSSPixels width = 1;
     CSSPixels height = 1;
     if (paintable_box.has_value()) {
-        auto reference_box = paintable_box->absolute_padding_box_rect();
+        auto reference_box = paintable_box->transform_box_rect();
         width = reference_box.width();
         height = reference_box.height();
     }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -208,6 +208,7 @@ public:
 
     virtual bool wants_mouse_events() const override;
 
+    CSSPixelRect transform_box_rect() const;
     virtual void resolve_paint_properties() override;
 
     RefPtr<ScrollFrame const> nearest_scroll_frame() const;


### PR DESCRIPTION
This fixes issue https://github.com/LadybirdBrowser/ladybird/issues/1269

The content box was always being used to resolve transform length percentages, instead of the transform box. This PR factors out computing the transform box from `PaintableBox::resolve_paint_properties`. So that `Transformation::to_matrix` can use it, as its reference box.