### PR TITLE
LibWeb: Throw a SyntaxError on invalid URL for Location href setter

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Location-set-invalid-href-url.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Location-set-invalid-href-url.txt
@@ -1,0 +1,1 @@
+Error setting href: SyntaxError: Invalid URL 'http://@:www.invalid-url.com'

--- a/Tests/LibWeb/Text/input/HTML/Location-set-invalid-href-url.html
+++ b/Tests/LibWeb/Text/input/HTML/Location-set-invalid-href-url.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        try {
+            location.href = 'http://@:www.invalid-url.com';
+        } catch (e) {
+            println(`Error setting href: ${e}`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -109,7 +109,7 @@ WebIDL::ExceptionOr<String> Location::href() const
 // https://html.spec.whatwg.org/multipage/history.html#the-location-interface:dom-location-href-2
 WebIDL::ExceptionOr<void> Location::set_href(String const& new_href)
 {
-    auto& vm = this->vm();
+    auto& realm = this->realm();
     auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
 
     // 1. If this's relevant Document is null, then return.
@@ -117,12 +117,14 @@ WebIDL::ExceptionOr<void> Location::set_href(String const& new_href)
     if (!relevant_document)
         return {};
 
-    // 2. Parse the given value relative to the entry settings object. If that failed, throw a TypeError exception.
+    // FIXME: 2. Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
     auto href_url = window.associated_document().parse_url(new_href.to_byte_string());
-    if (!href_url.is_valid())
-        return vm.throw_completion<JS::URIError>(TRY_OR_THROW_OOM(vm, String::formatted("Invalid URL '{}'", new_href)));
 
-    // 3. Location-object navigate given the resulting URL record.
+    // 3. If url is failure, then throw a "SyntaxError" DOMException.
+    if (!href_url.is_valid())
+        return WebIDL::SyntaxError::create(realm, MUST(String::formatted("Invalid URL '{}'", new_href)));
+
+    // 4. Location-object navigate this to url.
     TRY(navigate(href_url));
 
     return {};


### PR DESCRIPTION
Aligning with a spec update, fixing 195 tests for:

https://wpt.live/url/failure.html


This, along with the hack patch:

```patch
diff --git a/Ladybird/Qt/WebContentView.cpp b/Ladybird/Qt/WebContentView.cpp
index 9c0cdb74ed6..bc54686d59b 100644
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -681,7 +681,7 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli

     update_screen_rects();

-    if (auto webdriver_content_ipc_path = WebView::Application::chrome_options().webdriver_content_ipc_path; webdriver_content_ipc_path.has_value())
+    if (auto webdriver_content_ipc_path = WebView::Application::chrome_options().webdriver_content_ipc_path; webdriver_content_ipc_path.has_value() && m_client_state.page_index < 2)
         client().async_connect_to_webdriver(m_client_state.page_index, *webdriver_content_ipc_path);
 }
```

And reverting 4a43d0ac986d6d20db724c5353c413537aa56c23 result in all of the 1205 tests to pass for https://wpt.live/url/failure.html