### PR TITLE
Tests: Use .invalid TLD for invalid requests

### DIFF
--- a/Tests/LibWeb/Text/expected/video-failed-load.txt
+++ b/Tests/LibWeb/Text/expected/video-failed-load.txt
@@ -1,3 +1,3 @@
 failed to load: "data:"
 failed to load: "file:///i-do-no-exist-i-swear"
-failed to load: "https://i-do-no-exist-i-swear.net.uk/"
+failed to load: "https://something.invalid/"

--- a/Tests/LibWeb/Text/input/DOM/Document-named-properties.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-named-properties.html
@@ -1,8 +1,8 @@
 <form name="bob">
     <button type="submit" id="fred" name="george" value="submit">Submit</button>
 </form>
-<img name="foo" id="bar" src="http://www.example.com" alt="Example" />
-<img id="baz" src="http://www.example.com" alt="Example" />
+<img name="foo" id="bar" src="http://something.invalid" alt="Example" />
+<img id="baz" src="http://something.invalid" alt="Example" />
 <form name="foo">
 </form>
 <meta name="kangaroo" />

--- a/Tests/LibWeb/Text/input/css/FontFace-load-urls.html
+++ b/Tests/LibWeb/Text/input/css/FontFace-load-urls.html
@@ -17,7 +17,7 @@
             println("FAILED");
         });
 
-        let notExistFont = new FontFace("NotExist", "url(https://example.com/not-exist.woff)");
+        let notExistFont = new FontFace("NotExist", "url(https://something.invalid/not-exist.woff)");
         await notExistFont.load().then(() => {
             println("FAILED");
         }, (reason) => {

--- a/Tests/LibWeb/Text/input/video-failed-load.html
+++ b/Tests/LibWeb/Text/input/video-failed-load.html
@@ -3,7 +3,7 @@
     const SOURCES = [
         "data:",
         "file:///i-do-no-exist-i-swear",
-        "https://i-do-no-exist-i-swear.net.uk",
+        "https://something.invalid",
     ];
 
     const runTest = source => {


### PR DESCRIPTION
RFC2606 and RFC6761 define .invalid as a guaranteed-invalid TLD, so let's use it. Theoretically this should make the request fail much faster.

This unfortunately doesn't affect my timeout issues, but it can't hurt.