### PR TITLE
Tests/LibWeb: Disable cross-origin-window-properties.html test for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,4 +1,5 @@
 [Skipped]
+Text/input/HTML/cross-origin-window-properties.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/WebAnimations/misc/DocumentTimeline.html


### PR DESCRIPTION
After https://github.com/LadybirdBrowser/ladybird/pull/1616 got merged this test started to occasionaly timeout on Linux CI: https://github.com/LadybirdBrowser/ladybird/actions/runs/11174338933/job/31063881592 https://github.com/LadybirdBrowser/ladybird/actions/runs/11177347649/job/31072646967?pr=1623

Since it's only this test that is timing out, I'm concluding that the event loop processing change is working fine and the issue lies with the test itself, so let's disable it for now.