### PR TITLE
LibWeb: Parse mimetypes on Blob and File

### DIFF
--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/Streams/ReadableStreamDefaultReader.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
@@ -197,17 +198,17 @@ JS::NonnullGCPtr<Blob> Blob::create(JS::Realm& realm, Optional<Vector<BlobPart>>
     auto type = String {};
     // 3. If the type member of the options argument is not the empty string, run the following sub-steps:
     if (options.has_value() && !options->type.is_empty()) {
-        // 1. If the type member is provided and is not the empty string, let t be set to the type dictionary member.
+        // FIXME: 1. If the type member is provided and is not the empty string, let t be set to the type dictionary member.
         //    If t contains any characters outside the range U+0020 to U+007E, then set t to the empty string and return from these substeps.
-        //    NOTE: t is set to empty string at declaration.
-        if (!options->type.is_empty()) {
-            if (is_basic_latin(options->type))
-                type = options->type;
-        }
+        // FIXME: 2. Convert every character in t to ASCII lowercase.
 
-        // 2. Convert every character in t to ASCII lowercase.
-        if (!type.is_empty())
-            type = MUST(Infra::to_ascii_lowercase(type));
+        // NOTE: The spec is out of date, and we are supposed to call into the MimeType parser here.
+        if (!options->type.is_empty()) {
+            auto maybe_parsed_type = MUST(Web::MimeSniff::MimeType::parse(options->type));
+
+            if (maybe_parsed_type.has_value())
+                type = MUST(maybe_parsed_type->serialized());
+        }
     }
 
     // 4. Return a Blob object referring to bytes as its associated byte sequence, with its size set to the length of bytes, and its type set to the value of t from the substeps above.

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -11,6 +11,7 @@
 #include <AK/GenericLexer.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/Utf8View.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/MimeSniff/MimeType.h>
@@ -33,9 +34,8 @@ static bool contains_only_http_quoted_string_token_code_points(StringView string
     // https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
     // An HTTP quoted-string token code point is U+0009 TAB, a code point in the range U+0020 SPACE to U+007E (~), inclusive,
     // or a code point in the range U+0080 through U+00FF (ÿ), inclusive.
-    for (char ch : string) {
-        // NOTE: This doesn't check for ch <= 0xFF, as ch is 8-bits and so that condition will always be true.
-        if (!(ch == '\t' || (ch >= 0x20 && ch <= 0x7E) || (u8)ch >= 0x80))
+    for (auto ch : Utf8View(string)) {
+        if (!(ch == '\t' || (ch >= 0x20 && ch <= 0x7E) || (ch >= 0x80 && ch <= 0xFF)))
             return false;
     }
     return true;


### PR DESCRIPTION
This makes us pass 1894 / 1898 tests on https://wpt.live/mimesniff/mime-types/parsing.any.html (up from the previous 1292/1898)

See https://github.com/w3c/FileAPI/issues/43 for details about the spec being out of date