### PR TITLE
LibWeb: Change inline float clearance to not reset margin collapsing

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/inline-float-clear.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/inline-float-clear.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x73 [BFC] children: not-inline
+    BlockContainer <body> at (9,9) content-size 687.5x48 children: not-inline
+      BlockContainer <(anonymous)> at (9,9) content-size 687.5x0 children: inline
+        TextNode <#text>
+      BlockContainer <div#A> at (9,9) content-size 687.5x16 children: not-inline
+      BlockContainer <(anonymous)> at (9,41) content-size 687.5x0 children: inline
+        TextNode <#text>
+        BlockContainer <div#B> at (648.5,41) content-size 48x16 floating [BFC] children: not-inline
+        TextNode <#text>
+        BlockContainer <div#C> at (648.5,57) content-size 48x16 floating [BFC] children: not-inline
+        TextNode <#text>
+      BlockContainer <div#D> at (9,41) content-size 687.5x16 children: not-inline
+      BlockContainer <(anonymous)> at (9,57) content-size 687.5x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x73]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 689.5x50]
+      PaintableWithLines (BlockContainer(anonymous)) [9,9 687.5x0]
+      PaintableWithLines (BlockContainer<DIV>#A) [9,9 687.5x16]
+      PaintableWithLines (BlockContainer(anonymous)) [9,41 687.5x0]
+        PaintableWithLines (BlockContainer<DIV>#B) [648.5,41 48x16]
+        PaintableWithLines (BlockContainer<DIV>#C) [648.5,57 48x16]
+      PaintableWithLines (BlockContainer<DIV>#D) [9,41 687.5x16]
+      PaintableWithLines (BlockContainer(anonymous)) [9,57 687.5x0]

--- a/Tests/LibWeb/Layout/input/block-and-inline/inline-float-clear.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/inline-float-clear.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<style> div { height: 1rem; } </style>
+<body style="font-size: 24px; width: 80rex; padding: 0; border: 1px solid black;">
+
+<div id=A style="margin-bottom: 1rem; background: green;"></div>
+<div id=B style="float: right; width: 3rem; background: orange;"></div>
+<div id=C style="float: right; clear: right; width: 3rem; background: red;"></div>
+<div id=D style="background: blue;"></div>

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -314,9 +314,11 @@ void InlineFormattingContext::generate_line_boxes()
 
         case InlineLevelIterator::Item::Type::FloatingElement:
             if (is<Box>(*item.node)) {
-                auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this);
-                if (introduce_clearance == BlockFormattingContext::DidIntroduceClearance::Yes)
-                    parent().reset_margin_state();
+                [[maybe_unused]] auto introduce_clearance = parent().clear_floating_boxes(*item.node, *this);
+                // Even if this introduces clearance, we do NOT reset
+                // the margin state, because that is clearance between
+                // floats and does not contribute to the height of the
+                // Inline Formatting Context.
                 parent().layout_floating_box(static_cast<Layout::Box const&>(*item.node), containing_block(), *m_available_space, 0, &line_builder);
             }
             break;


### PR DESCRIPTION
When a block container has `clear` set and some clearance is applied, that clearance prevents margins from adjoining and therefore resets the margin state. But when a floating box has `clear` set, that clearance only goes between floating boxes so should not reset margin state. BlockFormattingContexts already do that correctly, and this PR changes InlineFormattingContext to do the same.

Fixes #1462; adds reduced input from that issue as test.