### PR TITLE
WebDriver: Add headers for Input State and Input Source

### DIFF
--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -44,6 +44,7 @@
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWeb/WebDriver/Screenshot.h>
 #include <WebContent/WebDriverConnection.h>
+#include <WebDriver/InputState.h>
 
 namespace WebContent {
 
@@ -2069,6 +2070,21 @@ Messages::WebDriverClient::DeleteAllCookiesResponse WebDriverConnection::delete_
     return JsonValue {};
 }
 
+// FIXME: Arguments/return types
+// To get the input state given session and browsing context:
+Web::WebDriver::InputState const& WebDriverConnection::get_the_input_state(Web::HTML::BrowsingContext const& /*context*/) const
+{
+    dbgln_if(WEBDRIVER_DEBUG, "FIXME: Implement get_the_input_state");
+    // FIXME: 1. Assert: browsing context is a top-level browsing context.
+
+    // FIXME: 2. Let input state map be session's browsing context input state map.
+
+    // FIXME: 3. If input state map does not contain browsing context, set input state map[browsing context] to create an input state.
+
+    // FIXME: 4. Return input state map[browsing context].
+    return m_input_state;
+}
+
 // 15.8 Release Actions, https://w3c.github.io/webdriver/#release-actions
 Messages::WebDriverClient::ReleaseActionsResponse WebDriverConnection::release_actions()
 {
@@ -2076,6 +2092,8 @@ Messages::WebDriverClient::ReleaseActionsResponse WebDriverConnection::release_a
     TRY(ensure_open_top_level_browsing_context());
 
     // FIXME: 2. Let input state be the result of get the input state with current session and current top-level browsing context.
+    auto const& input_state = get_the_input_state(m_page_client->page().top_level_browsing_context());
+    (void)input_state; // to silence compiler
 
     // FIXME: 3. Let actions options be a new actions options with the is element origin steps set to represents a web element, and the get element origin steps set to get a WebElement origin.
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -23,6 +23,7 @@
 #include <WebContent/Forward.h>
 #include <WebContent/WebDriverClientEndpoint.h>
 #include <WebContent/WebDriverServerEndpoint.h>
+#include <WebDriver/InputState.h>
 
 namespace WebContent {
 
@@ -115,6 +116,8 @@ private:
     using StartNodeGetter = Function<ErrorOr<Web::DOM::ParentNode*, Web::WebDriver::Error>()>;
     ErrorOr<JsonArray, Web::WebDriver::Error> find(StartNodeGetter&& start_node_getter, Web::WebDriver::LocationStrategy using_, StringView value);
 
+    Web::WebDriver::InputState const& get_the_input_state(Web::HTML::BrowsingContext const& context) const;
+
     struct ScriptArguments {
         ByteString script;
         JS::MarkedVector<JS::Value> arguments;
@@ -135,6 +138,12 @@ private:
 
     // https://w3c.github.io/webdriver/#dfn-session-script-timeout
     Web::WebDriver::TimeoutsConfiguration m_timeouts_configuration;
+
+    // https://w3c.github.io/webdriver/#input-state
+    // FIXME: Might end up replacing this with a browsing
+    // context input map as per
+    // https://w3c.github.io/webdriver/#dfn-browsing-context-input-state-map
+    Web::WebDriver::InputState m_input_state;
 };
 
 }

--- a/Userland/Services/WebDriver/CMakeLists.txt
+++ b/Userland/Services/WebDriver/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     Client.cpp
     Session.cpp
     WebContentConnection.cpp
+    InputSource.cpp
     main.cpp
 )
 

--- a/Userland/Services/WebDriver/InputSource.cpp
+++ b/Userland/Services/WebDriver/InputSource.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Noah Bright <noah.bright.1@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <WebDriver/InputSource.h>
+#include <WebDriver/InputState.h>
+
+namespace Web::WebDriver {
+
+// To get a pointer id given input state and subtype :
+static unsigned get_a_pointer_id(InputState const& input_state, String const& subtype)
+{
+    // 1. Let minimum id be 0 if subtype is "mouse", or 2 otherwise.
+    unsigned minimum_id = (subtype == "mouse") ? 0 : 2;
+
+    // 2. Let pointer ids be an empty set.
+    HashTable<unsigned> pointer_ids;
+
+    // 3. Let sources be the result of getting the values with input state's input state map.
+    // Does the HashMap only have this function for keys? Could implement for values
+    Vector<NonnullOwnPtr<InputSource>> sources;
+    for (auto const& [_, v] : input_state.get_input_state_map())
+        sources.append(v);
+
+    // FIXME: 4. For each source in sources.:
+    for (auto const& source : sources) {
+        //     FIXME: 1. If source is a pointer input source, append source's pointerId to pointer ids.
+        //     FIXME: Input id is a UUID, which we treat as strings
+        //     Here it's necessary to treat them as integers,
+        //     FIXME: How to switch on the type inside the pointer?
+
+        if (source->input_id() == "pointer") // this condition is wrong
+            pointer_ids.set(source->input_id());
+    }
+
+    // FIXME: 5. Return the smallest integer that is greater than or equal to minimum id and that is not contained in pointer ids.
+    // This would be easier to implement if we heap pushed into pointer_ids
+
+    return minimum_id; // placeholder
+}
+
+// FIXME: Check return type
+static ErrorOr<NonnullOwnPtr<Web::WebDriver::InputSource>> create(InputState const& input_state, String const& type,
+    String const& subtype)
+{
+    // FIXME: The InputSource as the template parameter was giving no matching
+    // ctor errors
+    NonnullOwnPtr<InputSource> source = make<NullInputSource>();
+    // 1. Run the substeps matching the first matching value of type:
+    //      "none"
+    //          Let source be the result of create a null input source.
+    if (type == "none")
+        source = NullInputSource::create();
+    //      "key"
+    //          Let source be the result of create a key input source.
+    else if (type == "key")
+        source = KeyInputSource::create();
+    //      "pointer"
+    //          Let source be the result of create a pointer input source with input state and subtype.
+    else if (type == "pointer")
+        source = PointerInputSource::create(input_state, subtype);
+    //      "wheel"
+    //          Let source be the result of create a wheel input source.
+    else if (type == "wheel")
+        source = WheelInputSource::create();
+    //      FIXME: Otherwise:
+    //          Return error with error code invalid argument.
+    // else
+    // return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument);
+
+    // 2. Return success with data source.
+    return source;
+}
+
+NonnullOwnPtr<NullInputSource> NullInputSource::create()
+{
+    return adopt_own(*new NullInputSource);
+}
+NonnullOwnPtr<KeyInputSource> KeyInputSource::create()
+{
+    return adopt_own(*new KeyInputSource);
+}
+NonnullOwnPtr<PointerInputSource> PointerInputSource::create(InputState const& input_state, String const& subtype)
+{
+    return adopt_own(*new PointerInputSource(input_state, subtype));
+}
+NonnullOwnPtr<WheelInputSource> WheelInputSource::create()
+{
+
+    return adopt_own(*new WheelInputSource);
+}
+
+PointerInputSource::PointerInputSource(InputState const& input_state, String const& subtype)
+    : m_subtype(subtype)
+    , m_pointer_id(get_a_pointer_id(input_state, subtype))
+{
+}
+
+}

--- a/Userland/Services/WebDriver/InputSource.h
+++ b/Userland/Services/WebDriver/InputSource.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, Noah Bright <noah.bright.1@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Debug.h>
+#include <AK/HashTable.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/String.h>
+
+namespace Web::WebDriver {
+
+// InputState has lists of InputSources, but the pointer input source constructor
+// depends on InputState, so the definitions are circular
+// forward declare InputState here
+class InputState;
+
+// https://w3c.github.io/webdriver/#input-sources
+class InputSource {
+public:
+    static ErrorOr<NonnullOwnPtr<InputSource>> create(InputState const&, String const&, String const&);
+    String const& input_id() const { return m_input_id; }
+
+private:
+    InputSource() { }
+    // Each input source has an input id which is stored as a key in the input state map.
+    // input id is a UUID
+    String m_input_id;
+};
+
+// https://w3c.github.io/webdriver/#null-input-source
+class NullInputSource : InputSource {
+public:
+    static NonnullOwnPtr<NullInputSource> create();
+    void pause(int tick_duration);
+    // leaving public null constructor for now
+    // Classes inheriting can't chain into private ctor
+    NullInputSource();
+
+private:
+    // NullInputSource();
+};
+
+// The other device types inherit from NullInputSource because they all need to Pause
+// but this leads to a non-leaf class as nonfinal, could restructure
+// https://w3c.github.io/webdriver/#key-input-source
+class KeyInputSource final : public NullInputSource {
+public:
+    static NonnullOwnPtr<KeyInputSource> create();
+    // FIXME: Implement when we have more clarity
+    // void keyDown();
+    // void keyUp();
+
+private:
+    HashTable<String> m_pressed;
+    bool m_alt { false };
+    bool m_ctrl { false };
+    bool m_meta { false };
+    bool m_shift { false };
+};
+
+// https://w3c.github.io/webdriver/#pointer-input-source
+class PointerInputSource final : public NullInputSource {
+public:
+    static NonnullOwnPtr<PointerInputSource> create(InputState const& input_state, String const& subtype);
+
+    // FIXME: Implement when we have more clarity
+    // void pointerDown();
+    // void pointerUp();
+    // void pointerMove();
+    // void pointerCancel();
+
+private:
+    PointerInputSource(InputState const& input_state, String const& subtype);
+    String m_subtype;
+    // The numeric id of the pointing device.
+    // This is a positive integer, with the values 0 and 1 reserved for mouse-type pointers.
+    unsigned m_pointer_id;
+    // A set of unsigned integers representing the pointer buttons that are currently depressed
+    HashTable<unsigned int> m_pressed;
+    // An unsigned integer representing the pointer x/y location in viewport coordinates
+    unsigned m_x { 0 }, m_y { 0 };
+};
+
+// https://w3c.github.io/webdriver/#wheel-input-source
+enum class WheelDirections { Up,
+    Down,
+    Left,
+    Right };
+
+class WheelInputSource final : public NullInputSource {
+public:
+    static NonnullOwnPtr<WheelInputSource> create();
+    WheelDirections scroll();
+
+private:
+    WheelInputSource();
+};
+}

--- a/Userland/Services/WebDriver/InputState.h
+++ b/Userland/Services/WebDriver/InputState.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Noah Bright <noah.bright.1@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/JsonObject.h>
+#include <AK/Queue.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <WebDriver/InputSource.h>
+#include <WebDriver/Session.h>
+
+namespace Web::WebDriver {
+
+// FIXME: Action object is an object, constructed with fields
+// property id, type, and subtype
+// this type might not express that
+using ActionObject = JsonObject;
+
+// https://w3c.github.io/webdriver/#input-state
+class InputState {
+public:
+    // To create an input state:
+    // FIXME: 1. Let input state be an input state with the input state map set to an empty map, and the input cancel list set to an empty list.
+    // FIXME: 2. Return input state
+    InputState() = default;
+
+    HashMap<String, NonnullOwnPtr<InputSource>> const& get_input_state_map() const { return m_input_state_map; }
+
+private:
+    // A map where keys are input ids, and the values are input sources.
+    // Input ids are UUIDs, which are strings
+    HashMap<String, NonnullOwnPtr<InputSource>> m_input_state_map;
+
+    // An input cancel list, which is a list of action objects. This list is used to manage
+    // dispatching events when resetting the state of the input source
+    Vector<ActionObject> m_input_cancel_list;
+
+    // An actions queue which is a queue that ensures that access to the input state is serialized.
+    // FIXME: template type - who accesses the ActionsQueue? I.e. how to reference the actions
+    // to cancel efficiently?
+    Queue<int> m_actions_queue;
+};
+
+}


### PR DESCRIPTION
For issue #1040

Endpoints 15.7 and 15.8 require input state and some associated state around that. This starts to implement that and get some scaffolding around those endpoints