### PR TITLE
Resolve document.fonts.ready() after fonts defined in CSS loaded

### DIFF
--- a/Tests/LibWeb/Text/input/css/FontFaceSet-setlike.html
+++ b/Tests/LibWeb/Text/input/css/FontFaceSet-setlike.html
@@ -2,7 +2,7 @@
 <script src="../include.js"></script>
 <script>
     test(() => {
-        const fontFaceSet = new FontFaceSet([]);
+        const fontFaceSet = document.fonts;
         const fontFace = new FontFace("Hash Sans", 'url(../../../../Ref/assets/HashSans.woff)');
 
         println("-- Empty FontFaceSet --");

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -29,9 +29,6 @@ JS::NonnullGCPtr<FontFaceSet> FontFaceSet::construct_impl(JS::Realm& realm, Vect
     for (auto const& face : initial_faces)
         set_entries->set_add(face);
 
-    if (set_entries->set_size() == 0)
-        WebIDL::resolve_promise(realm, *ready_promise);
-
     return realm.heap().allocate<FontFaceSet>(realm, realm, ready_promise, set_entries);
 }
 
@@ -44,9 +41,8 @@ FontFaceSet::FontFaceSet(JS::Realm& realm, JS::NonnullGCPtr<WebIDL::Promise> rea
     : DOM::EventTarget(realm)
     , m_set_entries(set_entries)
     , m_ready_promise(ready_promise)
+    , m_status(Bindings::FontFaceSetLoadStatus::Loaded)
 {
-    bool const is_ready = ready()->state() == JS::Promise::State::Fulfilled;
-    m_status = is_ready ? Bindings::FontFaceSetLoadStatus::Loaded : Bindings::FontFaceSetLoadStatus::Loading;
 }
 
 void FontFaceSet::initialize(JS::Realm& realm)
@@ -160,6 +156,11 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> FontFaceSet::load(String co
 JS::NonnullGCPtr<JS::Promise> FontFaceSet::ready() const
 {
     return verify_cast<JS::Promise>(*m_ready_promise->promise());
+}
+
+void FontFaceSet::resolve_ready_promise()
+{
+    WebIDL::resolve_promise(realm(), *m_ready_promise);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.h
@@ -43,6 +43,8 @@ public:
     JS::NonnullGCPtr<JS::Promise> ready() const;
     Bindings::FontFaceSetLoadStatus status() const { return m_status; }
 
+    void resolve_ready_promise();
+
 private:
     FontFaceSet(JS::Realm&, JS::NonnullGCPtr<WebIDL::Promise> ready_promise, JS::NonnullGCPtr<JS::Set> set_entries);
 

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.idl
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.idl
@@ -17,8 +17,6 @@ enum FontFaceSetLoadStatus { "loading", "loaded" };
 // https://drafts.csswg.org/css-font-loading/#fontfaceset
 [Exposed=(Window,Worker)]
 interface FontFaceSet : EventTarget {
-    constructor(sequence<FontFace> initialFaces);
-
     setlike<FontFace>;
     FontFaceSet add(FontFace font);
     boolean delete(FontFace font);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2863,4 +2863,16 @@ void StyleComputer::pop_ancestor(DOM::Element const& element)
     });
 }
 
+size_t StyleComputer::number_of_css_font_faces_with_loading_in_progress() const
+{
+    size_t count = 0;
+    for (auto const& [_, loaders] : m_loaded_fonts) {
+        for (auto const& loader : loaders) {
+            if (loader->is_loading())
+                ++count;
+        }
+    }
+    return count;
+}
+
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -159,6 +159,8 @@ public:
 
     [[nodiscard]] bool has_has_selectors() const { return m_has_has_selectors; }
 
+    size_t number_of_css_font_faces_with_loading_in_progress() const;
+
 private:
     enum class ComputeStyleMode {
         Normal,
@@ -260,6 +262,8 @@ public:
 
     RefPtr<Gfx::Font> font_with_point_size(float point_size);
     void start_loading_next_url();
+
+    bool is_loading() const { return resource() && resource()->is_pending(); }
 
 private:
     // ^ResourceClient


### PR DESCRIPTION
This is an ad-hoc implementation that resolves the ready() promise once
the document and all fonts collected by the style computer are done
loading. A spec-compliant implementation would include creating a proxy
CSS::FontFace for each @font-face and correctly implementing the
specification steps for font fetching, but we are far from there yet.

This hackish implementation should yield good WPT progress because it
will actually start waiting for the Ahem font to load before capturing
layout measurements. For example, it makes
https://wpt.live/css/css-grid/abspos/positioned-grid-descendants-001.html
go from 0/100 to 36/100 passing subtests.