### PR TITLE
Tests: Allow specifying a build preset for rebaseline-libweb-test

### DIFF
--- a/Tests/LibWeb/rebaseline-libweb-test
+++ b/Tests/LibWeb/rebaseline-libweb-test
@@ -16,7 +16,15 @@ input_dir=$(dirname $t)
 expected_dir=$(echo $input_dir | sed s/input/expected/)
 test_name=$(basename $t .html)
 
-cd $LADYBIRD_SOURCE_DIR/Build/ladybird
+if [[ "$BUILD_PRESET" == "Sanitizer" ]]; then
+    build_dir=$LADYBIRD_SOURCE_DIR/Build/ladybird-sanitizers
+elif [[ "$BUILD_PRESET" == "Debug" ]]; then
+    build_dir=$LADYBIRD_SOURCE_DIR/Build/ladybird-debug
+else
+    build_dir=$LADYBIRD_SOURCE_DIR/Build/ladybird
+fi
+
+cd "$build_dir" || echo "Couldn’t cd to build directory" >&2 && exit 1
 
 if [[ -f ./bin/headless-browser ]]; then
     ladybird_headless_binary=./bin/headless-browser


### PR DESCRIPTION
This change enables using the `rebaseline-libweb-test` script with Debug and Sanitizer builds — and allows specifying which build to use when using `rebaseline-libweb-test` to generate new test-expectations files.

The mechanism used is to check the BUILD_PRESET environment variable.

Otherwise, without this change, there’s no way to use the `rebaseline-libweb-test` script with Debug and Sanitizer builds — except by manually hacking the script locally to hardcode a directory name.

If this seems too hacky/kludgy and it’d seem better to instead add a new command-line option (rather than relying on an environment variable), I could update the patch to do it that way instead.