### PR TITLE
LibWeb: Do not try to load a font if format detection has failed

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -190,9 +190,6 @@ ErrorOr<NonnullRefPtr<Gfx::Typeface>> FontLoader::try_load_font()
         }
     }
 
-    auto ttf = Gfx::Typeface::try_load_from_externally_owned_memory(resource()->encoded_data());
-    if (!ttf.is_error())
-        return ttf.release_value();
     return Error::from_string_literal("Automatic format detection failed");
 }
 


### PR DESCRIPTION
Skia is more permissive when it comes to font loading, compared to our own OpenType implementation, which it has superseded, parsing an invalid TTF does not result in an error but rather produces a font that is incorrectly displayed. This change updates the FontLoader to address this behavior and to stop attempting to parse a font as a last resort when format detection has failed.

Fixes regression on x.com when text is not displayed introduced in a9d5a99568b41c83d724a9d8f81c1fdfe10a830e