### PR TITLE
LibWeb: Obtain basename before passing base_url to ClassicScript::create

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -377,7 +377,8 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
 
                 // 7. Let script be the result of creating a classic script given handler, settings object, base URL, and fetch options.
                 // FIXME: Pass fetch options.
-                auto script = ClassicScript::create(base_url.basename(), source, settings_object, move(base_url));
+                auto basename = base_url.basename();
+                auto script = ClassicScript::create(basename, source, settings_object, move(base_url));
 
                 // 8. Run the classic script script.
                 (void)script->run();


### PR DESCRIPTION
This would previously crash because it depended on a specific order for evaluating function arguments, which is undefined.

Test page (used to crash before this commit): https://www.newyorker.com/magazine/2024/10/21/alexei-navalny-patriot-memoir

This crashes for me with:
```
» /usr/bin/c++ --version
c++ (Gentoo Hardened 14.2.1_p20240921 p1) 14.2.1 20240921
```