### PR TITLE
UI/Qt: Move "Open in New Tab" to the top of the link context menu

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -554,8 +554,8 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     });
 
     m_link_context_menu = new QMenu("Link context menu", this);
-    m_link_context_menu->addAction(open_link_action);
     m_link_context_menu->addAction(open_link_in_new_tab_action);
+    m_link_context_menu->addAction(open_link_action);
     m_link_context_menu->addSeparator();
     m_link_context_menu->addAction(m_link_context_menu_copy_url_action);
     m_link_context_menu->addSeparator();


### PR DESCRIPTION
Other browsers put this entry at the top as well.