### PR TITLE
LibWeb: Make CSS font loader tolerate WPT web server shenanigans

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -251,13 +251,16 @@ public:
     Vector<Gfx::UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
     RefPtr<Gfx::Typeface> vector_font() const { return m_vector_font; }
 
-    virtual void resource_did_load() override;
-    virtual void resource_did_fail() override;
-
     RefPtr<Gfx::Font> font_with_point_size(float point_size);
     void start_loading_next_url();
 
 private:
+    // ^ResourceClient
+    virtual void resource_did_load() override;
+    virtual void resource_did_fail() override;
+
+    void resource_did_load_or_fail();
+
     ErrorOr<NonnullRefPtr<Gfx::Typeface>> try_load_font();
 
     StyleComputer& m_style_computer;

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -120,9 +120,11 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, HTTP::HeaderM
     });
 }
 
-void Resource::did_fail(Badge<ResourceLoader>, ByteString const& error, Optional<u32> status_code)
+void Resource::did_fail(Badge<ResourceLoader>, ByteString const& error, ReadonlyBytes data, HTTP::HeaderMap const& headers, Optional<u32> status_code)
 {
     m_error = error;
+    m_encoded_data = ByteBuffer::copy(data).release_value_but_fixme_should_propagate_errors();
+    m_response_headers = headers;
     m_status_code = move(status_code);
     m_state = State::Failed;
 

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -68,7 +68,7 @@ public:
     void for_each_client(Function<void(ResourceClient&)>);
 
     void did_load(Badge<ResourceLoader>, ReadonlyBytes data, HTTP::HeaderMap const&, Optional<u32> status_code);
-    void did_fail(Badge<ResourceLoader>, ByteString const& error, Optional<u32> status_code);
+    void did_fail(Badge<ResourceLoader>, ByteString const& error, ReadonlyBytes data, HTTP::HeaderMap const&, Optional<u32> status_code);
 
 protected:
     explicit Resource(Type, LoadRequest const&);

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -121,8 +121,8 @@ RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, LoadRequest&
         [=](auto data, auto& headers, auto status_code) {
             const_cast<Resource&>(*resource).did_load({}, data, headers, status_code);
         },
-        [=](auto& error, auto status_code, auto, auto) {
-            const_cast<Resource&>(*resource).did_fail({}, error, status_code);
+        [=](auto& error, auto status_code, auto data, auto& headers) {
+            const_cast<Resource&>(*resource).did_fail({}, error, data, headers, status_code);
         });
 
     return resource;


### PR DESCRIPTION
The web server for WPT has a tendency to just disconnect after sending us a resource. This makes curl think an error occurred, but it's actually still recoverable and we have the data.

So instead of just bailing, do what we already do for other kinds of resources and try to parse the data we got. If it works out, great!

It would be nice to solve this in the networking layer instead, but I'll leave that as an exercise for our future selves.