### PR TITLE
LibWeb: Fix wrong assumption that repeat() is always first track [GFC]

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/fixed-tracks-followed-by-repeat-auto-fill.txt
+++ b/Tests/LibWeb/Layout/expected/grid/fixed-tracks-followed-by-repeat-auto-fill.txt
@@ -1,0 +1,78 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x51 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x35 children: not-inline
+      Box <div.grid-container> at (8,8) content-size 784x35 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (18,18) content-size 80x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [55,18 5.546875x15] baseline: 11.703125
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,18) content-size 80x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [164,18 7.71875x15] baseline: 11.703125
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (238,18) content-size 30x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [249,18 7.953125x15] baseline: 11.703125
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (298,18) content-size 30x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [310,18 6.78125x15] baseline: 11.703125
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (358,18) content-size 30x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [369,18 7.390625x15] baseline: 11.703125
+              "5"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (418,18) content-size 30x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [429,18 7.640625x15] baseline: 11.703125
+              "6"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (478,18) content-size 30x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [489,18 7.625x15] baseline: 11.703125
+              "7"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (538,18) content-size 30x15 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [549,18 8.296875x15] baseline: 11.703125
+              "8"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,43) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x51]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x35]
+      PaintableBox (Box<DIV>.grid-container) [8,8 784x35]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [8,8 100x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [118,8 100x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [228,8 50x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [288,8 50x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [348,8 50x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [408,8 50x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [468,8 50x35]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [528,8 50x35]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,43 784x0]

--- a/Tests/LibWeb/Layout/input/grid/fixed-tracks-followed-by-repeat-auto-fill.html
+++ b/Tests/LibWeb/Layout/input/grid/fixed-tracks-followed-by-repeat-auto-fill.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<style>
+    .grid-container {
+        display: grid;
+        grid-template-columns: 100px 100px repeat(auto-fill, minmax(50px, 1fr));
+        grid-gap: 10px;
+    }
+
+    .grid-item {
+        background-color: #4caf50;
+        padding: 10px;
+        text-align: center;
+        color: white;
+        font-size: 14px;
+    }
+</style>
+<div class="grid-container">
+    <div class="grid-item">1</div>
+    <div class="grid-item">2</div>
+    <div class="grid-item">3</div>
+    <div class="grid-item">4</div>
+    <div class="grid-item">5</div>
+    <div class="grid-item">6</div>
+    <div class="grid-item">7</div>
+    <div class="grid-item">8</div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -88,7 +88,7 @@ CSSPixels GridFormattingContext::resolve_definite_track_size(CSS::GridSize const
     return 0;
 }
 
-int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimension dimension)
+int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimension dimension, CSS::ExplicitGridTrack const& repeated_track)
 {
     // https://www.w3.org/TR/css-grid-2/#auto-repeat
     // 7.2.3.2. Repeat-to-fill: auto-fill and auto-fit repetitions
@@ -102,12 +102,11 @@ int GridFormattingContext::count_of_repeated_auto_fill_or_fit_tracks(GridDimensi
     // content box of its grid container
 
     auto const& grid_computed_values = grid_container().computed_values();
-    auto const& track_list = dimension == GridDimension::Row ? grid_computed_values.grid_template_rows().track_list() : grid_computed_values.grid_template_columns().track_list();
     CSSPixels size_of_repeated_tracks = 0;
     // (treating each track as its max track sizing function if that is definite or its minimum track sizing
     // function otherwise, flooring the max track sizing function by the min track sizing function if both
     // are definite, and taking gap into account)
-    auto const& repeat_track_list = track_list.first().repeat().grid_track_size_list().track_list();
+    auto const& repeat_track_list = repeated_track.repeat().grid_track_size_list().track_list();
     for (auto const& explicit_grid_track : repeat_track_list) {
         auto const& track_sizing_function = explicit_grid_track;
         CSSPixels track_size = 0;
@@ -422,7 +421,7 @@ void GridFormattingContext::initialize_grid_tracks_from_definition(GridDimension
         int repeat_count = 1;
         if (track_definition.is_repeat()) {
             if (track_definition.repeat().is_auto_fill() || track_definition.repeat().is_auto_fit())
-                repeat_count = count_of_repeated_auto_fill_or_fit_tracks(dimension);
+                repeat_count = count_of_repeated_auto_fill_or_fit_tracks(dimension, track_definition);
             else
                 repeat_count = track_definition.repeat().repeat_count();
         }
@@ -2096,7 +2095,7 @@ void GridFormattingContext::init_grid_lines(GridDimension dimension)
                 } else if (explicit_track.is_repeat()) {
                     int repeat_count = 0;
                     if (explicit_track.repeat().is_auto_fill() || explicit_track.repeat().is_auto_fit())
-                        repeat_count = count_of_repeated_auto_fill_or_fit_tracks(dimension);
+                        repeat_count = count_of_repeated_auto_fill_or_fit_tracks(dimension, explicit_track);
                     else
                         repeat_count = explicit_track.repeat().repeat_count();
                     auto const& repeat_track = explicit_track.repeat();

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -248,7 +248,7 @@ private:
 
     Optional<int> get_line_index_by_line_name(GridDimension dimension, String const&);
     CSSPixels resolve_definite_track_size(CSS::GridSize const&, AvailableSpace const&);
-    int count_of_repeated_auto_fill_or_fit_tracks(GridDimension);
+    int count_of_repeated_auto_fill_or_fit_tracks(GridDimension, CSS::ExplicitGridTrack const& repeated_track);
 
     void build_grid_areas();
 


### PR DESCRIPTION
Fixes crashing in
https://wpt.live/css/css-grid/grid-definition/grid-auto-fit-columns-001.html