### PR TITLE
LibWeb: Allow intrinsic width layout to see definite heights

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 100x100 flex-container(row) [FFC] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 100x100 flex-item [SVG] children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 100x100 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableBox (Box<BODY>) [8,8 100x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
+        SVGPathPaintable (SVGGeometryBox<rect>) [8,8 100x100]

--- a/Tests/LibWeb/Layout/input/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.html
+++ b/Tests/LibWeb/Layout/input/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body {
+        display: flex;
+        width: max-content;
+        height: 100px;
+    }
+</style><body><svg viewBox="0 0 10 10" xmlns="http://www.w3.org/2000/svg"><rect x=0 y=0 width=10 height=10 fill=green></svg>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1465,7 +1465,6 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     auto& box_state = throwaway_state.get_mutable(box);
     box_state.width_constraint = SizeConstraint::MinContent;
     box_state.set_indefinite_content_width();
-    box_state.set_indefinite_content_height();
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     if (!context) {
@@ -1473,7 +1472,10 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
     }
 
     auto available_width = AvailableSize::make_min_content();
-    auto available_height = AvailableSize::make_indefinite();
+    auto available_height = box_state.has_definite_height()
+        ? AvailableSize::make_definite(box_state.content_height())
+        : AvailableSize::make_indefinite();
+
     context->run(AvailableSpace(available_width, available_height));
 
     cache.min_content_width = context->automatic_content_width();
@@ -1503,7 +1505,6 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
     auto& box_state = throwaway_state.get_mutable(box);
     box_state.width_constraint = SizeConstraint::MaxContent;
     box_state.set_indefinite_content_width();
-    box_state.set_indefinite_content_height();
 
     auto context = const_cast<FormattingContext*>(this)->create_independent_formatting_context_if_needed(throwaway_state, LayoutMode::IntrinsicSizing, box);
     if (!context) {
@@ -1511,7 +1512,10 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
     }
 
     auto available_width = AvailableSize::make_max_content();
-    auto available_height = AvailableSize::make_indefinite();
+    auto available_height = box_state.has_definite_height()
+        ? AvailableSize::make_definite(box_state.content_height())
+        : AvailableSize::make_indefinite();
+
     context->run(AvailableSpace(available_width, available_height));
 
     cache.max_content_width = context->automatic_content_width();


### PR DESCRIPTION
We were already allowing intrinsic height layout to see definite widths, and I can't think of a reason *not* to allow it the other way around.

More importantly, this fixes an issue where things with an aspect ratio didn't have a height to resolve against before.

Makes the logo show up on https://basecamp.com/ :^)

Before:
<img width="958" alt="Screenshot 2024-10-05 at 18 56 41" src="https://github.com/user-attachments/assets/586b7845-53e3-49b0-8dd7-8d891ad69ee9">

After:
<img width="958" alt="Screenshot 2024-10-05 at 18 56 24" src="https://github.com/user-attachments/assets/cddc49aa-9190-4c75-aa0a-5fbdba8334d5">

