### PR TITLE
 LibWeb: Add a cache for ScrollFrame::cumulative_offset()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5550,10 +5550,10 @@ RefPtr<Painting::DisplayList> Document::record_display_list(PaintConfig config)
     Vector<RefPtr<Painting::ScrollFrame>> scroll_state;
     scroll_state.resize(viewport_paintable.scroll_state.size() + viewport_paintable.sticky_state.size());
     for (auto& [_, scrollable_frame] : viewport_paintable.scroll_state) {
-        scroll_state[scrollable_frame->id] = scrollable_frame;
+        scroll_state[scrollable_frame->id()] = scrollable_frame;
     }
     for (auto& [_, scrollable_frame] : viewport_paintable.sticky_state) {
-        scroll_state[scrollable_frame->id] = scrollable_frame;
+        scroll_state[scrollable_frame->id()] = scrollable_frame;
     }
 
     display_list->set_scroll_state(move(scroll_state));

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -12,14 +12,14 @@ namespace Web::Painting {
 Optional<int> ClippableAndScrollable::own_scroll_frame_id() const
 {
     if (m_own_scroll_frame)
-        return m_own_scroll_frame->id;
+        return m_own_scroll_frame->id();
     return {};
 }
 
 Optional<int> ClippableAndScrollable::scroll_frame_id() const
 {
     if (m_enclosing_scroll_frame)
-        return m_enclosing_scroll_frame->id;
+        return m_enclosing_scroll_frame->id();
     return {};
 }
 
@@ -51,7 +51,7 @@ void ClippableAndScrollable::apply_clip(PaintContext& context) const
     for (auto const& clip_rect : clip_rects) {
         Optional<i32> clip_scroll_frame_id;
         if (clip_rect.enclosing_scroll_frame)
-            clip_scroll_frame_id = clip_rect.enclosing_scroll_frame->id;
+            clip_scroll_frame_id = clip_rect.enclosing_scroll_frame->id();
         display_list_recorder.set_scroll_frame_id(clip_scroll_frame_id);
         auto rect = context.rounded_device_rect(clip_rect.rect).to_type<int>();
         auto corner_radii = clip_rect.corner_radii.as_corners(context);

--- a/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
+++ b/Userland/Libraries/LibWeb/Painting/ClippableAndScrollable.h
@@ -28,7 +28,7 @@ public:
     [[nodiscard]] CSSPixelPoint own_scroll_frame_offset() const
     {
         if (m_own_scroll_frame)
-            return m_own_scroll_frame->own_offset;
+            return m_own_scroll_frame->own_offset();
         return {};
     }
     void set_own_scroll_frame(RefPtr<ScrollFrame> scroll_frame) { m_own_scroll_frame = scroll_frame; }

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -37,7 +37,7 @@ void DisplayListPlayer::execute(DisplayList& display_list)
 
         if (command.has<PaintScrollBar>()) {
             auto& paint_scroll_bar = command.get<PaintScrollBar>();
-            auto const& scroll_offset = scroll_state[paint_scroll_bar.scroll_frame_id]->own_offset;
+            auto const& scroll_offset = scroll_state[paint_scroll_bar.scroll_frame_id]->own_offset();
             if (paint_scroll_bar.vertical) {
                 auto offset = scroll_offset.y() * paint_scroll_bar.scroll_size;
                 paint_scroll_bar.rect.translate_by(0, -offset.to_int() * device_pixels_per_css_pixel);

--- a/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -10,17 +10,30 @@
 
 namespace Web::Painting {
 
-struct ScrollFrame : public RefCounted<ScrollFrame> {
-    i32 id { -1 };
-    CSSPixelPoint own_offset;
-    RefPtr<ScrollFrame const> parent;
+class ScrollFrame : public RefCounted<ScrollFrame> {
+public:
+    ScrollFrame(i32 id, RefPtr<ScrollFrame const> parent)
+        : m_id(id)
+        , m_parent(move(parent))
+    {
+    }
+
+    i32 id() const { return m_id; }
 
     CSSPixelPoint cumulative_offset() const
     {
-        if (parent)
-            return parent->cumulative_offset() + own_offset;
-        return own_offset;
+        if (m_parent)
+            return m_parent->cumulative_offset() + m_own_offset;
+        return m_own_offset;
     }
+
+    CSSPixelPoint own_offset() const { return m_own_offset; }
+    void set_own_offset(CSSPixelPoint offset) { m_own_offset = offset; }
+
+private:
+    i32 m_id { -1 };
+    RefPtr<ScrollFrame const> m_parent;
+    CSSPixelPoint m_own_offset;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
+++ b/Userland/Libraries/LibWeb/Painting/ScrollFrame.h
@@ -22,18 +22,30 @@ public:
 
     CSSPixelPoint cumulative_offset() const
     {
-        if (m_parent)
-            return m_parent->cumulative_offset() + m_own_offset;
-        return m_own_offset;
+        if (!m_cached_cumulative_offset.has_value()) {
+            m_cached_cumulative_offset = m_own_offset;
+            if (m_parent) {
+                m_cached_cumulative_offset.value() += m_parent->cumulative_offset();
+            }
+        }
+        return m_cached_cumulative_offset.value();
     }
 
     CSSPixelPoint own_offset() const { return m_own_offset; }
-    void set_own_offset(CSSPixelPoint offset) { m_own_offset = offset; }
+    void set_own_offset(CSSPixelPoint offset)
+    {
+        m_cached_cumulative_offset.clear();
+        m_own_offset = offset;
+    }
 
 private:
     i32 m_id { -1 };
     RefPtr<ScrollFrame const> m_parent;
     CSSPixelPoint m_own_offset;
+
+    // Caching here relies on the fact that offsets of all scroll frames are invalidated when any of them changes,
+    // so we don't need to worry about invalidating the cache when the parent's offset changes.
+    mutable Optional<CSSPixelPoint> m_cached_cumulative_offset;
 };
 
 }


### PR DESCRIPTION
Calculating cumulative scroll offset is visible in profiles on very large pages, so let's add a simple caching for it.