### PR TITLE
LibWeb: Move updating the rendering into HTML task

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -1330,9 +1330,13 @@ JS::NonnullGCPtr<WebIDL::Promise> Animation::current_finished_promise() const
 
 void Animation::invalidate_effect()
 {
-    if (m_effect) {
-        if (auto target = m_effect->target(); target && target->paintable()) {
-            target->document().set_needs_animated_style_update();
+    if (!m_effect) {
+        return;
+    }
+
+    if (auto* target = m_effect->target(); target) {
+        target->document().set_needs_animated_style_update();
+        if (target->paintable()) {
             target->paintable()->set_needs_display();
         }
     }

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -559,9 +559,6 @@ WebIDL::ExceptionOr<void> Animation::play()
 // https://www.w3.org/TR/web-animations-1/#play-an-animation
 WebIDL::ExceptionOr<void> Animation::play_an_animation(AutoRewind auto_rewind)
 {
-    if (auto document = document_for_timing())
-        document->ensure_animation_timer();
-
     // 1. Let aborted pause be a boolean flag that is true if animation has a pending pause task, and false otherwise.
     auto aborted_pause = m_pending_pause_task == TaskState::Scheduled;
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5337,11 +5337,11 @@ void Document::set_needs_to_refresh_scroll_state(bool b)
 
 Vector<JS::Handle<DOM::Range>> Document::find_matching_text(String const& query, CaseSensitivity case_sensitivity)
 {
-    if (!layout_node())
-        return {};
-
     // Ensure the layout tree exists before searching for text matches.
     update_layout();
+
+    if (!layout_node())
+        return {};
 
     auto const& text_blocks = layout_node()->text_blocks();
     if (text_blocks.is_empty())

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4568,31 +4568,6 @@ void Document::remove_replaced_animations()
     }
 }
 
-void Document::ensure_animation_timer()
-{
-    constexpr static auto timer_delay_ms = 1000 / 60;
-    if (!m_animation_driver_timer) {
-        m_animation_driver_timer = Core::Timer::create_repeating(timer_delay_ms, [this] {
-            bool has_animations = false;
-            for (auto& timeline : m_associated_animation_timelines) {
-                if (!timeline->associated_animations().is_empty()) {
-                    has_animations = true;
-                    break;
-                }
-            }
-            if (!has_animations) {
-                m_animation_driver_timer->stop();
-                return;
-            }
-            auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&realm().global_object());
-            VERIFY(window_or_worker);
-            update_animations_and_send_events(window_or_worker->performance()->now());
-        });
-    }
-
-    m_animation_driver_timer->start();
-}
-
 Vector<JS::NonnullGCPtr<Animations::Animation>> Document::get_animations()
 {
     Vector<JS::NonnullGCPtr<Animations::Animation>> relevant_animations;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -624,7 +624,6 @@ public:
     void append_pending_animation_event(PendingAnimationEvent const&);
     void update_animations_and_send_events(Optional<double> const& timestamp);
     void remove_replaced_animations();
-    void ensure_animation_timer();
 
     Vector<JS::NonnullGCPtr<Animations::Animation>> get_animations();
 

--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -18,19 +18,10 @@ namespace Web::HTML {
 struct AnimationFrameCallbackDriver {
     using Callback = Function<void(double)>;
 
-    AnimationFrameCallbackDriver()
-    {
-        m_timer = Core::Timer::create_single_shot(16, [] {
-            HTML::main_thread_event_loop().schedule();
-        });
-    }
-
     [[nodiscard]] WebIDL::UnsignedLong add(Callback handler)
     {
         auto id = ++m_animation_frame_callback_identifier;
         m_callbacks.set(id, move(handler));
-        if (!m_timer->is_active())
-            m_timer->start();
         return id;
     }
 
@@ -60,7 +51,6 @@ private:
     WebIDL::UnsignedLong m_animation_frame_callback_identifier { 0 };
 
     OrderedHashMap<WebIDL::UnsignedLong, Callback> m_callbacks;
-    RefPtr<Core::Timer> m_timer;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -42,6 +42,7 @@ public:
     void spin_until(JS::SafeFunction<bool()> goal_condition);
     void spin_processing_tasks_with_source_until(Task::Source, JS::SafeFunction<bool()> goal_condition);
     void process();
+    void queue_task_to_update_the_rendering();
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#termination-nesting-level
     size_t termination_nesting_level() const { return m_termination_nesting_level; }
@@ -114,7 +115,7 @@ private:
 
     bool m_skip_event_loop_processing_steps { false };
 
-    bool m_is_running_reflow_steps { false };
+    bool m_is_running_rendering_task { false };
 };
 
 EventLoop& main_thread_event_loop();

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -63,6 +63,9 @@ public:
         // https://html.spec.whatwg.org/multipage/server-sent-events.html#remote-event-task-source
         RemoteEvent,
 
+        // https://html.spec.whatwg.org/multipage/webappapis.html#rendering-task-source
+        Rendering,
+
         // !!! IMPORTANT: Keep this field last!
         // This serves as the base value of all unique task sources.
         // Some elements, such as the HTMLMediaElement, must have a unique task source per instance.

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -844,8 +844,6 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         return EventResult::Dropped;
 
     JS::NonnullGCPtr<DOM::Document> document = *m_navigable->active_document();
-    if (!document->layout_node())
-        return EventResult::Dropped;
 
     if (key == UIEvents::KeyCode::Key_Tab) {
         if (modifiers & UIEvents::KeyModifier::Mod_Shift)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -383,7 +383,6 @@ public:
     virtual void inspector_did_execute_console_script([[maybe_unused]] String const& script) { }
     virtual void inspector_did_export_inspector_html([[maybe_unused]] String const& html) { }
 
-    virtual void schedule_repaint() = 0;
     virtual bool is_ready_to_paint() const = 0;
 
     virtual DisplayListPlayerType display_list_player_type() const = 0;

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -79,7 +79,6 @@ public:
     virtual void paint_next_frame() override { }
     virtual void process_screenshot_requests() override { }
     virtual void paint(DevicePixelRect const&, Painting::BackingStore&, Web::PaintOptions = {}) override { }
-    virtual void schedule_repaint() override { }
     virtual bool is_ready_to_paint() const override { return true; }
 
     virtual DisplayListPlayerType display_list_player_type() const override { return m_host_page->client().display_list_player_type(); }

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -34,7 +34,6 @@ public:
     };
     static void set_use_skia_painter(UseSkiaPainter);
 
-    virtual void schedule_repaint() override;
     virtual bool is_ready_to_paint() const override;
 
     virtual Web::Page& page() override { return *m_page; }
@@ -191,7 +190,6 @@ private:
     enum class PaintState {
         Ready,
         WaitingForClient,
-        PaintWhenReady,
     };
 
     PaintState m_paint_state { PaintState::Ready };
@@ -212,6 +210,8 @@ private:
     WeakPtr<WebContentConsoleClient> m_top_level_document_console_client;
 
     JS::Handle<JS::GlobalObject> m_console_global_object;
+
+    RefPtr<Core::Timer> m_paint_refresh_timer;
 };
 
 }

--- a/Userland/Services/WebWorker/PageHost.h
+++ b/Userland/Services/WebWorker/PageHost.h
@@ -35,7 +35,6 @@ public:
     virtual void process_screenshot_requests() override {};
     virtual void paint(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;
-    virtual void schedule_repaint() override {};
     virtual bool is_ready_to_paint() const override { return true; }
     virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }
 


### PR DESCRIPTION
Implements https://github.com/whatwg/html/pull/10007 which basically
moves style, layout and painting from HTML processing task into HTML
task with "rendering" source.

The biggest difference is that now we no longer schedule HTML event loop
processing whenever we might need a repaint, but instead queue a global
rendering task 60 times per second that will check if any documents
need a style/layout/paint update.

That is a great simplification of our repaint scheduling model. Before
we had:
- Optional timer that schedules animation updates 60 hz
- Optional timer that schedules rAF updates
- PaintWhenReady state to schedule a paint if navigable doesn't have a
  rendering opportunity on the last event loop iteration

Now all that is gone and replaced with a single timer that drives
repainting at 60 hz and we don't have to worry about excessive repaints.

In the future, hard-coded 60 hz refresh interval could be replaced with
CADisplayLink on macOS and similar API on linux to drive repainting in
synchronization with display's refresh rate.