### PR TITLE
LibWeb: Update (not replace) timeout values in WebDriver's Set Timeouts

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -148,6 +148,15 @@ run_wpt() {
     execute_wpt
 }
 
+serve_wpt()
+{
+    ensure_wpt_repository
+
+    pushd "${WPT_SOURCE_DIR}" > /dev/null
+        ./wpt serve
+    popd > /dev/null
+}
+
 compare_wpt() {
     ensure_wpt_repository
     METADATA_DIR=$(mktemp -d)
@@ -160,13 +169,16 @@ compare_wpt() {
     rm -rf "${METADATA_DIR}"
 }
 
-if [[ "$CMD" =~ ^(update|run|compare)$ ]]; then
+if [[ "$CMD" =~ ^(update|run|serve|compare)$ ]]; then
     case "$CMD" in
         update)
             update_wpt
             ;;
         run)
             run_wpt
+            ;;
+        serve)
+            serve_wpt
             ;;
         compare)
             INPUT_LOG_NAME="$(pwd -P)/$1"

--- a/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.cpp
@@ -32,12 +32,21 @@ JsonObject timeouts_object(TimeoutsConfiguration const& timeouts)
 // https://w3c.github.io/webdriver/#dfn-deserialize-as-timeouts-configuration
 ErrorOr<TimeoutsConfiguration, Error> json_deserialize_as_a_timeouts_configuration(JsonValue const& timeouts)
 {
+    // 2. Let configuration be a new timeouts configuration.
+    TimeoutsConfiguration configuration {};
+
+    TRY(json_deserialize_as_a_timeouts_configuration_into(timeouts, configuration));
+
+    // 4. Return success with data configuration.
+    return configuration;
+}
+
+// https://w3c.github.io/webdriver/#dfn-deserialize-as-timeouts-configuration
+ErrorOr<void, Error> json_deserialize_as_a_timeouts_configuration_into(JsonValue const& timeouts, TimeoutsConfiguration& configuration)
+{
     // 1. Set timeouts to the result of converting a JSON-derived JavaScript value to an Infra value with timeouts.
     if (!timeouts.is_object())
         return Error::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
-
-    // 2. Let configuration be a new timeouts configuration.
-    TimeoutsConfiguration configuration {};
 
     // 3. For each key → value in timeouts:
     TRY(timeouts.as_object().try_for_each_member([&](auto const& key, JsonValue const& value) -> ErrorOr<void, Error> {
@@ -78,8 +87,7 @@ ErrorOr<TimeoutsConfiguration, Error> json_deserialize_as_a_timeouts_configurati
         return {};
     }));
 
-    // 4. Return success with data configuration.
-    return configuration;
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.h
+++ b/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.h
@@ -15,8 +15,8 @@ namespace Web::WebDriver {
 // https://w3c.github.io/webdriver/#dfn-timeouts-configuration
 struct TimeoutsConfiguration {
     Optional<u64> script_timeout { 30'000 };
-    u64 page_load_timeout { 300'000 };
-    u64 implicit_wait_timeout { 0 };
+    Optional<u64> page_load_timeout { 300'000 };
+    Optional<u64> implicit_wait_timeout { 0 };
 };
 
 JsonObject timeouts_object(TimeoutsConfiguration const&);

--- a/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.h
+++ b/Userland/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.h
@@ -21,5 +21,6 @@ struct TimeoutsConfiguration {
 
 JsonObject timeouts_object(TimeoutsConfiguration const&);
 ErrorOr<TimeoutsConfiguration, Error> json_deserialize_as_a_timeouts_configuration(JsonValue const&);
+ErrorOr<void, Error> json_deserialize_as_a_timeouts_configuration_into(JsonValue const&, TimeoutsConfiguration&);
 
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -243,11 +243,15 @@ Messages::WebDriverClient::GetTimeoutsResponse WebDriverConnection::get_timeouts
 // 9.2 Set Timeouts, https://w3c.github.io/webdriver/#dfn-set-timeouts
 Messages::WebDriverClient::SetTimeoutsResponse WebDriverConnection::set_timeouts(JsonValue const& payload)
 {
+    // FIXME: Spec issue: As written, the spec replaces the timeouts configuration with the newly provided values. But
+    //        all other implementations update the existing configuration with any new values instead. WPT relies on
+    //        this behavior, and sends us one timeout value at time.
+    //        https://github.com/w3c/webdriver/issues/1596
+
     // 1. Let timeouts be the result of trying to JSON deserialize as a timeouts configuration the request’s parameters.
-    auto timeouts = TRY(Web::WebDriver::json_deserialize_as_a_timeouts_configuration(payload));
+    TRY(Web::WebDriver::json_deserialize_as_a_timeouts_configuration_into(payload, m_timeouts_configuration));
 
     // 2. Make the session timeouts the new timeouts.
-    m_timeouts_configuration = move(timeouts);
 
     // 3. Return success with data null.
     return JsonValue {};

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -2316,6 +2316,7 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::handle_any_user_prompt
 }
 
 // https://w3c.github.io/webdriver/#dfn-waiting-for-the-navigation-to-complete
+// FIXME: Update this AO to the latest spec steps.
 ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::wait_for_navigation_to_complete()
 {
     // 1. If the current session has a page loading strategy of none, return success with data null.
@@ -2332,11 +2333,10 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::wait_for_navigation_to
 
     // 3. Start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout in milliseconds, return an error with error code timeout.
     auto page_load_timeout_fired = false;
-    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout, [&] {
+    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout.value_or(300'000), [&] {
         page_load_timeout_fired = true;
     });
     timer->start();
-
     // 4. If there is an ongoing attempt to navigate the current browsing context that has not yet matured, wait for navigation to mature.
     Web::Platform::EventLoopPlugin::the().spin_until([&] {
         return page_load_timeout_fired || navigable->ongoing_navigation().has<Empty>();
@@ -2377,7 +2377,7 @@ void WebDriverConnection::restore_the_window()
     // Do not return from this operation until the visibility state of the top-level browsing context’s active document has reached the visible state, or until the operation times out.
     // FIXME: It isn't clear which timeout should be used here.
     auto page_load_timeout_fired = false;
-    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout, [&] {
+    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout.value_or(300'000), [&] {
         page_load_timeout_fired = true;
     });
     timer->start();
@@ -2407,7 +2407,7 @@ Gfx::IntRect WebDriverConnection::iconify_the_window()
     // Do not return from this operation until the visibility state of the top-level browsing context’s active document has reached the hidden state, or until the operation times out.
     // FIXME: It isn't clear which timeout should be used here.
     auto page_load_timeout_fired = false;
-    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout, [&] {
+    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout.value_or(300'000), [&] {
         page_load_timeout_fired = true;
     });
     timer->start();
@@ -2421,10 +2421,11 @@ Gfx::IntRect WebDriverConnection::iconify_the_window()
 }
 
 // https://w3c.github.io/webdriver/#dfn-find
+// FIXME: Update this AO to the latest spec steps.
 ErrorOr<JsonArray, Web::WebDriver::Error> WebDriverConnection::find(StartNodeGetter&& start_node_getter, Web::WebDriver::LocationStrategy using_, StringView value)
 {
     // 1. Let end time be the current time plus the session implicit wait timeout.
-    auto end_time = MonotonicTime::now() + AK::Duration::from_milliseconds(static_cast<i64>(m_timeouts_configuration.implicit_wait_timeout));
+    auto end_time = MonotonicTime::now() + AK::Duration::from_milliseconds(static_cast<i64>(m_timeouts_configuration.implicit_wait_timeout.value_or(0)));
 
     // 2. Let location strategy be equal to using.
     auto location_strategy = using_;


### PR DESCRIPTION
WPT sends us the following Set Timeouts invocations:
```
POST /session/<session id>/timeouts: {"implicit":0}
POST /session/<session id>/timeouts: {"pageLoad":3000}
POST /session/<session id>/timeouts: {"script":1000}
```

So after the last invocation, our page load timeout would be set back to 5 minutes. 