### PR TITLE
LibWeb: Clean up HTMLInputElement-related includes

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -6,10 +6,12 @@
 
 #include <AK/GenericLexer.h>
 #include <AK/Random.h>
+#include <LibWeb/FileAPI/File.h>
 #include <LibWeb/HTML/FormControlInfrastructure.h>
 #include <LibWeb/HTML/FormDataEvent.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
 #include <LibWeb/HTML/HTMLDataListElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/Infra/Strings.h>

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -11,7 +11,6 @@
 #include <AK/Time.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/HTML/HTMLElement.h>
-#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/HTML/Navigable.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -4,11 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibGfx/Font/Font.h>
-#include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/CheckBox.h>
-#include <LibWeb/Layout/Label.h>
 #include <LibWeb/Painting/CheckBoxPaintable.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.h
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Layout/FormAssociatedLabelableNode.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -6,6 +6,8 @@
  */
 
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/Layout/RadioButton.h>
 #include <LibWeb/Painting/RadioButtonPaintable.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.h
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Layout/FormAssociatedLabelableNode.h>
 
 namespace Web::Layout {

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -9,6 +9,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLImageElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/CheckBox.h>
 #include <LibWeb/Layout/Label.h>
 #include <LibWeb/Painting/CheckBoxPaintable.h>

--- a/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/CheckBoxPaintable.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/Layout/CheckBox.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Painting/LabelablePaintable.h>
 
 namespace Web::Painting {

--- a/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.h
+++ b/Userland/Libraries/LibWeb/Painting/RadioButtonPaintable.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/Layout/RadioButton.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/Painting/LabelablePaintable.h>
 
 namespace Web::Painting {

--- a/Userland/Libraries/LibWeb/XHR/FormDataIterator.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormDataIterator.cpp
@@ -8,6 +8,7 @@
 #include <LibJS/Runtime/Iterator.h>
 #include <LibWeb/Bindings/FormDataIteratorPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/FileAPI/File.h>
 #include <LibWeb/XHR/FormDataIterator.h>
 
 namespace Web::Bindings {


### PR DESCRIPTION
This mainly uses forward declarations as appropriate for input element related files. This reduces the number of targets being built when we change HTMLInputElement.h from 430 to 44.