### PR TITLE
Inspector: Store as global Variable

### DIFF
--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -189,6 +189,16 @@ inspector.clearInspectedDOMNode = () => {
     }
 };
 
+inspector.setGlobalVariable = nodeID => {
+    if (nodeID === null) {
+        return;
+    }
+
+    let domNode = document.querySelector(`[data-id="${nodeID}"]`);
+
+    storeDOMNodeAsGlobalVariable(domNode);
+};
+
 inspector.editDOMNodeID = nodeID => {
     if (pendingEditDOMNode === null) {
         return;
@@ -483,6 +493,18 @@ const parseDOMAttributes = value => {
     element.innerHTML = `<div ${value}></div>`;
 
     return element.children[0].attributes;
+};
+
+let totalGlobalVariables = 0;
+const storeDOMNodeAsGlobalVariable = domNode => {
+    if (domNode === null) {
+        return;
+    }
+
+    const domNodeID = domNode.dataset.id;
+
+    inspector.inspectDOMNodeID(domNodeID);
+    inspector.setDOMNodeAsGlobalVariable(domNodeID, "temp" + ++totalGlobalVariables);
 };
 
 const editDOMNode = (domNode, textToSelect) => {

--- a/Ladybird/AppKit/UI/Inspector.mm
+++ b/Ladybird/AppKit/UI/Inspector.mm
@@ -190,6 +190,11 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
     m_inspector_client->context_menu_copy_dom_node();
 }
 
+- (void)storeDOMNodeAsGlobalVariable:(id)sender
+{
+    m_inspector_client->context_menu_store_dom_node_as_global_variable();
+}
+
 - (void)screenshotDOMNode:(id)sender
 {
     m_inspector_client->context_menu_screenshot_dom_node();
@@ -314,6 +319,12 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
         [_dom_node_tag_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Take node screenshot"
                                                                        action:@selector(screenshotDOMNode:)
                                                                 keyEquivalent:@""]];
+
+        [_dom_node_tag_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_dom_node_tag_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Store as global variable"
+                                                                       action:@selector(storeDOMNodeAsGlobalVariable:)
+                                                                keyEquivalent:@""]];
     }
 
     return _dom_node_tag_context_menu;
@@ -362,6 +373,12 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
                                                                       keyEquivalent:@""]];
         [_dom_node_attribute_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Take node screenshot"
                                                                              action:@selector(screenshotDOMNode:)
+                                                                      keyEquivalent:@""]];
+
+        [_dom_node_attribute_context_menu addItem:[NSMenuItem separatorItem]];
+
+        [_dom_node_attribute_context_menu addItem:[[NSMenuItem alloc] initWithTitle:@"Store as global variable"
+                                                                             action:@selector(storeDOMNodeAsGlobalVariable:)
                                                                       keyEquivalent:@""]];
     }
 

--- a/Ladybird/Qt/InspectorWidget.cpp
+++ b/Ladybird/Qt/InspectorWidget.cpp
@@ -36,6 +36,9 @@ InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
     m_copy_node_action = new QAction("&Copy HTML", this);
     connect(m_copy_node_action, &QAction::triggered, [this]() { m_inspector_client->context_menu_copy_dom_node(); });
 
+    m_store_node_global_variable = new QAction("&Store as global variable", this);
+    connect(m_store_node_global_variable, &QAction::triggered, [this]() { m_inspector_client->context_menu_store_dom_node_as_global_variable(); });
+
     m_screenshot_node_action = new QAction("Take node &screenshot", this);
     connect(m_screenshot_node_action, &QAction::triggered, [this]() { m_inspector_client->context_menu_screenshot_dom_node(); });
 
@@ -86,6 +89,8 @@ InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
     m_dom_node_tag_context_menu->addSeparator();
     m_dom_node_tag_context_menu->addAction(m_copy_node_action);
     m_dom_node_tag_context_menu->addAction(m_screenshot_node_action);
+    m_dom_node_tag_context_menu->addSeparator();
+    m_dom_node_tag_context_menu->addAction(m_store_node_global_variable);
 
     m_dom_node_attribute_context_menu = new QMenu("DOM attribute context menu", this);
     m_dom_node_attribute_context_menu->addAction(m_edit_node_action);
@@ -99,6 +104,8 @@ InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
     m_dom_node_attribute_context_menu->addSeparator();
     m_dom_node_attribute_context_menu->addAction(m_copy_node_action);
     m_dom_node_attribute_context_menu->addAction(m_screenshot_node_action);
+    m_dom_node_attribute_context_menu->addSeparator();
+    m_dom_node_attribute_context_menu->addAction(m_store_node_global_variable);
 
     m_cookie_context_menu = new QMenu("Cookie context menu", this);
     m_cookie_context_menu->addAction(m_delete_cookie_action);

--- a/Ladybird/Qt/InspectorWidget.h
+++ b/Ladybird/Qt/InspectorWidget.h
@@ -51,6 +51,7 @@ private:
 
     QAction* m_edit_node_action { nullptr };
     QAction* m_copy_node_action { nullptr };
+    QAction* m_store_node_global_variable { nullptr };
     QAction* m_screenshot_node_action { nullptr };
     QAction* m_create_child_element_action { nullptr };
     QAction* m_create_child_text_node_action { nullptr };

--- a/Userland/Libraries/LibWeb/Internals/Inspector.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.cpp
@@ -49,6 +49,11 @@ void Inspector::inspect_dom_node(i32 node_id, Optional<i32> const& pseudo_elemen
     }));
 }
 
+void Inspector::set_dom_node_as_global_variable(i32 node_id, String const& variable_name)
+{
+    inspector_page_client().inspector_did_set_dom_node_as_global_variable(node_id, variable_name);
+}
+
 void Inspector::set_dom_node_text(i32 node_id, String const& text)
 {
     inspector_page_client().inspector_did_set_dom_node_text(node_id, text);

--- a/Userland/Libraries/LibWeb/Internals/Inspector.h
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.h
@@ -26,6 +26,7 @@ public:
     void set_dom_node_tag(i32 node_id, String const& tag);
     void add_dom_node_attributes(i32 node_id, JS::NonnullGCPtr<DOM::NamedNodeMap> attributes);
     void replace_dom_node_attribute(i32 node_id, WebIDL::UnsignedLongLong attribute_index, JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes);
+    void set_dom_node_as_global_variable(i32 node_id, String const& variable_name);
 
     void request_dom_tree_context_menu(i32 node_id, i32 client_x, i32 client_y, String const& type, Optional<String> const& tag, Optional<WebIDL::UnsignedLongLong> const& attribute_index);
 

--- a/Userland/Libraries/LibWeb/Internals/Inspector.idl
+++ b/Userland/Libraries/LibWeb/Internals/Inspector.idl
@@ -8,6 +8,7 @@
     undefined setDOMNodeText(long nodeID, DOMString text);
     undefined setDOMNodeTag(long nodeID, DOMString tag);
     undefined addDOMNodeAttributes(long nodeID, NamedNodeMap attributes);
+    undefined setDOMNodeAsGlobalVariable(long nodeID, DOMString variableName);
     undefined replaceDOMNodeAttribute(long nodeID, unsigned long long attributeIndex, NamedNodeMap replacementAttributes);
 
     undefined requestDOMTreeContextMenu(long nodeID, long clientX, long clientY, DOMString type, DOMString? tag, unsigned long long? attributeIndex);

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -374,6 +374,7 @@ public:
     virtual void inspector_did_load() { }
     virtual void inspector_did_select_dom_node([[maybe_unused]] i32 node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement::Type> const& pseudo_element) { }
     virtual void inspector_did_set_dom_node_text([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& text) { }
+    virtual void inspector_did_set_dom_node_as_global_variable([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& variable_name) { }
     virtual void inspector_did_set_dom_node_tag([[maybe_unused]] i32 node_id, [[maybe_unused]] String const& tag) { }
     virtual void inspector_did_add_dom_node_attributes([[maybe_unused]] i32 node_id, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> attributes) { }
     virtual void inspector_did_replace_dom_node_attribute([[maybe_unused]] i32 node_id, [[maybe_unused]] size_t attribute_index, [[maybe_unused]] JS::NonnullGCPtr<DOM::NamedNodeMap> replacement_attributes) { }

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -207,6 +207,10 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
         m_content_web_view.add_dom_node_attributes(node_id, attributes);
     };
 
+    m_inspector_web_view.on_inspector_did_set_dom_node_as_global_variable = [this](auto node_id, auto const& variable_name) {
+        m_content_web_view.set_dom_node_as_global_variable(node_id, variable_name);
+    };
+
     m_inspector_web_view.on_inspector_replaced_dom_node_attribute = [this](auto node_id, u32 attribute_index, auto const& replacement_attributes) {
         auto const& attribute = m_dom_node_attributes.get(node_id)->at(attribute_index);
         m_content_web_view.replace_dom_node_attribute(node_id, attribute.name, replacement_attributes);
@@ -389,6 +393,15 @@ void InspectorClient::context_menu_edit_dom_node()
     auto script = MUST(String::formatted("inspector.editDOMNodeID({});", m_context_menu_data->dom_node_id));
     m_inspector_web_view.run_javascript(script);
 
+    m_context_menu_data.clear();
+}
+
+void InspectorClient::context_menu_store_dom_node_as_global_variable()
+{
+    VERIFY(m_context_menu_data.has_value());
+
+    auto script = MUST(String::formatted("inspector.setGlobalVariable({});"sv, m_context_menu_data->dom_node_id));
+    m_inspector_web_view.run_javascript(script);
     m_context_menu_data.clear();
 }
 

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -41,6 +41,7 @@ public:
     void context_menu_copy_dom_node_attribute_value();
     void context_menu_delete_cookie();
     void context_menu_delete_all_cookies();
+    void context_menu_store_dom_node_as_global_variable();
 
     Function<void(Gfx::IntPoint)> on_requested_dom_node_text_context_menu;
     Function<void(Gfx::IntPoint, String const&)> on_requested_dom_node_tag_context_menu;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -280,6 +280,11 @@ void ViewImplementation::set_dom_node_tag(i32 node_id, String name)
     client().async_set_dom_node_tag(page_id(), node_id, move(name));
 }
 
+void ViewImplementation::set_dom_node_as_global_variable(i32 node_id, String variable_name)
+{
+    client().async_set_dom_node_as_global_variable(page_id(), node_id, move(variable_name));
+}
+
 void ViewImplementation::add_dom_node_attributes(i32 node_id, Vector<Attribute> attributes)
 {
     client().async_add_dom_node_attributes(page_id(), node_id, move(attributes));

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -95,6 +95,7 @@ public:
     void set_dom_node_tag(i32 node_id, String name);
     void add_dom_node_attributes(i32 node_id, Vector<Attribute> attributes);
     void replace_dom_node_attribute(i32 node_id, String name, Vector<Attribute> replacement_attributes);
+    void set_dom_node_as_global_variable(i32 node_id, String variable_name);
     void create_child_element(i32 node_id);
     void create_child_text_node(i32 node_id);
     void clone_dom_node(i32 node_id);
@@ -219,6 +220,7 @@ public:
     Function<void(i32, Optional<Web::CSS::Selector::PseudoElement::Type> const&)> on_inspector_selected_dom_node;
     Function<void(i32, String const&)> on_inspector_set_dom_node_text;
     Function<void(i32, String const&)> on_inspector_set_dom_node_tag;
+    Function<void(i32, String const&)> on_inspector_did_set_dom_node_as_global_variable;
     Function<void(i32, Vector<Attribute> const&)> on_inspector_added_dom_node_attributes;
     Function<void(i32, size_t, Vector<Attribute> const&)> on_inspector_replaced_dom_node_attribute;
     Function<void(i32, Gfx::IntPoint, String const&, Optional<String> const&, Optional<size_t> const&)> on_inspector_requested_dom_tree_context_menu;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -625,6 +625,14 @@ void WebContentClient::inspector_did_select_dom_node(u64 page_id, i32 node_id, O
     }
 }
 
+void WebContentClient::inspector_did_set_dom_node_as_global_variable(u64 page_id, i32 node_id, String const& variable_name)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_inspector_did_set_dom_node_as_global_variable)
+            view->on_inspector_did_set_dom_node_as_global_variable(node_id, variable_name);
+    }
+}
+
 void WebContentClient::inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String const& text)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -117,6 +117,7 @@ private:
     virtual void did_allocate_backing_stores(u64 page_id, i32 front_bitmap_id, Gfx::ShareableBitmap const&, i32 back_bitmap_id, Gfx::ShareableBitmap const&) override;
     virtual void inspector_did_load(u64 page_id) override;
     virtual void inspector_did_select_dom_node(u64 page_id, i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
+    virtual void inspector_did_set_dom_node_as_global_variable(u64 page_id, i32 node_id, String const& variable_name) override;
     virtual void inspector_did_set_dom_node_text(u64 page_id, i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(u64 page_id, i32 node_id, String const& tag) override;
     virtual void inspector_did_add_dom_node_attributes(u64 page_id, i32 node_id, Vector<Attribute> const& attributes) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -822,6 +822,35 @@ void ConnectionFromClient::get_dom_node_html(u64 page_id, i32 node_id)
     async_did_get_dom_node_html(page_id, move(html));
 }
 
+void ConnectionFromClient::set_dom_node_as_global_variable(u64 page_id, i32 node_id, String const& variable_name)
+{
+    auto* dom_node = Web::DOM::Node::from_unique_id(node_id);
+    if (!dom_node)
+        return;
+
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    // TODO: Implement Setting global variable
+    auto& realm = dom_node->realm();
+    auto& global_object = realm.global_object();
+
+    auto exception = global_object.set(JS::PropertyKey(variable_name), JS::Value(dom_node), JS::Object::ShouldThrowExceptions::No);
+
+    if (exception.is_error())
+        return;
+
+    StringBuilder builder;
+    builder.append("'Stored in "sv);
+    builder.append(variable_name);
+    builder.append("'\n"sv);
+
+    js_console_input(page_id, builder.to_byte_string());
+
+    async_inspector_did_set_dom_node_as_global_variable(page_id, node_id, variable_name);
+}
+
 void ConnectionFromClient::take_document_screenshot(u64 page_id)
 {
     auto page = this->page(page_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -91,6 +91,8 @@ private:
     virtual void remove_dom_node(u64 page_id, i32 node_id) override;
     virtual void get_dom_node_html(u64 page_id, i32 node_id) override;
 
+    virtual void set_dom_node_as_global_variable(u64 page_id, i32 node_id, String const& variable_name) override;
+
     virtual void set_content_filters(u64 page_id, Vector<String> const&) override;
     virtual void set_autoplay_allowed_on_all_websites(u64 page_id) override;
     virtual void set_autoplay_allowlist(u64 page_id, Vector<String> const& allowlist) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -618,6 +618,11 @@ void PageClient::inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::S
     client().async_inspector_did_select_dom_node(m_id, node_id, pseudo_element);
 }
 
+void PageClient::inspector_did_set_dom_node_as_global_variable(i32 node_id, String const& variable_name)
+{
+    client().async_inspector_did_set_dom_node_as_global_variable(m_id, node_id, variable_name);
+}
+
 void PageClient::inspector_did_set_dom_node_text(i32 node_id, String const& text)
 {
     client().async_inspector_did_set_dom_node_text(m_id, node_id, text);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -163,6 +163,7 @@ private:
     virtual void page_did_allocate_backing_stores(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) override;
     virtual IPC::File request_worker_agent() override;
     virtual void inspector_did_load() override;
+    virtual void inspector_did_set_dom_node_as_global_variable(i32 node_id, String const& variable_name) override;
     virtual void inspector_did_select_dom_node(i32 node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(i32 node_id, String const& text) override;
     virtual void inspector_did_set_dom_node_tag(i32 node_id, String const& tag) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -112,5 +112,6 @@ endpoint WebContentClient
     inspector_did_request_cookie_context_menu(u64 page_id, size_t cookie_index, Gfx::IntPoint position) =|
     inspector_did_execute_console_script(u64 page_id, String script) =|
     inspector_did_export_inspector_html(u64 page_id, String html) =|
+    inspector_did_set_dom_node_as_global_variable(u64 page_id, i32 node_id, String variable_name) =|
 
 }

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -60,6 +60,8 @@ endpoint WebContentServer
     remove_dom_node(u64 page_id, i32 node_id) =|
     get_dom_node_html(u64 page_id, i32 node_id) =|
 
+    set_dom_node_as_global_variable(u64 page_id, i32 node_id, String variable_name) =|
+
     take_document_screenshot(u64 page_id) =|
     take_dom_node_screenshot(u64 page_id, i32 node_id) =|
 


### PR DESCRIPTION
Adds the ability to right click any DOM node and store it as a global variable for console usage. 
I personally use this all the time in the other browsers.

<img width="382" alt="Screenshot 2024-09-30 at 9 48 29 PM" src="https://github.com/user-attachments/assets/34e03e2d-9ee8-4579-9d9c-8582cd144cc0">


<img width="664" alt="Screenshot 2024-09-30 at 9 49 34 PM" src="https://github.com/user-attachments/assets/49a3b36b-e185-434c-a264-5fd70592f265">
