### PR TITLE
LibWeb: Reject Promise in createImageBitmap for Not Implemented Types

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
@@ -1,0 +1,7 @@
+Blob              [Success]: [object ImageBitmap]
+ImageData         [ Error ]: Error: Not Implemented: createImageBitmap() for non-blob types
+HTMLImageElement  [ Error ]: TypeError: No union types matched
+SVGImageElement   [ Error ]: TypeError: No union types matched
+HTMLCanvasElement [ Error ]: TypeError: No union types matched
+ImageBitmap       [ Error ]: TypeError: No union types matched
+HTMLVideoElement  [ Error ]: TypeError: No union types matched

--- a/Tests/LibWeb/Text/input/HTML/image-bitmap-from-invalid-types-no-crash.html
+++ b/Tests/LibWeb/Text/input/HTML/image-bitmap-from-invalid-types-no-crash.html
@@ -1,0 +1,49 @@
+<script src="../include.js"></script>
+<script>
+    let canvas = document.createElement("canvas");
+
+    canvas.width = 20;
+    canvas.height = 20;
+
+    let ctx = canvas.getContext("2d");
+    ctx.fillStyle = "rgb(255, 0, 0)";
+    ctx.fillRect(0, 0, 10, 10);
+
+    let imageData = ctx.getImageData(0, 0, 20, 20);
+
+    let img = document.createElement("img");
+
+    let svgImg = document.createElement("img");
+    svgImg = document.createElementNS("http://www.w3.org/2000/svg", "image");
+
+    let video = document.createElement("video");
+    let file = new Blob([
+        new Uint8Array([
+            255, 10, 8, 16, 0, 9, 8, 6, 1, 0, 40, 0, 75, 56, 73, 152, 108, 128, 253, 145, 96, 0,
+        ]),
+    ]);
+    let imageBitmap = createImageBitmap(file, 0, 0, 0, 0);
+
+    const types = [
+        [file, "Blob"],
+        [imageData, "ImageData"],
+        [img, "HTMLImageElement"],
+        [svgImg, "SVGImageElement"],
+        [canvas, "HTMLCanvasElement"],
+        [imageBitmap, "ImageBitmap"],
+        [video, "HTMLVideoElement"],
+    ];
+
+    asyncTest(async done => {
+        for (const [type, name] of types) {
+            try {
+                const result = await createImageBitmap(type, 0, 0, 20, 20);
+                println(`${name.padEnd(17, " ")} [Success]: ${result}`);
+            } catch (err) {
+                println(`${name.padEnd(17, " ")} [ Error ]: ${err}`);
+            }
+        }
+
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -245,6 +245,7 @@ JS::NonnullGCPtr<JS::Promise> WindowOrWorkerGlobalScopeMixin::create_image_bitma
             dbgln("(STUBBED) createImageBitmap() for non-blob types");
             (void)sx;
             (void)sy;
+            p->reject(JS::Error::create(relevant_realm(*p), "Not Implemented: createImageBitmap() for non-blob types"sv));
         });
 
     // 7. Return p.


### PR DESCRIPTION
If we don't reject the Promise, it lasts forever, so rejecting non implemented Promise functions is essential, to not timeout in e.g. WPT tests

A test that now "just" fails and doesn't timeout would be e.g. [html/canvas/element/manual/imagebitmap/createImageBitmap-exif-orientation_none.html](https://wpt.live/html/canvas/element/manual/imagebitmap/createImageBitmap-exif-orientation_none.html)

But most if not all the timeouts from [html/canvas/element/manual/imagebitmap](https://wpt.fyi/results/html/canvas/element/manual/imagebitmap?product=ladybird&q=status%3Atimeout) now fail with an error, rather than taking 10 seconds, this should bring the test runtime down by round about 120 secs (just an estimate)  but doesn't increase passing tests.

Note: 

I also searched for similar thing sin the codebase, and this seems to be the only place, where we don't reject stubbed promises.


The test I made checks all possible inputs to `createImageBitmap` (many of them aren't supported by the IDL) but I thought it would be good to test that none of them crashes, if the test should be reduced to a minimal working (crashing / non crashing after this PR) set, feel free to tell me 😉  