### PR TITLE
LibWeb: Return computed grid-template-rows/columns if there's no used

### DIFF
--- a/Tests/LibWeb/Text/expected/getComputedStyle-grid-template-rows-columns.txt
+++ b/Tests/LibWeb/Text/expected/getComputedStyle-grid-template-rows-columns.txt
@@ -1,2 +1,3 @@
-  100px 100px
+        100px 100px
 50px 50px
+auto auto

--- a/Tests/LibWeb/Text/input/getComputedStyle-grid-template-rows-columns.html
+++ b/Tests/LibWeb/Text/input/getComputedStyle-grid-template-rows-columns.html
@@ -10,12 +10,25 @@
         height: 50px;
         background-color: lightblue;
     }
+
+    .not-a-grid {
+        grid-template-columns: auto auto;
+    }
 </style>
-<div class="grid-container" style="grid-template-columns: auto auto"><div class="grid-item"></div><div class="grid-item"></div><div class="grid-item"></div><div class="grid-item"></div></div>
+<div class="grid-container" style="grid-template-columns: auto auto">
+    <div class="grid-item"></div>
+    <div class="grid-item"></div>
+    <div class="grid-item"></div>
+    <div class="grid-item"></div>
+</div>
+<div class="not-a-grid"></div>
 <script>
     test(() => {
         const grid = document.querySelector(".grid-container");
         println(getComputedStyle(grid).gridTemplateColumns);
         println(getComputedStyle(grid).gridTemplateRows);
+
+        const not_a_grid = document.querySelector(".not-a-grid");
+        println(getComputedStyle(not_a_grid).gridTemplateColumns);
     });
 </script>

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -250,16 +250,6 @@ RefPtr<CSSStyleValue const> ResolvedCSSStyleDeclaration::style_value_for_propert
         return style_value_for_shadow(layout_node.computed_values().box_shadow());
     case PropertyID::Color:
         return CSSColorValue::create_from_color(layout_node.computed_values().color());
-    // For grid-template-columns and grid-template-rows the resolved value is the used value.
-    // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
-    case PropertyID::GridTemplateColumns: {
-        auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
-        return paintable_box.used_values_for_grid_template_columns();
-    }
-    case PropertyID::GridTemplateRows: {
-        auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
-        return paintable_box.used_values_for_grid_template_rows();
-    }
     case PropertyID::OutlineColor:
         return CSSColorValue::create_from_color(layout_node.computed_values().outline_color());
     case PropertyID::TextDecorationColor:
@@ -530,6 +520,20 @@ RefPtr<CSSStyleValue const> ResolvedCSSStyleDeclaration::style_value_for_propert
         dbgln_if(LIBWEB_CSS_DEBUG, "Computed style for custom properties was requested (?)");
         return nullptr;
     default:
+        // For grid-template-columns and grid-template-rows the resolved value is the used value.
+        // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
+        if (property_id == PropertyID::GridTemplateColumns) {
+            auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
+            if (auto used_values_for_grid_template_columns = paintable_box.used_values_for_grid_template_columns()) {
+                return used_values_for_grid_template_columns;
+            }
+        } else if (property_id == PropertyID::GridTemplateRows) {
+            auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
+            if (auto used_values_for_grid_template_rows = paintable_box.used_values_for_grid_template_rows()) {
+                return used_values_for_grid_template_rows;
+            }
+        }
+
         if (!property_is_shorthand(property_id))
             return get_computed_value(property_id);
 


### PR DESCRIPTION
If grid-template-rows or grid-template-columns queried for a box that is not a grid container, the result should be computed value instead of null.

Fixes crashing in inspector.