### PR TITLE
LibWeb: Always call `document.close` after `document.write`

### DIFF
--- a/Tests/LibWeb/Layout/input/document-write-incomplete-tag.html
+++ b/Tests/LibWeb/Layout/input/document-write-incomplete-tag.html
@@ -3,6 +3,7 @@
 <script type="text/javascript">
     document.write("<p");
     document.write(">hello</p>");
+    document.close();
 </script>
 
 <p>friends!</p>

--- a/Tests/LibWeb/Text/input/HTML/document-write-flush-character-insertions.html
+++ b/Tests/LibWeb/Text/input/HTML/document-write-flush-character-insertions.html
@@ -2,5 +2,6 @@
 <script>
     test(() => {
         document.write("PASS");
+        document.close();
     });
 </script>


### PR DESCRIPTION
This ensures the HTML parser completes running if it previously stopped at an insertion point during a call to `document.write`.