### PR TITLE
Meta: Allow `ladybird.sh` to run any target in the MacOS app bundle

### DIFF
--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -208,7 +208,11 @@ build_and_run_lagom_target() {
     local lagom_args=("${CMD_ARGS[@]:1}")
 
     if [ -z "$lagom_target" ]; then
-        lagom_target="ladybird"
+        lagom_target="Ladybird"
+    fi
+
+    if [ "$lagom_target" = "ladybird" ]; then
+        lagom_target="Ladybird"
     fi
 
     # FIXME: Find some way to centralize these b/w CMakePresets.json, CI files, Documentation and here.
@@ -219,14 +223,10 @@ build_and_run_lagom_target() {
 
     build_target "${lagom_target}"
 
-    if [ "$lagom_target" = "ladybird" ] && [ "$(uname -s)" = "Darwin" ]; then
-        "$BUILD_DIR/bin/Ladybird.app/Contents/MacOS/Ladybird" "${lagom_args[@]}"
+    if [[ "$lagom_target" =~ ^(headless-browser|ImageDecoder|Ladybird|RequestServer|WebContent|WebDriver|WebWorker)$ ]] && [ "$(uname -s)" = "Darwin" ]; then
+        "$BUILD_DIR/bin/Ladybird.app/Contents/MacOS/$lagom_target" "${lagom_args[@]}"
     else
-        local lagom_bin="$lagom_target"
-        if [ "$lagom_bin" = "ladybird" ]; then
-            lagom_bin="Ladybird"
-        fi
-        "$BUILD_DIR/bin/$lagom_bin" "${lagom_args[@]}"
+        "$BUILD_DIR/bin/$lagom_target" "${lagom_args[@]}"
     fi
 }
 


### PR DESCRIPTION
Previously, using `ladybird.sh run` with any target that was part of the MacOS app bundle would try to run the given executable from the wrong directory.