### PR TITLE
UI/Qt: Do not create signal notifiers until after an event loop exists

### DIFF
--- a/Ladybird/Qt/EventLoopImplementationQt.cpp
+++ b/Ladybird/Qt/EventLoopImplementationQt.cpp
@@ -209,6 +209,14 @@ void EventLoopImplementationQt::post_event(Core::EventReceiver& receiver, Nonnul
         wake();
 }
 
+void EventLoopImplementationQt::set_main_loop()
+{
+    m_main_loop = true;
+
+    auto& event_loop_manager = static_cast<EventLoopManagerQt&>(Core::EventLoopManager::the());
+    event_loop_manager.set_main_loop_signal_notifiers({});
+}
+
 static void qt_timer_fired(Core::TimerShouldFireWhenNotVisible should_fire_when_not_visible, Core::EventReceiver& object)
 {
     if (should_fire_when_not_visible == Core::TimerShouldFireWhenNotVisible::No) {
@@ -330,6 +338,10 @@ bool EventLoopManagerQt::event_target_received_event(Badge<EventLoopImplementati
 
 EventLoopManagerQt::EventLoopManagerQt()
     : m_main_thread_event_target(make<EventLoopImplementationQtEventTarget>())
+{
+}
+
+void EventLoopManagerQt::set_main_loop_signal_notifiers(Badge<EventLoopImplementationQt>)
 {
     MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, m_signal_socket_fds));
     m_signal_socket_notifier = new QSocketNotifier(m_signal_socket_fds[0], QSocketNotifier::Read);

--- a/Ladybird/Qt/EventLoopImplementationQt.h
+++ b/Ladybird/Qt/EventLoopImplementationQt.h
@@ -18,6 +18,7 @@
 
 namespace Ladybird {
 
+class EventLoopImplementationQt;
 class EventLoopImplementationQtEventTarget;
 
 class EventLoopManagerQt final : public Core::EventLoopManager {
@@ -37,6 +38,8 @@ public:
 
     virtual int register_signal(int, Function<void(int)>) override;
     virtual void unregister_signal(int) override;
+
+    void set_main_loop_signal_notifiers(Badge<EventLoopImplementationQt>);
 
 private:
     static void handle_signal(int);
@@ -77,7 +80,7 @@ public:
     virtual bool was_exit_requested() const override { return false; }
     virtual void notify_forked_and_in_child() override { }
 
-    void set_main_loop() { m_main_loop = true; }
+    void set_main_loop();
 
 private:
     friend class EventLoopManagerQt;


### PR DESCRIPTION
We are currently creating a signal socket and socket notifier before the Qt event loop itself has been created. Thus, when we receive a signal, we are not actually notified when we write that signal number to the signal socket.

This was also the source of the following error message being displayed on every launch of the browser:

    QSocketNotifier: Can only be used with threads started with QThread

Fixes #1137