### PR TITLE
LibWebView: Remove some WebView callbacks that we can handle entirely inside LibWebView

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -554,30 +554,6 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [self updateViewportRect:Ladybird::WebViewBridge::ForResize::Yes];
     };
 
-    m_web_view_bridge->on_navigate_back = [weak_self]() {
-        LadybirdWebView* self = weak_self;
-        if (self == nil) {
-            return;
-        }
-        [self navigateBack];
-    };
-
-    m_web_view_bridge->on_navigate_forward = [weak_self]() {
-        LadybirdWebView* self = weak_self;
-        if (self == nil) {
-            return;
-        }
-        [self navigateForward];
-    };
-
-    m_web_view_bridge->on_refresh = [weak_self]() {
-        LadybirdWebView* self = weak_self;
-        if (self == nil) {
-            return;
-        }
-        [self reload];
-    };
-
     m_web_view_bridge->on_request_tooltip_override = [weak_self](auto, auto const& tooltip) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -11,7 +11,6 @@
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/CookieJar.h>
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <LibWebView/URL.h>
@@ -996,26 +995,6 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         auto device_pixel_ratio = m_web_view_bridge->device_pixel_ratio();
         auto* event = Ladybird::create_context_menu_mouse_event(self, Gfx::IntPoint { content_position.x() / device_pixel_ratio, content_position.y() / device_pixel_ratio });
         [NSMenu popUpContextMenu:self.select_dropdown withEvent:event forView:self];
-    };
-
-    m_web_view_bridge->on_get_all_cookies = [](auto const& url) {
-        return WebView::Application::cookie_jar().get_all_cookies(url);
-    };
-
-    m_web_view_bridge->on_get_named_cookie = [](auto const& url, auto const& name) {
-        return WebView::Application::cookie_jar().get_named_cookie(url, name);
-    };
-
-    m_web_view_bridge->on_get_cookie = [](auto const& url, auto source) {
-        return WebView::Application::cookie_jar().get_cookie(url, source);
-    };
-
-    m_web_view_bridge->on_set_cookie = [](auto const& url, auto const& cookie, auto source) {
-        WebView::Application::cookie_jar().set_cookie(url, cookie, source);
-    };
-
-    m_web_view_bridge->on_update_cookie = [](auto const& cookie) {
-        WebView::Application::cookie_jar().update_cookie(cookie);
     };
 
     m_web_view_bridge->on_restore_window = [weak_self]() {

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -801,26 +801,6 @@ void BrowserWindow::initialize_tab(Tab* tab)
         (void)modifiers;
     };
 
-    tab->view().on_get_all_cookies = [](auto const& url) {
-        return WebView::Application::cookie_jar().get_all_cookies(url);
-    };
-
-    tab->view().on_get_named_cookie = [](auto const& url, auto const& name) {
-        return WebView::Application::cookie_jar().get_named_cookie(url, name);
-    };
-
-    tab->view().on_get_cookie = [](auto& url, auto source) {
-        return WebView::Application::cookie_jar().get_cookie(url, source);
-    };
-
-    tab->view().on_set_cookie = [](auto& url, auto& cookie, auto source) {
-        WebView::Application::cookie_jar().set_cookie(url, cookie, source);
-    };
-
-    tab->view().on_update_cookie = [](auto const& cookie) {
-        WebView::Application::cookie_jar().update_cookie(cookie);
-    };
-
     m_tabs_container->setTabIcon(m_tabs_container->indexOf(tab), tab->favicon());
     create_close_button_for_tab(tab);
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -330,18 +330,6 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
         view().request_style_sheet_source(identifier);
     };
 
-    view().on_navigate_back = [this]() {
-        back();
-    };
-
-    view().on_navigate_forward = [this]() {
-        forward();
-    };
-
-    view().on_refresh = [this]() {
-        reload();
-    };
-
     view().on_restore_window = [this]() {
         m_window->showNormal();
     };

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -431,13 +431,10 @@ void WebContentView::mouseReleaseEvent(QMouseEvent* event)
 {
     enqueue_native_event(Web::MouseEvent::Type::MouseUp, *event);
 
-    if (event->button() == Qt::MouseButton::BackButton) {
-        if (on_navigate_back)
-            on_navigate_back();
-    } else if (event->button() == Qt::MouseButton::ForwardButton) {
-        if (on_navigate_forward)
-            on_navigate_forward();
-    }
+    if (event->button() == Qt::MouseButton::BackButton)
+        traverse_the_history_by_delta(-1);
+    else if (event->button() == Qt::MouseButton::ForwardButton)
+        traverse_the_history_by_delta(1);
 }
 
 void WebContentView::wheelEvent(QWheelEvent* event)

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -171,9 +171,6 @@ public:
     Function<void(URL::URL const&, bool)> on_load_start;
     Function<void(URL::URL const&)> on_load_finish;
     Function<void(ByteString const& path, i32)> on_request_file;
-    Function<void()> on_navigate_back;
-    Function<void()> on_navigate_forward;
-    Function<void()> on_refresh;
     Function<void(Gfx::Bitmap const&)> on_favicon_change;
     Function<void(Gfx::StandardCursor)> on_cursor_change;
     Function<void(Gfx::IntPoint, ByteString const&)> on_request_tooltip_override;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -198,11 +198,6 @@ public:
     Function<void(String const&)> on_received_dom_node_html;
     Function<void(i32 message_id)> on_received_console_message;
     Function<void(i32 start_index, Vector<ByteString> const& message_types, Vector<ByteString> const& messages)> on_received_console_messages;
-    Function<Vector<Web::Cookie::Cookie>(URL::URL const& url)> on_get_all_cookies;
-    Function<Optional<Web::Cookie::Cookie>(URL::URL const& url, String const& name)> on_get_named_cookie;
-    Function<String(URL::URL const& url, Web::Cookie::Source source)> on_get_cookie;
-    Function<void(URL::URL const& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source)> on_set_cookie;
-    Function<void(Web::Cookie::Cookie const& cookie)> on_update_cookie;
     Function<void(i32 count_waiting)> on_resource_status_change;
     Function<void()> on_restore_window;
     Function<Gfx::IntPoint(Gfx::IntPoint)> on_reposition_window;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -8,6 +8,7 @@
 #include "Application.h"
 #include "ViewImplementation.h"
 #include <LibWeb/Cookie/ParsedCookie.h>
+#include <LibWebView/CookieJar.h>
 
 namespace WebView {
 
@@ -425,50 +426,29 @@ void WebContentClient::did_change_favicon(u64 page_id, Gfx::ShareableBitmap cons
     }
 }
 
-Messages::WebContentClient::DidRequestAllCookiesResponse WebContentClient::did_request_all_cookies(u64 page_id, URL::URL const& url)
+Messages::WebContentClient::DidRequestAllCookiesResponse WebContentClient::did_request_all_cookies(URL::URL const& url)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_get_all_cookies)
-            return view->on_get_all_cookies(url);
-    }
-
-    return Vector<Web::Cookie::Cookie> {};
+    return Application::cookie_jar().get_all_cookies(url);
 }
 
-Messages::WebContentClient::DidRequestNamedCookieResponse WebContentClient::did_request_named_cookie(u64 page_id, URL::URL const& url, String const& name)
+Messages::WebContentClient::DidRequestNamedCookieResponse WebContentClient::did_request_named_cookie(URL::URL const& url, String const& name)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_get_named_cookie)
-            return view->on_get_named_cookie(url, name);
-    }
-
-    return OptionalNone {};
+    return Application::cookie_jar().get_named_cookie(url, name);
 }
 
-Messages::WebContentClient::DidRequestCookieResponse WebContentClient::did_request_cookie(u64 page_id, URL::URL const& url, Web::Cookie::Source source)
+Messages::WebContentClient::DidRequestCookieResponse WebContentClient::did_request_cookie(URL::URL const& url, Web::Cookie::Source source)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_get_cookie)
-            return view->on_get_cookie(url, source);
-    }
-
-    return String {};
+    return Application::cookie_jar().get_cookie(url, source);
 }
 
-void WebContentClient::did_set_cookie(u64 page_id, URL::URL const& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source)
+void WebContentClient::did_set_cookie(URL::URL const& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_set_cookie)
-            view->on_set_cookie(url, cookie, source);
-    }
+    Application::cookie_jar().set_cookie(url, cookie, source);
 }
 
-void WebContentClient::did_update_cookie(u64 page_id, Web::Cookie::Cookie const& cookie)
+void WebContentClient::did_update_cookie(Web::Cookie::Cookie const& cookie)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_update_cookie)
-            view->on_update_cookie(cookie);
-    }
+    Application::cookie_jar().update_cookie(cookie);
 }
 
 Messages::WebContentClient::DidRequestNewWebViewResponse WebContentClient::did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab const& activate_tab, Web::HTML::WebViewHints const& hints, Optional<u64> const& page_index)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -102,26 +102,20 @@ void WebContentClient::did_find_in_page(u64 page_id, size_t current_match_index,
 
 void WebContentClient::did_request_navigate_back(u64 page_id)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_navigate_back)
-            view->on_navigate_back();
-    }
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->traverse_the_history_by_delta(-1);
 }
 
 void WebContentClient::did_request_navigate_forward(u64 page_id)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_navigate_forward)
-            view->on_navigate_forward();
-    }
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->traverse_the_history_by_delta(1);
 }
 
 void WebContentClient::did_request_refresh(u64 page_id)
 {
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_refresh)
-            view->on_refresh();
-    }
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->reload();
 }
 
 void WebContentClient::did_request_cursor_change(u64 page_id, i32 cursor_type)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -88,11 +88,11 @@ private:
     virtual void did_request_set_prompt_text(u64 page_id, String const& message) override;
     virtual void did_request_accept_dialog(u64 page_id) override;
     virtual void did_request_dismiss_dialog(u64 page_id) override;
-    virtual Messages::WebContentClient::DidRequestAllCookiesResponse did_request_all_cookies(u64 page_id, URL::URL const&) override;
-    virtual Messages::WebContentClient::DidRequestNamedCookieResponse did_request_named_cookie(u64 page_id, URL::URL const&, String const&) override;
-    virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(u64 page_id, URL::URL const&, Web::Cookie::Source) override;
-    virtual void did_set_cookie(u64 page_id, URL::URL const&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
-    virtual void did_update_cookie(u64 page_id, Web::Cookie::Cookie const&) override;
+    virtual Messages::WebContentClient::DidRequestAllCookiesResponse did_request_all_cookies(URL::URL const&) override;
+    virtual Messages::WebContentClient::DidRequestNamedCookieResponse did_request_named_cookie(URL::URL const&, String const&) override;
+    virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(URL::URL const&, Web::Cookie::Source) override;
+    virtual void did_set_cookie(URL::URL const&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
+    virtual void did_update_cookie(Web::Cookie::Cookie const&) override;
     virtual Messages::WebContentClient::DidRequestNewWebViewResponse did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab const&, Web::HTML::WebViewHints const&, Optional<u64> const& page_index) override;
     virtual void did_request_activate_tab(u64 page_id) override;
     virtual void did_close_browsing_context(u64 page_id) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -479,17 +479,17 @@ void PageClient::page_did_change_favicon(Gfx::Bitmap const& favicon)
 
 Vector<Web::Cookie::Cookie> PageClient::page_did_request_all_cookies(URL::URL const& url)
 {
-    return client().did_request_all_cookies(m_id, url);
+    return client().did_request_all_cookies(url);
 }
 
 Optional<Web::Cookie::Cookie> PageClient::page_did_request_named_cookie(URL::URL const& url, String const& name)
 {
-    return client().did_request_named_cookie(m_id, url, name);
+    return client().did_request_named_cookie(url, name);
 }
 
 String PageClient::page_did_request_cookie(URL::URL const& url, Web::Cookie::Source source)
 {
-    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestCookie>(m_id, move(url), source);
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidRequestCookie>(url, source);
     if (!response) {
         dbgln("WebContent client disconnected during DidRequestCookie. Exiting peacefully.");
         exit(0);
@@ -499,7 +499,7 @@ String PageClient::page_did_request_cookie(URL::URL const& url, Web::Cookie::Sou
 
 void PageClient::page_did_set_cookie(URL::URL const& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source)
 {
-    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidSetCookie>(m_id, url, cookie, source);
+    auto response = client().send_sync_but_allow_failure<Messages::WebContentClient::DidSetCookie>(url, cookie, source);
     if (!response) {
         dbgln("WebContent client disconnected during DidSetCookie. Exiting peacefully.");
         exit(0);
@@ -508,7 +508,7 @@ void PageClient::page_did_set_cookie(URL::URL const& url, Web::Cookie::ParsedCoo
 
 void PageClient::page_did_update_cookie(Web::Cookie::Cookie cookie)
 {
-    client().async_did_update_cookie(m_id, move(cookie));
+    client().async_did_update_cookie(move(cookie));
 }
 
 void PageClient::page_did_update_resource_count(i32 count_waiting)

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -66,11 +66,11 @@ endpoint WebContentClient
     did_get_internal_page_info(u64 page_id, WebView::PageInfoType type, String info) =|
 
     did_change_favicon(u64 page_id, Gfx::ShareableBitmap favicon) =|
-    did_request_all_cookies(u64 page_id, URL::URL url) => (Vector<Web::Cookie::Cookie> cookies)
-    did_request_named_cookie(u64 page_id, URL::URL url, String name) => (Optional<Web::Cookie::Cookie> cookie)
-    did_request_cookie(u64 page_id, URL::URL url, Web::Cookie::Source source) => (String cookie)
-    did_set_cookie(u64 page_id, URL::URL url, Web::Cookie::ParsedCookie cookie, Web::Cookie::Source source) => ()
-    did_update_cookie(u64 page_id, Web::Cookie::Cookie cookie) =|
+    did_request_all_cookies(URL::URL url) => (Vector<Web::Cookie::Cookie> cookies)
+    did_request_named_cookie(URL::URL url, String name) => (Optional<Web::Cookie::Cookie> cookie)
+    did_request_cookie(URL::URL url, Web::Cookie::Source source) => (String cookie)
+    did_set_cookie(URL::URL url, Web::Cookie::ParsedCookie cookie, Web::Cookie::Source source) => ()
+    did_update_cookie(Web::Cookie::Cookie cookie) =|
     did_update_resource_count(u64 page_id, i32 count_waiting) =|
     did_request_new_web_view(u64 page_id, Web::HTML::ActivateTab activate_tab, Web::HTML::WebViewHints hints, Optional<u64> page_index) => (String handle)
     did_request_activate_tab(u64 page_id) =|

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -45,13 +45,10 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibRequests/RequestClient.h>
 #include <LibURL/URL.h>
-#include <LibWeb/Cookie/Cookie.h>
-#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/CookieJar.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -130,14 +127,6 @@ private:
         : m_request_client(move(request_client))
         , m_image_decoder_client(move(image_decoder_client))
     {
-        on_get_cookie = [](auto const& url, auto source) {
-            return WebView::Application::cookie_jar().get_cookie(url, source);
-        };
-
-        on_set_cookie = [](auto const& url, auto const& cookie, auto source) {
-            WebView::Application::cookie_jar().set_cookie(url, cookie, source);
-        };
-
         on_request_worker_agent = [this]() {
             auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), *m_request_client));
             return worker_client->dup_socket();


### PR DESCRIPTION
This removes cookie and history traversal callbacks. We do not need to go to the chromes to handle these any longer.