### PR TITLE
fixing line in XML serializer the enure public ID is empty before app…

### DIFF
--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -839,7 +839,7 @@ static WebIDL::ExceptionOr<String> serialize_document_type(DOM::DocumentType con
     }
 
     // 8. If the node's systemId is not the empty string and the node's publicId is set to the empty string, then append the following, in the order listed, to markup:
-    if (!document_type.system_id().is_empty() && !document_type.public_id().is_empty()) {
+    if (!document_type.system_id().is_empty() && document_type.public_id().is_empty()) {
         // 1. " " (U+0020 SPACE);
         // 2. The string "SYSTEM".
         markup.append(" SYSTEM"sv);


### PR DESCRIPTION
LibWeb: XMLSerializer parsing of DOCUMENT TAG markup is now correctly adds SYSTEM on blank system ID case

Tests from wpt xml tests failed due to an incorrect if statement
http://wpt.live/domparsing/xml-serialization.xhtml

The statement was previous written to only add SYSTEM if both the system id and public id are both NOT empty. However SYSTEM should be added in the case that only public ID is empty.

(This is one of my first PR's I tried to follow the rules to the best of my ability, apologies if I messed anything up)