### PR TITLE
LibWeb: Some juicy speedups for selector matching on vercel.com and Tailwind CSS sites in general

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -44,7 +44,7 @@ void Selector::collect_ancestor_hashes()
     auto last_combinator = m_compound_selectors.last().combinator;
     for (ssize_t compound_selector_index = static_cast<ssize_t>(m_compound_selectors.size()) - 2; compound_selector_index >= 0; --compound_selector_index) {
         auto const& compound_selector = m_compound_selectors[compound_selector_index];
-        if (last_combinator == Combinator::Descendant) {
+        if (last_combinator == Combinator::Descendant || last_combinator == Combinator::ImmediateChild) {
             for (auto const& simple_selector : compound_selector.simple_selectors) {
                 switch (simple_selector.type) {
                 case SimpleSelector::Type::Id:

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2700,8 +2700,10 @@ NonnullOwnPtr<StyleComputer::RuleCache> StyleComputer::make_rule_cache_for_casca
                     }
                 }
 
+                // NOTE: We traverse the simple selectors in reverse order to make sure that class/ID buckets are preferred over tag buckets
+                //       in the common case of div.foo or div#foo selectors.
                 bool added_to_bucket = false;
-                for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors) {
+                for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors.in_reverse()) {
                     if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Id) {
                         rule_cache->rules_by_id.ensure(simple_selector.name()).append(move(matching_rule));
                         ++num_id_rules;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2627,6 +2627,31 @@ void StyleComputer::build_rule_cache_if_needed() const
     const_cast<StyleComputer&>(*this).build_rule_cache();
 }
 
+static Optional<FlyString> is_roundabout_selector_bucketable_as_class(CSS::Selector::SimpleSelector const& simple_selector)
+{
+    if (simple_selector.type != CSS::Selector::SimpleSelector::Type::PseudoClass)
+        return {};
+
+    if (simple_selector.pseudo_class().type != CSS::PseudoClass::Is
+        && simple_selector.pseudo_class().type != CSS::PseudoClass::Where)
+        return {};
+
+    if (simple_selector.pseudo_class().argument_selector_list.size() != 1)
+        return {};
+
+    auto const& argument_selector = *simple_selector.pseudo_class().argument_selector_list.first();
+
+    auto const& compound_selector = argument_selector.compound_selectors().last();
+    if (compound_selector.simple_selectors.size() != 1)
+        return {};
+
+    auto const& inner_simple_selector = compound_selector.simple_selectors.first();
+    if (inner_simple_selector.type != CSS::Selector::SimpleSelector::Type::Class)
+        return {};
+
+    return inner_simple_selector.name();
+}
+
 NonnullOwnPtr<StyleComputer::RuleCache> StyleComputer::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_origin)
 {
     auto rule_cache = make<RuleCache>();
@@ -2685,6 +2710,13 @@ NonnullOwnPtr<StyleComputer::RuleCache> StyleComputer::make_rule_cache_for_casca
                     }
                     if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Class) {
                         rule_cache->rules_by_class.ensure(simple_selector.name()).append(move(matching_rule));
+                        ++num_class_rules;
+                        added_to_bucket = true;
+                        break;
+                    }
+                    // NOTE: Selectors like `:is/where(.foo)` and `:is/where(.foo .bar)` are bucketed as class selectors for `foo` and `bar` respectively.
+                    if (auto class_ = is_roundabout_selector_bucketable_as_class(simple_selector); class_.has_value()) {
+                        rule_cache->rules_by_class.ensure(class_.value()).append(move(matching_rule));
                         ++num_class_rules;
                         added_to_bucket = true;
                         break;


### PR DESCRIPTION
Basically:
- Allow immediate child (>) combinator to get quickly rejected by the ancestor filter.
- Bucket div#foo and div.foo as ID/class respectively, rather than as tag(div)
- Bucket :is(.foo) and :where(.foo) as class rules rather than as generic rules

Average full style update times on my machine:
- https://vercel.com 470ms -> 240ms
- https://tailwindcss.com 1400ms -> 350ms