### PR TITLE
LibWeb: Return document URL if formAction attribute is missing or empty

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLFormElement-action.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLFormElement-action.txt
@@ -1,0 +1,3 @@
+  form.action initial value: http://www.example.com/
+Final segment of form.action after setting to the empty string: HTMLFormElement-action.html
+Final segment of form.action after setting to "../test.html": test.html

--- a/Tests/LibWeb/Text/expected/HTML/formAction-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/formAction-attribute.txt
@@ -1,3 +1,6 @@
-button.formAction initial value: http://www.example.com/
+   button.formAction initial value: http://www.example.com/
 Final segment of button.formAction after setting to the empty string: formAction-attribute.html
 Final segment of button.formAction after setting to "../test.html": test.html
+input.formAction initial value: http://www.example.com/
+Final segment of input.formAction after setting to the empty string: formAction-attribute.html
+Final segment of input.formAction after setting to "../test.html": test.html

--- a/Tests/LibWeb/Text/expected/HTML/formAction-attribute.txt
+++ b/Tests/LibWeb/Text/expected/HTML/formAction-attribute.txt
@@ -1,0 +1,3 @@
+button.formAction initial value: http://www.example.com/
+Final segment of button.formAction after setting to the empty string: formAction-attribute.html
+Final segment of button.formAction after setting to "../test.html": test.html

--- a/Tests/LibWeb/Text/input/HTML/HTMLFormElement-action.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLFormElement-action.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<form action="http://www.example.com/"></form>
+<script>
+    test(() => {
+        const formElement = document.querySelector('form');
+        println(`form.action initial value: ${formElement.action}`);
+        formElement.action = "";
+        println(`Final segment of form.action after setting to the empty string: ${formElement.action.split('/').pop()}`);
+        formElement.action = "../test.html";
+        println(`Final segment of form.action after setting to "../test.html": ${formElement.action.split('/').pop()}`);
+        formElement.remove();
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/formAction-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/formAction-attribute.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <script src="../include.js"></script>
 <button formaction="http://www.example.com/"></button>
+<input formaction="http://www.example.com/">
 <script>
     test(() => {
         const elementNames = [
             "button",
+            "input",
         ];
         for (const elementName of elementNames) {
             const element = document.querySelector(elementName);

--- a/Tests/LibWeb/Text/input/HTML/formAction-attribute.html
+++ b/Tests/LibWeb/Text/input/HTML/formAction-attribute.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<button formaction="http://www.example.com/"></button>
+<script>
+    test(() => {
+        const elementNames = [
+            "button",
+        ];
+        for (const elementName of elementNames) {
+            const element = document.querySelector(elementName);
+            println(`${elementName}.formAction initial value: ${element.formAction}`);
+            element.formAction = "";
+            println(`Final segment of ${elementName}.formAction after setting to the empty string: ${element.formAction.split('/').pop()}`);
+            element.formAction = "../test.html";
+            println(`Final segment of ${elementName}.formAction after setting to "../test.html": ${element.formAction.split('/').pop()}`);
+            element.remove();
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -166,6 +166,27 @@ void FormAssociatedElement::reset_form_owner()
     }
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-formaction
+String FormAssociatedElement::form_action() const
+{
+    // The formAction IDL attribute must reflect the formaction content attribute, except that on getting, when the content attribute is missing or its value is the empty string,
+    // the element's node document's URL must be returned instead.
+    auto& html_element = form_associated_element_to_html_element();
+    auto form_action_attribute = html_element.attribute(HTML::AttributeNames::formaction);
+    if (!form_action_attribute.has_value() || form_action_attribute.value().is_empty()) {
+        return html_element.document().url_string();
+    }
+
+    auto document_base_url = html_element.document().base_url();
+    return MUST(document_base_url.complete_url(form_action_attribute.value()).to_string());
+}
+
+WebIDL::ExceptionOr<void> FormAssociatedElement::set_form_action(String const& value)
+{
+    auto& html_element = form_associated_element_to_html_element();
+    return html_element.set_attribute(HTML::AttributeNames::formaction, value);
+}
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
 void FormAssociatedTextControlElement::relevant_value_was_changed(JS::GCPtr<DOM::Text> text_node)
 {

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -98,6 +98,9 @@ public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-form-reset-control
     virtual void reset_algorithm() {};
 
+    String form_action() const;
+    WebIDL::ExceptionOr<void> set_form_action(String const&);
+
 protected:
     FormAssociatedElement() = default;
     virtual ~FormAssociatedElement() = default;

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -15,7 +15,7 @@ interface HTMLButtonElement : HTMLElement {
 
     [CEReactions, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement? form;
-    [CEReactions, Reflect=formaction] attribute USVString formAction;
+    [CEReactions] attribute USVString formAction;
     [CEReactions, Reflect=formenctype] attribute DOMString formEnctype;
     [CEReactions, Reflect=formmethod] attribute DOMString formMethod;
     [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -604,12 +604,12 @@ String HTMLFormElement::action() const
     // The action IDL attribute must reflect the content attribute of the same name, except that on getting, when the
     // content attribute is missing or its value is the empty string, the element's node document's URL must be returned
     // instead.
-    if (auto maybe_action = attribute(AttributeNames::action);
-        maybe_action.has_value() && !maybe_action.value().is_empty()) {
-        return maybe_action.value();
+    auto form_action_attribute = attribute(AttributeNames::action);
+    if (!form_action_attribute.has_value() || form_action_attribute.value().is_empty()) {
+        return document().url_string();
     }
 
-    return MUST(document().url().to_string());
+    return MUST(document().base_url().complete_url(form_action_attribute.value()).to_string());
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-action

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -17,7 +17,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement? form;
     attribute FileList? files;
-    [FIXME, CEReactions] attribute USVString formAction;
+    [CEReactions] attribute USVString formAction;
     [FIXME, CEReactions] attribute DOMString formEnctype;
     [FIXME, CEReactions] attribute DOMString formMethod;
     [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;


### PR DESCRIPTION
Also implement the `formAction` attribute for `HTMLInputElement`.

Fixes the following web platform tests
* https://wpt.live/html/semantics/forms/attributes-common-to-form-controls/formaction.html
* https://wpt.live/html/semantics/forms/attributes-common-to-form-controls/formAction_document_address.html