### PR TITLE
LibWeb: Fix table overflow issues

### DIFF
--- a/Tests/LibWeb/Layout/expected/blockify-layout-internal-box-without-crashing.txt
+++ b/Tests/LibWeb/Layout/expected/blockify-layout-internal-box-without-crashing.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x4 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 4x4 [BFC] children: not-inline
         Box <table> at (8,8) content-size 4x4 table-box [TFC] children: not-inline
-          Box <tbody> at (8,8) content-size 0x0 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 0x0 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 0x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (10,10) content-size 0x0 table-cell [BFC] children: not-inline
                 BlockContainer <td> at (9,9) content-size 0x0 positioned [BFC] children: not-inline
@@ -13,7 +13,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x4]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 4x4]
         PaintableBox (Box<TABLE>) [8,8 4x4]
-          PaintableBox (Box<TBODY>) [8,8 0x0] overflow: [8,8 2x2]
+          PaintableBox (Box<TBODY>) [10,10 0x0] overflow: [8,8 2x2]
             PaintableBox (Box<TR>) [10,10 0x0] overflow: [8,8 2x2]
               PaintableWithLines (BlockContainer(anonymous)) [10,10 0x0] overflow: [8,8 2x2]
                 PaintableWithLines (BlockContainer<TD>) [8,8 2x2]

--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-should-not-be-affected-by-presentational-hints.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (10,10) content-size 780x106 children: not-inline
       TableWrapper <(anonymous)> at (10,10) content-size 110x106 [BFC] children: not-inline
         Box <table> at (11,11) content-size 108x104 table-box [TFC] children: not-inline
-          Box <tbody> at (11,11) content-size 104x100 table-row-group children: not-inline
+          Box <tbody> at (13,13) content-size 104x100 table-row-group children: not-inline
             Box <tr> at (13,13) content-size 104x100 table-row children: not-inline
               BlockContainer <td> at (15,62) content-size 100x2 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (16,63) content-size 98x0 children: inline
@@ -14,7 +14,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [9,9 782x108]
       PaintableWithLines (TableWrapper(anonymous)) [10,10 110x106]
         PaintableBox (Box<TABLE>) [10,10 110x106]
-          PaintableBox (Box<TBODY>) [11,11 104x100] overflow: [11,11 106x102]
+          PaintableBox (Box<TBODY>) [13,13 104x100]
             PaintableBox (Box<TR>) [13,13 104x100]
               PaintableWithLines (BlockContainer<TD>) [13,13 104x100]
                 PaintableWithLines (BlockContainer(anonymous)) [15,62 100x2]

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -9,8 +9,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           TableWrapper <(anonymous)> at (14.34375,8) content-size 156.796875x27 floating [BFC] children: not-inline
             Box <table.middle> at (15.34375,9) content-size 154.796875x25 table-box [TFC] children: not-inline
-              Box <tbody> at (15.34375,9) content-size 148.796875x21 table-row-group children: not-inline
-                Box <tr> at (17.34375,11) content-size 148.796875x21 table-row children: not-inline
+              Box <tbody> at (17.34375,11) content-size 150.796875x21 table-row-group children: not-inline
+                Box <tr> at (17.34375,11) content-size 150.796875x21 table-row children: not-inline
                   BlockContainer <td> at (19.34375,13) content-size 69.59375x17 table-cell [BFC] children: inline
                     frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x17] baseline: 13.296875
                         "2"
@@ -35,8 +35,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             TextPaintable (TextNode<#text>)
           PaintableWithLines (TableWrapper(anonymous)) [14.34375,8 156.796875x27]
             PaintableBox (Box<TABLE>.middle) [14.34375,8 156.796875x27]
-              PaintableBox (Box<TBODY>) [15.34375,9 148.796875x21] overflow: [15.34375,9 152.796875x23]
-                PaintableBox (Box<TR>) [17.34375,11 148.796875x21] overflow: [17.34375,11 150.796875x21]
+              PaintableBox (Box<TBODY>) [17.34375,11 150.796875x21]
+                PaintableBox (Box<TR>) [17.34375,11 150.796875x21]
                   PaintableWithLines (BlockContainer<TD>) [17.34375,11 73.59375x21]
                     TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [92.9375,11 75.203125x21]

--- a/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x46 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 27.90625x46 [BFC] children: not-inline
         Box <table> at (8,8) content-size 27.90625x46 table-box [TFC] children: not-inline
-          Box <tbody> at (8,8) content-size 21.90625x38 table-row-group children: not-inline
-            Box <tr> at (10,10) content-size 21.90625x19 table-row children: not-inline
+          Box <tbody> at (10,10) content-size 23.90625x42 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 23.90625x19 table-row children: not-inline
               BlockContainer <td> at (11,11) content-size 9.09375x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
                     "1"
@@ -13,12 +13,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 frag 0 from TextNode start: 0, length: 1, rect: [24.09375,22.5 8.8125x17] baseline: 13.296875
                     "2"
                 TextNode <#text>
-            Box <tr> at (10,31) content-size 21.90625x19 table-row children: not-inline
+            Box <tr> at (10,31) content-size 23.90625x19 table-row children: not-inline
               BlockContainer <td> at (11,32) content-size 9.09375x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [11,32 9.09375x17] baseline: 13.296875
                     "3"
                 TextNode <#text>
-            Box <tr> at (10,52) content-size 21.90625x0 table-row children: not-inline
+            Box <tr> at (10,52) content-size 23.90625x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (10,52) content-size 11.09375x0 table-cell [BFC] children: not-inline
       BlockContainer <(anonymous)> at (8,54) content-size 784x0 children: inline
         TextNode <#text>
@@ -28,15 +28,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x46]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 27.90625x46]
         PaintableBox (Box<TABLE>) [8,8 27.90625x46]
-          PaintableBox (Box<TBODY>) [8,8 21.90625x38] overflow: [8,8 25.90625x44]
-            PaintableBox (Box<TR>) [10,10 21.90625x19] overflow: [10,10 23.90625x42]
+          PaintableBox (Box<TBODY>) [10,10 23.90625x42]
+            PaintableBox (Box<TR>) [10,10 23.90625x19] overflow: [10,10 23.90625x42]
               PaintableWithLines (BlockContainer<TD>) [10,10 11.09375x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [23.09375,10 10.8125x42]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,31 21.90625x19]
+            PaintableBox (Box<TR>) [10,31 23.90625x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 11.09375x19]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,52 21.90625x0]
+            PaintableBox (Box<TR>) [10,52 23.90625x0]
               PaintableWithLines (BlockContainer(anonymous)) [10,52 11.09375x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,54 784x0]

--- a/Tests/LibWeb/Layout/expected/table/abspos-pseudo-element-inside-table.txt
+++ b/Tests/LibWeb/Layout/expected/table/abspos-pseudo-element-inside-table.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x4 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 784x4 [BFC] children: not-inline
         Box <table> at (8,8) content-size 784x4 table-box [TFC] children: not-inline
-          Box <thead> at (8,8) content-size 0x0 table-header-group children: not-inline
+          Box <thead> at (10,10) content-size 0x0 table-header-group children: not-inline
             Box <tr> at (10,10) content-size 0x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (0,590) content-size 800x10 positioned [BFC] children: inline
                 TextNode <#text>
@@ -13,6 +13,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x4] overflow: [0,8 800x592]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x4] overflow: [0,8 800x592]
         PaintableBox (Box<TABLE>) [8,8 784x4] overflow: [0,8 800x592]
-          PaintableBox (Box<THEAD>) [8,8 0x0] overflow: [0,10 800x590]
+          PaintableBox (Box<THEAD>) [10,10 0x0] overflow: [0,10 800x590]
             PaintableBox (Box<TR>) [10,10 0x0] overflow: [0,590 800x10]
               PaintableWithLines (BlockContainer(anonymous)) [0,590 800x10]

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -5,10 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 6x23 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 0x19 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 2x19 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,10) content-size 0x19 table-row children: not-inline
+            Box <tr> at (10,10) content-size 2x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,11) content-size 0x17 table-cell [BFC] children: inline
@@ -27,7 +27,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 6x23] overflow: [8,8 17.265625x23]
         PaintableBox (Box<TABLE>) [8,8 6x23] overflow: [8,8 17.265625x23]
-          PaintableBox (Box<TBODY>) [8,8 0x19] overflow: [10,10 15.265625x20]
-            PaintableBox (Box<TR>) [10,10 0x19] overflow: [10,10 15.265625x20]
+          PaintableBox (Box<TBODY>) [10,10 2x19] overflow: [10,10 15.265625x20]
+            PaintableBox (Box<TR>) [10,10 2x19] overflow: [10,10 15.265625x20]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x19] overflow: [10,10 15.265625x20]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -16,7 +16,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,10) content-size 95.171875x19 table-header-group children: not-inline
+          Box <thead> at (10,29) content-size 95.171875x19 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (10,29) content-size 95.171875x19 table-row children: not-inline
@@ -32,7 +32,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,29) content-size 95.171875x19 table-row-group children: not-inline
+          Box <tbody> at (10,50) content-size 95.171875x19 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (10,50) content-size 95.171875x19 table-row children: not-inline
@@ -48,7 +48,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (8,48) content-size 95.171875x19 table-footer-group children: not-inline
+          Box <tfoot> at (10,71) content-size 95.171875x19 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (10,71) content-size 95.171875x19 table-row children: not-inline
@@ -77,15 +77,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<TABLE>#full-table) [8,27 99.171875x65] overflow: [8,10 99.171875x82]
           PaintableWithLines (BlockContainer<CAPTION>) [8,10 82.734375x17] overflow: [8,10 90.734375x17]
             TextPaintable (TextNode<#text>)
-          PaintableBox (Box<THEAD>) [8,10 95.171875x19] overflow: [8,10 97.171875x38]
+          PaintableBox (Box<THEAD>) [10,29 95.171875x19]
             PaintableBox (Box<TR>) [10,29 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,29 95.171875x19]
                 TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TBODY>) [8,29 95.171875x19] overflow: [8,29 97.171875x40]
+          PaintableBox (Box<TBODY>) [10,50 95.171875x19]
             PaintableBox (Box<TR>) [10,50 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,50 95.171875x19]
                 TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TFOOT>) [8,48 95.171875x19] overflow: [8,48 97.171875x42]
+          PaintableBox (Box<TFOOT>) [10,71 95.171875x19]
             PaintableBox (Box<TR>) [10,71 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,71 95.171875x19]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x45 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 42.265625x45 [BFC] children: not-inline
         Box <table> at (18,18) content-size 22.265625x25 table-box [TFC] children: not-inline
-          Box <tbody> at (18,18) content-size 18.265625x21 table-row-group children: not-inline
+          Box <tbody> at (20,20) content-size 18.265625x21 table-row-group children: not-inline
             Box <tr> at (20,20) content-size 18.265625x21 table-row children: not-inline
               BlockContainer <td> at (22,22) content-size 14.265625x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x17] baseline: 13.296875
@@ -15,7 +15,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x45]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 42.265625x45]
         PaintableBox (Box<TABLE>) [8,8 42.265625x45]
-          PaintableBox (Box<TBODY>) [18,18 18.265625x21] overflow: [18,18 20.265625x23]
+          PaintableBox (Box<TBODY>) [20,20 18.265625x21]
             PaintableBox (Box<TR>) [20,20 18.265625x21]
               PaintableWithLines (BlockContainer<TD>) [20,20 18.265625x21]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-attribute.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x35 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 32.265625x35 [BFC] children: not-inline
         Box <table> at (13,13) content-size 22.265625x25 table-box [TFC] children: not-inline
-          Box <tbody> at (13,13) content-size 18.265625x21 table-row-group children: not-inline
+          Box <tbody> at (15,15) content-size 18.265625x21 table-row-group children: not-inline
             Box <tr> at (15,15) content-size 18.265625x21 table-row children: not-inline
               BlockContainer <td> at (17,17) content-size 14.265625x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x17] baseline: 13.296875
@@ -15,7 +15,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x35]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 32.265625x35]
         PaintableBox (Box<TABLE>) [8,8 32.265625x35]
-          PaintableBox (Box<TBODY>) [13,13 18.265625x21] overflow: [13,13 20.265625x23]
+          PaintableBox (Box<TBODY>) [15,15 18.265625x21]
             PaintableBox (Box<TR>) [15,15 18.265625x21]
               PaintableWithLines (BlockContainer<TD>) [15,15 18.265625x21]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (23,13) content-size 113.609375x67 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (23,13) content-size 83.609375x47 table-row-group children: not-inline
-            Box <tr> at (33,23) content-size 83.609375x47 table-row children: not-inline
+          Box <tbody> at (33,23) content-size 93.609375x47 table-row-group children: not-inline
+            Box <tr> at (33,23) content-size 93.609375x47 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (48,38) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -29,8 +29,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x77]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 143.609375x77]
         PaintableBox (Box<TABLE>) [8,8 143.609375x77]
-          PaintableBox (Box<TBODY>) [23,13 83.609375x47] overflow: [23,13 103.609375x57]
-            PaintableBox (Box<TR>) [33,23 83.609375x47] overflow: [33,23 93.609375x47]
+          PaintableBox (Box<TBODY>) [33,23 93.609375x47]
+            PaintableBox (Box<TR>) [33,23 93.609375x47]
               PaintableWithLines (BlockContainer<TD>) [33,23 44.265625x47]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [87.265625,23 39.34375x47]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -9,10 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x255 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x195 table-row-group children: not-inline
+          Box <tbody> at (29,19) content-size 201.90625x235 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,19) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,68) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,68) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,79) content-size 88.8125x17 table-cell [BFC] children: inline
@@ -52,7 +52,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,117) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,117) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -75,7 +75,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,166) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,166) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -98,7 +98,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,215) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,215) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -133,34 +133,34 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 243.90625x257]
         PaintableBox (Box<TABLE>) [8,8 243.90625x257]
-          PaintableBox (Box<TBODY>) [9,9 161.90625x195] overflow: [9,9 221.90625x245]
-            PaintableBox (Box<TR>) [29,19 161.90625x39] overflow: [29,19 201.90625x39]
+          PaintableBox (Box<TBODY>) [29,19 201.90625x235]
+            PaintableBox (Box<TR>) [29,19 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,68 161.90625x39] overflow: [29,68 201.90625x39]
+            PaintableBox (Box<TR>) [29,68 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,68 130.8125x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,68 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,117 161.90625x39] overflow: [29,117 201.90625x39]
+            PaintableBox (Box<TR>) [29,117 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,117 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,117 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,117 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,166 161.90625x39] overflow: [29,166 201.90625x39]
+            PaintableBox (Box<TR>) [29,166 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,166 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,166 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,166 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,215 161.90625x39] overflow: [29,215 201.90625x39]
+            PaintableBox (Box<TR>) [29,215 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,215 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,215 54.546875x39]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -9,10 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x255 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x195 table-row-group children: not-inline
+          Box <tbody> at (29,19) content-size 201.90625x235 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,19) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,54.5) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,68) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,68) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: inline
@@ -52,7 +52,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,117) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,117) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -75,7 +75,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,166) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,166) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -98,7 +98,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,215) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,215) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -133,34 +133,34 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 243.90625x257]
         PaintableBox (Box<TABLE>) [8,8 243.90625x257]
-          PaintableBox (Box<TBODY>) [9,9 161.90625x195] overflow: [9,9 221.90625x245]
-            PaintableBox (Box<TR>) [29,19 161.90625x39] overflow: [29,19 201.90625x88]
+          PaintableBox (Box<TBODY>) [29,19 201.90625x235]
+            PaintableBox (Box<TR>) [29,19 201.90625x39] overflow: [29,19 201.90625x88]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x88]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,68 161.90625x39] overflow: [29,68 201.90625x39]
+            PaintableBox (Box<TR>) [29,68 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [105.265625,68 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,68 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,117 161.90625x39] overflow: [29,117 201.90625x39]
+            PaintableBox (Box<TR>) [29,117 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,117 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,117 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,117 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,166 161.90625x39] overflow: [29,166 201.90625x39]
+            PaintableBox (Box<TR>) [29,166 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,166 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,166 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,166 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,215 161.90625x39] overflow: [29,215 201.90625x39]
+            PaintableBox (Box<TR>) [29,215 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,215 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,215 54.546875x39]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table.middle> at (125.59375,8) content-size 478.234375x23 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (125.59375,8) content-size 474.234375x19 table-row-group children: not-inline
+          Box <tbody> at (127.59375,10) content-size 474.234375x19 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (127.59375,10) content-size 474.234375x19 table-row children: not-inline
@@ -39,7 +39,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         TextPaintable (TextNode<#text>)
       PaintableWithLines (TableWrapper(anonymous)) [125.59375,8 478.234375x23]
         PaintableBox (Box<TABLE>.middle) [125.59375,8 478.234375x23]
-          PaintableBox (Box<TBODY>) [125.59375,8 474.234375x19] overflow: [125.59375,8 476.234375x21]
+          PaintableBox (Box<TBODY>) [127.59375,10 474.234375x19]
             PaintableBox (Box<TR>) [127.59375,10 474.234375x19]
               PaintableWithLines (BlockContainer<TD>) [127.59375,10 474.234375x19]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -9,10 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 241.90625x255 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 161.90625x195 table-row-group children: not-inline
+          Box <tbody> at (29,19) content-size 201.90625x235 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,19) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,19) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -35,7 +35,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,68) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,68) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,79) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -58,7 +58,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,117) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,117) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -81,7 +81,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,166) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,166) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -104,7 +104,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (29,215) content-size 161.90625x39 table-row children: not-inline
+            Box <tr> at (29,215) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -139,36 +139,36 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 243.90625x257]
         PaintableBox (Box<TABLE>) [8,8 243.90625x257]
-          PaintableBox (Box<TBODY>) [9,9 161.90625x195] overflow: [9,9 221.90625x245]
-            PaintableBox (Box<TR>) [29,19 161.90625x39] overflow: [29,19 201.90625x39]
+          PaintableBox (Box<TBODY>) [29,19 201.90625x235]
+            PaintableBox (Box<TR>) [29,19 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,68 161.90625x39] overflow: [29,68 201.90625x39]
+            PaintableBox (Box<TR>) [29,68 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,68 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,68 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,68 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,117 161.90625x39] overflow: [29,117 201.90625x39]
+            PaintableBox (Box<TR>) [29,117 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,117 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,117 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,117 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,166 161.90625x39] overflow: [29,166 201.90625x39]
+            PaintableBox (Box<TR>) [29,166 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,166 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,166 54.546875x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,166 51.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [29,215 161.90625x39] overflow: [29,215 201.90625x39]
+            PaintableBox (Box<TR>) [29,215 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,215 56.265625x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,215 54.546875x39]

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table.table-border-black> at (9,9) content-size 172.296875x71 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 166.296875x63 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 166.296875x21 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 168.296875x67 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 168.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 82.015625x17 table-cell [BFC] children: inline
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,34) content-size 166.296875x21 table-row children: not-inline
+            Box <tr> at (11,34) content-size 168.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,36) content-size 82.015625x17 table-cell [BFC] children: inline
@@ -40,7 +40,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,57) content-size 166.296875x21 table-row children: not-inline
+            Box <tr> at (11,57) content-size 168.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,59) content-size 82.015625x17 table-cell [BFC] children: inline
@@ -240,18 +240,18 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x260]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 174.296875x73]
         PaintableBox (Box<TABLE>.table-border-black) [8,8 174.296875x73]
-          PaintableBox (Box<TBODY>) [9,9 166.296875x63] overflow: [9,9 170.296875x69]
-            PaintableBox (Box<TR>) [11,11 166.296875x21] overflow: [11,11 168.296875x21]
+          PaintableBox (Box<TBODY>) [11,11 168.296875x67]
+            PaintableBox (Box<TR>) [11,11 168.296875x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 86.015625x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,11 80.28125x21]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [11,34 166.296875x21] overflow: [11,34 168.296875x21]
+            PaintableBox (Box<TR>) [11,34 168.296875x21]
               PaintableWithLines (BlockContainer<TD>) [11,34 86.015625x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,34 80.28125x21]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [11,57 166.296875x21] overflow: [11,57 168.296875x21]
+            PaintableBox (Box<TR>) [11,57 168.296875x21]
               PaintableWithLines (BlockContainer<TD>) [11,57 86.015625x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,57 80.28125x21]

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (8,8) content-size 95.171875x19 table-header-group children: not-inline
+          Box <thead> at (10,10) content-size 95.171875x19 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (10,10) content-size 95.171875x19 table-row children: not-inline
@@ -29,7 +29,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,27) content-size 95.171875x19 table-row-group children: not-inline
+          Box <tbody> at (10,31) content-size 95.171875x19 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (10,31) content-size 95.171875x19 table-row children: not-inline
@@ -45,7 +45,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (8,46) content-size 95.171875x19 table-footer-group children: not-inline
+          Box <tfoot> at (10,52) content-size 95.171875x19 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (10,52) content-size 95.171875x19 table-row children: not-inline
@@ -72,15 +72,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<TABLE>#full-table) [8,8 99.171875x65] overflow: [8,8 99.171875x82]
           PaintableWithLines (BlockContainer<CAPTION>) [8,73 82.734375x17] overflow: [8,73 90.734375x17]
             TextPaintable (TextNode<#text>)
-          PaintableBox (Box<THEAD>) [8,8 95.171875x19] overflow: [8,8 97.171875x21]
+          PaintableBox (Box<THEAD>) [10,10 95.171875x19]
             PaintableBox (Box<TR>) [10,10 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,10 95.171875x19]
                 TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TBODY>) [8,27 95.171875x19] overflow: [8,27 97.171875x23]
+          PaintableBox (Box<TBODY>) [10,31 95.171875x19]
             PaintableBox (Box<TR>) [10,31 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 95.171875x19]
                 TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TFOOT>) [8,46 95.171875x19] overflow: [8,46 97.171875x25]
+          PaintableBox (Box<TFOOT>) [10,52 95.171875x19]
             PaintableBox (Box<TR>) [10,52 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,52 95.171875x19]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -8,10 +8,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table#table> at (8,8) content-size 80x23 table-box [TFC] children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tbody> at (8,8) content-size 72x19 table-row-group children: not-inline
+            Box <tbody> at (10,10) content-size 76x19 table-row-group children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              Box <tr> at (10,10) content-size 72x19 table-row children: not-inline
+              Box <tr> at (10,10) content-size 76x19 table-row children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
                 BlockContainer <td> at (11,11) content-size 17.828125x17 table-cell [BFC] children: inline
@@ -46,8 +46,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableWithLines (BlockContainer(anonymous)) [8,8 80x0]
         PaintableWithLines (TableWrapper(anonymous)) [8,8 80x23]
           PaintableBox (Box<TABLE>#table) [8,8 80x23]
-            PaintableBox (Box<TBODY>) [8,8 72x19] overflow: [8,8 78x21]
-              PaintableBox (Box<TR>) [10,10 72x19] overflow: [10,10 76x19]
+            PaintableBox (Box<TBODY>) [10,10 76x19]
+              PaintableBox (Box<TR>) [10,10 76x19]
                 PaintableWithLines (BlockContainer<TD>) [10,10 19.828125x19]
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [31.828125,10 13.828125x19]

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -5,10 +5,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 784x44 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 776x38 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 780x40 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,10) content-size 776x19 table-row children: not-inline
+            Box <tr> at (10,10) content-size 780x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (11,11) content-size 300.640625x17 table-cell [BFC] children: inline
@@ -31,7 +31,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,31) content-size 776x19 table-row children: not-inline
+            Box <tr> at (10,31) content-size 780x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,32) content-size 300.640625x17 table-cell [BFC] children: inline
@@ -62,15 +62,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x44]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x44]
         PaintableBox (Box<TABLE>) [8,8 784x44]
-          PaintableBox (Box<TBODY>) [8,8 776x38] overflow: [8,8 782x42]
-            PaintableBox (Box<TR>) [10,10 776x19] overflow: [10,10 780x19]
+          PaintableBox (Box<TBODY>) [10,10 780x40]
+            PaintableBox (Box<TR>) [10,10 780x19]
               PaintableWithLines (BlockContainer<TH>) [10,10 302.640625x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [314.640625,10 170.71875x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [487.359375,10 302.640625x19]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,31 776x19] overflow: [10,31 780x19]
+            PaintableBox (Box<TR>) [10,31 780x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 302.640625x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [314.640625,31 170.71875x19]

--- a/Tests/LibWeb/Layout/expected/table/cell-with-max-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-with-max-width.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x108 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 276x108 [BFC] children: not-inline
         Box <table> at (8,8) content-size 276x108 table-box [TFC] children: not-inline
-          Box <tbody> at (8,8) content-size 272x104 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 272x104 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 272x104 table-row children: not-inline
               BlockContainer <td> at (11,11) content-size 270x102 table-cell [BFC] children: not-inline
                 BlockContainer <div> at (11,11) content-size 270x102 children: not-inline
@@ -28,7 +28,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x108]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 276x108]
         PaintableBox (Box<TABLE>) [8,8 276x108]
-          PaintableBox (Box<TBODY>) [8,8 272x104] overflow: [8,8 274x106]
+          PaintableBox (Box<TBODY>) [10,10 272x104]
             PaintableBox (Box<TR>) [10,10 272x104]
               PaintableWithLines (BlockContainer<TD>) [10,10 272x104]
                 PaintableWithLines (BlockContainer<DIV>) [11,11 270x102]

--- a/Tests/LibWeb/Layout/expected/table/colgroup-with-two-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/colgroup-with-two-cols.txt
@@ -6,11 +6,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           BlockContainer <colgroup#my-group> (not painted) table-column-group children: not-inline
             BlockContainer <col> (not painted) children: not-inline
             BlockContainer <col> (not painted) children: not-inline
-          Box <tbody> at (8,8) content-size 0x0 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 0x0 table-row-group children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x2]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 46x2]
         PaintableBox (Box<TABLE>) [8,8 46x2]
-          PaintableBox (Box<TBODY>) [8,8 0x0]
+          PaintableBox (Box<TBODY>) [10,10 0x0]

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table.ambox> at (9,9) content-size 782x108 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 776x104 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 776x104 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 778x104 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 778x104 table-row children: not-inline
               BlockContainer <td.mbox-image> at (12,38) content-size 50x50 table-cell [BFC] children: not-inline
                 BlockContainer <div.mbox-image-div> at (12,38) content-size 50x50 children: not-inline
               BlockContainer <td.mbox-text> at (66,12) content-size 722x102 table-cell [BFC] children: inline
@@ -29,8 +29,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x110]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x110]
         PaintableBox (Box<TABLE>.ambox) [8,8 784x110]
-          PaintableBox (Box<TBODY>) [9,9 776x104] overflow: [9,9 780x106]
-            PaintableBox (Box<TR>) [11,11 776x104] overflow: [11,11 778x104]
+          PaintableBox (Box<TBODY>) [11,11 778x104]
+            PaintableBox (Box<TR>) [11,11 778x104]
               PaintableWithLines (BlockContainer<TD>.mbox-image) [11,11 52x104]
                 PaintableWithLines (BlockContainer<DIV>.mbox-image-div) [12,38 50x50]
               PaintableWithLines (BlockContainer<TD>.mbox-text) [65,11 724x104]

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <table> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
         TableWrapper <(anonymous)> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
           Box <(anonymous)> at (9,9) content-size 135.984375x44 inline-table table-box [TFC] children: not-inline
-            Box <tbody> at (9,9) content-size 129.984375x38 table-row-group children: not-inline
-              Box <tr> at (11,11) content-size 129.984375x19 table-row children: not-inline
+            Box <tbody> at (11,11) content-size 131.984375x40 table-row-group children: not-inline
+              Box <tr> at (11,11) content-size 131.984375x19 table-row children: not-inline
                 BlockContainer <td> at (12,12) content-size 87.90625x17 table-cell [BFC] children: inline
                   frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x17] baseline: 13.296875
                       "ID"
@@ -15,7 +15,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17] baseline: 13.296875
                       "null"
                   TextNode <#text>
-              Box <tr> at (11,32) content-size 129.984375x19 table-row children: not-inline
+              Box <tr> at (11,32) content-size 131.984375x19 table-row children: not-inline
                 BlockContainer <td> at (12,33) content-size 87.90625x17 table-cell [BFC] children: inline
                   frag 0 from TextNode start: 0, length: 11, rect: [12,33 87.90625x17] baseline: 13.296875
                       "Is Selected"
@@ -31,13 +31,13 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<TABLE>) [8,8 137.984375x46]
         PaintableWithLines (TableWrapper(anonymous)) [9,9 135.984375x44]
           PaintableBox (Box(anonymous)) [9,9 135.984375x44]
-            PaintableBox (Box<TBODY>) [9,9 129.984375x38] overflow: [9,9 133.984375x42]
-              PaintableBox (Box<TR>) [11,11 129.984375x19] overflow: [11,11 131.984375x19]
+            PaintableBox (Box<TBODY>) [11,11 131.984375x40]
+              PaintableBox (Box<TR>) [11,11 131.984375x19]
                 PaintableWithLines (BlockContainer<TD>) [11,11 89.90625x19]
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,11 40.078125x19]
                   TextPaintable (TextNode<#text>)
-              PaintableBox (Box<TR>) [11,32 129.984375x19] overflow: [11,32 131.984375x19]
+              PaintableBox (Box<TR>) [11,32 131.984375x19]
                 PaintableWithLines (BlockContainer<TD>) [11,32 89.90625x19]
                   TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,32 40.078125x19]

--- a/Tests/LibWeb/Layout/expected/table/internal-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/internal-alignment.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x204 children: not-inline
         TableWrapper <(anonymous)> at (300,8) content-size 200x204 [BFC] children: not-inline
           Box <table> at (301,9) content-size 198x202 table-box [TFC] children: not-inline
-            Box <tbody> at (301,9) content-size 194x198 table-row-group children: not-inline
+            Box <tbody> at (303,11) content-size 194x198 table-row-group children: not-inline
               Box <tr> at (303,11) content-size 194x198 table-row children: not-inline
                 BlockContainer <td> at (304,85.5) content-size 192x49 table-cell [BFC] children: not-inline
                   BlockContainer <p> at (304,101.5) content-size 192x17 children: inline
@@ -18,7 +18,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<DIV>) [8,8 784x204]
         PaintableWithLines (TableWrapper(anonymous)) [300,8 200x204]
           PaintableBox (Box<TABLE>) [300,8 200x204]
-            PaintableBox (Box<TBODY>) [301,9 194x198] overflow: [301,9 196x200]
+            PaintableBox (Box<TBODY>) [303,11 194x198]
               PaintableBox (Box<TR>) [303,11 194x198]
                 PaintableWithLines (BlockContainer<TD>) [303,11 194x198]
                   PaintableWithLines (BlockContainer<P>) [304,101.5 192x17]

--- a/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
+++ b/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x23 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 37.609375x23 [BFC] children: not-inline
         Box <table> at (8,8) content-size 37.609375x23 table-box [TFC] children: not-inline
-          Box <tbody> at (8,8) content-size 33.609375x19 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 33.609375x19 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 33.609375x19 table-row children: not-inline
               BlockContainer <td.ab> at (11,11) content-size 31.609375x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x17] baseline: 13.296875
@@ -17,7 +17,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 37.609375x23]
         PaintableBox (Box<TABLE>) [8,8 37.609375x23]
-          PaintableBox (Box<TBODY>) [8,8 33.609375x19] overflow: [8,8 35.609375x21]
+          PaintableBox (Box<TBODY>) [10,10 33.609375x19]
             PaintableBox (Box<TR>) [10,10 33.609375x19]
               PaintableWithLines (BlockContainer<TD>.ab) [10,10 33.609375x19]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -15,10 +15,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <thead> at (10,10) content-size 53.046875x21 table-header-group children: not-inline
+          Box <thead> at (12,44) content-size 55.046875x21 table-header-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,44) content-size 53.046875x21 table-row children: not-inline
+            Box <tr> at (12,44) content-size 55.046875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,46) content-size 21.25x17 table-cell [BFC] children: inline
@@ -37,10 +37,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (10,31) content-size 53.046875x21 table-row-group children: not-inline
+          Box <tbody> at (12,67) content-size 55.046875x21 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,67) content-size 53.046875x21 table-row children: not-inline
+            Box <tr> at (12,67) content-size 55.046875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,69) content-size 21.25x17 table-cell [BFC] children: inline
@@ -59,10 +59,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tfoot> at (10,52) content-size 53.046875x21 table-footer-group children: not-inline
+          Box <tfoot> at (12,90) content-size 55.046875x21 table-footer-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (12,90) content-size 53.046875x21 table-row children: not-inline
+            Box <tr> at (12,90) content-size 55.046875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (14,92) content-size 21.25x17 table-cell [BFC] children: inline
@@ -92,20 +92,20 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<TABLE>#full-table) [8,40 63.046875x75] overflow: [8,8 61.046875x105]
           PaintableWithLines (BlockContainer<CAPTION>) [8,8 59.046875x34]
             TextPaintable (TextNode<#text>)
-          PaintableBox (Box<THEAD>) [10,10 53.046875x21] overflow: [10,10 57.046875x55]
-            PaintableBox (Box<TR>) [12,44 53.046875x21] overflow: [12,44 55.046875x21]
+          PaintableBox (Box<THEAD>) [12,44 55.046875x21]
+            PaintableBox (Box<TR>) [12,44 55.046875x21]
               PaintableWithLines (BlockContainer<TD>) [12,44 25.25x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,44 27.796875x21]
                 TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TBODY>) [10,31 53.046875x21] overflow: [10,31 57.046875x57]
-            PaintableBox (Box<TR>) [12,67 53.046875x21] overflow: [12,67 55.046875x21]
+          PaintableBox (Box<TBODY>) [12,67 55.046875x21]
+            PaintableBox (Box<TR>) [12,67 55.046875x21]
               PaintableWithLines (BlockContainer<TD>) [12,67 25.25x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,67 27.796875x21]
                 TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TFOOT>) [10,52 53.046875x21] overflow: [10,52 57.046875x59]
-            PaintableBox (Box<TR>) [12,90 53.046875x21] overflow: [12,90 55.046875x21]
+          PaintableBox (Box<TFOOT>) [12,90 55.046875x21]
+            PaintableBox (Box<TR>) [12,90 55.046875x21]
               PaintableWithLines (BlockContainer<TD>) [12,90 25.25x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,90 27.796875x21]

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 79.4375x65 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 75.4375x59 table-row-group children: not-inline
+          Box <tbody> at (11,11) content-size 75.4375x61 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 75.4375x21 table-row children: not-inline
               BlockContainer <td> at (13,13) content-size 71.4375x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x17] baseline: 13.296875
@@ -30,7 +30,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x67]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 81.4375x67]
         PaintableBox (Box<TABLE>) [8,8 81.4375x67]
-          PaintableBox (Box<TBODY>) [9,9 75.4375x59] overflow: [9,9 77.4375x63]
+          PaintableBox (Box<TBODY>) [11,11 75.4375x61]
             PaintableBox (Box<TR>) [11,11 75.4375x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 75.4375x21]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
@@ -3,12 +3,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x212 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x212 [BFC] children: not-inline
         Box <table> at (9,9) content-size 198x210 table-box [TFC] children: not-inline
-          Box <tbody> at (9,9) content-size 194x206 table-row-group children: not-inline
+          Box <tbody> at (11,11) content-size 194x206 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 194x206 table-row children: not-inline
               BlockContainer <td> at (12,12) content-size 192x204 table-cell [BFC] children: not-inline
                 TableWrapper <(anonymous)> at (158.890625,12) content-size 45.109375x204 [BFC] children: not-inline
                   Box <table> at (159.890625,13) content-size 43.109375x202 table-box [TFC] children: not-inline
-                    Box <tbody> at (159.890625,13) content-size 39.109375x198 table-row-group children: not-inline
+                    Box <tbody> at (161.890625,15) content-size 39.109375x198 table-row-group children: not-inline
                       Box <tr> at (161.890625,15) content-size 39.109375x198 table-row children: not-inline
                         BlockContainer <td> at (162.890625,105.5) content-size 37.109375x17 table-cell [BFC] children: inline
                           frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105.5 37.109375x17] baseline: 13.296875
@@ -20,12 +20,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x212]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 200x212]
         PaintableBox (Box<TABLE>) [8,8 200x212]
-          PaintableBox (Box<TBODY>) [9,9 194x206] overflow: [9,9 196x208]
+          PaintableBox (Box<TBODY>) [11,11 194x206]
             PaintableBox (Box<TR>) [11,11 194x206]
               PaintableWithLines (BlockContainer<TD>) [11,11 194x206]
                 PaintableWithLines (TableWrapper(anonymous)) [158.890625,12 45.109375x204]
                   PaintableBox (Box<TABLE>) [158.890625,12 45.109375x204]
-                    PaintableBox (Box<TBODY>) [159.890625,13 39.109375x198] overflow: [159.890625,13 41.109375x200]
+                    PaintableBox (Box<TBODY>) [161.890625,15 39.109375x198]
                       PaintableBox (Box<TR>) [161.890625,15 39.109375x198]
                         PaintableWithLines (BlockContainer<TD>) [161.890625,15 39.109375x198]
                           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -9,10 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (13,13) content-size 105.828125x114 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (13,13) content-size 99.828125x108 table-row-group children: not-inline
+          Box <tbody> at (15,15) content-size 101.828125x110 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (15,15) content-size 99.828125x54 table-row children: not-inline
+            Box <tr> at (15,15) content-size 101.828125x54 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (25,33.5) content-size 11.5625x17 table-cell [BFC] children: inline
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (63.5625,30) content-size 38.265625x80 table-box [TFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
-                    Box <tbody> at (63.5625,30) content-size 34.265625x74 table-row-group children: not-inline
+                    Box <tbody> at (65.5625,32) content-size 34.265625x76 table-row-group children: not-inline
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
                       Box <tr> at (65.5625,32) content-size 34.265625x37 table-row children: not-inline
@@ -61,7 +61,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (15,71) content-size 99.828125x54 table-row children: not-inline
+            Box <tr> at (15,71) content-size 101.828125x54 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (25,89.5) content-size 11.5625x17 table-cell [BFC] children: inline
@@ -84,15 +84,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 115.828125x124]
         PaintableBox (Box<TABLE>) [8,8 115.828125x124]
-          PaintableBox (Box<TBODY>) [13,13 99.828125x108] overflow: [13,13 103.828125x112]
-            PaintableBox (Box<TR>) [15,15 99.828125x54] overflow: [15,15 101.828125x110]
+          PaintableBox (Box<TBODY>) [15,15 101.828125x110]
+            PaintableBox (Box<TR>) [15,15 101.828125x54] overflow: [15,15 101.828125x110]
               PaintableWithLines (BlockContainer<TD>) [15,15 31.5625x54]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [48.5625,15 68.265625x110]
                 PaintableWithLines (BlockContainer(anonymous)) [58.5625,25 48.265625x0]
                 PaintableWithLines (TableWrapper(anonymous)) [58.5625,25 48.265625x90]
                   PaintableBox (Box<TABLE>) [58.5625,25 48.265625x90]
-                    PaintableBox (Box<TBODY>) [63.5625,30 34.265625x74] overflow: [63.5625,30 36.265625x78]
+                    PaintableBox (Box<TBODY>) [65.5625,32 34.265625x76]
                       PaintableBox (Box<TR>) [65.5625,32 34.265625x37]
                         PaintableWithLines (BlockContainer<TD>) [65.5625,32 34.265625x37]
                           TextPaintable (TextNode<#text>)
@@ -100,7 +100,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                         PaintableWithLines (BlockContainer<TD>) [65.5625,71 34.265625x37]
                           TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [58.5625,115 48.265625x0]
-            PaintableBox (Box<TR>) [15,71 99.828125x54]
+            PaintableBox (Box<TR>) [15,71 101.828125x54]
               PaintableWithLines (BlockContainer<TD>) [15,71 31.5625x54]
                 TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,132 784x0]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -5,12 +5,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         BlockContainer <div> at (8,8) content-size 200x31 [BFC] children: not-inline
           TableWrapper <(anonymous)> at (8,8) content-size 200x31 [BFC] children: not-inline
             Box <table.outer> at (9,9) content-size 198x29 table-box [TFC] children: not-inline
-              Box <tbody> at (9,9) content-size 194x25 table-row-group children: not-inline
+              Box <tbody> at (11,11) content-size 194x25 table-row-group children: not-inline
                 Box <tr> at (11,11) content-size 194x25 table-row children: not-inline
                   BlockContainer <td> at (12,12) content-size 192x23 table-cell [BFC] children: not-inline
                     TableWrapper <(anonymous)> at (12,12) content-size 192x23 [BFC] children: not-inline
                       Box <table.inner> at (12,12) content-size 192x23 table-box [TFC] children: not-inline
-                        Box <tbody> at (12,12) content-size 188x19 table-row-group children: not-inline
+                        Box <tbody> at (14,14) content-size 188x19 table-row-group children: not-inline
                           Box <tr> at (14,14) content-size 188x19 table-row children: not-inline
                             BlockContainer <td> at (15,15) content-size 186x17 table-cell [BFC] children: inline
                               frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x17] baseline: 13.296875
@@ -24,12 +24,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableWithLines (BlockContainer<DIV>) [8,8 200x31]
           PaintableWithLines (TableWrapper(anonymous)) [8,8 200x31]
             PaintableBox (Box<TABLE>.outer) [8,8 200x31]
-              PaintableBox (Box<TBODY>) [9,9 194x25] overflow: [9,9 196x27]
+              PaintableBox (Box<TBODY>) [11,11 194x25]
                 PaintableBox (Box<TR>) [11,11 194x25]
                   PaintableWithLines (BlockContainer<TD>) [11,11 194x25]
                     PaintableWithLines (TableWrapper(anonymous)) [12,12 192x23]
                       PaintableBox (Box<TABLE>.inner) [12,12 192x23]
-                        PaintableBox (Box<TBODY>) [12,12 188x19] overflow: [12,12 190x21]
+                        PaintableBox (Box<TBODY>) [14,14 188x19]
                           PaintableBox (Box<TR>) [14,14 188x19]
                             PaintableWithLines (BlockContainer<TD>) [14,14 188x19]
                               TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/propagate-style-update-to-wrapper.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table#t> at (8,8) content-size 6x6 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 2x2 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 2x2 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 2x2 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
@@ -20,6 +20,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x0] overflow: [8,8 6x6]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 6x6]
         PaintableBox (Box<TABLE>#t) [8,8 6x6]
-          PaintableBox (Box<TBODY>) [8,8 2x2] overflow: [8,8 4x4]
+          PaintableBox (Box<TBODY>) [10,10 2x2]
             PaintableBox (Box<TR>) [10,10 2x2]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x2]

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 49.21875x25 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 43.21875x19 table-row-group children: not-inline
-            Box <tr> at (10,10) content-size 43.21875x9.5 table-row children: not-inline
+          Box <tbody> at (10,10) content-size 45.21875x21 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 45.21875x9.5 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,14.75) content-size 0x0 table-cell [BFC] children: not-inline
@@ -23,7 +23,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,21.5) content-size 43.21875x9.5 table-row children: not-inline
+            Box <tr> at (10,21.5) content-size 45.21875x9.5 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,26.25) content-size 0x0 table-cell [BFC] children: not-inline
@@ -37,11 +37,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x25]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 49.21875x25]
         PaintableBox (Box<TABLE>) [8,8 49.21875x25]
-          PaintableBox (Box<TBODY>) [8,8 43.21875x19] overflow: [8,8 47.21875x23]
-            PaintableBox (Box<TR>) [10,10 43.21875x9.5] overflow: [10,10 45.21875x21]
+          PaintableBox (Box<TBODY>) [10,10 45.21875x21]
+            PaintableBox (Box<TR>) [10,10 45.21875x9.5] overflow: [10,10 45.21875x21]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x9.5]
               PaintableWithLines (BlockContainer<TD>) [14,10 41.21875x21]
                 InlinePaintable (InlineNode<A>)
                   TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,21.5 43.21875x9.5]
+            PaintableBox (Box<TR>) [10,21.5 45.21875x9.5]
               PaintableWithLines (BlockContainer<TD>) [10,21.5 2x9.5]

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -9,10 +9,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 73.828125x113 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 67.828125x107 table-row-group children: not-inline
+          Box <tbody> at (11,11) content-size 69.828125x109 table-row-group children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,11) content-size 67.828125x53.5 table-row children: not-inline
+            Box <tr> at (11,11) content-size 69.828125x53.5 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,29.25) content-size 11.5625x17 table-cell [BFC] children: inline
@@ -28,7 +28,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (43.5625,18) content-size 30.265625x95 table-box [TFC] children: not-inline
                     BlockContainer <(anonymous)> (not painted) children: inline
                       TextNode <#text>
-                    Box <tbody> at (43.5625,18) content-size 26.265625x87 table-row-group children: not-inline
+                    Box <tbody> at (45.5625,20) content-size 26.265625x91 table-row-group children: not-inline
                       BlockContainer <(anonymous)> (not painted) children: inline
                         TextNode <#text>
                       Box <tr> at (45.5625,20) content-size 26.265625x29 table-row children: not-inline
@@ -72,7 +72,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (11,66.5) content-size 67.828125x53.5 table-row children: not-inline
+            Box <tr> at (11,66.5) content-size 69.828125x53.5 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (17,84.75) content-size 11.5625x17 table-cell [BFC] children: inline
@@ -95,15 +95,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 75.828125x115]
         PaintableBox (Box<TABLE>) [8,8 75.828125x115]
-          PaintableBox (Box<TBODY>) [9,9 67.828125x107] overflow: [9,9 71.828125x111]
-            PaintableBox (Box<TR>) [11,11 67.828125x53.5] overflow: [11,11 69.828125x109]
+          PaintableBox (Box<TBODY>) [11,11 69.828125x109]
+            PaintableBox (Box<TR>) [11,11 69.828125x53.5] overflow: [11,11 69.828125x109]
               PaintableWithLines (BlockContainer<TD>) [11,11 23.5625x53.5]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36.5625,11 44.265625x109]
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 32.265625x0]
                 PaintableWithLines (TableWrapper(anonymous)) [42.5625,17 32.265625x97]
                   PaintableBox (Box<TABLE>) [42.5625,17 32.265625x97]
-                    PaintableBox (Box<TBODY>) [43.5625,18 26.265625x87] overflow: [43.5625,18 28.265625x93]
+                    PaintableBox (Box<TBODY>) [45.5625,20 26.265625x91]
                       PaintableBox (Box<TR>) [45.5625,20 26.265625x29]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,20 26.265625x29]
                           TextPaintable (TextNode<#text>)
@@ -114,7 +114,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,82 26.265625x29]
                           TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,114 32.265625x0]
-            PaintableBox (Box<TR>) [11,66.5 67.828125x53.5]
+            PaintableBox (Box<TR>) [11,66.5 69.828125x53.5]
               PaintableWithLines (BlockContainer<TD>) [11,66.5 23.5625x53.5]
                 TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,123 784x0]

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -9,8 +9,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 229.359375x86 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 221.359375x76 table-row-group children: not-inline
-            Box <tr> at (10,10) content-size 221.359375x19 table-row children: not-inline
+          Box <tbody> at (10,10) content-size 225.359375x82 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
@@ -33,7 +33,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,31) content-size 221.359375x19 table-row children: not-inline
+            Box <tr> at (10,31) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,42.5) content-size 70.046875x17 table-cell [BFC] children: inline
@@ -56,7 +56,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,52) content-size 221.359375x19 table-row children: not-inline
+            Box <tr> at (10,52) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: inline
@@ -73,7 +73,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (10,73) content-size 221.359375x19 table-row children: not-inline
+            Box <tr> at (10,73) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
@@ -106,27 +106,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 229.359375x86]
         PaintableBox (Box<TABLE>) [8,8 229.359375x86]
-          PaintableBox (Box<TBODY>) [8,8 221.359375x76] overflow: [8,8 227.359375x84]
-            PaintableBox (Box<TR>) [10,10 221.359375x19] overflow: [10,10 225.359375x19]
+          PaintableBox (Box<TBODY>) [10,10 225.359375x82]
+            PaintableBox (Box<TR>) [10,10 225.359375x19]
               PaintableWithLines (BlockContainer<TH>) [10,10 72.046875x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [84.046875,10 74.515625x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [160.5625,10 74.796875x19]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,31 221.359375x19] overflow: [10,31 225.359375x40]
+            PaintableBox (Box<TR>) [10,31 225.359375x19] overflow: [10,31 225.359375x40]
               PaintableWithLines (BlockContainer<TD>) [10,31 72.046875x40]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [84.046875,31 74.515625x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,31 74.796875x19]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,52 221.359375x19] overflow: [10,52 225.359375x19]
+            PaintableBox (Box<TR>) [10,52 225.359375x19]
               PaintableWithLines (BlockContainer<TD>) [84.046875,52 74.515625x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,52 74.796875x19]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [10,73 221.359375x19] overflow: [10,73 225.359375x19]
+            PaintableBox (Box<TR>) [10,73 225.359375x19]
               PaintableWithLines (BlockContainer<TD>) [10,73 72.046875x19]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [84.046875,73 74.515625x19]

--- a/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/stretch-to-fixed-height.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (19,19) content-size 2x78 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (19,19) content-size 0x0 table-row-group children: not-inline
-            Box <tr> at (21,31) content-size 0x0 table-row children: not-inline
+          Box <tbody> at (21,21) content-size 0x0 table-row-group children: not-inline
+            Box <tr> at (21,21) content-size 0x0 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
 
@@ -15,5 +15,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 24x100]
         PaintableBox (Box<TABLE>) [8,8 24x100]
-          PaintableBox (Box<TBODY>) [19,19 0x0] overflow: [21,31 0x0]
-            PaintableBox (Box<TR>) [21,31 0x0]
+          PaintableBox (Box<TBODY>) [21,21 0x0]
+            PaintableBox (Box<TR>) [21,21 0x0]

--- a/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <center> at (8,8) content-size 784x104 children: not-inline
         TableWrapper <(anonymous)> at (204,8) content-size 392x104 [BFC] children: not-inline
           Box <table> at (204,8) content-size 392x104 table-box [TFC] children: not-inline
-            Box <tbody> at (204,8) content-size 388x100 table-row-group children: not-inline
+            Box <tbody> at (206,10) content-size 388x100 table-row-group children: not-inline
               Box <tr> at (206,10) content-size 388x100 table-row children: not-inline
                 BlockContainer <td> at (207,60) content-size 386x0 table-cell [BFC] children: inline
                   TextNode <#text>
@@ -15,6 +15,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<CENTER>) [8,8 784x104]
         PaintableWithLines (TableWrapper(anonymous)) [204,8 392x104]
           PaintableBox (Box<TABLE>) [204,8 392x104]
-            PaintableBox (Box<TBODY>) [204,8 388x100] overflow: [204,8 390x102]
+            PaintableBox (Box<TBODY>) [206,10 388x100]
               PaintableBox (Box<TR>) [206,10 388x100]
                 PaintableWithLines (BlockContainer<TD>) [206,10 388x100]

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 100x25 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 91.984375x21 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 91.984375x21 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 95.984375x21 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 95.984375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 19x17 table-cell [BFC] children: inline
@@ -35,8 +35,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 102x27]
         PaintableBox (Box<TABLE>) [8,8 102x27]
-          PaintableBox (Box<TBODY>) [9,9 91.984375x21] overflow: [9,9 97.984375x23]
-            PaintableBox (Box<TR>) [11,11 91.984375x21] overflow: [11,11 95.984375x21]
+          PaintableBox (Box<TBODY>) [11,11 95.984375x21]
+            PaintableBox (Box<TR>) [11,11 95.984375x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 23x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36,11 45.984375x21]

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,100) content-size 784x204 children: not-inline
       TableWrapper <(anonymous)> at (108,100) content-size 89.34375x204 [BFC] children: not-inline
         Box <table> at (109,101) content-size 87.34375x202 table-box [TFC] children: not-inline
-          Box <tbody> at (109,101) content-size 83.34375x198 table-row-group children: not-inline
+          Box <tbody> at (111,103) content-size 83.34375x198 table-row-group children: not-inline
             Box <tr> at (111,103) content-size 83.34375x198 table-row children: not-inline
               BlockContainer <td> at (112,193.5) content-size 81.34375x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 10, rect: [112,193.5 81.34375x17] baseline: 13.296875
@@ -17,7 +17,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,100 784x204]
       PaintableWithLines (TableWrapper(anonymous)) [108,100 89.34375x204]
         PaintableBox (Box<TABLE>) [108,100 89.34375x204]
-          PaintableBox (Box<TBODY>) [109,101 83.34375x198] overflow: [109,101 85.34375x200]
+          PaintableBox (Box<TBODY>) [111,103 83.34375x198]
             PaintableBox (Box<TR>) [111,103 83.34375x198]
               PaintableWithLines (BlockContainer<TD>) [111,103 83.34375x198]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       TableWrapper <(anonymous)> at (370.1875,8) content-size 59.625x204 [BFC] children: not-inline
         Box <table> at (371.1875,9) content-size 57.625x202 table-box [TFC] children: not-inline
-          Box <tbody> at (371.1875,9) content-size 53.625x198 table-row-group children: not-inline
+          Box <tbody> at (373.1875,11) content-size 53.625x198 table-row-group children: not-inline
             Box <tr> at (373.1875,11) content-size 53.625x198 table-row children: not-inline
               BlockContainer <td> at (374.1875,101.5) content-size 51.625x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101.5 51.625x17] baseline: 13.296875
@@ -17,7 +17,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (TableWrapper(anonymous)) [370.1875,8 59.625x204]
         PaintableBox (Box<TABLE>) [370.1875,8 59.625x204]
-          PaintableBox (Box<TBODY>) [371.1875,9 53.625x198] overflow: [371.1875,9 55.625x200]
+          PaintableBox (Box<TBODY>) [373.1875,11 53.625x198]
             PaintableBox (Box<TR>) [373.1875,11 53.625x198]
               PaintableWithLines (BlockContainer<TD>) [373.1875,11 53.625x198]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 498.1875x204 [BFC] children: not-inline
         Box <table> at (9,9) content-size 496.1875x202 table-box [TFC] children: not-inline
-          Box <tbody> at (9,9) content-size 488.1875x198 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 488.1875x198 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 492.1875x198 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 492.1875x198 table-row children: not-inline
               BlockContainer <td> at (71,71) content-size 26.640625x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x17] baseline: 13.296875
                     "top"
@@ -25,8 +25,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 498.1875x204]
         PaintableBox (Box<TABLE>) [8,8 498.1875x204]
-          PaintableBox (Box<TBODY>) [9,9 488.1875x198] overflow: [9,9 494.1875x200]
-            PaintableBox (Box<TR>) [11,11 488.1875x198] overflow: [11,11 492.1875x198]
+          PaintableBox (Box<TBODY>) [11,11 492.1875x198]
+            PaintableBox (Box<TR>) [11,11 492.1875x198]
               PaintableWithLines (BlockContainer<TD>) [11,11 146.640625x198]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.640625,11 165.4375x198]

--- a/Tests/LibWeb/Layout/expected/table/table-max-content-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-max-content-width.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x124 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 126x124 [BFC] children: not-inline
         Box <table.table> at (18,18) content-size 106x104 table-box [TFC] children: not-inline
-          Box <tbody> at (18,18) content-size 102x100 table-row-group children: not-inline
+          Box <tbody> at (20,20) content-size 102x100 table-row-group children: not-inline
             Box <tr> at (20,20) content-size 102x100 table-row children: not-inline
               BlockContainer <td> at (21,70) content-size 100x0 table-cell [BFC] children: not-inline
 
@@ -12,6 +12,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x124]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 126x124]
         PaintableBox (Box<TABLE>.table) [8,8 126x124]
-          PaintableBox (Box<TBODY>) [18,18 102x100] overflow: [18,18 104x102]
+          PaintableBox (Box<TBODY>) [20,20 102x100]
             PaintableBox (Box<TR>) [20,20 102x100]
               PaintableWithLines (BlockContainer<TD>) [20,20 102x100]

--- a/Tests/LibWeb/Layout/expected/table/table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-width.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x214 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 784x214 [BFC] children: not-inline
         Box <table.table> at (108,108) content-size 584x14 table-box [TFC] children: not-inline
-          Box <tbody> at (108,108) content-size 580x10 table-row-group children: not-inline
+          Box <tbody> at (110,110) content-size 580x10 table-row-group children: not-inline
             Box <tr> at (110,110) content-size 580x10 table-row children: not-inline
               BlockContainer <td.cell> at (111,115) content-size 578x0 table-cell [BFC] children: not-inline
 
@@ -12,6 +12,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x214]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 784x214]
         PaintableBox (Box<TABLE>.table) [8,8 784x214]
-          PaintableBox (Box<TBODY>) [108,108 580x10] overflow: [108,108 582x12]
+          PaintableBox (Box<TBODY>) [110,110 580x10]
             PaintableBox (Box<TR>) [110,110 580x10]
               PaintableWithLines (BlockContainer<TD>.cell) [110,110 580x10]

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 144.1875x204 [BFC] children: not-inline
         Box <table> at (9,9) content-size 142.1875x202 table-box [TFC] children: not-inline
-          Box <tbody> at (9,9) content-size 134.1875x198 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 134.1875x198 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 138.1875x198 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 138.1875x198 table-row children: not-inline
               BlockContainer <td> at (12,12) content-size 26.640625x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x17] baseline: 13.296875
                     "top"
@@ -25,8 +25,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 144.1875x204]
         PaintableBox (Box<TABLE>) [8,8 144.1875x204]
-          PaintableBox (Box<TBODY>) [9,9 134.1875x198] overflow: [9,9 140.1875x200]
-            PaintableBox (Box<TR>) [11,11 134.1875x198] overflow: [11,11 138.1875x198]
+          PaintableBox (Box<TBODY>) [11,11 138.1875x198]
+            PaintableBox (Box<TR>) [11,11 138.1875x198]
               PaintableWithLines (BlockContainer<TD>) [11,11 28.640625x198]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [41.640625,11 47.4375x198]

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 56.46875x19 table-row-group children: not-inline
+          Box <tbody> at (10,37) content-size 56.46875x19 table-row-group children: not-inline
             Box <tr> at (10,37) content-size 56.46875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
@@ -31,7 +31,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-2 800x602]
         PaintableBox (Box<TABLE>) [8,35 60.46875x23] overflow: [8,-2 60.46875x60]
           PaintableWithLines (BlockContainer<CAPTION>) [8,-2 60.46875x37]
             TextPaintable (TextNode<#text>)
-          PaintableBox (Box<TBODY>) [8,8 56.46875x19] overflow: [8,8 58.46875x48]
+          PaintableBox (Box<TBODY>) [10,37 56.46875x19]
             PaintableBox (Box<TR>) [10,37 56.46875x19]
               PaintableWithLines (BlockContainer<TD>) [10,37 56.46875x19]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/tr-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/tr-valign.txt
@@ -3,8 +3,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x510 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 216x510 [BFC] children: not-inline
         Box <table> at (9,9) content-size 214x508 table-box [TFC] children: not-inline
-          Box <tbody> at (9,9) content-size 208x504 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 208x504 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 210x504 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 210x504 table-row children: not-inline
               BlockContainer <td> at (12,12) content-size 102x502 table-cell [BFC] children: not-inline
                 BlockContainer <div> at (13,13) content-size 100x500 children: not-inline
               BlockContainer <td> at (118,12) content-size 102x102 table-cell [BFC] children: not-inline
@@ -16,8 +16,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x510]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 216x510]
         PaintableBox (Box<TABLE>) [8,8 216x510]
-          PaintableBox (Box<TBODY>) [9,9 208x504] overflow: [9,9 212x506]
-            PaintableBox (Box<TR>) [11,11 208x504] overflow: [11,11 210x504]
+          PaintableBox (Box<TBODY>) [11,11 210x504]
+            PaintableBox (Box<TR>) [11,11 210x504]
               PaintableWithLines (BlockContainer<TD>) [11,11 104x504]
                 PaintableWithLines (BlockContainer<DIV>) [12,12 102x502]
               PaintableWithLines (BlockContainer<TD>) [117,11 104x504]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -10,8 +10,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <col> (not painted) children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 412x21 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 412x21 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 414x21 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 414x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 46x17 table-cell [BFC] children: inline
@@ -34,8 +34,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27]
         PaintableBox (Box<TABLE>) [8,8 420x27]
-          PaintableBox (Box<TBODY>) [9,9 412x21] overflow: [9,9 416x23]
-            PaintableBox (Box<TR>) [11,11 412x21] overflow: [11,11 414x21]
+          PaintableBox (Box<TBODY>) [11,11 414x21]
+            PaintableBox (Box<TR>) [11,11 414x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 50x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [63,11 362x21]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -10,8 +10,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <col> (not painted) children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 412x21 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 412x21 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 414x21 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 414x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -34,8 +34,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27]
         PaintableBox (Box<TABLE>) [8,8 420x27]
-          PaintableBox (Box<TBODY>) [9,9 412x21] overflow: [9,9 416x23]
-            PaintableBox (Box<TR>) [11,11 412x21] overflow: [11,11 414x21]
+          PaintableBox (Box<TBODY>) [11,11 414x21]
+            PaintableBox (Box<TR>) [11,11 414x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x21]

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -5,8 +5,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 418x25 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (9,9) content-size 412x21 table-row-group children: not-inline
-            Box <tr> at (11,11) content-size 412x21 table-row children: not-inline
+          Box <tbody> at (11,11) content-size 414x21 table-row-group children: not-inline
+            Box <tr> at (11,11) content-size 414x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: inline
@@ -29,8 +29,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x27]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 420x27]
         PaintableBox (Box<TABLE>) [8,8 420x27]
-          PaintableBox (Box<TBODY>) [9,9 412x21] overflow: [9,9 416x23]
-            PaintableBox (Box<TR>) [11,11 412x21] overflow: [11,11 414x21]
+          PaintableBox (Box<TBODY>) [11,11 414x21]
+            PaintableBox (Box<TR>) [11,11 414x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x21]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x21]

--- a/Tests/LibWeb/Layout/expected/zero_percent_width_nested_table.txt
+++ b/Tests/LibWeb/Layout/expected/zero_percent_width_nested_table.txt
@@ -3,12 +3,12 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x12 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 12x12 [BFC] children: not-inline
         Box <table> at (8,8) content-size 12x12 table-box [TFC] children: not-inline
-          Box <tbody> at (8,8) content-size 8x8 table-row-group children: not-inline
+          Box <tbody> at (10,10) content-size 8x8 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 8x8 table-row children: not-inline
               BlockContainer <td> at (11,11) content-size 6x6 table-cell [BFC] children: not-inline
                 TableWrapper <(anonymous)> at (11,11) content-size 6x6 [BFC] children: not-inline
                   Box <table> at (11,11) content-size 6x6 table-box [TFC] children: not-inline
-                    Box <tbody> at (11,11) content-size 2x2 table-row-group children: not-inline
+                    Box <tbody> at (13,13) content-size 2x2 table-row-group children: not-inline
                       Box <tr> at (13,13) content-size 2x2 table-row children: not-inline
                         BlockContainer <td> at (14,14) content-size 0x0 table-cell [BFC] children: inline
                           TextNode <#text>
@@ -18,11 +18,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x12]
       PaintableWithLines (TableWrapper(anonymous)) [8,8 12x12]
         PaintableBox (Box<TABLE>) [8,8 12x12]
-          PaintableBox (Box<TBODY>) [8,8 8x8] overflow: [8,8 10x10]
+          PaintableBox (Box<TBODY>) [10,10 8x8]
             PaintableBox (Box<TR>) [10,10 8x8]
               PaintableWithLines (BlockContainer<TD>) [10,10 8x8]
                 PaintableWithLines (TableWrapper(anonymous)) [11,11 6x6]
                   PaintableBox (Box<TABLE>) [11,11 6x6]
-                    PaintableBox (Box<TBODY>) [11,11 2x2] overflow: [11,11 4x4]
+                    PaintableBox (Box<TBODY>) [13,13 2x2]
                       PaintableBox (Box<TR>) [13,13 2x2]
                         PaintableWithLines (BlockContainer<TD>) [13,13 2x2]


### PR DESCRIPTION
Fix several table-related overflow issues.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/1525 #1510

## Issue

Currently, tables are producing overflow when they shouldn't (specifically row groups and row elements are getting overflow). This is because they either aren't using border spacing in their offset calculation (the case for row groups) or they aren't taking border spacing into account in their width calculations (the case for row elements).

## Changes

1. Include vertical border spacing in row group offset calculation so that they are axis-aligned with child row/cell elements:

![image](https://github.com/user-attachments/assets/169f5ac3-5d9d-443c-b019-1f6b6d624f08)

This makes it so there isn't horizontal and vertical overflow caused by child row/cell elements.

2. Include horizontal border spacing in `tr` width calculations:

![image](https://github.com/user-attachments/assets/4d6137b2-7ed3-4eab-af40-df49264c7b97)

This makes it so `tr` elements don't have overflow anymore when there are multiple columns.

3. Apply vertical caption offset to row group top offset:

![image](https://github.com/user-attachments/assets/bc575402-e777-4810-ba06-26f851ff9885)

4. Don't double-count top padding when calculating vertical offset for rows and row groups:

![image](https://github.com/user-attachments/assets/23573882-08fc-4f8e-84dd-ed67bb926c47)

## Rebaselined tests

- [x] css-pseudo-element-should-not-be-affected-by-presentational-hints.html
- [x] zero_percent_width_nested_table.html
- [x] table-fixup-with-rowspan.html
- [x] table/basic.html
- [x] table/width-distribution-and-constrained-columns-size-on-col.html
- [x] table/row-outer-size-with-computed-size.html
- [x] table/border-attribute.html
- [x] table/inline-table-width.html
- [x] table/cell-with-max-width.html
- [x] table/propagate-style-update-to-wrapper.html
- [x] table/borders.html
- [x] table/width-distribution-and-constrained-columns-increased-size-on-col.html
- [x] table/width-distribution-and-constrained-columns.html
- [x] table/table-width.html
- [x] table/border-spacing-with-percentage-width.html
- [x] table/stretch-to-fixed-height.html
- [x] table/multi-line-cell.html
- [x] table/columns-width-distribution-1.html
- [x] table/border-spacing-and-borders-table-width.html
- [x] table/style-invalidation-propagation-to-table-wrapper.html
- [x] table/border-spacing-colspan.html
- [x] table/bottom-caption.html
- [x] table/internal-alignment.html
- [x] table/table-cellpadding.html
- [x] table/nested-table-box-width.html
- [x] table/colgroup-with-two-cols.html
- [x] table/percentage-width-for-nested-table-is-like-auto.html
- [x] table/long-caption-increases-width.html
- [x] table/rowspan.html
- [x] table/border-attribute-overridden-by-css.html
- [x] table/top-caption-with-padding.html
- [x] table/nested-table-alignment.html
- [x] table/table-align-center-with-margin.html
- [x] table/tr-valign.html
- [x] table/avoid-div-by-zero-in-table-measures.html
  - #1790
- [x] table/cell-relative-to-specified-table-width.html
- [x] table/td-valign.html
- [x] table/cell-auto-max-width-table-percentage-width.html
- [x] table/row-span-and-nested-tables.html
- [x] table/border-spacing.html
- [x] table/table-max-content-width.html
- [x] table/border-spacing-rowspan.html
- [x] table/table-align-center.html
- [x] table/abspos-pseudo-element-inside-table.html
- [x] table/keyword-value-does-not-constrain-column.html
- [x] table/sum-of-percentage-column-widths-less-than-100.html
- [x] blockify-layout-internal-box-without-crashing.html
- [x] grid/floating-table-wrapper-width.html
