### PR TITLE
LibGfx: Remove unreachable code in fill/strokeStyle serialization

### DIFF
--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -43,9 +43,7 @@ String Color::to_string(HTMLCompatibleSerialization html_compatible_serializatio
     }
 
     // Otherwise, for sRGB the CSS serialization of sRGB values is used and for other color spaces, the relevant serialization of the <color> value.
-    if (alpha() < 255)
-        return MUST(String::formatted("rgba({}, {}, {}, {})", red(), green(), blue(), alpha() / 255.0));
-    return MUST(String::formatted("rgb({}, {}, {})", red(), green(), blue()));
+    return MUST(String::formatted("rgba({}, {}, {}, {})", red(), green(), blue(), alpha() / 255.0));
 }
 
 String Color::to_string_without_alpha() const


### PR DESCRIPTION
The resent commit (4590c081c2) to fix fill/strokeStyle serialization introduced unreachable code.

The Color::alpha() function return a u8. After checking whether alpha is equal to 255, the only other outcome is that alpha is LESS than 255. Thus no second check is required.