### PR TITLE
Meta: Add an option for building against AppKit

### DIFF
--- a/Meta/gn/secondary/Ladybird/BUILD.gn
+++ b/Meta/gn/secondary/Ladybird/BUILD.gn
@@ -1,4 +1,5 @@
 import("//Ladybird/compile_qt_resource_file.gni")
+import("//Ladybird/enable_appkit.gni")
 import("//Ladybird/enable_qt.gni")
 import("//Ladybird/link_qt.gni")
 import("//Ladybird/moc_qt_objects.gni")
@@ -110,7 +111,7 @@ executable("ladybird_executable") {
       ":compile_resource_file",
       ":generate_moc",
     ]
-  } else {
+  } else if (enable_appkit) {
     sources += [
       "AppKit/Application/Application.mm",
       "AppKit/Application/ApplicationBridge.cpp",

--- a/Meta/gn/secondary/Ladybird/enable_appkit.gni
+++ b/Meta/gn/secondary/Ladybird/enable_appkit.gni
@@ -1,0 +1,4 @@
+declare_args() {
+  # Build the Ladybird application using the AppKit chrome.
+  enable_appkit = current_os == "mac"
+}


### PR DESCRIPTION
The build assumed QT or AppKit are the only build UI frameworks. This extends the default assumption away from that to start experimenting with building on other platforms.