### PR TITLE
LibWeb: Implement navigator.deviceMemory

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1751,6 +1751,11 @@ unsigned hardware_concurrency()
     return sysconf(_SC_NPROCESSORS_ONLN);
 }
 
+u64 physical_memory_bytes()
+{
+    return sysconf(_SC_PHYS_PAGES) * PAGE_SIZE;
+}
+
 ErrorOr<String> resolve_executable_from_environment(StringView filename, int flags)
 {
     if (filename.is_empty())

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -283,6 +283,7 @@ ErrorOr<void> posix_fallocate(int fd, off_t offset, off_t length);
 #endif
 
 unsigned hardware_concurrency();
+u64 physical_memory_bytes();
 
 ErrorOr<String> resolve_executable_from_environment(StringView filename, int flags = 0);
 

--- a/Userland/Libraries/LibWeb/HTML/Navigator.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.h
@@ -10,6 +10,7 @@
 #include <LibWeb/HTML/MimeTypeArray.h>
 #include <LibWeb/HTML/NavigatorBeacon.h>
 #include <LibWeb/HTML/NavigatorConcurrentHardware.h>
+#include <LibWeb/HTML/NavigatorDeviceMemory.h>
 #include <LibWeb/HTML/NavigatorID.h>
 #include <LibWeb/HTML/NavigatorLanguage.h>
 #include <LibWeb/HTML/NavigatorOnLine.h>
@@ -23,6 +24,7 @@ namespace Web::HTML {
 class Navigator : public Bindings::PlatformObject
     , public NavigatorBeaconMixin
     , public NavigatorConcurrentHardwareMixin
+    , public NavigatorDeviceMemoryMixin
     , public NavigatorIDMixin
     , public NavigatorLanguageMixin
     , public NavigatorOnLineMixin

--- a/Userland/Libraries/LibWeb/HTML/Navigator.idl
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.idl
@@ -1,10 +1,11 @@
 #import <Clipboard/Clipboard.idl>
 #import <HTML/MimeTypeArray.idl>
 #import <HTML/NavigatorBeacon.idl>
+#import <HTML/NavigatorConcurrentHardware.idl>
+#import <HTML/NavigatorDeviceMemory.idl>
 #import <HTML/NavigatorID.idl>
 #import <HTML/NavigatorLanguage.idl>
 #import <HTML/NavigatorOnLine.idl>
-#import <HTML/NavigatorConcurrentHardware.idl>
 #import <HTML/PluginArray.idl>
 #import <HTML/ServiceWorkerContainer.idl>
 #import <HTML/UserActivation.idl>
@@ -72,3 +73,4 @@ Navigator includes NavigatorPlugins;
 Navigator includes NavigatorConcurrentHardware;
 Navigator includes NavigatorAutomationInformation;
 Navigator includes NavigatorStorage;
+Navigator includes NavigatorDeviceMemory;

--- a/Userland/Libraries/LibWeb/HTML/NavigatorDeviceMemory.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorDeviceMemory.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BuiltinWrappers.h>
+#include <LibCore/System.h>
+#include <LibWeb/WebIDL/Types.h>
+
+namespace Web::HTML {
+
+class NavigatorDeviceMemoryMixin {
+public:
+    // https://www.w3.org/TR/device-memory/#computing-device-memory-value
+    WebIDL::Double device_memory() const
+    {
+        // The value is calculated by using the actual device memory in MiB then rounding it to the
+        // nearest number where only the most signicant bit can be set and the rest are zeros
+        // (nearest power of two).
+        auto memory_in_bytes = Core::System::physical_memory_bytes();
+        auto memory_in_mib = memory_in_bytes / MiB;
+        auto required_bits = AK::count_required_bits(memory_in_mib);
+        auto lower_memory_in_mib = static_cast<u64>(1) << (required_bits - 1);
+        auto upper_memory_in_mib = static_cast<u64>(1) << required_bits;
+        auto rounded_memory_in_mib = upper_memory_in_mib - memory_in_mib <= memory_in_mib - lower_memory_in_mib
+            ? upper_memory_in_mib
+            : lower_memory_in_mib;
+
+        // Then dividing that number by 1024.0 to get the value in GiB.
+        auto memory_in_gib = static_cast<WebIDL::Double>(rounded_memory_in_mib) / 1024.0;
+
+        // An upper bound and a lower bound should be set on the list of values.
+        return AK::clamp(memory_in_gib, 1.0, 4.0);
+    }
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/NavigatorDeviceMemory.idl
+++ b/Userland/Libraries/LibWeb/HTML/NavigatorDeviceMemory.idl
@@ -1,0 +1,5 @@
+// https://www.w3.org/TR/device-memory/#sec-device-memory-js-api
+[SecureContext, Exposed=(Window,Worker)]
+interface mixin NavigatorDeviceMemory {
+    readonly attribute double deviceMemory;
+};

--- a/Userland/Libraries/LibWeb/HTML/WorkerNavigator.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerNavigator.h
@@ -9,6 +9,7 @@
 
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/NavigatorConcurrentHardware.h>
+#include <LibWeb/HTML/NavigatorDeviceMemory.h>
 #include <LibWeb/HTML/NavigatorID.h>
 #include <LibWeb/HTML/NavigatorLanguage.h>
 #include <LibWeb/HTML/NavigatorOnLine.h>
@@ -20,6 +21,7 @@ namespace Web::HTML {
 
 class WorkerNavigator : public Bindings::PlatformObject
     , public NavigatorConcurrentHardwareMixin
+    , public NavigatorDeviceMemoryMixin
     , public NavigatorIDMixin
     , public NavigatorLanguageMixin
     , public NavigatorOnLineMixin

--- a/Userland/Libraries/LibWeb/HTML/WorkerNavigator.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerNavigator.idl
@@ -1,7 +1,8 @@
+#import <HTML/NavigatorConcurrentHardware.idl>
+#import <HTML/NavigatorDeviceMemory.idl>
 #import <HTML/NavigatorID.idl>
 #import <HTML/NavigatorLanguage.idl>
 #import <HTML/NavigatorOnLine.idl>
-#import <HTML/NavigatorConcurrentHardware.idl>
 #import <MediaCapabilitiesAPI/MediaCapabilities.idl>
 #import <StorageAPI/NavigatorStorage.idl>
 
@@ -20,3 +21,4 @@ WorkerNavigator includes NavigatorLanguage;
 WorkerNavigator includes NavigatorOnLine;
 WorkerNavigator includes NavigatorConcurrentHardware;
 WorkerNavigator includes NavigatorStorage;
+WorkerNavigator includes NavigatorDeviceMemory;

--- a/Userland/Libraries/LibWeb/WebIDL/Types.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Types.h
@@ -42,4 +42,9 @@ using LongLong = i64;
 // The unsigned long long type is an unsigned integer type that has values in the range [0, 18446744073709551615].
 using UnsignedLongLong = u64;
 
+// https://webidl.spec.whatwg.org/#idl-double
+// The double type is a floating point numeric type that corresponds to the set of finite
+// double-precision 64-bit IEEE 754 floating point numbers. [IEEE-754]
+using Double = f64;
+
 }


### PR DESCRIPTION
Fixes at least 2 subtests in wpt/device-memory.