### PR TITLE
LibWeb: Don't invalidate layout tree on all DOM node removals

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -1000,7 +1000,7 @@ void KeyframeEffect::update_style_properties()
     if (invalidation.relayout)
         document.set_needs_layout();
     if (invalidation.rebuild_layout_tree)
-        document.invalidate_layout();
+        document.invalidate_layout_tree();
     if (invalidation.repaint)
         document.set_needs_to_resolve_paint_only_properties();
     if (invalidation.rebuild_stacking_context_tree)

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1049,7 +1049,7 @@ void Document::set_needs_layout()
     schedule_layout_update();
 }
 
-void Document::invalidate_layout()
+void Document::invalidate_layout_tree()
 {
     tear_down_layout_tree();
     schedule_layout_update();
@@ -1282,7 +1282,7 @@ void Document::update_style()
         invalidate_display_list();
     }
     if (invalidation.rebuild_layout_tree) {
-        invalidate_layout();
+        invalidate_layout_tree();
     } else {
         if (invalidation.relayout)
             set_needs_layout();
@@ -2739,7 +2739,7 @@ void Document::evaluate_media_rules()
     if (any_media_queries_changed_match_state) {
         style_computer().invalidate_rule_cache();
         invalidate_style(StyleInvalidationReason::MediaQueryChangedMatchState);
-        invalidate_layout();
+        invalidate_layout_tree();
     }
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -243,7 +243,7 @@ public:
 
     void set_needs_layout();
 
-    void invalidate_layout();
+    void invalidate_layout_tree();
     void invalidate_stacking_context_tree();
 
     virtual bool is_child_allowed(Node const&) const override;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -826,7 +826,7 @@ WebIDL::ExceptionOr<void> Element::set_inner_html(StringView value)
 
         if (context->is_connected()) {
             // NOTE: Since the DOM has changed, we have to rebuild the layout tree.
-            context->document().invalidate_layout();
+            context->document().invalidate_layout_tree();
         }
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -208,7 +208,7 @@ void Node::set_text_content(Optional<String> const& maybe_content)
 
     if (is_connected()) {
         document().invalidate_style(StyleInvalidationReason::NodeSetTextContent);
-        document().invalidate_layout();
+        document().invalidate_layout_tree();
     }
 
     document().bump_dom_tree_version();
@@ -656,7 +656,7 @@ void Node::insert_before(JS::NonnullGCPtr<Node> node, JS::GCPtr<Node> child, boo
     if (is_connected()) {
         // FIXME: This will need to become smarter when we implement the :has() selector.
         invalidate_style(StyleInvalidationReason::NodeInsertBefore);
-        document().invalidate_layout();
+        document().invalidate_layout_tree();
     }
 
     document().bump_dom_tree_version();
@@ -855,7 +855,7 @@ void Node::remove(bool suppress_observers)
         // Since the tree structure has changed, we need to invalidate both style and layout.
         // In the future, we should find a way to only invalidate the parts that actually need it.
         document().invalidate_style(StyleInvalidationReason::NodeRemove);
-        document().invalidate_layout();
+        document().invalidate_layout_tree();
     }
 
     document().bump_dom_tree_version();

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -88,7 +88,7 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_inner_html(StringView value)
 
         if (this->is_connected()) {
             // NOTE: Since the DOM has changed, we have to rebuild the layout tree.
-            this->document().invalidate_layout();
+            this->document().invalidate_layout_tree();
         }
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -987,7 +987,7 @@ void HTMLInputElement::update_file_input_shadow_tree()
         m_file_label->set_text_content(MUST(String::formatted("No {} selected.", files_label)));
     }
 
-    document().invalidate_layout();
+    document().invalidate_layout_tree();
 }
 
 void HTMLInputElement::create_range_input_shadow_tree()
@@ -1315,7 +1315,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::handle_src_attribute(String const& v
             });
 
             m_load_event_delayer.clear();
-            document().invalidate_layout();
+            document().invalidate_layout_tree();
         },
         [this, &realm]() {
             // 2. Otherwise, if the fetching process fails without a response from the remote server, or completes but the

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -363,7 +363,7 @@ void HTMLObjectElement::update_layout_and_child_objects(Representation represent
 
     m_representation = representation;
     invalidate_style(DOM::StyleInvalidationReason::HTMLObjectElementUpdateLayoutAndChildObjects);
-    document().invalidate_layout();
+    document().invalidate_layout_tree();
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -45,7 +45,7 @@ void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<Strin
         if (transform_list.has_value())
             m_transform = transform_from_transform_list(*transform_list);
         // FIXME: This should only invalidate the contents of the SVG.
-        document().invalidate_layout();
+        document().invalidate_layout_tree();
     }
 }
 


### PR DESCRIPTION
DOM nodes that didn't have a layout node before being removed from the DOM are not going to change the shape of the layout tree after being removed.
    
Observing this, we can avoid a full layout tree rebuild on some DOM node removals.
    
This avoids a bunch of tree building work when loading https://x.com/