### PR TITLE
LibWeb: Resolve flex item % main size to 0 during min-content sizing

### DIFF
--- a/Tests/LibWeb/Layout/expected/flex/flex-item-percentage-main-size-during-min-content-sizing.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-item-percentage-main-size-during-min-content-sizing.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  Box <html> at (0,0) content-size 60x50 flex-container(row) [FFC] children: not-inline
+    Box <body> at (8,3) content-size 44x44 flex-container(row) flex-item [FFC] children: not-inline
+      ImageBox <img> at (8,3) content-size 44x44 flex-item children: not-inline
+      BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableBox (Box<HTML>) [0,0 60x50]
+    PaintableBox (Box<BODY>) [8,3 44x44]
+      ImagePaintable (ImageBox<IMG>) [8,3 44x44]

--- a/Tests/LibWeb/Layout/input/flex/flex-item-percentage-main-size-during-min-content-sizing.html
+++ b/Tests/LibWeb/Layout/input/flex/flex-item-percentage-main-size-during-min-content-sizing.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<style type="text/css">
+  * {
+    outline: 1px solid black;
+  }
+  html {
+    display: flex;
+    align-items: center;
+    width: 60px;
+    height: 50px;
+  }
+  body {
+    display: flex;
+  }
+  img {
+    width: 100%;
+  }
+</style>
+<body><img src="../120.png">

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -587,6 +587,13 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
             return get_pixel_height(child_box, size);
         }
 
+        // AD-HOC: If we're sizing the flex container under a min-content constraint in the main axis,
+        //         flex items resolve percentages in the main axis to 0.
+        if (m_available_space_for_items->main.is_min_content()
+            && computed_main_size(item.box).contains_percentage()) {
+            return CSSPixels(0);
+        }
+
         // B. If the flex item has ...
         //    - an intrinsic aspect ratio,
         //    - a used flex basis of content, and


### PR DESCRIPTION
When the flex container is sized under a min-content constraint in the main axis, any flex items with a percentage main size should collapse to zero width, not take up their own intrinsic min-content size.

This is not in the spec, but matches how other browsers behave.

Fixes an issue where the cartoons on https://basecamp.com/ were way too large. :^)

Before:
<img width="1257" alt="Screenshot 2024-10-06 at 15 25 44" src="https://github.com/user-attachments/assets/80778c6b-1191-4882-8631-67fe7fd69d79">

After:
<img width="1257" alt="Screenshot 2024-10-06 at 15 25 26" src="https://github.com/user-attachments/assets/732e8df2-d6f3-4666-bbb1-f60aeb238900">
