### PR TITLE
LibWeb: Expose `crypto` object to workers

### DIFF
--- a/Tests/LibWeb/Text/expected/Worker/Worker-crypto.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-crypto.txt
@@ -1,0 +1,1 @@
+Type of self.crypto: [object Crypto]

--- a/Tests/LibWeb/Text/input/Worker/Worker-crypto.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-crypto.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        let work = new Worker("worker-crypto.js");
+        work.onmessage = (evt) => {
+            println(`Type of self.crypto: ${evt.data}`);
+            done();
+        };
+    });
+</script>

--- a/Tests/LibWeb/Text/input/Worker/worker-crypto.js
+++ b/Tests/LibWeb/Text/input/Worker/worker-crypto.js
@@ -1,0 +1,1 @@
+postMessage(self.crypto.toString());

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -24,7 +24,6 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/Screen.h>
-#include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Event.h>
@@ -120,7 +119,6 @@ void Window::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_current_event);
     visitor.visit(m_screen);
     visitor.visit(m_location);
-    visitor.visit(m_crypto);
     visitor.visit(m_navigator);
     visitor.visit(m_navigation);
     visitor.visit(m_custom_element_registry);
@@ -1551,16 +1549,6 @@ JS::GCPtr<Selection::Selection> Window::get_selection() const
 {
     // The method must invoke and return the result of getSelection() on this's Window.document attribute.
     return associated_document().get_selection();
-}
-
-// https://w3c.github.io/webcrypto/#dom-windoworworkerglobalscope-crypto
-JS::NonnullGCPtr<Crypto::Crypto> Window::crypto()
-{
-    auto& realm = this->realm();
-
-    if (!m_crypto)
-        m_crypto = heap().allocate<Crypto::Crypto>(realm, realm);
-    return JS::NonnullGCPtr { *m_crypto };
 }
 
 // https://html.spec.whatwg.org/multipage/obsolete.html#dom-window-captureevents

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -210,8 +210,6 @@ public:
 
     JS::GCPtr<Selection::Selection> get_selection() const;
 
-    [[nodiscard]] JS::NonnullGCPtr<Crypto::Crypto> crypto();
-
     void capture_events();
     void release_events();
 
@@ -270,7 +268,6 @@ private:
     // https://html.spec.whatwg.org/multipage/webappapis.html#import-maps-allowed
     bool m_import_maps_allowed { true };
 
-    JS::GCPtr<Crypto::Crypto> m_crypto;
     JS::GCPtr<CSS::Screen> m_screen;
     JS::GCPtr<Navigator> m_navigator;
     JS::GCPtr<Location> m_location;

--- a/Userland/Libraries/LibWeb/HTML/Window.idl
+++ b/Userland/Libraries/LibWeb/HTML/Window.idl
@@ -1,4 +1,3 @@
-#import <Crypto/Crypto.idl>
 #import <CSS/MediaQueryList.idl>
 #import <CSS/Screen.idl>
 #import <CSS/VisualViewport.idl>
@@ -107,9 +106,6 @@ interface Window : EventTarget {
 
     // https://w3c.github.io/selection-api/#extensions-to-window-interface
     Selection? getSelection();
-
-    // https://w3c.github.io/webcrypto/#crypto-interface
-    [SameObject] readonly attribute Crypto crypto;
 
     undefined captureEvents();
     undefined releaseEvents();

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Fetch/FetchMethod.h>
 #include <LibWeb/HTML/CanvasRenderingContext2D.h>
 #include <LibWeb/HTML/ErrorEvent.h>
@@ -72,6 +73,7 @@ void WindowOrWorkerGlobalScopeMixin::visit_edges(JS::Cell::Visitor& visitor)
     for (auto& entry : m_performance_entry_buffer_map)
         entry.value.visit_edges(visitor);
     visitor.visit(m_registered_event_sources);
+    visitor.visit(m_crypto);
 }
 
 void WindowOrWorkerGlobalScopeMixin::finalize()
@@ -836,6 +838,17 @@ void WindowOrWorkerGlobalScopeMixin::report_error(JS::Value e)
         // https://html.spec.whatwg.org/multipage/webappapis.html#report-the-exception
         report_exception_to_console(e, realm, ErrorInPromise::No);
     }
+}
+
+// https://w3c.github.io/webcrypto/#dom-windoworworkerglobalscope-crypto
+JS::NonnullGCPtr<Crypto::Crypto> WindowOrWorkerGlobalScopeMixin::crypto()
+{
+    auto& platform_object = this_impl();
+    auto& realm = platform_object.realm();
+
+    if (!m_crypto)
+        m_crypto = platform_object.heap().allocate<Crypto::Crypto>(realm, realm);
+    return JS::NonnullGCPtr { *m_crypto };
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -78,6 +78,8 @@ public:
 
     void report_error(JS::Value e);
 
+    [[nodiscard]] JS::NonnullGCPtr<Crypto::Crypto> crypto();
+
 protected:
     void initialize(JS::Realm&);
     void visit_edges(JS::Cell::Visitor&);
@@ -116,6 +118,8 @@ private:
     JS::GCPtr<IndexedDB::IDBFactory> m_indexed_db;
 
     mutable JS::GCPtr<JS::Object> m_supported_entry_types_array;
+
+    JS::GCPtr<Crypto::Crypto> m_crypto;
 
     bool m_error_reporting_mode { false };
 };

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.idl
@@ -1,3 +1,4 @@
+#import <Crypto/Crypto.idl>
 #import <Fetch/Request.idl>
 #import <Fetch/Response.idl>
 #import <HighResolutionTime/Performance.idl>
@@ -48,4 +49,7 @@ interface mixin WindowOrWorkerGlobalScope {
 
     // https://w3c.github.io/IndexedDB/#factory-interface
     [SameObject] readonly attribute IDBFactory indexedDB;
+
+    // https://w3c.github.io/webcrypto/#crypto-interface
+    [SameObject] readonly attribute Crypto crypto;
 };


### PR DESCRIPTION
This change moves the `crypto()` getter from `Window` to `WorkerOrWindowGlobalScope`. This aligns our implementation with the WebCrypto specification.

This prevents 52 WPT tests in the `WebCryptoAPI` directory from timing out when this change is put on top of #1416.