### PR TITLE
LibGfx: Fix inconsistent skia includes

### DIFF
--- a/Userland/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Userland/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -11,8 +11,8 @@
 
 #include <core/SkData.h>
 #include <core/SkFontMgr.h>
-#include <include/core/SkRefCnt.h>
-#include <include/core/SkTypeface.h>
+#include <core/SkRefCnt.h>
+#include <core/SkTypeface.h>
 #ifndef AK_OS_ANDROID
 #    include <ports/SkFontMgr_fontconfig.h>
 #else


### PR DESCRIPTION
The "include/" #include prefix is not used anywhere else in the codebase, and does not work with distro packages.

(For some reason both variants work with vcpkg skia)