### PR TITLE
LibWeb: Fire iframe load event on document close

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/document-close-iframe-load-event.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-close-iframe-load-event.txt
@@ -1,0 +1,1 @@
+Onload event fired

--- a/Tests/LibWeb/Text/input/HTML/document-close-iframe-load-event.html
+++ b/Tests/LibWeb/Text/input/HTML/document-close-iframe-load-event.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const iframe = document.createElement('iframe');
+        document.body.appendChild(iframe);
+        iframe.contentDocument.open();
+        iframe.onload = () => {
+            println("Onload event fired");
+            iframe.remove();
+            done();
+        };
+        iframe.contentDocument.close();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -705,6 +705,9 @@ WebIDL::ExceptionOr<void> Document::close()
     // FIXME: 6. Run the tokenizer, processing resulting tokens as they are emitted, and stopping when the tokenizer reaches the explicit "EOF" character or spins the event loop.
     m_parser->run();
 
+    // AD-HOC: This ensures that a load event is fired if the node navigable's container is an iframe.
+    completely_finish_loading();
+
     return {};
 }
 


### PR DESCRIPTION
This matches the behavior of other browsers.

This gets rid of many timeouts for the HTML parser WPT tests in the `html/syntax/parsing` subdirectory

These are the results of running `./Meta/WPT.sh run html/syntax/parsing`:

Before:
```
  Ran 208 tests finished in 213.4 seconds.
  • 59 ran as expected. 0 tests skipped.
  • 22 tests crashed unexpectedly
  • 103 tests timed out unexpectedly
  • 24 tests had unexpected subtest results
```
After:
```
Ran 208 tests finished in 173.5 seconds.
  • 87 ran as expected. 0 tests skipped.
  • 38 tests crashed unexpectedly
  • 2 tests timed out unexpectedly
  • 81 tests had unexpected subtest results
```
