### PR TITLE
LibWebView: Add a storage tab to the Inspector to manage cookies

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -276,6 +276,9 @@ details > :not(:first-child) {
 .property-table td {
     padding: 4px;
     text-align: left;
+
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 #fonts {

--- a/Base/res/ladybird/inspector.html
+++ b/Base/res/ladybird/inspector.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="color-scheme" content="dark light">
+    <title>Inspector</title>
+
+    <style type="text/css">@INSPECTOR_STYLE@</style>
+    <link href="@INSPECTOR_CSS@" rel="stylesheet" />
+</head>
+<body>
+    <div class="split-view">
+        <div id="inspector-top" class="split-view-container" style="height: 60%">
+            <div class="tab-controls-container">
+                <div class="global-controls"></div>
+
+                <div class="tab-controls">
+                    <button id="dom-tree-button" onclick="selectTopTab(this, 'dom-tree')">DOM Tree</button>
+                    <button id="accessibility-tree-button" onclick="selectTopTab(this, 'accessibility-tree')">Accessibility Tree</button>
+                    <button id="style-sheets-button" onclick="selectTopTab(this, 'style-sheets')">Style Sheets</button>
+                </div>
+
+                <div class="global-controls">
+                    <button id="export-inspector-button" title="Export the Inspector to an HTML file" onclick="inspector.exportInspector()"></button>
+                </div>
+            </div>
+
+            <div id="dom-tree" class="tab-content html"></div>
+            <div id="accessibility-tree" class="tab-content"></div>
+
+            <div id="style-sheets" class="tab-content" style="padding: 0">
+                <div class="tab-header">
+                    <select id="style-sheet-picker" disabled onchange="loadStyleSheet()">
+                        <option value="." selected>No style sheets found</option>
+                    </select>
+                </div>
+
+                <div id="style-sheet-source"></div>
+            </div>
+        </div>
+
+        <div id="inspector-separator" class="split-view-separator">
+            <svg viewBox="0 0 16 5" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="2" cy="2.5" r="2" />
+                <circle cx="8" cy="2.5" r="2" />
+                <circle cx="14" cy="2.5" r="2" />
+            </svg>
+        </div>
+
+        <div id="inspector-bottom" class="split-view-container" style="height: calc(40% - 5px)">
+            <div class="tab-controls-container">
+                <div class="global-controls"></div>
+
+                <div class="tab-controls">
+                    <button id="console-button" onclick="selectBottomTab(this, 'console')">Console</button>
+                    <button id="computed-style-button" onclick="selectBottomTab(this, 'computed-style')">Computed Style</button>
+                    <button id="resolved-style-button" onclick="selectBottomTab(this, 'resolved-style')">Resolved Style</button>
+                    <button id="custom-properties-button" onclick="selectBottomTab(this, 'custom-properties')">Custom Properties</button>
+                    <button id="font-button" onclick="selectBottomTab(this, 'fonts')">Fonts</button>
+                </div>
+
+                <div class="global-controls"></div>
+            </div>
+
+            <div id="console" class="tab-content">
+                <div class="console">
+                    <div id="console-output" class="console-output"></div>
+                    <div class="console-input">
+                        <label for="console-input" class="console-prompt">&gt;&gt;</label>
+                        <input id="console-input" type="text" placeholder="Enter statement to execute">
+                        <button id="console-clear" title="Clear the console output" onclick="inspector.clearConsoleOutput()">X</button>
+                    </div>
+                </div>
+            </div>
+
+            @COMPUTED_STYLE@
+            @RESOVLED_STYLE@
+            @CUSTOM_PROPERTIES@
+
+            <div id="fonts" class="tab-content">
+                <div id="fonts-list"></div>
+            </div>
+        </div>
+    </div>
+
+    <script type="text/javascript" src="@INSPECTOR_JS@"></script>
+</body>
+</html>

--- a/Base/res/ladybird/inspector.html
+++ b/Base/res/ladybird/inspector.html
@@ -16,6 +16,7 @@
                 <div class="tab-controls">
                     <button id="dom-tree-button" onclick="selectTopTab(this, 'dom-tree')">DOM Tree</button>
                     <button id="accessibility-tree-button" onclick="selectTopTab(this, 'accessibility-tree')">Accessibility Tree</button>
+                    <button id="storage-button" onclick="selectTopTab(this, 'storage')">Storage</button>
                     <button id="style-sheets-button" onclick="selectTopTab(this, 'style-sheets')">Style Sheets</button>
                 </div>
 
@@ -26,6 +27,32 @@
 
             <div id="dom-tree" class="tab-content html"></div>
             <div id="accessibility-tree" class="tab-content"></div>
+
+            <div id="storage" class="tab-content" style="padding: 0">
+                <div class="tab-header">
+                    <select id="storage-picker">
+                        <option value="cookies" selected>Cookies</option>
+                    </select>
+                </div>
+
+                <div id="cookie-storage">
+                    <table class="property-table">
+                        <thead>
+                            <tr>
+                                <th style="width: 10%">Name</th>
+                                <th style="width: 15%">Value</th>
+                                <th style="width: 10%">Domain</th>
+                                <th style="width: 5%">Path</th>
+                                <th style="width: 20%">Created</th>
+                                <th style="width: 20%">Last Accessed</th>
+                                <th style="width: 20%">Expires</th>
+                            </tr>
+                        </thead>
+                        <tbody id="cookie-table">
+                        </tbody>
+                    </table>
+                </div>
+            </div>
 
             <div id="style-sheets" class="tab-content" style="padding: 0">
                 <div class="tab-header">

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -235,6 +235,11 @@ inspector.setCookies = cookies => {
             addColumn(row, new Date(cookie.creationTime).toLocaleString());
             addColumn(row, new Date(cookie.lastAccessTime).toLocaleString());
             addColumn(row, new Date(cookie.expiryTime).toLocaleString());
+
+            row.addEventListener("contextmenu", event => {
+                inspector.requestCookieContextMenu(cookie.index, event.clientX, event.clientY);
+                event.preventDefault();
+            });
         });
 
     oldTable.parentNode.replaceChild(newTable, oldTable);

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -103,6 +103,9 @@ inspector.reset = () => {
     let accessibilityTree = document.getElementById("accessibility-tree");
     accessibilityTree.innerHTML = "";
 
+    let cookieTable = document.getElementById("cookie-table");
+    cookieTable.innerHTML = "";
+
     let styleSheetPicker = document.getElementById("style-sheet-picker");
     styleSheetPicker.replaceChildren();
 
@@ -206,6 +209,35 @@ inspector.addAttributeToDOMNodeID = nodeID => {
     addAttributeToDOMNode(pendingEditDOMNode);
 
     pendingEditDOMNode = null;
+};
+
+inspector.setCookies = cookies => {
+    let oldTable = document.getElementById("cookie-table");
+
+    let newTable = document.createElement("tbody");
+    newTable.setAttribute("id", oldTable.id);
+
+    const addColumn = (row, value) => {
+        let column = row.insertCell();
+        column.innerText = value;
+        column.title = value;
+    };
+
+    cookies
+        .sort((lhs, rhs) => lhs.name.localeCompare(rhs.name))
+        .forEach(cookie => {
+            let row = newTable.insertRow();
+
+            addColumn(row, cookie.name);
+            addColumn(row, cookie.value);
+            addColumn(row, cookie.domain);
+            addColumn(row, cookie.path);
+            addColumn(row, new Date(cookie.creationTime).toLocaleString());
+            addColumn(row, new Date(cookie.lastAccessTime).toLocaleString());
+            addColumn(row, new Date(cookie.expiryTime).toLocaleString());
+        });
+
+    oldTable.parentNode.replaceChild(newTable, oldTable);
 };
 
 inspector.setStyleSheets = styleSheets => {

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -103,6 +103,15 @@ inspector.reset = () => {
     let accessibilityTree = document.getElementById("accessibility-tree");
     accessibilityTree.innerHTML = "";
 
+    let styleSheetPicker = document.getElementById("style-sheet-picker");
+    styleSheetPicker.replaceChildren();
+
+    let styleSheetSource = document.getElementById("style-sheet-source");
+    styleSheetSource.innerHTML = "";
+
+    let fontsList = document.getElementById("fonts-list");
+    fontsList.innerHTML = "";
+
     selectedDOMNode = null;
     pendingEditDOMNode = null;
 

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -47,6 +47,7 @@ private:
     QMenu* m_dom_node_text_context_menu { nullptr };
     QMenu* m_dom_node_tag_context_menu { nullptr };
     QMenu* m_dom_node_attribute_context_menu { nullptr };
+    QMenu* m_cookie_context_menu { nullptr };
 
     QAction* m_edit_node_action { nullptr };
     QAction* m_copy_node_action { nullptr };
@@ -58,6 +59,8 @@ private:
     QAction* m_add_attribute_action { nullptr };
     QAction* m_remove_attribute_action { nullptr };
     QAction* m_copy_attribute_value_action { nullptr };
+    QAction* m_delete_cookie_action { nullptr };
+    QAction* m_delete_all_cookies_action { nullptr };
 };
 
 }

--- a/Ladybird/cmake/ResourceFiles.cmake
+++ b/Ladybird/cmake/ResourceFiles.cmake
@@ -63,6 +63,7 @@ list(TRANSFORM BROWSER_ICONS PREPEND "${LADYBIRD_SOURCE_DIR}/Base/res/icons/brow
 set(WEB_RESOURCES
     about.html
     inspector.css
+    inspector.html
     inspector.js
     newtab.html
 )

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -77,6 +77,11 @@ void Inspector::request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 cli
     inspector_page_client().inspector_did_request_dom_tree_context_menu(node_id, { client_x, client_y }, type, tag, attribute_index.map([](auto index) { return static_cast<size_t>(index); }));
 }
 
+void Inspector::request_cookie_context_menu(WebIDL::UnsignedLongLong cookie_index, i32 client_x, i32 client_y)
+{
+    inspector_page_client().inspector_did_request_cookie_context_menu(cookie_index, { client_x, client_y });
+}
+
 void Inspector::request_style_sheet_source(String const& type_string, Optional<i32> const& dom_node_unique_id, Optional<String> const& url)
 {
     auto type = CSS::style_sheet_identifier_type_from_string(type_string);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -29,6 +29,8 @@ public:
 
     void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index);
 
+    void request_cookie_context_menu(WebIDL::UnsignedLongLong cookie_index, i32 client_x, i32 client_y);
+
     void request_style_sheet_source(String const& type, Optional<i32> const& dom_node_unique_id, Optional<String> const& url);
 
     void execute_console_script(String const& script);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -12,6 +12,8 @@
 
     undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tag, unsigned long long? attributeIndex);
 
+    undefined requestCookieContextMenu(unsigned long long cookieIndex, long clientX, long clientY);
+
     undefined requestStyleSheetSource(DOMString type, long? domNodeID, DOMString? url);
 
     undefined executeConsoleScript(DOMString script);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -377,6 +377,7 @@ public:
     virtual void inspector_did_add_dom_node_attributes([[maybe_unused]] i32 node_id, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> attributes) { }
     virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] size_t attribute_index, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }
     virtual void inspector_did_request_dom_tree_context_menu([[maybe_unused]] i32 node_id, [[maybe_unused]] CSSPixelPoint position, [[maybe_unused]] String const& type, [[maybe_unused]] Optional<String> const& tag, [[maybe_unused]] Optional<size_t> const& attribute_index) { }
+    virtual void inspector_did_request_cookie_context_menu([[maybe_unused]] size_t cookie_index, [[maybe_unused]] CSSPixelPoint position) { }
     virtual void inspector_did_request_style_sheet_source([[maybe_unused]] CSS::StyleSheetIdentifier const& identifier) { }
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
     virtual void inspector_did_export_inspector_html([[maybe_unused]] String const& html) { }

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -39,10 +39,13 @@ public:
     void context_menu_add_dom_node_attribute();
     void context_menu_remove_dom_node_attribute();
     void context_menu_copy_dom_node_attribute_value();
+    void context_menu_delete_cookie();
+    void context_menu_delete_all_cookies();
 
     Function<void(Gfx::IntPoint)> on_requested_dom_node_text_context_menu;
     Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_tag_context_menu;
     Function<void(Gfx::IntPoint, String const&, Attribute const&)> on_requested_dom_node_attribute_context_menu;
+    Function<void(Gfx::IntPoint, Web::Cookie::Cookie const&)> on_requested_cookie_context_menu;
 
 private:
     void load_inspector();
@@ -85,6 +88,7 @@ private:
     HashMap<int, Vector<Attribute>> m_dom_node_attributes;
 
     Vector<Web::Cookie::Cookie> m_cookies;
+    Optional<size_t> m_cookie_context_menu_index;
 
     i32 m_highest_notified_message_index { -1 };
     i32 m_highest_received_message_index { -1 };

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -51,6 +51,8 @@ private:
     String generate_accessibility_tree(JsonObject const&);
     void select_node(i32 node_id);
 
+    void load_cookies();
+
     void request_console_messages();
     void handle_console_message(i32 message_index);
     void handle_console_messages(i32 start_index, ReadonlySpan<ByteString> message_types, ReadonlySpan<ByteString> messages);
@@ -81,6 +83,8 @@ private:
     Optional<ContextMenuData> m_context_menu_data;
 
     HashMap<int, Vector<Attribute>> m_dom_node_attributes;
+
+    Vector<Web::Cookie::Cookie> m_cookies;
 
     i32 m_highest_notified_message_index { -1 };
     i32 m_highest_received_message_index { -1 };

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -223,6 +223,7 @@ public:
     Function<void(i32, Vector<Attribute> const&)> on_inspector_added_dom_node_attributes;
     Function<void(i32, size_t, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
     Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&, Optional<size_t> const&)> on_inspector_requested_dom_tree_context_menu;
+    Function<void(size_t, Gfx::IntPoint)> on_inspector_requested_cookie_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
     Function<void(String const&)> on_inspector_exported_inspector_html;
     Function<IPC::File()> on_request_worker_agent;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -685,6 +685,14 @@ void WebContentClient::inspector_did_request_dom_tree_context_menu(u64 page_id, 
     }
 }
 
+void WebContentClient::inspector_did_request_cookie_context_menu(u64 page_id, size_t cookie_index, Gfx::IntPoint position)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_inspector_requested_cookie_context_menu)
+            view->on_inspector_requested_cookie_context_menu(cookie_index, view->to_widget_position(position));
+    }
+}
+
 void WebContentClient::inspector_did_execute_console_script(u64 page_id, String const& script)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -120,6 +120,7 @@ private:
     virtual void inspector_did_add_dom_node_attributes(u64 page_id, i32 node_id, Vector<Attribute> const& attributes) override;
     virtual void inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, size_t attribute_index, Vector<Attribute> const& replacement_attributes) override;
     virtual void inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index) override;
+    virtual void inspector_did_request_cookie_context_menu(u64 page_id, size_t cookie_index, Gfx::IntPoint position) override;
     virtual void inspector_did_execute_console_script(u64 page_id, String const& script) override;
     virtual void inspector_did_export_inspector_html(u64 page_id, String const& html) override;
     virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -658,6 +658,11 @@ void PageClient::inspector_did_request_dom_tree_context_menu(i32 node_id, Web::C
     client().async_inspector_did_request_dom_tree_context_menu(m_id, node_id, page().css_to_device_point(position).to_type<int>(), type, tag, attribute_index);
 }
 
+void PageClient::inspector_did_request_cookie_context_menu(size_t cookie_index, Web::CSSPixelPoint position)
+{
+    client().async_inspector_did_request_cookie_context_menu(m_id, cookie_index, page().css_to_device_point(position).to_type<int>());
+}
+
 void PageClient::inspector_did_request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& identifier)
 {
     client().async_inspector_did_request_style_sheet_source(m_id, identifier);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -169,6 +169,7 @@ private:
     virtual void inspector_did_add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> attributes) override;
     virtual void inspector_did_replace_dom_node_attribute(i32 node_id, size_t attribute_index, JS::NonnullGCPtr<Web::DOM::NamedNodeMap> replacement_attributes) override;
     virtual void inspector_did_request_dom_tree_context_menu(i32 node_id, Web::CSSPixelPoint position, String const& type, Optional<String> const& tag, Optional<size_t> const& attribute_index) override;
+    virtual void inspector_did_request_cookie_context_menu(size_t cookie_index, Web::CSSPixelPoint position) override;
     virtual void inspector_did_request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& stylesheet_source) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
     virtual void inspector_did_export_inspector_html(String const& script) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -105,6 +105,7 @@ endpoint WebContentClient
     inspector_did_add_dom_node_attributes(u64 page_id, i32 node_id, Vector<WebView::Attribute> attributes) =|
     inspector_did_replace_dom_node_attribute(u64 page_id, i32 node_id, size_t attribute_index, Vector<WebView::Attribute> replacement_attributes) =|
     inspector_did_request_dom_tree_context_menu(u64 page_id, i32 node_id, Gfx::IntPoint position, String type, Optional<String> tag, Optional<size_t> attribute_index) =|
+    inspector_did_request_cookie_context_menu(u64 page_id, size_t cookie_index, Gfx::IntPoint position) =|
     inspector_did_execute_console_script(u64 page_id, String script) =|
     inspector_did_export_inspector_html(u64 page_id, String html) =|
 


### PR DESCRIPTION
This adds a storage tab which contains just a cookie viewer for now. In the future, storage like Local Storage and Indexed DB can be added here as well.

<img width="987" alt="Screenshot 2024-09-06 at 2 19 57 PM" src="https://github.com/user-attachments/assets/2db6ec72-6ab9-4780-bbb4-a211f3bddfe7">



https://github.com/user-attachments/assets/07d318b4-0139-493a-8da4-fae83a75f86d


