### PR TITLE
Meta: Account for platform specific linking

### DIFF
--- a/Meta/gn/build/libs/simdutf/BUILD.gn
+++ b/Meta/gn/build/libs/simdutf/BUILD.gn
@@ -1,6 +1,10 @@
 import("//Meta/gn/build/libs/third_party.gni")
 
 third_party_dependency("simdutf") {
-  libs = [ "simdutf" ]
+  if (current_os == "win") {
+    libs = [ "simdutf.lib" ]
+  } else {
+    libs = [ "simdutf" ]
+  }
   extra_public_configs = [ "//Meta/gn/build:pic" ]
 }


### PR DESCRIPTION
On Windows, similar to AIX, we would link against the import library rather than the actual library (at least when doing dynamic linking). Adjust the `libs` setting to allow linking properly on Windows. This reduces the number of undefined symbols when linking AK to 1.