### PR TITLE
LibWebView: Use LibSyntax for view-source highlighting, so CSS and JS get highlighted!

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1044,7 +1044,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         if (self == nil) {
             return;
         }
-        auto html = WebView::highlight_source(url, source);
+        auto html = WebView::highlight_source(MUST(url.to_string()), source, Syntax::Language::HTML, WebView::HighlightOutputMode::FullDocument);
 
         [self.observer onCreateNewTab:html
                                   url:url

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -322,7 +322,7 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     QObject::connect(focus_location_editor_action, &QAction::triggered, this, &Tab::focus_location_editor);
 
     view().on_received_source = [this](auto const& url, auto const& source) {
-        auto html = WebView::highlight_source(url, source);
+        auto html = WebView::highlight_source(MUST(url.to_string()), source, Syntax::Language::HTML, WebView::HighlightOutputMode::FullDocument);
         m_window->new_tab_from_content(html, Web::HTML::ActivateTab::Yes);
     };
 

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Debug.h>
 #include <LibJS/SyntaxHighlighter.h>
+#include <LibJS/Token.h>
 #include <LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.h>
 #include <LibWeb/HTML/Parser/HTMLTokenizer.h>
 #include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>
@@ -88,10 +89,11 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         } else if (token->is_end_tag()) {
             if (token->tag_name().is_one_of("script"sv, "style"sv)) {
                 if (state == State::Javascript) {
+                    VERIFY(static_cast<u64>(AugmentedTokenKind::__Count) + first_free_token_kind_serial_value() < JS_TOKEN_START_VALUE);
                     Syntax::ProxyHighlighterClient proxy_client {
                         *m_client,
                         substring_start_position,
-                        static_cast<u64>(AugmentedTokenKind::__Count) + first_free_token_kind_serial_value(),
+                        JS_TOKEN_START_VALUE,
                         substring_builder.string_view()
                     };
                     {
@@ -106,10 +108,11 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
                     folding_regions.extend(proxy_client.corrected_folding_regions());
                     substring_builder.clear();
                 } else if (state == State::CSS) {
+                    VERIFY(static_cast<u64>(AugmentedTokenKind::__Count) + first_free_token_kind_serial_value() + static_cast<u64>(JS::TokenType::_COUNT_OF_TOKENS) < CSS_TOKEN_START_VALUE);
                     Syntax::ProxyHighlighterClient proxy_client {
                         *m_client,
                         substring_start_position,
-                        static_cast<u64>(AugmentedTokenKind::__Count) + first_free_token_kind_serial_value(),
+                        CSS_TOKEN_START_VALUE,
                         substring_builder.string_view()
                     };
                     {

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -14,16 +14,6 @@
 
 namespace Web::HTML {
 
-enum class AugmentedTokenKind : u32 {
-    AttributeName,
-    AttributeValue,
-    OpenTag,
-    CloseTag,
-    Comment,
-    Doctype,
-    __Count,
-};
-
 bool SyntaxHighlighter::is_identifier(u64 token) const
 {
     if (!token)

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
@@ -10,6 +10,16 @@
 
 namespace Web::HTML {
 
+enum class AugmentedTokenKind : u32 {
+    AttributeName,
+    AttributeValue,
+    OpenTag,
+    CloseTag,
+    Comment,
+    Doctype,
+    __Count,
+};
+
 class SyntaxHighlighter : public Syntax::Highlighter {
 public:
     SyntaxHighlighter() = default;

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
@@ -26,9 +26,6 @@ public:
 protected:
     virtual Vector<MatchingTokenPair> matching_token_pairs_impl() const override;
     virtual bool token_types_equal(u64, u64) const override;
-
-    size_t m_line { 1 };
-    size_t m_column { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h
@@ -23,6 +23,9 @@ public:
     virtual Optional<StringView> comment_suffix() const override { return "-->"sv; }
     virtual void rehighlight(Palette const&) override;
 
+    static constexpr u64 JS_TOKEN_START_VALUE = 1000;
+    static constexpr u64 CSS_TOKEN_START_VALUE = 2000;
+
 protected:
     virtual Vector<MatchingTokenPair> matching_token_pairs_impl() const override;
     virtual bool token_types_equal(u64, u64) const override;

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -48,7 +48,7 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibWebView webview)
-target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL)
+target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSyntax)
 target_compile_definitions(LibWebView PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENABLE_PUBLIC_SUFFIX_DOWNLOAD}>)
 
 # Third-party

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -129,11 +129,10 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
     };
 
     m_content_web_view.on_received_style_sheet_source = [this](Web::CSS::StyleSheetIdentifier const& identifier, String const& source) {
-        // TODO: Highlight it
-        auto escaped_source = escape_html_entities(source.bytes()).replace("\t"sv, "    "sv, ReplaceMode::All);
+        auto html = highlight_source(identifier.url.value_or({}), source, Syntax::Language::CSS, HighlightOutputMode::SourceOnly);
         auto script = MUST(String::formatted("inspector.setStyleSheetSource({}, \"{}\");",
             style_sheet_identifier_to_json(identifier),
-            MUST(encode_base64(escaped_source.bytes()))));
+            MUST(encode_base64(html.bytes()))));
         m_inspector_web_view.run_javascript(script);
     };
 

--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -244,7 +244,7 @@ static String generate_style()
 
     .line {
         counter-increment: line;
-        white-space: nowrap;
+        white-space: pre;
     }
 
     .line::before {

--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -1,15 +1,135 @@
 /*
  * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/StringBuilder.h>
 #include <LibURL/URL.h>
-#include <LibWeb/HTML/Parser/HTMLTokenizer.h>
+#include <LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.h>
 #include <LibWebView/SourceHighlighter.h>
 
 namespace WebView {
+
+SourceDocument::SourceDocument(StringView source)
+    : m_source(source)
+{
+    m_source.for_each_split_view('\n', AK::SplitBehavior::KeepEmpty, [&](auto line) {
+        m_lines.append(Syntax::TextDocumentLine { *this, line });
+    });
+}
+
+Syntax::TextDocumentLine& SourceDocument::line(size_t line_index)
+{
+    return m_lines[line_index];
+}
+
+Syntax::TextDocumentLine const& SourceDocument::line(size_t line_index) const
+{
+    return m_lines[line_index];
+}
+
+SourceHighlighterClient::SourceHighlighterClient(StringView source, Syntax::Language language)
+    : m_document(SourceDocument::create(source))
+{
+    // HACK: Syntax highlighters require a palette, but we don't actually care about the output styling, only the type of token for each span.
+    //       Also, getting a palette from the chrome is nontrivial. So, create a dummy blank one and use that.
+    auto buffer = MUST(Core::AnonymousBuffer::create_with_size(sizeof(Gfx::SystemTheme)));
+    auto palette_impl = Gfx::PaletteImpl::create_with_anonymous_buffer(buffer);
+    Gfx::Palette dummy_palette { palette_impl };
+
+    switch (language) {
+    case Syntax::Language::HTML:
+        m_highlighter = make<Web::HTML::SyntaxHighlighter>();
+        break;
+    default:
+        break;
+    }
+
+    if (m_highlighter) {
+        m_highlighter->attach(*this);
+        m_highlighter->rehighlight(dummy_palette);
+    }
+}
+
+Vector<Syntax::TextDocumentSpan> const& SourceHighlighterClient::spans() const
+{
+    return document().spans();
+}
+
+void SourceHighlighterClient::set_span_at_index(size_t index, Syntax::TextDocumentSpan span)
+{
+    document().set_span_at_index(index, span);
+}
+
+Vector<Syntax::TextDocumentFoldingRegion>& SourceHighlighterClient::folding_regions()
+{
+    return document().folding_regions();
+}
+
+Vector<Syntax::TextDocumentFoldingRegion> const& SourceHighlighterClient::folding_regions() const
+{
+    return document().folding_regions();
+}
+
+ByteString SourceHighlighterClient::highlighter_did_request_text() const
+{
+    return document().text();
+}
+
+void SourceHighlighterClient::highlighter_did_request_update()
+{
+    // No-op
+}
+
+Syntax::Document& SourceHighlighterClient::highlighter_did_request_document()
+{
+    return document();
+}
+
+Syntax::TextPosition SourceHighlighterClient::highlighter_did_request_cursor() const
+{
+    return {};
+}
+
+void SourceHighlighterClient::highlighter_did_set_spans(Vector<Syntax::TextDocumentSpan> spans)
+{
+    document().set_spans(span_collection_index, move(spans));
+}
+
+void SourceHighlighterClient::highlighter_did_set_folding_regions(Vector<Syntax::TextDocumentFoldingRegion> folding_regions)
+{
+    document().set_folding_regions(move(folding_regions));
+}
+
+String highlight_source(URL::URL const& url, StringView source)
+{
+    SourceHighlighterClient highlighter_client { source, Syntax::Language::HTML };
+    return highlighter_client.to_html_string(url);
+}
+
+StringView SourceHighlighterClient::class_for_token(u64 token_type) const
+{
+    switch (static_cast<Web::HTML::AugmentedTokenKind>(token_type)) {
+    case Web::HTML::AugmentedTokenKind::AttributeName:
+        return "attribute-name"sv;
+    case Web::HTML::AugmentedTokenKind::AttributeValue:
+        return "attribute-value"sv;
+    case Web::HTML::AugmentedTokenKind::OpenTag:
+    case Web::HTML::AugmentedTokenKind::CloseTag:
+        return "tag"sv;
+    case Web::HTML::AugmentedTokenKind::Comment:
+        return "comment"sv;
+    case Web::HTML::AugmentedTokenKind::Doctype:
+        return "doctype"sv;
+    case Web::HTML::AugmentedTokenKind::__Count:
+    default:
+        break;
+    }
+
+    return "unknown"sv;
+}
 
 static String generate_style()
 {
@@ -52,45 +172,12 @@ static String generate_style()
     return MUST(builder.to_string());
 }
 
-String highlight_source(URL::URL const& url, StringView source)
+String SourceHighlighterClient::to_html_string(URL::URL const& url) const
 {
-    Web::HTML::HTMLTokenizer tokenizer { source, "utf-8"sv };
     StringBuilder builder;
 
-    builder.append(R"~~~(
-<!DOCTYPE html>
-<html>
-<head>
-    <meta name="color-scheme" content="dark light">)~~~"sv);
-
-    builder.appendff("<title>View Source - {}</title>", url);
-    builder.appendff("<style type=\"text/css\">{}</style>", generate_style());
-    builder.append(R"~~~(
-</head>
-<body>
-<pre class="html">
-<span class="line">)~~~"sv);
-
-    size_t previous_position = 0;
-
-    auto append_source = [&](auto end_position, Optional<StringView> const& class_name = {}) {
-        if (end_position <= previous_position)
-            return;
-
-        auto segment = source.substring_view(previous_position, end_position - previous_position);
-
-        auto append_class_start = [&]() {
-            if (class_name.has_value())
-                builder.appendff("<span class=\"{}\">"sv, *class_name);
-        };
-        auto append_class_end = [&]() {
-            if (class_name.has_value())
-                builder.append("</span>"sv);
-        };
-
-        append_class_start();
-
-        for (auto code_point : Utf8View { segment }) {
+    auto append_escaped = [&](Utf32View text) {
+        for (auto code_point : text) {
             if (code_point == '&') {
                 builder.append("&amp;"sv);
             } else if (code_point == 0xA0) {
@@ -99,56 +186,104 @@ String highlight_source(URL::URL const& url, StringView source)
                 builder.append("&lt;"sv);
             } else if (code_point == '>') {
                 builder.append("&gt;"sv);
-            } else if (code_point == '\n') {
-                append_class_end();
-                builder.append("</span>\n<span class=\"line\">"sv);
-                append_class_start();
             } else {
                 builder.append_code_point(code_point);
             }
         }
-
-        append_class_end();
-        previous_position = end_position;
     };
 
-    for (auto token = tokenizer.next_token(); token.has_value(); token = tokenizer.next_token()) {
-        if (token->is_comment()) {
-            append_source(token->start_position().byte_offset);
-            append_source(token->end_position().byte_offset, "comment"sv);
-        } else if (token->is_start_tag() || token->is_end_tag()) {
-            auto tag_name_start = token->start_position().byte_offset;
+    auto start_token = [&](u64 type) {
+        builder.appendff("<span class=\"{}\">", class_for_token(type));
+    };
+    auto end_token = [&]() {
+        builder.append("</span>"sv);
+    };
 
-            append_source(tag_name_start);
-            append_source(tag_name_start + token->tag_name().bytes().size(), "tag"sv);
+    builder.append(R"~~~(
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="color-scheme" content="dark light">)~~~"sv);
 
-            token->for_each_attribute([&](auto const& attribute) {
-                append_source(attribute.name_start_position.byte_offset);
-                append_source(attribute.name_end_position.byte_offset, "attribute-name"sv);
+    builder.appendff("<title>View Source - {}</title>", escape_html_entities(MUST(url.to_string())));
+    builder.appendff("<style type=\"text/css\">{}</style>", generate_style());
+    builder.append(R"~~~(
+</head>
+<body>
+<pre class="html">)~~~"sv);
 
-                append_source(attribute.value_start_position.byte_offset);
-                append_source(attribute.value_end_position.byte_offset, "attribute-value"sv);
+    size_t span_index = 0;
+    for (size_t line_index = 0; line_index < document().line_count(); ++line_index) {
+        auto& line = document().line(line_index);
+        auto line_view = line.view();
+        builder.append("<div class=\"line\">"sv);
 
-                return IterationDecision::Continue;
-            });
+        size_t next_column = 0;
 
-            append_source(token->end_position().byte_offset);
-        } else {
-            append_source(token->end_position().byte_offset);
+        auto draw_text_helper = [&](size_t start, size_t end, Optional<Syntax::TextDocumentSpan const&> span) {
+            size_t length = end - start;
+            if (length == 0)
+                return;
+            auto text = line_view.substring_view(start, length);
+            if (span.has_value()) {
+                start_token(span->data);
+                append_escaped(text);
+                end_token();
+            } else {
+                append_escaped(text);
+            }
+        };
 
-            if (token->is_end_of_file())
+        while (span_index < document().spans().size()) {
+            auto& span = document().spans()[span_index];
+            if (span.range.start().line() > line_index) {
+                // No more spans in this line, moving on
                 break;
+            }
+            size_t span_start;
+            if (span.range.start().line() < line_index) {
+                span_start = 0;
+            } else {
+                span_start = span.range.start().column();
+            }
+            size_t span_end;
+            bool span_consumed;
+            if (span.range.end().line() > line_index) {
+                span_end = line.length();
+                span_consumed = false;
+            } else {
+                span_end = span.range.end().column();
+                span_consumed = true;
+            }
+
+            if (span_start != next_column) {
+                // Draw unspanned text between spans
+                draw_text_helper(next_column, span_start, {});
+            }
+            draw_text_helper(span_start, span_end, span);
+            next_column = span_end;
+            if (!span_consumed) {
+                // Continue with same span on next line
+                break;
+            } else {
+                ++span_index;
+            }
         }
+        // Draw unspanned text after last span
+        if (next_column < line.length()) {
+            draw_text_helper(next_column, line.length(), {});
+        }
+
+        builder.append("</div>"sv);
     }
 
     builder.append(R"~~~(
-</span>
 </pre>
 </body>
 </html>
 )~~~"sv);
 
-    return MUST(builder.to_string());
+    return builder.to_string_without_validation();
 }
 
 }

--- a/Userland/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.cpp
@@ -232,48 +232,7 @@ StringView SourceHighlighterClient::class_for_token(u64 token_type) const
     }
 }
 
-static String generate_style()
-{
-    StringBuilder builder;
-
-    builder.append(HTML_HIGHLIGHTER_STYLE);
-    builder.append(R"~~~(
-    .html {
-        counter-reset: line;
-    }
-
-    .line {
-        counter-increment: line;
-        white-space: pre;
-    }
-
-    .line::before {
-        content: counter(line) " ";
-
-        display: inline-block;
-        width: 2.5em;
-
-        padding-right: 0.5em;
-        text-align: right;
-    }
-
-    @media (prefers-color-scheme: dark) {
-        .line::before {
-            color: darkgrey;
-        }
-    }
-
-    @media (prefers-color-scheme: light) {
-        .line::before {
-            color: dimgray;
-        }
-    }
-)~~~"sv);
-
-    return MUST(builder.to_string());
-}
-
-String SourceHighlighterClient::to_html_string(URL::URL const& url) const
+String SourceHighlighterClient::to_html_string(String const& url, HighlightOutputMode mode) const
 {
     StringBuilder builder;
 
@@ -306,9 +265,9 @@ String SourceHighlighterClient::to_html_string(URL::URL const& url) const
 <head>
     <meta name="color-scheme" content="dark light">)~~~"sv);
 
-    builder.appendff("<title>View Source - {}</title>", escape_html_entities(MUST(url.to_string())));
-    builder.appendff("<style type=\"text/css\">{}</style>", generate_style());
-    builder.append(R"~~~(
+        builder.appendff("<title>View Source - {}</title>", escape_html_entities(url));
+        builder.appendff("<style type=\"text/css\">{}</style>", HTML_HIGHLIGHTER_STYLE);
+        builder.append(R"~~~(
 </head>
 <body>
 <pre class="html">)~~~"sv);

--- a/Userland/Libraries/LibWebView/SourceHighlighter.h
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.h
@@ -84,6 +84,8 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
             --name-color: orange;
             --value-color: deepskyblue;
             --internal-color: darkgrey;
+            --string-color: goldenrod;
+            --error-color: red;
         }
     }
 
@@ -94,6 +96,8 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
             --name-color: darkorange;
             --value-color: blue;
             --internal-color: dimgrey;
+            --string-color: darkgoldenrod;
+            --error-color: darkred;
         }
     }
 
@@ -117,6 +121,19 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
     }
     .internal {
         color: var(--internal-color);
+    }
+    .invalid {
+        color: var(--error-color);
+        text-decoration: currentColor wavy underline;
+    }
+    .at-keyword, .function, .keyword, .control-keyword, .url {
+        color: var(--keyword-color);
+    }
+    .number, .hash {
+        color: var(--value-color);
+    }
+    .string {
+        color: var(--string-color);
     }
 )~~~"sv;
 

--- a/Userland/Libraries/LibWebView/SourceHighlighter.h
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.h
@@ -76,6 +76,7 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
         html {
             background-color: rgb(30, 30, 30);
             color: white;
+            counter-reset: line;
         }
 
         :root {
@@ -86,6 +87,7 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
             --internal-color: darkgrey;
             --string-color: goldenrod;
             --error-color: red;
+            --line-number-color: darkgrey;
         }
     }
 
@@ -98,12 +100,30 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
             --internal-color: dimgrey;
             --string-color: darkgoldenrod;
             --error-color: darkred;
+            --line-number-color: dimgrey;
         }
     }
 
     .html {
         font-size: 10pt;
         font-family: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    }
+
+    .line {
+        counter-increment: line;
+        white-space: pre;
+    }
+
+    .line::before {
+        content: counter(line) " ";
+
+        display: inline-block;
+        width: 2.5em;
+
+        padding-right: 0.5em;
+        text-align: right;
+
+        color: var(--line-number-color);
     }
 
     .tag {

--- a/Userland/Libraries/LibWebView/SourceHighlighter.h
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.h
@@ -15,6 +15,11 @@
 
 namespace WebView {
 
+enum class HighlightOutputMode {
+    FullDocument, // Include HTML header, title, style sheet, etc
+    SourceOnly,   // Just the highlighted source
+};
+
 class SourceDocument final : public Syntax::Document {
 public:
     static NonnullRefPtr<SourceDocument> create(StringView source)
@@ -45,7 +50,7 @@ public:
     SourceHighlighterClient(StringView source, Syntax::Language);
     virtual ~SourceHighlighterClient() = default;
 
-    String to_html_string(URL::URL const&) const;
+    String to_html_string(String const&, HighlightOutputMode) const;
 
 private:
     // ^ Syntax::HighlighterClient
@@ -68,7 +73,7 @@ private:
     OwnPtr<Syntax::Highlighter> m_highlighter;
 };
 
-String highlight_source(URL::URL const&, StringView);
+String highlight_source(String const&, StringView, Syntax::Language, HighlightOutputMode);
 
 constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
     @media (prefers-color-scheme: dark) {

--- a/Userland/Libraries/LibWebView/SourceHighlighter.h
+++ b/Userland/Libraries/LibWebView/SourceHighlighter.h
@@ -71,6 +71,32 @@ private:
 String highlight_source(URL::URL const&, StringView);
 
 constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
+    @media (prefers-color-scheme: dark) {
+        /* FIXME: We should be able to remove the HTML style when "color-scheme" is supported */
+        html {
+            background-color: rgb(30, 30, 30);
+            color: white;
+        }
+
+        :root {
+            --comment-color: lightgreen;
+            --keyword-color: orangered;
+            --name-color: orange;
+            --value-color: deepskyblue;
+            --internal-color: darkgrey;
+        }
+    }
+
+    @media (prefers-color-scheme: light) {
+        :root {
+            --comment-color: green;
+            --keyword-color: red;
+            --name-color: darkorange;
+            --value-color: blue;
+            --internal-color: dimgrey;
+        }
+    }
+
     .html {
         font-size: 10pt;
         font-family: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
@@ -78,47 +104,19 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
 
     .tag {
         font-weight: 600;
+        color: var(--keyword-color);
     }
-
-    @media (prefers-color-scheme: dark) {
-        /* FIXME: We should be able to remove the HTML style when "color-scheme" is supported */
-        html {
-            background-color: rgb(30, 30, 30);
-            color: white;
-        }
-        .comment {
-            color: lightgreen;
-        }
-        .tag {
-            color: orangered;
-        }
-        .attribute-name {
-            color: orange;
-        }
-        .attribute-value {
-            color: deepskyblue;
-        }
-        .internal {
-            color: darkgrey;
-        }
+    .comment {
+        color: var(--comment-color);
     }
-
-    @media (prefers-color-scheme: light) {
-        .comment {
-            color: green;
-        }
-        .tag {
-            color: red;
-        }
-        .attribute-name {
-            color: darkorange;
-        }
-        .attribute-value {
-            color: blue;
-        }
-        .internal {
-            color: dimgray;
-        }
+    .attribute-name {
+        color: var(--name-color);
+    }
+    .attribute-value {
+        color: var(--value-color);
+    }
+    .internal {
+        color: var(--internal-color);
     }
 )~~~"sv;
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4f7cad5b-392c-4427-b84b-b1c9088ce910)

Someone with an aesthetic sense will want to come in and decide which type of token should be which colour, but the important part here is that it works. 🎉

Some of this is in preparation for syntax-highlighting in the style sheet inspector, which I'll work on soon.