### PR TITLE
Meta: Fix ladybird.sh to support CDPATH being set

### DIFF
--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -3,7 +3,7 @@
 set -e
 
 SCRIPT_PATH="$(dirname "${0}")"
-cd "${SCRIPT_PATH}"
+CDPATH='' cd "${SCRIPT_PATH}"
 
 BEST_CLANG_CANDIDATE=""
 

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( CDPATH='' cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # shellcheck source=/dev/null
 . "${DIR}/shell_include.sh"

--- a/Meta/check-debug-flags.sh
+++ b/Meta/check-debug-flags.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.."
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.."
 
 MISSING_FLAGS=n
 

--- a/Meta/check-markdown.sh
+++ b/Meta/check-markdown.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.."
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.."
 
 if [ -z "${MARKDOWN_CHECK_BINARY:-}" ] ; then
     if ! [ -d Build/lagom/ ] ; then

--- a/Meta/check-png-sizes.sh
+++ b/Meta/check-png-sizes.sh
@@ -5,8 +5,8 @@ set -eo pipefail
 # How many bytes optipng has to be able to strip out of the file for the optimization to be worth it. The default is 1 KiB.
 : "${MINIMUM_OPTIMIZATION_BYTES:=1024}"
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.."
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.."
 
 if ! command -v optipng >/dev/null ; then
     echo 'optipng is not installed, skipping png size check.'

--- a/Meta/configure-clangd.sh
+++ b/Meta/configure-clangd.sh
@@ -6,8 +6,8 @@ function usage {
     echo "compilation database according to the selected build type."
 }
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 # Check if the user has sed.
 

--- a/Meta/gn/build/toolchain/BUILD.gn
+++ b/Meta/gn/build/toolchain/BUILD.gn
@@ -136,7 +136,7 @@ template("unix_toolchain") {
     if (current_os == "ios" || current_os == "mac") {
       tool("copy_bundle_data") {
         # https://github.com/nico/hack/blob/master/notes/copydir.md
-        _copydir = "cd {{source}} && " +
+        _copydir = "CDPATH='' cd {{source}} && " +
                    "find . | cpio -pdl \"\$OLDPWD\"/{{output}} 2>/dev/null"
         command = "rm -rf {{output}} && if [[ -d {{source}} ]]; then " +
                   _copydir + "; else " + unix_copy_command + "; fi"

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -53,7 +53,7 @@ if [ "$CMD" = "help" ]; then
     exit 0
 fi
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( CDPATH='' cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # shellcheck source=/dev/null
 . "${DIR}/shell_include.sh"
@@ -141,7 +141,7 @@ delete_target() {
 }
 
 build_vcpkg() {
-    ( cd "$LADYBIRD_SOURCE_DIR/Toolchain" && python3 ./BuildVcpkg.py )
+    ( CDPATH='' cd "$LADYBIRD_SOURCE_DIR/Toolchain" && python3 ./BuildVcpkg.py )
 }
 
 ensure_toolchain() {

--- a/Meta/lint-ci.sh
+++ b/Meta/lint-ci.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 BOLD_RED='\033[0;1;31m'
 GREEN='\033[0;32m'

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "1" ]; then
     files=()

--- a/Meta/lint-executable-resources.sh
+++ b/Meta/lint-executable-resources.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "$script_path/.."
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "$script_path/.."
 
 if [ "$(uname -s)" = "Darwin" ]; then
     # MacOS's find does not support '-executable' OR '-perm /mode'.

--- a/Meta/lint-gn.sh
+++ b/Meta/lint-gn.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
     files=()

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
     files=()

--- a/Meta/lint-python.sh
+++ b/Meta/lint-python.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
     files=()

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -2,8 +2,8 @@
 
 set -eo pipefail
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "$script_path/.."
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "$script_path/.."
 
 if [ "$#" -eq "0" ]; then
     files=()

--- a/Meta/lint-swift.sh
+++ b/Meta/lint-swift.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
-cd "${script_path}/.." || exit 1
+script_path=$(CDPATH='' cd -P -- "$(dirname -- "$0")" && pwd -P)
+CDPATH='' cd "${script_path}/.." || exit 1
 
 if [ "$#" -eq "0" ]; then
     files=()

--- a/Meta/refresh-ladybird-qtcreator.sh
+++ b/Meta/refresh-ladybird-qtcreator.sh
@@ -9,6 +9,6 @@ then
     echo "    export LADYBIRD_SOURCE_DIR=${LADYBIRD_SOURCE_DIR}"
 fi
 
-cd "${LADYBIRD_SOURCE_DIR}"
+CDPATH='' cd "${LADYBIRD_SOURCE_DIR}"
 
 find . \( -name Base -o -name Patches -o -name Ports -o -name Root -o -name Toolchain -o -name Build \) -prune -o \( -name '*.ipc' -or -name '*.cpp' -or -name '*.idl' -or -name '*.h' -or -name '*.in' -or -name '*.css' -or -name '*.cmake' -or -name '*.json' -or -name 'CMakeLists.txt' \) -print > ladybird.files

--- a/Toolchain/BuildGN.sh
+++ b/Toolchain/BuildGN.sh
@@ -3,7 +3,7 @@
 # This script builds the GN meta-build system
 set -e
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( CDPATH='' cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # shellcheck source=/dev/null
 . "${DIR}/../Meta/shell_include.sh"
@@ -23,7 +23,7 @@ pushd "$DIR"/Tarballs
 
 [ ! -d gn ] && git clone $GIT_REPO
 
-cd gn
+CDPATH='' cd gn
 git fetch origin
 git checkout $GIT_REV
 

--- a/UI/Android/BuildLagomTools.sh
+++ b/UI/Android/BuildLagomTools.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+DIR="$( CDPATH='' cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 LADYBIRD_SOURCE_DIR="$(realpath "${DIR}"/../..)"
 

--- a/UI/Android/gradlew
+++ b/UI/Android/gradlew
@@ -36,9 +36,9 @@ while [ -h "$PRG" ] ; do
     fi
 done
 SAVED="`pwd`"
-cd "`dirname \"$PRG\"`/" >/dev/null
+CDPATH='' cd "`dirname \"$PRG\"`/" >/dev/null
 APP_HOME="`pwd -P`"
-cd "$SAVED" >/dev/null
+CDPATH='' cd "$SAVED" >/dev/null
 
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`


### PR DESCRIPTION
When the CDPATH environment variable is set, `cd` can print out the `pwd` to stdout after changing. This change clears the variable before using `cd` when setting `DIR`.

Without the change, DIR will have the `pwd` twice separated by `\n` and the `. "${DIR}/shell_include.sh"` a few lines later fails, which then kills the script as `set -e` is done on line `3`. I worked this out using `set -x` before that section to see what it was including, and remembering that I was playing around with `CDPATH` recently!

From the [bash manual](https://www.gnu.org/software/bash/manual/bash.html#index-cd):
> If a non-empty directory name from CDPATH is used, or if ‘-’ is the first argument, and the directory change is successful, the absolute pathname of the new working directory is written to the standard output.
