### PR TITLE
LibWeb: Use grid area size for abspos grid items alignment

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/abspos-item-with-grid-area-aligned-in-center.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-item-with-grid-area-aligned-in-center.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (1,1) content-size 798x220 [BFC] children: not-inline
+    BlockContainer <body> at (10,10) content-size 780x202 children: not-inline
+      Box <div.grid> at (11,11) content-size 200x200 positioned [GFC] children: not-inline
+        BlockContainer <div.abspos-item> at (137,37) content-size 48x48 positioned [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x222]
+    PaintableWithLines (BlockContainer<BODY>) [9,9 782x204]
+      PaintableBox (Box<DIV>.grid) [10,10 202x202]
+        PaintableWithLines (BlockContainer<DIV>.abspos-item) [136,36 50x50]

--- a/Tests/LibWeb/Layout/input/grid/abspos-item-with-grid-area-aligned-in-center.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-item-with-grid-area-aligned-in-center.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html><style>
+* {
+    border: 1px solid black;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: 100px 100px;
+    grid-template-rows: 100px 100px;
+    grid-template-areas: "a b"
+                         "c c";
+    position: relative;
+    width: 200px;
+}
+
+.abspos-item {
+    position: absolute;
+    box-sizing: border-box;
+    background-color: magenta;
+    width: 50px;
+    height: 50px;
+    grid-area: b;
+    align-self: center;
+    justify-self: center;
+}
+</style><div class="grid"><div class="abspos-item"></div></div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1936,8 +1936,7 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
     compute_height_for_absolutely_positioned_element(box, available_space, BeforeOrAfterInsideLayout::After);
 
     if (computed_values.inset().left().is_auto() && computed_values.inset().right().is_auto()) {
-        auto containing_block_width = containing_block_state.content_width();
-        auto width_left_for_alignment = containing_block_width - box_state.margin_box_width();
+        auto width_left_for_alignment = grid_area_rect.width() - box_state.margin_box_width();
         switch (justification_for_item(box)) {
         case CSS::JustifyItems::Normal:
         case CSS::JustifyItems::Stretch:
@@ -1962,8 +1961,7 @@ void GridFormattingContext::layout_absolutely_positioned_element(Box const& box)
     }
 
     if (computed_values.inset().top().is_auto() && computed_values.inset().bottom().is_auto()) {
-        auto containing_block_height = containing_block_state.content_height();
-        auto height_left_for_alignment = containing_block_height - box_state.margin_box_height();
+        auto height_left_for_alignment = grid_area_rect.height() - box_state.margin_box_height();
         switch (alignment_for_item(box)) {
         case CSS::AlignItems::Baseline:
             // FIXME: Not implemented


### PR DESCRIPTION
Fixes yet another case of GFC bug, where Node::containing_block() should not be used for grid items, because their containing block is grid area which is not represented in layout tree.