### PR TITLE
CMake: fix codesigning error on Intel macOS

### DIFF
--- a/Ladybird/CMakeLists.txt
+++ b/Ladybird/CMakeLists.txt
@@ -34,7 +34,7 @@ function(create_ladybird_bundle target_name)
             COMMAND "${CMAKE_COMMAND}" -E create_symlink "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}" "${bundle_dir}/Contents/lib"
         )
 
-        if (NOT CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo")
+        if (NOT CMAKE_BUILD_TYPE MATCHES "Release|RelWithDebInfo" AND "arm64" IN_LIST CMAKE_OSX_ARCHITECTURES)
             add_custom_command(TARGET ${target_name} POST_BUILD
                 COMMAND codesign -s - -v -f --entitlements "${LADYBIRD_SOURCE_DIR}/Meta/debug.plist" "${bundle_dir}"
             )


### PR DESCRIPTION
Without this fix trying to build a Debug build on x86_64 macOS fails with the error `Build/ladybird-debug/bin/Ladybird.app: code object is not signed at all`. Thanks to @ADKaster for help with the fix :^)