### PR TITLE
Tests: Make rebaseline's build-dir check unambiguous

### DIFF
--- a/Tests/LibWeb/rebaseline-libweb-test
+++ b/Tests/LibWeb/rebaseline-libweb-test
@@ -24,7 +24,7 @@ else
     build_dir=$LADYBIRD_SOURCE_DIR/Build/ladybird
 fi
 
-cd "$build_dir" || echo "Couldn’t cd to build directory" >&2 && exit 1
+cd "$build_dir" || { echo "Couldn’t cd to build directory" >&2 && exit 1; }
 
 if [[ -f ./bin/headless-browser ]]; then
     ladybird_headless_binary=./bin/headless-browser


### PR DESCRIPTION
At least on my Linux machine using zsh, this line was interpreted as

`( cd "$build_dir" || echo ... ) && exit 1`

instead of the intended

`cd "$build_dir" || ( echo ... && exit 1 )`

...meaning that it always exited regardless of whether it found the build dir or not. So, let's make the intended precedence explicit.