### PR TITLE
LibWeb+LibWebView: Some native coloring for widgets used on the inspector

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -24,6 +24,7 @@
         --console-table-row-hover: rgb(80, 79, 79);
         --console-table-border: gray;
         --property-table-head: rgb(57, 57, 57);
+        --property-table-row: rgb(45, 45, 45);
     }
 }
 
@@ -48,6 +49,7 @@
         --console-table-row-hover: rgb(199, 198, 198);
         --console-table-border: gray;
         --property-table-head: rgb(229, 229, 229);
+        --property-table-row: rgb(240, 240, 240);
     }
 }
 
@@ -279,6 +281,10 @@ details > :not(:first-child) {
 
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.property-table tr:nth-child(even) {
+    background-color: var(--property-table-row);
 }
 
 #fonts {

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -93,8 +93,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];
 
         m_settings = {
-            .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
             .scripting_enabled = WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
+            .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
         };
 
         if (auto const& user_agent_preset = WebView::Application::web_content_options().user_agent_preset; user_agent_preset.has_value())

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -25,6 +25,7 @@
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/Paintable.h>
 
 namespace Web::HTML {
 
@@ -528,13 +529,16 @@ void HTMLSelectElement::create_shadow_tree_if_needed()
     MUST(border->append_child(*m_inner_text_element));
 
     // FIXME: Find better way to add chevron icon
+    auto chevron_fill_color = document().page().palette().base_text();
+    auto chevron_svg = MUST(String::formatted("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path fill=\"{}\" d=\"M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z\"/></svg>", chevron_fill_color));
+
     m_chevron_icon_element = DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML).release_value_but_fixme_should_propagate_errors();
     MUST(m_chevron_icon_element->set_attribute(HTML::AttributeNames::style, R"~~~(
         width: 16px;
         height: 16px;
         margin-left: 4px;
     )~~~"_string));
-    MUST(m_chevron_icon_element->set_inner_html("<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M7.41,8.58L12,13.17L16.59,8.58L18,10L12,16L6,10L7.41,8.58Z\" /></svg>"sv));
+    MUST(m_chevron_icon_element->set_inner_html(chevron_svg));
     MUST(border->append_child(*m_chevron_icon_element));
 
     update_inner_text_element();

--- a/Userland/Libraries/LibWebView/Native.css
+++ b/Userland/Libraries/LibWebView/Native.css
@@ -9,16 +9,18 @@ html {
 }
 
 input, textarea {
+    background-color: -libweb-palette-base;
     border-color: -libweb-palette-threed-shadow1;
+    color: -libweb-palette-base-text;
 }
 
-button, input[type=submit], input[type=button], input[type=reset] {
+button, input[type=submit], input[type=button], input[type=reset], select {
     background-color: -libweb-palette-button;
     border-color: -libweb-palette-threed-shadow1;
     color: -libweb-palette-button-text;
 }
 
-button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=reset]:hover {
+button:hover, input[type=submit]:hover, input[type=button]:hover, input[type=reset]:hover, select:hover {
     background-color: -libweb-palette-hover-highlight;
 }
 


### PR DESCRIPTION
\+ a build fix for a compiler error I just started getting on macOS

<img width="987" alt="dark" src="https://github.com/user-attachments/assets/8a960e82-59aa-4339-aeae-aae12e85ddbd">

<img width="987" alt="light" src="https://github.com/user-attachments/assets/4bedcabc-39ae-439b-b4ee-c30adaa9de0e">
