### PR TITLE
AK: Address MSVC/Windows portability for logging

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -25,6 +25,10 @@
 #    include <android/log.h>
 #endif
 
+#if defined(AK_OS_WINDOWS)
+#    include <io.h>
+#endif
+
 namespace AK {
 
 class FormatParser : public GenericLexer {
@@ -1213,6 +1217,8 @@ void vdbg(StringView fmtstr, TypeErasedFormatParams& params, bool newline)
 
 #ifdef AK_OS_ANDROID
     __android_log_write(ANDROID_LOG_DEBUG, s_log_tag_name, string.characters_without_null_termination());
+#elif defined(AK_OS_WINDOWS)
+    [[maybe_unused]] auto rc = _write(_fileno(stderr), string.characters_without_null_termination(), string.length());
 #else
     [[maybe_unused]] auto rc = write(STDERR_FILENO, string.characters_without_null_termination(), string.length());
 #endif


### PR DESCRIPTION
`STDERR_FILENO` is pretty common but not part of the standard. On Windows, in order to get a file number, one must use `_fileno` to convert the `FILE *` to a file number. Adopt this pattern similar to the Android path which uses platform specific operations.