### PR TITLE
LibWeb: Coalesce detail events and update task dispatch to use global_obj

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/DOMParser-fires-details-ontoggle.txt
+++ b/Tests/LibWeb/Text/expected/DOM/DOMParser-fires-details-ontoggle.txt
@@ -1,0 +1,1 @@
+DOMParser toggle event is true

--- a/Tests/LibWeb/Text/expected/HTML/HTMLDetailsElement-coalesce-events.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLDetailsElement-coalesce-events.txt
@@ -1,0 +1,4 @@
+details9.open set to true
+details9.open is still true
+target.open is false
+this should be called

--- a/Tests/LibWeb/Text/expected/HTML/HTMLDetailsElement-toggle-should-be-trusted.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLDetailsElement-toggle-should-be-trusted.txt
@@ -1,0 +1,1 @@
+target is trusted: true

--- a/Tests/LibWeb/Text/input/DOM/DOMParser-fires-details-ontoggle.html
+++ b/Tests/LibWeb/Text/input/DOM/DOMParser-fires-details-ontoggle.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        new DOMParser().parseFromString("<details open>", "text/html").querySelector("details").ontoggle = function(e) {
+            println(`DOMParser toggle event is ${e.target.open}`);
+            done();
+        };
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLDetailsElement-coalesce-events.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLDetailsElement-coalesce-events.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<details id="details9" open>
+  <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+</details>
+<script>
+    asyncTest(done => {
+        details9 = document.getElementById('details9');
+
+        details9.ontoggle = function(e) {
+            println(`target.open is ${e.target.open}`)
+            if (e.target.open) {
+                println("this should not be called")
+            } else {
+                println("this should be called")
+                done()
+            }
+        }
+        details9.open = true;
+        println("details9.open set to true")
+        println(`details9.open is still ${details9.open}`)
+
+        // End the test by retrigging the event
+        details9.open = false;
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/HTMLDetailsElement-toggle-should-be-trusted.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLDetailsElement-toggle-should-be-trusted.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<details id="details1" open>
+  <p>Hi</p>
+</details>
+<script>
+    asyncTest(done => {
+        details1 = document.getElementById('details1');
+        details1.ontoggle = function(e) {
+            println(`target is trusted: ${e.isTrusted}`);
+            done();
+        }
+
+        details1.open = false;
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -899,7 +899,8 @@ void Element::make_html_uppercased_qualified_name()
 // https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task
 HTML::TaskID Element::queue_an_element_task(HTML::Task::Source source, Function<void()> steps)
 {
-    return queue_a_task(source, HTML::main_thread_event_loop(), document(), JS::create_heap_function(heap(), move(steps)));
+    auto& global_object = HTML::relevant_global_object(*this);
+    return HTML::queue_global_task(source, global_object, JS::create_heap_function(heap(), move(steps)));
 }
 
 // https://html.spec.whatwg.org/multipage/syntax.html#void-elements

--- a/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -59,6 +59,13 @@ void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<Strin
 
     // https://html.spec.whatwg.org/multipage/interactive-elements.html#details-notification-task-steps
     if (name == HTML::AttributeNames::open) {
+
+        // if the open attribute was there previously and the new value is also there elide the event per spec
+        // > When the open attribute is toggled several times in succession the resulting tasks essentially get coalesced so that only one event is fired.
+        if (old_value.has_value() && value.has_value()) {
+            return;
+        }
+
         // 1. If the open attribute is added, queue a details toggle event task given the details element, "closed", and "open".
         if (value.has_value()) {
             queue_a_details_toggle_event_task("closed"_string, "open"_string);

--- a/Userland/Libraries/LibWeb/HTML/ToggleEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ToggleEvent.cpp
@@ -14,7 +14,9 @@ JS_DEFINE_ALLOCATOR(ToggleEvent);
 
 JS::NonnullGCPtr<ToggleEvent> ToggleEvent::create(JS::Realm& realm, FlyString const& event_name, ToggleEventInit event_init)
 {
-    return realm.heap().allocate<ToggleEvent>(realm, realm, event_name, move(event_init));
+    auto event = realm.heap().allocate<ToggleEvent>(realm, realm, event_name, move(event_init));
+    event->set_is_trusted(true);
+    return event;
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<ToggleEvent>> ToggleEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, ToggleEventInit event_init)


### PR DESCRIPTION
Fixes the following test suite: http://wpt.live/html/semantics/interactive-elements/the-details-element/toggleEvent.html

<img width="1317" alt="image" src="https://github.com/user-attachments/assets/8e91b603-6127-4b9a-9891-b700338f1e3f">

We update the element task queue to be spec compliant by passing the global object to the `queue_global_task` instead of assuming it should be a document. 

https://html.spec.whatwg.org/multipage/webappapis.html#queue-an-element-task

Then we coalesce detail events that do not change the `open` attribute