### PR TITLE
LibWeb: A couple cursor + selection quality of life improvements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1147,7 +1147,8 @@ void HTMLInputElement::did_receive_focus()
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style();
 
-    document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
+    if (auto cursor = document().cursor_position(); !cursor || m_text_node != cursor->node())
+        document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, m_text_node->length()));
 }
 
 void HTMLInputElement::did_lose_focus()

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -77,7 +77,8 @@ void HTMLTextAreaElement::did_receive_focus()
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style();
 
-    document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
+    if (auto cursor = document().cursor_position(); !cursor || m_text_node != cursor->node())
+        document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, 0));
 }
 
 void HTMLTextAreaElement::did_lose_focus()


### PR DESCRIPTION
1. Place the cursor where the user clicked when an editable text node is focused:

https://github.com/user-attachments/assets/0ac98c62-0cd9-4f36-bd23-f5efe386afeb


2. Allow using shift + arrow/home/end keys to modify selections of non-editable text nodes


https://github.com/user-attachments/assets/d3440c4a-20c4-4cc9-be9e-101293ac7818

