### PR TITLE
LibWeb: Fire error event when script has an execution error

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-onerror.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-onerror.txt
@@ -1,0 +1,1 @@
+onerror event fired: Error: Uncaught error

--- a/Tests/LibWeb/Text/input/HTML/Window-onerror.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-onerror.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        window.addEventListener("error", (event) => {
+            println(`onerror event fired: ${event.error}`);
+            done();
+        });
+
+        try {
+            throw new Error("FAIL");
+        } catch (e) {}
+
+        throw new Error("Uncaught error");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
 #include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
 
@@ -91,8 +92,10 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<JS::Handle<DOM::DOMEvent
 
         // If this throws an exception, then:
         if (result.is_error()) {
-            // 1. Report the exception.
-            HTML::report_exception(result, realm);
+            // 1. Report exception for listener’s callback’s corresponding JavaScript object’s associated realm’s global object.
+            auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&global);
+            VERIFY(window_or_worker);
+            window_or_worker->report_an_exception(*result.release_error().value());
 
             // FIXME: 2. Set legacyOutputDidListenersThrowFlag if given. (Only used by IndexedDB currently)
         }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
+#include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
 #include <LibWeb/WebIDL/DOMException.h>
 
 namespace Web::HTML {
@@ -126,8 +127,10 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::En
         // 3. Otherwise, rethrow errors is false. Perform the following steps:
         VERIFY(rethrow_errors == RethrowErrors::No);
 
-        // 1. Report the exception given by evaluationStatus.[[Value]] for script.
-        report_exception(evaluation_status, settings_object().realm());
+        // 1. Report an exception given by evaluationStatus.[[Value]] for script's settings object's global object.
+        auto* window_or_worker = dynamic_cast<WindowOrWorkerGlobalScopeMixin*>(&settings.global_object());
+        VERIFY(window_or_worker);
+        window_or_worker->report_an_exception(*evaluation_status.value());
 
         // 2. Clean up after running script with settings.
         settings.clean_up_after_running_script();

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -747,6 +747,13 @@ JS::NonnullGCPtr<JS::Object> WindowOrWorkerGlobalScopeMixin::supported_entry_typ
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-reporterror
 void WindowOrWorkerGlobalScopeMixin::report_error(JS::Value e)
 {
+    // The reportError(e) method steps are to report an exception e for this.
+    report_an_exception(e);
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#report-an-exception
+void WindowOrWorkerGlobalScopeMixin::report_an_exception(JS::Value const& e)
+{
     auto& target = static_cast<DOM::EventTarget&>(this_impl());
     auto& realm = relevant_realm(target);
     auto& vm = realm.vm();

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -77,6 +77,7 @@ public:
     JS::NonnullGCPtr<IndexedDB::IDBFactory> indexed_db();
 
     void report_error(JS::Value e);
+    void report_an_exception(JS::Value const& e);
 
     [[nodiscard]] JS::NonnullGCPtr<Crypto::Crypto> crypto();
 


### PR DESCRIPTION
We now use the "report an exception" AO when a script has an execution error. This has mostly replaced the older "report the exception" AO in various specifications. Using this newer AO ensures that `window.onerror` is invoked when a script has an execution error.

NOTE: The "report an exception" AO we are now using implements a previous version of the specification, so does not follow the most recent spec text.

There are many other places in the specification where "report an exception" is now used where "report the exception" was used previously, I haven't updated all these places as part of this PR.

This stops a large number of WPT timeouts. For example, these are the results when running `./Meta/WPT.sh run css/css-typed-om/`:

Before:
```
Ran 362 tests finished in 185.0 seconds.
  • 12 ran as expected. 0 tests skipped.
  • 4 tests failed unexpectedly
  • 248 tests timed out unexpectedly
  • 98 tests had unexpected subtest results
```

After:
```
Ran 362 tests finished in 34.2 seconds.
  • 12 ran as expected. 0 tests skipped.
  • 267 tests had errors unexpectedly
  • 4 tests failed unexpectedly
  • 80 tests had unexpected subtest results
```