### PR TITLE
Report network errors on finish and set default timeout for all requests

### DIFF
--- a/Userland/Libraries/LibRequests/CMakeLists.txt
+++ b/Userland/Libraries/LibRequests/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(SOURCES
+    NetworkErrorEnum.h
     Request.cpp
     RequestClient.cpp
     WebSocket.cpp

--- a/Userland/Libraries/LibRequests/NetworkErrorEnum.h
+++ b/Userland/Libraries/LibRequests/NetworkErrorEnum.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Requests {
+
+enum class NetworkError {
+    UnableToResolveProxy,
+    UnableToResolveHost,
+    UnableToConnect,
+    TimeoutReached,
+    TooManyRedirects,
+    SSLHandshakeFailed,
+    SSLVerificationFailed,
+    MalformedUrl,
+    Unknown
+};
+
+}

--- a/Userland/Libraries/LibRequests/Request.cpp
+++ b/Userland/Libraries/LibRequests/Request.cpp
@@ -52,13 +52,13 @@ void Request::set_buffered_request_finished_callback(BufferedRequestFinished on_
         m_internal_buffered_data->response_code = move(response_code);
     };
 
-    on_finish = [this, on_buffered_request_finished = move(on_buffered_request_finished)](auto success, auto total_size) {
+    on_finish = [this, on_buffered_request_finished = move(on_buffered_request_finished)](auto total_size, auto network_error) {
         auto output_buffer = ByteBuffer::create_uninitialized(m_internal_buffered_data->payload_stream.used_buffer_size()).release_value_but_fixme_should_propagate_errors();
         m_internal_buffered_data->payload_stream.read_until_filled(output_buffer).release_value_but_fixme_should_propagate_errors();
 
         on_buffered_request_finished(
-            success,
             total_size,
+            network_error,
             m_internal_buffered_data->response_headers,
             m_internal_buffered_data->response_code,
             output_buffer);
@@ -81,10 +81,10 @@ void Request::set_unbuffered_request_callbacks(HeadersReceived on_headers_receiv
     set_up_internal_stream_data(move(on_data_received));
 }
 
-void Request::did_finish(Badge<RequestClient>, bool success, u64 total_size)
+void Request::did_finish(Badge<RequestClient>, u64 total_size, Optional<NetworkError> const& network_error)
 {
     if (on_finish)
-        on_finish(success, total_size);
+        on_finish(total_size, network_error);
 }
 
 void Request::did_receive_headers(Badge<RequestClient>, HTTP::HeaderMap const& response_headers, Optional<u32> response_code)
@@ -113,9 +113,9 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
         m_internal_stream_data->read_stream = MUST(Core::File::adopt_fd(fd(), Core::File::OpenMode::Read));
 
     auto user_on_finish = move(on_finish);
-    on_finish = [this](auto success, auto total_size) {
-        m_internal_stream_data->success = success;
+    on_finish = [this](auto total_size, auto network_error) {
         m_internal_stream_data->total_size = total_size;
+        m_internal_stream_data->network_error = network_error;
         m_internal_stream_data->request_done = true;
         m_internal_stream_data->on_finish();
     };
@@ -123,7 +123,7 @@ void Request::set_up_internal_stream_data(DataReceived on_data_available)
     m_internal_stream_data->on_finish = [this, user_on_finish = move(user_on_finish)]() {
         if (!m_internal_stream_data->user_finish_called && m_internal_stream_data->read_stream->is_eof()) {
             m_internal_stream_data->user_finish_called = true;
-            user_on_finish(m_internal_stream_data->success, m_internal_stream_data->total_size);
+            user_on_finish(m_internal_stream_data->total_size, m_internal_stream_data->network_error);
         }
     };
 

--- a/Userland/Libraries/LibRequests/RequestClient.cpp
+++ b/Userland/Libraries/LibRequests/RequestClient.cpp
@@ -68,11 +68,11 @@ bool RequestClient::set_certificate(Badge<Request>, Request& request, ByteString
     return IPCProxy::set_certificate(request.id(), move(certificate), move(key));
 }
 
-void RequestClient::request_finished(i32 request_id, bool success, u64 total_size)
+void RequestClient::request_finished(i32 request_id, u64 total_size, Optional<NetworkError> const& network_error)
 {
     RefPtr<Request> request;
     if ((request = m_requests.get(request_id).value_or(nullptr))) {
-        request->did_finish({}, success, total_size);
+        request->did_finish({}, total_size, network_error);
     }
     m_requests.remove(request_id);
 }

--- a/Userland/Libraries/LibRequests/RequestClient.h
+++ b/Userland/Libraries/LibRequests/RequestClient.h
@@ -40,7 +40,7 @@ private:
     virtual void die() override;
 
     virtual void request_started(i32, IPC::File const&) override;
-    virtual void request_finished(i32, bool, u64) override;
+    virtual void request_finished(i32, u64, Optional<NetworkError> const&) override;
     virtual void certificate_requested(i32) override;
     virtual void headers_became_available(i32, HTTP::HeaderMap const&, Optional<u32> const&) override;
 

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -285,6 +285,7 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString const& metho
     set_option(CURLOPT_ACCEPT_ENCODING, "gzip, deflate, br");
     set_option(CURLOPT_URL, url.to_string().value().to_byte_string().characters());
     set_option(CURLOPT_PORT, url.port_or_default());
+    set_option(CURLOPT_TIMEOUT, 90L);
 
     if (method == "GET"sv) {
         set_option(CURLOPT_HTTPGET, 1L);

--- a/Userland/Services/RequestServer/RequestClient.ipc
+++ b/Userland/Services/RequestServer/RequestClient.ipc
@@ -1,10 +1,11 @@
 #include <LibHTTP/HeaderMap.h>
+#include <LibRequests/NetworkErrorEnum.h>
 #include <LibURL/URL.h>
 
 endpoint RequestClient
 {
     request_started(i32 request_id, IPC::File fd) =|
-    request_finished(i32 request_id, bool success, u64 total_size) =|
+    request_finished(i32 request_id, u64 total_size, Optional<Requests::NetworkError> network_error) =|
     headers_became_available(i32 request_id, HTTP::HeaderMap response_headers, Optional<u32> status_code) =|
 
     // Websocket API


### PR DESCRIPTION
This allows us to bubble up network errors to API consumers after finishing a request.

Sample logs:
```
8018.574 WebContent(49434): ResourceLoader: Failed load of: "https://localhost:7174/", Error: SSL verification failed (status code: 0), Duration: 4ms
8059.510 WebContent(49434): ResourceLoader: Failed load of: "https://localhost/notfound", Error: Unable to connect (status code: 0), Duration: 4ms
```


Sample error page:
![image](https://github.com/user-attachments/assets/951d8fba-9566-4b6f-b579-39ebb4adccec)