### PR TITLE
RequestServer: Use libcurl for HTTP and HTTPS downloads

### DIFF
--- a/Ladybird/AppKit/Application/Application.mm
+++ b/Ladybird/AppKit/Application/Application.mm
@@ -137,11 +137,6 @@ static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decod
     return worker_client->dup_socket();
 }
 
-- (void)dumpConnectionInfo:(id)sender
-{
-    m_request_server_client->dump_connection_info();
-}
-
 #pragma mark - NSApplication
 
 - (void)terminate:(id)sender

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -642,9 +642,6 @@
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Dump Local Storage"
                                                 action:@selector(dumpLocalStorage:)
                                          keyEquivalent:@""]];
-    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Dump Connection Info"
-                                                action:@selector(dumpConnectionInfo:)
-                                         keyEquivalent:@""]];
     [submenu addItem:[NSMenuItem separatorItem]];
 
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Show Line Box Borders"

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -431,11 +431,6 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         debug_request("dump-local-storage");
     });
 
-    auto* dump_connection_info = new QAction("Dump Co&nnection Info", this);
-    dump_connection_info->setIcon(load_icon_from_uri("resource://icons/16x16/network.png"sv));
-    debug_menu->addAction(dump_connection_info);
-    QObject::connect(dump_connection_info, &QAction::triggered, this, &BrowserWindow::dump_connection_info);
-
     debug_menu->addSeparator();
 
     m_show_line_box_borders_action = new QAction("Show Line Box Borders", this);
@@ -1237,12 +1232,6 @@ void BrowserWindow::closeEvent(QCloseEvent* event)
     QObject::deleteLater();
 
     QMainWindow::closeEvent(event);
-}
-
-void BrowserWindow::dump_connection_info()
-{
-    if (auto& application = static_cast<Application&>(WebView::Application::the()); application.request_server_client)
-        application.request_server_client->dump_connection_info();
 }
 
 }

--- a/Ladybird/Qt/BrowserWindow.h
+++ b/Ladybird/Qt/BrowserWindow.h
@@ -183,8 +183,6 @@ private:
     Web::CSS::PreferredColorScheme m_preferred_color_scheme;
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme);
 
-    static void dump_connection_info();
-
     QTabWidget* m_tabs_container { nullptr };
     Tab* m_current_tab { nullptr };
     QMenu* m_zoom_menu { nullptr };

--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -6,13 +6,6 @@ set(CMAKE_AUTOUIC OFF)
 
 set(REQUESTSERVER_SOURCES
     ${REQUESTSERVER_SOURCE_DIR}/ConnectionFromClient.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/ConnectionCache.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/Request.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/HttpRequest.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/HttpProtocol.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/HttpsRequest.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/HttpsProtocol.cpp
-    ${REQUESTSERVER_SOURCE_DIR}/Protocol.cpp
 )
 
 if (ANDROID)
@@ -34,7 +27,7 @@ target_link_libraries(RequestServer PRIVATE requestserver)
 
 target_include_directories(requestserver PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(requestserver PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(requestserver PUBLIC LibCore LibMain LibCrypto LibFileSystem LibHTTP LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading CURL::libcurl)
+target_link_libraries(requestserver PUBLIC LibCore LibMain LibCrypto LibFileSystem LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading CURL::libcurl)
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
     target_link_libraries(requestserver PUBLIC nsl socket)

--- a/Ladybird/RequestServer/CMakeLists.txt
+++ b/Ladybird/RequestServer/CMakeLists.txt
@@ -26,12 +26,15 @@ else()
     add_library(requestserver STATIC ${REQUESTSERVER_SOURCES})
 endif()
 
+find_package(PkgConfig)
+find_package(CURL REQUIRED)
+
 add_executable(RequestServer main.cpp)
 target_link_libraries(RequestServer PRIVATE requestserver)
 
 target_include_directories(requestserver PRIVATE ${LADYBIRD_SOURCE_DIR}/Userland/Services/)
 target_include_directories(requestserver PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/..)
-target_link_libraries(requestserver PUBLIC LibCore LibMain LibCrypto LibFileSystem LibHTTP LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading)
+target_link_libraries(requestserver PUBLIC LibCore LibMain LibCrypto LibFileSystem LibHTTP LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibThreading CURL::libcurl)
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries
     target_link_libraries(requestserver PUBLIC nsl socket)

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -17,8 +17,6 @@
 #include <LibMain/Main.h>
 #include <LibTLS/Certificate.h>
 #include <RequestServer/ConnectionFromClient.h>
-#include <RequestServer/HttpProtocol.h>
-#include <RequestServer/HttpsProtocol.h>
 
 #if defined(AK_OS_MACOS)
 #    include <LibCore/Platform/ProcessStatisticsMach.h>
@@ -70,9 +68,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (!mach_server_name.is_empty())
         Core::Platform::register_with_mach_server(mach_server_name);
 #endif
-
-    RequestServer::HttpProtocol::install();
-    RequestServer::HttpsProtocol::install();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ConnectionFromClient>());
 

--- a/Ladybird/RequestServer/main.cpp
+++ b/Ladybird/RequestServer/main.cpp
@@ -24,6 +24,10 @@
 #    include <LibCore/Platform/ProcessStatisticsMach.h>
 #endif
 
+namespace RequestServer {
+extern ByteString g_default_certificate_path;
+}
+
 static ErrorOr<ByteString> find_certificates(StringView serenity_resource_root)
 {
     auto cert_path = ByteString::formatted("{}/ladybird/cacert.pem", serenity_resource_root);
@@ -54,6 +58,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // Ensure the certificates are read out here.
     if (certificates.is_empty())
         certificates.append(TRY(find_certificates(serenity_resource_root)));
+    else
+        RequestServer::g_default_certificate_path = certificates.first();
+
     DefaultRootCACertificates::set_default_certificate_paths(certificates.span());
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 

--- a/Userland/Libraries/LibIPC/CMakeLists.txt
+++ b/Userland/Libraries/LibIPC/CMakeLists.txt
@@ -6,4 +6,4 @@ set(SOURCES
 )
 
 serenity_lib(LibIPC ipc)
-target_link_libraries(LibIPC PRIVATE LibCore LibURL)
+target_link_libraries(LibIPC PRIVATE LibCore LibURL LibThreading)

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -26,9 +26,41 @@ ConnectionBase::ConnectionBase(IPC::Stub& local_stub, NonnullOwnPtr<Core::LocalS
         (void)drain_messages_from_peer();
         handle_messages();
     };
+
+    m_send_queue = adopt_ref(*new SendQueue);
+    m_send_thread = Threading::Thread::construct([this, queue = m_send_queue]() -> intptr_t {
+        for (;;) {
+            queue->mutex.lock();
+            if (queue->messages.is_empty())
+                queue->condition.wait();
+
+            if (!queue->running) {
+                queue->mutex.unlock();
+                break;
+            }
+
+            auto message = queue->messages.take_first();
+            queue->mutex.unlock();
+
+            if (auto result = message.transfer_message(*m_socket); result.is_error()) {
+                dbgln("ConnectionBase::send_thread: {}", result.error());
+                continue;
+            }
+        }
+        return 0;
+    });
+    m_send_thread->start();
 }
 
-ConnectionBase::~ConnectionBase() = default;
+ConnectionBase::~ConnectionBase()
+{
+    {
+        Threading::MutexLocker locker(m_send_queue->mutex);
+        m_send_queue->running = false;
+        m_send_queue->condition.signal();
+    }
+    m_send_thread->detach();
+}
 
 bool ConnectionBase::is_open() const
 {
@@ -47,9 +79,10 @@ ErrorOr<void> ConnectionBase::post_message(MessageBuffer buffer)
     if (!m_socket->is_open())
         return Error::from_string_literal("Trying to post_message during IPC shutdown");
 
-    if (auto result = buffer.transfer_message(*m_socket); result.is_error()) {
-        shutdown_with_error(result.error());
-        return result.release_error();
+    {
+        Threading::MutexLocker locker(m_send_queue->mutex);
+        m_send_queue->messages.append(move(buffer));
+        m_send_queue->condition.signal();
     }
 
     m_responsiveness_timer->start();

--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -19,6 +19,10 @@ ConnectionBase::ConnectionBase(IPC::Stub& local_stub, NonnullOwnPtr<Core::LocalS
     , m_socket(move(socket))
     , m_local_endpoint_magic(local_endpoint_magic)
 {
+    socklen_t socket_buffer_size = 128 * KiB;
+    (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_SNDBUF, &socket_buffer_size, sizeof(socket_buffer_size));
+    (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_RCVBUF, &socket_buffer_size, sizeof(socket_buffer_size));
+
     m_responsiveness_timer = Core::Timer::create_single_shot(3000, [this] { may_have_become_unresponsive(); });
     m_socket->on_ready_to_read = [this] {
         NonnullRefPtr protect = *this;

--- a/Userland/Libraries/LibRequests/Request.cpp
+++ b/Userland/Libraries/LibRequests/Request.cpp
@@ -19,7 +19,6 @@ bool Request::stop()
 {
     on_headers_received = nullptr;
     on_finish = nullptr;
-    on_progress = nullptr;
     on_certificate_requested = nullptr;
 
     m_internal_buffered_data = nullptr;
@@ -86,12 +85,6 @@ void Request::did_finish(Badge<RequestClient>, bool success, u64 total_size)
 {
     if (on_finish)
         on_finish(success, total_size);
-}
-
-void Request::did_progress(Badge<RequestClient>, Optional<u64> total_size, u64 downloaded_size)
-{
-    if (on_progress)
-        on_progress(total_size, downloaded_size);
 }
 
 void Request::did_receive_headers(Badge<RequestClient>, HTTP::HeaderMap const& response_headers, Optional<u32> response_code)

--- a/Userland/Libraries/LibRequests/Request.h
+++ b/Userland/Libraries/LibRequests/Request.h
@@ -51,11 +51,9 @@ public:
     // mutually exclusive with `set_buffered_request_finished_callback`.
     void set_unbuffered_request_callbacks(HeadersReceived, DataReceived, RequestFinished);
 
-    Function<void(Optional<u64> total_size, u64 downloaded_size)> on_progress;
     Function<CertificateAndKey()> on_certificate_requested;
 
     void did_finish(Badge<RequestClient>, bool success, u64 total_size);
-    void did_progress(Badge<RequestClient>, Optional<u64> total_size, u64 downloaded_size);
     void did_receive_headers(Badge<RequestClient>, HTTP::HeaderMap const& response_headers, Optional<u32> response_code);
     void did_request_certificates(Badge<RequestClient>);
 

--- a/Userland/Libraries/LibRequests/RequestClient.cpp
+++ b/Userland/Libraries/LibRequests/RequestClient.cpp
@@ -77,13 +77,6 @@ void RequestClient::request_finished(i32 request_id, bool success, u64 total_siz
     m_requests.remove(request_id);
 }
 
-void RequestClient::request_progress(i32 request_id, Optional<u64> const& total_size, u64 downloaded_size)
-{
-    if (auto request = const_cast<Request*>(m_requests.get(request_id).value_or(nullptr))) {
-        request->did_progress({}, total_size, downloaded_size);
-    }
-}
-
 void RequestClient::headers_became_available(i32 request_id, HTTP::HeaderMap const& response_headers, Optional<u32> const& status_code)
 {
     auto request = const_cast<Request*>(m_requests.get(request_id).value_or(nullptr));

--- a/Userland/Libraries/LibRequests/RequestClient.cpp
+++ b/Userland/Libraries/LibRequests/RequestClient.cpp
@@ -96,45 +96,61 @@ void RequestClient::certificate_requested(i32 request_id)
 
 RefPtr<WebSocket> RequestClient::websocket_connect(const URL::URL& url, ByteString const& origin, Vector<ByteString> const& protocols, Vector<ByteString> const& extensions, HTTP::HeaderMap const& request_headers)
 {
-    auto connection_id = IPCProxy::websocket_connect(url, origin, protocols, extensions, request_headers);
-    if (connection_id < 0)
-        return nullptr;
-    auto connection = WebSocket::create_from_id({}, *this, connection_id);
-    m_websockets.set(connection_id, connection);
+    auto websocket_id = m_next_websocket_id++;
+    IPCProxy::async_websocket_connect(websocket_id, url, origin, protocols, extensions, request_headers);
+    auto connection = WebSocket::create_from_id({}, *this, websocket_id);
+    m_websockets.set(websocket_id, connection);
     return connection;
 }
 
-void RequestClient::websocket_connected(i32 connection_id)
+void RequestClient::websocket_connected(i64 websocket_id)
 {
-    auto maybe_connection = m_websockets.get(connection_id);
+    auto maybe_connection = m_websockets.get(websocket_id);
     if (maybe_connection.has_value())
         maybe_connection.value()->did_open({});
 }
 
-void RequestClient::websocket_received(i32 connection_id, bool is_text, ByteBuffer const& data)
+void RequestClient::websocket_received(i64 websocket_id, bool is_text, ByteBuffer const& data)
 {
-    auto maybe_connection = m_websockets.get(connection_id);
+    auto maybe_connection = m_websockets.get(websocket_id);
     if (maybe_connection.has_value())
         maybe_connection.value()->did_receive({}, data, is_text);
 }
 
-void RequestClient::websocket_errored(i32 connection_id, i32 message)
+void RequestClient::websocket_errored(i64 websocket_id, i32 message)
 {
-    auto maybe_connection = m_websockets.get(connection_id);
+    auto maybe_connection = m_websockets.get(websocket_id);
     if (maybe_connection.has_value())
         maybe_connection.value()->did_error({}, message);
 }
 
-void RequestClient::websocket_closed(i32 connection_id, u16 code, ByteString const& reason, bool clean)
+void RequestClient::websocket_closed(i64 websocket_id, u16 code, ByteString const& reason, bool clean)
 {
-    auto maybe_connection = m_websockets.get(connection_id);
+    auto maybe_connection = m_websockets.get(websocket_id);
     if (maybe_connection.has_value())
         maybe_connection.value()->did_close({}, code, reason, clean);
 }
 
-void RequestClient::websocket_certificate_requested(i32 connection_id)
+void RequestClient::websocket_ready_state_changed(i64 websocket_id, u32 ready_state)
 {
-    auto maybe_connection = m_websockets.get(connection_id);
+    auto maybe_connection = m_websockets.get(websocket_id);
+    if (maybe_connection.has_value()) {
+        VERIFY(ready_state <= static_cast<u32>(WebSocket::ReadyState::Closed));
+        maybe_connection.value()->set_ready_state(static_cast<WebSocket::ReadyState>(ready_state));
+    }
+}
+
+void RequestClient::websocket_subprotocol(i64 websocket_id, ByteString const& subprotocol)
+{
+    auto maybe_connection = m_websockets.get(websocket_id);
+    if (maybe_connection.has_value()) {
+        maybe_connection.value()->set_subprotocol_in_use(subprotocol);
+    }
+}
+
+void RequestClient::websocket_certificate_requested(i64 websocket_id)
+{
+    auto maybe_connection = m_websockets.get(websocket_id);
     if (maybe_connection.has_value())
         maybe_connection.value()->did_request_certificates({});
 }

--- a/Userland/Libraries/LibRequests/RequestClient.cpp
+++ b/Userland/Libraries/LibRequests/RequestClient.cpp
@@ -146,9 +146,4 @@ void RequestClient::websocket_certificate_requested(i32 connection_id)
         maybe_connection.value()->did_request_certificates({});
 }
 
-void RequestClient::dump_connection_info()
-{
-    async_dump_connection_info();
-}
-
 }

--- a/Userland/Libraries/LibRequests/RequestClient.h
+++ b/Userland/Libraries/LibRequests/RequestClient.h
@@ -36,8 +36,6 @@ public:
     bool stop_request(Badge<Request>, Request&);
     bool set_certificate(Badge<Request>, Request&, ByteString, ByteString);
 
-    void dump_connection_info();
-
 private:
     virtual void die() override;
 

--- a/Userland/Libraries/LibRequests/RequestClient.h
+++ b/Userland/Libraries/LibRequests/RequestClient.h
@@ -44,14 +44,18 @@ private:
     virtual void certificate_requested(i32) override;
     virtual void headers_became_available(i32, HTTP::HeaderMap const&, Optional<u32> const&) override;
 
-    virtual void websocket_connected(i32) override;
-    virtual void websocket_received(i32, bool, ByteBuffer const&) override;
-    virtual void websocket_errored(i32, i32) override;
-    virtual void websocket_closed(i32, u16, ByteString const&, bool) override;
-    virtual void websocket_certificate_requested(i32) override;
+    virtual void websocket_connected(i64 websocket_id) override;
+    virtual void websocket_received(i64 websocket_id, bool, ByteBuffer const&) override;
+    virtual void websocket_errored(i64 websocket_id, i32) override;
+    virtual void websocket_closed(i64 websocket_id, u16, ByteString const&, bool) override;
+    virtual void websocket_ready_state_changed(i64 websocket_id, u32 ready_state) override;
+    virtual void websocket_subprotocol(i64 websocket_id, ByteString const& subprotocol) override;
+    virtual void websocket_certificate_requested(i64 websocket_id) override;
 
     HashMap<i32, RefPtr<Request>> m_requests;
-    HashMap<i32, NonnullRefPtr<WebSocket>> m_websockets;
+    HashMap<i64, NonnullRefPtr<WebSocket>> m_websockets;
+
+    i64 m_next_websocket_id { 0 };
 };
 
 }

--- a/Userland/Libraries/LibRequests/RequestClient.h
+++ b/Userland/Libraries/LibRequests/RequestClient.h
@@ -40,7 +40,6 @@ private:
     virtual void die() override;
 
     virtual void request_started(i32, IPC::File const&) override;
-    virtual void request_progress(i32, Optional<u64> const&, u64) override;
     virtual void request_finished(i32, bool, u64) override;
     virtual void certificate_requested(i32) override;
     virtual void headers_became_available(i32, HTTP::HeaderMap const&, Optional<u32> const&) override;

--- a/Userland/Libraries/LibRequests/WebSocket.h
+++ b/Userland/Libraries/LibRequests/WebSocket.h
@@ -44,16 +44,18 @@ public:
         Closed = 3,
     };
 
-    static NonnullRefPtr<WebSocket> create_from_id(Badge<RequestClient>, RequestClient& client, i32 connection_id)
+    static NonnullRefPtr<WebSocket> create_from_id(Badge<RequestClient>, RequestClient& client, i64 websocket_id)
     {
-        return adopt_ref(*new WebSocket(client, connection_id));
+        return adopt_ref(*new WebSocket(client, websocket_id));
     }
 
-    int id() const { return m_connection_id; }
+    i64 id() const { return m_websocket_id; }
 
     ReadyState ready_state();
+    void set_ready_state(ReadyState);
 
     ByteString subprotocol_in_use();
+    void set_subprotocol_in_use(ByteString);
 
     void send(ByteBuffer binary_or_text_message, bool is_text);
     void send(StringView text_message);
@@ -72,9 +74,11 @@ public:
     void did_request_certificates(Badge<RequestClient>);
 
 private:
-    explicit WebSocket(RequestClient&, i32 connection_id);
+    explicit WebSocket(RequestClient&, i64 websocket_id);
     WeakPtr<RequestClient> m_client;
-    int m_connection_id { -1 };
+    ReadyState m_ready_state { ReadyState::Connecting };
+    ByteString m_subprotocol;
+    i64 m_websocket_id { -1 };
 };
 
 }

--- a/Userland/Libraries/LibWebSocket/WebSocket.h
+++ b/Userland/Libraries/LibWebSocket/WebSocket.h
@@ -46,6 +46,8 @@ public:
     Function<void()> on_open;
     Function<void(u16 code, ByteString reason, bool was_clean)> on_close;
     Function<void(Message message)> on_message;
+    Function<void(ReadyState)> on_ready_state_change;
+    Function<void(ByteString)> on_subprotocol;
 
     enum class Error {
         CouldNotEstablishConnection,
@@ -96,6 +98,8 @@ private:
     };
 
     InternalState m_state { InternalState::NotStarted };
+
+    void set_state(InternalState);
 
     ByteString m_subprotocol_in_use { ByteString::empty() };
 

--- a/Userland/Libraries/LibWebView/RequestServerAdapter.cpp
+++ b/Userland/Libraries/LibWebView/RequestServerAdapter.cpp
@@ -19,12 +19,6 @@ ErrorOr<NonnullRefPtr<RequestServerRequestAdapter>> RequestServerRequestAdapter:
 RequestServerRequestAdapter::RequestServerRequestAdapter(NonnullRefPtr<Requests::Request> request)
     : m_request(request)
 {
-    request->on_progress = [weak_this = make_weak_ptr()](Optional<u64> total_size, u64 downloaded_size) {
-        if (auto strong_this = weak_this.strong_ref())
-            if (strong_this->on_progress)
-                strong_this->on_progress(total_size, downloaded_size);
-    };
-
     request->on_certificate_requested = [weak_this = make_weak_ptr()]() {
         if (auto strong_this = weak_this.strong_ref()) {
             if (strong_this->on_certificate_requested) {

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -116,11 +116,6 @@ size_t ConnectionFromClient::on_data_received(void* buffer, size_t size, size_t 
 
     request->downloaded_so_far += total_size;
 
-    request->client->async_request_progress(
-        request->request_id,
-        content_length_for_ipc,
-        request->downloaded_so_far);
-
     return total_size;
 }
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,44 +14,194 @@
 #include <LibWebSocket/ConnectionInfo.h>
 #include <LibWebSocket/Message.h>
 #include <RequestServer/ConnectionFromClient.h>
-#include <RequestServer/Protocol.h>
-#include <RequestServer/Request.h>
 #include <RequestServer/RequestClientEndpoint.h>
+#include <curl/curl.h>
 #include <netdb.h>
 
 namespace RequestServer {
 
-template<typename Pool>
-struct Looper : public Threading::ThreadPoolLooper<Pool> {
-    IterationDecision next(Pool& pool, bool wait);
-    Core::EventLoop event_loop;
-};
+ByteString g_default_certificate_path;
+static HashMap<int, RefPtr<ConnectionFromClient>> s_connections;
+static IDAllocator s_client_ids;
 
-struct ThreadPoolEntry {
-    NonnullRefPtr<ConnectionFromClient> client;
-    ConnectionFromClient::Work work;
-};
-static Threading::ThreadPool<ThreadPoolEntry, Looper> s_thread_pool {
-    [](ThreadPoolEntry entry) {
-        entry.client->worker_do_work(move(entry.work));
+struct ConnectionFromClient::ActiveRequest {
+    CURLM* multi { nullptr };
+    CURL* easy { nullptr };
+    i32 request_id { 0 };
+    RefPtr<Core::Notifier> notifier;
+    WeakPtr<ConnectionFromClient> client;
+    int writer_fd { 0 };
+    HTTP::HeaderMap headers;
+    bool got_all_headers { false };
+    size_t downloaded_so_far { 0 };
+    String url;
+    ByteBuffer body;
+
+    ActiveRequest(ConnectionFromClient& client, CURLM* multi, CURL* easy, i32 request_id, int writer_fd)
+        : multi(multi)
+        , easy(easy)
+        , request_id(request_id)
+        , client(client)
+        , writer_fd(writer_fd)
+    {
+    }
+
+    ~ActiveRequest()
+    {
+        MUST(Core::System::close(writer_fd));
+        auto result = curl_multi_remove_handle(multi, easy);
+        VERIFY(result == CURLM_OK);
+        curl_easy_cleanup(easy);
+    }
+
+    void flush_headers_if_needed()
+    {
+        if (got_all_headers)
+            return;
+        got_all_headers = true;
+        long http_status_code = 0;
+        auto result = curl_easy_getinfo(easy, CURLINFO_RESPONSE_CODE, &http_status_code);
+        VERIFY(result == CURLE_OK);
+        client->async_headers_became_available(request_id, headers, http_status_code);
     }
 };
 
-static HashMap<int, RefPtr<ConnectionFromClient>> s_connections;
-static IDAllocator s_client_ids;
+size_t ConnectionFromClient::on_header_received(void* buffer, size_t size, size_t nmemb, void* user_data)
+{
+    auto* request = static_cast<ActiveRequest*>(user_data);
+    size_t total_size = size * nmemb;
+    auto header_line = StringView { static_cast<char const*>(buffer), total_size };
+    if (auto colon_index = header_line.find(':'); colon_index.has_value()) {
+        auto name = header_line.substring_view(0, colon_index.value()).trim_whitespace();
+        auto value = header_line.substring_view(colon_index.value() + 1, header_line.length() - colon_index.value() - 1).trim_whitespace();
+        request->headers.set(name, value);
+    }
+    return total_size;
+}
+
+size_t ConnectionFromClient::on_data_received(void* buffer, size_t size, size_t nmemb, void* user_data)
+{
+    auto* request = static_cast<ActiveRequest*>(user_data);
+    request->flush_headers_if_needed();
+
+    size_t total_size = size * nmemb;
+
+    size_t remaining_length = total_size;
+    u8 const* remaining_data = static_cast<u8 const*>(buffer);
+    while (remaining_length > 0) {
+        auto result = Core::System::write(request->writer_fd, { remaining_data, remaining_length });
+        if (result.is_error()) {
+            if (result.error().code() != EAGAIN) {
+                dbgln("on_data_received: write failed: {}", result.error());
+                VERIFY_NOT_REACHED();
+            }
+            sched_yield();
+            continue;
+        }
+        auto nwritten = result.value();
+        if (nwritten == 0) {
+            dbgln("on_data_received: write returned 0");
+            VERIFY_NOT_REACHED();
+        }
+        remaining_data += nwritten;
+        remaining_length -= nwritten;
+    }
+
+    Optional<u64> content_length_for_ipc;
+    curl_off_t content_length = -1;
+    auto res = curl_easy_getinfo(request->easy, CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &content_length);
+    if (res == CURLE_OK && content_length != -1) {
+        content_length_for_ipc = content_length;
+    }
+
+    request->downloaded_so_far += total_size;
+
+    request->client->async_request_progress(
+        request->request_id,
+        content_length_for_ipc,
+        request->downloaded_so_far);
+
+    return total_size;
+}
+
+int ConnectionFromClient::on_socket_callback(CURL*, int sockfd, int what, void* user_data, void*)
+{
+    auto* client = static_cast<ConnectionFromClient*>(user_data);
+
+    if (what == CURL_POLL_REMOVE) {
+        client->m_read_notifiers.remove(sockfd);
+        client->m_write_notifiers.remove(sockfd);
+        return 0;
+    }
+
+    if (what & CURL_POLL_IN) {
+        client->m_read_notifiers.ensure(sockfd, [client, sockfd, multi = client->m_curl_multi] {
+            auto notifier = Core::Notifier::construct(sockfd, Core::NotificationType::Read);
+            notifier->on_activation = [client, sockfd, multi] {
+                int still_running = 0;
+                auto result = curl_multi_socket_action(multi, sockfd, CURL_CSELECT_IN, &still_running);
+                VERIFY(result == CURLM_OK);
+                client->check_active_requests();
+            };
+            notifier->set_enabled(true);
+            return notifier;
+        });
+    }
+
+    if (what & CURL_POLL_OUT) {
+        client->m_write_notifiers.ensure(sockfd, [client, sockfd, multi = client->m_curl_multi] {
+            auto notifier = Core::Notifier::construct(sockfd, Core::NotificationType::Write);
+            notifier->on_activation = [client, sockfd, multi] {
+                int still_running = 0;
+                auto result = curl_multi_socket_action(multi, sockfd, CURL_CSELECT_OUT, &still_running);
+                VERIFY(result == CURLM_OK);
+                client->check_active_requests();
+            };
+            notifier->set_enabled(true);
+            return notifier;
+        });
+    }
+
+    return 0;
+}
+
+int ConnectionFromClient::on_timeout_callback(void*, long timeout_ms, void* user_data)
+{
+    auto* client = static_cast<ConnectionFromClient*>(user_data);
+    if (timeout_ms < 0) {
+        client->m_timer->stop();
+    } else {
+        client->m_timer->restart(timeout_ms);
+    }
+    return 0;
+}
 
 ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> socket)
     : IPC::ConnectionFromClient<RequestClientEndpoint, RequestServerEndpoint>(*this, move(socket), s_client_ids.allocate())
 {
     s_connections.set(client_id(), *this);
+
+    m_curl_multi = curl_multi_init();
+
+    auto set_option = [this](auto option, auto value) {
+        auto result = curl_multi_setopt(m_curl_multi, option, value);
+        VERIFY(result == CURLM_OK);
+    };
+    set_option(CURLMOPT_SOCKETFUNCTION, &on_socket_callback);
+    set_option(CURLMOPT_SOCKETDATA, this);
+    set_option(CURLMOPT_TIMERFUNCTION, &on_timeout_callback);
+    set_option(CURLMOPT_TIMERDATA, this);
+
+    m_timer = Core::Timer::create_single_shot(0, [this] {
+        int still_running = 0;
+        auto result = curl_multi_socket_action(m_curl_multi, CURL_SOCKET_TIMEOUT, 0, &still_running);
+        VERIFY(result == CURLM_OK);
+        check_active_requests();
+    });
 }
 
 ConnectionFromClient::~ConnectionFromClient()
 {
-    m_requests.with_locked([](HashMap<i32, OwnPtr<Request>>& map) {
-        for (auto& entry : map)
-            entry.value->cancel();
-    });
 }
 
 class Job : public RefCounted<Job>
@@ -96,85 +246,6 @@ private:
     inline static HashMap<URL::URL, WeakPtr<Job>> s_jobs {};
 };
 
-template<typename Pool>
-IterationDecision Looper<Pool>::next(Pool& pool, bool wait)
-{
-    bool should_exit = false;
-    auto timer = Core::Timer::create_repeating(100, [&] {
-        if (Threading::ThreadPoolLooper<Pool>::next(pool, false) == IterationDecision::Break) {
-            event_loop.quit(0);
-            should_exit = true;
-        }
-    });
-
-    timer->start();
-    if (!wait) {
-        event_loop.deferred_invoke([&] {
-            event_loop.quit(0);
-        });
-    }
-
-    event_loop.exec();
-
-    if (should_exit)
-        return IterationDecision::Break;
-    return IterationDecision::Continue;
-}
-
-void ConnectionFromClient::worker_do_work(Work work)
-{
-    work.visit(
-        [&](StartRequest& start_request) {
-            auto* protocol = Protocol::find_by_name(start_request.url.scheme().to_byte_string());
-            if (!protocol) {
-                dbgln("StartRequest: No protocol handler for URL: '{}'", start_request.url);
-                auto lock = Threading::MutexLocker(m_ipc_mutex);
-                (void)post_message(Messages::RequestClient::RequestFinished(start_request.request_id, false, 0));
-                return;
-            }
-            auto request = protocol->start_request(start_request.request_id, *this, start_request.method, start_request.url, start_request.request_headers, start_request.request_body, start_request.proxy_data);
-            if (!request) {
-                dbgln("StartRequest: Protocol handler failed to start request: '{}'", start_request.url);
-                auto lock = Threading::MutexLocker(m_ipc_mutex);
-                (void)post_message(Messages::RequestClient::RequestFinished(start_request.request_id, false, 0));
-                return;
-            }
-            auto id = request->id();
-            auto fd = request->request_fd();
-            m_requests.with_locked([&](auto& map) { map.set(id, move(request)); });
-            auto lock = Threading::MutexLocker(m_ipc_mutex);
-            (void)post_message(Messages::RequestClient::RequestStarted(start_request.request_id, IPC::File::adopt_fd(fd)));
-        },
-        [&](EnsureConnection& ensure_connection) {
-            auto& url = ensure_connection.url;
-            auto& cache_level = ensure_connection.cache_level;
-
-            if (cache_level == CacheLevel::ResolveOnly) {
-                Core::deferred_invoke([host = url.serialized_host().release_value_but_fixme_should_propagate_errors().to_byte_string()] {
-                    dbgln("EnsureConnection: DNS-preload for {}", host);
-                    auto resolved_host = Core::Socket::resolve_host(host, Core::Socket::SocketType::Stream);
-                    if (resolved_host.is_error())
-                        dbgln("EnsureConnection: DNS-preload failed for {}", host);
-                });
-                dbgln("EnsureConnection: DNS-preload for {} done", url);
-                return;
-            }
-
-            dbgln("EnsureConnection: Pre-connect to {}", url);
-            auto do_preconnect = [=, job = Job::ensure(url)](auto& cache) {
-                ConnectionCache::ensure_connection(cache, url, move(job));
-            };
-
-            if (url.scheme() == "http"sv)
-                do_preconnect(ConnectionCache::g_tcp_connection_cache);
-            else if (url.scheme() == "https"sv)
-                do_preconnect(ConnectionCache::g_tls_connection_cache);
-            else
-                dbgln("EnsureConnection: Invalid URL scheme: '{}'", url.scheme());
-        },
-        [&](Empty) {});
-}
-
 void ConnectionFromClient::die()
 {
     auto client_id = this->client_id();
@@ -207,93 +278,148 @@ Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_
     return IPC::File::adopt_fd(socket_fds[1]);
 }
 
-void ConnectionFromClient::enqueue(Work work)
-{
-    s_thread_pool.submit({ *this, move(work) });
-}
-
 Messages::RequestServer::IsSupportedProtocolResponse ConnectionFromClient::is_supported_protocol(ByteString const& protocol)
 {
-    bool supported = Protocol::find_by_name(protocol.to_lowercase());
-    return supported;
+    return protocol == "http"sv || protocol == "https"sv;
 }
 
 void ConnectionFromClient::start_request(i32 request_id, ByteString const& method, URL::URL const& url, HTTP::HeaderMap const& request_headers, ByteBuffer const& request_body, Core::ProxyData const& proxy_data)
 {
     if (!url.is_valid()) {
         dbgln("StartRequest: Invalid URL requested: '{}'", url);
-        auto lock = Threading::MutexLocker(m_ipc_mutex);
-        (void)post_message(Messages::RequestClient::RequestFinished(request_id, false, 0));
+        async_request_finished(request_id, false, 0);
         return;
     }
 
-    auto headers = request_headers;
-    if (!headers.contains("Accept-Encoding"))
-        headers.set("Accept-Encoding", "gzip, deflate, br");
+    auto* easy = curl_easy_init();
+    if (!easy) {
+        dbgln("StartRequest: Failed to initialize curl easy handle");
+        return;
+    }
 
-    enqueue(StartRequest {
-        .request_id = request_id,
-        .method = method,
-        .url = url,
-        .request_headers = move(headers),
-        .request_body = request_body,
-        .proxy_data = proxy_data,
-    });
+    auto fds_or_error = Core::System::pipe2(O_NONBLOCK);
+    if (fds_or_error.is_error()) {
+        dbgln("StartRequest: Failed to create pipe: {}", fds_or_error.error());
+        return;
+    }
+
+    auto fds = fds_or_error.release_value();
+    auto writer_fd = fds[1];
+    auto reader_fd = fds[0];
+    async_request_started(request_id, IPC::File::adopt_fd(reader_fd));
+
+    auto request = make<ActiveRequest>(*this, m_curl_multi, easy, request_id, writer_fd);
+    request->url = url.to_string().value();
+
+    auto set_option = [easy](auto option, auto value) {
+        auto result = curl_easy_setopt(easy, option, value);
+        if (result != CURLE_OK) {
+            dbgln("StartRequest: Failed to set curl option: {}", curl_easy_strerror(result));
+            return false;
+        }
+        return true;
+    };
+
+    if (!g_default_certificate_path.is_empty())
+        set_option(CURLOPT_CAINFO, g_default_certificate_path.characters());
+
+    set_option(CURLOPT_ACCEPT_ENCODING, "gzip, deflate, br");
+    set_option(CURLOPT_URL, url.to_string().value().to_byte_string().characters());
+    set_option(CURLOPT_PORT, url.port_or_default());
+
+    if (method == "GET"sv) {
+        set_option(CURLOPT_HTTPGET, 1L);
+    } else if (method == "POST"sv) {
+        request->body = request_body;
+        set_option(CURLOPT_POSTFIELDSIZE, request->body.size());
+        set_option(CURLOPT_POSTFIELDS, request->body.data());
+    } else if (method == "HEAD") {
+        set_option(CURLOPT_NOBODY, 1L);
+    }
+    set_option(CURLOPT_CUSTOMREQUEST, method.characters());
+
+    set_option(CURLOPT_FOLLOWLOCATION, 0);
+
+    struct curl_slist* curl_headers = nullptr;
+    for (auto const& header : request_headers.headers()) {
+        auto header_string = ByteString::formatted("{}: {}", header.name, header.value);
+        curl_headers = curl_slist_append(curl_headers, header_string.characters());
+    }
+    set_option(CURLOPT_HTTPHEADER, curl_headers);
+
+    // FIXME: Set up proxy if applicable
+    (void)proxy_data;
+
+    set_option(CURLOPT_WRITEFUNCTION, &on_data_received);
+    set_option(CURLOPT_WRITEDATA, reinterpret_cast<void*>(request.ptr()));
+
+    set_option(CURLOPT_HEADERFUNCTION, &on_header_received);
+    set_option(CURLOPT_HEADERDATA, reinterpret_cast<void*>(request.ptr()));
+
+    auto result = curl_multi_add_handle(m_curl_multi, easy);
+    VERIFY(result == CURLM_OK);
+
+    m_active_requests.set(request_id, move(request));
+}
+
+void ConnectionFromClient::check_active_requests()
+{
+    auto request_from_easy_handle = [this](CURL* easy) -> ActiveRequest* {
+        for (auto& it : m_active_requests) {
+            if (it.value->easy == easy)
+                return it.value.ptr();
+        }
+        return nullptr;
+    };
+
+    int msgs_in_queue = 0;
+    while (auto* msg = curl_multi_info_read(m_curl_multi, &msgs_in_queue)) {
+        if (msg->msg != CURLMSG_DONE)
+            continue;
+
+        auto* request = request_from_easy_handle(msg->easy_handle);
+        request->flush_headers_if_needed();
+
+        async_request_finished(request->request_id, msg->data.result == CURLE_OK, request->downloaded_so_far);
+
+        m_active_requests.remove(request->request_id);
+    }
 }
 
 Messages::RequestServer::StopRequestResponse ConnectionFromClient::stop_request(i32 request_id)
 {
-    return m_requests.with_locked([&](auto& map) {
-        auto* request = const_cast<Request*>(map.get(request_id).value_or(nullptr));
-        bool success = false;
-        if (request) {
-            request->stop();
-            map.remove(request_id);
-            success = true;
-        }
-        return success;
-    });
-}
-
-void ConnectionFromClient::did_receive_headers(Badge<Request>, Request& request)
-{
-    auto lock = Threading::MutexLocker(m_ipc_mutex);
-    async_headers_became_available(request.id(), request.response_headers(), request.status_code());
-}
-
-void ConnectionFromClient::did_finish_request(Badge<Request>, Request& request, bool success)
-{
-    if (request.total_size().has_value()) {
-        auto lock = Threading::MutexLocker(m_ipc_mutex);
-        async_request_finished(request.id(), success, request.total_size().value());
+    auto request = m_active_requests.take(request_id);
+    if (!request.has_value()) {
+        dbgln("StopRequest: Request ID {} not found", request_id);
+        return false;
     }
 
-    m_requests.with_locked([&](auto& map) { map.remove(request.id()); });
+    return true;
 }
 
-void ConnectionFromClient::did_progress_request(Badge<Request>, Request& request)
+void ConnectionFromClient::did_receive_headers(Badge<Request>, Request&)
 {
-    auto lock = Threading::MutexLocker(m_ipc_mutex);
-    async_request_progress(request.id(), request.total_size(), request.downloaded_size());
 }
 
-void ConnectionFromClient::did_request_certificates(Badge<Request>, Request& request)
+void ConnectionFromClient::did_finish_request(Badge<Request>, Request&, bool)
 {
-    auto lock = Threading::MutexLocker(m_ipc_mutex);
-    async_certificate_requested(request.id());
+}
+
+void ConnectionFromClient::did_progress_request(Badge<Request>, Request&)
+{
+}
+
+void ConnectionFromClient::did_request_certificates(Badge<Request>, Request&)
+{
+    TODO();
 }
 
 Messages::RequestServer::SetCertificateResponse ConnectionFromClient::set_certificate(i32 request_id, ByteString const& certificate, ByteString const& key)
 {
-    return m_requests.with_locked([&](auto& map) {
-        auto* request = const_cast<Request*>(map.get(request_id).value_or(nullptr));
-        bool success = false;
-        if (request) {
-            request->set_certificate(certificate, key);
-            success = true;
-        }
-        return success;
-    });
+    (void)request_id;
+    (void)certificate;
+    (void)key;
+    TODO();
 }
 
 void ConnectionFromClient::ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel const& cache_level)
@@ -303,10 +429,8 @@ void ConnectionFromClient::ensure_connection(URL::URL const& url, ::RequestServe
         return;
     }
 
-    enqueue(EnsureConnection {
-        .url = url,
-        .cache_level = cache_level,
-    });
+    (void)cache_level;
+    dbgln("FIXME: EnsureConnection: Pre-connect to {}", url);
 }
 
 static i32 s_next_websocket_id = 1;
@@ -326,19 +450,15 @@ Messages::RequestServer::WebsocketConnectResponse ConnectionFromClient::websocke
     auto id = ++s_next_websocket_id;
     auto connection = WebSocket::WebSocket::create(move(connection_info));
     connection->on_open = [this, id]() {
-        auto lock = Threading::MutexLocker(m_ipc_mutex);
         async_websocket_connected(id);
     };
     connection->on_message = [this, id](auto message) {
-        auto lock = Threading::MutexLocker(m_ipc_mutex);
         async_websocket_received(id, message.is_text(), message.data());
     };
     connection->on_error = [this, id](auto message) {
-        auto lock = Threading::MutexLocker(m_ipc_mutex);
         async_websocket_errored(id, (i32)message);
     };
     connection->on_close = [this, id](u16 code, ByteString reason, bool was_clean) {
-        auto lock = Threading::MutexLocker(m_ipc_mutex);
         async_websocket_closed(id, code, move(reason), was_clean);
     };
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -42,12 +42,10 @@ private:
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, ByteString const&, ByteString const&) override;
     virtual void ensure_connection(URL::URL const& url, ::RequestServer::CacheLevel const& cache_level) override;
 
-    virtual Messages::RequestServer::WebsocketConnectResponse websocket_connect(URL::URL const&, ByteString const&, Vector<ByteString> const&, Vector<ByteString> const&, HTTP::HeaderMap const&) override;
-    virtual Messages::RequestServer::WebsocketReadyStateResponse websocket_ready_state(i32) override;
-    virtual Messages::RequestServer::WebsocketSubprotocolInUseResponse websocket_subprotocol_in_use(i32) override;
-    virtual void websocket_send(i32, bool, ByteBuffer const&) override;
-    virtual void websocket_close(i32, u16, ByteString const&) override;
-    virtual Messages::RequestServer::WebsocketSetCertificateResponse websocket_set_certificate(i32, ByteString const&, ByteString const&) override;
+    virtual void websocket_connect(i64 websocket_id, URL::URL const&, ByteString const&, Vector<ByteString> const&, Vector<ByteString> const&, HTTP::HeaderMap const&) override;
+    virtual void websocket_send(i64 websocket_id, bool, ByteBuffer const&) override;
+    virtual void websocket_close(i64 websocket_id, u16, ByteString const&) override;
+    virtual Messages::RequestServer::WebsocketSetCertificateResponse websocket_set_certificate(i64, ByteString const&, ByteString const&) override;
 
     HashMap<i32, RefPtr<WebSocket::WebSocket>> m_websockets;
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -49,8 +49,6 @@ private:
     virtual void websocket_close(i32, u16, ByteString const&) override;
     virtual Messages::RequestServer::WebsocketSetCertificateResponse websocket_set_certificate(i32, ByteString const&, ByteString const&) override;
 
-    virtual void dump_connection_info() override;
-
     HashMap<i32, RefPtr<WebSocket::WebSocket>> m_websockets;
 
     struct ActiveRequest;

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -9,11 +9,13 @@ endpoint RequestClient
 
     // Websocket API
     // FIXME: See if this can be merged with the regular APIs
-    websocket_connected(i32 connection_id) =|
-    websocket_received(i32 connection_id, bool is_text, ByteBuffer data) =|
-    websocket_errored(i32 connection_id, i32 message) =|
-    websocket_closed(i32 connection_id, u16 code, ByteString reason, bool clean) =|
-    websocket_certificate_requested(i32 request_id) =|
+    websocket_connected(i64 websocket_id) =|
+    websocket_received(i64 websocket_id, bool is_text, ByteBuffer data) =|
+    websocket_errored(i64 websocket_id, i32 message) =|
+    websocket_closed(i64 websocket_id, u16 code, ByteString reason, bool clean) =|
+    websocket_ready_state_changed(i64 websocket_id, u32 ready_state) =|
+    websocket_subprotocol(i64 websocket_id, ByteString subprotocol) =|
+    websocket_certificate_requested(i64 websocket_id) =|
 
     // Certificate requests
     certificate_requested(i32 request_id) =|

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -4,7 +4,6 @@
 endpoint RequestClient
 {
     request_started(i32 request_id, IPC::File fd) =|
-    request_progress(i32 request_id, Optional<u64> total_size, u64 downloaded_size) =|
     request_finished(i32 request_id, bool success, u64 total_size) =|
     headers_became_available(i32 request_id, HTTP::HeaderMap response_headers, Optional<u32> status_code) =|
 

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -16,11 +16,9 @@ endpoint RequestServer
     ensure_connection(URL::URL url, ::RequestServer::CacheLevel cache_level) =|
 
     // Websocket Connection API
-    websocket_connect(URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, HTTP::HeaderMap additional_request_headers) => (i32 connection_id)
-    websocket_ready_state(i32 connection_id) => (u32 ready_state)
-    websocket_subprotocol_in_use(i32 connection_id) => (ByteString subprotocol_in_use)
-    websocket_send(i32 connection_id, bool is_text, ByteBuffer data) =|
-    websocket_close(i32 connection_id, u16 code, ByteString reason) =|
-    websocket_set_certificate(i32 request_id, ByteString certificate, ByteString key) => (bool success)
+    websocket_connect(i64 websocket_id, URL::URL url, ByteString origin, Vector<ByteString> protocols, Vector<ByteString> extensions, HTTP::HeaderMap additional_request_headers) =|
+    websocket_send(i64 websocket_id, bool is_text, ByteBuffer data) =|
+    websocket_close(i64 websocket_id, u16 code, ByteString reason) =|
+    websocket_set_certificate(i64 request_id, ByteString certificate, ByteString key) => (bool success)
 
 }

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -23,5 +23,4 @@ endpoint RequestServer
     websocket_close(i32 connection_id, u16 code, ByteString reason) =|
     websocket_set_certificate(i32 request_id, ByteString certificate, ByteString key) => (bool success)
 
-    dump_connection_info() =|
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,6 +2,12 @@
   "builtin-baseline": "3508985146f1b1d248c67ead13f8f54be5b4f5da",
   "dependencies": [
     {
+      "name": "curl",
+      "features": [
+        "brotli", "http2"
+      ]
+    },
+    {
       "name": "fontconfig",
       "platform": "linux | freebsd | openbsd | osx"
     },


### PR DESCRIPTION
This replaces the use of our home-grown implementations inherited from SerenityOS.