### PR TITLE
LibWeb: Don't crash when calling getBBox() on the outermost SVG element

### DIFF
--- a/Tests/LibWeb/Text/expected/SVG/getBBox-outermost-svg-element-crash.txt
+++ b/Tests/LibWeb/Text/expected/SVG/getBBox-outermost-svg-element-crash.txt
@@ -1,0 +1,1 @@
+  Bounding box of empty SVG element - x: 0, y: 0, width: 0, height: 0

--- a/Tests/LibWeb/Text/input/SVG/getBBox-outermost-svg-element-crash.html
+++ b/Tests/LibWeb/Text/input/SVG/getBBox-outermost-svg-element-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<svg></svg>
+<script>
+    test(() => {
+        const svgElement = document.querySelector("svg");
+        const boundingBox = svgElement.getBBox();
+        println(`Bounding box of empty SVG element - x: ${boundingBox.x}, y: ${boundingBox.y}, width: ${boundingBox.width}, height: ${boundingBox.height}`);
+        svgElement.remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -132,7 +132,7 @@ JS::GCPtr<SVGSVGElement> SVGElement::owner_svg_element()
     // The ownerSVGElement IDL attribute represents the nearest ancestor ‘svg’ element.
     // On getting ownerSVGElement, the nearest ancestor ‘svg’ element is returned;
     // if the current element is the outermost svg element, then null is returned.
-    return first_ancestor_of_type<SVGSVGElement>();
+    return shadow_including_first_ancestor_of_type<SVGSVGElement>();
 }
 
 JS::NonnullGCPtr<SVGAnimatedLength> SVGElement::svg_animated_length_for_property(CSS::PropertyID property) const

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -262,6 +262,7 @@ Optional<float> SVGGraphicsElement::stroke_width() const
     return width.to_px(*layout_node(), scaled_viewport_size).to_double();
 }
 
+// https://svgwg.org/svg2-draft/types.html#__svg__SVGGraphicsElement__getBBox
 JS::NonnullGCPtr<Geometry::DOMRect> SVGGraphicsElement::get_b_box(Optional<SVGBoundingBoxOptions>)
 {
     // FIXME: It should be possible to compute this without layout updates. The bounding box is within the
@@ -272,7 +273,10 @@ JS::NonnullGCPtr<Geometry::DOMRect> SVGGraphicsElement::get_b_box(Optional<SVGBo
     if (!layout_node())
         return Geometry::DOMRect::create(realm());
     // Invert the SVG -> screen space transform.
-    auto svg_element_rect = shadow_including_first_ancestor_of_type<SVG::SVGSVGElement>()->paintable_box()->absolute_rect();
+    auto owner_svg_element = this->owner_svg_element();
+    if (!owner_svg_element)
+        return Geometry::DOMRect::create(realm());
+    auto svg_element_rect = owner_svg_element->paintable_box()->absolute_rect();
     auto inverse_transform = static_cast<Painting::SVGGraphicsPaintable&>(*paintable_box()).computed_transforms().svg_to_css_pixels_transform().inverse();
     auto translated_rect = paintable_box()->absolute_rect().to_type<float>().translated(-svg_element_rect.location().to_type<float>());
     if (inverse_transform.has_value())


### PR DESCRIPTION
Previously, doing this would cause a crash, as we assumed that the caller always had a parent `SVGSVGElement`. We now return an empty `DOMRect` in this case. This matches the behavior of other browsers.

Fixes #739