### PR TITLE
LibWeb: Always blockify the root element

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-all-unset.txt
+++ b/Tests/LibWeb/Layout/expected/css-all-unset.txt
@@ -1,5 +1,5 @@
-Viewport <#document> at (0,0) content-size 800x600 children: inline
-  InlineNode <html>
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x17 [BFC] children: inline
     InlineNode <head>
       InlineNode <style>
         frag 0 from TextNode start: 1, length: 18, rect: [0,0 134.984375x17] baseline: 13.296875
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: inline
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  InlinePaintable (InlineNode<HTML>)
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x17]
     InlinePaintable (InlineNode<HEAD>)
       InlinePaintable (InlineNode<STYLE>)
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/html-display-contents.txt
+++ b/Tests/LibWeb/Layout/expected/html-display-contents.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 3, rect: [8,8 18.828125x17] baseline: 13.296875
+          "lol"
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/html-display-inline.txt
+++ b/Tests/LibWeb/Layout/expected/html-display-inline.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 3, rect: [8,8 18.828125x17] baseline: 13.296875
+          "lol"
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/replaced-within-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-within-max-content.txt
@@ -7,7 +7,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 0 from ImageBox start: 0, length: 0, rect: [8,8 150x150] baseline: 150
         ImageBox <img.replaced> at (8,8) content-size 150x150 children: not-inline
           (SVG-as-image isolated context)
-          Viewport <#document> at (0,0) content-size 150x150 [BFC] children: inline
+          Viewport <#document> at (0,0) content-size 150x150 [BFC] children: not-inline
             SVGSVGBox <svg> at (0,0) content-size 150x150 [SVG] children: not-inline
               SVGGeometryBox <path> at (0,0) content-size 150x150 children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
       ImageBox <img> at (8,8) content-size 50x100 children: not-inline
         (SVG-as-image isolated context)
-        Viewport <#document> at (0,0) content-size 50x100 [BFC] children: inline
+        Viewport <#document> at (0,0) content-size 50x100 [BFC] children: not-inline
           SVGSVGBox <svg> at (0,0) content-size 50x100 [SVG] children: not-inline
             SVGGeometryBox <rect> at (0,0) content-size 50x100 children: not-inline
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x1568 children: not-inline
       ImageBox <img> at (8,8) content-size 784x1568 children: not-inline
         (SVG-as-image isolated context)
-        Viewport <#document> at (0,0) content-size 784x1568 [BFC] children: inline
+        Viewport <#document> at (0,0) content-size 784x1568 [BFC] children: not-inline
           SVGSVGBox <svg> at (0,0) content-size 784x1568 [SVG] children: inline
             TextNode <#text>
             SVGGeometryBox <rect> at (0,0) content-size 784x1568 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-zero-intrinsic-size-and-no-viewbox.txt
@@ -1,9 +1,9 @@
-Viewport <#document> at (0,0) content-size 800x600 children: inline
-  InlineNode <svg>
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <svg> at (0,0) content-size 800x0 children: inline
     TextNode <#text>
     InlineNode <rect>
     TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  InlinePaintable (InlineNode<svg>)
+  PaintableWithLines (BlockContainer<svg>) [0,0 800x0]
     InlinePaintable (InlineNode<rect>)

--- a/Tests/LibWeb/Layout/expected/zero-height-viewport-svg-image.txt
+++ b/Tests/LibWeb/Layout/expected/zero-height-viewport-svg-image.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 0 from ImageBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       ImageBox <img> at (8,8) content-size 300x150 children: not-inline
         (SVG-as-image isolated context)
-        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: inline
+        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: not-inline
           SVGSVGBox <svg> at (0,0) content-size 300x150 [SVG] children: not-inline
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/zero-width-viewport-svg-image.txt
+++ b/Tests/LibWeb/Layout/expected/zero-width-viewport-svg-image.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 0 from ImageBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       ImageBox <img> at (8,8) content-size 300x150 children: not-inline
         (SVG-as-image isolated context)
-        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: inline
+        Viewport <#document> at (0,0) content-size 300x150 [BFC] children: not-inline
           SVGSVGBox <svg> at (0,0) content-size 300x150 [SVG] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/input/html-display-contents.html
+++ b/Tests/LibWeb/Layout/input/html-display-contents.html
@@ -1,0 +1,1 @@
+<html style="display:contents"><body>lol

--- a/Tests/LibWeb/Layout/input/html-display-inline.html
+++ b/Tests/LibWeb/Layout/input/html-display-inline.html
@@ -1,0 +1,1 @@
+<html style="display:inline">lol

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2177,8 +2177,16 @@ void StyleComputer::transform_box_type_if_needed(StyleProperties& style, DOM::El
     // (This has no effect on display types that generate no box at all, such as none or contents.)
 
     auto display = style.display();
-    if (display.is_none() || display.is_contents())
+
+    if (display.is_none() || (display.is_contents() && !element.is_document_element()))
         return;
+
+    // https://drafts.csswg.org/css-display/#root
+    // The root element’s display type is always blockified, and its principal box always establishes an independent formatting context.
+    if (element.is_document_element() && !display.is_block_outside()) {
+        style.set_property(CSS::PropertyID::Display, DisplayStyleValue::create(Display::from_short(CSS::Display::Short::Block)));
+        return;
+    }
 
     auto new_display = display;
 


### PR DESCRIPTION
This is what the spec tells us to do:

    The root element’s display type is always blockified,
    and its principal box always establishes an independent
    formatting context.

    Additionally, a display of contents computes to block
    on the root element.

Spec link: https://drafts.csswg.org/css-display/#root

Fixes #1562 