### PR TITLE
LibWeb: Let style elements remember which StyleSheetList they live in

### DIFF
--- a/Tests/LibWeb/Text/expected/ShadowDOM/replace-declarative-shadow-root-with-style-sheet.txt
+++ b/Tests/LibWeb/Text/expected/ShadowDOM/replace-declarative-shadow-root-with-style-sheet.txt
@@ -1,0 +1,1 @@
+   PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/ShadowDOM/replace-declarative-shadow-root-with-style-sheet.html
+++ b/Tests/LibWeb/Text/input/ShadowDOM/replace-declarative-shadow-root-with-style-sheet.html
@@ -1,0 +1,9 @@
+<div id="hmmst"><template shadowrootmode="open"><div><style></style></div></template></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        hmmst.attachShadow({ mode: "open" });
+        println("PASS (didn't crash)");
+        hmmst.remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -14,19 +14,21 @@ namespace Web::DOM {
 
 class StyleElementUtils {
 public:
-    void update_a_style_block(DOM::Element& style_element, JS::GCPtr<DOM::Node> old_parent_if_removed_from = nullptr);
+    void update_a_style_block(DOM::Element& style_element);
 
     CSS::CSSStyleSheet* sheet() { return m_associated_css_style_sheet; }
     CSS::CSSStyleSheet const* sheet() const { return m_associated_css_style_sheet; }
 
-    void visit_edges(JS::Cell::Visitor& visitor)
-    {
-        visitor.visit(m_associated_css_style_sheet);
-    }
+    [[nodiscard]] JS::GCPtr<CSS::StyleSheetList> style_sheet_list() { return m_style_sheet_list; }
+    [[nodiscard]] JS::GCPtr<CSS::StyleSheetList const> style_sheet_list() const { return m_style_sheet_list; }
+
+    void visit_edges(JS::Cell::Visitor&);
 
 private:
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet
     JS::GCPtr<CSS::CSSStyleSheet> m_associated_css_style_sheet;
+
+    JS::GCPtr<CSS::StyleSheetList> m_style_sheet_list;
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
+++ b/Userland/Libraries/LibWeb/DOM/StyleElementUtils.h
@@ -19,6 +19,11 @@ public:
     CSS::CSSStyleSheet* sheet() { return m_associated_css_style_sheet; }
     CSS::CSSStyleSheet const* sheet() const { return m_associated_css_style_sheet; }
 
+    void visit_edges(JS::Cell::Visitor& visitor)
+    {
+        visitor.visit(m_associated_css_style_sheet);
+    }
+
 private:
     // https://www.w3.org/TR/cssom/#associated-css-style-sheet
     JS::GCPtr<CSS::CSSStyleSheet> m_associated_css_style_sheet;

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -46,7 +46,7 @@ void HTMLStyleElement::inserted()
 
 void HTMLStyleElement::removed_from(Node* old_parent)
 {
-    m_style_element_utils.update_a_style_block(*this, old_parent);
+    m_style_element_utils.update_a_style_block(*this);
     Base::removed_from(old_parent);
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -29,7 +29,7 @@ void HTMLStyleElement::initialize(JS::Realm& realm)
 void HTMLStyleElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_style_element_utils.sheet());
+    m_style_element_utils.visit_edges(visitor);
 }
 
 void HTMLStyleElement::children_changed()

--- a/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -27,7 +27,7 @@ void SVGStyleElement::initialize(JS::Realm& realm)
 void SVGStyleElement::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_style_element_utils.sheet());
+    m_style_element_utils.visit_edges(visitor);
 }
 
 void SVGStyleElement::children_changed()

--- a/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -44,7 +44,7 @@ void SVGStyleElement::inserted()
 
 void SVGStyleElement::removed_from(Node* old_parent)
 {
-    m_style_element_utils.update_a_style_block(*this, old_parent);
+    m_style_element_utils.update_a_style_block(*this);
     Base::removed_from(old_parent);
 }
 


### PR DESCRIPTION
Instead of trying to locate the relevant StyleSheetList on style element removal from the DOM, we now simply keep a pointer to the list instead.
    
This fixes an issue where using attachShadow() on an element that had a declarative shadow DOM would cause any style elements present to use the wrong StyleSheetList when removing themselves from the tree.