### PR TITLE
LibWeb: remove constexpr from ServiceWorker::RegistrationKey operator==

### DIFF
--- a/Userland/Libraries/LibWeb/ServiceWorker/Registration.cpp
+++ b/Userland/Libraries/LibWeb/ServiceWorker/Registration.cpp
@@ -13,7 +13,7 @@ struct RegistrationKey {
     StorageAPI::StorageKey key;
     ByteString serialized_scope_url;
 
-    constexpr bool operator==(RegistrationKey const&) const = default;
+    bool operator==(RegistrationKey const&) const = default;
 };
 
 // FIXME: Surely this needs hooks to be cleared and manipulated at the UA level


### PR DESCRIPTION
Looks like the Web::ServiceWorker::RegistrationKey struct members do not have `constexpr operator==`.