### PR TITLE
LibWeb: Support jumping across word boundaries in text nodes

### DIFF
--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -113,6 +113,16 @@ bool code_point_has_control_general_category(u32 code_point)
     return code_point_has_general_category(code_point, U_CONTROL_CHAR);
 }
 
+bool code_point_has_punctuation_general_category(u32 code_point)
+{
+    return code_point_has_general_category(code_point, GENERAL_CATEGORY_PUNCTUATION);
+}
+
+bool code_point_has_separator_general_category(u32 code_point)
+{
+    return code_point_has_general_category(code_point, GENERAL_CATEGORY_SEPARATOR);
+}
+
 bool code_point_has_space_separator_general_category(u32 code_point)
 {
     return code_point_has_general_category(code_point, U_SPACE_SEPARATOR);

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -18,6 +18,8 @@ Optional<GeneralCategory> general_category_from_string(StringView);
 bool code_point_has_general_category(u32 code_point, GeneralCategory general_category);
 
 bool code_point_has_control_general_category(u32 code_point);
+bool code_point_has_punctuation_general_category(u32 code_point);
+bool code_point_has_separator_general_category(u32 code_point);
 bool code_point_has_space_separator_general_category(u32 code_point);
 
 Optional<Property> property_from_string(StringView);

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -128,8 +128,8 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     document().set_needs_layout();
 
-    if (m_segmenter)
-        m_segmenter->set_segmented_text(m_data);
+    if (m_grapheme_segmenter)
+        m_grapheme_segmenter->set_segmented_text(m_data);
 
     return {};
 }
@@ -155,14 +155,14 @@ WebIDL::ExceptionOr<void> CharacterData::delete_data(size_t offset, size_t count
     return replace_data(offset, count, String {});
 }
 
-Unicode::Segmenter& CharacterData::segmenter()
+Unicode::Segmenter& CharacterData::grapheme_segmenter()
 {
-    if (!m_segmenter) {
-        m_segmenter = Unicode::Segmenter::create(Unicode::SegmenterGranularity::Grapheme);
-        m_segmenter->set_segmented_text(m_data);
+    if (!m_grapheme_segmenter) {
+        m_grapheme_segmenter = Unicode::Segmenter::create(Unicode::SegmenterGranularity::Grapheme);
+        m_grapheme_segmenter->set_segmented_text(m_data);
     }
 
-    return *m_segmenter;
+    return *m_grapheme_segmenter;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -130,6 +130,8 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     if (m_grapheme_segmenter)
         m_grapheme_segmenter->set_segmented_text(m_data);
+    if (m_word_segmenter)
+        m_word_segmenter->set_segmented_text(m_data);
 
     return {};
 }
@@ -163,6 +165,16 @@ Unicode::Segmenter& CharacterData::grapheme_segmenter()
     }
 
     return *m_grapheme_segmenter;
+}
+
+Unicode::Segmenter& CharacterData::word_segmenter()
+{
+    if (!m_word_segmenter) {
+        m_word_segmenter = Unicode::Segmenter::create(Unicode::SegmenterGranularity::Word);
+        m_word_segmenter->set_segmented_text(m_data);
+    }
+
+    return *m_word_segmenter;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -41,6 +41,7 @@ public:
     WebIDL::ExceptionOr<void> replace_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units, String const&);
 
     Unicode::Segmenter& grapheme_segmenter();
+    Unicode::Segmenter& word_segmenter();
 
 protected:
     CharacterData(Document&, NodeType, String const&);
@@ -51,6 +52,7 @@ private:
     String m_data;
 
     OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
+    OwnPtr<Unicode::Segmenter> m_word_segmenter;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.h
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.h
@@ -40,7 +40,7 @@ public:
     WebIDL::ExceptionOr<void> delete_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units);
     WebIDL::ExceptionOr<void> replace_data(size_t offset_in_utf16_code_units, size_t count_in_utf16_code_units, String const&);
 
-    Unicode::Segmenter& segmenter();
+    Unicode::Segmenter& grapheme_segmenter();
 
 protected:
     CharacterData(Document&, NodeType, String const&);
@@ -50,7 +50,7 @@ protected:
 private:
     String m_data;
 
-    OwnPtr<Unicode::Segmenter> m_segmenter;
+    OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5423,6 +5423,24 @@ bool Document::decrement_cursor_position_offset()
     return true;
 }
 
+bool Document::increment_cursor_position_to_next_word()
+{
+    if (!m_cursor_position->increment_offset_to_next_word())
+        return false;
+
+    reset_cursor_blink_cycle();
+    return true;
+}
+
+bool Document::decrement_cursor_position_to_previous_word()
+{
+    if (!m_cursor_position->decrement_offset_to_previous_word())
+        return false;
+
+    reset_cursor_blink_cycle();
+    return true;
+}
+
 void Document::user_did_edit_document_text(Badge<EditEventHandler>)
 {
     reset_cursor_blink_cycle();

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -693,6 +693,8 @@ public:
     void set_cursor_position(JS::NonnullGCPtr<DOM::Position>);
     bool increment_cursor_position_offset();
     bool decrement_cursor_position_offset();
+    bool increment_cursor_position_to_next_word();
+    bool decrement_cursor_position_to_previous_word();
 
     bool cursor_blink_state() const { return m_cursor_blink_state; }
 

--- a/Userland/Libraries/LibWeb/DOM/Position.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Position.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Utf8View.h>
+#include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/DOM/Position.h>
@@ -64,6 +65,60 @@ bool Position::decrement_offset()
 
     // NOTE: Already at beginning of current node.
     return false;
+}
+
+static bool should_continue_beyond_word(Utf8View const& word)
+{
+    for (auto code_point : word) {
+        if (!Unicode::code_point_has_punctuation_general_category(code_point) && !Unicode::code_point_has_separator_general_category(code_point))
+            return false;
+    }
+
+    return true;
+}
+
+bool Position::increment_offset_to_next_word()
+{
+    if (!is<DOM::Text>(*m_node) || offset_is_at_end_of_node())
+        return false;
+
+    auto& node = static_cast<DOM::Text&>(*m_node);
+
+    while (true) {
+        if (auto offset = node.word_segmenter().next_boundary(m_offset); offset.has_value()) {
+            auto word = node.data().code_points().substring_view(m_offset, *offset - m_offset);
+            m_offset = *offset;
+
+            if (should_continue_beyond_word(word))
+                continue;
+        }
+
+        break;
+    }
+
+    return true;
+}
+
+bool Position::decrement_offset_to_previous_word()
+{
+    if (!is<DOM::Text>(*m_node) || m_offset == 0)
+        return false;
+
+    auto& node = static_cast<DOM::Text&>(*m_node);
+
+    while (true) {
+        if (auto offset = node.word_segmenter().previous_boundary(m_offset); offset.has_value()) {
+            auto word = node.data().code_points().substring_view(*offset, m_offset - *offset);
+            m_offset = *offset;
+
+            if (should_continue_beyond_word(word))
+                continue;
+        }
+
+        break;
+    }
+
+    return true;
 }
 
 bool Position::offset_is_at_end_of_node() const

--- a/Userland/Libraries/LibWeb/DOM/Position.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Position.cpp
@@ -41,7 +41,7 @@ bool Position::increment_offset()
 
     auto& node = verify_cast<DOM::Text>(*m_node);
 
-    if (auto offset = node.segmenter().next_boundary(m_offset); offset.has_value()) {
+    if (auto offset = node.grapheme_segmenter().next_boundary(m_offset); offset.has_value()) {
         m_offset = *offset;
         return true;
     }
@@ -57,7 +57,7 @@ bool Position::decrement_offset()
 
     auto& node = verify_cast<DOM::Text>(*m_node);
 
-    if (auto offset = node.segmenter().previous_boundary(m_offset); offset.has_value()) {
+    if (auto offset = node.grapheme_segmenter().previous_boundary(m_offset); offset.has_value()) {
         m_offset = *offset;
         return true;
     }

--- a/Userland/Libraries/LibWeb/DOM/Position.h
+++ b/Userland/Libraries/LibWeb/DOM/Position.h
@@ -36,6 +36,9 @@ public:
     bool increment_offset();
     bool decrement_offset();
 
+    bool increment_offset_to_next_word();
+    bool decrement_offset_to_previous_word();
+
     bool equals(JS::NonnullGCPtr<Position> other) const
     {
         return m_node.ptr() == other->m_node.ptr() && m_offset == other->m_offset;

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.cpp
@@ -22,7 +22,7 @@ void EditEventHandler::handle_delete_character_after(JS::NonnullGCPtr<DOM::Docum
     auto& node = verify_cast<DOM::Text>(*cursor_position->node());
     auto& text = node.data();
 
-    auto next_offset = node.segmenter().next_boundary(cursor_position->offset());
+    auto next_offset = node.grapheme_segmenter().next_boundary(cursor_position->offset());
     if (!next_offset.has_value()) {
         // FIXME: Move to the next node and delete the first character there.
         return;

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -929,6 +929,19 @@ bool EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u32 code
             return true;
         }
 
+#if defined(AK_OS_MACOS)
+        if ((modifiers & UIEvents::Mod_Super) != 0) {
+            if (key == UIEvents::KeyCode::Key_Left) {
+                key = UIEvents::KeyCode::Key_Home;
+                modifiers &= ~UIEvents::Mod_Super;
+            }
+            if (key == UIEvents::KeyCode::Key_Right) {
+                key = UIEvents::KeyCode::Key_End;
+                modifiers &= ~UIEvents::Mod_Super;
+            }
+        }
+#endif
+
         if (key == UIEvents::KeyCode::Key_Left || key == UIEvents::KeyCode::Key_Right) {
             auto increment_or_decrement_cursor = [&]() {
                 if ((modifiers & UIEvents::Mod_PlatformWordJump) == 0) {

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -931,9 +931,15 @@ bool EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u32 code
 
         if (key == UIEvents::KeyCode::Key_Left || key == UIEvents::KeyCode::Key_Right) {
             auto increment_or_decrement_cursor = [&]() {
+                if ((modifiers & UIEvents::Mod_PlatformWordJump) == 0) {
+                    if (key == UIEvents::KeyCode::Key_Left)
+                        return document->decrement_cursor_position_offset();
+                    return document->increment_cursor_position_offset();
+                }
+
                 if (key == UIEvents::KeyCode::Key_Left)
-                    return document->decrement_cursor_position_offset();
-                return document->increment_cursor_position_offset();
+                    return document->decrement_cursor_position_to_previous_word();
+                return document->increment_cursor_position_to_next_word();
             };
 
             if ((modifiers & UIEvents::Mod_Shift) == 0) {

--- a/Userland/Libraries/LibWeb/UIEvents/KeyCode.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyCode.h
@@ -185,8 +185,10 @@ enum KeyModifier {
 
 #if defined(AK_OS_MACOS)
     Mod_PlatformCtrl = Mod_Super,
+    Mod_PlatformWordJump = Mod_Alt,
 #else
     Mod_PlatformCtrl = Mod_Ctrl,
+    Mod_PlatformWordJump = Mod_Ctrl,
 #endif
 };
 


### PR DESCRIPTION
This supports using the ctrl+arrow keys on Linux and option+arrow keys on macOS to jump by word in text nodes (as well as holding shift to select the jumped word).


https://github.com/user-attachments/assets/e107ecdc-e6ae-4ef9-a0c8-120f6f8f3062



