### PR TITLE
AppKit/UI Corrected initialization order of fields in TabSettings struct

### DIFF
--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -93,8 +93,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [self.toolbar setSizeMode:NSToolbarSizeModeRegular];
 
         m_settings = {
-            .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
             .scripting_enabled = WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
+            .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
         };
 
         if (auto const& user_agent_preset = WebView::Application::web_content_options().user_agent_preset; user_agent_preset.has_value())


### PR DESCRIPTION
I fixed the issue where an error occurred due to a mismatch between the declaration order and the initialization order of properties.[TabController code](https://github.com/LadybirdBrowser/ladybird/blob/master/Ladybird/AppKit/UI/TabController.h#L16-L17)

command
```sh
CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ ./Meta/ladybird.sh run
```

error message
```txt
error: ISO C++ requires field designators to be specified in declaration order; field 'block_popups' will be initialized after field 'scripting_enabled' [-Werror,-Wreorder-init-list]
   97 |             .scripting_enabled = WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
```