### PR TITLE
LibJS: Update wording from Console spec

### DIFF
--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -346,7 +346,7 @@ ThrowCompletionOr<Value> Console::trace()
 
     auto& vm = realm().vm();
 
-    // 1. Let trace be some implementation-specific, potentially-interactive representation of the callstack from where this function was called.
+    // 1. Let trace be some implementation-defined, potentially-interactive representation of the callstack from where this function was called.
     Console::Trace trace;
     auto& execution_context_stack = vm.execution_context_stack();
     // NOTE: -2 to skip the console.trace() execution context


### PR DESCRIPTION
https://github.com/whatwg/console/pull/240 is an editorial change to use the term "implementation-defined" more consistently. This seems to be the only instance in the spec text which we quote verbatim.