### PR TITLE
LibWeb/WebSocket: Allow sending binary blob data over a websocket

### DIFF
--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -287,7 +287,11 @@ void WebSocket::on_message(ByteBuffer message, bool is_text)
 
     if (m_binary_type == "blob") {
         // type indicates that the data is Binary and binaryType is "blob"
-        TODO();
+        HTML::MessageEventInit event_init;
+        event_init.data = FileAPI::Blob::create(realm(), message, "text/plain;charset=utf-8"_string);
+        event_init.origin = url().release_value_but_fixme_should_propagate_errors();
+        dispatch_event(HTML::MessageEvent::create(realm(), HTML::EventNames::message, event_init));
+        return;
     } else if (m_binary_type == "arraybuffer") {
         // type indicates that the data is Binary and binaryType is "arraybuffer"
         HTML::MessageEventInit event_init;

--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -615,6 +615,10 @@ void WebSocket::fatal_error(WebSocket::Error error)
 
 void WebSocket::discard_connection()
 {
+    if (m_discard_connection_requested)
+        return;
+    m_discard_connection_requested = true;
+
     deferred_invoke([this] {
         VERIFY(m_impl);
         m_impl->discard_connection();

--- a/Userland/Libraries/LibWebSocket/WebSocket.h
+++ b/Userland/Libraries/LibWebSocket/WebSocket.h
@@ -109,6 +109,8 @@ private:
     bool m_has_read_server_handshake_connection { false };
     bool m_has_read_server_handshake_accept { false };
 
+    bool m_discard_connection_requested { false };
+
     u16 m_last_close_code { 1005 };
     ByteString m_last_close_message;
 


### PR DESCRIPTION
Running `./Meta/WPT.sh run websockets` gives the following results.

Before:

```
Ran 758 tests finished in 187.2 seconds.
  • 324 ran as expected. 0 tests skipped.
  • 7 tests crashed unexpectedly
  • 45 tests had errors unexpectedly
  • 193 tests timed out unexpectedly
  • 360 tests had unexpected subtest results
```

After:

```
Ran 758 tests finished in 182.2 seconds.
  • 335 ran as expected. 0 tests skipped.
  • 45 tests had errors unexpectedly
  • 189 tests timed out unexpectedly
  • 356 tests had unexpected subtest results
```