### PR TITLE
Meta: Support a different build configuration for WPT.sh

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -12,13 +12,18 @@ ensure_ladybird_source_dir
 WPT_SOURCE_DIR=${WPT_SOURCE_DIR:-"${LADYBIRD_SOURCE_DIR}/Tests/LibWeb/WPT/wpt"}
 WPT_REPOSITORY_URL=${WPT_REPOSITORY_URL:-"https://github.com/web-platform-tests/wpt.git"}
 
+BUILD_PRESET=${BUILD_PRESET:-default}
+
+BUILD_DIR=$(get_build_dir "$BUILD_PRESET")
+
 default_binary_path() {
     if [ "$(uname -s)" = "Darwin" ]; then
-        echo "${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/Ladybird.app/Contents/MacOS/"
+        echo "${BUILD_DIR}/bin/Ladybird.app/Contents/MacOS/"
     else
-        echo "${LADYBIRD_SOURCE_DIR}/Build/ladybird/bin/"
+        echo "${BUILD_DIR}/bin/"
     fi
 }
+
 LADYBIRD_BINARY=${LADYBIRD_BINARY:-"$(default_binary_path)/Ladybird"}
 WEBDRIVER_BINARY=${WEBDRIVER_BINARY:-"$(default_binary_path)/WebDriver"}
 WPT_PROCESSES=${WPT_PROCESSES:-$(get_number_of_processing_units)}

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -4,12 +4,13 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-LADYBIRD_SOURCE_DIR="$(realpath "${DIR}"/..)"
-WPT_SOURCE_DIR=${WPT_SOURCE_DIR:-"${LADYBIRD_SOURCE_DIR}/Tests/LibWeb/WPT/wpt"}
-WPT_REPOSITORY_URL=${WPT_REPOSITORY_URL:-"https://github.com/web-platform-tests/wpt.git"}
-
 # shellcheck source=/dev/null
 . "${DIR}/shell_include.sh"
+
+ensure_ladybird_source_dir
+
+WPT_SOURCE_DIR=${WPT_SOURCE_DIR:-"${LADYBIRD_SOURCE_DIR}/Tests/LibWeb/WPT/wpt"}
+WPT_REPOSITORY_URL=${WPT_REPOSITORY_URL:-"https://github.com/web-platform-tests/wpt.git"}
 
 default_binary_path() {
     if [ "$(uname -s)" = "Darwin" ]; then

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -95,18 +95,7 @@ cmd_with_target() {
 
     ensure_ladybird_source_dir
 
-    # Note: Keep in sync with buildDir defaults in CMakePresets.json
-    case "${BUILD_PRESET}" in
-        "default")
-            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird"
-            ;;
-        "Debug")
-            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird-debug"
-            ;;
-        "Sanitizer")
-            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird-sanitizers"
-            ;;
-    esac
+    BUILD_DIR=$(get_build_dir "$BUILD_PRESET")
 
     CMAKE_ARGS+=("-DCMAKE_INSTALL_PREFIX=$LADYBIRD_SOURCE_DIR/Build/ladybird-install-${BUILD_PRESET}")
 

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -83,10 +83,6 @@ EOF
 
 fi
 
-get_top_dir() {
-    git rev-parse --show-toplevel
-}
-
 create_build_dir() {
     check_program_version_at_least CMake cmake 3.25 || exit 1
     cmake --preset "$BUILD_PRESET" "${CMAKE_ARGS[@]}" -S "$LADYBIRD_SOURCE_DIR" -B "$BUILD_DIR"
@@ -97,10 +93,7 @@ cmd_with_target() {
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER=${CC}")
     CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=${CXX}")
 
-    if [ ! -d "$LADYBIRD_SOURCE_DIR" ]; then
-        LADYBIRD_SOURCE_DIR="$(get_top_dir)"
-        export LADYBIRD_SOURCE_DIR
-    fi
+    ensure_ladybird_source_dir
 
     # Note: Keep in sync with buildDir defaults in CMakePresets.json
     case "${BUILD_PRESET}" in

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -60,3 +60,26 @@ ensure_ladybird_source_dir() {
         export LADYBIRD_SOURCE_DIR
     fi
 }
+
+get_build_dir() {
+    ensure_ladybird_source_dir
+
+    # Note: Keep in sync with buildDir defaults in CMakePresets.json
+    case "$1" in
+        "default")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird"
+            ;;
+        "Debug")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird-debug"
+            ;;
+        "Sanitizer")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/ladybird-sanitizers"
+            ;;
+        *)
+            echo "Unknown BUILD_PRESET: '$1'" >&2
+            exit 1
+            ;;
+    esac
+
+    echo "${BUILD_DIR}"
+}

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -49,3 +49,14 @@ get_number_of_processing_units() {
 
   ($number_of_processing_units)
 }
+
+get_top_dir() {
+    git rev-parse --show-toplevel
+}
+
+ensure_ladybird_source_dir() {
+    if [ -z "$LADYBIRD_SOURCE_DIR" ] || [ ! -d "$LADYBIRD_SOURCE_DIR" ]; then
+        LADYBIRD_SOURCE_DIR="$(get_top_dir)"
+        export LADYBIRD_SOURCE_DIR
+    fi
+}


### PR DESCRIPTION
I generally use the Debug build configuration instead of the default one. While I don't use `ladybird.sh`, I do use `WPT.sh` - so change the script to support a different build folder in line with `ladybird.sh`'s implementation.