### PR TITLE
Meta: Clean up generated CMake uservars

### DIFF
--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -134,6 +134,10 @@ build_target() {
 
 delete_target() {
     [ ! -d "$BUILD_DIR" ] || rm -rf "$BUILD_DIR"
+
+    # Delete the vcpkg user variables created by this script if they exist
+    VCPKG_USER_VARS="$LADYBIRD_SOURCE_DIR/Meta/CMake/vcpkg/user-variables.cmake"
+    [ ! -f "$VCPKG_USER_VARS" ] || rm "$VCPKG_USER_VARS"
 }
 
 build_vcpkg() {


### PR DESCRIPTION
Prior to this change, running ./Meta/ladybird.sh rebuild would not remove the user-variables.cmake file that was generated by the build script. This caused errors when testing out the .devcontainer on my Mac because the pkg-config binary lived in different dirs in the container vs host.