### PR TITLE
LibWeb: Don't crash when resolving style of grid template properties

### DIFF
--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-no-paintable.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-no-paintable.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/getComputedStyle-no-paintable.html
+++ b/Tests/LibWeb/Text/input/css/getComputedStyle-no-paintable.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const noPaintableElement = document.createElement("br");
+        document.body.appendChild(noPaintableElement);
+        const style = getComputedStyle(noPaintableElement);
+        let values = [];
+        for (const propertyName of style) {
+            values.push(style[propertyName]);
+        }
+        noPaintableElement.remove();
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -523,14 +523,18 @@ RefPtr<CSSStyleValue const> ResolvedCSSStyleDeclaration::style_value_for_propert
         // For grid-template-columns and grid-template-rows the resolved value is the used value.
         // https://www.w3.org/TR/css-grid-2/#resolved-track-list-standalone
         if (property_id == PropertyID::GridTemplateColumns) {
-            auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
-            if (auto used_values_for_grid_template_columns = paintable_box.used_values_for_grid_template_columns()) {
-                return used_values_for_grid_template_columns;
+            if (layout_node.paintable()) {
+                auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
+                if (auto used_values_for_grid_template_columns = paintable_box.used_values_for_grid_template_columns()) {
+                    return used_values_for_grid_template_columns;
+                }
             }
         } else if (property_id == PropertyID::GridTemplateRows) {
-            auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
-            if (auto used_values_for_grid_template_rows = paintable_box.used_values_for_grid_template_rows()) {
-                return used_values_for_grid_template_rows;
+            if (layout_node.paintable()) {
+                auto const& paintable_box = verify_cast<Painting::PaintableBox const>(*layout_node.paintable());
+                if (auto used_values_for_grid_template_rows = paintable_box.used_values_for_grid_template_rows()) {
+                    return used_values_for_grid_template_rows;
+                }
             }
         }
 


### PR DESCRIPTION
Previously, attempting to get the computed value for a grid-template-rows or grid-template-columns property would cause a crash if the element had no associated paintable.

This fixes a crash in the inspector that I saw when clicking on a `<br>` tag.