### PR TITLE
UI/AppKit: Implement opening child web views from e.g. `window.open`

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.h
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.h
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
 #include <LibWeb/HTML/ActivateTab.h>
+#include <LibWebView/Forward.h>
 
 #import <Cocoa/Cocoa.h>
 
@@ -31,6 +32,11 @@
                                    url:(URL::URL const&)url
                                fromTab:(nullable Tab*)tab
                            activateTab:(Web::HTML::ActivateTab)activate_tab;
+
+- (nonnull TabController*)createChildTab:(Optional<URL::URL> const&)url
+                                 fromTab:(nonnull Tab*)tab
+                             activateTab:(Web::HTML::ActivateTab)activate_tab
+                               pageIndex:(u64)page_index;
 
 - (void)setActiveTab:(nonnull Tab*)tab;
 - (nullable Tab*)activeTab;

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -97,7 +97,10 @@
                    activateTab:(Web::HTML::ActivateTab)activate_tab
 {
     auto* controller = [self createNewTab:activate_tab fromTab:tab];
-    [controller loadURL:url.value_or(WebView::Application::chrome_options().new_tab_page_url)];
+
+    if (url.has_value()) {
+        [controller loadURL:*url];
+    }
 
     return controller;
 }

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -116,6 +116,20 @@
     return controller;
 }
 
+- (nonnull TabController*)createChildTab:(Optional<URL::URL> const&)url
+                                 fromTab:(nonnull Tab*)tab
+                             activateTab:(Web::HTML::ActivateTab)activate_tab
+                               pageIndex:(u64)page_index
+{
+    auto* controller = [self createChildTab:activate_tab fromTab:tab pageIndex:page_index];
+
+    if (url.has_value()) {
+        [controller loadURL:*url];
+    }
+
+    return controller;
+}
+
 - (void)setActiveTab:(Tab*)tab
 {
     self.active_tab = tab;
@@ -175,6 +189,29 @@
                                fromTab:(nullable Tab*)tab
 {
     auto* controller = [[TabController alloc] init];
+    [self initializeTabController:controller
+                      activateTab:activate_tab
+                          fromTab:tab];
+
+    return controller;
+}
+
+- (nonnull TabController*)createChildTab:(Web::HTML::ActivateTab)activate_tab
+                                 fromTab:(nonnull Tab*)tab
+                               pageIndex:(u64)page_index
+{
+    auto* controller = [[TabController alloc] initAsChild:tab pageIndex:page_index];
+    [self initializeTabController:controller
+                      activateTab:activate_tab
+                          fromTab:tab];
+
+    return controller;
+}
+
+- (void)initializeTabController:(TabController*)controller
+                    activateTab:(Web::HTML::ActivateTab)activate_tab
+                        fromTab:(nullable Tab*)tab
+{
     [controller showWindow:nil];
 
     if (tab) {
@@ -192,7 +229,6 @@
 
     [self.managed_tabs addObject:controller];
     [controller onCreateNewTab];
-    return controller;
 }
 
 - (void)closeCurrentTab:(id)sender

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -20,7 +20,7 @@
 
 @protocol LadybirdWebViewObserver <NSObject>
 
-- (String const&)onCreateNewTab:(URL::URL const&)url
+- (String const&)onCreateNewTab:(Optional<URL::URL> const&)url
                     activateTab:(Web::HTML::ActivateTab)activate_tab;
 
 - (String const&)onCreateNewTab:(StringView)html

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -27,6 +27,10 @@
                             url:(URL::URL const&)url
                     activateTab:(Web::HTML::ActivateTab)activate_tab;
 
+- (String const&)onCreateChildTab:(Optional<URL::URL> const&)url
+                      activateTab:(Web::HTML::ActivateTab)activate_tab
+                        pageIndex:(u64)page_index;
+
 - (void)loadURL:(URL::URL const&)url;
 - (void)onLoadStart:(URL::URL const&)url isRedirect:(BOOL)is_redirect;
 - (void)onLoadFinish:(URL::URL const&)url;
@@ -47,6 +51,9 @@
 @interface LadybirdWebView : NSClipView <NSMenuDelegate>
 
 - (instancetype)init:(id<LadybirdWebViewObserver>)observer;
+- (instancetype)initAsChild:(id<LadybirdWebViewObserver>)observer
+                     parent:(LadybirdWebView*)parent
+                  pageIndex:(u64)page_index;
 
 - (void)loadURL:(URL::URL const&)url;
 - (void)loadHTML:(StringView)html;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -323,7 +323,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
             return String {};
         }
         // FIXME: Create a child tab that re-uses the ConnectionFromClient of the parent tab
-        return [self.observer onCreateNewTab:"about:blank"sv activateTab:activate_tab];
+        return [self.observer onCreateNewTab:{} activateTab:activate_tab];
     };
 
     m_web_view_bridge->on_request_web_content = [weak_self]() {

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -25,6 +25,7 @@ public:
     virtual ~WebViewBridge() override;
 
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) override;
+    void initialize_client_as_child(WebViewBridge const& parent, u64 page_index);
 
     float device_pixel_ratio() const { return m_device_pixel_ratio; }
     void set_device_pixel_ratio(float device_pixel_ratio);

--- a/Ladybird/AppKit/UI/Tab.h
+++ b/Ladybird/AppKit/UI/Tab.h
@@ -6,11 +6,17 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 #import <Cocoa/Cocoa.h>
 
 @class LadybirdWebView;
 
 @interface Tab : NSWindow
+
+- (instancetype)init;
+- (instancetype)initAsChild:(Tab*)parent
+                  pageIndex:(u64)page_index;
 
 - (void)tabWillClose;
 

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -61,6 +61,19 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
 - (instancetype)init
 {
+    auto* web_view = [[LadybirdWebView alloc] init:self];
+    return [self initWithWebView:web_view];
+}
+
+- (instancetype)initAsChild:(Tab*)parent
+                  pageIndex:(u64)page_index
+{
+    auto* web_view = [[LadybirdWebView alloc] initAsChild:self parent:[parent web_view] pageIndex:page_index];
+    return [self initWithWebView:web_view];
+}
+
+- (instancetype)initWithWebView:(LadybirdWebView*)web_view
+{
     auto screen_rect = [[NSScreen mainScreen] frame];
     auto position_x = (NSWidth(screen_rect) - WINDOW_WIDTH) / 2;
     auto position_y = (NSHeight(screen_rect) - WINDOW_HEIGHT) / 2;
@@ -77,7 +90,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
         // Remember last window position
         self.frameAutosaveName = @"window";
 
-        self.web_view = [[LadybirdWebView alloc] init:self];
+        self.web_view = web_view;
         [self.web_view setPostsBoundsChangedNotifications:YES];
 
         self.favicon = [Tab defaultFavicon];
@@ -291,6 +304,21 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
                                           url:url
                                       fromTab:self
                                   activateTab:activate_tab];
+
+    auto* tab = (Tab*)[controller window];
+    return [[tab web_view] handle];
+}
+
+- (String const&)onCreateChildTab:(Optional<URL::URL> const&)url
+                      activateTab:(Web::HTML::ActivateTab)activate_tab
+                        pageIndex:(u64)page_index
+{
+    auto* delegate = (ApplicationDelegate*)[NSApp delegate];
+
+    auto* controller = [delegate createChildTab:url
+                                        fromTab:self
+                                    activateTab:activate_tab
+                                      pageIndex:page_index];
 
     auto* tab = (Tab*)[controller window];
     return [[tab web_view] handle];

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -268,7 +268,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
 #pragma mark - LadybirdWebViewObserver
 
-- (String const&)onCreateNewTab:(URL::URL const&)url
+- (String const&)onCreateNewTab:(Optional<URL::URL> const&)url
                     activateTab:(Web::HTML::ActivateTab)activate_tab
 {
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -11,6 +11,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class Tab;
+
 struct TabSettings {
     BOOL should_show_line_box_borders { NO };
     BOOL scripting_enabled { YES };
@@ -23,6 +25,8 @@ struct TabSettings {
 @interface TabController : NSWindowController <NSWindowDelegate>
 
 - (instancetype)init;
+- (instancetype)initAsChild:(Tab*)parent
+                  pageIndex:(u64)page_index;
 
 - (void)loadURL:(URL::URL const&)url;
 - (void)loadHTML:(StringView)html url:(URL::URL const&)url;

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -214,7 +214,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 
     self.tab.titlebarAppearsTransparent = NO;
 
-    [delegate createNewTab:OptionalNone {}
+    [delegate createNewTab:WebView::Application::chrome_options().new_tab_page_url
                    fromTab:[self tab]
                activateTab:Web::HTML::ActivateTab::Yes];
 


### PR DESCRIPTION
This has been implemented in Qt for quite some time. This patch adds the
same feature to AppKit. This is needed to run many WPT subtests with the
AppKit chrome. This is also needed to handle `window.open`, `target=_blank`
link clicks, etc.

Fixes #1386 

One such WPT test that requires this is:
```bash
» ./Meta/WPT.sh run --log-mach results.log /cookies/domain/domain-attribute-idn-host.sub.https.html

Running 1 tests in web-platform-tests

Ran 1 tests finished in 4.2 seconds.
  • 1 ran as expected. 0 tests skipped.
```

https://github.com/user-attachments/assets/3fa11469-fd84-4f6e-8386-c60c118164f9





