### PR TITLE
LibWeb: Don't attempt to set selection if control has no selectable text

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-select-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-select-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/HTMLInputElement-select-crash.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLInputElement-select-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const inputElement = document.createElement("input");
+        inputElement.type = "color";
+        inputElement.value = "#000000";
+        inputElement.select();
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2365,6 +2365,9 @@ HTMLInputElement::ValueAttributeMode HTMLInputElement::value_attribute_mode() co
 
 void HTMLInputElement::selection_was_changed(size_t selection_start, size_t selection_end)
 {
+    if (!m_text_node)
+        return;
+
     document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, selection_end));
 
     if (auto selection = document().get_selection())

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -463,6 +463,9 @@ void HTMLTextAreaElement::queue_firing_input_event()
 
 void HTMLTextAreaElement::selection_was_changed(size_t selection_start, size_t selection_end)
 {
+    if (!m_text_node)
+        return;
+
     document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, selection_end));
 
     if (auto selection = document().get_selection())


### PR DESCRIPTION
Fixes: http://wpt.live/html/semantics/forms/textfieldselection/selection.html