### PR TITLE
LibJS: Extend supported date string formats

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -181,6 +181,7 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%Y-%m-%eT%T%X%z"sv,                   // "2024-01-26T22:10:11.306+0000"
         "%m/%e/%Y,%t%T%t%p"sv,                 // "1/27/2024, 9:28:30 AM"
         "%Y-%m-%e"sv,                          // "2024-1-15"
+        "%Y-%m-%e%t%T%tGMT%z"sv                // "2024-07-05 00:00:00 GMT-0800"
     };
 
     for (auto const& format : extra_formats) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -27,6 +27,7 @@ test("basic functionality", () => {
     expect(Date.parse("Sun Jan 21 2024 21:11:31 GMT 0100 (Central European Standard Time)")).toBe(
         1705867891000
     );
+    expect(Date.parse("2024-07-05 00:00:00 GMT-0200")).toBe(1720144800000);
     expect(Date.parse("2024-01-15 00:00:01")).toBe(1705298401000);
     expect(Date.parse("Tue Nov 07 2023 10:05:55  UTC")).toBe(1699351555000);
     expect(Date.parse("Wed Apr 17 23:08:53 2019")).toBe(1555560533000);


### PR DESCRIPTION
Add support for the following date string format when opening [twitch](https://www.twitch.tv/).

```
12460.242 WebContent(113831): Unable to parse date string: "2024-07-05 00:00:00 GMT-0800"
12460.463 WebContent(113831): Unable to parse date string: "2024-07-05 00:00:00 GMT-0800"
12460.511 WebContent(113831): Unable to parse date string: "2024-07-05 00:00:00 GMT-0800"
```


