### PR TITLE
LibWeb: Stub in CSP List

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -12,6 +12,19 @@
 
 namespace Web::DOM {
 
+// https://w3c.github.io/webappsec-csp/#should-block-inline
+enum class InlineType {
+    Script,
+    ScriptAttribute,
+    Style,
+    StyleAttribute
+};
+
+enum class ShouldBeBlockedByContentSecurityPolicy {
+    Allowed,
+    Blocked
+};
+
 class StyleElementUtils {
 public:
     void update_a_style_block(DOM::Element& style_element);

--- a/Userland/Libraries/LibWeb/HTML/Policy.h
+++ b/Userland/Libraries/LibWeb/HTML/Policy.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2024, Noah Bright <noah.bright.1@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashTable.h>
+#include <AK/String.h>
+#include <LibURL/Origin.h>
+
+// https://w3c.github.io/webappsec-csp/#framework-policy
+namespace Web::HTML {
+
+enum class PolicyDisposition {
+    Enforce,
+    Report
+};
+
+enum class PolicySource {
+    Head,
+    Meta
+};
+
+// https://w3c.github.io/webappsec-csp/#content-security-policy-object
+struct Policy {
+    // https://w3c.github.io/webappsec-csp/#directives
+    OrderedHashMap<String, Optional<HashTable<String>>> directive_set;
+    PolicyDisposition disposition;
+    PolicySource source;
+    URL::Origin self_origin;
+};
+
+using CSPList = Vector<Policy>;
+
+}

--- a/Userland/Libraries/LibWeb/HTML/PolicyContainers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PolicyContainers.cpp
@@ -6,7 +6,32 @@
 
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/PolicyContainers.h>
+#include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WorkerGlobalScope.h>
+
+namespace Web::HTML {
+
+// https://w3c.github.io/webappsec-csp/#get-csp-of-object
+Optional<CSPList> retrieve_the_csp_list_of_an_object(JS::Object const& object)
+{
+    // 1. If object is a Document return object’s policy container's CSP list.
+    if (is<DOM::Document>(object))
+        return verify_cast<DOM::Document>(object).policy_container().csp_list;
+
+    // FIXME: 2. If object is a Window or a WorkerGlobalScope or a WorkletGlobalScope, return environment settings object’s policy container's CSP list.
+    //           WorkletGlobalScope not yet defined
+    if (is<Window>(object))
+        return verify_cast<Window>(object).associated_document().policy_container().csp_list;
+
+    if (is<WorkerGlobalScope>(object))
+        return verify_cast<WorkerGlobalScope>(object).policy_container().csp_list;
+
+    // 3. Return null.
+    return {};
+}
+}
 
 namespace IPC {
 

--- a/Userland/Libraries/LibWeb/HTML/PolicyContainers.h
+++ b/Userland/Libraries/LibWeb/HTML/PolicyContainers.h
@@ -7,7 +7,9 @@
 #pragma once
 
 #include <LibIPC/Forward.h>
+#include <LibJS/Runtime/Object.h>
 #include <LibWeb/HTML/EmbedderPolicy.h>
+#include <LibWeb/HTML/Policy.h>
 #include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 
 namespace Web::HTML {
@@ -16,7 +18,8 @@ namespace Web::HTML {
 // A policy container is a struct containing policies that apply to a Document, a WorkerGlobalScope, or a WorkletGlobalScope. It has the following items:
 struct PolicyContainer {
     // https://html.spec.whatwg.org/multipage/origin.html#policy-container-csp-list
-    // FIXME: A CSP list, which is a CSP list. It is initially empty.
+    // A CSP list, which is a CSP list. It is initially empty.
+    CSPList csp_list {};
 
     // https://html.spec.whatwg.org/multipage/origin.html#policy-container-embedder-policy
     // An embedder policy, which is an embedder policy. It is initially a new embedder policy.
@@ -26,6 +29,9 @@ struct PolicyContainer {
     // A referrer policy, which is a referrer policy. It is initially the default referrer policy.
     ReferrerPolicy::ReferrerPolicy referrer_policy { ReferrerPolicy::DEFAULT_REFERRER_POLICY };
 };
+
+// https://w3c.github.io/webappsec-csp/#get-csp-of-object
+Optional<CSPList> retrieve_the_csp_list_of_an_object(JS::Object const&);
 
 }
 


### PR DESCRIPTION
Working backwards from
https://html.spec.whatwg.org/multipage/semantics.html#update-a-style-block

One of the steps in the above algorithm is
https://w3c.github.io/webappsec-csp/#should-block-inline

In implementing Should element’s inline type behavior be blocked by Content Security Policy?, add class declarations for Directives, Policy's, and CSP Lists