### PR TITLE
LibWeb: Use LayoutState::UsedValues::containing_block_used_values() more

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -456,7 +456,7 @@ void BlockFormattingContext::compute_height(Box const& box, AvailableSpace const
         auto margins = box_state.margin_top + box_state.margin_bottom;
 
         // 2. Let size be the size of the initial containing block in the block flow direction minus margins.
-        auto size = m_state.get(*box.containing_block()).content_height() - margins;
+        auto size = box_state.containing_block_used_values()->content_height() - margins;
 
         // 3. Return the bigger value of size and the normal border box size the element would have
         //    according to the CSS specification.

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1670,64 +1670,57 @@ CSSPixels FormattingContext::calculate_inner_height(Layout::Box const& box, Avai
 
 CSSPixels FormattingContext::containing_block_width_for(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*node.containing_block());
-    auto const& node_state = m_state.get(node);
-
-    switch (node_state.width_constraint) {
+    auto const& used_values = m_state.get(node);
+    switch (used_values.width_constraint) {
     case SizeConstraint::MinContent:
         return 0;
     case SizeConstraint::MaxContent:
         return CSSPixels::max();
     case SizeConstraint::None:
-        return containing_block_state.content_width();
+        return used_values.containing_block_used_values()->content_width();
     }
     VERIFY_NOT_REACHED();
 }
 
 CSSPixels FormattingContext::containing_block_height_for(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*node.containing_block());
-    auto const& node_state = m_state.get(node);
+    auto const& used_values = m_state.get(node);
 
-    switch (node_state.height_constraint) {
+    switch (used_values.height_constraint) {
     case SizeConstraint::MinContent:
         return 0;
     case SizeConstraint::MaxContent:
         return CSSPixels::max();
     case SizeConstraint::None:
-        return containing_block_state.content_height();
+        return used_values.containing_block_used_values()->content_height();
     }
     VERIFY_NOT_REACHED();
 }
 
 AvailableSize FormattingContext::containing_block_width_as_available_size(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*node.containing_block());
-    auto const& node_state = m_state.get(node);
-
-    switch (node_state.width_constraint) {
+    auto const& used_values = m_state.get(node);
+    switch (used_values.width_constraint) {
     case SizeConstraint::MinContent:
         return AvailableSize::make_min_content();
     case SizeConstraint::MaxContent:
         return AvailableSize::make_max_content();
     case SizeConstraint::None:
-        return AvailableSize::make_definite(containing_block_state.content_width());
+        return AvailableSize::make_definite(used_values.containing_block_used_values()->content_width());
     }
     VERIFY_NOT_REACHED();
 }
 
 AvailableSize FormattingContext::containing_block_height_as_available_size(NodeWithStyleAndBoxModelMetrics const& node) const
 {
-    auto const& containing_block_state = m_state.get(*node.containing_block());
-    auto const& node_state = m_state.get(node);
-
-    switch (node_state.height_constraint) {
+    auto const& used_values = m_state.get(node);
+    switch (used_values.height_constraint) {
     case SizeConstraint::MinContent:
         return AvailableSize::make_min_content();
     case SizeConstraint::MaxContent:
         return AvailableSize::make_max_content();
     case SizeConstraint::None:
-        return AvailableSize::make_definite(containing_block_state.content_height());
+        return AvailableSize::make_definite(used_values.containing_block_used_values()->content_height());
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -849,8 +849,8 @@ void TableFormattingContext::compute_table_height()
         for (size_t i = 0; i < cell.column_span; ++i)
             span_width += m_columns[cell.column_index + i].used_width;
 
-        auto width_of_containing_block = m_state.get(*cell.box->containing_block()).content_width();
-        auto height_of_containing_block = m_state.get(*cell.box->containing_block()).content_height();
+        auto width_of_containing_block = cell_state.containing_block_used_values()->content_width();
+        auto height_of_containing_block = cell_state.containing_block_used_values()->content_height();
 
         cell_state.padding_top = cell.box->computed_values().padding().top().to_px(cell.box, width_of_containing_block);
         cell_state.padding_bottom = cell.box->computed_values().padding().bottom().to_px(cell.box, width_of_containing_block);


### PR DESCRIPTION
Use this cached pointer to the containing block's used values when obviously possible. This avoids a hash lookup each time, and these hash lookups do show up in profiles.