### PR TITLE
LibWeb: Improve handling of http-equiv pragmas

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -90,6 +90,11 @@ void HTMLMetaElement::inserted()
     auto http_equiv = http_equiv_state();
     if (http_equiv.has_value()) {
         switch (http_equiv.value()) {
+        case HttpEquivAttributeState::EncodingDeclaration:
+            // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-content-type
+            // The Encoding declaration state is just an alternative form of setting the charset attribute: it is a character encoding declaration.
+            // This state's user agent requirements are all handled by the parsing section of the specification.
+            break;
         case HttpEquivAttributeState::Refresh: {
             // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-refresh
             // 1. If the meta element has no content attribute, or if that attribute's value is the empty string, then return.
@@ -105,6 +110,17 @@ void HTMLMetaElement::inserted()
             document().shared_declarative_refresh_steps(input, this);
             break;
         }
+        case HttpEquivAttributeState::SetCookie:
+            // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-set-cookie
+            // This pragma is non-conforming and has no effect.
+            // User agents are required to ignore this pragma.
+            break;
+        case HttpEquivAttributeState::XUACompatible:
+            // https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-http-equiv-x-ua-compatible
+            // In practice, this pragma encourages Internet Explorer to more closely follow the specifications.
+            // For meta elements with an http-equiv attribute in the X-UA-Compatible state, the content attribute must have a value that is an ASCII case-insensitive match for the string "IE=edge".
+            // User agents are required to ignore this pragma.
+            break;
         default:
             dbgln("FIXME: Implement '{}' http-equiv state", get_attribute_value(AttributeNames::http_equiv));
             break;

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -38,7 +38,7 @@ Optional<HTMLMetaElement::HttpEquivAttributeState> HTMLMetaElement::http_equiv_s
     auto value = get_attribute_value(HTML::AttributeNames::http_equiv);
 
 #define __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(keyword, state) \
-    if (value.equals_ignoring_ascii_case(#keyword##sv))            \
+    if (value.equals_ignoring_ascii_case(keyword##sv))             \
         return HTMLMetaElement::HttpEquivAttributeState::state;
     ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTES
 #undef __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE

--- a/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMetaElement.h
@@ -16,7 +16,7 @@ namespace Web::HTML {
     __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("content-language", ContentLanguage) \
     __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("content-type", EncodingDeclaration) \
     __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("default-style", DefaultStyle)       \
-    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE(refresh, Refresh)                    \
+    __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("refresh", Refresh)                  \
     __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("set-cookie", SetCookie)             \
     __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("x-ua-compatible", XUACompatible)    \
     __ENUMERATE_HTML_META_HTTP_EQUIV_ATTRIBUTE("content-security-policy", ContentSecurityPolicy)


### PR DESCRIPTION
The mapping from string keyword to state enum was incorrect, meaning the FIXME for unimplemented states was never printed.

This PR also includes branches for states which do not require any handling on insertion, most notably "content-type", which is already handled in the HTML parser.