### PR TITLE
LibWeb: Add CEReactions to all IDL for all ARIA attributes

### DIFF
--- a/Userland/Libraries/LibWeb/ARIA/ARIAMixin.idl
+++ b/Userland/Libraries/LibWeb/ARIA/ARIAMixin.idl
@@ -1,54 +1,54 @@
-// https://www.w3.org/TR/wai-aria-1.2/#ARIAMixin
+// https://w3c.github.io/aria/#ARIAMixin
 interface mixin ARIAMixin {
-	attribute DOMString? role;
+	[CEReactions] attribute DOMString? role;
 
-	attribute DOMString? ariaAtomic;
-	attribute DOMString? ariaAutoComplete;
-	attribute DOMString? ariaBusy;
-	attribute DOMString? ariaChecked;
-	attribute DOMString? ariaColCount;
-	attribute DOMString? ariaColIndex;
+	[CEReactions] attribute DOMString? ariaAtomic;
+	[CEReactions] attribute DOMString? ariaAutoComplete;
+	[CEReactions] attribute DOMString? ariaBusy;
+	[CEReactions] attribute DOMString? ariaChecked;
+	[CEReactions] attribute DOMString? ariaColCount;
+	[CEReactions] attribute DOMString? ariaColIndex;
 
-	attribute DOMString? ariaColSpan;
+	[CEReactions] attribute DOMString? ariaColSpan;
 
-	attribute DOMString? ariaCurrent;
+	[CEReactions] attribute DOMString? ariaCurrent;
 
 
 
-	attribute DOMString? ariaDisabled;
+	[CEReactions] attribute DOMString? ariaDisabled;
 
-	attribute DOMString? ariaExpanded;
+	[CEReactions] attribute DOMString? ariaExpanded;
 
-	attribute DOMString? ariaHasPopup;
-	attribute DOMString? ariaHidden;
-	attribute DOMString? ariaInvalid;
-	attribute DOMString? ariaKeyShortcuts;
-	attribute DOMString? ariaLabel;
+	[CEReactions] attribute DOMString? ariaHasPopup;
+	[CEReactions] attribute DOMString? ariaHidden;
+	[CEReactions] attribute DOMString? ariaInvalid;
+	[CEReactions] attribute DOMString? ariaKeyShortcuts;
+	[CEReactions] attribute DOMString? ariaLabel;
 
-	attribute DOMString? ariaLevel;
-	attribute DOMString? ariaLive;
-	attribute DOMString? ariaModal;
-	attribute DOMString? ariaMultiLine;
-	attribute DOMString? ariaMultiSelectable;
-	attribute DOMString? ariaOrientation;
+	[CEReactions] attribute DOMString? ariaLevel;
+	[CEReactions] attribute DOMString? ariaLive;
+	[CEReactions] attribute DOMString? ariaModal;
+	[CEReactions] attribute DOMString? ariaMultiLine;
+	[CEReactions] attribute DOMString? ariaMultiSelectable;
+	[CEReactions] attribute DOMString? ariaOrientation;
 
-	attribute DOMString? ariaPlaceholder;
-	attribute DOMString? ariaPosInSet;
-	attribute DOMString? ariaPressed;
-	attribute DOMString? ariaReadOnly;
-	attribute DOMString? ariaRelevant;
+	[CEReactions] attribute DOMString? ariaPlaceholder;
+	[CEReactions] attribute DOMString? ariaPosInSet;
+	[CEReactions] attribute DOMString? ariaPressed;
+	[CEReactions] attribute DOMString? ariaReadOnly;
+	[CEReactions] attribute DOMString? ariaRelevant;
 
-	attribute DOMString? ariaRequired;
-	attribute DOMString? ariaRoleDescription;
-	attribute DOMString? ariaRowCount;
-	attribute DOMString? ariaRowIndex;
+	[CEReactions] attribute DOMString? ariaRequired;
+	[CEReactions] attribute DOMString? ariaRoleDescription;
+	[CEReactions] attribute DOMString? ariaRowCount;
+	[CEReactions] attribute DOMString? ariaRowIndex;
 
-	attribute DOMString? ariaRowSpan;
-	attribute DOMString? ariaSelected;
-	attribute DOMString? ariaSetSize;
-	attribute DOMString? ariaSort;
-	attribute DOMString? ariaValueMax;
-	attribute DOMString? ariaValueMin;
-	attribute DOMString? ariaValueNow;
-	attribute DOMString? ariaValueText;
+	[CEReactions] attribute DOMString? ariaRowSpan;
+	[CEReactions] attribute DOMString? ariaSelected;
+	[CEReactions] attribute DOMString? ariaSetSize;
+	[CEReactions] attribute DOMString? ariaSort;
+	[CEReactions] attribute DOMString? ariaValueMax;
+	[CEReactions] attribute DOMString? ariaValueMin;
+	[CEReactions] attribute DOMString? ariaValueNow;
+	[CEReactions] attribute DOMString? ariaValueText;
 };


### PR DESCRIPTION
This change adds the `[CEReactions]` attributes to all ARIA attributes in the ARIAMixin WebIDL — as required by the WebIDL in the current spec at https://w3c.github.io/aria/#ARIAMixin, and by the WPT test case at http://wpt.live/custom-elements/reactions/AriaMixin-string-attributes.html, and as implemented in other existing engines.

Otherwise, without this change, Ladybird doesn’t conform to the current spec, fails all those tests, and isn’t interoperable with other engines.

Note that this change causes Ladybird to pass 78 tests at https://wpt.fyi/results/custom-elements/reactions/AriaMixin-string-attributes.html?product=ladybird which it has been failing. The reason we don’t yet pass all 88 of those tests there is: there are 5 attributes which were added to the ARIA spec after our initial ARIA implementation — so we don’t yet implement those attributes at all.

But I’m working on a patch for those 5 other attributes — and after I have that finished, we’ll be passing  88/88 of those WPT tests.