### PR TITLE
Revert "WebContent+WebDriver: Inform WebDriver when a window is closed"

### DIFF
--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -538,9 +538,6 @@ void PageClient::page_did_close_top_level_traversable()
     // FIXME: Rename this IPC call
     client().async_did_close_browsing_context(m_id);
 
-    if (m_webdriver)
-        m_webdriver->async_window_closed();
-
     // NOTE: This only removes the strong reference the PageHost has for this PageClient.
     //       It will be GC'd 'later'.
     m_owner.remove_page({}, m_id);

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -1,7 +1,6 @@
 #include <LibWeb/WebDriver/Response.h>
 
 endpoint WebDriverServer {
-    window_closed() =|
     script_executed(Web::WebDriver::Response response) =|
     actions_performed(Web::WebDriver::Response response) =|
 }

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -20,11 +20,6 @@ void WebContentConnection::die()
         on_close();
 }
 
-void WebContentConnection::window_closed()
-{
-    shutdown();
-}
-
 void WebContentConnection::script_executed(Web::WebDriver::Response const& response)
 {
     if (on_script_executed)

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -27,7 +27,6 @@ public:
 private:
     virtual void die() override;
 
-    virtual void window_closed() override;
     virtual void script_executed(Web::WebDriver::Response const&) override;
     virtual void actions_performed(Web::WebDriver::Response const&) override;
 };


### PR DESCRIPTION
This reverts commit 556a0936dd329fbfe00469b8831a6efae311733b.

This was causing a large slow down in WPT, and a crash on macOS during session shutdown when running WebDriver manually.