### PR TITLE
LibWeb: Make sure style is up-to-date in getAnimations()

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAnimations/misc/get-animations-should-make-sure-style-is-updated.txt
+++ b/Tests/LibWeb/Text/expected/WebAnimations/misc/get-animations-should-make-sure-style-is-updated.txt
@@ -1,0 +1,1 @@
+This is a animated div  animation count: 1

--- a/Tests/LibWeb/Text/input/WebAnimations/misc/get-animations-should-make-sure-style-is-updated.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/misc/get-animations-should-make-sure-style-is-updated.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../../include.js"></script>
+<style>
+    @keyframes test {
+        from {
+            background-color: green;
+        }
+        to {
+            background-color: yellow;
+        }
+    }
+
+    #animated {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        animation: test 2s infinite;
+    }
+</style>
+<div id="animated">This is a animated div</div>
+<script>
+    const animationCount = document.getElementById("animated").getAnimations().length;
+    test(() => {
+        println(`animation count: ${animationCount}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Animations/Animatable.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.cpp
@@ -61,6 +61,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> Animatable::animate(Optional<JS
 // https://www.w3.org/TR/web-animations-1/#dom-animatable-getanimations
 Vector<JS::NonnullGCPtr<Animation>> Animatable::get_animations(GetAnimationsOptions options)
 {
+    verify_cast<DOM::Element>(*this).document().update_style();
+    return get_animations_internal(options);
+}
+
+Vector<JS::NonnullGCPtr<Animation>> Animatable::get_animations_internal(GetAnimationsOptions options)
+{
     // Returns the set of relevant animations for this object, or, if an options parameter is passed with subtree set to
     // true, returns the set of relevant animations for a subtree for this object.
 

--- a/Userland/Libraries/LibWeb/Animations/Animatable.h
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.h
@@ -41,6 +41,7 @@ public:
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> animate(Optional<JS::Handle<JS::Object>> keyframes, Variant<Empty, double, KeyframeAnimationOptions> options = {});
     Vector<JS::NonnullGCPtr<Animation>> get_animations(GetAnimationsOptions options = {});
+    Vector<JS::NonnullGCPtr<Animation>> get_animations_internal(GetAnimationsOptions options = {});
 
     void associate_with_animation(JS::NonnullGCPtr<Animation>);
     void disassociate_with_animation(JS::NonnullGCPtr<Animation>);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1563,7 +1563,7 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
         }
     }
 
-    auto animations = element.get_animations({ .subtree = false });
+    auto animations = element.get_animations_internal({ .subtree = false });
     for (auto& animation : animations) {
         if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
             auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());


### PR DESCRIPTION
StyleComputer is responsible for assigning animation targets, so we have to make sure there are no pending style updates before querying animations of an element.

This change also introduces a version of getAnimations() that does not check style updates and used by StyleComputer to avoid mutual recursion.