### PR TITLE
WebDriver: Partial implementation of switch-to-parent endpoint

### DIFF
--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -47,6 +47,7 @@
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWeb/WebDriver/Screenshot.h>
 #include <WebContent/WebDriverConnection.h>
+#include <sys/proc.h>
 
 namespace WebContent {
 
@@ -575,23 +576,30 @@ Messages::WebDriverClient::SwitchToParentFrameResponse WebDriverConnection::swit
     dbgln("FIXME: WebDriverConnection::switch_to_parent_frame()");
 
     // FIXME: 1. If session's current browsing context is already the top-level browsing context:
+    if (current_browsing_context().top_level_browsing_context()->is_top_level()) {
 
-    {
         // FIXME: 1. If session's current browsing context is no longer open, return error with error code no such window.
+        if (current_browsing_context().has_navigable_been_destroyed()) {
+            return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "no such window"sv);
+        }
 
         // FIXME: 2. Return success with data null.
+        return JsonValue {};
     }
 
     // FIXME: 2. If session's current parent browsing context is no longer open, return error with error code no such window.
+    if (current_parent_browsing_context().has_navigable_been_destroyed()) {
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "no such window"sv);
+    }
 
     // FIXME: 3. Try to handle any user prompts with session.
+    TRY(handle_any_user_prompts());
 
     // FIXME: 4. If session's current parent browsing context is not null, set the current browsing context with session and current parent browsing context.
 
     // FIXME: 5. Update any implementation-specific state that would result from the user selecting session's current browsing context for interaction, without altering OS-level focus.
 
     // FIXME: 6. Return success with data null.
-
     return JsonValue {};
 }
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -105,6 +105,7 @@ private:
     virtual Messages::WebDriverClient::EnsureTopLevelBrowsingContextIsOpenResponse ensure_top_level_browsing_context_is_open() override;
 
     Web::HTML::BrowsingContext& current_browsing_context() { return *m_current_browsing_context; }
+    Web::HTML::BrowsingContext& current_parent_browsing_context() { return *m_current_parent_browsing_context; }
     JS::GCPtr<Web::HTML::BrowsingContext> current_top_level_browsing_context();
 
     ErrorOr<void, Web::WebDriver::Error> ensure_current_browsing_context_is_open();
@@ -144,6 +145,9 @@ private:
 
     // https://w3c.github.io/webdriver/#dfn-current-browsing-context
     JS::Handle<Web::HTML::BrowsingContext> m_current_browsing_context;
+
+    // https://w3c.github.io/webdriver/#dfn-current-parent-browsing-context
+    JS::Handle<Web::HTML::BrowsingContext> m_current_parent_browsing_context;
 };
 
 }


### PR DESCRIPTION
This PR addresses issue #1040

- Introduced `m_current_parent_browsing_context`

https://w3c.github.io/webdriver/#dfn-current-parent-browsing-context