### PR TITLE
LibWeb: Implement `history.scrollRestoration`

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/History-scrollRestoration.txt
+++ b/Tests/LibWeb/Text/expected/HTML/History-scrollRestoration.txt
@@ -1,0 +1,4 @@
+auto
+auto
+manual
+auto

--- a/Tests/LibWeb/Text/input/HTML/History-scrollRestoration.html
+++ b/Tests/LibWeb/Text/input/HTML/History-scrollRestoration.html
@@ -1,0 +1,12 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(history.scrollRestoration);
+        history.scrollRestoration = 'bad value';
+        println(history.scrollRestoration);
+        history.scrollRestoration = 'manual';
+        println(history.scrollRestoration);
+        history.scrollRestoration = 'auto';
+        println(history.scrollRestoration);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -229,4 +229,43 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value d
     return {};
 }
 
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-scroll-restoration
+WebIDL::ExceptionOr<Bindings::ScrollRestoration> History::scroll_restoration() const
+{
+    // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
+    if (!m_associated_document->is_fully_active())
+        return WebIDL::SecurityError::create(realm(), "Cannot obtain scroll restoration mode for a document that isn't fully active."_fly_string);
+
+    // 2. Return this's node navigable's active session history entry's scroll restoration mode.
+    auto scroll_restoration_mode = m_associated_document->navigable()->active_session_history_entry()->scroll_restoration_mode();
+    switch (scroll_restoration_mode) {
+    case ScrollRestorationMode::Auto:
+        return Bindings::ScrollRestoration::Auto;
+    case ScrollRestorationMode::Manual:
+        return Bindings::ScrollRestoration::Manual;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-history-scroll-restoration
+WebIDL::ExceptionOr<void> History::set_scroll_restoration(Bindings::ScrollRestoration scroll_restoration)
+{
+    // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
+    if (!m_associated_document->is_fully_active())
+        return WebIDL::SecurityError::create(realm(), "Cannot set scroll restoration mode for a document that isn't fully active."_fly_string);
+
+    // 2. Set this's node navigable's active session history entry's scroll restoration mode to the given value.
+    auto active_session_history_entry = m_associated_document->navigable()->active_session_history_entry();
+    switch (scroll_restoration) {
+    case Bindings::ScrollRestoration::Auto:
+        active_session_history_entry->set_scroll_restoration_mode(ScrollRestorationMode::Auto);
+        break;
+    case Bindings::ScrollRestoration::Manual:
+        active_session_history_entry->set_scroll_restoration_mode(ScrollRestorationMode::Manual);
+        break;
+    }
+
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/History.h
+++ b/Userland/Libraries/LibWeb/HTML/History.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibWeb/Bindings/HistoryPrototype.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
@@ -29,6 +30,8 @@ public:
     WebIDL::ExceptionOr<void> back();
     WebIDL::ExceptionOr<void> forward();
     WebIDL::ExceptionOr<u64> length() const;
+    WebIDL::ExceptionOr<Bindings::ScrollRestoration> scroll_restoration() const;
+    WebIDL::ExceptionOr<void> set_scroll_restoration(Bindings::ScrollRestoration);
     WebIDL::ExceptionOr<JS::Value> state() const;
 
     u64 m_index { 0 };

--- a/Userland/Libraries/LibWeb/HTML/History.idl
+++ b/Userland/Libraries/LibWeb/HTML/History.idl
@@ -5,7 +5,7 @@ enum ScrollRestoration { "auto", "manual" };
 [Exposed=Window]
 interface History {
     readonly attribute unsigned long length;
-    [FIXME] attribute ScrollRestoration scrollRestoration;
+    attribute ScrollRestoration scrollRestoration;
     readonly attribute any state;
     undefined go(optional long delta = 0);
     undefined back();


### PR DESCRIPTION
Resolved this FIXME that I found by looking at https://hyprland.org. Having two enums (IDL `ScrollRestoration` enum and `Web::HTML::ScrollRestorationMode`) is a bit awkward, but they're documented in two different specs as such.