### PR TITLE
LibWeb: Use correct resolved type for round() CSS function

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-round-function-with-percentage-value.txt
+++ b/Tests/LibWeb/Layout/expected/css-round-function-with-percentage-value.txt
@@ -1,0 +1,15 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      BlockContainer <div.wrapper> at (8,8) content-size 200x17 children: not-inline
+        BlockContainer <div.box> at (48,8) content-size 100x17 children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [48,8 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer<DIV>.wrapper) [8,8 200x17]
+        PaintableWithLines (BlockContainer<DIV>.box) [8,8 140x17]
+          TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/css-round-function-with-percentage-value.html
+++ b/Tests/LibWeb/Layout/input/css-round-function-with-percentage-value.html
@@ -1,0 +1,11 @@
+<style>
+.wrapper {
+    width: 200px;
+}
+.box {
+    padding-left: round(up, 20%, 1px);
+    width: 100px;
+    background-color: magenta;
+}
+</style>
+<div class="wrapper"><div class="box">1</div></div>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -2079,7 +2079,6 @@ bool RoundCalculationNode::contains_percentage() const
 
 CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Optional<Length::ResolutionContext const&> context, CalculatedStyleValue::PercentageBasis const& percentage_basis) const
 {
-    auto resolved_type = m_x->resolved_type().value();
     auto node_a = m_x->resolve(context, percentage_basis);
     auto node_b = m_y->resolve(context, percentage_basis);
 
@@ -2088,6 +2087,8 @@ CalculatedStyleValue::CalculationResult RoundCalculationNode::resolve(Optional<L
 
     auto upper_b = ceil(node_a_value / node_b_value) * node_b_value;
     auto lower_b = floor(node_a_value / node_b_value) * node_b_value;
+
+    auto resolved_type = node_a.resolved_type();
 
     if (m_strategy == RoundingStrategy::Nearest) {
         auto upper_diff = fabs(upper_b - node_a_value);
@@ -2592,6 +2593,19 @@ void CalculatedStyleValue::CalculationResult::invert()
         [&](Percentage const& percentage) {
             m_value = Percentage { 1 / percentage.value() };
         });
+}
+
+CalculatedStyleValue::ResolvedType CalculatedStyleValue::CalculationResult::resolved_type() const
+{
+    return m_value.visit(
+        [](Number const&) { return ResolvedType::Number; },
+        [](Angle const&) { return ResolvedType::Angle; },
+        [](Flex const&) { return ResolvedType::Flex; },
+        [](Frequency const&) { return ResolvedType::Frequency; },
+        [](Length const&) { return ResolvedType::Length; },
+        [](Percentage const&) { return ResolvedType::Percentage; },
+        [](Resolution const&) { return ResolvedType::Resolution; },
+        [](Time const&) { return ResolvedType::Time; });
 }
 
 String CalculatedStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -65,6 +65,8 @@ public:
 
         Value const& value() const { return m_value; }
 
+        ResolvedType resolved_type() const;
+
         [[nodiscard]] bool operator==(CalculationResult const&) const = default;
 
     private:


### PR DESCRIPTION
Function is defined as `round(<rounding-strategy>?, A, B?)`

With this change resolved type is `typeof(resolve(A))`, instead of `typeof(A)`.

For example `round(up, 20%, 1px)` with 200px percentage basis is now correctly resolved in 40px instead of 40%.

Progress on https://www.notion.so/ landing page.

Before:
<img width="1204" alt="Screenshot 2024-09-17 at 17 58 44" src="https://github.com/user-attachments/assets/6c85c055-02e7-4fa0-82c7-1a729391e9de">


After:
<img width="1204" alt="Screenshot 2024-09-17 at 17 58 11" src="https://github.com/user-attachments/assets/80e14376-e458-4863-bfb0-0e77b9128bbf">


