### PR TITLE
LibLine: Correctly slice completion substrings as unicode strings

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -383,7 +383,13 @@ void Editor::insert(ByteString const& string)
 
 void Editor::insert(StringView string_view)
 {
-    for (auto ch : Utf8View { string_view })
+    auto view = Utf8View { string_view };
+    insert(view);
+}
+
+void Editor::insert(Utf8View& view)
+{
+    for (auto ch : view)
         insert(ch);
 }
 
@@ -1205,7 +1211,7 @@ ErrorOr<void> Editor::handle_read_event()
             m_chars_touched_in_the_middle++;
 
             for (auto& view : completion_result.insert)
-                insert(view.as_string());
+                insert(view);
 
             auto stderr_stream = TRY(Core::File::standard_error());
             TRY(reposition_cursor(*stderr_stream));

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -218,6 +218,7 @@ public:
     void clear_line();
     void insert(ByteString const&);
     void insert(StringView);
+    void insert(Utf8View&);
     void insert(Utf32View const&);
     void insert(u32 const);
     void stylize(Span const&, Style const&);

--- a/Userland/Libraries/LibLine/SuggestionManager.cpp
+++ b/Userland/Libraries/LibLine/SuggestionManager.cpp
@@ -141,14 +141,14 @@ SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion
         if (mode == CompletePrefix) {
             // Only auto-complete *if possible*.
             if (can_complete) {
-                result.insert.append(suggestion.text_view().substring_view(suggestion.invariant_offset, m_largest_common_suggestion_prefix_length - suggestion.invariant_offset));
+                result.insert.append(suggestion.text_view().unicode_substring_view(suggestion.invariant_offset, m_largest_common_suggestion_prefix_length - suggestion.invariant_offset));
                 m_last_shown_suggestion_display_length = m_largest_common_suggestion_prefix_length;
                 // Do not increment the suggestion index, as the first tab should only be a *peek*.
                 if (m_suggestions.size() == 1) {
                     // If there's one suggestion, commit and forget.
                     result.new_completion_mode = DontComplete;
                     // Add in the trivia of the last selected suggestion.
-                    result.insert.append(suggestion.trivia_view());
+                    result.insert.append(suggestion.trailing_trivia.code_points());
                     m_last_shown_suggestion_display_length = 0;
                     result.style_to_apply = suggestion.style;
                     m_last_shown_suggestion_was_complete = true;
@@ -161,9 +161,9 @@ SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion
             m_last_shown_suggestion_was_complete = false;
             m_last_shown_suggestion = ByteString::empty();
         } else {
-            result.insert.append(suggestion.text_view().substring_view(suggestion.invariant_offset, suggestion.text_view().length() - suggestion.invariant_offset));
+            result.insert.append(suggestion.text_view().unicode_substring_view(suggestion.invariant_offset, suggestion.text_view().length() - suggestion.invariant_offset));
             // Add in the trivia of the last selected suggestion.
-            result.insert.append(suggestion.trivia_view());
+            result.insert.append(suggestion.trailing_trivia.code_points());
             m_last_shown_suggestion_display_length += suggestion.trivia_view().length();
         }
     } else {


### PR DESCRIPTION
Ports a fix from Serenity's LibLine.
https://github.com/SerenityOS/serenity/commit/cee0d979cca45c7299fd8872417f22f9bb021502