### PR TITLE
LibWeb: Do not spin the event loop on processing iframe attributes

### DIFF
--- a/Tests/LibWeb/Text/expected/iframe-removed-asyncronously.txt
+++ b/Tests/LibWeb/Text/expected/iframe-removed-asyncronously.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/iframe-removed-asyncronously.html
+++ b/Tests/LibWeb/Text/input/iframe-removed-asyncronously.html
@@ -1,0 +1,20 @@
+<body>
+</body>
+<script src="include.js"></script>
+<script>
+    asyncTest(done => {
+        let frame = document.body.appendChild(document.createElement("iframe"));
+
+        setTimeout(() => {
+            frame.remove();
+
+            setTimeout(() => {
+                println("PASS! (Didn't crash)");
+                done();
+            }, 0);
+
+          }, 0);
+
+        frame.src = `../data/iframe-with-border-radius-svg.html`;
+    })
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -77,12 +77,6 @@ void HTMLIFrameElement::process_the_iframe_attributes(bool initial_insertion)
     if (!content_navigable())
         return;
 
-    // Make sure applying of history step caused by potential sync navigation to "about:blank"
-    // is finished. Otherwise, it might interrupt navigation caused by changing src or srcdoc.
-    if (!initial_insertion && !content_navigable_initialized()) {
-        main_thread_event_loop().spin_processing_tasks_with_source_until(Task::Source::NavigationAndTraversal, [this] { return content_navigable_initialized(); });
-    }
-
     // 1. If element's srcdoc attribute is specified, then:
     if (has_attribute(HTML::AttributeNames::srcdoc)) {
         // 1. Set element's current navigation was lazy loaded boolean to false.


### PR DESCRIPTION
Partially reverting a3149c1ce95a5ee5f58d3303d01722a0fcb54256.

Spinning the event loop was causing a crash on:

https://wpt.live/url/percent-encoding.window.html

As it was turning what is meant to be a synchronous operation into an asynchronous one.

The sequence demonstrated by the reproducing test is as follows:
  * A src attribute is changed for the iframe
  * process_the_iframe_attributes entered with valid content navigable
  * Event loop is spun, allowing the queued iframe removal to execute
  * process_the_iframe_attributes continues with null content navigable
  * 💥