### PR TITLE
CI: Use explicit label for test262 workflow

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   run_and_update_results:
-    runs-on: self-hosted
+    runs-on: test262-runner
     if: always() && github.repository == 'LadybirdBrowser/ladybird' && github.ref == 'refs/heads/master'
 
     concurrency: libjs-test262


### PR DESCRIPTION
Merely specifying `self-hosted` is not enough - to get closer to reproducible timings, we want these jobs to run on dedicated hardware. The `test262-runner` label was introduced for runners that offer this.