### PR TITLE
LibWeb: Add CanvasImageSource to ImageBitmapSource in the idl

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -519,9 +519,24 @@ private:
 template<typename... Ts>
 struct TypeList<Variant<Ts...>> : TypeList<Ts...> { };
 
+namespace Detail {
+template<typename T1, typename T2>
+struct FlattenVariant;
+
+template<typename... Ts1, typename... Ts2>
+struct FlattenVariant<::AK::Variant<Ts1...>, ::AK::Variant<Ts2...>> {
+    using type = ::AK::Variant<Ts1..., Ts2...>;
+};
+
+}
+
+template<typename T1, typename T2>
+using FlattenVariant = Detail::FlattenVariant<T1, T2>::type;
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::Empty;
+using AK::FlattenVariant;
 using AK::Variant;
 #endif

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -302,3 +302,19 @@ TEST_CASE(variant_equality)
         EXPECT_EQ(variant1, variant2);
     }
 }
+
+TEST_CASE(flatten_variant)
+{
+
+    using InnerVariant = Variant<Empty, int>;
+    using OuterVariant = FlattenVariant<InnerVariant, Variant<float>>;
+    using MyVariant = Variant<Empty, int, float>;
+
+    EXPECT_EQ((TypeList<MyVariant>::size), 3u);
+    EXPECT_EQ((TypeList<OuterVariant>::size), 3u);
+
+    using OuterList = TypeList<OuterVariant>;
+    EXPECT((IsSame<typename OuterList::template Type<0>, Empty>));
+    EXPECT((IsSame<typename OuterList::template Type<1>, int>));
+    EXPECT((IsSame<typename OuterList::template Type<2>, float>));
+}

--- a/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
+++ b/Tests/LibWeb/Text/expected/HTML/image-bitmap-from-invalid-types-no-crash.txt
@@ -1,7 +1,7 @@
 Blob              [Success]: [object ImageBitmap]
 ImageData         [ Error ]: Error: Not Implemented: createImageBitmap() for non-blob types
-HTMLImageElement  [ Error ]: TypeError: No union types matched
-SVGImageElement   [ Error ]: TypeError: No union types matched
-HTMLCanvasElement [ Error ]: TypeError: No union types matched
+HTMLImageElement  [ Error ]: InvalidStateError: image argument is not usable
+SVGImageElement   [ Error ]: InvalidStateError: image argument is not usable
+HTMLCanvasElement [ Error ]: Error: Not Implemented: createImageBitmap() for non-blob types
 ImageBitmap       [ Error ]: TypeError: No union types matched
-HTMLVideoElement  [ Error ]: TypeError: No union types matched
+HTMLVideoElement  [ Error ]: InvalidStateError: image argument is not usable

--- a/Userland/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.idl
@@ -1,3 +1,4 @@
+#import <HTML/Window.idl>
 #import <HTML/WorkerGlobalScope.idl>
 
 // https://html.spec.whatwg.org/multipage/workers.html#dedicatedworkerglobalscope

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -3,6 +3,7 @@
 #import <HTML/ElementInternals.idl>
 #import <DOM/Element.idl>
 #import <DOM/EventHandler.idl>
+#import <HTML/HTMLOrSVGElement.idl>
 
 // https://html.spec.whatwg.org/multipage/semantics.html#htmlelement
 [Exposed=Window]
@@ -56,18 +57,6 @@ interface mixin ElementContentEditable {
     [FIXME, CEReactions] attribute DOMString enterKeyHint;
     readonly attribute boolean isContentEditable;
     [FIXME, CEReactions] attribute DOMString inputMode;
-};
-
-// https://html.spec.whatwg.org/#htmlorsvgelement
-interface mixin HTMLOrSVGElement {
-    [SameObject] readonly attribute DOMStringMap dataset;
-    [FIXME] attribute DOMString nonce; // intentionally no [CEReactions]
-
-    [CEReactions, Reflect] attribute boolean autofocus;
-    [CEReactions] attribute long tabIndex;
-    // FIXME: Support the optional FocusOptions parameter.
-    undefined focus();
-    undefined blur();
 };
 
 HTMLElement includes ElementCSSInlineStyle;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOrSVGElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOrSVGElement.idl
@@ -1,0 +1,13 @@
+#import <HTML/DOMStringMap.idl>
+
+// https://html.spec.whatwg.org/#htmlorsvgelement
+interface mixin HTMLOrSVGElement {
+    [SameObject] readonly attribute DOMStringMap dataset;
+    [FIXME] attribute DOMString nonce; // intentionally no [CEReactions]
+
+    [CEReactions, Reflect] attribute boolean autofocus;
+    [CEReactions] attribute long tabIndex;
+    // FIXME: Support the optional FocusOptions parameter.
+    undefined focus();
+    undefined blur();
+};

--- a/Userland/Libraries/LibWeb/HTML/ImageBitmap.h
+++ b/Userland/Libraries/LibWeb/HTML/ImageBitmap.h
@@ -16,7 +16,7 @@
 
 namespace Web::HTML {
 
-using ImageBitmapSource = Variant<CanvasImageSource, JS::Handle<FileAPI::Blob>, JS::Handle<ImageData>>;
+using ImageBitmapSource = FlattenVariant<CanvasImageSource, Variant<JS::Handle<FileAPI::Blob>, JS::Handle<ImageData>>>;
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapoptions
 struct ImageBitmapOptions {

--- a/Userland/Libraries/LibWeb/HTML/ImageBitmap.idl
+++ b/Userland/Libraries/LibWeb/HTML/ImageBitmap.idl
@@ -1,5 +1,8 @@
 #import <FileAPI/Blob.idl>
 #import <HTML/ImageData.idl>
+#import <HTML/CanvasRenderingContext2D.idl>
+#import <HTML/Canvas/CanvasDrawImage.idl>
+
 
 // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#images-2
 [Exposed=(Window,Worker), Serializable, Transferable]
@@ -9,8 +12,9 @@ interface ImageBitmap {
     undefined close();
 };
 
-// FIXME: This should also includes CanvasImageSource
-typedef (Blob or
+// https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#imagebitmapsource
+typedef (CanvasImageSource or
+         Blob or
          ImageData) ImageBitmapSource;
 
 enum ImageOrientation { "from-image", "flipY" };

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.idl
@@ -1,6 +1,7 @@
 #import <CSS/FontFaceSet.idl>
 #import <DOM/EventTarget.idl>
 #import <DOM/EventHandler.idl>
+#import <HTML/Window.idl>
 #import <HTML/WindowOrWorkerGlobalScope.idl>
 #import <HTML/WorkerLocation.idl>
 #import <HTML/WorkerNavigator.idl>

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.idl
@@ -1,9 +1,11 @@
 #import <CSS/ElementCSSInlineStyle.idl>
 #import <DOM/Element.idl>
-#import <HTML/HTMLElement.idl>
+#import <DOM/EventHandler.idl>
 #import <HTML/DOMStringMap.idl>
 #import <SVG/SVGAnimatedString.idl>
+#import <HTML/HTMLOrSVGElement.idl>
 #import <SVG/SVGSVGElement.idl>
+#import <HTML/HTMLElement.idl>
 
 // https://svgwg.org/svg2-draft/types.html#InterfaceSVGElement
 [Exposed=Window]


### PR DESCRIPTION
This is divided into 2 commits:
- The first one modifies the idl files quite a bit for such a small change, but it was necessary 😓 
- The second one fixes the arising error, which is:
The generation from the idl file creates a flattened Variant of the nested typedef, so `ImageBitmapSource` from the idl is 
`Variant<A,B,C,D,E>` and the manual `ImageBitmapSource` is `Variant<Variant<A,B,C>,D,E>` (A,B,... are just abbreviations, to keep it short and readable)

There are three possible fixes for this: 
- Don't create flattened versions of typedefs, when generating variants from idl 
:x:  This is a bad idea, as it might affect other parts
- Copy the inner types of `CanvasImageSource` to `ImageBitmapSource`  
:x:   as `CanvasImageSource` isn't fully implemented yet, it is subject to change, so we would have to change it in two place in the future
- Create a C++ template, that Flattens a Variant, and then write something like `ImageBitmapSource = FlattenVariant<CanvasImageSource, D,E>;`
✔️  I find this to be the best solution

So I solved this, by adding a new `FlattenVariant` type, that solves this, I added a test for that.