### PR TITLE
headless-browser: Support running LibWeb tests concurrently

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -6,7 +6,10 @@ Text/input/WebAnimations/misc/DocumentTimeline.html
 Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-crypto.html
 Text/input/Worker/Worker-echo.html
+Text/input/Worker/Worker-importScripts.html
 Text/input/Worker/Worker-location.html
+Text/input/Worker/Worker-module.html
+Text/input/Worker/Worker-performance.html
 Text/input/window-scrollTo.html
 Ref/unicode-range.html
 Ref/css-keyframe-fill-forwards.html


### PR DESCRIPTION
We currently create a single WebView and run all 1400+ LibWeb tests in
serial over that WebView. Instead, let's create as many WebViews as
there are processes on the system, and run LibWeb tests concurrently
over those views.

To do this performantly requires that we never block the main thread of
the headless-browser process once the tests are running. Doing so will
effectively pause execution of all other tests. So test execution is now
Promise-based.

On my machine (with a hardware concurrency of 32), this reduces the run
time of LibWeb tests from 31.382s to 3.640s. CPU utilization increases
from 5% to 67%.