### PR TITLE
LibWeb: Consider last resort font in font list

### DIFF
--- a/Userland/Libraries/LibGfx/FontCascadeList.h
+++ b/Userland/Libraries/LibGfx/FontCascadeList.h
@@ -20,7 +20,7 @@ public:
 
     size_t size() const { return m_fonts.size(); }
     bool is_empty() const { return m_fonts.is_empty() && !m_last_resort_font; }
-    Font const& first() const { return *m_fonts.first().font; }
+    Font const& first() const { return !m_fonts.is_empty() ? *m_fonts.first().font : *m_last_resort_font; }
 
     template<typename Callback>
     void for_each_font_entry(Callback callback) const


### PR DESCRIPTION
Getting the first font in a font cascade list with an empty font list results in an OOTB index error. If the font list is empty, the last resort font should be returned instead.

This fixes an error when loading https://vut.cz