### PR TITLE
LibWebView: Increase the open file limit in a more central location

### DIFF
--- a/Ladybird/AppKit/main.mm
+++ b/Ladybird/AppKit/main.mm
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     platform_init();
 
-    auto chrome_process = TRY(WebView::ChromeProcess::create());
+    WebView::ChromeProcess chrome_process;
 
     if (auto const& chrome_options = WebView::Application::chrome_options(); chrome_options.force_new_process == WebView::ForceNewProcess::No) {
         auto disposition = TRY(chrome_process.connect(chrome_options.raw_urls, chrome_options.new_window));

--- a/Ladybird/Qt/main.cpp
+++ b/Ladybird/Qt/main.cpp
@@ -73,7 +73,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     platform_init();
 
-    auto chrome_process = TRY(WebView::ChromeProcess::create());
+    WebView::ChromeProcess chrome_process;
 
     if (app->chrome_options().force_new_process == WebView::ForceNewProcess::No) {
         auto disposition = TRY(chrome_process.connect(app->chrome_options().raw_urls, app->chrome_options().new_window));

--- a/Userland/Libraries/LibWebView/Application.cpp
+++ b/Userland/Libraries/LibWebView/Application.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Environment.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 #include <LibCore/TimeZoneWatcher.h>
 #include <LibFileSystem/FileSystem.h>
 #include <LibImageDecoderClient/Client.h>
@@ -55,6 +56,10 @@ Application::~Application()
 
 void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_page_url)
 {
+    // Increase the open file limit, as the default limits on Linux cause us to run out of file descriptors with around 15 tabs open.
+    if (auto result = Core::System::set_resource_limits(RLIMIT_NOFILE, 8192); result.is_error())
+        warnln("Unable to increase open file limit: {}", result.error());
+
     Vector<ByteString> raw_urls;
     Vector<ByteString> certificates;
     bool new_window = false;

--- a/Userland/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Userland/Libraries/LibWebView/ChromeProcess.cpp
@@ -25,15 +25,6 @@ private:
     UIProcessClient(NonnullOwnPtr<Core::LocalSocket>);
 };
 
-ErrorOr<ChromeProcess> ChromeProcess::create()
-{
-    // Increase the open file limit, as the default limits on Linux cause us to run out of file descriptors with around 15 tabs open.
-    if (auto result = Core::System::set_resource_limits(RLIMIT_NOFILE, 8192); result.is_error())
-        warnln("Unable to increase open file limit: {}", result.error());
-
-    return ChromeProcess {};
-}
-
 ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteString> const& raw_urls, NewWindow new_window)
 {
     static constexpr auto process_name = "Ladybird"sv;

--- a/Userland/Libraries/LibWebView/ChromeProcess.h
+++ b/Userland/Libraries/LibWebView/ChromeProcess.h
@@ -49,7 +49,7 @@ public:
         ExitProcess,
     };
 
-    static ErrorOr<ChromeProcess> create();
+    ChromeProcess() = default;
     ~ChromeProcess();
 
     ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, NewWindow new_window);
@@ -58,8 +58,6 @@ public:
     Function<void(Vector<URL::URL> const&)> on_new_window;
 
 private:
-    ChromeProcess() = default;
-
     ErrorOr<void> connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, NewWindow new_window);
     ErrorOr<void> connect_as_server(ByteString const& socket_path);
 


### PR DESCRIPTION
We don't create a ChromeProcess in headless-browser, so it is currently not increasing it's open file limit. This is causing crashes on macOS, which has a very low default limit.