### PR TITLE
LibWeb: Forbid reentrancy of style-layout-repaint in EventLoop

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -174,6 +174,17 @@ void EventLoop::process()
     // 8. Microtasks: Perform a microtask checkpoint.
     perform_a_microtask_checkpoint();
 
+    if (m_is_running_reflow_steps) {
+        // NOTE: If we entered style-layout-repaint steps, then we need to wait for them to finish before doing next iteration.
+        schedule();
+        return;
+    }
+
+    m_is_running_reflow_steps = true;
+    ScopeGuard const guard = [this] {
+        m_is_running_reflow_steps = false;
+    };
+
     // 9. Let hasARenderingOpportunity be false.
     [[maybe_unused]] bool has_a_rendering_opportunity = false;
 

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -113,6 +113,8 @@ private:
     bool m_execution_paused { false };
 
     bool m_skip_event_loop_processing_steps { false };
+
+    bool m_is_running_reflow_steps { false };
 };
 
 EventLoop& main_thread_event_loop();


### PR DESCRIPTION
If the execution of the event loop's processing steps is interrupted, it's not possible to start the next iteration until the ongoing steps are done.

Fixes crashing on https://playbiolab.com/ in
VERIFY(page.client().is_ready_to_paint()) caused by attempting to start the next repaint before the ongoing repaint is done.