### PR TITLE
LibWebView+UI: Move the database and cookie jar to WebView::Application

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -13,7 +13,6 @@
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/HTML/ActivateTab.h>
-#include <LibWebView/CookieJar.h>
 
 #import <Cocoa/Cocoa.h>
 
@@ -22,7 +21,7 @@
 
 @interface ApplicationDelegate : NSObject <NSApplicationDelegate>
 
-- (nullable instancetype)initWithCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar;
+- (nullable instancetype)init;
 
 - (nonnull TabController*)createNewTab:(Optional<URL::URL> const&)url
                                fromTab:(nullable Tab*)tab
@@ -38,7 +37,6 @@
 
 - (void)removeTab:(nonnull TabController*)controller;
 
-- (WebView::CookieJar&)cookieJar;
 - (Web::CSS::PreferredColorScheme)preferredColorScheme;
 - (Web::CSS::PreferredContrast)preferredContrast;
 - (Web::CSS::PreferredMotion)preferredMotion;

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -5,6 +5,7 @@
  */
 
 #include <LibWebView/Application.h>
+#include <LibWebView/CookieJar.h>
 #include <LibWebView/SearchEngine.h>
 
 #import <Application/ApplicationDelegate.h>
@@ -30,9 +31,6 @@
 
 @interface ApplicationDelegate () <TaskManagerDelegate>
 {
-    // This will always be populated, but we cannot have a non-default constructible instance variable.
-    OwnPtr<WebView::CookieJar> m_cookie_jar;
-
     Web::CSS::PreferredColorScheme m_preferred_color_scheme;
     Web::CSS::PreferredContrast m_preferred_contrast;
     Web::CSS::PreferredMotion m_preferred_motion;
@@ -61,7 +59,7 @@
 
 @implementation ApplicationDelegate
 
-- (instancetype)initWithCookieJar:(NonnullOwnPtr<WebView::CookieJar>)cookie_jar
+- (instancetype)init
 {
     if (self = [super init]) {
         [NSApp setMainMenu:[[NSMenu alloc] init]];
@@ -78,8 +76,6 @@
         [[NSApp mainMenu] addItem:[self createHelpMenu]];
 
         self.managed_tabs = [[NSMutableArray alloc] init];
-
-        m_cookie_jar = move(cookie_jar);
 
         m_preferred_color_scheme = Web::CSS::PreferredColorScheme::Auto;
         m_preferred_contrast = Web::CSS::PreferredContrast::Auto;
@@ -136,11 +132,6 @@
             [self.task_manager_controller.window close];
         }
     }
-}
-
-- (WebView::CookieJar&)cookieJar
-{
-    return *m_cookie_jar;
 }
 
 - (Web::CSS::PreferredColorScheme)preferredColorScheme
@@ -333,7 +324,7 @@
 
 - (void)dumpCookies:(id)sender
 {
-    m_cookie_jar->dump_cookies();
+    WebView::Application::cookie_jar().dump_cookies();
 }
 
 - (NSMenuItem*)createApplicationMenu

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -10,6 +10,8 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
+#include <LibWebView/Application.h>
+#include <LibWebView/CookieJar.h>
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <LibWebView/URL.h>
@@ -973,28 +975,23 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     };
 
     m_web_view_bridge->on_get_all_cookies = [](auto const& url) {
-        auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        return [delegate cookieJar].get_all_cookies(url);
+        return WebView::Application::cookie_jar().get_all_cookies(url);
     };
 
     m_web_view_bridge->on_get_named_cookie = [](auto const& url, auto const& name) {
-        auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        return [delegate cookieJar].get_named_cookie(url, name);
+        return WebView::Application::cookie_jar().get_named_cookie(url, name);
     };
 
     m_web_view_bridge->on_get_cookie = [](auto const& url, auto source) {
-        auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        return [delegate cookieJar].get_cookie(url, source);
+        return WebView::Application::cookie_jar().get_cookie(url, source);
     };
 
     m_web_view_bridge->on_set_cookie = [](auto const& url, auto const& cookie, auto source) {
-        auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        [delegate cookieJar].set_cookie(url, cookie, source);
+        WebView::Application::cookie_jar().set_cookie(url, cookie, source);
     };
 
     m_web_view_bridge->on_update_cookie = [](auto const& cookie) {
-        auto* delegate = (ApplicationDelegate*)[NSApp delegate];
-        [delegate cookieJar].update_cookie(cookie);
+        WebView::Application::cookie_jar().update_cookie(cookie);
     };
 
     m_web_view_bridge->on_restore_window = [weak_self]() {

--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -12,8 +12,6 @@
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/ChromeProcess.h>
-#include <LibWebView/CookieJar.h>
-#include <LibWebView/Database.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -84,15 +82,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             view->did_allocate_iosurface_backing_stores(message.front_backing_store_id, move(message.front_backing_store_port), message.back_backing_store_id, move(message.back_backing_store_port));
     };
 
-    auto database = TRY(WebView::Database::create());
-    auto cookie_jar = TRY(WebView::CookieJar::create(*database));
-
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
     TRY([application launchRequestServer]);
 
     TRY([application launchImageDecoder]);
 
-    auto* delegate = [[ApplicationDelegate alloc] initWithCookieJar:move(cookie_jar)];
+    auto* delegate = [[ApplicationDelegate alloc] init];
     [NSApp setDelegate:delegate];
 
     return WebView::Application::the().execute();

--- a/Ladybird/Qt/Application.cpp
+++ b/Ladybird/Qt/Application.cpp
@@ -110,9 +110,9 @@ void Application::close_task_manager_window()
     }
 }
 
-BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar& cookie_jar, BrowserWindow::IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
+BrowserWindow& Application::new_window(Vector<URL::URL> const& initial_urls, BrowserWindow::IsPopupWindow is_popup_window, Tab* parent_tab, Optional<u64> page_index)
 {
-    auto* window = new BrowserWindow(initial_urls, cookie_jar, is_popup_window, parent_tab, move(page_index));
+    auto* window = new BrowserWindow(initial_urls, is_popup_window, parent_tab, move(page_index));
     set_active_window(*window);
     window->show();
     if (initial_urls.is_empty()) {

--- a/Ladybird/Qt/Application.h
+++ b/Ladybird/Qt/Application.h
@@ -34,7 +34,7 @@ public:
     NonnullRefPtr<ImageDecoderClient::Client> image_decoder_client() const { return *m_image_decoder_client; }
     ErrorOr<void> initialize_image_decoder();
 
-    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     void show_task_manager_window();
     void close_task_manager_window();

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -35,7 +35,7 @@ public:
         Yes,
     };
 
-    BrowserWindow(Vector<URL::URL> const& initial_urls, WebView::CookieJar&, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
+    BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow is_popup_window = IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
     WebContentView& view() const { return m_current_tab->view(); }
 
@@ -213,8 +213,6 @@ private:
     ByteString m_navigator_compatibility_mode {};
 
     SettingsDialog* m_settings_dialog { nullptr };
-
-    WebView::CookieJar& m_cookie_jar;
 
     IsPopupWindow m_is_popup_window { IsPopupWindow::No };
 };

--- a/Userland/Libraries/LibWebView/Application.cpp
+++ b/Userland/Libraries/LibWebView/Application.cpp
@@ -12,6 +12,8 @@
 #include <LibFileSystem/FileSystem.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/CookieJar.h>
+#include <LibWebView/Database.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
 #include <LibWebView/WebContentClient.h>
@@ -138,6 +140,13 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     };
 
     create_platform_options(m_chrome_options, m_web_content_options);
+
+    if (m_chrome_options.disable_sql_database == DisableSQLDatabase::No) {
+        m_database = Database::create().release_value_but_fixme_should_propagate_errors();
+        m_cookie_jar = CookieJar::create(*m_database).release_value_but_fixme_should_propagate_errors();
+    } else {
+        m_cookie_jar = CookieJar::create();
+    }
 }
 
 int Application::execute()

--- a/Userland/Libraries/LibWebView/Application.h
+++ b/Userland/Libraries/LibWebView/Application.h
@@ -34,6 +34,8 @@ public:
     static ChromeOptions const& chrome_options() { return the().m_chrome_options; }
     static WebContentOptions const& web_content_options() { return the().m_web_content_options; }
 
+    static CookieJar& cookie_jar() { return *the().m_cookie_jar; }
+
     Core::EventLoop& event_loop() { return m_event_loop; }
 
     void add_child_process(Process&&);
@@ -76,6 +78,9 @@ private:
 
     ChromeOptions m_chrome_options;
     WebContentOptions m_web_content_options;
+
+    RefPtr<Database> m_database;
+    OwnPtr<CookieJar> m_cookie_jar;
 
     OwnPtr<Core::TimeZoneWatcher> m_time_zone_watcher;
 


### PR DESCRIPTION
The main motivator here was noticing that `--disable-sql-database` did not work with AppKit. Rather than re-implementing this there, move ownership of these classes to `WebView::Application`, so that each UI does not need to individually worry about it.