### PR TITLE
Documentation: Add macOS version requirement for building AppKit in `BuildInstructionsLadybird.md`

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -200,6 +200,8 @@ Ladybird will be built with one of the following browser chromes (graphical fron
 * [Qt](https://doc.qt.io/qt-6/) - The chrome used on all other platforms.
 * [Android UI](https://developer.android.com/develop/ui) - The native chrome on Android.
 
+To build the AppKit chrome, make sure your version of macOS is >= 14.0.
+
 The Qt chrome is available on platforms where it is not the default as well (except on Android). To build the
 Qt chrome, install the Qt dependencies for your platform, and enable the Qt chrome via CMake:
 


### PR DESCRIPTION
Just a small add to `BuildInstructionsLadybird.md`. MacOS Sonoma (14.0) or above is required to build the AppKit chrome. 

It was not building on my machine (MacOS Ventura 13.6) and gave the following build error:

```
/Users/abi/Stuffs/Cloned/ladybird/Ladybird/AppKit/UI/SearchPanel.mm:66:36: error: use of undeclared identifier 'NSBezelStyleAccessoryBarAction'
   66 |         [search_done setBezelStyle:NSBezelStyleAccessoryBarAction];
      |                                    ^
```
Reason being that `NSBezelStyleAccessoryBarAction` is [only available for macOS 14+](https://developer.apple.com/documentation/appkit/nsbezelstyle/nsbezelstyleaccessorybaraction).

