### PR TITLE
LibWeb: Don't crash when determining slot element auto directionality

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/dir-slot-auto-directionality.txt
+++ b/Tests/LibWeb/Text/expected/HTML/dir-slot-auto-directionality.txt
@@ -1,0 +1,1 @@
+    Slot directionality: ltr

--- a/Tests/LibWeb/Text/input/HTML/dir-slot-auto-directionality.html
+++ b/Tests/LibWeb/Text/input/HTML/dir-slot-auto-directionality.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="root">
+    <span></span>
+</div>
+<script>
+    const root = document.getElementById("root");
+    test(() => {
+        const shadowTree = `<slot dir="auto"></slot>`;
+        const shadow = document.querySelector("#root").attachShadow({mode: "open"});
+        shadow.innerHTML = shadowTree;
+        println(`Slot directionality: ${getComputedStyle(shadow.querySelector("slot")).direction}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -2643,7 +2643,7 @@ Optional<Element::Directionality> Element::auto_directionality() const
                     VERIFY(child->is_element());
 
                     // 2. Set childDirection to the auto directionality of child.
-                    child_direction = static_cast<HTML::HTMLElement const&>(*this).auto_directionality();
+                    child_direction = static_cast<HTML::HTMLElement const&>(*child).auto_directionality();
                 }
 
                 // 4. If childDirection is not null, then return childDirection.


### PR DESCRIPTION
Fixes a crash in the following tests:
* https://wpt.live/html/dom/elements/global-attributes/dir-slots-directionality.html
* https://wpt.live/html/dom/elements/global-attributes/dir-auto-dynamic-changes.window.html
* https://wpt.live/html/dom/elements/global-attributes/dir-shadow-05.html
* https://wpt.live/html/dom/elements/global-attributes/dir-shadow-06.html
* https://wpt.live/html/dom/elements/global-attributes/dir-shadow-41.html
* https://wpt.live/html/dom/elements/global-attributes/dir-shadow-42.html
