### PR TITLE
CMake: Don't install service libraries or fonts

### DIFF
--- a/Ladybird/cmake/InstallRules.cmake
+++ b/Ladybird/cmake/InstallRules.cmake
@@ -43,19 +43,6 @@ list(REMOVE_DUPLICATES all_required_lagom_libraries)
 # Remove ladybird shlib if it exists
 list(REMOVE_ITEM all_required_lagom_libraries ladybird)
 
-# Install service impl libraries if they exist
-macro(install_service_lib service)
-    if (TARGET ${service})
-      get_target_property(target_type ${service} TYPE)
-      if ("${target_type}" STREQUAL STATIC_LIBRARY)
-          list(APPEND all_required_lagom_libraries ${service})
-      endif()
-    endif()
-endmacro()
-foreach(service IN LISTS webcontent requestserver websocket webworker)
-    install_service_lib(${service})
-endforeach()
-
 if (APPLE)
     # Fixup the app bundle and copy:
     #   - Libraries from lib/ to Ladybird.app/Contents/lib

--- a/Ladybird/cmake/ResourceFiles.cmake
+++ b/Ladybird/cmake/ResourceFiles.cmake
@@ -178,8 +178,6 @@ function(copy_resources_to_build base_directory bundle_target)
 endfunction()
 
 function(install_ladybird_resources destination component)
-    install(FILES ${EMOJI} DESTINATION "${destination}/emoji" COMPONENT ${component})
-    install(FILES ${FONTS} DESTINATION "${destination}/fonts" COMPONENT ${component})
     install(FILES ${16x16_ICONS} DESTINATION "${destination}/icons/16x16" COMPONENT ${component})
     install(FILES ${32x32_ICONS} DESTINATION "${destination}/icons/32x32" COMPONENT ${component})
     install(FILES ${48x48_ICONS} DESTINATION "${destination}/icons/48x48" COMPONENT ${component})


### PR DESCRIPTION
This pattern was in place for out of tree chromes. If needed we can add
it back, but there's no current interest in such chromes.

On macOS, it's a bit trickier to not install them, as we're using the
MACOSX_PACKAGE_LOCATION file property to get them into the build
directory and install tree in the same way.