### PR TITLE
Meta: Make `download_file` work on Windows

### DIFF
--- a/Meta/gn/build/download_file.py
+++ b/Meta/gn/build/download_file.py
@@ -70,7 +70,7 @@ def main():
         try:
             with tempfile.NamedTemporaryFile(delete=False, dir=output_file.parent) as out:
                 out.write(f.read())
-                os.rename(out.name, output_file)
+            os.rename(out.name, output_file)
         except IOError:
             os.unlink(out.name)
 


### PR DESCRIPTION
The file is not committed to disk until the close which occurs at the termination of the scope. Extract the `rename` to outside the scope allowing this to work on Windows. The `download_file` utility downloads a file in the `gn` build.