### PR TITLE
LibWeb: Define static position calculation separately for each FC

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1329,4 +1329,13 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
     return max_width;
 }
 
+StaticPositionRect BlockFormattingContext::calculate_static_position_rect(Box const& box) const
+{
+    StaticPositionRect static_position;
+    auto const& box_state = m_state.get(box);
+    auto offset_to_static_parent = content_box_rect_in_static_position_ancestor_coordinate_space(box, *box.containing_block());
+    static_position.rect = { offset_to_static_parent.location().translated(0, box_state.vertical_offset_of_parent_block_container), { 0, 0 } };
+    return static_position;
+}
+
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -25,6 +25,7 @@ public:
     virtual void run(AvailableSpace const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
+    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     auto const& left_side_floats() const { return m_left_floats; }
     auto const& right_side_floats() const { return m_right_floats; }

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -24,7 +24,7 @@ public:
 
     Box const& flex_container() const { return context_box(); }
 
-    virtual StaticPositionRect calculate_static_position_rect(Box const&) const override;
+    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
 private:
     [[nodiscard]] bool should_treat_main_size_as_auto(Box const&) const;

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -107,7 +107,6 @@ public:
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;
 
-    virtual StaticPositionRect calculate_static_position_rect(Box const&) const;
     bool can_skip_is_anonymous_text_run(Box&);
 
     void compute_inset(NodeWithStyleAndBoxModelMetrics const&);

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2508,6 +2508,18 @@ CSSPixels GridFormattingContext::calculate_minimum_contribution(GridItem const& 
     return calculate_min_content_contribution(item, dimension);
 }
 
+StaticPositionRect GridFormattingContext::calculate_static_position_rect(Box const& box) const
+{
+    // Result of this function is only used when containing block is not a grid container.
+    // If the containing block is a grid container then static position is a grid area rect and
+    // layout_absolutely_positioned_element() defined for GFC knows how to handle this case.
+    StaticPositionRect static_position;
+    auto const& box_state = m_state.get(box);
+    auto offset_to_static_parent = content_box_rect_in_static_position_ancestor_coordinate_space(box, *box.containing_block());
+    static_position.rect = { offset_to_static_parent.location().translated(0, 0), { box_state.content_width(), box_state.content_height() } };
+    return static_position;
+}
+
 }
 
 namespace AK {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -109,6 +109,7 @@ public:
     virtual void run(AvailableSpace const& available_space) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
+    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     Box const& grid_container() const { return context_box(); }
 

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.h
@@ -26,6 +26,7 @@ public:
     virtual void run(AvailableSpace const&) override;
     virtual CSSPixels automatic_content_height() const override;
     virtual CSSPixels automatic_content_width() const override;
+    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     void dimension_box_on_line(Box const&, LayoutMode);
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1849,6 +1849,15 @@ CSSPixels TableFormattingContext::border_spacing_vertical() const
     return computed_values.border_spacing_vertical().to_px(table_box());
 }
 
+StaticPositionRect TableFormattingContext::calculate_static_position_rect(Box const& box) const
+{
+    // FIXME: Implement static position calculation for table descendants instead of always returning a rectangle with zero position and size.
+    StaticPositionRect static_position;
+    auto offset_to_static_parent = content_box_rect_in_static_position_ancestor_coordinate_space(box, *box.containing_block());
+    static_position.rect = { offset_to_static_parent.location(), { 0, 0 } };
+    return static_position;
+}
+
 template<>
 Vector<TableFormattingContext::Row>& TableFormattingContext::table_rows_or_columns()
 {

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.h
@@ -28,6 +28,7 @@ public:
     virtual void run(AvailableSpace const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
+    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     Box const& table_box() const { return context_box(); }
     TableWrapper const& table_wrapper() const


### PR DESCRIPTION
Static position of a box is defined by formatting context type it belongs to, so let's define this algorithm separately for each FC instead of assuming FormattingContext::calculate_static_position_rect() understands how to handle all of them.

Also with this change calculate_static_position_rect() is no longer virtual function.