### PR TITLE
UI/Qt: Do not perform search if query text is empty

### DIFF
--- a/Ladybird/Qt/LocationEdit.cpp
+++ b/Ladybird/Qt/LocationEdit.cpp
@@ -31,6 +31,9 @@ LocationEdit::LocationEdit(QWidget* parent)
     });
 
     connect(this, &QLineEdit::returnPressed, [&] {
+        if (text().isEmpty())
+            return;
+
         clearFocus();
 
         Optional<StringView> search_engine_url;

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -823,6 +823,8 @@ void Tab::copy_link_url(URL::URL const& url)
 
 void Tab::location_edit_return_pressed()
 {
+    if (m_location_edit->text().isEmpty())
+        return;
     navigate(m_location_edit->url());
 }
 


### PR DESCRIPTION
On master, clear text from location bar and press enter. If search engine is enabled it will search empty string, if not it will reload the current page.