### PR TITLE
Tests/LibWeb: Add layout test for float box with box-sizing=border-box

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/floating-box-with-box-sizing-border-box.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/floating-box-with-box-sizing-border-box.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x208 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      BlockContainer <div.box> at (108,108) content-size 100x0 floating [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x208]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 300x200]
+      PaintableWithLines (BlockContainer<DIV>.box) [8,8 300x200]

--- a/Tests/LibWeb/Layout/input/block-and-inline/floating-box-with-box-sizing-border-box.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/floating-box-with-box-sizing-border-box.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html><style>
+.box {
+    float: left;
+    width: 300px;
+    height: 200px;
+    padding: 100px;
+    background-color: magenta;
+    box-sizing: border-box;
+}
+</style><div class="box"></div>


### PR DESCRIPTION
Adds a test for d6a31d80c05db05c34cd56ca865658a5b82dbb69 that was mistakenly ommited in the first place.