### PR TITLE
WebDriver: Implement helper functions for ElementClear endpoint

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -82,6 +82,7 @@ public:
     WebIDL::ExceptionOr<void> set_relevant_value(String const& value) override { return set_value(value); }
 
     virtual void set_dirty_value_flag(bool flag) override { m_dirty_value = flag; }
+    virtual void set_dirty_checkedness(bool flag) { m_dirty_checkedness = flag; }
 
     void commit_pending_changes();
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -122,6 +122,8 @@ public:
 
     void set_dirty_value_flag(Badge<FormAssociatedElement>, bool flag) { m_dirty_value = flag; }
 
+    void set_raw_value(String);
+
 protected:
     void selection_was_changed(size_t selection_start, size_t selection_end) override;
 
@@ -130,8 +132,6 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
-
-    void set_raw_value(String);
 
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;


### PR DESCRIPTION
Fill out some low hanging fruit within the endpoint itself, and (mostly) implement the helper functions clear a content editable element, clear a resettable element, element is a candidate for constraint validation, and element satisfies its constraints (just a stub). Some of these should probably be associated with Element and its subclasses

There are several architecture issues that make it difficult/not expressive to implement these functions, like needing to track whether certain elements have ancestor nodes of a certain type. It might take a pretty close review to pick them all out :/ but they're all marked with FIXME