### PR TITLE
LibWeb : Manage channelCountMode and channelCount for DynamicsCompressor

### DIFF
--- a/Tests/LibWeb/Text/expected/WebAudio/compressor-node-channel-cound-mode.txt
+++ b/Tests/LibWeb/Text/expected/WebAudio/compressor-node-channel-cound-mode.txt
@@ -1,0 +1,6 @@
+clamped-max
+explicit
+NotSupportedError
+clamped-max
+explicit
+NotSupportedError

--- a/Tests/LibWeb/Text/input/WebAudio/compressor-node-channel-cound-mode.html
+++ b/Tests/LibWeb/Text/input/WebAudio/compressor-node-channel-cound-mode.html
@@ -1,0 +1,36 @@
+<script src="../include.js"></script>
+<script>
+test(() => {
+  const context = new (window.AudioContext || window.webkitAudioContext)();
+  const validModes = ['clamped-max', 'explicit'];
+  const invalidMode = 'max';
+
+  // Test valid channelCountMode values via constructor
+  validModes.forEach(mode => {
+      const node = new DynamicsCompressorNode(context, { channelCountMode: mode });
+      println(node.channelCountMode);
+  });
+
+  // Test invalid channelCountMode via constructor
+  try {
+      new DynamicsCompressorNode(context, { channelCountMode: invalidMode });
+  } catch (error) {
+      println(error.name);
+  }
+
+  // Test valid channelCountMode values via setter
+  validModes.forEach(mode => {
+      const node = new DynamicsCompressorNode(context);
+      node.channelCountMode = mode;
+      println(node.channelCountMode);
+  });
+
+  // Test invalid channelCountMode via setter
+  try {
+      const node = new DynamicsCompressorNode(context);
+      node.channelCountMode = invalidMode;
+  } catch (error) {
+      println(error.name);
+  }
+});
+</script>

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
@@ -21,28 +21,28 @@ AudioNode::AudioNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> contex
 
 AudioNode::~AudioNode() = default;
 
-WebIDL::ExceptionOr<void> AudioNode::initialize_audio_node_options(JS::NonnullGCPtr<BaseAudioContext> context, AudioNodeOptions const& given_options, AudioNodeOptions const& default_options)
+WebIDL::ExceptionOr<void> AudioNode::initialize_audio_node_options(AudioNodeOptions const& given_options, AudioNodeDefaultOptions const& default_options)
 {
-    // FIXME: Context will be used in the future implementation.
-    (void)context; // Cast to void to avoid unused parameter warning.
-
     // Set channel count, fallback to default if not provided
     if (given_options.channel_count.has_value()) {
         TRY(set_channel_count(given_options.channel_count.value()));
-    } else if (default_options.channel_count.has_value()) {
-        TRY(set_channel_count(default_options.channel_count.value()));
+    } else {
+        TRY(set_channel_count(default_options.channel_count));
     }
 
     // Set channel count mode, fallback to default if not provided
     if (given_options.channel_count_mode.has_value()) {
         TRY(set_channel_count_mode(given_options.channel_count_mode.value()));
-    } else if (default_options.channel_count_mode.has_value()) {
-        TRY(set_channel_count_mode(default_options.channel_count_mode.value()));
+    } else {
+        TRY(set_channel_count_mode(default_options.channel_count_mode));
     }
 
     // Set channel interpretation, fallback to default if not provided
-    Bindings::ChannelInterpretation channel_interpretation_to_set = given_options.channel_interpretation.value_or(default_options.channel_interpretation.value_or(Bindings::ChannelInterpretation::Speakers));
-    TRY(set_channel_interpretation(channel_interpretation_to_set));
+    if (given_options.channel_interpretation.has_value()) {
+        TRY(set_channel_interpretation(given_options.channel_interpretation.value()));
+    } else {
+        TRY(set_channel_interpretation(default_options.channel_interpretation));
+    }
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
@@ -21,6 +21,32 @@ AudioNode::AudioNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> contex
 
 AudioNode::~AudioNode() = default;
 
+WebIDL::ExceptionOr<void> AudioNode::initialize_audio_node_options(JS::NonnullGCPtr<BaseAudioContext> context, AudioNodeOptions const& given_options, AudioNodeOptions const& default_options)
+{
+    // FIXME: Context will be used in the future implementation.
+    (void)context; // Cast to void to avoid unused parameter warning.
+
+    // Set channel count, fallback to default if not provided
+    if (given_options.channel_count.has_value()) {
+        TRY(set_channel_count(given_options.channel_count.value()));
+    } else if (default_options.channel_count.has_value()) {
+        TRY(set_channel_count(default_options.channel_count.value()));
+    }
+
+    // Set channel count mode, fallback to default if not provided
+    if (given_options.channel_count_mode.has_value()) {
+        TRY(set_channel_count_mode(given_options.channel_count_mode.value()));
+    } else if (default_options.channel_count_mode.has_value()) {
+        TRY(set_channel_count_mode(default_options.channel_count_mode.value()));
+    }
+
+    // Set channel interpretation, fallback to default if not provided
+    Bindings::ChannelInterpretation channel_interpretation_to_set = given_options.channel_interpretation.value_or(default_options.channel_interpretation.value_or(Bindings::ChannelInterpretation::Speakers));
+    TRY(set_channel_interpretation(channel_interpretation_to_set));
+
+    return {};
+}
+
 // https://webaudio.github.io/web-audio-api/#dom-audionode-connect
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioNode>> AudioNode::connect(JS::NonnullGCPtr<AudioNode> destination_node, WebIDL::UnsignedLong output, WebIDL::UnsignedLong input)
 {

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.h
@@ -22,6 +22,12 @@ struct AudioNodeOptions {
     Optional<Bindings::ChannelInterpretation> channel_interpretation;
 };
 
+struct AudioNodeDefaultOptions {
+    WebIDL::UnsignedLong channel_count;
+    Bindings::ChannelCountMode channel_count_mode;
+    Bindings::ChannelInterpretation channel_interpretation;
+};
+
 // https://webaudio.github.io/web-audio-api/#AudioNode
 class AudioNode : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(AudioNode, DOM::EventTarget);
@@ -62,7 +68,7 @@ public:
     WebIDL::ExceptionOr<void> set_channel_interpretation(Bindings::ChannelInterpretation);
     Bindings::ChannelInterpretation channel_interpretation();
 
-    WebIDL::ExceptionOr<void> initialize_audio_node_options(JS::NonnullGCPtr<BaseAudioContext> context, AudioNodeOptions const& given_options, AudioNodeOptions const& default_options);
+    WebIDL::ExceptionOr<void> initialize_audio_node_options(AudioNodeOptions const& given_options, AudioNodeDefaultOptions const& default_options);
 
 protected:
     AudioNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>);

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.h
@@ -18,8 +18,8 @@ namespace Web::WebAudio {
 // https://webaudio.github.io/web-audio-api/#AudioNodeOptions
 struct AudioNodeOptions {
     Optional<WebIDL::UnsignedLong> channel_count;
-    Bindings::ChannelCountMode channel_count_mode;
-    Bindings::ChannelInterpretation channel_interpretation;
+    Optional<Bindings::ChannelCountMode> channel_count_mode;
+    Optional<Bindings::ChannelInterpretation> channel_interpretation;
 };
 
 // https://webaudio.github.io/web-audio-api/#AudioNode
@@ -57,10 +57,12 @@ public:
     virtual WebIDL::ExceptionOr<void> set_channel_count(WebIDL::UnsignedLong);
     virtual WebIDL::UnsignedLong channel_count() const { return m_channel_count; }
 
-    WebIDL::ExceptionOr<void> set_channel_count_mode(Bindings::ChannelCountMode);
+    virtual WebIDL::ExceptionOr<void> set_channel_count_mode(Bindings::ChannelCountMode);
     Bindings::ChannelCountMode channel_count_mode();
     WebIDL::ExceptionOr<void> set_channel_interpretation(Bindings::ChannelInterpretation);
     Bindings::ChannelInterpretation channel_interpretation();
+
+    WebIDL::ExceptionOr<void> initialize_audio_node_options(JS::NonnullGCPtr<BaseAudioContext> context, AudioNodeOptions const& given_options, AudioNodeOptions const& default_options);
 
 protected:
     AudioNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>);

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.cpp
@@ -27,16 +27,17 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DynamicsCompressorNode>> DynamicsCompressor
     auto node = realm.vm().heap().allocate<DynamicsCompressorNode>(realm, realm, context, options);
 
     // Default options for channel count and interpretation
-    AudioNodeOptions default_options;
+    // https://webaudio.github.io/web-audio-api/#DynamicsCompressorNode
+    AudioNodeDefaultOptions default_options;
     default_options.channel_count_mode = Bindings::ChannelCountMode::ClampedMax;
     default_options.channel_interpretation = Bindings::ChannelInterpretation::Speakers;
+    default_options.channel_count = 2;
+    // FIXME: Set tail-time to yes
 
-    // Initialize the AudioNode with the given options, default options, and context
-    TRY(node->initialize_audio_node_options(context, options, default_options));
+    TRY(node->initialize_audio_node_options(options, default_options));
 
     return node;
 }
-
 
 DynamicsCompressorNode::DynamicsCompressorNode(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext> context, DynamicsCompressorOptions const& options)
     : AudioNode(realm, context)
@@ -74,6 +75,18 @@ WebIDL::ExceptionOr<void> DynamicsCompressorNode::set_channel_count_mode(Binding
 
     // If the mode is valid, call the base class implementation
     return AudioNode::set_channel_count_mode(mode);
+}
+
+// https://webaudio.github.io/web-audio-api/#dom-audionode-channelcount
+WebIDL::ExceptionOr<void> DynamicsCompressorNode::set_channel_count(WebIDL::UnsignedLong channel_count)
+{
+    if (channel_count > 2) {
+        // Return a NotSupportedError if 'max' is used
+        return WebIDL::NotSupportedError::create(realm(), "DynamicsCompressorNode does not support channel count greater than 2"_string);
+    }
+
+    // If the mode is valid, call the base class implementation
+    return AudioNode::set_channel_count(channel_count);
 }
 
 }

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
@@ -41,6 +41,7 @@ public:
     float reduction() const { return m_reduction; }
 
     WebIDL::ExceptionOr<void> set_channel_count_mode(Bindings::ChannelCountMode) override;
+    WebIDL::ExceptionOr<void> set_channel_count(WebIDL::UnsignedLong) override;
 
 protected:
     DynamicsCompressorNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, DynamicsCompressorOptions const& = {});

--- a/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/DynamicsCompressorNode.h
@@ -40,6 +40,8 @@ public:
     JS::NonnullGCPtr<AudioParam const> release() const { return m_release; }
     float reduction() const { return m_reduction; }
 
+    WebIDL::ExceptionOr<void> set_channel_count_mode(Bindings::ChannelCountMode) override;
+
 protected:
     DynamicsCompressorNode(JS::Realm&, JS::NonnullGCPtr<BaseAudioContext>, DynamicsCompressorOptions const& = {});
 


### PR DESCRIPTION
This PR help passing more WPT tests under [/webaudio/the-audio-api/the-dynamicscompressornode-interface/ctor-dynamicscompressor.html](http://wpt.live//webaudio/the-audio-api/the-dynamicscompressornode-interface/ctor-dynamicscompressor.html)
I have managed to write a test to show the issue (Ladybird passes it manually only with this PR), however, I have not actually managed to automate it...