### PR TITLE
LibWeb: Support Document.onreadystatechange

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/onreadystatechange.txt
+++ b/Tests/LibWeb/Text/expected/HTML/onreadystatechange.txt
@@ -1,0 +1,1 @@
+interactive

--- a/Tests/LibWeb/Text/input/HTML/onreadystatechange.html
+++ b/Tests/LibWeb/Text/input/HTML/onreadystatechange.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    let readyStates = []
+    document.onreadystatechange = function() {
+        readyStates.push(document.readyState);
+    }
+    test(() => {
+        println(readyStates);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5676,4 +5676,14 @@ void Document::set_onreadystatechange(WebIDL::CallbackType* value)
     set_event_handler_attribute(HTML::EventNames::readystatechange, value);
 }
 
+WebIDL::CallbackType* Document::onvisibilitychange()
+{
+    return event_handler_attribute(HTML::EventNames::visibilitychange);
+}
+
+void Document::set_onvisibilitychange(WebIDL::CallbackType* value)
+{
+    set_event_handler_attribute(HTML::EventNames::visibilitychange, value);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5666,4 +5666,14 @@ Document::StepsToFireBeforeunloadResult Document::steps_to_fire_beforeunload(boo
     return { unload_prompt_shown, unload_prompt_canceled };
 }
 
+WebIDL::CallbackType* Document::onreadystatechange()
+{
+    return event_handler_attribute(HTML::EventNames::readystatechange);
+}
+
+void Document::set_onreadystatechange(WebIDL::CallbackType* value)
+{
+    set_event_handler_attribute(HTML::EventNames::readystatechange, value);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -734,6 +734,9 @@ public:
     [[nodiscard]] WebIDL::CallbackType* onreadystatechange();
     void set_onreadystatechange(WebIDL::CallbackType*);
 
+    [[nodiscard]] WebIDL::CallbackType* onvisibilitychange();
+    void set_onvisibilitychange(WebIDL::CallbackType*);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -731,6 +731,9 @@ public:
     };
     StepsToFireBeforeunloadResult steps_to_fire_beforeunload(bool unload_prompt_shown);
 
+    [[nodiscard]] WebIDL::CallbackType* onreadystatechange();
+    void set_onreadystatechange(WebIDL::CallbackType*);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -149,6 +149,10 @@ interface Document : Node {
     boolean queryCommandState(DOMString commandId);
     boolean queryCommandSupported(DOMString commandId);
     DOMString queryCommandValue(DOMString commandId);
+
+    // special event handler IDL attributes that only apply to Document objects
+    [LegacyLenientThis] attribute EventHandler onreadystatechange;
+    [FIXME] attribute EventHandler onvisibilitychange;
 };
 
 dictionary ElementCreationOptions {

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -152,7 +152,7 @@ interface Document : Node {
 
     // special event handler IDL attributes that only apply to Document objects
     [LegacyLenientThis] attribute EventHandler onreadystatechange;
-    [FIXME] attribute EventHandler onvisibilitychange;
+    attribute EventHandler onvisibilitychange;
 };
 
 dictionary ElementCreationOptions {


### PR DESCRIPTION
This is just a standard IDL event attribute handler.

Fixes at least one WPT test:
https://wpt.live/html/dom/documents/resource-metadata-management/document-readyState.html