### PR TITLE
LibWeb: Abort dependent signals before firing abort event

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/AbortSignal-any-crash.txt
+++ b/Tests/LibWeb/Text/expected/DOM/AbortSignal-any-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/DOM/AbortSignal-any-crash.html
+++ b/Tests/LibWeb/Text/input/DOM/AbortSignal-any-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const abortController = new AbortController();
+        const signal = AbortSignal.any([abortController.signal]);
+        abortController.signal.addEventListener("abort", () => { AbortSignal.any([signal]) });
+        abortController.abort();
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
Previously, there was a bug in the specification that would cause an assertion failure, due to the abort event being fired before all dependent signals were aborted.

Relevant WHATWG issue: https://github.com/whatwg/dom/issues/1293

Fixes: https://wpt.live/dom/abort/crashtests/any-on-abort.html