### PR TITLE
UI+WebDriver: Add an option to enable autoplay globally

### DIFF
--- a/Ladybird/AppKit/Application/ApplicationDelegate.mm
+++ b/Ladybird/AppKit/Application/ApplicationDelegate.mm
@@ -561,6 +561,10 @@
 
     [submenu addItem:search_engine_menu_item];
 
+    [submenu addItem:[[NSMenuItem alloc] initWithTitle:@"Enable Autoplay"
+                                                action:@selector(toggleAutoplay:)
+                                         keyEquivalent:@""]];
+
     [menu setSubmenu:submenu];
     return menu;
 }

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -86,6 +86,8 @@
 
 - (void)debugRequest:(ByteString const&)request argument:(ByteString const&)argument;
 
+- (void)setEnableAutoplay:(BOOL)enabled;
+
 - (void)viewSource;
 
 @end

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -257,6 +257,11 @@ struct HideCursor {
     m_web_view_bridge->debug_request(request, argument);
 }
 
+- (void)setEnableAutoplay:(BOOL)enabled
+{
+    m_web_view_bridge->set_enable_autoplay(enabled);
+}
+
 - (void)viewSource
 {
     m_web_view_bridge->get_source();

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -106,6 +106,11 @@ void WebViewBridge::enqueue_input_event(Web::KeyEvent event)
     ViewImplementation::enqueue_input_event(move(event));
 }
 
+void WebViewBridge::set_enable_autoplay(bool enabled)
+{
+    ViewImplementation::set_enable_autoplay(enabled);
+}
+
 Optional<WebViewBridge::Paintable> WebViewBridge::paintable()
 {
     Gfx::Bitmap* bitmap = nullptr;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -48,6 +48,8 @@ public:
     void enqueue_input_event(Web::DragEvent);
     void enqueue_input_event(Web::KeyEvent);
 
+    void set_enable_autoplay(bool enabled);
+
     struct Paintable {
         Gfx::Bitmap& bitmap;
         Gfx::IntSize bitmap_size;

--- a/Ladybird/AppKit/UI/TabController.h
+++ b/Ladybird/AppKit/UI/TabController.h
@@ -17,6 +17,7 @@ struct TabSettings {
     BOOL should_show_line_box_borders { NO };
     BOOL scripting_enabled { YES };
     BOOL block_popups { YES };
+    BOOL autoplay_enabled { NO };
     BOOL same_origin_policy_enabled { NO };
     ByteString user_agent_name { "Disabled"sv };
     ByteString navigator_compatibility_mode { "chrome"sv };
@@ -48,6 +49,7 @@ struct TabSettings {
 
 - (void)setPopupBlocking:(BOOL)block_popups;
 - (void)setScripting:(BOOL)enabled;
+- (void)setAutoplay:(BOOL)enabled;
 - (void)debugRequest:(ByteString const&)request argument:(ByteString const&)argument;
 
 - (void)focusLocationToolbarItem;

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -101,6 +101,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         m_settings = {
             .scripting_enabled = WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
             .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
+            .autoplay_enabled = WebView::Application::web_content_options().enable_autoplay == WebView::EnableAutoplay::Yes ? YES : NO,
         };
 
         if (auto const& user_agent_preset = WebView::Application::web_content_options().user_agent_preset; user_agent_preset.has_value())
@@ -163,6 +164,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 {
     [self setPopupBlocking:m_settings.block_popups];
     [self setScripting:m_settings.scripting_enabled];
+    [self setAutoplay:m_settings.autoplay_enabled];
 }
 
 - (void)zoomIn:(id)sender
@@ -385,6 +387,17 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 - (void)setPopupBlocking:(BOOL)block_popups
 {
     [self debugRequest:"block-pop-ups" argument:block_popups ? "on" : "off"];
+}
+
+- (void)toggleAutoplay:(id)sender
+{
+    m_settings.autoplay_enabled = !m_settings.autoplay_enabled;
+    [self setAutoplay:m_settings.autoplay_enabled];
+}
+
+- (void)setAutoplay:(BOOL)enabled
+{
+    [[[self tab] web_view] setEnableAutoplay:m_settings.autoplay_enabled];
 }
 
 - (void)toggleSameOriginPolicy:(id)sender
@@ -628,6 +641,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         [item setState:(m_settings.user_agent_name == [[item title] UTF8String]) ? NSControlStateValueOn : NSControlStateValueOff];
     } else if ([item action] == @selector(setNavigatorCompatibilityMode:)) {
         [item setState:(m_settings.navigator_compatibility_mode == [[[item title] lowercaseString] UTF8String]) ? NSControlStateValueOn : NSControlStateValueOff];
+    } else if ([item action] == @selector(toggleAutoplay:)) {
+        [item setState:m_settings.autoplay_enabled ? NSControlStateValueOn : NSControlStateValueOff];
     }
 
     return YES;

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -103,6 +103,12 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         });
     });
 
+    QObject::connect(Settings::the(), &Settings::enable_autoplay_changed, this, [this](bool enable) {
+        for_each_tab([enable](auto& tab) {
+            tab.set_enable_autoplay(enable);
+        });
+    });
+
     QObject::connect(Settings::the(), &Settings::preferred_languages_changed, this, [this](QStringList languages) {
         Vector<String> preferred_languages;
         preferred_languages.ensure_capacity(languages.length());
@@ -818,6 +824,7 @@ void BrowserWindow::initialize_tab(Tab* tab)
     tab->set_preferred_languages(preferred_languages);
     tab->set_navigator_compatibility_mode(navigator_compatibility_mode());
     tab->set_enable_do_not_track(Settings::the()->enable_do_not_track());
+    tab->set_enable_autoplay(WebView::Application::web_content_options().enable_autoplay == WebView::EnableAutoplay::Yes || Settings::the()->enable_autoplay());
     tab->view().set_preferred_color_scheme(m_preferred_color_scheme);
 }
 

--- a/Ladybird/Qt/Settings.cpp
+++ b/Ladybird/Qt/Settings.cpp
@@ -142,6 +142,17 @@ void Settings::set_enable_do_not_track(bool enable)
     emit enable_do_not_track_changed(enable);
 }
 
+bool Settings::enable_autoplay()
+{
+    return m_qsettings->value("enable_autoplay", false).toBool();
+}
+
+void Settings::set_enable_autoplay(bool enable)
+{
+    m_qsettings->setValue("enable_autoplay", enable);
+    emit enable_autoplay_changed(enable);
+}
+
 bool Settings::show_menubar()
 {
     return m_qsettings->value("show_menubar", false).toBool();

--- a/Ladybird/Qt/Settings.h
+++ b/Ladybird/Qt/Settings.h
@@ -67,6 +67,9 @@ public:
     bool enable_do_not_track();
     void set_enable_do_not_track(bool enable);
 
+    bool enable_autoplay();
+    void set_enable_autoplay(bool enable);
+
     bool show_menubar();
     void set_show_menubar(bool show_menubar);
 
@@ -76,6 +79,7 @@ signals:
     void search_engine_changed(WebView::SearchEngine engine);
     void preferred_languages_changed(QStringList const& languages);
     void enable_do_not_track_changed(bool enable);
+    void enable_autoplay_changed(bool enable);
 
 protected:
     Settings();

--- a/Ladybird/Qt/SettingsDialog.cpp
+++ b/Ladybird/Qt/SettingsDialog.cpp
@@ -9,6 +9,7 @@
 #include "Settings.h"
 #include "StringUtils.h"
 #include <LibURL/URL.h>
+#include <LibWebView/Application.h>
 #include <LibWebView/SearchEngine.h>
 #include <QLabel>
 #include <QMenu>
@@ -65,6 +66,17 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
         Settings::the()->set_enable_do_not_track(state == Qt::Checked);
     });
 
+    m_enable_autoplay = new QCheckBox(this);
+    if (WebView::Application::web_content_options().enable_autoplay == WebView::EnableAutoplay::Yes) {
+        m_enable_autoplay->setChecked(true);
+    } else {
+        m_enable_autoplay->setChecked(Settings::the()->enable_autoplay());
+    }
+
+    QObject::connect(m_enable_autoplay, &QCheckBox::stateChanged, this, [&](int state) {
+        Settings::the()->set_enable_autoplay(state == Qt::Checked);
+    });
+
     setup_search_engines();
 
     m_layout->addRow(new QLabel("Page on New Tab", this), m_new_tab_page);
@@ -74,6 +86,7 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
     m_layout->addRow(new QLabel("Enable Autocomplete", this), m_enable_autocomplete);
     m_layout->addRow(new QLabel("Autocomplete Engine", this), m_autocomplete_engine_dropdown);
     m_layout->addRow(new QLabel("Send web sites a \"Do Not Track\" request", this), m_enable_do_not_track);
+    m_layout->addRow(new QLabel("Enable autoplay on all websites", this), m_enable_autoplay);
 
     setWindowTitle("Settings");
     setLayout(m_layout);

--- a/Ladybird/Qt/SettingsDialog.h
+++ b/Ladybird/Qt/SettingsDialog.h
@@ -34,6 +34,7 @@ private:
     QCheckBox* m_enable_autocomplete { nullptr };
     QPushButton* m_autocomplete_engine_dropdown { nullptr };
     QCheckBox* m_enable_do_not_track { nullptr };
+    QCheckBox* m_enable_autoplay { nullptr };
 };
 
 }

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -965,4 +965,9 @@ void Tab::set_enable_do_not_track(bool enable)
     m_view->set_enable_do_not_track(enable);
 }
 
+void Tab::set_enable_autoplay(bool enable)
+{
+    m_view->set_enable_autoplay(enable);
+}
+
 }

--- a/Ladybird/Qt/Tab.h
+++ b/Ladybird/Qt/Tab.h
@@ -78,6 +78,8 @@ public:
 
     void set_enable_do_not_track(bool);
 
+    void set_enable_autoplay(bool);
+
     bool url_is_hidden() const { return m_location_edit->url_is_hidden(); }
     void set_url_is_hidden(bool url_is_hidden) { m_location_edit->set_url_is_hidden(url_is_hidden); }
 

--- a/Ladybird/WebDriver/main.cpp
+++ b/Ladybird/WebDriver/main.cpp
@@ -47,6 +47,7 @@ static ErrorOr<pid_t> launch_browser(ByteString const& socket_path, bool use_qt_
 
     arguments.append("--allow-popups");
     arguments.append("--force-new-process");
+    arguments.append("--enable-autoplay");
     if (use_qt_networking)
         arguments.append("--enable-qt-networking");
     if (force_cpu_painting)

--- a/Userland/Libraries/LibWebView/Application.cpp
+++ b/Userland/Libraries/LibWebView/Application.cpp
@@ -69,6 +69,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     bool log_all_js_exceptions = false;
     bool enable_idl_tracing = false;
     bool enable_http_cache = false;
+    bool enable_autoplay = false;
     bool expose_internals_object = false;
     bool force_cpu_painting = false;
     bool force_fontconfig = false;
@@ -88,6 +89,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
+    args_parser.add_option(enable_autoplay, "Enable multimedia autoplay", "enable-autoplay");
     args_parser.add_option(expose_internals_object, "Expose internals object", "expose-internals-object");
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
@@ -145,6 +147,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
         .expose_internals_object = expose_internals_object ? ExposeInternalsObject::Yes : ExposeInternalsObject::No,
         .force_cpu_painting = force_cpu_painting ? ForceCPUPainting::Yes : ForceCPUPainting::No,
         .force_fontconfig = force_fontconfig ? ForceFontconfig::Yes : ForceFontconfig::No,
+        .enable_autoplay = enable_autoplay ? EnableAutoplay::Yes : EnableAutoplay::No,
     };
 
     create_platform_options(m_chrome_options, m_web_content_options);

--- a/Userland/Libraries/LibWebView/Options.h
+++ b/Userland/Libraries/LibWebView/Options.h
@@ -40,6 +40,11 @@ enum class DisableSQLDatabase {
     Yes,
 };
 
+enum class EnableAutoplay {
+    No,
+    Yes,
+};
+
 struct ChromeOptions {
     Vector<URL::URL> urls;
     Vector<ByteString> raw_urls;
@@ -108,6 +113,7 @@ struct WebContentOptions {
     ExposeInternalsObject expose_internals_object { ExposeInternalsObject::No };
     ForceCPUPainting force_cpu_painting { ForceCPUPainting::No };
     ForceFontconfig force_fontconfig { ForceFontconfig::No };
+    EnableAutoplay enable_autoplay { EnableAutoplay::No };
 };
 
 }

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -193,6 +193,15 @@ void ViewImplementation::set_enable_do_not_track(bool enable)
     client().async_set_enable_do_not_track(page_id(), enable);
 }
 
+void ViewImplementation::set_enable_autoplay(bool enable)
+{
+    if (enable) {
+        client().async_set_autoplay_allowed_on_all_websites(page_id());
+    } else {
+        client().async_set_autoplay_allowlist(page_id(), {});
+    }
+}
+
 ByteString ViewImplementation::selected_text()
 {
     return client().get_selected_text(page_id());

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -73,6 +73,8 @@ public:
 
     void set_enable_do_not_track(bool);
 
+    void set_enable_autoplay(bool);
+
     ByteString selected_text();
     Optional<String> selected_text_with_whitespace_collapsed();
     void select_all();


### PR DESCRIPTION
This PR adds a command line option `--enable-autoplay`, which enables multimedia autoplay on all websites. An option has also been added to the Qt settings dialog to toggle this option.

The motivation behind this change was to enable autoplay when running WPT tests, as the `webvtt/` tests require autoplay to be enabled, otherwise a significant number of tests time out.

Running `./Meta/WPT.sh run webvtt` gives the following results:

Before:

```
Ran 320 tests finished in 300.6 seconds.
  • 4 ran as expected. 0 tests skipped.
  • 1 tests failed unexpectedly
  • 295 tests timed out unexpectedly
  • 71 tests had unexpected subtest results
```

After:

```
Ran 320 tests finished in 75.5 seconds.
  • 12 ran as expected. 0 tests skipped.
  • 230 tests failed unexpectedly
  • 58 tests timed out unexpectedly
  • 71 tests had unexpected subtest results
```