### PR TITLE
LibWeb: Update "parse a sizes attribute" and related algorithms

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/CSS/BUILD.gn
@@ -60,6 +60,7 @@ source_set("CSS") {
     "SelectorEngine.cpp",
     "Serialize.cpp",
     "Size.cpp",
+    "Sizing.cpp",
     "StyleComputer.cpp",
     "StyleInvalidation.cpp",
     "StyleProperties.cpp",

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -99,6 +99,7 @@ set(SOURCES
     CSS/SelectorEngine.cpp
     CSS/Serialize.cpp
     CSS/Size.cpp
+    CSS/Sizing.cpp
     CSS/StyleComputer.cpp
     CSS/StyleInvalidation.cpp
     CSS/StyleProperties.cpp

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -39,6 +39,7 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/Parser/Rule.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/Sizing.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
@@ -86,6 +87,7 @@
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/CSS/StyleValues/UnresolvedStyleValue.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Infra/Strings.h>
 
@@ -7927,29 +7929,43 @@ private:
 };
 
 // https://html.spec.whatwg.org/multipage/images.html#parsing-a-sizes-attribute
-LengthOrCalculated Parser::Parser::parse_as_sizes_attribute()
+LengthOrCalculated Parser::Parser::parse_as_sizes_attribute([[maybe_unused]] DOM::Element const& element, HTML::HTMLImageElement const* img)
 {
+    // When asked to parse a sizes attribute from an element element, with an img element or null img:
+
     // 1. Let unparsed sizes list be the result of parsing a comma-separated list of component values
     //    from the value of element's sizes attribute (or the empty string, if the attribute is absent).
+    // NOTE: The sizes attribute has already been tokenized into m_token_stream by this point.
     auto unparsed_sizes_list = parse_a_comma_separated_list_of_component_values(m_token_stream);
 
     // 2. Let size be null.
     Optional<LengthOrCalculated> size;
 
+    auto size_is_auto = [&size]() {
+        return !size->is_calculated() && size->value().is_auto();
+    };
+
+    auto remove_all_consecutive_whitespace_tokens_from_the_end_of = [](auto& tokens) {
+        while (!tokens.is_empty() && tokens.last().is_token() && tokens.last().token().is(Token::Type::Whitespace))
+            tokens.take_last();
+    };
+
     // 3. For each unparsed size in unparsed sizes list:
-    for (auto& unparsed_size : unparsed_sizes_list) {
+    for (auto i = 0u; i < unparsed_sizes_list.size(); i++) {
+        auto& unparsed_size = unparsed_sizes_list[i];
+
         // 1. Remove all consecutive <whitespace-token>s from the end of unparsed size.
         //    If unparsed size is now empty, that is a parse error; continue.
-        while (!unparsed_size.is_empty() && unparsed_size.last().is_token() && unparsed_size.last().token().is(Token::Type::Whitespace))
-            unparsed_size.take_last();
+        remove_all_consecutive_whitespace_tokens_from_the_end_of(unparsed_size);
         if (unparsed_size.is_empty()) {
             log_parse_error();
+            dbgln_if(CSS_PARSER_DEBUG, "-> Failed in step 3.1; all whitespace");
             continue;
         }
 
         // 2. If the last component value in unparsed size is a valid non-negative <source-size-value>,
-        //    let size be its value and remove the component value from unparsed size.
-        //    FIXME: Any CSS function other than the math functions is invalid.
+        //    then set size to its value and remove the component value from unparsed size.
+        //    Any CSS function other than the math functions is invalid.
         //    Otherwise, there is a parse error; continue.
         auto last_value_stream = TokenStream<ComponentValue>::of_single_token(unparsed_size.last());
         if (auto source_size_value = parse_source_size_value(last_value_stream); source_size_value.has_value()) {
@@ -7957,33 +7973,55 @@ LengthOrCalculated Parser::Parser::parse_as_sizes_attribute()
             unparsed_size.take_last();
         } else {
             log_parse_error();
+            dbgln_if(CSS_PARSER_DEBUG, "-> Failed in step 3.2; couldn't parse {} as a <source-size-value>", unparsed_size.last().to_debug_string());
             continue;
         }
 
-        // 3. Remove all consecutive <whitespace-token>s from the end of unparsed size.
-        while (!unparsed_size.is_empty() && unparsed_size.last().is_token() && unparsed_size.last().token().is(Token::Type::Whitespace))
-            unparsed_size.take_last();
+        // 3. If size is auto, and img is not null, and img is being rendered, and img allows auto-sizes,
+        //    then set size to the concrete object size width of img, in CSS pixels.
+        // FIXME: "img is being rendered" - we just see if it has a bitmap for now
+        if (size_is_auto() && img && img->immutable_bitmap() && img->allows_auto_sizes()) {
+            // FIXME: The spec doesn't seem to tell us how to determine the concrete size of an <img>, so use the default sizing algorithm.
+            //        Should this use some of the methods from FormattingContext?
+            auto concrete_size = run_default_sizing_algorithm(
+                img->width(), img->height(),
+                img->natural_width(), img->natural_height(), img->intrinsic_aspect_ratio(),
+                // NOTE: https://html.spec.whatwg.org/multipage/rendering.html#img-contain-size
+                CSSPixelSize { 300, 150 });
+            size = Length::make_px(concrete_size.width());
+        }
 
-        // If unparsed size is now empty, then return size.
-        if (unparsed_size.is_empty())
-            return size.value();
+        // 4. Remove all consecutive <whitespace-token>s from the end of unparsed size.
+        //    If unparsed size is now empty:
+        remove_all_consecutive_whitespace_tokens_from_the_end_of(unparsed_size);
+        if (unparsed_size.is_empty()) {
+            // 1. If this was not the last item in unparsed sizes list, that is a parse error.
+            if (i != unparsed_sizes_list.size() - 1) {
+                log_parse_error();
+                dbgln_if(CSS_PARSER_DEBUG, "-> Failed in step 3.4.1; is unparsed size #{}, count {}", i, unparsed_sizes_list.size());
+            }
 
-        // FIXME: If this was not the keyword auto and it was not the last item in unparsed sizes list, that is a parse error.
+            // 2. If size is not auto, then return size. Otherwise, continue.
+            if (!size_is_auto())
+                return size.release_value();
+            continue;
+        }
 
-        // 4. Parse the remaining component values in unparsed size as a <media-condition>.
+        // 5. Parse the remaining component values in unparsed size as a <media-condition>.
         //    If it does not parse correctly, or it does parse correctly but the <media-condition> evaluates to false, continue.
         TokenStream<ComponentValue> token_stream { unparsed_size };
         auto media_condition = parse_media_condition(token_stream, MediaCondition::AllowOr::Yes);
-        auto context_window = m_context.window();
-        if (context_window && media_condition && media_condition->evaluate(*context_window) == MatchResult::True) {
-            return size.value();
+        auto const* context_window = m_context.window();
+        if (!media_condition || (context_window && media_condition->evaluate(*context_window) == MatchResult::False)) {
+            continue;
         }
 
-        // 5. If size is not auto, then return size.
-        if (size.value().is_calculated() || !size.value().value().is_auto())
+        // 5. If size is not auto, then return size. Otherwise, continue.
+        if (!size_is_auto())
             return size.value();
     }
 
+    // 4. Return 100vw.
     return Length(100, Length::Type::Vw);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7929,9 +7929,14 @@ private:
 };
 
 // https://html.spec.whatwg.org/multipage/images.html#parsing-a-sizes-attribute
-LengthOrCalculated Parser::Parser::parse_as_sizes_attribute([[maybe_unused]] DOM::Element const& element, HTML::HTMLImageElement const* img)
+LengthOrCalculated Parser::Parser::parse_as_sizes_attribute(DOM::Element const& element, HTML::HTMLImageElement const* img)
 {
     // When asked to parse a sizes attribute from an element element, with an img element or null img:
+
+    // AD-HOC: If element has no sizes attribute, this algorithm always logs a parse error and then returns 100vw.
+    //         The attribute is optional, so avoid spamming the debug log with false positives by just returning early.
+    if (!element.has_attribute(HTML::AttributeNames::sizes))
+        return Length(100, Length::Type::Vw);
 
     // 1. Let unparsed sizes list be the result of parsing a comma-separated list of component values
     //    from the value of element's sizes attribute (or the empty string, if the attribute is absent).

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -75,7 +75,7 @@ public:
 
     static NonnullRefPtr<CSSStyleValue> resolve_unresolved_style_value(ParsingContext const&, DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, PropertyID, UnresolvedStyleValue const&);
 
-    [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute();
+    [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute(DOM::Element const& element, HTML::HTMLImageElement const* img = nullptr);
 
 private:
     Parser(ParsingContext const&, Vector<Token>);

--- a/Userland/Libraries/LibWeb/CSS/Sizing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Sizing.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Sizing.h"
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-images/#default-sizing
+CSSPixelSize run_default_sizing_algorithm(
+    Optional<CSSPixels> specified_width, Optional<CSSPixels> specified_height,
+    Optional<CSSPixels> natural_width, Optional<CSSPixels> natural_height,
+    Optional<CSSPixelFraction> natural_aspect_ratio,
+    CSSPixelSize default_size)
+{
+    // If the specified size is a definite width and height, the concrete object size is given that width and height.
+    if (specified_width.has_value() && specified_height.has_value())
+        return CSSPixelSize { specified_width.value(), specified_height.value() };
+    // If the specified size is only a width or height (but not both) then the concrete object size is given that specified width or height.
+    // The other dimension is calculated as follows:
+    if (specified_width.has_value() || specified_height.has_value()) {
+        // 1. If the object has a natural aspect ratio,
+        // the missing dimension of the concrete object size is calculated using that aspect ratio and the present dimension.
+        if (natural_aspect_ratio.has_value() && !natural_aspect_ratio->might_be_saturated()) {
+            if (specified_width.has_value())
+                return CSSPixelSize { specified_width.value(), (CSSPixels(1) / natural_aspect_ratio.value()) * specified_width.value() };
+            if (specified_height.has_value())
+                return CSSPixelSize { specified_height.value() * natural_aspect_ratio.value(), specified_height.value() };
+        }
+        // 2. Otherwise, if the missing dimension is present in the object’s natural dimensions,
+        // the missing dimension is taken from the object’s natural dimensions.
+        if (specified_height.has_value() && natural_width.has_value())
+            return CSSPixelSize { natural_width.value(), specified_height.value() };
+        if (specified_width.has_value() && natural_height.has_value())
+            return CSSPixelSize { specified_width.value(), natural_height.value() };
+        // 3. Otherwise, the missing dimension of the concrete object size is taken from the default object size.
+        if (specified_height.has_value())
+            return CSSPixelSize { default_size.width(), specified_height.value() };
+        if (specified_width.has_value())
+            return CSSPixelSize { specified_width.value(), default_size.height() };
+        VERIFY_NOT_REACHED();
+    }
+    // If the specified size has no constraints:
+    // 1. If the object has a natural height or width, its size is resolved as if its natural dimensions were given as the specified size.
+    if (natural_width.has_value() || natural_height.has_value())
+        return run_default_sizing_algorithm(natural_width, natural_height, natural_width, natural_height, natural_aspect_ratio, default_size);
+    // FIXME: 2. Otherwise, its size is resolved as a contain constraint against the default object size.
+    return default_size;
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Sizing.h
+++ b/Userland/Libraries/LibWeb/CSS/Sizing.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/PixelUnits.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-images/#default-sizing
+CSSPixelSize run_default_sizing_algorithm(
+    Optional<CSSPixels> specified_width, Optional<CSSPixels> specified_height,
+    Optional<CSSPixels> natural_width, Optional<CSSPixels> natural_height,
+    Optional<CSSPixelFraction> natural_aspect_ratio,
+    CSSPixelSize default_size);
+
+}

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1171,4 +1171,17 @@ void HTMLImageElement::set_decoding(String decoding)
         m_decoding_hint = ImageDecodingHint::Auto;
 }
 
+bool HTMLImageElement::allows_auto_sizes() const
+{
+    // An img element allows auto-sizes if:
+    // - its loading attribute is in the Lazy state, and
+    // - its sizes attribute's value is "auto" (ASCII case-insensitive), or starts with "auto," (ASCII case-insensitive).
+    if (lazy_loading_attribute() != LazyLoading::Lazy)
+        return false;
+    auto sizes = attribute(HTML::AttributeNames::sizes);
+    return sizes.has_value()
+        && (sizes->equals_ignoring_ascii_case("auto"sv)
+            || sizes->starts_with_bytes("auto,"sv, AK::CaseSensitivity::CaseInsensitive));
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -990,7 +990,12 @@ static void update_the_source_set(DOM::Element& element)
         });
     }
 
-    // 4. For each child in elements:
+    // 4. Let img be el if el is an img element, otherwise null.
+    HTMLImageElement* img = nullptr;
+    if (is<HTMLImageElement>(element))
+        img = static_cast<HTMLImageElement*>(&element);
+
+    // 5. For each child in elements:
     for (auto child : elements) {
         // 1. If child is el:
         if (child == &element) {
@@ -1039,11 +1044,13 @@ static void update_the_source_set(DOM::Element& element)
                     default_source = href_value.release_value();
             }
 
-            // 10. Let el's source set be the result of creating a source set given default source, srcset, and sizes.
+            // 10. Let el's source set be the result of creating a source set given default source, srcset, sizes, and img.
             if (is<HTMLImageElement>(element))
-                static_cast<HTMLImageElement&>(element).set_source_set(SourceSet::create(element, default_source, srcset, sizes));
+                static_cast<HTMLImageElement&>(element).set_source_set(SourceSet::create(element, default_source, srcset, sizes, img));
             else if (is<HTMLLinkElement>(element))
                 TODO();
+
+            // 11. Return.
             return;
         }
         // 2. If child is not a source element, then continue.
@@ -1070,8 +1077,8 @@ static void update_the_source_set(DOM::Element& element)
             }
         }
 
-        // 7. Parse child's sizes attribute, and let source set's source size be the returned value.
-        source_set.m_source_size = parse_a_sizes_attribute(element.document(), child->get_attribute_value(HTML::AttributeNames::sizes));
+        // 7. Parse child's sizes attribute with img, and let source set's source size be the returned value.
+        source_set.m_source_size = parse_a_sizes_attribute(element, child->get_attribute_value(HTML::AttributeNames::sizes), img);
 
         // 8. If child has a type attribute, and its value is an unknown or unsupported MIME type, continue to the next child.
         if (child->has_attribute(HTML::AttributeNames::type)) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -94,6 +94,9 @@ public:
     // https://html.spec.whatwg.org/multipage/images.html#upgrade-the-pending-request-to-the-current-request
     void upgrade_pending_request_to_current_request();
 
+    // https://html.spec.whatwg.org/multipage/embedded-content.html#allows-auto-sizes
+    bool allows_auto_sizes() const;
+
     // ^Layout::ImageProvider
     virtual bool is_image_available() const override;
     virtual Optional<CSSPixels> intrinsic_width() const override;

--- a/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SourceSet.cpp
@@ -339,15 +339,17 @@ descriptor_parser:
 }
 
 // https://html.spec.whatwg.org/multipage/images.html#parse-a-sizes-attribute
-CSS::LengthOrCalculated parse_a_sizes_attribute(DOM::Document const& document, StringView sizes)
+CSS::LengthOrCalculated parse_a_sizes_attribute(DOM::Element const& element, StringView sizes, HTML::HTMLImageElement const* img)
 {
-    auto css_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext { document }, sizes);
-    return css_parser.parse_as_sizes_attribute();
+    auto css_parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext { element.document() }, sizes);
+    return css_parser.parse_as_sizes_attribute(element, img);
 }
 
 // https://html.spec.whatwg.org/multipage/images.html#create-a-source-set
-SourceSet SourceSet::create(DOM::Element const& element, String default_source, String srcset, String sizes)
+SourceSet SourceSet::create(DOM::Element const& element, String const& default_source, String const& srcset, String const& sizes, HTML::HTMLImageElement const* img)
 {
+    // When asked to create a source set given a string default source, a string srcset, a string sizes, and an element or null img:
+
     // 1. Let source set be an empty source set.
     SourceSet source_set;
 
@@ -355,8 +357,8 @@ SourceSet SourceSet::create(DOM::Element const& element, String default_source, 
     if (!srcset.is_empty())
         source_set = parse_a_srcset_attribute(srcset);
 
-    // 3. Let source size be the result of parsing sizes.
-    source_set.m_source_size = parse_a_sizes_attribute(element.document(), sizes);
+    // 3. Let source size be the result of parsing sizes with img.
+    source_set.m_source_size = parse_a_sizes_attribute(element, sizes, img);
 
     // 4. If default source is not the empty string and source set does not contain an image source
     //    with a pixel density descriptor value of 1, and no image source with a width descriptor,

--- a/Userland/Libraries/LibWeb/HTML/SourceSet.h
+++ b/Userland/Libraries/LibWeb/HTML/SourceSet.h
@@ -33,7 +33,7 @@ struct ImageSourceAndPixelDensity {
 
 // https://html.spec.whatwg.org/multipage/images.html#source-set
 struct SourceSet {
-    static SourceSet create(DOM::Element const&, String default_source, String srcset, String sizes);
+    static SourceSet create(DOM::Element const& element, String const& default_source, String const& srcset, String const& sizes, HTML::HTMLImageElement const* img = nullptr);
 
     [[nodiscard]] bool is_empty() const;
 
@@ -50,6 +50,6 @@ struct SourceSet {
 };
 
 SourceSet parse_a_srcset_attribute(StringView);
-[[nodiscard]] CSS::LengthOrCalculated parse_a_sizes_attribute(DOM::Document const&, StringView);
+[[nodiscard]] CSS::LengthOrCalculated parse_a_sizes_attribute(DOM::Element const& element, StringView sizes, HTML::HTMLImageElement const* img = nullptr);
 
 }

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/Sizing.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
@@ -13,48 +14,6 @@
 #include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Painting {
-
-// https://drafts.csswg.org/css-images/#default-sizing
-static CSSPixelSize run_default_sizing_algorithm(
-    Optional<CSSPixels> specified_width, Optional<CSSPixels> specified_height,
-    Optional<CSSPixels> natural_width, Optional<CSSPixels> natural_height,
-    Optional<CSSPixelFraction> natural_aspect_ratio,
-    CSSPixelSize default_size)
-{
-    // If the specified size is a definite width and height, the concrete object size is given that width and height.
-    if (specified_width.has_value() && specified_height.has_value())
-        return CSSPixelSize { specified_width.value(), specified_height.value() };
-    // If the specified size is only a width or height (but not both) then the concrete object size is given that specified width or height.
-    // The other dimension is calculated as follows:
-    if (specified_width.has_value() || specified_height.has_value()) {
-        // 1. If the object has a natural aspect ratio,
-        // the missing dimension of the concrete object size is calculated using that aspect ratio and the present dimension.
-        if (natural_aspect_ratio.has_value() && !natural_aspect_ratio->might_be_saturated()) {
-            if (specified_width.has_value())
-                return CSSPixelSize { specified_width.value(), (CSSPixels(1) / natural_aspect_ratio.value()) * specified_width.value() };
-            if (specified_height.has_value())
-                return CSSPixelSize { specified_height.value() * natural_aspect_ratio.value(), specified_height.value() };
-        }
-        // 2. Otherwise, if the missing dimension is present in the object’s natural dimensions,
-        // the missing dimension is taken from the object’s natural dimensions.
-        if (specified_height.has_value() && natural_width.has_value())
-            return CSSPixelSize { natural_width.value(), specified_height.value() };
-        if (specified_width.has_value() && natural_height.has_value())
-            return CSSPixelSize { specified_width.value(), natural_height.value() };
-        // 3. Otherwise, the missing dimension of the concrete object size is taken from the default object size.
-        if (specified_height.has_value())
-            return CSSPixelSize { default_size.width(), specified_height.value() };
-        if (specified_width.has_value())
-            return CSSPixelSize { specified_width.value(), default_size.height() };
-        VERIFY_NOT_REACHED();
-    }
-    // If the specified size has no constraints:
-    // 1. If the object has a natural height or width, its size is resolved as if its natural dimensions were given as the specified size.
-    if (natural_width.has_value() || natural_height.has_value())
-        return run_default_sizing_algorithm(natural_width, natural_height, natural_width, natural_height, natural_aspect_ratio, default_size);
-    // FIXME: 2. Otherwise, its size is resolved as a contain constraint against the default object size.
-    return default_size;
-}
 
 static RefPtr<DisplayList> compute_text_clip_paths(PaintContext& context, Paintable const& paintable, CSSPixelPoint containing_block_location)
 {
@@ -373,7 +332,7 @@ ResolvedBackground resolve_background_layers(Vector<CSS::BackgroundLayerData> co
             if (!layer.size_y.is_auto())
                 specified_height = layer.size_y.to_px(layout_node, background_positioning_area.height());
         }
-        auto concrete_image_size = run_default_sizing_algorithm(
+        auto concrete_image_size = CSS::run_default_sizing_algorithm(
             specified_width, specified_height,
             image.natural_width(), image.natural_height(), image.natural_aspect_ratio(),
             background_positioning_area.size());


### PR DESCRIPTION
Noticed our spec comments didn't match the current spec, so this updates a few algorithms related to the `sizes` attribute. (Yay spec comments!)

Also, because it's what led me to investigate `sizes` in the first place: skip the algorithm entirely when the attribute is empty, so that we don't get useless parse errors spamming the console.

http://wpt.live/html/semantics/embedded-content/the-img-element/sizes/parse-a-sizes-attribute-standards-mode.html passes now, and didn't before, but that might be a fluke? It's hard to tell because a few of these `sizes`-related WPT tests are flakey.