### PR TITLE
LibWeb: Return a WindowProxy from `document.defaultView`

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Document-defaultView.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-defaultView.txt
@@ -1,0 +1,1 @@
+document.defaultView === window: true

--- a/Tests/LibWeb/Text/input/DOM/Document-defaultView.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-defaultView.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`document.defaultView === window: ${document.defaultView === window}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -698,6 +698,22 @@ WebIDL::ExceptionOr<void> Document::close()
     return {};
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-document-defaultview
+JS::GCPtr<HTML::WindowProxy> Document::default_view()
+{
+    // If this's browsing context is null, then return null.
+    if (!browsing_context())
+        return {};
+
+    // 2. Return this's browsing context's WindowProxy object.
+    return browsing_context()->window_proxy();
+}
+
+JS::GCPtr<HTML::WindowProxy const> Document::default_view() const
+{
+    return const_cast<Document*>(this)->default_view();
+}
+
 HTML::Origin Document::origin() const
 {
     return m_origin;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -370,8 +370,8 @@ public:
     WebIDL::ExceptionOr<JS::GCPtr<HTML::WindowProxy>> open(StringView url, StringView name, StringView features);
     WebIDL::ExceptionOr<void> close();
 
-    HTML::Window* default_view() { return m_window.ptr(); }
-    HTML::Window const* default_view() const { return m_window.ptr(); }
+    JS::GCPtr<HTML::WindowProxy const> default_view() const;
+    JS::GCPtr<HTML::WindowProxy> default_view();
 
     String const& content_type() const { return m_content_type; }
     void set_content_type(String content_type) { m_content_type = move(content_type); }

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -48,7 +48,7 @@ interface Document : Node {
     readonly attribute DOMString inputEncoding;
     readonly attribute DOMString contentType;
 
-    readonly attribute Window? defaultView;
+    readonly attribute WindowProxy? defaultView;
 
     [CEReactions] Document open(optional DOMString unused1, optional DOMString unused2);
     WindowProxy? open(USVString url, DOMString name, DOMString features);

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1246,7 +1246,8 @@ double Element::scroll_top() const
         return 0.0;
 
     // 3. Let window be the value of document’s defaultView attribute.
-    auto* window = document.default_view();
+    // FIXME: The specification expects defaultView to be a Window object, but defaultView actually returns a WindowProxy object.
+    auto window = document.window();
 
     // 4. If window is null, return zero and terminate these steps.
     if (!window)
@@ -1276,6 +1277,7 @@ double Element::scroll_top() const
     return paintable_box()->scroll_offset().y().to_double();
 }
 
+// https://drafts.csswg.org/cssom-view/#dom-element-scrollleft
 double Element::scroll_left() const
 {
     // 1. Let document be the element’s node document.
@@ -1286,7 +1288,8 @@ double Element::scroll_left() const
         return 0.0;
 
     // 3. Let window be the value of document’s defaultView attribute.
-    auto* window = document.default_view();
+    // FIXME: The specification expects defaultView to be a Window object, but defaultView actually returns a WindowProxy object.
+    auto window = document.window();
 
     // 4. If window is null, return zero and terminate these steps.
     if (!window)
@@ -1332,7 +1335,8 @@ void Element::set_scroll_left(double x)
         return;
 
     // 5. Let window be the value of document’s defaultView attribute.
-    auto* window = document.default_view();
+    // FIXME: The specification expects defaultView to be a Window object, but defaultView actually returns a WindowProxy object.
+    auto window = document.window();
 
     // 6. If window is null, terminate these steps.
     if (!window)
@@ -1388,7 +1392,8 @@ void Element::set_scroll_top(double y)
         return;
 
     // 5. Let window be the value of document’s defaultView attribute.
-    auto* window = document.default_view();
+    // FIXME: The specification expects defaultView to be a Window object, but defaultView actually returns a WindowProxy object.
+    auto window = document.window();
 
     // 6. If window is null, terminate these steps.
     if (!window)
@@ -2347,7 +2352,8 @@ void Element::scroll(double x, double y)
         return;
 
     // 5. Let window be the value of document’s defaultView attribute.
-    auto* window = document.default_view();
+    // FIXME: The specification expects defaultView to be a Window object, but defaultView actually returns a WindowProxy object.
+    auto window = document.window();
 
     // 6. If window is null, terminate these steps.
     if (!window)


### PR DESCRIPTION
This PR updates `document.defaultView` to follow the most recent spec steps, which say that `WindowProxy?` should be returned rather than `Window?`.

I also had to update a few methods that called this method, but still expect it to return a Window object. In these cases, we now use `Document::window()` instead, so that the previous behavior is retained.

This prevents 291 WPT tests in the `editing` directory from timing out. Running `./Meta/WPT.sh run editing` gives the following results:
NOTE: The majority of these tests still error out, because we don't implement the `send_keys()` WebDriver endpoint, but they now fail a lot faster than previously.

Before:

```
Ran 724 tests finished in 692.4 seconds.
  • 141 ran as expected. 0 tests skipped.
  • 1 tests crashed unexpectedly
  • 37 tests had errors unexpectedly
  • 296 tests timed out unexpectedly
  • 249 tests had unexpected subtest results
```

After:
```
Ran 724 tests finished in 173.9 seconds.
  • 175 ran as expected. 0 tests skipped.
  • 1 tests crashed unexpectedly
  • 277 tests had errors unexpectedly
  • 5 tests timed out unexpectedly
  • 266 tests had unexpected subtest results
```

Fixes: http://wpt.live/html/browsers/the-window-object/Document-defaultView.html    
