### PR TITLE
LibWeb: Allow SVG root elements to have visible overflow

### DIFF
--- a/Tests/LibWeb/Ref/reference/svg-overflow-hidden-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-overflow-hidden-ref.html
@@ -1,0 +1,6 @@
+<style>
+    svg { 
+        height: 200px;
+    }
+</style>
+<svg class="visible" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="50" height="100" fill="green"></rect></svg>

--- a/Tests/LibWeb/Ref/reference/svg-overflow-visible-ref.html
+++ b/Tests/LibWeb/Ref/reference/svg-overflow-visible-ref.html
@@ -1,0 +1,6 @@
+<style>
+    svg { 
+        height: 200px;
+    }
+</style>
+<svg class="visible" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="50" height="200" fill="green"></rect></svg>

--- a/Tests/LibWeb/Ref/svg-overflow-hidden.html
+++ b/Tests/LibWeb/Ref/svg-overflow-hidden.html
@@ -1,0 +1,8 @@
+<link rel="match" href="reference/svg-overflow-hidden-ref.html" />
+<style>
+    svg { 
+        width: 100px; 
+        overflow: hidden;
+    }
+</style>
+<svg class="visible" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="50" height="200" fill="green"></rect></svg>

--- a/Tests/LibWeb/Ref/svg-overflow-visible.html
+++ b/Tests/LibWeb/Ref/svg-overflow-visible.html
@@ -1,0 +1,8 @@
+<link rel="match" href="reference/svg-overflow-visible-ref.html" />
+<style>
+    svg { 
+        width: 100px; 
+        overflow: visible;
+    }
+</style>
+<svg class="visible" viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><rect x="0" y="0" width="50" height="200" fill="green"></rect></svg>

--- a/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -32,9 +32,7 @@ void SVGSVGPaintable::before_children_paint(PaintContext& context, PaintPhase ph
     if (phase != PaintPhase::Foreground)
         return;
     context.display_list_recorder().save();
-    auto clip_rect = absolute_rect();
     context.display_list_recorder().set_scroll_frame_id(scroll_frame_id());
-    context.display_list_recorder().add_clip_rect(context.enclosing_device_rect(clip_rect).to_type<int>());
 }
 
 void SVGSVGPaintable::after_children_paint(PaintContext& context, PaintPhase phase) const


### PR DESCRIPTION
We were overly aggressive in clipping SVG roots, which effectively made them behave as if they always had `overflow: hidden`.

This fixes incorrect clipping of the logo on https://basecamp.com/