### PR TITLE
Meta: Update devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,11 @@
 {
     "name": "Ladybird",
-    "image": "mcr.microsoft.com/devcontainers/base:jammy",
+    "image": "mcr.microsoft.com/devcontainers/base:noble",
 
     // Features to add to the dev container. More info: https://containers.dev/implementors/features.
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
-        "ghcr.io/devcontainers-contrib/features/pre-commit:1": {},
+        "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
         "./features/ladybird": {
             "llvm_version": 18,
         },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
     "name": "Ladybird",
     "image": "mcr.microsoft.com/devcontainers/base:noble",
-
     // Features to add to the dev container. More info: https://containers.dev/implementors/features.
     "features": {
         "ghcr.io/devcontainers/features/github-cli:1": {},
@@ -15,9 +14,11 @@
             "vncPort": "5901"
         }
     },
-
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [6080, 5901],
+    "forwardPorts": [
+        6080,
+        5901
+    ],
     "portsAttributes": {
         "5901": {
             "label": "VNC"
@@ -26,13 +27,52 @@
             "label": "Web VNC"
         }
     },
-
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "pre-commit install; pre-commit install --hook-type commit-msg"
-
+    "postCreateCommand": "pre-commit install; pre-commit install --hook-type commit-msg",
     // Configure tool-specific properties.
-    // "customizations": {},
-
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cmake-tools",
+                "llvm-vs-code-extensions.vscode-clangd",
+                "eamodio.gitlens"
+            ],
+            "settings": {
+                // Excluding the generated directories keeps your file view clean and speeds up search.
+                "files.exclude": {
+                    "**/.git": true,
+                    "Toolchain/Local/**": true,
+                    "Toolchain/Tarballs/**": true,
+                    "Toolchain/Build/**": true,
+                    "Build/**": true,
+                },
+                "search.exclude": {
+                    "**/.git": true,
+                    "Toolchain/Local/**": true,
+                    "Toolchain/Tarballs/**": true,
+                    "Toolchain/Build/**": true,
+                    "Build/**": true,
+                },
+                // Force clang-format to respect Ladybird's .clang-format style file. This is not necessary if you're not using the Microsoft C++ extension.
+                "C_Cpp.clang_format_style": "file",
+                // Tab settings
+                "editor.tabSize": 4,
+                "editor.useTabStops": false,
+                // format trailing new lines
+                "files.trimFinalNewlines": true,
+                "files.insertFinalNewline": true,
+                // git commit message length
+                "git.inputValidationLength": 72,
+                "git.inputValidationSubjectLength": 72,
+                // If clangd was obtained from a package manager, its path can be set here.
+                // Note: This has to be adjusted manually, to the "llvm_version" from above
+                "clangd.path": "clangd-18",
+                "clangd.arguments": [
+                    "--header-insertion=never" // See https://github.com/clangd/clangd/issues/1247
+                ]
+            }
+        }
+    }
     // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
     // "remoteUser": "root",
 }

--- a/.devcontainer/features/ladybird/devcontainer-feature.json
+++ b/.devcontainer/features/ladybird/devcontainer-feature.json
@@ -9,6 +9,7 @@
             "proposals": [
                 17,
                 18,
+                19,
                 "trunk"
             ],
             "default": 18,

--- a/.devcontainer/features/ladybird/install.sh
+++ b/.devcontainer/features/ladybird/install.sh
@@ -28,7 +28,7 @@ install_llvm_key() {
 ### Install packages
 
 apt update -y
-apt install -y lsb-release git python3 autoconf autoconf-archive automake build-essential cmake libavcodec-dev libgl1-mesa-dev ninja-build qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev qt6-wayland ccache fonts-liberation2 zip unzip curl tar
+apt install -y lsb-release git python3 autoconf autoconf-archive automake build-essential cmake libavcodec-dev libavformat-dev libavutil-dev libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev qt6-wayland ccache fonts-liberation2 zip unzip curl tar
 ### Ensure new enough host compiler is available
 
 VERSION="0.0.0"

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -13,6 +13,7 @@ CMake 3.25 or newer must be available in $PATH.
 
 ### Debian/Ubuntu:
 
+<!-- Note: If you change something here, please also change it in the `devcontainer/devcontainer.json` file. -->
 ```bash
 sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libavcodec-dev libavformat-dev libavutil-dev libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
 ```


### PR DESCRIPTION
While trying to run the dev container, I faced a few issues:
- the packages were outdated
- some needed packages were missing

This includes the following: 
In Ubuntu 20.04 (jammy) we don't have the minimum CMake version of 3.25, we could add it by using the [kitware apt repo](https://apt.kitware.com/ubuntu/) or by using the newer LTS (See below)
Some packages, that are needed for them to be compiled by vcpkg are missing, they were added to `Documentation/BuildInstructionsLadybird.md` but not to the devcontainer `install.sh` script. e.g. `libavformat-dev` or `nasm`.

Also jammy is the older LTS, the newer LTS noble (22.04) is already out by a half year, so using the newer `mcr.microsoft.com/devcontainers/base` image is a good idea. The official apt repos for llvm also support llvm 19 (see [here](https://apt.llvm.org/noble/dists/)) So I added this to the suggestion, so that everyone is aware, that it already works (personally I already switched to llvm 19, also while working on ladybird, but it's using llvm 18 everywhere else, so I kept that)

`devcontainer.json` also supports a `customizations` files, so I added the recommended extensions and settings there too, taken from `Documentation/VSCodeConfiguration.md` I find it easier, to have those in there, as it really helps.
you rebuild it 

Except the update to noble for the never CMake (which we also could theoretically do with the kitware repo) and the addition of the new packages, everything is optional, but I find it a good idea and it follows repos conventions :) 

I tested the devcontainer locally and it works perfectly now :)

A general note, to those who never worked with devontainers, everything that is installed manually after booting it up, gets removed (the container gets reset) when you rebuild it, so having more in there is a better idea, since uninstalling something is way easier, then manually installing the correct thing :)