### PR TITLE
Appkit+Qt+LibWeb+LibWebView: Dock inspector in browser window

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -147,6 +147,9 @@ body {
 }
 
 .global-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
     margin: 0 8px 0 8px;
 }
 
@@ -167,6 +170,17 @@ body {
 }
 
 #export-inspector-button:hover {
+    background-color: var(--tab-button-background);
+}
+
+#close-inspector-button {
+    background-image: url("resource://icons/16x16/close-tab.png");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-color: var(--tab-controls);
+}
+
+#close-inspector-button:hover {
     background-color: var(--tab-button-background);
 }
 

--- a/Base/res/ladybird/inspector.html
+++ b/Base/res/ladybird/inspector.html
@@ -22,6 +22,8 @@
 
                 <div class="global-controls">
                     <button id="export-inspector-button" title="Export the Inspector to an HTML file" onclick="inspector.exportInspector()"></button>
+
+                    @CLOSE_INSPECTOR_BUTTON@
                 </div>
             </div>
 

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -96,6 +96,26 @@ inspector.exportInspector = () => {
     inspector.exportInspectorHTML(html);
 };
 
+inspector.close = () => {
+    inspector.closeInspector();
+};
+
+inspector.setCloseInspectorButtonVisibility = isVisible => {
+    const closeInspectorButton = document.getElementById("close-inspector-button");
+
+    if (!closeInspectorButton) {
+        console.error("Could not find close-inspector-button button");
+        return;
+    }
+
+    let display = "none";
+    if (isVisible) {
+        display = "block";
+    }
+
+    closeInspectorButton.style.display = display;
+};
+
 inspector.reset = () => {
     let domTree = document.getElementById("dom-tree");
     domTree.innerHTML = "";

--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -606,6 +606,9 @@
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Inspector"
                                                 action:@selector(openInspector:)
                                          keyEquivalent:@"I"]];
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Inspector Pane"
+                                                action:@selector(openInspectorPane:)
+                                         keyEquivalent:@""]];
     [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Open Task Manager"
                                                 action:@selector(openTaskManager:)
                                          keyEquivalent:@"M"]];

--- a/Ladybird/AppKit/CMakeLists.txt
+++ b/Ladybird/AppKit/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(ladybird_impl STATIC
     UI/Event.mm
     UI/Inspector.mm
     UI/InspectorController.mm
+    UI/InspectorWindow.mm
     UI/LadybirdWebView.mm
     UI/LadybirdWebViewBridge.cpp
     UI/Palette.mm

--- a/Ladybird/AppKit/UI/Inspector.h
+++ b/Ladybird/AppKit/UI/Inspector.h
@@ -11,7 +11,7 @@
 @class LadybirdWebView;
 @class Tab;
 
-@interface Inspector : NSWindow
+@interface Inspector : NSScrollView
 
 - (instancetype)init:(Tab*)tab;
 

--- a/Ladybird/AppKit/UI/Inspector.h
+++ b/Ladybird/AppKit/UI/Inspector.h
@@ -13,13 +13,17 @@
 
 @interface Inspector : NSScrollView
 
-- (instancetype)init:(Tab*)tab;
+- (instancetype)init:(Tab*)tab
+          isWindowed:(BOOL)is_windowed;
 
 - (void)inspect;
 - (void)reset;
 
 - (void)selectHoveredElement;
 
+- (void)setIsWindowed:(BOOL)is_windowed;
+
+@property (nonatomic, strong) NSScrollView* inspector_scroll_view;
 @property (nonatomic, strong) LadybirdWebView* web_view;
 
 @end

--- a/Ladybird/AppKit/UI/Inspector.mm
+++ b/Ladybird/AppKit/UI/Inspector.mm
@@ -19,9 +19,6 @@
 #    error "This project requires ARC"
 #endif
 
-static constexpr CGFloat const WINDOW_WIDTH = 875;
-static constexpr CGFloat const WINDOW_HEIGHT = 825;
-
 static constexpr NSInteger CONTEXT_MENU_EDIT_NODE_TAG = 1;
 static constexpr NSInteger CONTEXT_MENU_REMOVE_ATTRIBUTE_TAG = 2;
 static constexpr NSInteger CONTEXT_MENU_COPY_ATTRIBUTE_VALUE_TAG = 3;
@@ -51,17 +48,7 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
 
 - (instancetype)init:(Tab*)tab
 {
-    auto tab_rect = [tab frame];
-    auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
-    auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
-
-    auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
-    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
-
-    self = [super initWithContentRect:window_rect
-                            styleMask:style_mask
-                              backing:NSBackingStoreBuffered
-                                defer:NO];
+    self = [super init];
 
     if (self) {
         self.tab = tab;
@@ -138,27 +125,9 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
             auto* event = Ladybird::create_context_menu_mouse_event(strong_self.web_view, position);
             [NSMenu popUpContextMenu:strong_self.cookie_context_menu withEvent:event forView:strong_self.web_view];
         };
-
-        auto* scroll_view = [[NSScrollView alloc] init];
-        [scroll_view setHasVerticalScroller:YES];
-        [scroll_view setHasHorizontalScroller:YES];
-        [scroll_view setLineScroll:24];
-
-        [scroll_view setContentView:self.web_view];
-        [scroll_view setDocumentView:[[NSView alloc] init]];
-
-        [self setContentView:scroll_view];
-        [self setTitle:@"Inspector"];
-        [self setIsVisible:YES];
     }
 
     return self;
-}
-
-- (void)dealloc
-{
-    auto& web_view = [[self.tab web_view] view];
-    web_view.clear_inspected_dom_node();
 }
 
 #pragma mark - Public methods

--- a/Ladybird/AppKit/UI/InspectorController.h
+++ b/Ladybird/AppKit/UI/InspectorController.h
@@ -13,7 +13,6 @@
 
 @interface InspectorController : NSWindowController
 
-- (instancetype)init:(Tab*)tab
-           inspector:(Inspector*)inspector;
+- (instancetype)init:(Tab*)tab;
 
 @end

--- a/Ladybird/AppKit/UI/InspectorController.mm
+++ b/Ladybird/AppKit/UI/InspectorController.mm
@@ -16,18 +16,15 @@
 @interface InspectorController () <NSWindowDelegate>
 
 @property (nonatomic, strong) Tab* tab;
-@property (nonatomic, strong) Inspector* inspector;
 
 @end
 
 @implementation InspectorController
 
 - (instancetype)init:(Tab*)tab
-           inspector:(Inspector*)inspector
 {
     if (self = [super init]) {
         self.tab = tab;
-        self.inspector = inspector;
     }
 
     return self;
@@ -44,9 +41,21 @@
 
 - (IBAction)showWindow:(id)sender
 {
-    self.window = [[InspectorWindow alloc] init:self.tab inspector:self.inspector];
+    self.window = [[InspectorWindow alloc] init:self.tab];
     [self.window setDelegate:self];
     [self.window makeKeyAndOrderFront:sender];
+}
+
+- (void)close
+{
+    // Temporarily remove the window delegate to prevent `windowWillClose`
+    // from being called. This avoids deallocating the inspector when
+    // we just want to move it to the main window and close the
+    // inspector's window
+    auto delegate = self.window.delegate;
+    [self.window setDelegate:nil];
+    [self.window close];
+    [self.window setDelegate:delegate];
 }
 
 #pragma mark - NSWindowDelegate

--- a/Ladybird/AppKit/UI/InspectorController.mm
+++ b/Ladybird/AppKit/UI/InspectorController.mm
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#import <UI/Inspector.h>
 #import <UI/InspectorController.h>
+#import <UI/InspectorWindow.h>
 #import <UI/LadybirdWebView.h>
 #import <UI/Tab.h>
 
@@ -16,15 +16,18 @@
 @interface InspectorController () <NSWindowDelegate>
 
 @property (nonatomic, strong) Tab* tab;
+@property (nonatomic, strong) Inspector* inspector;
 
 @end
 
 @implementation InspectorController
 
 - (instancetype)init:(Tab*)tab
+           inspector:(Inspector*)inspector
 {
     if (self = [super init]) {
         self.tab = tab;
+        self.inspector = inspector;
     }
 
     return self;
@@ -32,16 +35,16 @@
 
 #pragma mark - Private methods
 
-- (Inspector*)inspector
+- (InspectorWindow*)inspectorWindow
 {
-    return (Inspector*)[self window];
+    return (InspectorWindow*)[self window];
 }
 
 #pragma mark - NSWindowController
 
 - (IBAction)showWindow:(id)sender
 {
-    self.window = [[Inspector alloc] init:self.tab];
+    self.window = [[InspectorWindow alloc] init:self.tab inspector:self.inspector];
     [self.window setDelegate:self];
     [self.window makeKeyAndOrderFront:sender];
 }
@@ -56,13 +59,13 @@
 - (void)windowDidResize:(NSNotification*)notification
 {
     if (![[self window] inLiveResize]) {
-        [[[self inspector] web_view] handleResize];
+        [[[self tab] web_view] handleResize];
     }
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification*)notification
 {
-    [[[self inspector] web_view] handleDevicePixelRatioChange];
+    [[[self tab] web_view] handleDevicePixelRatioChange];
 }
 
 @end

--- a/Ladybird/AppKit/UI/InspectorWindow.h
+++ b/Ladybird/AppKit/UI/InspectorWindow.h
@@ -15,7 +15,6 @@
 
 @interface InspectorWindow : NSWindow
 
-- (instancetype)init:(Tab*)tab
-           inspector:(Inspector*)inspector;
+- (instancetype)init:(Tab*)tab;
 
 @end

--- a/Ladybird/AppKit/UI/InspectorWindow.h
+++ b/Ladybird/AppKit/UI/InspectorWindow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Neil Viloria <neilcviloria@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,9 +10,10 @@
 #import <Cocoa/Cocoa.h>
 #import <UI/Inspector.h>
 
+@class LadybirdWebView;
 @class Tab;
 
-@interface InspectorController : NSWindowController
+@interface InspectorWindow : NSWindow
 
 - (instancetype)init:(Tab*)tab
            inspector:(Inspector*)inspector;

--- a/Ladybird/AppKit/UI/InspectorWindow.mm
+++ b/Ladybird/AppKit/UI/InspectorWindow.mm
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Neil Viloria <neilcviloria@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWebView/InspectorClient.h>
+
+#import <UI/InspectorWindow.h>
+#import <UI/LadybirdWebView.h>
+#import <UI/Tab.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+static constexpr CGFloat const WINDOW_WIDTH = 875;
+static constexpr CGFloat const WINDOW_HEIGHT = 825;
+
+@interface InspectorWindow ()
+{
+    OwnPtr<WebView::InspectorClient> m_inspector_client;
+}
+
+@property (nonatomic, strong) Tab* tab;
+
+@end
+
+@implementation InspectorWindow
+
+@synthesize tab = _tab;
+
+- (instancetype)init:(Tab*)tab
+           inspector:(Inspector*)inspector
+{
+    auto tab_rect = [tab frame];
+    auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
+    auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
+
+    auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
+    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+
+    self = [super initWithContentRect:window_rect
+                            styleMask:style_mask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        self.tab = tab;
+
+        auto* scroll_view = [[NSScrollView alloc] init];
+        [scroll_view setHasVerticalScroller:YES];
+        [scroll_view setHasHorizontalScroller:YES];
+        [scroll_view setLineScroll:24];
+
+        [scroll_view setContentView:inspector.web_view];
+        [scroll_view setDocumentView:[[NSView alloc] init]];
+
+        [self setContentView:scroll_view];
+        [self setTitle:@"Inspector"];
+        [self setIsVisible:YES];
+    }
+    return self;
+}
+
+@end

--- a/Ladybird/AppKit/UI/InspectorWindow.mm
+++ b/Ladybird/AppKit/UI/InspectorWindow.mm
@@ -32,7 +32,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 825;
 @synthesize tab = _tab;
 
 - (instancetype)init:(Tab*)tab
-           inspector:(Inspector*)inspector
 {
     auto tab_rect = [tab frame];
     auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
@@ -49,15 +48,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 825;
     if (self) {
         self.tab = tab;
 
-        auto* scroll_view = [[NSScrollView alloc] init];
-        [scroll_view setHasVerticalScroller:YES];
-        [scroll_view setHasHorizontalScroller:YES];
-        [scroll_view setLineScroll:24];
-
-        [scroll_view setContentView:inspector.web_view];
-        [scroll_view setDocumentView:[[NSView alloc] init]];
-
-        [self setContentView:scroll_view];
+        [self setContentView:tab.inspector];
         [self setTitle:@"Inspector"];
         [self setIsVisible:YES];
     }

--- a/Ladybird/AppKit/UI/Tab.h
+++ b/Ladybird/AppKit/UI/Tab.h
@@ -10,6 +10,8 @@
 
 #import <Cocoa/Cocoa.h>
 
+@class Inspector;
+
 @class LadybirdWebView;
 
 @interface Tab : NSWindow
@@ -24,5 +26,7 @@
 - (void)onInspectorClosed;
 
 @property (nonatomic, strong) LadybirdWebView* web_view;
+
+@property (nonatomic, strong) Inspector* inspector;
 
 @end

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -363,6 +363,15 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         }
     });
 
+    auto* inspector_pane_action = new QAction("Open Inspector Pane", this);
+    inspector_pane_action->setIcon(load_icon_from_uri("resource://icons/browser/dom-tree.png"sv));
+    inspect_menu->addAction(inspector_pane_action);
+    QObject::connect(inspector_pane_action, &QAction::triggered, this, [this] {
+        if (m_current_tab) {
+            m_current_tab->show_inspector_pane();
+        }
+    });
+
     auto* task_manager_action = new QAction("Open Task &Manager", this);
     task_manager_action->setIcon(load_icon_from_uri("resource://icons/16x16/app-system-monitor.png"sv));
     task_manager_action->setShortcuts({ QKeySequence("Ctrl+Shift+M") });

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -22,7 +22,7 @@ class InspectorWidget final : public QWidget {
     Q_OBJECT
 
 public:
-    InspectorWidget(QWidget* tab, WebContentView& content_view);
+    InspectorWidget(QWidget* tab, WebContentView& content_view, Qt::WindowType window_type);
     virtual ~InspectorWidget() override;
 
     void inspect();
@@ -30,6 +30,8 @@ public:
 
     void select_hovered_node();
     void select_default_node();
+
+    void setWindowFlag(Qt::WindowType flag, bool on = true);
 
 public slots:
     void device_pixel_ratio_changed(qreal dpi);

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -70,8 +70,11 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     focus_location_editor_action->setShortcut(QKeySequence("Ctrl+L"));
     addAction(focus_location_editor_action);
 
+    m_splitter = new QSplitter(this);
+    m_splitter->addWidget(m_view);
+
     m_layout->addWidget(m_toolbar);
-    m_layout->addWidget(m_view);
+    m_layout->addWidget(m_splitter);
     m_layout->addWidget(m_find_in_page);
 
     m_hamburger_button = new QToolButton(m_toolbar);
@@ -875,18 +878,33 @@ void Tab::recreate_toolbar_icons()
 void Tab::show_inspector_window(InspectorTarget inspector_target)
 {
     if (!m_inspector_widget)
-        m_inspector_widget = new InspectorWidget(this, view());
-    else
-        m_inspector_widget->inspect();
+        m_inspector_widget = new InspectorWidget(this, view(), Qt::Window);
+    else {
+        m_inspector_widget->setParent(nullptr);
+        m_inspector_widget->setWindowFlag(Qt::Window);
+    }
 
     m_inspector_widget->show();
+    m_inspector_widget->resize(875, 825);
     m_inspector_widget->activateWindow();
     m_inspector_widget->raise();
 
     if (inspector_target == InspectorTarget::HoveredElement)
         m_inspector_widget->select_hovered_node();
+}
+
+void Tab::show_inspector_pane()
+{
+    if (!m_inspector_widget)
+        m_inspector_widget = new InspectorWidget(this, view(), Qt::Widget);
     else
-        m_inspector_widget->select_default_node();
+        m_inspector_widget->setWindowFlag(Qt::Widget);
+
+    m_splitter->addWidget(m_inspector_widget);
+
+    m_splitter->setSizes({ 200, 100 });
+
+    m_inspector_widget->show();
 }
 
 void Tab::show_find_in_page()

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -16,6 +16,7 @@
 #include <QLineEdit>
 #include <QMenu>
 #include <QPointer>
+#include <QSplitter>
 #include <QToolBar>
 #include <QToolButton>
 #include <QWidget>
@@ -51,6 +52,7 @@ public:
         HoveredElement
     };
     void show_inspector_window(InspectorTarget = InspectorTarget::Document);
+    void show_inspector_pane();
 
     void show_find_in_page();
     void find_previous();
@@ -105,6 +107,7 @@ private:
 
     void close_sub_widgets();
 
+    QSplitter* m_splitter { nullptr };
     QBoxLayout* m_layout { nullptr };
     QToolBar* m_toolbar { nullptr };
     QToolButton* m_hamburger_button { nullptr };

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -101,4 +101,9 @@ void Inspector::export_inspector_html(String const& html)
     inspector_page_client().inspector_did_export_inspector_html(html);
 }
 
+void Inspector::close_inspector()
+{
+    inspector_page_client().inspector_did_close();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -37,6 +37,8 @@ public:
 
     void export_inspector_html(String const& html);
 
+    void close_inspector();
+
 private:
     explicit Inspector(JS::Realm&);
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -20,4 +20,5 @@
 
     undefined exportInspectorHTML(DOMString html);
 
+    undefined closeInspector();
 };

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -383,6 +383,7 @@ public:
     virtual void inspector_did_request_style_sheet_source([[maybe_unused]] CSS::StyleSheetIdentifier const& identifier) { }
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
     virtual void inspector_did_export_inspector_html([[maybe_unused]] String const& html) { }
+    virtual void inspector_did_close() { }
 
     virtual bool is_ready_to_paint() const = 0;
 

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -19,7 +19,7 @@ namespace WebView {
 
 class InspectorClient {
 public:
-    InspectorClient(ViewImplementation& content_web_view, ViewImplementation& inspector_web_view);
+    InspectorClient(ViewImplementation& content_web_view, ViewImplementation& inspector_web_view, bool is_windowed);
     ~InspectorClient();
 
     void inspect();
@@ -41,11 +41,13 @@ public:
     void context_menu_copy_dom_node_attribute_value();
     void context_menu_delete_cookie();
     void context_menu_delete_all_cookies();
+    void set_is_windowed(bool is_windowed);
 
     Function<void(Gfx::IntPoint)> on_requested_dom_node_text_context_menu;
     Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_tag_context_menu;
     Function<void(Gfx::IntPoint, String const&, Attribute const&)> on_requested_dom_node_attribute_context_menu;
     Function<void(Gfx::IntPoint, Web::Cookie::Cookie const&)> on_requested_cookie_context_menu;
+    Function<void()> on_requested_close;
 
 private:
     void load_inspector();
@@ -93,6 +95,8 @@ private:
     i32 m_highest_notified_message_index { -1 };
     i32 m_highest_received_message_index { -1 };
     bool m_waiting_for_messages { false };
+
+    bool m_is_windowed { false };
 };
 
 }

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -226,6 +226,7 @@ public:
     Function<void(String const&)> on_inspector_executed_console_script;
     Function<void(String const&)> on_inspector_exported_inspector_html;
     Function<IPC::File()> on_request_worker_agent;
+    Function<void()> on_inspector_closed;
 
     virtual Web::DevicePixelSize viewport_size() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -694,6 +694,14 @@ void WebContentClient::inspector_did_export_inspector_html(u64 page_id, String c
     }
 }
 
+void WebContentClient::inspector_did_close(u64 page_id)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_inspector_closed)
+            view->on_inspector_closed();
+    }
+}
+
 Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request_worker_agent(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -126,6 +126,7 @@ private:
     virtual void inspector_did_request_cookie_context_menu(u64 page_id, size_t cookie_index, Gfx::IntPoint position) override;
     virtual void inspector_did_execute_console_script(u64 page_id, String const& script) override;
     virtual void inspector_did_export_inspector_html(u64 page_id, String const& html) override;
+    virtual void inspector_did_close(u64 page_id) override;
     virtual Messages::WebContentClient::RequestWorkerAgentResponse request_worker_agent(u64 page_id) override;
     virtual void inspector_did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> const& stylesheets) override;
     virtual void inspector_did_request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -674,6 +674,11 @@ void PageClient::inspector_did_export_inspector_html(String const& html)
     client().async_inspector_did_export_inspector_html(m_id, html);
 }
 
+void PageClient::inspector_did_close()
+{
+    client().async_inspector_did_close(m_id);
+}
+
 ErrorOr<void> PageClient::connect_to_webdriver(ByteString const& webdriver_ipc_path)
 {
     VERIFY(!m_webdriver);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -173,6 +173,7 @@ private:
     virtual void inspector_did_request_style_sheet_source(Web::CSS::StyleSheetIdentifier const& stylesheet_source) override;
     virtual void inspector_did_execute_console_script(String const& script) override;
     virtual void inspector_did_export_inspector_html(String const& script) override;
+    virtual void inspector_did_close() override;
 
     Web::Layout::Viewport* layout_root();
     void setup_palette();

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -113,5 +113,6 @@ endpoint WebContentClient
     inspector_did_request_cookie_context_menu(u64 page_id, size_t cookie_index, Gfx::IntPoint position) =|
     inspector_did_execute_console_script(u64 page_id, String script) =|
     inspector_did_export_inspector_html(u64 page_id, String html) =|
+    inspector_did_close(u64 page_id) =|
 
 }


### PR DESCRIPTION
# Description
This PR allows for the inspector to be docked in the window beside the web content. There are some issues with the `<select/>` tag dropdowns that are within the inspector but didn't address them as they were out of scope for this feature. 

This PR also sets the ground work to have up, down, left, right and windowed inspector positions in a `<select/>` within the inspector and also have the browser remember what the last size and position that inspector was in last which I hope to follow up this PR with

### Appkit

https://github.com/user-attachments/assets/fc05425e-56c9-44e1-9ad6-ef94084c5298

### Qt

https://github.com/user-attachments/assets/3f7d96eb-664c-4834-8ad7-d3149e821303

