### PR TITLE
Meta: Update vcpkg to fix build error

### DIFF
--- a/Toolchain/BuildVcpkg.sh
+++ b/Toolchain/BuildVcpkg.sh
@@ -21,7 +21,7 @@ if [ "$ci" -eq 0 ]; then
 fi
 
 GIT_REPO="https://github.com/microsoft/vcpkg.git"
-GIT_REV="a39a74405f277773aba08018bb797cb4a6614d0c" # 2024.09.19
+GIT_REV="2960d7d80e8d09c84ae8abf15c12196c2ca7d39a" # 2024.09.30
 PREFIX_DIR="$DIR/Local/vcpkg"
 
 mkdir -p "$DIR/Tarballs"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "builtin-baseline": "a39a74405f277773aba08018bb797cb4a6614d0c",
+  "builtin-baseline": "2960d7d80e8d09c84ae8abf15c12196c2ca7d39a",
   "dependencies": [
     {
       "name": "curl",


### PR DESCRIPTION
Fixes missing symbol on macOS Silicon and now it builds successfully.

Fixes #1526 