### PR TITLE
LibJS: Add "month day, year" support to Date.parse

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -168,6 +168,7 @@ static double parse_date_string(ByteString const& date_string)
         "%m/%e/%Y%t%R%t%z"sv,                  // "12/05/2022 10:00 -0800"
         "%Y/%m/%e%t%R"sv,                      // "2014/11/14 13:05"
         "%Y-%m-%e%t%R"sv,                      // "2014-11-14 13:05"
+        "%B%t%e,%t%Y"sv,                       // "June 5, 2023"
         "%B%t%e,%t%Y%t%T"sv,                   // "June 5, 2023 17:00:00"
         "%b%t%d%t%Y%t%Z"sv,                    // "Jan 01 1970 GMT"
         "%a%t%b%t%e%t%T%t%Y%t%z"sv,            // "Wed Apr 17 23:08:53 2019 +0000"

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -150,7 +150,7 @@ static double parse_simplified_iso8601(ByteString const& iso_8601)
     return time_clip(time_ms);
 }
 
-static double parse_date_string(ByteString const& date_string)
+static double parse_date_string(VM& vm, ByteString const& date_string)
 {
     auto value = parse_simplified_iso8601(date_string);
     if (isfinite(value))
@@ -188,6 +188,7 @@ static double parse_date_string(ByteString const& date_string)
             return 1000.0 * maybe_datetime->timestamp();
     }
 
+    vm.host_unrecognized_date_string(date_string);
     return NAN;
 }
 
@@ -257,7 +258,7 @@ ThrowCompletionOr<NonnullGCPtr<Object>> DateConstructor::construct(FunctionObjec
             if (primitive.is_string()) {
                 // 1. Assert: The next step never returns an abrupt completion because Type(v) is String.
                 // 2. Let tv be the result of parsing v as a date, in exactly the same manner as for the parse method (21.4.3.2).
-                time_value = parse_date_string(primitive.as_string().byte_string());
+                time_value = parse_date_string(vm, primitive.as_string().byte_string());
             }
             // iii. Else,
             else {
@@ -334,7 +335,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateConstructor::parse)
 
     auto date_string = TRY(vm.argument(0).to_byte_string(vm));
 
-    return Value(parse_date_string(date_string));
+    return Value(parse_date_string(vm, date_string));
 }
 
 // 21.4.3.4 Date.UTC ( year [ , month [ , date [ , hours [ , minutes [ , seconds [ , ms ] ] ] ] ] ] ), https://tc39.es/ecma262/#sec-date.utc

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -164,6 +164,10 @@ VM::VM(OwnPtr<CustomData> custom_data, ErrorMessages error_messages)
 
         return HandledByHost::Handled;
     };
+
+    // AD-HOC: Inform the host that we received a date string we were unable to parse.
+    host_unrecognized_date_string = [](StringView) {
+    };
 }
 
 VM::~VM() = default;

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -274,6 +274,7 @@ public:
     Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
     Function<ThrowCompletionOr<void>(Object&)> host_ensure_can_add_private_element;
     Function<ThrowCompletionOr<HandledByHost>(ArrayBuffer&, size_t)> host_resize_array_buffer;
+    Function<void(StringView)> host_unrecognized_date_string;
 
     Vector<StackTraceElement> stack_trace() const;
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -121,6 +121,20 @@ test("yy{/,-}mm{/,-}dd hh:mm extension", () => {
     expectStringToGiveDate("2014-11-14 13:05", 2014, 11, 14, 13, 5);
 });
 
+test("Month dd, yy extension", () => {
+    function expectStringToGiveDate(input, fullYear, month, dayInMonth) {
+        const date = new Date(Date.parse(input));
+        expect(date.getFullYear()).toBe(fullYear);
+        expect(date.getMonth() + 1).toBe(month);
+        expect(date.getDate()).toBe(dayInMonth);
+    }
+
+    expectStringToGiveDate("May 15, 2023", 2023, 5, 15);
+    expectStringToGiveDate("May 22, 2023", 2023, 5, 22);
+    expectStringToGiveDate("May 30, 2023", 2023, 5, 30);
+    expectStringToGiveDate("June 5, 2023", 2023, 6, 5);
+});
+
 test("Month dd, yy hh:mm:ss extension", () => {
     function expectStringToGiveDate(input, fullYear, month, dayInMonth, hours, minutes, seconds) {
         // Since the timezone is not specified we just say it has to equal the date parts.

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -545,6 +545,10 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
         HTML::fetch_single_imported_module_script(realm, url.release_value(), *fetch_client, destination, fetch_options, *settings_object, fetch_referrer, module_request, perform_fetch, on_single_fetch_complete);
     };
 
+    s_main_thread_vm->host_unrecognized_date_string = [](StringView date) {
+        dbgln("Unable to parse date string: \"{}\"", date);
+    };
+
     return {};
 }
 


### PR DESCRIPTION
Used on https://rauchg.com

Before:
![before](https://github.com/user-attachments/assets/74ae488c-8ada-4a82-a2d3-5f8a3d656bf7)

After:
![after](https://github.com/user-attachments/assets/5b6c01b6-037a-4a92-a11c-a0b9133457c2)
