### PR TITLE
LibWeb/Layout: Set a specific width and height for the layout

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Format.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Layout/AvailableSpace.h>
 #include <LibWeb/Layout/BlockContainer.h>
@@ -570,6 +571,8 @@ void LayoutState::UsedValues::set_node(NodeWithStyle& node, UsedValues const* co
 
 void LayoutState::UsedValues::set_content_width(CSSPixels width)
 {
+    if (width > max_width)
+        width = max_width;
     VERIFY(!width.might_be_saturated());
     if (width < 0) {
         // Negative widths are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.
@@ -584,6 +587,8 @@ void LayoutState::UsedValues::set_content_width(CSSPixels width)
 
 void LayoutState::UsedValues::set_content_height(CSSPixels height)
 {
+    if (height > max_height)
+        height = max_height;
     VERIFY(!height.might_be_saturated());
     if (height < 0) {
         // Negative heights are not allowed in CSS. We have a bug somewhere! Clamp to 0 to avoid doing too much damage.

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -200,6 +200,9 @@ struct LayoutState {
         CSSPixels m_content_width { 0 };
         CSSPixels m_content_height { 0 };
 
+        CSSPixels max_width { 10000 };
+        CSSPixels max_height { 10000 };
+
         bool m_has_definite_width { false };
         bool m_has_definite_height { false };
 


### PR DESCRIPTION
Fixes crashes on 4 websites.

https://telegraph.co.uk
https://cnbc.com
https://godotengine.org
https://resetera.com

Fixes #1236 
Fixes #1577 
Fixes #1249 
Fixes #139 
Fixes #645 