### PR TITLE
LibWeb: Print FIXME instead of crashing in abspos SVG element layout

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/abspos-svg-polygon.txt
+++ b/Tests/LibWeb/Layout/expected/svg/abspos-svg-polygon.txt
@@ -1,0 +1,14 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x200 positioned children: inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
+        SVGSVGBox <svg> at (8,8) content-size 200x200 [SVG] children: not-inline
+          SVGGeometryBox <polygon> at (48,18) content-size 120x170 positioned [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x200]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,8 200x200]
+          SVGPathPaintable (SVGGeometryBox<polygon>) [48,18 120x170]

--- a/Tests/LibWeb/Layout/input/svg/abspos-svg-polygon.html
+++ b/Tests/LibWeb/Layout/input/svg/abspos-svg-polygon.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><div style="position: relative"><svg width="200" height="200"><polygon points="100,10 40,180 160,180" style="position:absolute; top: 100px; left: 100px;" />

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1222,6 +1222,11 @@ StaticPositionRect FormattingContext::calculate_static_position_rect(Box const& 
 
 void FormattingContext::layout_absolutely_positioned_element(Box const& box, AvailableSpace const& available_space)
 {
+    if (box.is_svg_box()) {
+        dbgln("FIXME: Implement support for absolutely positioned SVG elements.");
+        return;
+    }
+
     auto& containing_block_state = m_state.get_mutable(*box.containing_block());
 
     // The size of the containing block of an abspos box is always definite from the perspective of the abspos box.


### PR DESCRIPTION
Currently we are crashing in `verify_cast<BlockContainer>(box)` on attempt to create BFC for SVG box.