### PR TITLE
LibWeb: Remove associated transitions when clearing transitions

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.cpp
@@ -150,6 +150,7 @@ void Animatable::remove_transition(CSS::PropertyID property_id)
 
 void Animatable::clear_transitions()
 {
+    m_associated_transitions.clear();
     m_transition_attribute_indices.clear();
     m_transition_attributes.clear();
 }


### PR DESCRIPTION
Fixes crash on https://nextjs.org

Fixes #1481 