### PR TITLE
LibWeb: Skip transitions for pseudo elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1238,7 +1238,8 @@ static void compute_transitioned_properties(StyleProperties const& style, DOM::E
 void StyleComputer::start_needed_transitions(StyleProperties const& previous_style, StyleProperties& new_style, DOM::Element& element, Optional<Selector::PseudoElement::Type> pseudo_element) const
 {
     // FIXME: Implement transitions for pseudo-elements
-    (void)pseudo_element;
+    if (pseudo_element.has_value())
+        return;
 
     // https://drafts.csswg.org/css-transitions/#transition-combined-duration
     auto combined_duration = [](Animations::Animatable::TransitionAttributes const& transition_attributes) {


### PR DESCRIPTION
Transitions are currently not implemented for pseudo elements which
causes the transition to be applied to the "real"/"parent" element. When
a transition adjusts width/height on a pseudo element this causes the
real elements layout to break.

As a quick fix we just skip doing transitions when they are against
pseudo elements.

Here is a minimal reproduction of the issue:
```html
<html>
  <head>
    <style>
      ul { display: flex; }
      p { border: 1px solid red; }
      p:after {
        content: "";
        width: 0;
      }
      li:hover p:after {
        content: "";
        width: 100px;
        transition: width 0.3s ease;
      }
    </style>
  </head>
  <body>
    <ul>
      <li><p>hello</p></li>
      <li><p>friends</p></li>
    </ul>
  </body>
</html>
```

And here is a screencast demonstrating the minimal reproduction:
[Screencast_20241006_223920-1.webm](https://github.com/user-attachments/assets/4aee6cf1-e47a-4c66-b289-a6366692e88d)
