### PR TITLE
Tests: Add some colorful pass/fail emoji to a test case

### DIFF
--- a/Tests/LibWeb/Text/expected/aria-attribute-reflection.txt
+++ b/Tests/LibWeb/Text/expected/aria-attribute-reflection.txt
@@ -1,231 +1,231 @@
                                              Element Reflection for ARIA properties
 Testing: role attribute reflects.
-    PASS: button is equal to button as expected.
-    PASS: checkbox is equal to checkbox as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: button is equal to button as expected.
+    ✅ PASS: checkbox is equal to checkbox as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-atomic attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-autocomplete attribute reflects.
-    PASS: list is equal to list as expected.
-    PASS: inline is equal to inline as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: list is equal to list as expected.
+    ✅ PASS: inline is equal to inline as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-braillelabel attribute reflects.
-    FAIL: undefined is not equal to x.
-    FAIL: x is not equal to y.
-    PASS: null is equal to null as expected.
-    FAIL: Expected false but got true.
-    PASS: undefined is equal to null as expected.
-    FAIL: Expected false but got true.
+    ❌ FAIL: undefined is not equal to x.
+    ❌ FAIL: x is not equal to y.
+    ✅ PASS: null is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
+    ✅ PASS: undefined is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
 Testing: aria-brailleroledescription attribute reflects.
-    FAIL: undefined is not equal to x.
-    FAIL: x is not equal to y.
-    PASS: null is equal to null as expected.
-    FAIL: Expected false but got true.
-    PASS: undefined is equal to null as expected.
-    FAIL: Expected false but got true.
+    ❌ FAIL: undefined is not equal to x.
+    ❌ FAIL: x is not equal to y.
+    ✅ PASS: null is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
+    ✅ PASS: undefined is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
 Testing: aria-busy attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-checked attribute reflects.
-    PASS: mixed is equal to mixed as expected.
-    PASS: true is equal to true as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: mixed is equal to mixed as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-colcount attribute reflects.
-    PASS: 5 is equal to 5 as expected.
-    PASS: 6 is equal to 6 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 5 is equal to 5 as expected.
+    ✅ PASS: 6 is equal to 6 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-colindex attribute reflects.
-    PASS: 1 is equal to 1 as expected.
-    PASS: 2 is equal to 2 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 1 is equal to 1 as expected.
+    ✅ PASS: 2 is equal to 2 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-colindextext attribute reflects.
-    FAIL: undefined is not equal to x.
-    FAIL: x is not equal to y.
-    PASS: null is equal to null as expected.
-    FAIL: Expected false but got true.
-    PASS: undefined is equal to null as expected.
-    FAIL: Expected false but got true.
+    ❌ FAIL: undefined is not equal to x.
+    ❌ FAIL: x is not equal to y.
+    ✅ PASS: null is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
+    ✅ PASS: undefined is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
 Testing: aria-colspan attribute reflects.
-    PASS: 2 is equal to 2 as expected.
-    PASS: 3 is equal to 3 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 2 is equal to 2 as expected.
+    ✅ PASS: 3 is equal to 3 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-current attribute reflects.
-    PASS: page is equal to page as expected.
-    PASS: step is equal to step as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: page is equal to page as expected.
+    ✅ PASS: step is equal to step as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-description attribute reflects.
-    FAIL: undefined is not equal to cold as ice.
-    FAIL: cold as ice is not equal to hot as fire.
-    PASS: null is equal to null as expected.
-    FAIL: Expected false but got true.
-    PASS: undefined is equal to null as expected.
-    FAIL: Expected false but got true.
+    ❌ FAIL: undefined is not equal to cold as ice.
+    ❌ FAIL: cold as ice is not equal to hot as fire.
+    ✅ PASS: null is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
+    ✅ PASS: undefined is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
 Testing: aria-disabled attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-expanded attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-haspopup attribute reflects.
-    PASS: menu is equal to menu as expected.
-    PASS: listbox is equal to listbox as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: menu is equal to menu as expected.
+    ✅ PASS: listbox is equal to listbox as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-hidden attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-invalid attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: grammar is equal to grammar as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: grammar is equal to grammar as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-keyshortcuts attribute reflects.
-    PASS: x is equal to x as expected.
-    PASS: y is equal to y as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: x is equal to x as expected.
+    ✅ PASS: y is equal to y as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-label attribute reflects.
-    PASS: x is equal to x as expected.
-    PASS: y is equal to y as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: x is equal to x as expected.
+    ✅ PASS: y is equal to y as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-level attribute reflects.
-    PASS: 1 is equal to 1 as expected.
-    PASS: 2 is equal to 2 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 1 is equal to 1 as expected.
+    ✅ PASS: 2 is equal to 2 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-live attribute reflects.
-    PASS: polite is equal to polite as expected.
-    PASS: assertive is equal to assertive as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: polite is equal to polite as expected.
+    ✅ PASS: assertive is equal to assertive as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-modal attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-multiline attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-multiselectable attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-orientation attribute reflects.
-    PASS: vertical is equal to vertical as expected.
-    PASS: horizontal is equal to horizontal as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: vertical is equal to vertical as expected.
+    ✅ PASS: horizontal is equal to horizontal as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-placeholder attribute reflects.
-    PASS: x is equal to x as expected.
-    PASS: y is equal to y as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: x is equal to x as expected.
+    ✅ PASS: y is equal to y as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-posinset attribute reflects.
-    PASS: 10 is equal to 10 as expected.
-    PASS: 11 is equal to 11 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 10 is equal to 10 as expected.
+    ✅ PASS: 11 is equal to 11 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-pressed attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-readonly attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-relevant attribute reflects.
-    PASS: text is equal to text as expected.
-    PASS: removals is equal to removals as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: text is equal to text as expected.
+    ✅ PASS: removals is equal to removals as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-required attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-roledescription attribute reflects.
-    PASS: x is equal to x as expected.
-    PASS: y is equal to y as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: x is equal to x as expected.
+    ✅ PASS: y is equal to y as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-rowcount attribute reflects.
-    PASS: 10 is equal to 10 as expected.
-    PASS: 11 is equal to 11 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 10 is equal to 10 as expected.
+    ✅ PASS: 11 is equal to 11 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-rowindex attribute reflects.
-    PASS: 1 is equal to 1 as expected.
-    PASS: 2 is equal to 2 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 1 is equal to 1 as expected.
+    ✅ PASS: 2 is equal to 2 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-rowindextext attribute reflects.
-    FAIL: undefined is not equal to x.
-    FAIL: x is not equal to y.
-    PASS: null is equal to null as expected.
-    FAIL: Expected false but got true.
-    PASS: undefined is equal to null as expected.
-    FAIL: Expected false but got true.
+    ❌ FAIL: undefined is not equal to x.
+    ❌ FAIL: x is not equal to y.
+    ✅ PASS: null is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
+    ✅ PASS: undefined is equal to null as expected.
+    ❌ FAIL: Expected false but got true.
 Testing: aria-rowspan attribute reflects.
-    PASS: 2 is equal to 2 as expected.
-    PASS: 3 is equal to 3 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 2 is equal to 2 as expected.
+    ✅ PASS: 3 is equal to 3 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-selected attribute reflects.
-    PASS: true is equal to true as expected.
-    PASS: false is equal to false as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: true is equal to true as expected.
+    ✅ PASS: false is equal to false as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-setsize attribute reflects.
-    PASS: 10 is equal to 10 as expected.
-    PASS: 11 is equal to 11 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 10 is equal to 10 as expected.
+    ✅ PASS: 11 is equal to 11 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-sort attribute reflects.
-    PASS: descending is equal to descending as expected.
-    PASS: ascending is equal to ascending as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: descending is equal to descending as expected.
+    ✅ PASS: ascending is equal to ascending as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-valuemax attribute reflects.
-    PASS: 99 is equal to 99 as expected.
-    PASS: 100 is equal to 100 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 99 is equal to 99 as expected.
+    ✅ PASS: 100 is equal to 100 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-valuemin attribute reflects.
-    PASS: 3 is equal to 3 as expected.
-    PASS: 2 is equal to 2 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 3 is equal to 3 as expected.
+    ✅ PASS: 2 is equal to 2 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-valuenow attribute reflects.
-    PASS: 50 is equal to 50 as expected.
-    PASS: 51 is equal to 51 as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 50 is equal to 50 as expected.
+    ✅ PASS: 51 is equal to 51 as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.
 Testing: aria-valuetext attribute reflects.
-    PASS: 50% is equal to 50% as expected.
-    PASS: 51% is equal to 51% as expected.
-    PASS: null is equal to null as expected.
-    PASS: null is equal to null as expected.
+    ✅ PASS: 50% is equal to 50% as expected.
+    ✅ PASS: 51% is equal to 51% as expected.
+    ✅ PASS: null is equal to null as expected.
+    ✅ PASS: null is equal to null as expected.

--- a/Tests/LibWeb/Text/input/aria-attribute-reflection.html
+++ b/Tests/LibWeb/Text/input/aria-attribute-reflection.html
@@ -7,14 +7,14 @@
     }
     function assert_false(expression) {
       if (expression) {
-          println("    FAIL: Expected false but got true.");
+          println("    ❌ FAIL: Expected false but got true.");
       }
     }
     function assert_equals(a, b) {
       if (a == b) {
-          println(`    PASS: ${a} is equal to ${b} as expected.`);
+          println(`    ✅ PASS: ${a} is equal to ${b} as expected.`);
       } else {
-          println(`    FAIL: ${a} is not equal to ${b}.`);
+          println(`    ❌ FAIL: ${a} is not equal to ${b}.`);
       }
     }
     function testNullable(element, jsAttr, contentAttr) {


### PR DESCRIPTION
Now we that we (again) have emoji being rendered as expected, one possible good internal use is: adding colored indicators in test cases.

This change adds green and red pass/fail emoji indicators to an in-tree test — to make it easier to manually scan through the test results and quickly see which cases are passing, and which are failing.

Output looks like this:

![image](https://github.com/user-attachments/assets/31f23f0f-31e9-4512-8003-2369c8119194)
