### PR TITLE
LibMedia+Ladybird: Use pkg_check_modules to find pulseaudio

### DIFF
--- a/Ladybird/WebContent/CMakeLists.txt
+++ b/Ladybird/WebContent/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(fontconfig)
+include(pulseaudio)
 
 set(WEBCONTENT_SOURCE_DIR ${LADYBIRD_SOURCE_DIR}/Userland/Services/WebContent/)
 
@@ -35,10 +36,6 @@ target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD
 target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
 target_link_libraries(webcontentservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibMedia LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient)
-
-if (HAVE_PULSEAUDIO)
-    target_compile_definitions(webcontentservice PUBLIC HAVE_PULSEAUDIO=1)
-endif()
 
 if (HAS_FONTCONFIG)
     target_link_libraries(webcontentservice PRIVATE Fontconfig::Fontconfig)

--- a/Meta/CMake/pulseaudio.cmake
+++ b/Meta/CMake/pulseaudio.cmake
@@ -1,0 +1,8 @@
+include_guard()
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(PULSEAUDIO IMPORTED_TARGET libpulse)
+
+if (PULSEAUDIO_FOUND)
+    set(HAVE_PULSEAUDIO ON CACHE BOOL "" FORCE)
+endif()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -132,8 +132,6 @@ if (ENABLE_FUZZERS)
     add_cxx_compile_options(-fno-omit-frame-pointer)
 endif()
 
-CHECK_INCLUDE_FILE(pulse/pulseaudio.h HAVE_PULSEAUDIO)
-
 add_library(JSClangPlugin INTERFACE)
 add_library(GenericClangPlugin INTERFACE)
 

--- a/Tests/LibMedia/CMakeLists.txt
+++ b/Tests/LibMedia/CMakeLists.txt
@@ -10,7 +10,3 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     lagom_test("${source}" LibMedia LIBS LibMedia LibFileSystem WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endforeach()
-
-if (HAVE_PULSEAUDIO)
-    target_compile_definitions(TestPlaybackStream PRIVATE HAVE_PULSEAUDIO=1)
-endif()

--- a/Userland/Libraries/LibMedia/CMakeLists.txt
+++ b/Userland/Libraries/LibMedia/CMakeLists.txt
@@ -1,4 +1,5 @@
 include(ffmpeg)
+include(pulseaudio)
 
 set(SOURCES
     Audio/Loader.cpp
@@ -33,8 +34,8 @@ if (HAVE_PULSEAUDIO)
         Audio/PlaybackStreamPulseAudio.cpp
         Audio/PulseAudioWrappers.cpp
     )
-    target_link_libraries(LibMedia PRIVATE pulse)
-    target_compile_definitions(LibMedia PRIVATE HAVE_PULSEAUDIO=1)
+    target_link_libraries(LibMedia PRIVATE PkgConfig::PULSEAUDIO)
+    target_compile_definitions(LibMedia PUBLIC HAVE_PULSEAUDIO=1)
 elseif (APPLE AND NOT IOS)
     target_sources(LibMedia PRIVATE Audio/PlaybackStreamAudioUnit.cpp)
 


### PR DESCRIPTION
Note that WebContent/CMakeLists.txt still uses HAVE_PULSEAUDIO to enable Qt Multimedia (or not).