### PR TITLE
LibMedia: Mark ffmpeg as required, and reorganize CMakeLists

### DIFF
--- a/Meta/CMake/ffmpeg.cmake
+++ b/Meta/CMake/ffmpeg.cmake
@@ -1,11 +1,6 @@
 include_guard()
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(AVCODEC IMPORTED_TARGET libavcodec)
-pkg_check_modules(AVFORMAT IMPORTED_TARGET libavformat)
-pkg_check_modules(AVUTIL IMPORTED_TARGET libavutil)
-
-if (AVCODEC_FOUND AND AVFORMAT_FOUND AND AVUTIL_FOUND)
-    set(HAS_FFMPEG ON CACHE BOOL "" FORCE)
-    add_compile_definitions(USE_FFMPEG=1)
-endif()
+pkg_check_modules(AVCODEC REQUIRED IMPORTED_TARGET libavcodec)
+pkg_check_modules(AVFORMAT REQUIRED IMPORTED_TARGET libavformat)
+pkg_check_modules(AVUTIL REQUIRED IMPORTED_TARGET libavutil)

--- a/Meta/gn/build/libs/ffmpeg/BUILD.gn
+++ b/Meta/gn/build/libs/ffmpeg/BUILD.gn
@@ -27,7 +27,6 @@ config("ffmpeg_config") {
     "avformat",
     "avutil",
   ]
-  defines = [ "USE_FFMPEG" ]
 }
 
 group("ffmpeg") {

--- a/Userland/Libraries/LibMedia/Audio/Loader.cpp
+++ b/Userland/Libraries/LibMedia/Audio/Loader.cpp
@@ -28,9 +28,7 @@ struct LoaderPluginInitializer {
 };
 
 static constexpr LoaderPluginInitializer s_initializers[] = {
-#ifdef USE_FFMPEG
     { FFmpegLoaderPlugin::sniff, FFmpegLoaderPlugin::create },
-#endif
 };
 
 ErrorOr<NonnullRefPtr<Loader>, LoaderError> Loader::create(StringView path)

--- a/Userland/Libraries/LibMedia/CMakeLists.txt
+++ b/Userland/Libraries/LibMedia/CMakeLists.txt
@@ -13,43 +13,37 @@ set(SOURCES
     VideoFrame.cpp
 )
 
-if (HAVE_PULSEAUDIO)
-    list(APPEND SOURCES
-        Audio/PlaybackStreamPulseAudio.cpp
-        Audio/PulseAudioWrappers.cpp
-    )
-endif()
-
-if (HAS_FFMPEG)
-    list(APPEND SOURCES
-        Audio/FFmpegLoader.cpp
-        FFmpeg/FFmpegVideoDecoder.cpp
-    )
-else()
-    list(APPEND SOURCES FFmpeg/FFmpegVideoDecoderStub.cpp)
-endif()
-
 serenity_lib(LibMedia media)
 target_link_libraries(LibMedia PRIVATE LibCore LibCrypto LibRIFF LibIPC LibGfx LibThreading LibUnicode)
 
-if (HAS_FFMPEG)
+if (NOT ANDROID)
+    target_sources(LibMedia PRIVATE
+            Audio/FFmpegLoader.cpp
+            FFmpeg/FFmpegVideoDecoder.cpp
+    )
     target_link_libraries(LibMedia PRIVATE PkgConfig::AVCODEC PkgConfig::AVFORMAT PkgConfig::AVUTIL)
+else()
+    # FIXME: Need to figure out how to build or replace ffmpeg libs on Android
+    target_sources(LibMedia PRIVATE FFmpeg/FFmpegVideoDecoderStub.cpp)
 endif()
 
+# Audio backend -- how we output audio to the speakers
 if (HAVE_PULSEAUDIO)
+    target_sources(LibMedia PRIVATE
+        Audio/PlaybackStreamPulseAudio.cpp
+        Audio/PulseAudioWrappers.cpp
+    )
     target_link_libraries(LibMedia PRIVATE pulse)
     target_compile_definitions(LibMedia PRIVATE HAVE_PULSEAUDIO=1)
-endif()
-
-if (APPLE AND NOT IOS)
+elseif (APPLE AND NOT IOS)
     target_sources(LibMedia PRIVATE Audio/PlaybackStreamAudioUnit.cpp)
 
     find_library(AUDIO_UNIT AudioUnit REQUIRED)
     target_link_libraries(LibMedia PRIVATE ${AUDIO_UNIT})
-endif()
-
-if (ANDROID)
+elseif (ANDROID)
     target_sources(LibMedia PRIVATE Audio/PlaybackStreamOboe.cpp)
     find_package(oboe REQUIRED CONFIG)
     target_link_libraries(LibMedia PRIVATE log oboe::oboe)
+else()
+    message(WARNING "No audio backend available")
 endif()


### PR DESCRIPTION
Now it should be clearer looking at the build scripts what options are available for building LibMedia, and what packages are required.