### PR TITLE
General code improvements (LibHTTP, LibURL, Fuzzers)

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -76,7 +76,7 @@ ErrorOr<ByteBuffer> HttpRequest::to_raw_request() const
         }
         // Finish headers.
         TRY(builder.try_append("\r\n"sv));
-        TRY(builder.try_append((char const*)m_body.data(), m_body.size()));
+        TRY(builder.try_append(reinterpret_cast<char const*>(m_body.data()), m_body.size()));
     } else {
         // Finish headers.
         TRY(builder.try_append("\r\n"sv));

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -590,7 +590,7 @@ void Job::finish_up()
         auto flattened_buffer = maybe_flattened_buffer.release_value();
 
         u8* flat_ptr = flattened_buffer.data();
-        for (auto& received_buffer : m_received_buffers) {
+        for (const auto& received_buffer : m_received_buffers) {
             memcpy(flat_ptr, received_buffer->pending_flush.data(), received_buffer->pending_flush.size());
             flat_ptr += received_buffer->pending_flush.size();
         }

--- a/Userland/Libraries/LibURL/Parser.cpp
+++ b/Userland/Libraries/LibURL/Parser.cpp
@@ -304,9 +304,8 @@ static void serialize_ipv6_address(IPv6Address const& address, StringBuilder& ou
         if (ignore0 && address[piece_index] == 0)
             continue;
 
-        // 2. Otherwise, if ignore0 is true, set ignore0 to false.
-        if (ignore0)
-            ignore0 = false;
+        // 2. Set ignore0 to false.
+        ignore0 = false;
 
         // 3. If compress is pieceIndex, then:
         if (compress == piece_index) {


### PR DESCRIPTION
- LibHTTP: Enforced proper typecasting and added const correctness
- LibURL: Fixed a case of `ignore0` being checked before assignment
- Fuzzers: Fixed some memory leaks