### PR TITLE
LibJS: Make function instantiation a bit more spec compliant

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -107,7 +107,7 @@ Value FunctionExpression::instantiate_ordinary_function_expression(VM& vm, Depre
     auto private_environment = vm.running_execution_context().private_environment;
 
     auto closure = ECMAScriptFunctionObject::create(realm, used_name, source_text(), body(), parameters(), function_length(), local_variables_names(), environment, private_environment, kind(), is_strict_mode(),
-        parsing_insights(), is_arrow_function());
+        parsing_insights(), false, is_arrow_function());
 
     // FIXME: 6. Perform SetFunctionName(closure, name).
     // FIXME: 7. Perform MakeConstructor(closure).
@@ -153,7 +153,7 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassMethod::class_element_evaluatio
     auto property_key_or_private_name = TRY(class_key_to_property_name(vm, *m_key, property_key));
 
     auto& method_function = *ECMAScriptFunctionObject::create(*vm.current_realm(), m_function->name(), m_function->source_text(), m_function->body(), m_function->parameters(), m_function->function_length(), m_function->local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, m_function->kind(), m_function->is_strict_mode(),
-        m_function->parsing_insights(), m_function->is_arrow_function());
+        m_function->parsing_insights(), false, m_function->is_arrow_function());
 
     auto method_value = Value(&method_function);
     method_function.make_method(target);
@@ -243,7 +243,7 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
         FunctionParsingInsights parsing_insights;
         parsing_insights.uses_this_from_environment = true;
         parsing_insights.uses_this = true;
-        initializer = make_handle(*ECMAScriptFunctionObject::create(realm, "field", ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, parsing_insights, false, property_key_or_private_name));
+        initializer = make_handle(*ECMAScriptFunctionObject::create(realm, "field", ByteString::empty(), *function_code, {}, 0, {}, vm.lexical_environment(), vm.running_execution_context().private_environment, FunctionKind::Normal, true, parsing_insights, false, false, property_key_or_private_name));
         initializer->make_method(target);
     }
 
@@ -290,7 +290,7 @@ ThrowCompletionOr<ClassElement::ClassValue> StaticInitializer::class_element_eva
     FunctionParsingInsights parsing_insights;
     parsing_insights.uses_this_from_environment = true;
     parsing_insights.uses_this = true;
-    auto body_function = ECMAScriptFunctionObject::create(realm, ByteString::empty(), ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, parsing_insights, false);
+    auto body_function = ECMAScriptFunctionObject::create(realm, ByteString::empty(), ByteString::empty(), *m_function_body, {}, 0, m_function_body->local_variables_names(), lexical_environment, private_environment, FunctionKind::Normal, true, parsing_insights);
 
     // 6. Perform MakeMethod(bodyFunction, homeObject).
     body_function->make_method(home_object);
@@ -353,6 +353,7 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> ClassExpression::create_class_const
         constructor.kind(),
         constructor.is_strict_mode(),
         parsing_insights,
+        false,
         constructor.is_arrow_function());
 
     class_constructor->set_name(class_name);

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1630,8 +1630,7 @@ void ScopeNode::block_declaration_instantiation(VM& vm, Environment* environment
             auto& function_declaration = static_cast<FunctionDeclaration const&>(declaration);
 
             // ii. Let fo be InstantiateFunctionObject of d with arguments env and privateEnv.
-            auto function = ECMAScriptFunctionObject::create(realm, function_declaration.name(), function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(),
-                function_declaration.parsing_insights());
+            auto function = ECMAScriptFunctionObject::instantiate_function_object(realm, environment, private_environment, function_declaration);
 
             // iii. Perform ! env.InitializeBinding(fn, fo). NOTE: This step is replaced in section B.3.2.6.
             if (function_declaration.name_identifier()->is_local()) {
@@ -1838,8 +1837,7 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(VM& vm, Global
     for (auto& declaration : functions_to_initialize.in_reverse()) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments env and privateEnv.
-        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), &global_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
-            declaration.parsing_insights());
+        auto function = ECMAScriptFunctionObject::instantiate_function_object(realm, &global_environment, private_environment, declaration);
 
         // c. Perform ? env.CreateGlobalFunctionBinding(fn, fo, false).
         TRY(global_environment.create_global_function_binding(declaration.name(), function, false));

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1261,7 +1261,7 @@ inline Value new_function(VM& vm, FunctionNode const& function_node, Optional<Id
         value = function_node.instantiate_ordinary_function_expression(vm, name);
     } else {
         value = ECMAScriptFunctionObject::create(*vm.current_realm(), function_node.name(), function_node.source_text(), function_node.body(), function_node.parameters(), function_node.function_length(), function_node.local_variables_names(), vm.lexical_environment(), vm.running_execution_context().private_environment, function_node.kind(), function_node.is_strict_mode(),
-            function_node.parsing_insights(), function_node.is_arrow_function());
+            function_node.parsing_insights(), false, function_node.is_arrow_function());
     }
 
     if (home_object.has_value()) {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -972,8 +972,7 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, Program const& pr
     for (auto& declaration : functions_to_initialize.in_reverse()) {
         // a. Let fn be the sole element of the BoundNames of f.
         // b. Let fo be InstantiateFunctionObject of f with arguments lexEnv and privateEnv.
-        auto function = ECMAScriptFunctionObject::create(realm, declaration.name(), declaration.source_text(), declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), lexical_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
-            declaration.parsing_insights());
+        auto function = ECMAScriptFunctionObject::instantiate_function_object(realm, lexical_environment, private_environment, declaration);
 
         // c. If varEnv is a global Environment Record, then
         if (global_var_environment) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -33,7 +33,116 @@ namespace JS {
 
 JS_DEFINE_ALLOCATOR(ECMAScriptFunctionObject);
 
-NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, FunctionParsingInsights parsing_insights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
+// 8.6.1 Runtime Semantics: InstantiateFunctionObject, https://tc39.es/ecma262/#sec-runtime-semantics-instantiatefunctionobject
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::instantiate_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration)
+{
+    switch (declaration.kind()) {
+    case FunctionKind::Normal:
+        return ECMAScriptFunctionObject::instantiate_ordinary_function_object(realm, global_environment, private_environment, declaration);
+    case FunctionKind::Generator:
+        return ECMAScriptFunctionObject::instantiate_generator_function_object(realm, global_environment, private_environment, declaration);
+    case FunctionKind::Async:
+        return ECMAScriptFunctionObject::instantiate_async_function_object(realm, global_environment, private_environment, declaration);
+    case FunctionKind::AsyncGenerator:
+        return ECMAScriptFunctionObject::instantiate_generator_function_object(realm, global_environment, private_environment, declaration);
+    }
+
+    VERIFY_NOT_REACHED();
+}
+
+// 15.2.4 Runtime Semantics: InstantiateOrdinaryFunctionObject, https://tc39.es/ecma262/#sec-runtime-semantics-instantiateordinaryfunctionobject
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::instantiate_ordinary_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration)
+{
+    // 1. Let name be the StringValue of BindingIdentifier.
+    // NOTE: Special case if the function is a default export of an anonymous function
+    //       it has name "*default*" but internally should have name "default".
+    auto name = (declaration.name().is_empty() || declaration.name() == ExportStatement::local_name_for_default) ? "default"sv : declaration.name();
+
+    // 2. Let sourceText be the source text matched by FunctionDeclaration.
+    auto source_text = declaration.source_text();
+
+    // 3. Let F be OrdinaryFunctionCreate(%Function.prototype%, sourceText, FormalParameters, FunctionBody, non-lexical-this, env, privateEnv).
+    auto function = ECMAScriptFunctionObject::create(realm, name, *realm.intrinsics().function_prototype(), source_text, declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), global_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
+        declaration.parsing_insights(), true);
+
+    // 4. Perform SetFunctionName(F, name).
+    function->set_function_name(PropertyKey(name.to_byte_string()));
+
+    // 5. Perform MakeConstructor(F).
+    function->make_constructor();
+
+    // 6. Return F.
+    return function;
+}
+
+// 15.8.2 Runtime Semantics: InstantiateAsyncFunctionObject, https://tc39.es/ecma262/#sec-runtime-semantics-instantiateasyncfunctionobject
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::instantiate_async_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration)
+{
+    // 1. Let name be the StringValue of BindingIdentifier.
+    // NOTE: Special case if the function is a default export of an anonymous function
+    //       it has name "*default*" but internally should have name "default".
+    auto name = (declaration.name().is_empty() || declaration.name() == ExportStatement::local_name_for_default) ? "default"sv : declaration.name();
+
+    // 2. Let sourceText be the source text matched by AsyncFunctionDeclaration.
+    auto source_text = declaration.source_text();
+
+    // 3. Let F be OrdinaryFunctionCreate(%AsyncFunction.prototype%, sourceText, FormalParameters, AsyncFunctionBody, non-lexical-this, env, privateEnv).
+    auto function = ECMAScriptFunctionObject::create(realm, name, *realm.intrinsics().async_function_prototype(), source_text, declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), global_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
+        declaration.parsing_insights(), true);
+
+    // 4. Perform SetFunctionName(F, name).
+    function->set_function_name(PropertyKey(name.to_byte_string()));
+
+    // 5. Return F.
+    return function;
+}
+
+// 15.5.3 Runtime Semantics: InstantiateGeneratorFunctionObject, https://tc39.es/ecma262/#sec-runtime-semantics-instantiategeneratorfunctionobject
+// 15.6.3 Runtime Semantics: InstantiateAsyncGeneratorFunctionObject, https://tc39.es/ecma262/#sec-runtime-semantics-instantiateasyncgeneratorfunctionobject
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::instantiate_generator_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration)
+{
+    // NOTE: InstantiateGeneratorFunctionObject and InstantiateAsyncGeneratorFunctionObject do the exact same thing, the only difference is which prototype is used,
+    // %GeneratorFunction.prototype% for GeneratorFunctionObject and %AsyncGeneratorFunction.prototype% for AsyncGeneratorFunctionObject.
+    VERIFY(declaration.kind() == FunctionKind::Generator || declaration.kind() == FunctionKind::AsyncGenerator);
+
+    // 1. Let name be the StringValue of BindingIdentifier.
+    // NOTE: Special case if the function is a default export of an anonymous function
+    //       it has name "*default*" but internally should have name "default".
+    auto name = (declaration.name().is_empty() || declaration.name() == ExportStatement::local_name_for_default) ? "default"sv : declaration.name();
+
+    // 2. Let sourceText be the source text matched by GeneratorDeclaration.
+    auto source_text = declaration.source_text();
+
+    // 3. Let F be OrdinaryFunctionCreate(%GeneratorFunction.prototype%, sourceText, FormalParameters, GeneratorBody, non-lexical-this, env, privateEnv).
+    // 3. Let F be OrdinaryFunctionCreate(%AsyncGeneratorFunction.prototype%, sourceText, FormalParameters, AsyncGeneratorBody, non-lexical-this, env, privateEnv).
+    Object* generator_function_prototype;
+    if (declaration.kind() == FunctionKind::Generator)
+        generator_function_prototype = realm.intrinsics().generator_function_prototype();
+    else
+        generator_function_prototype = realm.intrinsics().async_generator_function_prototype();
+
+    NonnullGCPtr<ECMAScriptFunctionObject> function = ECMAScriptFunctionObject::create(realm, name, *generator_function_prototype, source_text, declaration.body(), declaration.parameters(), declaration.function_length(), declaration.local_variables_names(), global_environment, private_environment, declaration.kind(), declaration.is_strict_mode(),
+        declaration.parsing_insights(), true);
+
+    // 4. Perform SetFunctionName(F, name).
+    function->set_function_name(PropertyKey(name.to_byte_string()));
+
+    // 5. Let prototype be OrdinaryObjectCreate(%GeneratorFunction.prototype.prototype%).
+    // 5. Let prototype be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
+    GCPtr<Object> prototype;
+    if (declaration.kind() == FunctionKind::Generator)
+        prototype = Object::create_prototype(realm, realm.intrinsics().generator_function_prototype_prototype());
+    else
+        prototype = Object::create_prototype(realm, realm.intrinsics().async_generator_function_prototype_prototype());
+
+    // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
+    MUST(function->define_property_or_throw(realm.vm().names.prototype, PropertyDescriptor { .value = prototype, .writable = true, .enumerable = false, .configurable = false }));
+
+    // 7. Return F.
+    return function;
+}
+
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, FunctionParsingInsights parsing_insights, bool skip_initialization, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
     Object* prototype = nullptr;
     switch (kind) {
@@ -50,15 +159,15 @@ NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& r
         prototype = realm.intrinsics().async_generator_function_prototype();
         break;
     }
-    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, *prototype, kind, is_strict, parsing_insights, is_arrow_function, move(class_field_initializer_name));
+    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, *prototype, kind, is_strict, parsing_insights, skip_initialization, is_arrow_function, move(class_field_initializer_name));
 }
 
-NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, FunctionParsingInsights parsing_insights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
+NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::create(Realm& realm, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind kind, bool is_strict, FunctionParsingInsights parsing_insights, bool skip_initialization, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
-    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, prototype, kind, is_strict, parsing_insights, is_arrow_function, move(class_field_initializer_name));
+    return realm.heap().allocate<ECMAScriptFunctionObject>(realm, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, move(local_variables_names), parent_environment, private_environment, prototype, kind, is_strict, parsing_insights, skip_initialization, is_arrow_function, move(class_field_initializer_name));
 }
 
-ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> formal_parameters, i32 function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind kind, bool strict, FunctionParsingInsights parsing_insights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
+ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> formal_parameters, i32 function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind kind, bool strict, FunctionParsingInsights parsing_insights, bool skip_initialization, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
     : FunctionObject(prototype)
     , m_name(move(name))
     , m_function_length(function_length)
@@ -75,6 +184,7 @@ ECMAScriptFunctionObject::ECMAScriptFunctionObject(DeprecatedFlyString name, Byt
     , m_contains_direct_call_to_eval(parsing_insights.contains_direct_call_to_eval)
     , m_is_arrow_function(is_arrow_function)
     , m_kind(kind)
+    , m_skip_initialization(skip_initialization)
 {
     // NOTE: This logic is from OrdinaryFunctionCreate, https://tc39.es/ecma262/#sec-ordinaryfunctioncreate
 
@@ -348,6 +458,13 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
     m_name_string = PrimitiveString::create(vm, m_name);
 
     MUST(define_property_or_throw(vm.names.length, { .value = Value(m_function_length), .writable = false, .enumerable = false, .configurable = true }));
+
+    // NOTE: When instantiating JS functions from functions that match the spec e.g (instantiate_ordinary_function_object) we won't need the code below, so let's skip it.
+    //       However, if we're instantiating from other places that do not match the spec, the code below is needed.
+    // FIXME: make sure functions that call ECMAScriptFunctionObject::create() won't need the code below then remove it.
+    if (m_skip_initialization)
+        return;
+
     MUST(define_property_or_throw(vm.names.name, { .value = m_name_string, .writable = false, .enumerable = false, .configurable = true }));
 
     if (!m_is_arrow_function) {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -131,9 +131,9 @@ NonnullGCPtr<ECMAScriptFunctionObject> ECMAScriptFunctionObject::instantiate_gen
     // 5. Let prototype be OrdinaryObjectCreate(%AsyncGeneratorFunction.prototype.prototype%).
     GCPtr<Object> prototype;
     if (declaration.kind() == FunctionKind::Generator)
-        prototype = Object::create_prototype(realm, realm.intrinsics().generator_function_prototype_prototype());
+        prototype = Object::create_with_premade_shape(realm.intrinsics().generator_function_prototype_shape());
     else
-        prototype = Object::create_prototype(realm, realm.intrinsics().async_generator_function_prototype_prototype());
+        prototype = Object::create_with_premade_shape(realm.intrinsics().async_generator_function_prototype_shape());
 
     // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: true, [[Enumerable]]: false, [[Configurable]]: false }).
     MUST(function->define_property_or_throw(realm.vm().names.prototype, PropertyDescriptor { .value = prototype, .writable = true, .enumerable = false, .configurable = false }));
@@ -471,17 +471,17 @@ void ECMAScriptFunctionObject::initialize(Realm& realm)
         Object* prototype = nullptr;
         switch (m_kind) {
         case FunctionKind::Normal:
-            prototype = Object::create_prototype(realm, realm.intrinsics().object_prototype());
+            prototype = Object::create_with_premade_shape(realm.intrinsics().object_prototype_shape());
             MUST(prototype->define_property_or_throw(vm.names.constructor, { .value = this, .writable = true, .enumerable = false, .configurable = true }));
             break;
         case FunctionKind::Generator:
             // prototype is "g1.prototype" in figure-2 (https://tc39.es/ecma262/img/figure-2.png)
-            prototype = Object::create_prototype(realm, realm.intrinsics().generator_function_prototype_prototype());
+            prototype = Object::create_with_premade_shape(realm.intrinsics().generator_function_prototype_shape());
             break;
         case FunctionKind::Async:
             break;
         case FunctionKind::AsyncGenerator:
-            prototype = Object::create_prototype(realm, realm.intrinsics().async_generator_function_prototype_prototype());
+            prototype = Object::create_with_premade_shape(realm.intrinsics().async_generator_function_prototype_shape());
             break;
         }
         // 27.7.4 AsyncFunction Instances, https://tc39.es/ecma262/#sec-async-function-instances

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -558,6 +558,44 @@ void ECMAScriptFunctionObject::visit_edges(Visitor& visitor)
         });
 }
 
+// 10.2.5 MakeConstructor ( F [ , writablePrototype [ , prototype ] ] ), https://tc39.es/ecma262/#sec-makeconstructor
+void ECMAScriptFunctionObject::make_constructor(GCPtr<Object> prototype)
+{
+    auto& vm = this->vm();
+
+    // 1. If F is an ECMAScript function object, then
+    // This is implicitly taken care of simply being in this method
+
+    // a. Assert: IsConstructor(F) is false.
+    VERIFY(is_class_constructor() == false);
+
+    // b. Assert: F is an extensible object that does not have a "prototype" own property.
+    VERIFY(MUST(is_extensible()));
+    VERIFY(!storage_has(vm.names.prototype));
+
+    // c. Set F.[[Construct]] to the definition specified in 10.2.2
+    // This is implicitly taken care of by the class ECMAScriptFunctionObject
+
+    // 3. Set F.[[ConstructorKind]] to base.
+    set_constructor_kind(ConstructorKind::Base);
+
+    // 4. If writablePrototype is not present, set writablePrototype to true.
+    bool writable_prototype = (prototype == nullptr);
+
+    // 5. If prototype is not present, then
+    if (prototype == nullptr) {
+        // a. Set prototype to OrdinaryObjectCreate(%Object.prototype%).
+        prototype = Object::create(*m_realm, m_realm->intrinsics().object_prototype());
+
+        // b. Perform ! DefinePropertyOrThrow(prototype, "constructor", PropertyDescriptor { [[Value]]: F, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: true }).
+        MUST(prototype->define_property_or_throw(vm.names.constructor, PropertyDescriptor { .value = this, .writable = writable_prototype, .enumerable = false, .configurable = true }));
+    }
+    // 6. Perform ! DefinePropertyOrThrow(F, "prototype", PropertyDescriptor { [[Value]]: prototype, [[Writable]]: writablePrototype, [[Enumerable]]: false, [[Configurable]]: false }).
+    MUST(define_property_or_throw(vm.names.prototype, PropertyDescriptor { .value = prototype, .writable = writable_prototype, .enumerable = false, .configurable = false }));
+
+    // 7. Return unused.
+}
+
 // 10.2.7 MakeMethod ( F, homeObject ), https://tc39.es/ecma262/#sec-makemethod
 void ECMAScriptFunctionObject::make_method(Object& home_object)
 {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -48,6 +48,7 @@ public:
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) override;
     virtual ThrowCompletionOr<NonnullGCPtr<Object>> internal_construct(ReadonlySpan<Value> arguments_list, FunctionObject& new_target) override;
 
+    void make_constructor(GCPtr<Object> prototype = nullptr);
     void make_method(Object& home_object);
 
     [[nodiscard]] bool is_module_wrapper() const { return m_is_module_wrapper; }
@@ -60,6 +61,7 @@ public:
     void set_name(DeprecatedFlyString const& name);
 
     void set_is_class_constructor() { m_is_class_constructor = true; }
+    bool is_class_constructor() const { return m_is_class_constructor; }
 
     auto& bytecode_executable() const { return m_bytecode_executable; }
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -39,8 +39,13 @@ public:
         Global,
     };
 
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
-    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool skip_initialization = false, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static NonnullGCPtr<ECMAScriptFunctionObject> create(Realm&, DeprecatedFlyString name, Object& prototype, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, FunctionKind, bool is_strict, FunctionParsingInsights, bool skip_initialization = false, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+
+    static NonnullGCPtr<ECMAScriptFunctionObject> instantiate_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration);
+    static NonnullGCPtr<ECMAScriptFunctionObject> instantiate_ordinary_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration);
+    static NonnullGCPtr<ECMAScriptFunctionObject> instantiate_async_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration);
+    static NonnullGCPtr<ECMAScriptFunctionObject> instantiate_generator_function_object(Realm& realm, Environment* global_environment, PrivateEnvironment* private_environment, FunctionNode const& declaration);
 
     virtual void initialize(Realm&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
@@ -111,7 +116,7 @@ protected:
     virtual Completion ordinary_call_evaluate_body();
 
 private:
-    ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, FunctionParsingInsights, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
+    ECMAScriptFunctionObject(DeprecatedFlyString name, ByteString source_text, Statement const& ecmascript_code, Vector<FunctionParameter> parameters, i32 m_function_length, Vector<DeprecatedFlyString> local_variables_names, Environment* parent_environment, PrivateEnvironment* private_environment, Object& prototype, FunctionKind, bool is_strict, FunctionParsingInsights, bool skip_initialization, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
 
     virtual bool is_ecmascript_function_object() const override { return true; }
     virtual void visit_edges(Visitor&) override;
@@ -167,6 +172,8 @@ private:
     bool m_is_module_wrapper { false };
     bool m_function_environment_needed { false };
     bool m_uses_this { false };
+    bool m_skip_initialization { false };
+
     Vector<VariableNameToInitialize> m_var_names_to_initialize_binding;
     Vector<DeprecatedFlyString> m_function_names_to_initialize_binding;
 

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -211,7 +211,16 @@ ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
     // These must be initialized separately as they have no companion constructor
     m_async_from_sync_iterator_prototype = heap().allocate<AsyncFromSyncIteratorPrototype>(realm, realm);
     m_async_generator_prototype = heap().allocate<AsyncGeneratorPrototype>(realm, realm);
+    m_async_generator_function_prototype_shape = heap().allocate_without_realm<Shape>(realm);
+    m_async_generator_function_prototype_shape->set_prototype_without_transition(m_async_generator_prototype);
+
     m_generator_prototype = heap().allocate<GeneratorPrototype>(realm, realm);
+    m_generator_function_prototype_shape = heap().allocate_without_realm<Shape>(realm);
+    m_generator_function_prototype_shape->set_prototype_without_transition(m_generator_prototype);
+
+    m_object_prototype_shape = heap().allocate_without_realm<Shape>(realm);
+    m_object_prototype_shape->set_prototype_without_transition(object_prototype());
+
     m_intl_segments_prototype = heap().allocate<Intl::SegmentsPrototype>(realm, realm);
     m_wrap_for_valid_iterator_prototype = heap().allocate<WrapForValidIteratorPrototype>(realm, realm);
 
@@ -364,7 +373,11 @@ JS_ENUMERATE_BUILTIN_NAMESPACE_OBJECTS
 void Intrinsics::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
+
     visitor.visit(m_realm);
+    visitor.visit(m_object_prototype_shape);
+    visitor.visit(m_generator_function_prototype_shape);
+    visitor.visit(m_async_generator_function_prototype_shape);
     visitor.visit(m_empty_object_shape);
     visitor.visit(m_new_object_shape);
     visitor.visit(m_iterator_result_object_shape);

--- a/Userland/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Userland/Libraries/LibJS/Runtime/Intrinsics.h
@@ -18,8 +18,11 @@ class Intrinsics final : public Cell {
 public:
     static ThrowCompletionOr<NonnullGCPtr<Intrinsics>> create(Realm&);
 
+    // Precomputed shapes for prototypes
+    NonnullGCPtr<Shape> object_prototype_shape() { return *m_object_prototype_shape; }
+    NonnullGCPtr<Shape> async_generator_function_prototype_shape() { return *m_async_generator_function_prototype_shape; }
+    NonnullGCPtr<Shape> generator_function_prototype_shape() { return *m_generator_function_prototype_shape; }
     NonnullGCPtr<Shape> empty_object_shape() { return *m_empty_object_shape; }
-
     NonnullGCPtr<Shape> new_object_shape() { return *m_new_object_shape; }
 
     [[nodiscard]] NonnullGCPtr<Shape> iterator_result_object_shape() { return *m_iterator_result_object_shape; }
@@ -121,6 +124,11 @@ private:
 #undef __JS_ENUMERATE
 
     NonnullGCPtr<Realm> m_realm;
+
+    // Precomputed shapes for prototypes
+    GCPtr<Shape> m_object_prototype_shape;
+    GCPtr<Shape> m_generator_function_prototype_shape;
+    GCPtr<Shape> m_async_generator_function_prototype_shape;
 
     GCPtr<Shape> m_empty_object_shape;
     GCPtr<Shape> m_new_object_shape;

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -495,13 +495,7 @@ ThrowCompletionOr<void> SourceTextModule::initialize_environment(VM& vm)
                 auto const& function_declaration = static_cast<FunctionDeclaration const&>(declaration);
 
                 // 1. Let fo be InstantiateFunctionObject of d with arguments env and privateEnv.
-                // NOTE: Special case if the function is a default export of an anonymous function
-                //       it has name "*default*" but internally should have name "default".
-                DeprecatedFlyString function_name = function_declaration.name();
-                if (function_name == ExportStatement::local_name_for_default)
-                    function_name = "default"sv;
-                auto function = ECMAScriptFunctionObject::create(realm(), function_name, function_declaration.source_text(), function_declaration.body(), function_declaration.parameters(), function_declaration.function_length(), function_declaration.local_variables_names(), environment, private_environment, function_declaration.kind(), function_declaration.is_strict_mode(),
-                    function_declaration.parsing_insights());
+                auto function = ECMAScriptFunctionObject::instantiate_function_object(realm(), environment, private_environment, function_declaration);
 
                 // 2. Perform ! env.InitializeBinding(dn, fo, normal).
                 MUST(environment->initialize_binding(vm, name, function, Environment::InitializeBindingHint::Normal));


### PR DESCRIPTION
We used to call `ECMAScriptFunctionObject::create()` to instantiate different types of JS functions with a lot of "prep" hidden in `ECMAScriptFunctionObject::initialize()`. This replaces that with `instantiate_function_object()` which matches the specs and organizes function initialization in one place.

To be safe I choose to skip the code in `ECMAScriptFunctionObject::initialize()` if we're instantiation from a   `instantiate_function_object()` otherwise that code will be executed since `ECMAScriptFunctionObject::create()` is called from a bunch of other places that may need it. I think ideally that code should be removed and JS function initialization should be done from functions that match the specs.

test262 diff:
```
None
```