### PR TITLE
LibJS: Add extra date format "d B Y"

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -181,7 +181,8 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%Y-%m-%eT%T%X%z"sv,                   // "2024-01-26T22:10:11.306+0000"
         "%m/%e/%Y,%t%T%t%p"sv,                 // "1/27/2024, 9:28:30 AM"
         "%Y-%m-%e"sv,                          // "2024-1-15"
-        "%Y-%m-%e%t%T%tGMT%z"sv                // "2024-07-05 00:00:00 GMT-0800"
+        "%Y-%m-%e%t%T%tGMT%z"sv,               // "2024-07-05 00:00:00 GMT-0800"
+        "%d%t%B%t%Y"sv                         // "01 February 2013"
     };
 
     for (auto const& format : extra_formats) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -33,6 +33,7 @@ test("basic functionality", () => {
     expect(Date.parse("Wed Apr 17 23:08:53 2019")).toBe(1555560533000);
     expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011000); // FIXME: support sub-second precision
     expect(Date.parse("1/27/2024, 9:28:30 AM")).toBe(1706369310000);
+    expect(Date.parse("01 February 2013")).toBe(1359698400000);
 
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
     setTimeZone(originalTimeZone);


### PR DESCRIPTION
This allows date strings like "01 February 2013" to be parsed. auth0.com also loads now because of this :^)