### PR TITLE
LibWeb: Disable worker-crypto test for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -3,6 +3,7 @@ Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-blob.html
+Text/input/Worker/Worker-crypto.html
 Text/input/Worker/Worker-echo.html
 Text/input/Worker/Worker-location.html
 Text/input/window-scrollTo.html


### PR DESCRIPTION
This times out on macOS CI.