### PR TITLE
Ladybird/Qt: Create new tab when creating new window

### DIFF
--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -606,7 +606,14 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
         tab.focus_location_editor();
     });
     QObject::connect(m_new_window_action, &QAction::triggered, this, [] {
-        (void)static_cast<Ladybird::Application*>(QApplication::instance())->new_window({});
+        auto& window = static_cast<Ladybird::Application*>(QApplication::instance())->new_window({});
+        auto& tab = window.new_tab_from_url(ak_url_from_qstring(Settings::the()->new_tab_page()), Web::HTML::ActivateTab::Yes);
+        tab.set_url_is_hidden(true);
+        tab.focus_location_editor();
+        if (Ladybird::Settings::the()->is_maximized())
+            window.showMaximized();
+        else
+            window.resize(Ladybird::Settings::the()->last_size());
     });
     QObject::connect(open_file_action, &QAction::triggered, this, &BrowserWindow::open_file);
     QObject::connect(settings_action, &QAction::triggered, this, [this] {


### PR DESCRIPTION
This PR implements the expected behavior when creating a new browser window.

Before:

![before](https://github.com/user-attachments/assets/aefce556-58cf-4058-a060-54486cf5b609)

After:

![after](https://github.com/user-attachments/assets/46ee785f-0c1f-4129-a4ab-62ee6248ac25)
