### PR TITLE
LibWeb: Removed unused is_fixed_position flag from PushStackingContext

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -112,7 +112,6 @@ struct StackingContextMask {
 
 struct PushStackingContext {
     float opacity;
-    bool is_fixed_position;
     // The bounding box of the source paintable (pre-transform).
     Gfx::IntRect source_paintable_rect;
     // A translation to be applied after the stacking context has been transformed.

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -493,10 +493,6 @@ void DisplayListPlayerSkia::push_stacking_context(PushStackingContext const& com
         canvas.clipShader(builder.makeShader());
     }
 
-    if (command.is_fixed_position) {
-        // FIXME: Resetting matrix is not correct when element is nested in a transformed stacking context
-        canvas.resetMatrix();
-    }
     canvas.concat(matrix);
 }
 

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -297,7 +297,6 @@ void DisplayListRecorder::push_stacking_context(PushStackingContextParams params
 {
     append(PushStackingContext {
         .opacity = params.opacity,
-        .is_fixed_position = params.is_fixed_position,
         .source_paintable_rect = params.source_paintable_rect,
         // No translations apply to fixed-position stacking contexts.
         .post_transform_translation = params.is_fixed_position


### PR DESCRIPTION
This flag is no longer needed after we switched to using scroll frames to account for fixed position.