### PR TITLE
Meta: Avoid messing with the system python in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,6 +13,14 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: 3.12
+        cache: 'pip'
+    - name: 'Install Python dependencies'
+      shell: bash
+      run: pip install pyyaml requests six
+
     - name: 'Install Dependencies'
       if: ${{ inputs.os == 'Linux' }}
       shell: bash
@@ -36,12 +44,6 @@ runs:
         tar -xzf ./wabt-1.0.35-ubuntu-20.04.tar.gz
         rm ./wabt-1.0.35-ubuntu-20.04.tar.gz
         echo "${{ github.workspace }}/wabt-1.0.35/bin" >> $GITHUB_PATH
-
-    - name: 'Install Python dependencies'
-      shell: bash
-      run: |
-        python3 -m pip install --break-system-packages --upgrade pip
-        pip3 install --break-system-packages pyyaml requests six
 
     - name: 'Select latest Xcode'
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -113,6 +113,7 @@ jobs:
             -DINCLUDE_WASM_SPEC_TESTS=ON \
             -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \
             ${{ steps.build-parameters.outputs.cmake_options }} \
+            -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }}
 
@@ -126,6 +127,7 @@ jobs:
             -DLAGOM_TOOLS_ONLY=ON \
             -DINSTALL_LAGOM_TOOLS=ON \
             -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/Build/tools-install \
+            -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_CXX_COMPILER=g++-13 \
             -Dpackage=LagomTools
@@ -133,6 +135,7 @@ jobs:
           ninja -C ${{ github.workspace }}/Build/tools-build install
 
           cmake --preset Fuzzers_CI -B Build \
+            -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \
             -DCMAKE_PREFIX_PATH=${{ github.workspace }}/Build/tools-install


### PR DESCRIPTION
This uses the setup-python action in the setup action to install python 3.12, and removes the --break-system-packages hack that the system pip requires.