### PR TITLE
LibWeb: Do not accept malformed xml namespace

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/domparser-parsefromstring-xml-parsererror.txt
+++ b/Tests/LibWeb/Text/expected/DOM/domparser-parsefromstring-xml-parsererror.txt
@@ -1,0 +1,21 @@
+<span x:test="testing">1</span> has 1 parseerror
+< span>2</span> has 1 parseerror
+<span :test="testing">3</span> has 1 parseerror
+<span><em>4</span></em> has 1 parseerror
+<span>5 has 1 parseerror
+6</span> has 1 parseerror
+<span>7< /span> has 1 parseerror
+<span>8</ span> has 1 parseerror
+<span novalue>9</span> has 1 parseerror
+<span ="noattr">10</span> has 1 parseerror
+<span ::="test">11</span> has 1 parseerror
+<span xmlns:="urn:x-test:test">12</span> has 1 parseerror
+<span xmlns:xmlns="">13</span> has 1 parseerror
+<span data-test=testing>14</span> has 1 parseerror
+15<span has 1 parseerror
+<8:test xmlns:8="urn:x-test:test">16</8:test> has 1 parseerror
+<span xmlns:p1 xmlns:p2="urn:x-test:test"/>17 has 1 parseerror
+text/xml has 1 parseerror
+application/xml has 1 parseerror
+application/xhtml+xml has 1 parseerror
+image/svg+xml has 1 parseerror

--- a/Tests/LibWeb/Text/input/DOM/domparser-parsefromstring-xml-parsererror.html
+++ b/Tests/LibWeb/Text/input/DOM/domparser-parsefromstring-xml-parsererror.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<link rel="match" href="reference/domparser-parsefromstring-xml-parsererror.html" />
+<script>
+const xhtml_prologue = '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"' +
+                       ' "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">\n' +
+                       '<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">\n' +
+                       '<body>\n',
+      xhtml_epilogue = '</body>\n</html>\n';
+  test(() => {
+  [
+    '<span x:test="testing">1</span>',                // undeclared 'x' namespace prefix
+    '< span>2</span>',                                // bad start tag
+    '<span :test="testing">3</span>',                 // empty namespace prefix
+    '<span><em>4</span></em>',                        // staggered tags
+    '<span>5',                                        // missing end </span> tag
+    '6</span>',                                       // missing start <span> tag
+    '<span>7< /span>',                                // bad end tag
+    '<span>8</ span>',                                // bad end tag
+    '<span novalue>9</span>',                         // missing attribute value
+    '<span ="noattr">10</span>',                      // missing attribute name
+    '<span ::="test">11</span>',                      // bad namespace prefix
+    '<span xmlns:="urn:x-test:test">12</span>',       // missing namespace prefix
+    '<span xmlns:xmlns="">13</span>',                 // invalid namespace prefix
+    '<span data-test=testing>14</span>',              // unquoted attribute value
+    '15<span',                                        // bad start tag
+    '<8:test xmlns:8="urn:x-test:test">16</8:test>',  // invalid namespace prefix
+    '<span xmlns:p1 xmlns:p2="urn:x-test:test"/>17',  // missing namespace URI
+  ].forEach((fragment, i) => {
+    var document_string = xhtml_prologue + fragment + xhtml_epilogue;
+    var doc = (new DOMParser).parseFromString(document_string, "application/xhtml+xml");
+    var parsererrors = doc.getElementsByTagName("parsererror");
+    println(`${fragment} has ${parsererrors.length} parseerror`);
+  });
+
+  [
+    'text/xml',
+    'application/xml',
+    'application/xhtml+xml',
+    'image/svg+xml'
+  ].forEach(mimeType => {
+    const doc = (new DOMParser()).parseFromString('<span x:test="testing">1</span>', mimeType);
+    var parsererrors = doc.getElementsByTagName("parsererror");
+    println(`${mimeType} has ${parsererrors.length} parseerror`);
+  });
+});
+</script>

--- a/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Userland/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -90,8 +90,16 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
         // https://www.w3.org/TR/2006/REC-xml-names11-20060816/#ns-decl
         if (attribute.key == "xmlns" || attribute.key.starts_with("xmlns:"sv)) {
             auto name = attribute.key;
-            // The prefix xmlns is used only to declare namespace bindings and is by definition bound to the namespace name http://www.w3.org/2000/xmlns/.
-            MUST(node->set_attribute_ns(Namespace::XMLNS, MUST(FlyString::from_deprecated_fly_string(name)), MUST(String::from_byte_string(attribute.value))));
+            if (!name.is_one_of("xmlns:"sv, "xmlns:xmlns"sv)) {
+                // The prefix xmlns is used only to declare namespace bindings and is by definition bound to the namespace name http://www.w3.org/2000/xmlns/.
+                MUST(node->set_attribute_ns(Namespace::XMLNS, MUST(FlyString::from_deprecated_fly_string(name)), MUST(String::from_byte_string(attribute.value))));
+            } else {
+                m_has_error = true;
+            }
+        } else if (attribute.key.contains(":"sv)) {
+            if (!attribute.key.starts_with("xml:"sv)) {
+                m_has_error = true;
+            }
         }
         MUST(node->set_attribute(MUST(FlyString::from_deprecated_fly_string(attribute.key)), MUST(String::from_byte_string(attribute.value))));
     }


### PR DESCRIPTION
This runs wpt [domparsing/DOMParser-parseFromString-xml-parsererror.html](https://wpt.fyi/results/domparsing/DOMParser-parseFromString-xml-parsererror.html?product=ladybird) that previously crashed because of a malformed XML namespace in the test.

The test now runs pass.