### PR TITLE
LibWeb: Clear grapheme segmenter when invalidating TextNode text

### DIFF
--- a/Tests/LibWeb/Ref/reference/textnode-segmenter-invalidation.html
+++ b/Tests/LibWeb/Ref/reference/textnode-segmenter-invalidation.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html><textarea>a
+b</textarea>

--- a/Tests/LibWeb/Ref/textnode-segmenter-invalidation.html
+++ b/Tests/LibWeb/Ref/textnode-segmenter-invalidation.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<head><link rel="match" href="reference/textnode-segmenter-invalidation.html" /></head>
+<textarea id="output"></textarea>
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        document.body.offsetWidth  // Force layout
+        document.getElementById('output').value = 'a\nb';
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -304,6 +304,7 @@ static ErrorOr<String> apply_text_transform(String const& string, CSS::TextTrans
 void TextNode::invalidate_text_for_rendering()
 {
     m_text_for_rendering = {};
+    m_grapheme_segmenter.clear();
 }
 
 String const& TextNode::text_for_rendering() const


### PR DESCRIPTION
We only set the grapheme segmenter's text once after creating a new segmenter, so we also need to clear it whenever we invalidate the text.

I come across this bug while debugging another issue. [This page](https://jakearchibald.com/2015/tasks-microtasks-queues-and-schedules/) shows the difference clearly:

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/e774585a-f7e1-4a95-906a-35ffa80c4fa3) | ![image](https://github.com/user-attachments/assets/a522c301-ff74-4ccd-8edd-81f2ad5c6331) |