### PR TITLE
LibWeb/HTML: Select html input elements with selectable text

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -232,8 +232,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::select()
     auto& html_element = form_associated_element_to_html_element();
     if (is<HTMLInputElement>(html_element)) {
         auto& input_element = static_cast<HTMLInputElement&>(html_element);
-        // FIXME: implement "or the corresponding control has no selectable text"
-        if (!input_element.select_applies())
+        if (!input_element.select_applies() || !input_element.has_selectable_text())
             return {};
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2300,6 +2300,29 @@ bool HTMLInputElement::selection_or_range_applies() const
     return selection_or_range_applies_for_type_state(type_state());
 }
 
+bool HTMLInputElement::has_selectable_text() const
+{
+    // Potential FIXME: Date, Month, Week, Time and LocalDateAndTime are rendered as a basic text input for now,
+    // thus they have selectable text, this need to change when we will have a visual date/time selector.
+
+    switch (type_state()) {
+    case TypeAttributeState::Text:
+    case TypeAttributeState::Search:
+    case TypeAttributeState::Telephone:
+    case TypeAttributeState::URL:
+    case TypeAttributeState::Password:
+    case TypeAttributeState::Date:
+    case TypeAttributeState::Month:
+    case TypeAttributeState::Week:
+    case TypeAttributeState::Time:
+    case TypeAttributeState::LocalDateAndTime:
+    case TypeAttributeState::Number:
+        return true;
+    default:
+        return false;
+    }
+}
+
 bool HTMLInputElement::selection_or_range_applies_for_type_state(TypeAttributeState type_state)
 {
     switch (type_state) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -204,6 +204,7 @@ public:
     bool step_up_or_down_applies() const;
     bool select_applies() const;
     bool selection_or_range_applies() const;
+    bool has_selectable_text() const;
 
     static bool selection_or_range_applies_for_type_state(TypeAttributeState);
 


### PR DESCRIPTION
only select input elements that select applies to and has a selectable text.
as per the specs in https://html.spec.whatwg.org/multipage/input.html#do-not-apply