### PR TITLE
LibWeb: Add a feature to LibWeb tests to fail on unhandled exceptions

### DIFF
--- a/Tests/LibWeb/Text/expected/all-window-properties.txt
+++ b/Tests/LibWeb/Text/expected/all-window-properties.txt
@@ -394,6 +394,7 @@ asyncTest
 printElement
 println
 promiseTest
+removeTestErrorHandler
 spoofCurrentURL
 test
 timeout

--- a/Tests/LibWeb/Text/input/HTML/Window-onerror.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-onerror.html
@@ -2,6 +2,9 @@
 <script src="../include.js"></script>
 <script>
     asyncTest(done => {
+
+        removeTestErrorHandler()
+
         window.addEventListener("error", (event) => {
             println(`onerror event fired: ${event.error}`);
             done();

--- a/Tests/LibWeb/Text/input/HTML/WindowOrWorkerGlobalScope-reportError.html
+++ b/Tests/LibWeb/Text/input/HTML/WindowOrWorkerGlobalScope-reportError.html
@@ -1,6 +1,8 @@
 <script src="../include.js"></script>
 <script>
     test(() => {
+        removeTestErrorHandler()
+
         window.onerror = (message, filename, lineno, colno, error) => {
             println(`message = ${message}`);
             println(`lineno = ${lineno}`);

--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -52,6 +52,20 @@ function timeout(ms) {
     return promise;
 }
 
+const __testErrorHandlerController = new AbortController();
+window.addEventListener(
+    "error",
+    event => {
+        println(`Uncaught Error In Test: ${event.message}`);
+        __finishTest();
+    },
+    { signal: __testErrorHandlerController.signal }
+);
+
+function removeTestErrorHandler() {
+    __testErrorHandlerController.abort();
+}
+
 document.addEventListener("DOMContentLoaded", function () {
     __outputElement = document.createElement("pre");
     __outputElement.setAttribute("id", "out");


### PR DESCRIPTION
Previously, if there was an unhandled exception in an async test, it might fail to call done() and timeout. Now we have a default "error" handler to catch unhandled exceptions and fail the test. A few tests want to actually test the behavior of window.onerror, so they need an escape hatch.