### PR TITLE
LibWeb: Ignore boxes wholly in the negative scrollable overflow region

### DIFF
--- a/Tests/LibWeb/Layout/expected/actually-ignore-the-negative-overflow-region.txt
+++ b/Tests/LibWeb/Layout/expected/actually-ignore-the-negative-overflow-region.txt
@@ -1,0 +1,9 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x16 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x0 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div> at (-5000,8) content-size 0x0 positioned [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x16]
+    PaintableBox (Box<BODY>) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [-5000,8 0x0]

--- a/Tests/LibWeb/Layout/input/actually-ignore-the-negative-overflow-region.html
+++ b/Tests/LibWeb/Layout/input/actually-ignore-the-negative-overflow-region.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body { display: flex; }
+    div {
+        position: absolute;
+        left: -5000px;
+    }
+</style><body><div>

--- a/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Userland/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -105,11 +105,13 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box)
                 return IterationDecision::Continue;
 
             auto child_border_box = child.paintable_box()->absolute_border_box_rect();
+
             // NOTE: Here we check that the child is not wholly in the negative scrollable overflow region.
-            if (child_border_box.bottom() > 0 && child_border_box.right() > 0) {
-                scrollable_overflow_rect = scrollable_overflow_rect.united(child_border_box);
-                content_overflow_rect = content_overflow_rect.united(child_border_box);
-            }
+            if (child_border_box.bottom() < 0 || child_border_box.right() < 0)
+                return IterationDecision::Continue;
+
+            scrollable_overflow_rect = scrollable_overflow_rect.united(child_border_box);
+            content_overflow_rect = content_overflow_rect.united(child_border_box);
 
             // - The scrollable overflow areas of all of the above boxes
             //   (including zero-area boxes and accounting for transforms as described above),


### PR DESCRIPTION
This fixes an issue where https://hey.com/ was horizontally scrollable even though it shouldn't be.