### PR TITLE
headless-browser: Only rebaseline tests that would have failed, and rebaseline currently failing test

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLSelectElement-value-change-trigger-onchange.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLSelectElement-value-change-trigger-onchange.txt
@@ -1,1 +1,1 @@
-  PASS
+PASS


### PR DESCRIPTION
Fixes a test currently failing on CI.