### PR TITLE
LibWeb: Limit the minimum scrollbar size to the overflown box's size

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -286,8 +286,10 @@ Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(Scrol
     auto scrollport_size = direction == ScrollDirection::Horizontal ? padding_rect.width() : padding_rect.height();
     if (scroll_overflow_size == 0)
         return {};
-    auto const min_thumb_length = 50;
+
+    auto min_thumb_length = min(scrollport_size, 24);
     auto thumb_length = max(scrollport_size * (scrollport_size / scroll_overflow_size), min_thumb_length);
+
     CSSPixelFraction scroll_size = 0;
     if (scroll_overflow_size > scrollport_size)
         scroll_size = (scrollport_size - thumb_length) / (scroll_overflow_size - scrollport_size);


### PR DESCRIPTION
Slight regression from #1184. If an overflown box had a height less than the hard-coded minimum scrollbar length, we would paint the scrollbar past the end of the box:

![before](https://github.com/user-attachments/assets/5961c50c-f528-4d1a-b057-96357c7596c6)

This reduces the minimum scrollbar size, and limits it to the height/width of the box:

![after](https://github.com/user-attachments/assets/707df17f-430c-4bf3-a6da-782577a16b4f)

![after](https://github.com/user-attachments/assets/1c6d4958-4463-4d92-9f69-4298fff73057)

Firefox actually seems to hide the scrollbar if the box is less than 40px. I haven't done that here, to err on the side of at least indicating that the box is scrollable.