### PR TITLE
LibWeb: Wait for the iframe load before completing the beforeunload test

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/beforeunload.txt
+++ b/Tests/LibWeb/Text/expected/DOM/beforeunload.txt
@@ -1,2 +1,3 @@
 Before unload event fired
 Default prevented: true
+iframe load: about:blank

--- a/Tests/LibWeb/Text/input/DOM/beforeunload.html
+++ b/Tests/LibWeb/Text/input/DOM/beforeunload.html
@@ -3,12 +3,18 @@
     asyncTest(done => {
         const iframe = document.createElement("iframe");
         document.body.appendChild(iframe);
+
         iframe.contentWindow.addEventListener("beforeunload", e => {
             println("Before unload event fired");
             e.preventDefault();
             println(`Default prevented: ${e.defaultPrevented}`);
+        });
+
+        iframe.addEventListener("load", e => {
+            println(`iframe load: ${e.target.src}`);
             done();
         });
+
         iframe.src = "about:blank";
     });
 </script>


### PR DESCRIPTION
This test caused some flakiness due to the about:blank load it triggers. It causes headless-browser to receive a load event for about:blank. If we have moved onto the next test before that event arrived, that test would ultimately time out, as its own load will have been dropped while the about:blank load is still ongoing.

This patch makes us wait for that iframe load event before completing the test.

We may want to consider never sending subframe load events to the UI process as well. We really only care about top-level page loads in the receivers of that event.