### PR TITLE
LibWeb: Simplify static position calculation for block-level boxes

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -640,8 +640,10 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     auto& box_state = m_state.get_mutable(box);
 
     if (box.is_absolutely_positioned()) {
-        box_state.vertical_offset_of_parent_block_container = m_y_offset_of_current_block_container.value();
-        box_state.set_static_position_rect(calculate_static_position_rect(box));
+        StaticPositionRect static_position;
+        auto offset_to_static_parent = content_box_rect_in_static_position_ancestor_coordinate_space(box, *box.containing_block());
+        static_position.rect = { offset_to_static_parent.location().translated(0, m_y_offset_of_current_block_container.value()), { 0, 0 } };
+        box_state.set_static_position_rect(static_position);
         return;
     }
 
@@ -1327,15 +1329,6 @@ CSSPixels BlockFormattingContext::greatest_child_width(Box const& box) const
         });
     }
     return max_width;
-}
-
-StaticPositionRect BlockFormattingContext::calculate_static_position_rect(Box const& box) const
-{
-    StaticPositionRect static_position;
-    auto const& box_state = m_state.get(box);
-    auto offset_to_static_parent = content_box_rect_in_static_position_ancestor_coordinate_space(box, *box.containing_block());
-    static_position.rect = { offset_to_static_parent.location().translated(0, box_state.vertical_offset_of_parent_block_container), { 0, 0 } };
-    return static_position;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -25,7 +25,6 @@ public:
     virtual void run(AvailableSpace const&) override;
     virtual CSSPixels automatic_content_width() const override;
     virtual CSSPixels automatic_content_height() const override;
-    StaticPositionRect calculate_static_position_rect(Box const&) const;
 
     auto const& left_side_floats() const { return m_left_floats; }
     auto const& right_side_floats() const { return m_right_floats; }

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.h
@@ -130,9 +130,6 @@ struct LayoutState {
         CSSPixels inset_top { 0 };
         CSSPixels inset_bottom { 0 };
 
-        // Used for calculating the static position of an abspos block-level box.
-        CSSPixels vertical_offset_of_parent_block_container { 0 };
-
         Vector<LineBox> line_boxes;
 
         CSSPixels margin_box_left() const { return margin_left + border_left_collapsed() + padding_left; }


### PR DESCRIPTION
There is no need to save vertical offset in UsedValues to use later, when static position could be assigned directly upon encountering abspos box.