### PR TITLE
LibWeb: Use available size in calculate_inner_height()

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/abspos-item-with-grid-area-and-percentage-size-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item-with-grid-area-and-percentage-size-2.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x220 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x202 children: not-inline
+      Box <div.grid> at (11,11) content-size 200x200 positioned [GFC] children: not-inline
+        BlockContainer <div.abspos-item> at (112,12) content-size 50x100 positioned [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.grid) [10,10 202x202]
+        PaintableWithLines (BlockContainer<DIV>.abspos-item) [111,11 52x102]

--- a/Tests/LibWeb/Layout/input/grid/abspos-item-with-grid-area-and-percentage-size-2.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-item-with-grid-area-and-percentage-size-2.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 100px 100px;
+    grid-template-rows: 100px 100px;
+    grid-template-areas: "a b"
+                         "a b";
+    position: relative;
+    width: 200px;
+}
+
+.abspos-item {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 50%;
+    height: 50%;
+    grid-area: b;
+}
+</style><div class="grid"><div class="abspos-item"></div></div>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1639,19 +1639,10 @@ CSSPixels FormattingContext::calculate_inner_width(Layout::Box const& box, Avail
     return width.resolved(box, width_of_containing_block).to_px(box);
 }
 
-CSSPixels FormattingContext::calculate_inner_height(Layout::Box const& box, AvailableSize const&, CSS::Size const& height) const
+CSSPixels FormattingContext::calculate_inner_height(Layout::Box const& box, AvailableSize const& available_height, CSS::Size const& height) const
 {
     VERIFY(!height.is_auto());
-
-    auto const* containing_block = box.non_anonymous_containing_block();
-    auto const& containing_block_state = m_state.get(*containing_block);
-    auto height_of_containing_block = containing_block_state.content_height();
-    if (box.computed_values().position() == CSS::Positioning::Absolute) {
-        // https://www.w3.org/TR/css-position-3/#def-cb
-        // If the box has position: absolute, then the containing block is formed by the padding edge of the ancestor
-        height_of_containing_block += containing_block_state.padding_top + containing_block_state.padding_bottom;
-    }
-
+    auto height_of_containing_block = available_height.to_px_or_zero();
     auto& computed_values = box.computed_values();
     if (computed_values.box_sizing() == CSS::BoxSizing::BorderBox) {
         auto width_of_containing_block = containing_block_width_for(box);

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1912,8 +1912,10 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
     auto column_span = column_placement_position.span;
 
     GridItem item { box, row_start, row_span, column_start, column_span };
-
-    auto available_space = get_available_space_for_item(item);
+    auto grid_area_rect = get_grid_area_rect(item);
+    auto available_width = AvailableSize::make_definite(grid_area_rect.width());
+    auto available_height = AvailableSize::make_definite(grid_area_rect.height());
+    AvailableSpace available_space { available_width, available_height };
 
     // The border computed values are not changed by the compute_height & width calculations below.
     // The spec only adjusts and computes sizes, insets and margins.
@@ -1993,9 +1995,8 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
     // The offset properties (top/right/bottom/left) then indicate offsets inwards from the corresponding
     // edges of this containing block, as normal.
     CSSPixelPoint used_offset;
-    auto grid_area_offset = get_grid_area_rect(item);
-    used_offset.set_x(grid_area_offset.x() + box_state.inset_left + box_state.margin_box_left());
-    used_offset.set_y(grid_area_offset.y() + box_state.inset_top + box_state.margin_box_top());
+    used_offset.set_x(grid_area_rect.x() + box_state.inset_left + box_state.margin_box_left());
+    used_offset.set_y(grid_area_rect.y() + box_state.inset_top + box_state.margin_box_top());
 
     // NOTE: Absolutely positioned boxes are relative to the *padding edge* of the containing block.
     used_offset.translate_by(-containing_block_state.padding_left, -containing_block_state.padding_top);


### PR DESCRIPTION
Although the parameter is named "available size," it is always supposed
to represent the containing block size whenever it has a definite value.
Therefore, it is possible to simply use this value instead of performing
a containing block lookup.

This change actually improves correctness for grid items whose
containing block is defined by the grid area, as
`Node::containing_block()` does not account for this.