### PR TITLE
WebDriver: Do not break WebDriver responses into multiple socket writes

### DIFF
--- a/Userland/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.cpp
@@ -303,14 +303,9 @@ ErrorOr<void, Client::WrappedError> Client::send_success_response(JsonValue resu
     builder.append("Content-Type: application/json; charset=utf-8\r\n"sv);
     builder.appendff("Content-Length: {}\r\n", content.length());
     builder.append("\r\n"sv);
+    builder.append(content);
 
-    auto builder_contents = TRY(builder.to_byte_buffer());
-    TRY(m_socket->write_until_depleted(builder_contents));
-
-    while (!content.is_empty()) {
-        auto bytes_sent = TRY(m_socket->write_some(content.bytes()));
-        content = content.substring_view(bytes_sent);
-    }
+    TRY(m_socket->write_until_depleted(builder.string_view()));
 
     if (!keep_alive)
         die();


### PR DESCRIPTION
WPT uses Python's `http.client.HTTPConnection` to send/receive WebDriver messages. For some reason, on Linux, we see an ~0.04s delay between the WPT server receiving the WebDriver response headers and its body. There are tests which make north of 1100 of these requests, which adds up to ~44s.

These connections are almost always going to be over localhost and able the be sent in a single write. So let's send the response all at once.

On my Linux machine, this reduces the runtime of `/cookies/name/name.html` from 45-60s down to 3-4s.