### PR TITLE
LibWeb: Reset a vector of contained abspos before collecting them again

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1132,6 +1132,10 @@ void Document::update_layout()
     }
 
     // Assign each box that establishes a formatting context a list of absolutely positioned children it should take care of during layout
+    m_layout_root->for_each_in_inclusive_subtree_of_type<Layout::Box>([&](auto& child) {
+        child.clear_contained_abspos_children();
+        return TraversalDecision::Continue;
+    });
     m_layout_root->for_each_in_inclusive_subtree([&](auto& child) {
         if (!child.is_absolutely_positioned())
             return TraversalDecision::Continue;

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -55,6 +55,7 @@ public:
     bool is_user_scrollable() const;
 
     void add_contained_abspos_child(JS::NonnullGCPtr<Node> child) { m_contained_abspos_children.append(child); }
+    void clear_contained_abspos_children() { m_contained_abspos_children.clear(); }
     Vector<JS::NonnullGCPtr<Node>> const& contained_abspos_children() const { return m_contained_abspos_children; }
 
     virtual void visit_edges(Cell::Visitor&) override;


### PR DESCRIPTION
Fixes a bug when a vector with contained absolutely positioned boxes keeps growing, resulting in more duplicated work on each subsequent layout.