### PR TITLE
 LibWeb: Assign static position for abspos boxes nested into TFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/abspos-pseudo-element-inside-table.txt
+++ b/Tests/LibWeb/Layout/expected/table/abspos-pseudo-element-inside-table.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x20 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x4 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 784x4 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 784x4 table-box [TFC] children: not-inline
+          Box <thead> at (8,8) content-size 0x0 table-header-group children: not-inline
+            Box <tr> at (10,10) content-size 0x0 table-row children: not-inline
+              BlockContainer <(anonymous)> at (0,590) content-size 800x10 positioned [BFC] children: inline
+                TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x20] overflow: [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x4] overflow: [0,8 800x592]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 784x4] overflow: [0,8 800x592]
+        PaintableBox (Box<TABLE>) [8,8 784x4] overflow: [0,8 800x592]
+          PaintableBox (Box<THEAD>) [8,8 0x0] overflow: [0,10 800x590]
+            PaintableBox (Box<TR>) [10,10 0x0] overflow: [0,590 800x10]
+              PaintableWithLines (BlockContainer(anonymous)) [0,590 800x10]

--- a/Tests/LibWeb/Layout/input/table/abspos-pseudo-element-inside-table.html
+++ b/Tests/LibWeb/Layout/input/table/abspos-pseudo-element-inside-table.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html><style>
+    table {
+        width: 100%;
+    }
+
+    th, td {
+        border: 1px solid #ccc;
+        padding: 8px;
+        text-align: left;
+    }
+
+    tr::before {
+        content: '';
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        width: 100%;
+        height: 10px;
+        background-color: red;
+    }
+</style><table><thead><tr></tr></thead></table>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -142,14 +142,17 @@ Optional<FormattingContext::Type> FormattingContext::formatting_context_type_cre
     if (box.children_are_inline())
         return {};
 
+    if (display.is_table_column() || display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group() || display.is_table_row() || display.is_table_column_group())
+        return {};
+
     // The box is a block container that doesn't create its own BFC.
     // It will be formatted by the containing BFC.
     if (!display.is_flow_inside()) {
         // HACK: Instead of crashing, create a dummy formatting context that does nothing.
-        // FIXME: Remove this once it's no longer needed. It currently swallows problem with standalone
-        //        table-related boxes that don't get fixed up by CSS anonymous table box generation.
+        // FIXME: We need this for <math> elements
         return Type::InternalDummy;
     }
+
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -152,7 +152,6 @@ Optional<FormattingContext::Type> FormattingContext::formatting_context_type_cre
         // FIXME: We need this for <math> elements
         return Type::InternalDummy;
     }
-
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -37,6 +37,8 @@ public:
 
     static bool border_is_less_specific(const CSS::BorderData& a, const CSS::BorderData& b);
 
+    virtual void parent_context_did_dimension_child_root_box() override;
+
 private:
     CSSPixels run_caption_layout(CSS::CaptionSide);
     CSSPixels compute_capmin();


### PR DESCRIPTION
TFC is not aware of how to correctly calculate a static position for abspos boxes, but assigning (0, 0) is better than crashing during abspos item layout.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/1382