### PR TITLE
LibWeb: Allow setting shorthand CSS properties via CSSStyleDeclaration

### DIFF
--- a/Tests/LibWeb/Text/expected/css/set-style-declaration-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/css/set-style-declaration-shorthand.txt
@@ -1,0 +1,46 @@
+Setting flex: 'none'; becomes...
+  flex-basis: 'auto'
+  flex-grow: '0'
+  flex-shrink: '0'
+  flex: '0 0 auto'
+  e.style.length: 3
+  > [0] flex-grow
+  > [1] flex-shrink
+  > [2] flex-basis
+
+Setting flex: 'auto 1 2'; becomes...
+  flex-basis: 'auto'
+  flex-grow: '1'
+  flex-shrink: '2'
+  flex: '1 2 auto'
+  e.style.length: 3
+  > [0] flex-grow
+  > [1] flex-shrink
+  > [2] flex-basis
+
+Setting flex: ''; becomes...
+  flex-basis: ''
+  flex-grow: ''
+  flex-shrink: ''
+  flex: ''
+  e.style.length: 0
+
+Setting border: '1px solid red'; becomes...
+  border-width: '1px 1px 1px 1px'
+  border-style: 'solid solid solid solid'
+  border-color: 'rgb(255, 0, 0) rgb(255, 0, 0) rgb(255, 0, 0) rgb(255, 0, 0)'
+  border: ''
+  e.style.length: 12
+  > [0] border-top-width
+  > [1] border-right-width
+  > [2] border-bottom-width
+  > [3] border-left-width
+  > [4] border-top-style
+  > [5] border-right-style
+  > [6] border-bottom-style
+  > [7] border-left-style
+  > [8] border-top-color
+  > [9] border-right-color
+  > [10] border-bottom-color
+  > [11] border-left-color
+

--- a/Tests/LibWeb/Text/input/css/set-style-declaration-shorthand.html
+++ b/Tests/LibWeb/Text/input/css/set-style-declaration-shorthand.html
@@ -1,0 +1,38 @@
+<script src="../include.js"></script>
+<script>
+    function testFlexValue(value) {
+        let e = document.createElement("div");
+        e.style.flex = value;
+        println("Setting flex: '" + value + "'; becomes...");
+        println("  flex-basis: '" + e.style.flexBasis + "'");
+        println("  flex-grow: '" + e.style.flexGrow + "'");
+        println("  flex-shrink: '" + e.style.flexShrink + "'");
+        println("  flex: '" + e.style.flex + "'");
+        println("  e.style.length: " + e.style.length);
+        for (let p = 0; p < e.style.length; ++p) {
+            println("  > [" + p + "] " + e.style[p]);
+        }
+        println("");
+    }
+    function testBorderValue(value) {
+        let e = document.createElement("div");
+        e.style.border = value;
+        println("Setting border: '" + value + "'; becomes...");
+        println("  border-width: '" + e.style.getPropertyValue('border-width') + "'");
+        println("  border-style: '" + e.style.borderStyle + "'");
+        println("  border-color: '" + e.style.borderColor + "'");
+        println("  border: '" + e.style.border + "'");
+        println("  e.style.length: " + e.style.length);
+        for (let p = 0; p < e.style.length; ++p) {
+            println("  > [" + p + "] " + e.style[p]);
+        }
+        println("");
+    }
+    test(() => {
+        testFlexValue("none");
+        testFlexValue("auto 1 2");
+        testFlexValue("");
+
+        testBorderValue("1px solid red");
+    });
+</script>


### PR DESCRIPTION
We now expand shorthands into their respective longhand values when assigning to a shorthand named property on a CSSStyleDeclaration.

We also make sure that shorthands can be round-tripped by correctly routing named property access through the getPropertyValue() AO, and expanding it to handle shorthands as well.

A lot of WPT tests for CSS parsing rely on these mechanisms and should now start working. :^)