### PR TITLE
LibWeb: Disable worker-blob and worker-location tests for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -2,7 +2,9 @@
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
+Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-echo.html
+Text/input/Worker/Worker-location.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html
 Ref/css-keyframe-fill-forwards.html


### PR DESCRIPTION
These frequently time out on macOS CI.