### PR TITLE
LibWeb: Improve grid area calculation for abspos items in GFC

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/abspos-placed-into-augmented-row-and-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-placed-into-augmented-row-and-column.txt
@@ -1,0 +1,50 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x286 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x270 children: not-inline
+      Box <div.grid-container> at (58,58) content-size 170x170 positioned [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,58) content-size 50x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,58 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,58) content-size 100x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,58 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,128) content-size 50x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,128 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,128) content-size 100x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,128 7.75x17] baseline: 13.296875
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.abspos-box> at (228,228) content-size 50x50 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,278) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x286]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x270]
+      PaintableBox (Box<DIV>.grid-container) [8,8 270x270]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,58 50x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,58 100x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,128 50x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,128 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.abspos-box) [228,228 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,278 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/abspos-with-auto-column-placed-in-augmented-row.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-with-auto-column-placed-in-augmented-row.txt
@@ -1,0 +1,50 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x286 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x270 children: not-inline
+      Box <div.grid-container> at (58,58) content-size 170x170 positioned [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,58) content-size 50x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,58 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,58) content-size 100x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,58 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,128) content-size 50x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,128 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,128) content-size 100x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,128 7.75x17] baseline: 13.296875
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.abspos-box> at (8,228) content-size 270x50 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,278) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x286]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x270]
+      PaintableBox (Box<DIV>.grid-container) [8,8 270x270]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,58 50x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,58 100x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,128 50x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,128 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.abspos-box) [8,228 270x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,278 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/abspos-with-auto-row-and-column-contained-by-grid.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-with-auto-row-and-column-contained-by-grid.txt
@@ -1,0 +1,50 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x286 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x270 children: not-inline
+      Box <div.grid-container> at (58,58) content-size 170x170 positioned [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,58) content-size 50x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,58 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,58) content-size 100x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,58 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,128) content-size 50x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,128 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,128) content-size 100x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,128 7.75x17] baseline: 13.296875
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.abspos-box> at (8,8) content-size 270x270 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,278) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x286]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x270]
+      PaintableBox (Box<DIV>.grid-container) [8,8 270x270]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,58 50x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,58 100x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,128 50x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,128 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.abspos-box) [8,8 270x270]
+      PaintableWithLines (BlockContainer(anonymous)) [8,278 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/abspos-with-auto-row-placed-in-augmented-column.txt
+++ b/Tests/LibWeb/Layout/expected/grid/abspos-with-auto-row-placed-in-augmented-column.txt
@@ -1,0 +1,50 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x286 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x270 children: not-inline
+      Box <div.grid-container> at (58,58) content-size 170x170 positioned [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,58) content-size 50x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,58 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,58) content-size 100x50 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,58 8.8125x17] baseline: 13.296875
+              "2"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (58,128) content-size 50x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [58,128 9.09375x17] baseline: 13.296875
+              "3"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.grid-item> at (128,128) content-size 100x100 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [128,128 7.75x17] baseline: 13.296875
+              "4"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div.abspos-box> at (228,8) content-size 50x270 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,278) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x286]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x270]
+      PaintableBox (Box<DIV>.grid-container) [8,8 270x270]
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,58 50x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,58 100x50]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [58,128 50x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.grid-item) [128,128 100x100]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<DIV>.abspos-box) [228,8 50x270]
+      PaintableWithLines (BlockContainer(anonymous)) [8,278 784x0]

--- a/Tests/LibWeb/Layout/input/grid/abspos-placed-into-augmented-row-and-column.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-placed-into-augmented-row-and-column.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<style>
+  .grid-container {
+    display: grid;
+    grid-template-columns: 50px 100px;
+    grid-template-rows: 50px 100px;
+    position: relative;
+    background-color: #ccc;
+    padding: 50px;
+    gap: 20px;
+    width: fit-content;
+  }
+  .grid-item {
+    background-color: #4caf50;
+  }
+  .abspos-box {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    grid-row: 3;
+    grid-column: 3;
+  }
+</style>
+<div class="grid-container">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+  <div class="abspos-box"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/abspos-with-auto-column-placed-in-augmented-row.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-with-auto-column-placed-in-augmented-row.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+  .grid-container {
+    display: grid;
+    grid-template-columns: 50px 100px;
+    grid-template-rows: 50px 100px;
+    position: relative;
+    background-color: #ccc;
+    padding: 50px;
+    gap: 20px;
+    width: fit-content;
+  }
+  .grid-item {
+    background-color: #4caf50;
+  }
+  .abspos-box {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    grid-row: 3;
+  }
+</style>
+<div class="grid-container">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+  <div class="abspos-box"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/abspos-with-auto-row-and-column-contained-by-grid.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-with-auto-row-and-column-contained-by-grid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+  .grid-container {
+    display: grid;
+    grid-template-columns: 50px 100px;
+    grid-template-rows: 50px 100px;
+    position: relative;
+    background-color: #ccc;
+    padding: 50px;
+    gap: 20px;
+    width: fit-content;
+  }
+  .grid-item {
+    background-color: #4caf50;
+  }
+  .abspos-box {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    width: 100%;
+    height: 100%;
+    background-color: red;
+  }
+</style>
+<div class="grid-container">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+  <div class="abspos-box"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/abspos-with-auto-row-placed-in-augmented-column.html
+++ b/Tests/LibWeb/Layout/input/grid/abspos-with-auto-row-placed-in-augmented-column.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+  .grid-container {
+    display: grid;
+    grid-template-columns: 50px 100px;
+    grid-template-rows: 50px 100px;
+    position: relative;
+    background-color: #ccc;
+    padding: 50px;
+    gap: 20px;
+    width: fit-content;
+  }
+  .grid-item {
+    background-color: #4caf50;
+  }
+  .abspos-box {
+    position: absolute;
+    top: 0px;
+    left: 0px;
+    bottom: 0px;
+    right: 0px;
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    grid-column: 3;
+  }
+</style>
+<div class="grid-container">
+  <div class="grid-item">1</div>
+  <div class="grid-item">2</div>
+  <div class="grid-item">3</div>
+  <div class="grid-item">4</div>
+  <div class="abspos-box"></div>
+</div>

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -12,6 +12,62 @@
 
 namespace Web::Layout {
 
+static Alignment to_alignment(CSS::JustifyContent value)
+{
+    switch (value) {
+    case CSS::JustifyContent::Left:
+        return Alignment::Start;
+    case CSS::JustifyContent::Right:
+        return Alignment::End;
+    case CSS::JustifyContent::Start:
+        return Alignment::Start;
+    case CSS::JustifyContent::End:
+        return Alignment::End;
+    case CSS::JustifyContent::Center:
+        return Alignment::Center;
+    case CSS::JustifyContent::SpaceBetween:
+        return Alignment::SpaceBetween;
+    case CSS::JustifyContent::SpaceAround:
+        return Alignment::SpaceAround;
+    case CSS::JustifyContent::SpaceEvenly:
+        return Alignment::SpaceEvenly;
+    case CSS::JustifyContent::Stretch:
+        return Alignment::Stretch;
+    case CSS::JustifyContent::Normal:
+        return Alignment::Normal;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+static Alignment to_alignment(CSS::AlignContent value)
+{
+    switch (value) {
+    case CSS::AlignContent::Start:
+        return Alignment::Start;
+    case CSS::AlignContent::End:
+        return Alignment::End;
+    case CSS::AlignContent::Center:
+        return Alignment::Center;
+    case CSS::AlignContent::SpaceBetween:
+        return Alignment::SpaceBetween;
+    case CSS::AlignContent::SpaceAround:
+        return Alignment::SpaceAround;
+    case CSS::AlignContent::SpaceEvenly:
+        return Alignment::SpaceEvenly;
+    case CSS::AlignContent::Stretch:
+        return Alignment::Stretch;
+    case CSS::AlignContent::Normal:
+        return Alignment::Normal;
+    case CSS::AlignContent::FlexStart:
+        return Alignment::Start;
+    case CSS::AlignContent::FlexEnd:
+        return Alignment::End;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 GridFormattingContext::GridTrack GridFormattingContext::GridTrack::create_from_definition(CSS::ExplicitGridTrack const& definition)
 {
     // NOTE: repeat() is expected to be expanded beforehand.
@@ -1689,45 +1745,30 @@ void GridFormattingContext::resolve_track_spacing(GridDimension const dimension)
         return;
 
     CSSPixels space_between_tracks = 0;
+    Alignment alignment;
     if (is_column_dimension) {
-        switch (grid_container().computed_values().justify_content()) {
-        case CSS::JustifyContent::SpaceBetween:
-            space_between_tracks = CSSPixels(total_gap_space / gap_track_count);
-            break;
-        case CSS::JustifyContent::SpaceAround:
-            space_between_tracks = CSSPixels(total_gap_space / (gap_track_count + 1));
-            break;
-        case CSS::JustifyContent::SpaceEvenly:
-            space_between_tracks = CSSPixels(total_gap_space / (gap_track_count + 2));
-            break;
-        case CSS::JustifyContent::Start:
-        case CSS::JustifyContent::End:
-        case CSS::JustifyContent::Center:
-        case CSS::JustifyContent::Stretch:
-        default:
-            break;
-        }
+        alignment = to_alignment(grid_container().computed_values().justify_content());
     } else {
-        switch (grid_container().computed_values().align_content()) {
-        case CSS::AlignContent::SpaceBetween:
-            space_between_tracks = CSSPixels(total_gap_space / gap_track_count);
-            break;
-        case CSS::AlignContent::SpaceAround:
-            space_between_tracks = CSSPixels(total_gap_space / (gap_track_count + 1));
-            break;
-        case CSS::AlignContent::SpaceEvenly:
-            space_between_tracks = CSSPixels(total_gap_space / (gap_track_count + 2));
-            break;
-        case CSS::AlignContent::Normal:
-        case CSS::AlignContent::Stretch:
-        case CSS::AlignContent::Start:
-        case CSS::AlignContent::FlexStart:
-        case CSS::AlignContent::End:
-        case CSS::AlignContent::FlexEnd:
-        case CSS::AlignContent::Center:
-        default:
-            break;
-        }
+        alignment = to_alignment(grid_container().computed_values().align_content());
+    }
+
+    switch (alignment) {
+    case Alignment::SpaceBetween:
+        space_between_tracks = CSSPixels(total_gap_space / gap_track_count);
+        break;
+    case Alignment::SpaceAround:
+        space_between_tracks = CSSPixels(total_gap_space / (gap_track_count + 1));
+        break;
+    case Alignment::SpaceEvenly:
+        space_between_tracks = CSSPixels(total_gap_space / (gap_track_count + 2));
+        break;
+    case Alignment::Normal:
+    case Alignment::Stretch:
+    case Alignment::Start:
+    case Alignment::End:
+    case Alignment::Center:
+    default:
+        break;
     }
 
     auto const& computed_gap = is_column_dimension ? grid_container().computed_values().column_gap() : grid_container().computed_values().row_gap();
@@ -2539,7 +2580,6 @@ StaticPositionRect GridFormattingContext::calculate_static_position_rect(Box con
     static_position.rect = { offset_to_static_parent.location().translated(0, 0), { box_state.content_width(), box_state.content_height() } };
     return static_position;
 }
-
 }
 
 namespace AK {

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -37,19 +37,20 @@ struct GridPosition {
 struct GridItem {
     JS::NonnullGCPtr<Box const> box;
 
-    int row;
-    size_t row_span;
-    int column;
-    size_t column_span;
+    // Position and span are empty if the item is auto-placed which could only be the case for abspos items
+    Optional<int> row;
+    Optional<size_t> row_span;
+    Optional<int> column;
+    Optional<size_t> column_span;
 
     [[nodiscard]] size_t span(GridDimension const dimension) const
     {
-        return dimension == GridDimension::Column ? column_span : row_span;
+        return dimension == GridDimension::Column ? column_span.value() : row_span.value();
     }
 
     [[nodiscard]] int raw_position(GridDimension const dimension) const
     {
-        return dimension == GridDimension::Column ? column : row;
+        return dimension == GridDimension::Column ? column.value() : row.value();
     }
 
     [[nodiscard]] CSSPixels add_margin_box_sizes(CSSPixels content_size, GridDimension dimension, LayoutState const& state) const
@@ -58,6 +59,11 @@ struct GridItem {
         if (dimension == GridDimension::Column)
             return box_state.margin_box_left() + content_size + box_state.margin_box_right();
         return box_state.margin_box_top() + content_size + box_state.margin_box_bottom();
+    }
+
+    [[nodiscard]] int gap_adjusted_position(GridDimension const dimension) const
+    {
+        return dimension == GridDimension::Column ? gap_adjusted_column() : gap_adjusted_row();
     }
 
     [[nodiscard]] int gap_adjusted_row() const;

--- a/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -17,6 +17,17 @@ enum class GridDimension {
     Column
 };
 
+enum class Alignment {
+    Normal,
+    SpaceBetween,
+    SpaceAround,
+    SpaceEvenly,
+    Center,
+    Start,
+    End,
+    Stretch,
+};
+
 struct GridPosition {
     int row;
     int column;


### PR DESCRIPTION
- Add support for placement of abspos items into track formed by last
  line and padding edge of grid container
- Correctly handle auto-positioned abspos items by placing them between
  padding edges of grid container

Fixes crashing on https://wpt.live/css/css-grid/abspos/positioned-grid-descendants-001.html