### PR TITLE
Meta: Drop the --no-ports arg from .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,6 @@ repos:
       - id: meta-lint-ci
         name: Running Meta/lint-ci.sh to ensure changes will pass linting on CI
         entry: bash Meta/lint-ci.sh
-        args: [ --no-ports ]
         stages: [ commit ]
         language: system
 


### PR DESCRIPTION
Our `Meta/lint-ci.sh` script doesn’t have support/handling for a `--no-ports` option, so there’s no need to pass such an option.