### PR TITLE
LibWeb: Replace tabs with 4 spaces in ARIAMixin.idl

### DIFF
--- a/Userland/Libraries/LibWeb/ARIA/ARIAMixin.idl
+++ b/Userland/Libraries/LibWeb/ARIA/ARIAMixin.idl
@@ -1,54 +1,42 @@
 // https://w3c.github.io/aria/#ARIAMixin
 interface mixin ARIAMixin {
-	[CEReactions] attribute DOMString? role;
-
-	[CEReactions] attribute DOMString? ariaAtomic;
-	[CEReactions] attribute DOMString? ariaAutoComplete;
-	[CEReactions] attribute DOMString? ariaBusy;
-	[CEReactions] attribute DOMString? ariaChecked;
-	[CEReactions] attribute DOMString? ariaColCount;
-	[CEReactions] attribute DOMString? ariaColIndex;
-
-	[CEReactions] attribute DOMString? ariaColSpan;
-
-	[CEReactions] attribute DOMString? ariaCurrent;
-
-
-
-	[CEReactions] attribute DOMString? ariaDisabled;
-
-	[CEReactions] attribute DOMString? ariaExpanded;
-
-	[CEReactions] attribute DOMString? ariaHasPopup;
-	[CEReactions] attribute DOMString? ariaHidden;
-	[CEReactions] attribute DOMString? ariaInvalid;
-	[CEReactions] attribute DOMString? ariaKeyShortcuts;
-	[CEReactions] attribute DOMString? ariaLabel;
-
-	[CEReactions] attribute DOMString? ariaLevel;
-	[CEReactions] attribute DOMString? ariaLive;
-	[CEReactions] attribute DOMString? ariaModal;
-	[CEReactions] attribute DOMString? ariaMultiLine;
-	[CEReactions] attribute DOMString? ariaMultiSelectable;
-	[CEReactions] attribute DOMString? ariaOrientation;
-
-	[CEReactions] attribute DOMString? ariaPlaceholder;
-	[CEReactions] attribute DOMString? ariaPosInSet;
-	[CEReactions] attribute DOMString? ariaPressed;
-	[CEReactions] attribute DOMString? ariaReadOnly;
-	[CEReactions] attribute DOMString? ariaRelevant;
-
-	[CEReactions] attribute DOMString? ariaRequired;
-	[CEReactions] attribute DOMString? ariaRoleDescription;
-	[CEReactions] attribute DOMString? ariaRowCount;
-	[CEReactions] attribute DOMString? ariaRowIndex;
-
-	[CEReactions] attribute DOMString? ariaRowSpan;
-	[CEReactions] attribute DOMString? ariaSelected;
-	[CEReactions] attribute DOMString? ariaSetSize;
-	[CEReactions] attribute DOMString? ariaSort;
-	[CEReactions] attribute DOMString? ariaValueMax;
-	[CEReactions] attribute DOMString? ariaValueMin;
-	[CEReactions] attribute DOMString? ariaValueNow;
-	[CEReactions] attribute DOMString? ariaValueText;
+    [CEReactions] attribute DOMString? role;
+    [CEReactions] attribute DOMString? ariaAtomic;
+    [CEReactions] attribute DOMString? ariaAutoComplete;
+    [CEReactions] attribute DOMString? ariaBusy;
+    [CEReactions] attribute DOMString? ariaChecked;
+    [CEReactions] attribute DOMString? ariaColCount;
+    [CEReactions] attribute DOMString? ariaColIndex;
+    [CEReactions] attribute DOMString? ariaColSpan;
+    [CEReactions] attribute DOMString? ariaCurrent;
+    [CEReactions] attribute DOMString? ariaDisabled;
+    [CEReactions] attribute DOMString? ariaExpanded;
+    [CEReactions] attribute DOMString? ariaHasPopup;
+    [CEReactions] attribute DOMString? ariaHidden;
+    [CEReactions] attribute DOMString? ariaInvalid;
+    [CEReactions] attribute DOMString? ariaKeyShortcuts;
+    [CEReactions] attribute DOMString? ariaLabel;
+    [CEReactions] attribute DOMString? ariaLevel;
+    [CEReactions] attribute DOMString? ariaLive;
+    [CEReactions] attribute DOMString? ariaModal;
+    [CEReactions] attribute DOMString? ariaMultiLine;
+    [CEReactions] attribute DOMString? ariaMultiSelectable;
+    [CEReactions] attribute DOMString? ariaOrientation;
+    [CEReactions] attribute DOMString? ariaPlaceholder;
+    [CEReactions] attribute DOMString? ariaPosInSet;
+    [CEReactions] attribute DOMString? ariaPressed;
+    [CEReactions] attribute DOMString? ariaReadOnly;
+    [CEReactions] attribute DOMString? ariaRelevant;
+    [CEReactions] attribute DOMString? ariaRequired;
+    [CEReactions] attribute DOMString? ariaRoleDescription;
+    [CEReactions] attribute DOMString? ariaRowCount;
+    [CEReactions] attribute DOMString? ariaRowIndex;
+    [CEReactions] attribute DOMString? ariaRowSpan;
+    [CEReactions] attribute DOMString? ariaSelected;
+    [CEReactions] attribute DOMString? ariaSetSize;
+    [CEReactions] attribute DOMString? ariaSort;
+    [CEReactions] attribute DOMString? ariaValueMax;
+    [CEReactions] attribute DOMString? ariaValueMin;
+    [CEReactions] attribute DOMString? ariaValueNow;
+    [CEReactions] attribute DOMString? ariaValueText;
 };


### PR DESCRIPTION
Also, remove blank lines. (https://w3c.github.io/aria/#ARIAMixin source doesn’t have any blank lines, and it’s not clear that the blank lines in ours follow any intended structure/logic.)