### PR TITLE
LibWeb: Implement Range's extension method

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/range-bounding-client-rect-with-nested-text.txt
+++ b/Tests/LibWeb/Text/expected/DOM/range-bounding-client-rect-with-nested-text.txt
@@ -1,0 +1,2 @@
+  Hello   Ladybird   Ladybird again   World    6
+4

--- a/Tests/LibWeb/Text/expected/DOM/range-get-client-rects.txt
+++ b/Tests/LibWeb/Text/expected/DOM/range-get-client-rects.txt
@@ -1,0 +1,2 @@
+ x   [object DOMRectList]
+[object DOMRect]

--- a/Tests/LibWeb/Text/input/DOM/range-bounding-client-rect-with-nested-text.html
+++ b/Tests/LibWeb/Text/input/DOM/range-bounding-client-rect-with-nested-text.html
@@ -1,0 +1,47 @@
+<!--refer to https://wpt.live/css/cssom-view/range-bounding-client-rect-with-nested-text.html -->
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>All the rectangles for the text nodes must included in getClientRects</title>
+<script src="../include.js"></script>
+<style>
+  .nullDims {
+    width: 0;
+    height: 0;
+  }
+
+  .nullDims > div {
+    position: absolute;
+    left: 10px;
+  }
+</style>
+<div id="container">
+  <div class="nullDims">
+    <div id="first" style="top: 10px">Hello</div>
+  </div>
+  <div class="nullDims">
+    <div id="second" style="top: 40px">Ladybird</div>
+  </div>
+  <div class="nullDims">
+    <div id="third" style="top: 70px">Ladybird again</div>
+  </div>
+  <div class="nullDims">
+    <div id="last" style="top: 100px">World</div>
+  </div>
+</div>
+<script>
+  test(function () {
+    const first = document.getElementById("first");
+    const last = document.getElementById("last");
+    const range = document.createRange();
+    range.setStart(first.firstChild, 0);
+    range.setEnd(last.firstChild, 3);
+
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+    let rects = Array.from(range.getClientRects());
+    println(rects.length);
+    rects = rects.filter(({ width, height }) => width > 0 && height > 0);
+    println(rects.length);
+  })
+</script>

--- a/Tests/LibWeb/Text/input/DOM/range-get-client-rects.html
+++ b/Tests/LibWeb/Text/input/DOM/range-get-client-rects.html
@@ -1,0 +1,19 @@
+<!--refer to https://wpt.live/css/cssom-view/DOMRectList.html -->
+<body>
+<div id="x">x</div>
+<script src="../include.js"></script>
+<script>
+    function print_class_string(object) {
+        println({}.toString.call(object));
+    }
+    test(() => {
+        const x = document.getElementById("x");
+        const range = document.createRange();
+        range.selectNodeContents(x);
+        const domRectList = range.getClientRects();
+        print_class_string(domRectList);
+        print_class_string(domRectList.item(0));
+    });
+</script>
+
+</body>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1194,7 +1194,7 @@ void Document::update_layout()
         page().client().page_did_layout();
     }
 
-    paintable()->recompute_selection_states();
+    paintable()->update_selection();
 
     m_needs_layout = false;
 

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -88,8 +88,8 @@ public:
 
     static HashTable<Range*>& live_ranges();
 
-    JS::NonnullGCPtr<Geometry::DOMRectList> get_client_rects() const;
-    JS::NonnullGCPtr<Geometry::DOMRect> get_bounding_client_rect() const;
+    JS::NonnullGCPtr<Geometry::DOMRectList> get_client_rects();
+    JS::NonnullGCPtr<Geometry::DOMRect> get_bounding_client_rect();
 
     bool contains_node(Node const&) const;
 

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -61,6 +61,7 @@ public:
     [[nodiscard]] bool is_absolutely_positioned() const { return m_absolutely_positioned; }
     [[nodiscard]] bool is_floating() const { return m_floating; }
     [[nodiscard]] bool is_inline() const { return m_inline; }
+    [[nodiscard]] bool is_selected() const { return m_selected; }
     [[nodiscard]] CSS::Display display() const { return layout_node().display(); }
 
     template<typename U, typename Callback>
@@ -240,6 +241,7 @@ public:
 
     SelectionState selection_state() const { return m_selection_state; }
     void set_selection_state(SelectionState state) { m_selection_state = state; }
+    void set_selected(bool selected) { m_selected = selected; }
 
     Gfx::AffineTransform compute_combined_css_transform() const;
 
@@ -266,6 +268,7 @@ private:
     bool m_absolutely_positioned : 1 { false };
     bool m_floating : 1 { false };
     bool m_inline : 1 { false };
+    bool m_selected : 1 { false };
 };
 
 inline DOM::Node* HitTestResult::dom_node()

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -56,21 +56,13 @@ int PaintableFragment::text_index_at(CSSPixels x) const
 
     return m_start + m_length;
 }
-
-CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
+CSSPixelRect PaintableFragment::range_rect(Gfx::Font const& font, DOM::Range const& range) const
 {
     if (paintable().selection_state() == Paintable::SelectionState::None)
         return {};
 
     if (paintable().selection_state() == Paintable::SelectionState::Full)
         return absolute_rect();
-
-    auto selection = paintable().document().get_selection();
-    if (!selection)
-        return {};
-    auto range = selection->range();
-    if (!range)
-        return {};
 
     // FIXME: m_start and m_length should be unsigned and then we won't need these casts.
     auto const start_index = static_cast<unsigned>(m_start);
@@ -80,16 +72,16 @@ CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
 
     if (paintable().selection_state() == Paintable::SelectionState::StartAndEnd) {
         // we are in the start/end node (both the same)
-        if (start_index > range->end_offset())
+        if (start_index > range.end_offset())
             return {};
-        if (end_index < range->start_offset())
-            return {};
-
-        if (range->start_offset() == range->end_offset())
+        if (end_index < range.start_offset())
             return {};
 
-        auto selection_start_in_this_fragment = max(0, range->start_offset() - m_start);
-        auto selection_end_in_this_fragment = min(m_length, range->end_offset() - m_start);
+        if (range.start_offset() == range.end_offset())
+            return {};
+
+        auto selection_start_in_this_fragment = max(0, range.start_offset() - m_start);
+        auto selection_end_in_this_fragment = min(m_length, range.end_offset() - m_start);
         auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
         auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
 
@@ -101,10 +93,10 @@ CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
     }
     if (paintable().selection_state() == Paintable::SelectionState::Start) {
         // we are in the start node
-        if (end_index < range->start_offset())
+        if (end_index < range.start_offset())
             return {};
 
-        auto selection_start_in_this_fragment = max(0, range->start_offset() - m_start);
+        auto selection_start_in_this_fragment = max(0, range.start_offset() - m_start);
         auto selection_end_in_this_fragment = m_length;
         auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
         auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
@@ -117,11 +109,11 @@ CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
     }
     if (paintable().selection_state() == Paintable::SelectionState::End) {
         // we are in the end node
-        if (start_index > range->end_offset())
+        if (start_index > range.end_offset())
             return {};
 
         auto selection_start_in_this_fragment = 0;
-        auto selection_end_in_this_fragment = min(range->end_offset() - m_start, m_length);
+        auto selection_end_in_this_fragment = min(range.end_offset() - m_start, m_length);
         auto pixel_distance_to_first_selected_character = CSSPixels::nearest_value_for(font.width(text.substring_view(0, selection_start_in_this_fragment)));
         auto pixel_width_of_selection = CSSPixels::nearest_value_for(font.width(text.substring_view(selection_start_in_this_fragment, selection_end_in_this_fragment - selection_start_in_this_fragment))) + 1;
 
@@ -132,6 +124,21 @@ CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
         return rect;
     }
     return {};
+}
+
+CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
+{
+    if (!paintable().is_selected())
+        return {};
+
+    auto selection = paintable().document().get_selection();
+    if (!selection)
+        return {};
+    auto range = selection->range();
+    if (!range)
+        return {};
+
+    return range_rect(font, *range);
 }
 
 StringView PaintableFragment::string_view() const

--- a/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -46,6 +46,7 @@ public:
     RefPtr<Gfx::GlyphRun> glyph_run() const { return m_glyph_run; }
 
     CSSPixelRect selection_rect(Gfx::Font const&) const;
+    CSSPixelRect range_rect(Gfx::Font const&, DOM::Range const&) const;
 
     CSSPixels width() const { return m_size.width(); }
     CSSPixels height() const { return m_size.height(); }

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -284,11 +284,11 @@ JS::GCPtr<Selection::Selection> ViewportPaintable::selection() const
     return const_cast<DOM::Document&>(document()).get_selection();
 }
 
-void ViewportPaintable::recompute_selection_states()
+void ViewportPaintable::update_selection()
 {
-    // 1. Start by resetting the selection state of all layout nodes to None.
+    // 1. Start by setting all layout nodes to unselected.
     for_each_in_inclusive_subtree([&](auto& layout_node) {
-        layout_node.set_selection_state(SelectionState::None);
+        layout_node.set_selected(false);
         return TraversalDecision::Continue;
     });
 
@@ -303,10 +303,28 @@ void ViewportPaintable::recompute_selection_states()
     auto* start_container = range->start_container();
     auto* end_container = range->end_container();
 
-    // 3. If the selection starts and ends in the same node:
+    // 3. Mark the nodes included in range selected.
+    for (auto* node = start_container; node && node != end_container->next_in_pre_order(); node = node->next_in_pre_order()) {
+        if (auto* paintable = node->paintable())
+            paintable->set_selected(true);
+    }
+}
+
+void ViewportPaintable::recompute_selection_states(DOM::Range& range)
+{
+    // 1. Start by resetting the selection state of all layout nodes to None.
+    for_each_in_inclusive_subtree([&](auto& layout_node) {
+        layout_node.set_selection_state(SelectionState::None);
+        return TraversalDecision::Continue;
+    });
+
+    auto* start_container = range.start_container();
+    auto* end_container = range.end_container();
+
+    // 2. If the selection starts and ends in the same node:
     if (start_container == end_container) {
         // 1. If the selection starts and ends at the same offset, return.
-        if (range->start_offset() == range->end_offset()) {
+        if (range.start_offset() == range.end_offset()) {
             // NOTE: A zero-length selection should not be visible.
             return;
         }
@@ -319,7 +337,7 @@ void ViewportPaintable::recompute_selection_states()
         }
     }
 
-    // 4. Mark the selection start node as Start (if text) or Full (if anything else).
+    // 3. Mark the selection start node as Start (if text) or Full (if anything else).
     if (auto* paintable = start_container->paintable()) {
         if (is<DOM::Text>(*start_container))
             paintable->set_selection_state(SelectionState::Start);
@@ -327,7 +345,7 @@ void ViewportPaintable::recompute_selection_states()
             paintable->set_selection_state(SelectionState::Full);
     }
 
-    // 5. Mark the selection end node as End (if text) or Full (if anything else).
+    // 4. Mark the selection end node as End (if text) or Full (if anything else).
     if (auto* paintable = end_container->paintable()) {
         if (is<DOM::Text>(*end_container))
             paintable->set_selection_state(SelectionState::End);
@@ -335,7 +353,7 @@ void ViewportPaintable::recompute_selection_states()
             paintable->set_selection_state(SelectionState::Full);
     }
 
-    // 6. Mark the nodes between start node and end node (in tree order) as Full.
+    // 5. Mark the nodes between start node and end node (in tree order) as Full.
     for (auto* node = start_container->next_in_pre_order(); node && node != end_container; node = node->next_in_pre_order()) {
         if (auto* paintable = node->paintable())
             paintable->set_selection_state(SelectionState::Full);

--- a/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -32,7 +32,8 @@ public:
     void resolve_paint_only_properties();
 
     JS::GCPtr<Selection::Selection> selection() const;
-    void recompute_selection_states();
+    void recompute_selection_states(DOM::Range&);
+    void update_selection();
 
     bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y) override;
 


### PR DESCRIPTION
This patch implements `Range::getClientRects` and `Range::getBoundingClientRect`. Since the rects returned by invoking getClientRects can be accessed without adding them to the Selection, `ViewportPaintable::recompute_selection_states` has been updated to accept a Range as a parameter, rather than acquiring it through the Document's Selection.

With this change, the following tests now pass:

- [range-bounding-client-rect-with-nested-text](https://wpt.live/css/cssom-view/range-bounding-client-rect-with-nested-text.html)
- [DOMRectList](https://wpt.live/css/cssom-view/DOMRectList.html)

Note: The test [range-bounding-client-rect-with-display-contents](https://wpt.live/css/cssom-view/range-bounding-client-rect-with-display-contents.html) still fails due to an issue with `Element::getClientRects`, which will be addressed in a future commit.