### PR TITLE
LibWeb: Use substring matching for content filters

### DIFF
--- a/Base/res/ladybird/default-config/BrowserContentFilters.txt
+++ b/Base/res/ladybird/default-config/BrowserContentFilters.txt
@@ -406,8 +406,8 @@ glassboxdigital.io
 go-mpulse.net
 go2speed.org
 google-analytics.com
-google.com/gen_204\?
-google.com/log\?
+google.com/gen_204?
+google.com/log?
 googleadservices.com
 googleoptimize.com
 googlesyndication.com

--- a/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
@@ -27,7 +27,7 @@ bool ContentFilter::is_filtered(const URL::URL& url) const
     auto url_string = url.to_byte_string();
 
     for (auto& pattern : m_patterns) {
-        if (url_string.matches(pattern.text, CaseSensitivity::CaseSensitive))
+        if (url_string.find(pattern.text).has_value())
             return true;
     }
     return false;
@@ -38,15 +38,7 @@ ErrorOr<void> ContentFilter::set_patterns(ReadonlySpan<String> patterns)
     m_patterns.clear_with_capacity();
 
     for (auto const& pattern : patterns) {
-        StringBuilder builder;
-
-        if (!pattern.starts_with('*'))
-            TRY(builder.try_append('*'));
-        TRY(builder.try_append(pattern));
-        if (!pattern.ends_with('*'))
-            TRY(builder.try_append('*'));
-
-        TRY(m_patterns.try_empend(TRY(builder.to_string())));
+        TRY(m_patterns.try_empend(pattern));
     }
 
     return {};


### PR DESCRIPTION
The existing content filters were only ever used to match substrings, so `ContentFilter::is_filtered` can be changed to use `StringUtils::find` instead of `StringUtils::matches`.

This results in a ~3.5x speedup (605ms -> 170ms) in a benchmark of 5210 urls.

(`url_string.find(pattern.text).has_value()` is slightly faster than `url_string.contains(pattern.text)`)

`ContentFilter::set_patterns` could also be simplified now that patterns are no longer being pre-processed, I haven't done that in this PR (but I can if you want)