### PR TITLE
LibWeb: Make DOMException take error message as a String

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2509,7 +2509,7 @@ static void generate_html_constructor(SourceGenerator& generator, IDL::Construct
 
     // 11. If element is an already constructed marker, then throw an "InvalidStateError" DOMException.
     if (element.has<HTML::AlreadyConstructedCustomElementMarker>())
-        return JS::throw_completion(WebIDL::InvalidStateError::create(realm, "Custom element has already been constructed"_fly_string));
+        return JS::throw_completion(WebIDL::InvalidStateError::create(realm, "Custom element has already been constructed"_string));
 
     // 12. Perform ? element.[[SetPrototypeOf]](prototype).
     auto actual_element = element.get<JS::Handle<DOM::Element>>();

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -430,7 +430,7 @@ void Animation::cancel(ShouldInvalidate should_invalidate)
         reset_an_animations_pending_tasks();
 
         // 2. Reject the current finished promise with a DOMException named "AbortError".
-        auto dom_exception = WebIDL::AbortError::create(realm, "Animation was cancelled"_fly_string);
+        auto dom_exception = WebIDL::AbortError::create(realm, "Animation was cancelled"_string);
         WebIDL::reject_promise(realm, current_finished_promise(), dom_exception);
 
         // 3. Set the [[PromiseIsHandled]] internal slot of the current finished promise to true.
@@ -490,9 +490,9 @@ WebIDL::ExceptionOr<void> Animation::finish()
     //    effect end is infinity, throw an "InvalidStateError" DOMException and abort these steps.
     auto effective_playback_rate = this->effective_playback_rate();
     if (effective_playback_rate == 0.0)
-        return WebIDL::InvalidStateError::create(realm(), "Animation with a playback rate of 0 cannot be finished"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Animation with a playback rate of 0 cannot be finished"_string);
     if (effective_playback_rate > 0.0 && isinf(associated_effect_end()))
-        return WebIDL::InvalidStateError::create(realm(), "Animation with no end cannot be finished"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Animation with no end cannot be finished"_string);
 
     // 2. Apply any pending playback rate to animation.
     apply_any_pending_playback_rate();
@@ -591,7 +591,7 @@ WebIDL::ExceptionOr<void> Animation::play_an_animation(AutoRewind auto_rewind)
             // -> If associated effect end is positive infinity,
             if (isinf(associated_effect_end) && associated_effect_end > 0.0) {
                 // throw an "InvalidStateError" DOMException and abort these steps.
-                return WebIDL::InvalidStateError::create(realm(), "Cannot rewind an animation with an infinite effect end"_fly_string);
+                return WebIDL::InvalidStateError::create(realm(), "Cannot rewind an animation with an infinite effect end"_string);
             }
             // -> Otherwise,
             //    Set seek time to animation’s associated effect end.
@@ -711,7 +711,7 @@ WebIDL::ExceptionOr<void> Animation::pause()
             auto associated_effect_end = this->associated_effect_end();
             if (isinf(associated_effect_end) && associated_effect_end > 0.0) {
                 // throw an "InvalidStateError" DOMException and abort these steps.
-                return WebIDL::InvalidStateError::create(realm(), "Cannot pause an animation with an infinite effect end"_fly_string);
+                return WebIDL::InvalidStateError::create(realm(), "Cannot pause an animation with an infinite effect end"_string);
             }
 
             // Otherwise,
@@ -837,7 +837,7 @@ WebIDL::ExceptionOr<void> Animation::reverse()
     // 1. If there is no timeline associated with animation, or the associated timeline is inactive throw an
     //    "InvalidStateError" DOMException and abort these steps.
     if (!m_timeline || m_timeline->is_inactive())
-        return WebIDL::InvalidStateError::create(realm, "Cannot reverse an animation with an inactive timeline"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Cannot reverse an animation with an inactive timeline"_string);
 
     // 2. Let original pending playback rate be animation’s pending playback rate.
     auto original_pending_playback_rate = m_pending_playback_rate;
@@ -1205,7 +1205,7 @@ void Animation::reset_an_animations_pending_tasks()
     apply_any_pending_playback_rate();
 
     // 5. Reject animation’s current ready promise with a DOMException named "AbortError".
-    auto dom_exception = WebIDL::AbortError::create(realm, "Animation was cancelled"_fly_string);
+    auto dom_exception = WebIDL::AbortError::create(realm, "Animation was cancelled"_string);
     WebIDL::reject_promise(realm, current_ready_promise(), dom_exception);
 
     // 6. Set the [[PromiseIsHandled]] internal slot of animation’s current ready promise to true.

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -60,7 +60,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // 2. If index is greater than length, then throw an IndexSizeError exception.
     if (index > length)
-        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds."_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds."_string);
 
     // 3. Set new rule to the results of performing parse a CSS rule on argument rule.
     // NOTE: The insert-a-css-rule spec expects `rule` to be a string, but the CSSStyleSheet.insertRule()
@@ -77,7 +77,7 @@ WebIDL::ExceptionOr<unsigned> CSSRuleList::insert_a_css_rule(Variant<StringView,
 
     // 4. If new rule is a syntax error, throw a SyntaxError exception.
     if (!new_rule)
-        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_string);
 
     // FIXME: 5. If new rule cannot be inserted into list at the zero-index position index due to constraints specified by CSS, then throw a HierarchyRequestError exception. [CSS21]
 
@@ -100,7 +100,7 @@ WebIDL::ExceptionOr<void> CSSRuleList::remove_a_css_rule(u32 index)
 
     // 2. If index is greater than or equal to length, then throw an IndexSizeError exception.
     if (index >= length)
-        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds."_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "CSS rule index out of bounds."_string);
 
     // 3. Set old rule to the indexth item in list.
     CSSRule& old_rule = m_rules[index];

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -46,7 +46,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleSheet>> CSSStyleSheet::construct_im
         // AD-HOC: This isn't explicitly mentioned in the specification, but multiple modern browsers do this.
         URL::URL url = sheet->location().has_value() ? sheet_location_url->complete_url(options->base_url.value()) : options->base_url.value();
         if (!url.is_valid())
-            return WebIDL::NotAllowedError::create(realm, "Constructed style sheets must have a valid base URL"_fly_string);
+            return WebIDL::NotAllowedError::create(realm, "Constructed style sheets must have a valid base URL"_string);
 
         sheet->set_base_url(url);
     }
@@ -135,7 +135,7 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(StringView rule, unsign
 
     // If the disallow modification flag is set, throw a NotAllowedError DOMException.
     if (disallow_modification())
-        return WebIDL::NotAllowedError::create(realm(), "Can't call insert_rule() on non-modifiable stylesheets."_fly_string);
+        return WebIDL::NotAllowedError::create(realm(), "Can't call insert_rule() on non-modifiable stylesheets."_string);
 
     // 3. Let parsed rule be the return value of invoking parse a rule with rule.
     auto context = m_style_sheet_list ? CSS::Parser::ParsingContext { m_style_sheet_list->document() } : CSS::Parser::ParsingContext { realm() };
@@ -143,11 +143,11 @@ WebIDL::ExceptionOr<unsigned> CSSStyleSheet::insert_rule(StringView rule, unsign
 
     // 4. If parsed rule is a syntax error, return parsed rule.
     if (!parsed_rule)
-        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Unable to parse CSS rule."_string);
 
     // 5. If parsed rule is an @import rule, and the constructed flag is set, throw a SyntaxError DOMException.
     if (constructed() && parsed_rule->type() == CSSRule::Type::Import)
-        return WebIDL::SyntaxError::create(realm(), "Can't insert @import rules into a constructed stylesheet."_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Can't insert @import rules into a constructed stylesheet."_string);
 
     // 6. Return the result of invoking insert a CSS rule rule in the CSS rules at index.
     auto result = m_rules->insert_a_css_rule(parsed_rule, index);
@@ -172,7 +172,7 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::delete_rule(unsigned index)
 
     // 2. If the disallow modification flag is set, throw a NotAllowedError DOMException.
     if (disallow_modification())
-        return WebIDL::NotAllowedError::create(realm(), "Can't call delete_rule() on non-modifiable stylesheets."_fly_string);
+        return WebIDL::NotAllowedError::create(realm(), "Can't call delete_rule() on non-modifiable stylesheets."_string);
 
     // 3. Remove a CSS rule in the CSS rules at index.
     auto result = m_rules->remove_a_css_rule(index);
@@ -193,12 +193,12 @@ JS::NonnullGCPtr<JS::Promise> CSSStyleSheet::replace(String text)
 
     // 2. If the constructed flag is not set, or the disallow modification flag is set, reject promise with a NotAllowedError DOMException and return promise.
     if (!constructed()) {
-        promise->reject(WebIDL::NotAllowedError::create(realm(), "Can't call replace() on non-constructed stylesheets"_fly_string));
+        promise->reject(WebIDL::NotAllowedError::create(realm(), "Can't call replace() on non-constructed stylesheets"_string));
         return promise;
     }
 
     if (disallow_modification()) {
-        promise->reject(WebIDL::NotAllowedError::create(realm(), "Can't call replace() on non-modifiable stylesheets"_fly_string));
+        promise->reject(WebIDL::NotAllowedError::create(realm(), "Can't call replace() on non-modifiable stylesheets"_string));
         return promise;
     }
 
@@ -237,9 +237,9 @@ WebIDL::ExceptionOr<void> CSSStyleSheet::replace_sync(StringView text)
 {
     // 1. If the constructed flag is not set, or the disallow modification flag is set, throw a NotAllowedError DOMException.
     if (!constructed())
-        return WebIDL::NotAllowedError::create(realm(), "Can't call replaceSync() on non-constructed stylesheets"_fly_string);
+        return WebIDL::NotAllowedError::create(realm(), "Can't call replaceSync() on non-constructed stylesheets"_string);
     if (disallow_modification())
-        return WebIDL::NotAllowedError::create(realm(), "Can't call replaceSync() on non-modifiable stylesheets"_fly_string);
+        return WebIDL::NotAllowedError::create(realm(), "Can't call replaceSync() on non-modifiable stylesheets"_string);
 
     // 2. Let rules be the result of running parse a stylesheet’s contents from text.
     auto context = m_style_sheet_list ? CSS::Parser::ParsingContext { m_style_sheet_list->document() } : CSS::Parser::ParsingContext { realm() };

--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -91,7 +91,7 @@ JS::NonnullGCPtr<FontFace> FontFace::construct_impl(JS::Realm& realm, String fam
         auto parser = CSS::Parser::Parser::create(CSS::Parser::ParsingContext(realm, base_url), *string);
         sources = parser.parse_as_font_face_src();
         if (sources.is_empty())
-            WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "FontFace constructor: Invalid source string"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "FontFace constructor: Invalid source string"_string));
     } else {
         auto buffer_source = source.get<JS::Handle<WebIDL::BufferSource>>();
         auto maybe_buffer = WebIDL::get_buffer_source_copy(buffer_source->raw_object());
@@ -105,7 +105,7 @@ JS::NonnullGCPtr<FontFace> FontFace::construct_impl(JS::Realm& realm, String fam
     }
 
     if (buffer.is_empty() && sources.is_empty())
-        WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "FontFace constructor: Invalid font source"_fly_string));
+        WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "FontFace constructor: Invalid font source"_string));
 
     auto font = realm.heap().allocate<FontFace>(realm, realm, promise, move(sources), move(buffer), move(family), descriptors);
 
@@ -215,7 +215,7 @@ WebIDL::ExceptionOr<void> FontFace::set_family(String const& string)
 {
     auto property = parse_property_string<CSS::PropertyID::FontFamily>(realm(), string);
     if (!property)
-        return WebIDL::SyntaxError::create(realm(), "FontFace.family setter: Invalid font descriptor"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "FontFace.family setter: Invalid font descriptor"_string);
 
     if (m_is_css_connected) {
         // FIXME: Propagate to the CSSFontFaceRule and update the font-family property
@@ -231,7 +231,7 @@ WebIDL::ExceptionOr<void> FontFace::set_style(String const& string)
 {
     auto property = parse_property_string<CSS::PropertyID::FontStyle>(realm(), string);
     if (!property)
-        return WebIDL::SyntaxError::create(realm(), "FontFace.style setter: Invalid font descriptor"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "FontFace.style setter: Invalid font descriptor"_string);
 
     if (m_is_css_connected) {
         // FIXME: Propagate to the CSSFontFaceRule and update the font-style property
@@ -247,7 +247,7 @@ WebIDL::ExceptionOr<void> FontFace::set_weight(String const& string)
 {
     auto property = parse_property_string<CSS::PropertyID::FontWeight>(realm(), string);
     if (!property)
-        return WebIDL::SyntaxError::create(realm(), "FontFace.weight setter: Invalid font descriptor"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "FontFace.weight setter: Invalid font descriptor"_string);
 
     if (m_is_css_connected) {
         // FIXME: Propagate to the CSSFontFaceRule and update the font-weight property
@@ -264,7 +264,7 @@ WebIDL::ExceptionOr<void> FontFace::set_stretch(String const& string)
     // NOTE: font-stretch is now an alias for font-width
     auto property = parse_property_string<CSS::PropertyID::FontWidth>(realm(), string);
     if (!property)
-        return WebIDL::SyntaxError::create(realm(), "FontFace.stretch setter: Invalid font descriptor"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "FontFace.stretch setter: Invalid font descriptor"_string);
 
     if (m_is_css_connected) {
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
@@ -280,43 +280,43 @@ WebIDL::ExceptionOr<void> FontFace::set_unicode_range(String const&)
 {
     // FIXME: This *should* work, but the <urange> production is hard to parse
     //        from just a value string in our implementation
-    return WebIDL::NotSupportedError::create(realm(), "unicode range is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "unicode range is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-featuresettings
 WebIDL::ExceptionOr<void> FontFace::set_feature_settings(String const&)
 {
-    return WebIDL::NotSupportedError::create(realm(), "feature settings is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "feature settings is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-variationsettings
 WebIDL::ExceptionOr<void> FontFace::set_variation_settings(String const&)
 {
-    return WebIDL::NotSupportedError::create(realm(), "variation settings is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "variation settings is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-display
 WebIDL::ExceptionOr<void> FontFace::set_display(String const&)
 {
-    return WebIDL::NotSupportedError::create(realm(), "display is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "display is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-ascentoverride
 WebIDL::ExceptionOr<void> FontFace::set_ascent_override(String const&)
 {
-    return WebIDL::NotSupportedError::create(realm(), "ascent override is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "ascent override is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-descentoverride
 WebIDL::ExceptionOr<void> FontFace::set_descent_override(String const&)
 {
-    return WebIDL::NotSupportedError::create(realm(), "descent override is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "descent override is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-linegapoverride
 WebIDL::ExceptionOr<void> FontFace::set_line_gap_override(String const&)
 {
-    return WebIDL::NotSupportedError::create(realm(), "line gap override is not yet implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "line gap override is not yet implemented"_string);
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-load
@@ -361,7 +361,7 @@ void FontFace::load_font_source()
                 //     1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
                 //        is "NetworkError" and set font face’s status attribute to "error".
                 font->m_status = Bindings::FontFaceLoadStatus::Error;
-                WebIDL::reject_promise(font->realm(), font->m_font_status_promise, WebIDL::NetworkError::create(font->realm(), "Failed to load font"_fly_string));
+                WebIDL::reject_promise(font->realm(), font->m_font_status_promise, WebIDL::NetworkError::create(font->realm(), "Failed to load font"_string));
 
                 // FIXME: For each FontFaceSet font face is in:
             }));

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -72,7 +72,7 @@ FontFaceSet::add(JS::Handle<FontFace> face)
 
     // 2. If font is CSS-connected, throw an InvalidModificationError exception and exit this algorithm immediately.
     if (face->is_css_connected()) {
-        return WebIDL::InvalidModificationError::create(realm(), "Cannot add a CSS-connected FontFace to a FontFaceSet"_fly_string);
+        return WebIDL::InvalidModificationError::create(realm(), "Cannot add a CSS-connected FontFace to a FontFaceSet"_string);
     }
 
     // 3. Add the font argument to the FontFaceSet’s set entries.
@@ -166,7 +166,7 @@ WebIDL::CallbackType* FontFaceSet::onloadingerror()
 JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> FontFaceSet::load(String const&, String const&)
 {
     // FIXME: Do the steps
-    auto promise = WebIDL::create_rejected_promise(realm(), WebIDL::NotSupportedError::create(realm(), "FontFaceSet::load is not yet implemented"_fly_string));
+    auto promise = WebIDL::create_rejected_promise(realm(), WebIDL::NotSupportedError::create(realm(), "FontFaceSet::load is not yet implemented"_string));
     return verify_cast<JS::Promise>(*promise->promise());
 }
 

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -603,7 +603,7 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
 
 static WebIDL::ExceptionOr<void> cannot_modify_computed_property_error(JS::Realm& realm)
 {
-    return WebIDL::NoModificationAllowedError::create(realm, "Cannot modify properties in result of getComputedStyle()"_fly_string);
+    return WebIDL::NoModificationAllowedError::create(realm, "Cannot modify properties in result of getComputedStyle()"_string);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
@@ -622,7 +622,7 @@ WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(StringView, 
 
 static WebIDL::ExceptionOr<String> cannot_remove_computed_property_error(JS::Realm& realm)
 {
-    return WebIDL::NoModificationAllowedError::create(realm, "Cannot remove properties from result of getComputedStyle()"_fly_string);
+    return WebIDL::NoModificationAllowedError::create(realm, "Cannot remove properties from result of getComputedStyle()"_string);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
@@ -653,7 +653,7 @@ String ResolvedCSSStyleDeclaration::serialized() const
 WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_css_text(StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
-    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_fly_string);
+    return WebIDL::NoModificationAllowedError::create(realm(), "Cannot modify properties in result of getComputedStyle()"_string);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/ScreenOrientation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ScreenOrientation.cpp
@@ -32,7 +32,7 @@ JS::NonnullGCPtr<ScreenOrientation> ScreenOrientation::create(JS::Realm& realm)
 // https://w3c.github.io/screen-orientation/#lock-method
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> ScreenOrientation::lock(Bindings::OrientationLockType)
 {
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: ScreenOrientation::lock() is not implemented"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: ScreenOrientation::lock() is not implemented"_string);
 }
 
 // https://w3c.github.io/screen-orientation/#unlock-method

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -161,7 +161,7 @@ JS::NonnullGCPtr<JS::Promise> Clipboard::write_text(String data)
             //    "NotAllowedError" DOMException in realm.
             queue_global_task(HTML::Task::Source::Permissions, realm.global_object(), JS::create_heap_function(realm.heap(), [&realm, promise]() mutable {
                 HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
-                WebIDL::reject_promise(realm, promise, WebIDL::NotAllowedError::create(realm, "Clipboard writing is only allowed through user activation"_fly_string));
+                WebIDL::reject_promise(realm, promise, WebIDL::NotAllowedError::create(realm, "Clipboard writing is only allowed through user activation"_string));
             }));
 
             // 2. Abort these steps.

--- a/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -48,7 +48,7 @@ WebIDL::ExceptionOr<JS::Handle<WebIDL::ArrayBufferView>> Crypto::get_random_valu
 {
     // 1. If array is not an Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array, then throw a TypeMismatchError and terminate the algorithm.
     if (!array->is_typed_array_base())
-        return WebIDL::TypeMismatchError::create(realm(), "array must be one of Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array"_fly_string);
+        return WebIDL::TypeMismatchError::create(realm(), "array must be one of Int8Array, Uint8Array, Uint8ClampedArray, Int16Array, Uint16Array, Int32Array, Uint32Array, BigInt64Array, or BigUint64Array"_string);
 
     auto const& typed_array = *array->bufferable_object().get<JS::NonnullGCPtr<JS::TypedArrayBase>>();
     auto typed_array_record = JS::make_typed_array_with_buffer_witness_record(typed_array, JS::ArrayBuffer::Order::SeqCst);
@@ -59,7 +59,7 @@ WebIDL::ExceptionOr<JS::Handle<WebIDL::ArrayBufferView>> Crypto::get_random_valu
 
     // 2. If the byteLength of array is greater than 65536, throw a QuotaExceededError and terminate the algorithm.
     if (JS::typed_array_byte_length(typed_array_record) > 65536)
-        return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536"_fly_string);
+        return WebIDL::QuotaExceededError::create(realm(), "array's byteLength may not be greater than 65536"_string);
 
     // FIXME: Handle SharedArrayBuffers
 

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -163,7 +163,7 @@ static WebIDL::ExceptionOr<Structure> parse_an_ASN1_structure(JS::Realm& realm, 
 
     // 5. If exactData was specified, and all of the bytes of data were not consumed during the parsing phase, then throw a DataError.
     if (exact_data && !decoder.eof())
-        return WebIDL::DataError::create(realm, "Not all bytes were consumed during the parsing phase"_fly_string);
+        return WebIDL::DataError::create(realm, "Not all bytes were consumed during the parsing phase"_string);
 
     // 6. Return the parsed ASN.1 structure.
     return structure;
@@ -397,7 +397,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> RSAOAEP::encrypt(Algorith
 
     // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Public)
-        return WebIDL::InvalidAccessError::create(realm, "Key is not a public key"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm, "Key is not a public key"_string);
 
     // 2. Let label be the contents of the label member of normalizedAlgorithm or the empty octet string if the label member of normalizedAlgorithm is not present.
     [[maybe_unused]] auto const& label = normalized_algorithm.label;
@@ -425,7 +425,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> RSAOAEP::decrypt(Algorith
 
     // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Private)
-        return WebIDL::InvalidAccessError::create(realm, "Key is not a private key"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm, "Key is not a private key"_string);
 
     // 2. Let label be the contents of the label member of normalizedAlgorithm or the empty octet string if the label member of normalizedAlgorithm is not present.
     [[maybe_unused]] auto const& label = normalized_algorithm.label;
@@ -540,7 +540,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
         // 4. If the algorithm object identifier field of the algorithm AlgorithmIdentifier field of spki
         //    is not equal to the rsaEncryption object identifier defined in [RFC3447], then throw a DataError.
         if (spki.algorithm.identifier != TLS::rsa_encryption_oid)
-            return WebIDL::DataError::create(m_realm, "Algorithm object identifier is not the rsaEncryption object identifier"_fly_string);
+            return WebIDL::DataError::create(m_realm, "Algorithm object identifier is not the rsaEncryption object identifier"_string);
 
         // 5. Let publicKey be the result of performing the parse an ASN.1 structure algorithm,
         //    with data as the subjectPublicKeyInfo field of spki, structure as the RSAPublicKey structure
@@ -577,7 +577,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
         // 4. If the algorithm object identifier field of the privateKeyAlgorithm PrivateKeyAlgorithm field of privateKeyInfo
         //    is not equal to the rsaEncryption object identifier defined in [RFC3447], then throw a DataError.
         if (private_key_info.algorithm.identifier != TLS::rsa_encryption_oid)
-            return WebIDL::DataError::create(m_realm, "Algorithm object identifier is not the rsaEncryption object identifier"_fly_string);
+            return WebIDL::DataError::create(m_realm, "Algorithm object identifier is not the rsaEncryption object identifier"_string);
 
         // 5. Let rsaPrivateKey be the result of performing the parse an ASN.1 structure algorithm,
         //    with data as the privateKey field of privateKeyInfo, structure as the RSAPrivateKey structure
@@ -603,7 +603,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
         //    -> Otherwise:
         //         Throw a DataError.
         if (!key_data.has<Bindings::JsonWebKey>())
-            return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_fly_string);
+            return WebIDL::DataError::create(m_realm, "keyData is not a JsonWebKey dictionary"_string);
         auto& jwk = key_data.get<Bindings::JsonWebKey>();
 
         // 2. If the d field of jwk is present and usages contains an entry which is not "decrypt" or "unwrapKey", then throw a SyntaxError.
@@ -626,11 +626,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
 
         // 4. If the kty field of jwk is not a case-sensitive string match to "RSA", then throw a DataError.
         if (jwk.kty != "RSA"_string)
-            return WebIDL::DataError::create(m_realm, "Invalid key type"_fly_string);
+            return WebIDL::DataError::create(m_realm, "Invalid key type"_string);
 
         // 5. If usages is non-empty and the use field of jwk is present and is not a case-sensitive string match to "enc", then throw a DataError.
         if (!usages.is_empty() && jwk.use.has_value() && *jwk.use != "enc"_string)
-            return WebIDL::DataError::create(m_realm, "Invalid use field"_fly_string);
+            return WebIDL::DataError::create(m_realm, "Invalid use field"_string);
 
         // 6. If the key_ops field of jwk is present, and is invalid according to the requirements of JSON Web Key [JWK]
         //    or does not contain all of the specified usages values, then throw a DataError.
@@ -642,7 +642,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
 
         // 7. If the ext field of jwk is present and has the value false and extractable is true, then throw a DataError.
         if (jwk.ext.has_value() && !*jwk.ext && extractable)
-            return WebIDL::DataError::create(m_realm, "Invalid ext field"_fly_string);
+            return WebIDL::DataError::create(m_realm, "Invalid ext field"_string);
 
         Optional<String> hash = {};
         // 8. -> If the alg field of jwk is not present:
@@ -674,7 +674,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
             // FIXME: Support 'other applicable specifications'
             // 1. Perform any key import steps defined by other applicable specifications, passing format, jwk and obtaining hash.
             // 2. If an error occurred or there are no applicable specifications, throw a DataError.
-            return WebIDL::DataError::create(m_realm, "Invalid alg field"_fly_string);
+            return WebIDL::DataError::create(m_realm, "Invalid alg field"_string);
         }
 
         // 9.  If hash is not undefined:
@@ -686,7 +686,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
             if (normalized_hash.parameter->name != TRY(normalized_algorithm.hash.visit([](String const& name) -> JS::ThrowCompletionOr<String> { return name; }, [&](JS::Handle<JS::Object> const& obj) -> JS::ThrowCompletionOr<String> {
                         auto name_property = TRY(obj->get("name"));
                         return name_property.to_string(m_realm->vm()); })))
-                return WebIDL::DataError::create(m_realm, "Invalid hash"_fly_string);
+                return WebIDL::DataError::create(m_realm, "Invalid hash"_string);
         }
 
         // 10. -> If the d field of jwk is present:
@@ -702,7 +702,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
             }
 
             if (!meets_requirements)
-                return WebIDL::DataError::create(m_realm, "Invalid JWK private key"_fly_string);
+                return WebIDL::DataError::create(m_realm, "Invalid JWK private key"_string);
 
             // FIXME: Spec error, it should say 'the RSA private key identified by interpreting jwk according to section 6.3.2'
             // 2. Let privateKey represent the RSA public key identified by interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
@@ -723,7 +723,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
         else {
             // 1. If jwk does not meet the requirements of Section 6.3.1 of JSON Web Algorithms [JWA], then throw a DataError.
             if (!jwk.e.has_value() || !jwk.n.has_value())
-                return WebIDL::DataError::create(m_realm, "Invalid JWK public key"_fly_string);
+                return WebIDL::DataError::create(m_realm, "Invalid JWK public key"_string);
 
             // 2. Let publicKey represent the RSA public key identified by interpreting jwk according to Section 6.3.1 of JSON Web Algorithms [JWA].
             auto public_key = TRY(parse_jwk_rsa_public_key(realm, jwk));
@@ -741,7 +741,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
 
     // -> Otherwise: throw a NotSupportedError.
     else {
-        return WebIDL::NotSupportedError::create(m_realm, "Unsupported key format"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "Unsupported key format"_string);
     }
 
     // 3. Let algorithm be a new RsaHashedKeyAlgorithm.
@@ -793,7 +793,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> RSAOAEP::export_key(Bindings::
     if (format == Bindings::KeyFormat::Spki) {
         // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
         if (key->type() != Bindings::KeyType::Public)
-            return WebIDL::InvalidAccessError::create(realm, "Key is not public"_fly_string);
+            return WebIDL::InvalidAccessError::create(realm, "Key is not public"_string);
 
         // 2. Let data be an instance of the subjectPublicKeyInfo ASN.1 structure defined in [RFC5280] with the following properties:
         // - Set the algorithm field to an AlgorithmIdentifier ASN.1 type with the following properties:
@@ -820,7 +820,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> RSAOAEP::export_key(Bindings::
     else if (format == Bindings::KeyFormat::Pkcs8) {
         // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
         if (key->type() != Bindings::KeyType::Private)
-            return WebIDL::InvalidAccessError::create(realm, "Key is not private"_fly_string);
+            return WebIDL::InvalidAccessError::create(realm, "Key is not private"_string);
 
         // 2. Let data be the result of encoding a privateKeyInfo structure with the following properties:
         // - Set the version field to 0.
@@ -943,7 +943,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> PBKDF2::import_key(AlgorithmPar
 {
     // 1. If format is not "raw", throw a NotSupportedError
     if (format != Bindings::KeyFormat::Raw) {
-        return WebIDL::NotSupportedError::create(m_realm, "Only raw format is supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "Only raw format is supported"_string);
     }
 
     // 2. If usages contains a value that is not "deriveKey" or "deriveBits", then throw a SyntaxError.
@@ -955,7 +955,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> PBKDF2::import_key(AlgorithmPar
 
     // 3. If extractable is not false, then throw a SyntaxError.
     if (extractable)
-        return WebIDL::SyntaxError::create(m_realm, "extractable must be false"_fly_string);
+        return WebIDL::SyntaxError::create(m_realm, "extractable must be false"_string);
 
     // 4. Let key be a new CryptoKey representing keyData.
     auto key = CryptoKey::create(m_realm, move(key_data));
@@ -1002,7 +1002,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> SHA::digest(AlgorithmPara
     auto digest = hash.digest();
     auto result_buffer = ByteBuffer::copy(digest.immutable_data(), hash.digest_size());
     if (result_buffer.is_error())
-        return WebIDL::OperationError::create(m_realm, "Failed to create result buffer"_fly_string);
+        return WebIDL::OperationError::create(m_realm, "Failed to create result buffer"_string);
 
     return JS::ArrayBuffer::create(m_realm, result_buffer.release_value());
 }
@@ -1032,14 +1032,14 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
 
         // FIXME: Support P-521
         if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-521"sv))
-            return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_fly_string);
+            return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_string);
     } else {
         // If the namedCurve member of normalizedAlgorithm is a value specified in an applicable specification:
         // Perform the ECDSA generation steps specified in that specification,
         // passing in normalizedAlgorithm and resulting in an elliptic curve key pair.
 
         // Otherwise: throw a NotSupportedError
-        return WebIDL::NotSupportedError::create(m_realm, "Only 'P-256', 'P-384' and 'P-521' is supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "Only 'P-256', 'P-384' and 'P-521' is supported"_string);
     }
 
     // NOTE: Spec jumps to 6 here for some reason
@@ -1049,7 +1049,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
         [](auto instance) { return instance.generate_private_key(); });
 
     if (maybe_private_key_data.is_error())
-        return WebIDL::OperationError::create(m_realm, "Failed to create valid crypto instance"_fly_string);
+        return WebIDL::OperationError::create(m_realm, "Failed to create valid crypto instance"_string);
 
     auto private_key_data = maybe_private_key_data.release_value();
 
@@ -1058,7 +1058,7 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
         [&](auto instance) { return instance.generate_public_key(private_key_data); });
 
     if (maybe_public_key_data.is_error())
-        return WebIDL::OperationError::create(m_realm, "Failed to create valid crypto instance"_fly_string);
+        return WebIDL::OperationError::create(m_realm, "Failed to create valid crypto instance"_string);
 
     auto public_key_data = maybe_public_key_data.release_value();
 
@@ -1120,7 +1120,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ECDSA::sign(AlgorithmPara
 
     // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Private)
-        return WebIDL::InvalidAccessError::create(realm, "Key is not a private key"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm, "Key is not a private key"_string);
 
     // 2. Let hashAlgorithm be the hash member of normalizedAlgorithm.
     [[maybe_unused]] auto const& hash_algorithm = normalized_algorithm.hash;
@@ -1143,7 +1143,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ECDSA::sign(AlgorithmPara
 
     // NOTE: The spec jumps to 9 here for some reason
     // FIXME: 9. Return the result of creating an ArrayBuffer containing result.
-    return WebIDL::NotSupportedError::create(realm, "ECDSA signing is not supported yet"_fly_string);
+    return WebIDL::NotSupportedError::create(realm, "ECDSA signing is not supported yet"_string);
 }
 
 // https://w3c.github.io/webcrypto/#ecdsa-operations
@@ -1154,7 +1154,7 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::
 
     // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Public)
-        return WebIDL::InvalidAccessError::create(realm, "Key is not a public key"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm, "Key is not a public key"_string);
 
     // 2. Let hashAlgorithm be the hash member of normalizedAlgorithm.
     [[maybe_unused]] auto const& hash_algorithm = TRY(normalized_algorithm.hash.visit(
@@ -1182,7 +1182,7 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::
 
     auto result_buffer = ByteBuffer::copy(digest.immutable_data(), hash.digest_size());
     if (result_buffer.is_error())
-        return WebIDL::OperationError::create(m_realm, "Failed to create result buffer"_fly_string);
+        return WebIDL::OperationError::create(m_realm, "Failed to create result buffer"_string);
 
     auto M = result_buffer.release_value();
 
@@ -1211,7 +1211,7 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::
 
         // FIXME: Support P-521
         if (named_curve.equals_ignoring_ascii_case("P-521"sv))
-            return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_fly_string);
+            return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_string);
 
         // Perform the ECDSA verifying process, as specified in [RFC6090], Section 5.3,
         // with M as the received message,
@@ -1237,7 +1237,7 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, JS::
             [&](auto instance) { return instance.verify(M, Q, encoded_signature); });
 
         if (maybe_result.is_error()) {
-            auto error_message = MUST(FlyString::from_utf8(maybe_result.error().string_literal()));
+            auto error_message = MUST(String::from_utf8(maybe_result.error().string_literal()));
             return WebIDL::OperationError::create(m_realm, error_message);
         }
 
@@ -1266,12 +1266,12 @@ WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<Crypto
     ::Crypto::Curves::Ed25519 curve;
     auto maybe_private_key = curve.generate_private_key();
     if (maybe_private_key.is_error())
-        return WebIDL::OperationError::create(m_realm, "Failed to generate private key"_fly_string);
+        return WebIDL::OperationError::create(m_realm, "Failed to generate private key"_string);
     auto private_key_data = maybe_private_key.release_value();
 
     auto maybe_public_key = curve.generate_public_key(private_key_data);
     if (maybe_public_key.is_error())
-        return WebIDL::OperationError::create(m_realm, "Failed to generate public key"_fly_string);
+        return WebIDL::OperationError::create(m_realm, "Failed to generate public key"_string);
     auto public_key_data = maybe_public_key.release_value();
 
     // 3. Let algorithm be a new KeyAlgorithm object.
@@ -1326,7 +1326,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ED25519::sign([[maybe_unu
 
     // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Private)
-        return WebIDL::InvalidAccessError::create(realm, "Key is not a private key"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm, "Key is not a private key"_string);
 
     // 2. Perform the Ed25519 signing process, as specified in [RFC8032], Section 5.1.6,
     // with message as M, using the Ed25519 private key associated with key.
@@ -1339,12 +1339,12 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> ED25519::sign([[maybe_unu
     ::Crypto::Curves::Ed25519 curve;
     auto maybe_public_key = curve.generate_public_key(private_key);
     if (maybe_public_key.is_error())
-        return WebIDL::OperationError::create(realm, "Failed to generate public key"_fly_string);
+        return WebIDL::OperationError::create(realm, "Failed to generate public key"_string);
     auto public_key = maybe_public_key.release_value();
 
     auto maybe_signature = curve.sign(public_key, private_key, message);
     if (maybe_signature.is_error())
-        return WebIDL::OperationError::create(realm, "Failed to sign message"_fly_string);
+        return WebIDL::OperationError::create(realm, "Failed to sign message"_string);
     auto signature = maybe_signature.release_value();
 
     // 3. Return a new ArrayBuffer associated with the relevant global object of this [HTML],
@@ -1359,7 +1359,7 @@ WebIDL::ExceptionOr<JS::Value> ED25519::verify([[maybe_unused]] AlgorithmParams 
 
     // 1. If the [[type]] internal slot of key is not "public", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Public)
-        return WebIDL::InvalidAccessError::create(realm, "Key is not a public key"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm, "Key is not a public key"_string);
 
     // NOTE: this is checked by ED25519::verify()
     // 2. If the key data of key represents an invalid point or a small-order element on the Elliptic Curve of Ed25519, return false.
@@ -1392,11 +1392,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> PBKDF2::derive_bits(Algor
     auto length = length_optional.value_or(0);
 
     if (length == 0 || length % 8 != 0)
-        return WebIDL::OperationError::create(realm, "Length must be greater than 0 and divisible by 8"_fly_string);
+        return WebIDL::OperationError::create(realm, "Length must be greater than 0 and divisible by 8"_string);
 
     // 2. If the iterations member of normalizedAlgorithm is zero, then throw an OperationError.
     if (normalized_algorithm.iterations == 0)
-        return WebIDL::OperationError::create(realm, "Iterations must be greater than 0"_fly_string);
+        return WebIDL::OperationError::create(realm, "Iterations must be greater than 0"_string);
 
     // 3. Let prf be the MAC Generation function described in Section 4 of [FIPS-198-1] using the hash function described by the hash member of normalizedAlgorithm.
     auto const& hash_algorithm = TRY(normalized_algorithm.hash.visit(
@@ -1437,7 +1437,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> PBKDF2::derive_bits(Algor
 
     // 5. If the key derivation operation fails, then throw an OperationError.
     if (result.is_error())
-        return WebIDL::OperationError::create(realm, "Failed to derive key"_fly_string);
+        return WebIDL::OperationError::create(realm, "Failed to derive key"_string);
 
     // 6. Return result
     return JS::ArrayBuffer::create(realm, result.release_value());

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -154,52 +154,52 @@ public:
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> encrypt(AlgorithmParams const&, JS::NonnullGCPtr<CryptoKey>, ByteBuffer const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "encrypt is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "encrypt is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> decrypt(AlgorithmParams const&, JS::NonnullGCPtr<CryptoKey>, ByteBuffer const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "decrypt is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "decrypt is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> sign(AlgorithmParams const&, JS::NonnullGCPtr<CryptoKey>, ByteBuffer const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "sign is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "sign is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::Value> verify(AlgorithmParams const&, JS::NonnullGCPtr<CryptoKey>, ByteBuffer const&, ByteBuffer const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "verify is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "verify is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> digest(AlgorithmParams const&, ByteBuffer const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "digest is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "digest is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::ArrayBuffer>> derive_bits(AlgorithmParams const&, JS::NonnullGCPtr<CryptoKey>, Optional<u32>)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "deriveBits is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "deriveBits is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> import_key(AlgorithmParams const&, Bindings::KeyFormat, CryptoKey::InternalKeyData, bool, Vector<Bindings::KeyUsage> const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "importKey is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "importKey is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<Variant<JS::NonnullGCPtr<CryptoKey>, JS::NonnullGCPtr<CryptoKeyPair>>> generate_key(AlgorithmParams const&, bool, Vector<Bindings::KeyUsage> const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "generateKey is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "generateKey is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Object>> export_key(Bindings::KeyFormat, JS::NonnullGCPtr<CryptoKey>)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "exportKey is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "exportKey is not supported"_string);
     }
 
     virtual WebIDL::ExceptionOr<JS::Value> get_key_length(AlgorithmParams const&)
     {
-        return WebIDL::NotSupportedError::create(m_realm, "getKeyLength is not supported"_fly_string);
+        return WebIDL::NotSupportedError::create(m_realm, "getKeyLength is not supported"_string);
     }
 
     static NonnullOwnPtr<AlgorithmMethods> create(JS::Realm& realm) { return adopt_own(*new AlgorithmMethods(realm)); }

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -153,13 +153,13 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::encrypt(AlgorithmIdentifier const& a
 
         // 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
         if (normalized_algorithm.parameter->name != key->algorithm_name()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_string));
             return;
         }
 
         // 9. If the [[usages]] internal slot of key does not contain an entry that is "encrypt", then throw an InvalidAccessError.
         if (!key->internal_usages().contains_slow(Bindings::KeyUsage::Encrypt)) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support encryption"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support encryption"_string));
             return;
         }
 
@@ -210,13 +210,13 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::decrypt(AlgorithmIdentifier const& a
 
         // 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
         if (normalized_algorithm.parameter->name != key->algorithm_name()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_string));
             return;
         }
 
         // 9. If the [[usages]] internal slot of key does not contain an entry that is "decrypt", then throw an InvalidAccessError.
         if (!key->internal_usages().contains_slow(Bindings::KeyUsage::Decrypt)) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support encryption"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support encryption"_string));
             return;
         }
 
@@ -325,14 +325,14 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::generate_key(
         result.visit(
             [&](JS::NonnullGCPtr<CryptoKey>& key) {
                 if ((key->type() == Bindings::KeyType::Secret || key->type() == Bindings::KeyType::Private) && key_usages.is_empty()) {
-                    WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_fly_string));
+                    WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_string));
                     return;
                 }
                 WebIDL::resolve_promise(realm, promise, key);
             },
             [&](JS::NonnullGCPtr<CryptoKeyPair>& key_pair) {
                 if (key_pair->private_key()->internal_usages().is_empty()) {
-                    WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_fly_string));
+                    WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_string));
                     return;
                 }
                 WebIDL::resolve_promise(realm, promise, key_pair);
@@ -400,7 +400,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::import_key(Bi
 
         // 11. If the [[type]] internal slot of result is "secret" or "private" and usages is empty, then throw a SyntaxError.
         if ((result->type() == Bindings::KeyType::Secret || result->type() == Bindings::KeyType::Private) && key_usages.is_empty()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_string));
             return;
         }
 
@@ -446,7 +446,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::export_key(Bi
 
         // 6. If the [[extractable]] internal slot of key is false, then throw an InvalidAccessError.
         if (!key->extractable()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key is not extractable"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key is not extractable"_string));
             return;
         }
 
@@ -497,13 +497,13 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::sign(Algorith
 
         // 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
         if (normalized_algorithm.parameter->name != key->algorithm_name()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_string));
             return;
         }
 
         // 9. If the [[usages]] internal slot of key does not contain an entry that is "sign", then throw an InvalidAccessError.
         if (!key->internal_usages().contains_slow(Bindings::KeyUsage::Sign)) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support signing"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support signing"_string));
             return;
         }
 
@@ -561,13 +561,13 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::verify(Algori
 
         // 9. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
         if (normalized_algorithm.parameter->name != key->algorithm_name()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_string));
             return;
         }
 
         // 10. If the [[usages]] internal slot of key does not contain an entry that is "verify", then throw an InvalidAccessError.
         if (!key->internal_usages().contains_slow(Bindings::KeyUsage::Verify)) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support verification"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support verification"_string));
             return;
         }
 
@@ -608,13 +608,13 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_bits(A
 
         // 7. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of baseKey then throw an InvalidAccessError.
         if (normalized_algorithm.parameter->name != base_key->algorithm_name()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_string));
             return;
         }
 
         // 8. If the [[usages]] internal slot of baseKey does not contain an entry that is "deriveBits", then throw an InvalidAccessError.
         if (!base_key->internal_usages().contains_slow(Bindings::KeyUsage::Derivebits)) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support deriving bits"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support deriving bits"_string));
             return;
         }
 
@@ -669,13 +669,13 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_key(Al
 
         // 11. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of baseKey then throw an InvalidAccessError.
         if (normalized_algorithm.parameter->name != base_key->algorithm_name()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Algorithm mismatch"_string));
             return;
         }
 
         // 12. If the [[usages]] internal slot of baseKey does not contain an entry that is "deriveKey", then throw an InvalidAccessError.
         if (!base_key->internal_usages().contains_slow(Bindings::KeyUsage::Derivekey)) {
-            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support deriving keys"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::InvalidAccessError::create(realm, "Key does not support deriving keys"_string));
             return;
         }
 
@@ -714,7 +714,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_key(Al
 
         // 16. If the [[type]] internal slot of result is "secret" or "private" and usages is empty, then throw a SyntaxError.
         if ((result.release_value()->type() == Bindings::KeyType::Secret || result.release_value()->type() == Bindings::KeyType::Private) && key_usages.is_empty()) {
-            WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_fly_string));
+            WebIDL::reject_promise(realm, promise, WebIDL::SyntaxError::create(realm, "usages must not be empty"_string));
             return;
         }
 

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -56,7 +56,7 @@ void AbortSignal::signal_abort(JS::Value reason)
     if (!reason.is_undefined())
         m_abort_reason = reason;
     else
-        m_abort_reason = WebIDL::AbortError::create(realm(), "Aborted without reason"_fly_string).ptr();
+        m_abort_reason = WebIDL::AbortError::create(realm(), "Aborted without reason"_string).ptr();
 
     // 3. Let dependentSignalsToAbort be a new list.
     Vector<JS::Handle<AbortSignal>> dependent_signals_to_abort;
@@ -133,7 +133,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::abort(JS::VM& vm
 
     // 2. Set signal’s abort reason to reason if it is given; otherwise to a new "AbortError" DOMException.
     if (reason.is_undefined())
-        reason = WebIDL::AbortError::create(*vm.current_realm(), "Aborted without reason"_fly_string).ptr();
+        reason = WebIDL::AbortError::create(*vm.current_realm(), "Aborted without reason"_string).ptr();
 
     signal->set_reason(reason);
 
@@ -158,7 +158,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AbortSignal>> AbortSignal::timeout(JS::VM& 
     window_or_worker->run_steps_after_a_timeout(milliseconds, [&realm, &global, signal]() {
         // 1. Queue a global task on the timer task source given global to signal abort given signal and a new "TimeoutError" DOMException.
         HTML::queue_global_task(HTML::Task::Source::TimerTask, global, JS::create_heap_function(realm.heap(), [&realm, signal]() mutable {
-            auto reason = WebIDL::TimeoutError::create(realm, "Signal timed out"_fly_string);
+            auto reason = WebIDL::TimeoutError::create(realm, "Signal timed out"_string);
             signal->signal_abort(reason);
         }));
     });

--- a/Userland/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
@@ -26,9 +26,9 @@ JS::NonnullGCPtr<WebIDL::ObservableArray> create_adopted_style_sheets_list(Docum
         // 1. If value’s constructed flag is not set, or its constructor document is not equal to this
         //    DocumentOrShadowRoot's node document, throw a "NotAllowedError" DOMException.
         if (!style_sheet.constructed())
-            return WebIDL::NotAllowedError::create(document.realm(), "StyleSheet's constructed flag is not set."_fly_string);
+            return WebIDL::NotAllowedError::create(document.realm(), "StyleSheet's constructed flag is not set."_string);
         if (!style_sheet.constructed() || style_sheet.constructor_document().ptr() != &document)
-            return WebIDL::NotAllowedError::create(document.realm(), "Sharing a StyleSheet between documents is not allowed."_fly_string);
+            return WebIDL::NotAllowedError::create(document.realm(), "Sharing a StyleSheet between documents is not allowed."_string);
 
         document.style_computer().load_fonts_from_sheet(style_sheet);
         document.style_computer().invalidate_rule_cache();

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -52,7 +52,7 @@ WebIDL::ExceptionOr<String> CharacterData::substring_data(size_t offset, size_t 
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(realm(), "Substring offset out of range."_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Substring offset out of range."_string);
 
     // 3. If offset plus count is greater than length, return a string whose value is the code units from the offsetth code unit
     //    to the end of node’s data, and then return.
@@ -74,7 +74,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(realm(), "Replacement offset out of range."_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Replacement offset out of range."_string);
 
     // 3. If offset plus count is greater than length, then set count to length minus offset.
     if (offset + count > length)

--- a/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DOMTokenList.cpp
@@ -270,14 +270,14 @@ WebIDL::ExceptionOr<void> DOMTokenList::validate_token(StringView token) const
 WebIDL::ExceptionOr<void> DOMTokenList::validate_token_not_empty(StringView token) const
 {
     if (token.is_empty())
-        return WebIDL::SyntaxError::create(realm(), "Non-empty DOM tokens are not allowed"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Non-empty DOM tokens are not allowed"_string);
     return {};
 }
 
 WebIDL::ExceptionOr<void> DOMTokenList::validate_token_not_whitespace(StringView token) const
 {
     if (any_of(token, Infra::is_ascii_whitespace))
-        return WebIDL::InvalidCharacterError::create(realm(), "DOM tokens containing ASCII whitespace are not allowed"_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm(), "DOM tokens containing ASCII whitespace are not allowed"_string);
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -558,11 +558,11 @@ WebIDL::ExceptionOr<void> Document::run_the_document_write_steps(StringView inpu
 {
     // 1. If document is an XML document, then throw an "InvalidStateError" DOMException.
     if (m_type == Type::XML)
-        return WebIDL::InvalidStateError::create(realm(), "write() called on XML document."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "write() called on XML document."_string);
 
     // 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0, then throw an "InvalidStateError" DOMException.
     if (m_throw_on_dynamic_markup_insertion_counter > 0)
-        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_string);
 
     // 3. If document's active parser was aborted is true, then return.
     if (m_active_parser_was_aborted)
@@ -605,18 +605,18 @@ WebIDL::ExceptionOr<Document*> Document::open(Optional<String> const&, Optional<
 
     // 1. If document is an XML document, then throw an "InvalidStateError" DOMException exception.
     if (m_type == Type::XML)
-        return WebIDL::InvalidStateError::create(realm(), "open() called on XML document."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "open() called on XML document."_string);
 
     // 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0, then throw an "InvalidStateError" DOMException.
     if (m_throw_on_dynamic_markup_insertion_counter > 0)
-        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_string);
 
     // FIXME: 3. Let entryDocument be the entry global object's associated Document.
     auto& entry_document = *this;
 
     // 4. If document's origin is not same origin to entryDocument's origin, then throw a "SecurityError" DOMException.
     if (origin() != entry_document.origin())
-        return WebIDL::SecurityError::create(realm(), "Document.origin() not the same as entryDocument's."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Document.origin() not the same as entryDocument's."_string);
 
     // 5. If document has an active parser whose script nesting level is greater than 0, then return document.
     if (m_parser && m_parser->script_nesting_level() > 0)
@@ -676,7 +676,7 @@ WebIDL::ExceptionOr<JS::GCPtr<HTML::WindowProxy>> Document::open(StringView url,
 {
     // 1. If this is not fully active, then throw an "InvalidAccessError" DOMException exception.
     if (!is_fully_active())
-        return WebIDL::InvalidAccessError::create(realm(), "Cannot perform open on a document that isn't fully active."_fly_string);
+        return WebIDL::InvalidAccessError::create(realm(), "Cannot perform open on a document that isn't fully active."_string);
 
     // 2. Return the result of running the window open steps with url, name, and features.
     return window()->open_impl(url, name, features);
@@ -687,11 +687,11 @@ WebIDL::ExceptionOr<void> Document::close()
 {
     // 1. If document is an XML document, then throw an "InvalidStateError" DOMException exception.
     if (m_type == Type::XML)
-        return WebIDL::InvalidStateError::create(realm(), "close() called on XML document."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "close() called on XML document."_string);
 
     // 2. If document's throw-on-dynamic-markup-insertion counter is greater than 0, then throw an "InvalidStateError" DOMException.
     if (m_throw_on_dynamic_markup_insertion_counter > 0)
-        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "throw-on-dynamic-markup-insertion-counter greater than zero."_string);
 
     // 3. If there is no script-created parser associated with the document, then return.
     if (!m_parser)
@@ -861,7 +861,7 @@ HTML::HTMLElement* Document::body()
 WebIDL::ExceptionOr<void> Document::set_body(HTML::HTMLElement* new_body)
 {
     if (!is<HTML::HTMLBodyElement>(new_body) && !is<HTML::HTMLFrameSetElement>(new_body))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid document body element, must be 'body' or 'frameset'"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid document body element, must be 'body' or 'frameset'"_string);
 
     auto* existing_body = body();
     if (existing_body) {
@@ -871,7 +871,7 @@ WebIDL::ExceptionOr<void> Document::set_body(HTML::HTMLElement* new_body)
 
     auto* document_element = this->document_element();
     if (!document_element)
-        return WebIDL::HierarchyRequestError::create(realm(), "Missing document element"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Missing document element"_string);
 
     (void)TRY(document_element->append_child(*new_body));
     return {};
@@ -1650,7 +1650,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> Document::create_element(String c
 
     // 1. If localName does not match the Name production, then throw an "InvalidCharacterError" DOMException.
     if (!is_valid_name(a_local_name))
-        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in tag name."_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in tag name."_string);
 
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
     if (document_type() == Type::HTML)
@@ -1711,11 +1711,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CDATASection>> Document::create_cdata_secti
 {
     // 1. If this is an HTML document, then throw a "NotSupportedError" DOMException.
     if (is_html_document())
-        return WebIDL::NotSupportedError::create(realm(), "This operation is not supported for HTML documents"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "This operation is not supported for HTML documents"_string);
 
     // 2. If data contains the string "]]>", then throw an "InvalidCharacterError" DOMException.
     if (data.contains("]]>"sv))
-        return WebIDL::InvalidCharacterError::create(realm(), "String may not contain ']]>'"_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm(), "String may not contain ']]>'"_string);
 
     // 3. Return a new CDATASection node with its data set to data and node document set to this.
     return heap().allocate<CDATASection>(realm(), *this, data);
@@ -1796,7 +1796,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Event>> Document::create_event(StringView i
 
     // 3. If constructor is null, then throw a "NotSupportedError" DOMException.
     if (!event) {
-        return WebIDL::NotSupportedError::create(realm, "No constructor for interface found"_fly_string);
+        return WebIDL::NotSupportedError::create(realm, "No constructor for interface found"_string);
     }
 
     // FIXME: 4. If the interface indicated by constructor is not exposed on the relevant global object of this, then throw a "NotSupportedError" DOMException.
@@ -1877,7 +1877,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Document::import_node(JS::NonnullGCP
 {
     // 1. If node is a document or shadow root, then throw a "NotSupportedError" DOMException.
     if (is<Document>(*node) || is<ShadowRoot>(*node))
-        return WebIDL::NotSupportedError::create(realm(), "Cannot import a document or shadow root."_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Cannot import a document or shadow root."_string);
 
     // 2. Return a clone of node, with this and the clone children flag set if deep is true.
     return node->clone_node(this, deep);
@@ -1951,10 +1951,10 @@ void Document::adopt_node(Node& node)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Document::adopt_node_binding(JS::NonnullGCPtr<Node> node)
 {
     if (is<Document>(*node))
-        return WebIDL::NotSupportedError::create(realm(), "Cannot adopt a document into a document"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Cannot adopt a document into a document"_string);
 
     if (is<ShadowRoot>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Cannot adopt a shadow root into a document"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Cannot adopt a shadow root into a document"_string);
 
     if (is<DocumentFragment>(*node) && verify_cast<DocumentFragment>(*node).host())
         return node;
@@ -2855,7 +2855,7 @@ bool Document::is_valid_name(String const& name)
 WebIDL::ExceptionOr<Document::PrefixAndTagName> Document::validate_qualified_name(JS::Realm& realm, FlyString const& qualified_name)
 {
     if (qualified_name.is_empty())
-        return WebIDL::InvalidCharacterError::create(realm, "Empty string is not a valid qualified name."_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm, "Empty string is not a valid qualified name."_string);
 
     auto utf8view = qualified_name.code_points();
 
@@ -2867,19 +2867,19 @@ WebIDL::ExceptionOr<Document::PrefixAndTagName> Document::validate_qualified_nam
         auto code_point = *it;
         if (code_point == ':') {
             if (colon_offset.has_value())
-                return WebIDL::InvalidCharacterError::create(realm, "More than one colon (:) in qualified name."_fly_string);
+                return WebIDL::InvalidCharacterError::create(realm, "More than one colon (:) in qualified name."_string);
             colon_offset = utf8view.byte_offset_of(it);
             at_start_of_name = true;
             continue;
         }
         if (at_start_of_name) {
             if (!is_valid_name_start_character(code_point))
-                return WebIDL::InvalidCharacterError::create(realm, "Invalid start of qualified name."_fly_string);
+                return WebIDL::InvalidCharacterError::create(realm, "Invalid start of qualified name."_string);
             at_start_of_name = false;
             continue;
         }
         if (!is_valid_name_character(code_point))
-            return WebIDL::InvalidCharacterError::create(realm, "Invalid character in qualified name."_fly_string);
+            return WebIDL::InvalidCharacterError::create(realm, "Invalid character in qualified name."_string);
     }
 
     if (!colon_offset.has_value())
@@ -2889,10 +2889,10 @@ WebIDL::ExceptionOr<Document::PrefixAndTagName> Document::validate_qualified_nam
         };
 
     if (*colon_offset == 0)
-        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't start with colon (:)."_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't start with colon (:)."_string);
 
     if (*colon_offset >= (qualified_name.bytes_as_string_view().length() - 1))
-        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't end with colon (:)."_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm, "Qualified name can't end with colon (:)."_string);
 
     return Document::PrefixAndTagName {
         .prefix = MUST(FlyString::from_utf8(qualified_name.bytes_as_string_view().substring_view(0, *colon_offset))),
@@ -3693,7 +3693,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> Document::create_attribute(String co
 {
     // 1. If localName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
     if (!is_valid_name(local_name))
-        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in attribute name."_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm(), "Invalid character in attribute name."_string);
 
     // 2. If this is an HTML document, then set localName to localName in ASCII lowercase.
     // 3. Return a new attribute whose local name is localName and node document is this.

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -173,7 +173,7 @@ WebIDL::ExceptionOr<void> Element::set_attribute(FlyString const& name, String c
 {
     // 1. If qualifiedName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
     if (!Document::is_valid_name(name.to_string()))
-        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty or contain invalid characters"_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty or contain invalid characters"_string);
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     bool insert_as_lowercase = namespace_uri() == Namespace::HTML && document().document_type() == Document::Type::HTML;
@@ -221,19 +221,19 @@ WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm& realm, Option
 
     // 6. If prefix is non-null and namespace is null, then throw a "NamespaceError" DOMException.
     if (prefix.has_value() && !namespace_.has_value())
-        return WebIDL::NamespaceError::create(realm, "Prefix is non-null and namespace is null."_fly_string);
+        return WebIDL::NamespaceError::create(realm, "Prefix is non-null and namespace is null."_string);
 
     // 7. If prefix is "xml" and namespace is not the XML namespace, then throw a "NamespaceError" DOMException.
     if (prefix == "xml"sv && namespace_ != Namespace::XML)
-        return WebIDL::NamespaceError::create(realm, "Prefix is 'xml' and namespace is not the XML namespace."_fly_string);
+        return WebIDL::NamespaceError::create(realm, "Prefix is 'xml' and namespace is not the XML namespace."_string);
 
     // 8. If either qualifiedName or prefix is "xmlns" and namespace is not the XMLNS namespace, then throw a "NamespaceError" DOMException.
     if ((qualified_name == "xmlns"sv || prefix == "xmlns"sv) && namespace_ != Namespace::XMLNS)
-        return WebIDL::NamespaceError::create(realm, "Either qualifiedName or prefix is 'xmlns' and namespace is not the XMLNS namespace."_fly_string);
+        return WebIDL::NamespaceError::create(realm, "Either qualifiedName or prefix is 'xmlns' and namespace is not the XMLNS namespace."_string);
 
     // 9. If namespace is the XMLNS namespace and neither qualifiedName nor prefix is "xmlns", then throw a "NamespaceError" DOMException.
     if (namespace_ == Namespace::XMLNS && !(qualified_name == "xmlns"sv || prefix == "xmlns"sv))
-        return WebIDL::NamespaceError::create(realm, "Namespace is the XMLNS namespace and neither qualifiedName nor prefix is 'xmlns'."_fly_string);
+        return WebIDL::NamespaceError::create(realm, "Namespace is the XMLNS namespace and neither qualifiedName nor prefix is 'xmlns'."_string);
 
     // 10. Return namespace, prefix, and localName.
     return QualifiedName { local_name, prefix, namespace_ };
@@ -341,7 +341,7 @@ WebIDL::ExceptionOr<bool> Element::toggle_attribute(FlyString const& name, Optio
 {
     // 1. If qualifiedName does not match the Name production in XML, then throw an "InvalidCharacterError" DOMException.
     if (!Document::is_valid_name(name.to_string()))
-        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty or contain invalid characters"_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm(), "Attribute name must not be empty or contain invalid characters"_string);
 
     // 2. If this is in the HTML namespace and its node document is an HTML document, then set qualifiedName to qualifiedName in ASCII lowercase.
     bool insert_as_lowercase = namespace_uri() == Namespace::HTML && document().document_type() == Document::Type::HTML;
@@ -658,11 +658,11 @@ WebIDL::ExceptionOr<void> Element::attach_a_shadow_root(Bindings::ShadowRootMode
 {
     // 1. If element’s namespace is not the HTML namespace, then throw a "NotSupportedError" DOMException.
     if (namespace_uri() != Namespace::HTML)
-        return WebIDL::NotSupportedError::create(realm(), "Element's namespace is not the HTML namespace"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Element's namespace is not the HTML namespace"_string);
 
     // 2. If element’s local name is not a valid shadow host name, then throw a "NotSupportedError" DOMException.
     if (!is_valid_shadow_host_name(local_name()))
-        return WebIDL::NotSupportedError::create(realm(), "Element's local name is not a valid shadow host name"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Element's local name is not a valid shadow host name"_string);
 
     // 3. If element’s local name is a valid custom element name, or element’s is value is not null, then:
     if (HTML::is_valid_custom_element_name(local_name()) || m_is_value.has_value()) {
@@ -671,7 +671,7 @@ WebIDL::ExceptionOr<void> Element::attach_a_shadow_root(Bindings::ShadowRootMode
 
         // 2. If definition is not null and definition’s disable shadow is true, then throw a "NotSupportedError" DOMException.
         if (definition && definition->disable_shadow())
-            return WebIDL::NotSupportedError::create(realm(), "Cannot attach a shadow root to a custom element that has disabled shadow roots"_fly_string);
+            return WebIDL::NotSupportedError::create(realm(), "Cannot attach a shadow root to a custom element that has disabled shadow roots"_string);
     }
 
     // 4. If element is a shadow host, then:
@@ -684,7 +684,7 @@ WebIDL::ExceptionOr<void> Element::attach_a_shadow_root(Bindings::ShadowRootMode
         // - currentShadowRoot’s mode is not mode,
         // then throw a "NotSupportedError" DOMException.
         if (!current_shadow_root->declarative() || current_shadow_root->mode() != mode) {
-            return WebIDL::NotSupportedError::create(realm(), "Element already is a shadow host"_fly_string);
+            return WebIDL::NotSupportedError::create(realm(), "Element already is a shadow host"_string);
         }
 
         // 3. Otherwise:
@@ -757,7 +757,7 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_string);
 
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
     auto sel = maybe_selectors.value();
@@ -776,7 +776,7 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_string);
 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
         // 4. For each element in elements, if match a selector against an element, using s, element, and scoping root this, returns success, return element.
@@ -1582,7 +1582,7 @@ WebIDL::ExceptionOr<void> Element::set_outer_html(String const& value)
 
     // 4. If parent is a Document, throw a "NoModificationAllowedError" DOMException.
     if (parent->is_document())
-        return WebIDL::NoModificationAllowedError::create(realm(), "Cannot set outer HTML on document"_fly_string);
+        return WebIDL::NoModificationAllowedError::create(realm(), "Cannot set outer HTML on document"_string);
 
     // 5. If parent is a DocumentFragment, set parent to the result of creating an element given this's node document, body, and the HTML namespace.
     if (parent->is_document_fragment())
@@ -1613,7 +1613,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
 
         // 2. If context is null or a Document, throw a "NoModificationAllowedError" DOMException.
         if (!context || context->is_document())
-            return WebIDL::NoModificationAllowedError::create(realm(), "insertAdjacentHTML: context is null or a Document"_fly_string);
+            return WebIDL::NoModificationAllowedError::create(realm(), "insertAdjacentHTML: context is null or a Document"_string);
     }
     // - If position is an ASCII case-insensitive match for the string "afterbegin"
     // - If position is an ASCII case-insensitive match for the string "beforeend"
@@ -1625,7 +1625,7 @@ WebIDL::ExceptionOr<void> Element::insert_adjacent_html(String const& position, 
     // Otherwise
     else {
         // Throw a "SyntaxError" DOMException.
-        return WebIDL::SyntaxError::create(realm(), "insertAdjacentHTML: invalid position argument"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "insertAdjacentHTML: invalid position argument"_string);
     }
 
     // 3. If context is not an Element or the following are all true:
@@ -2132,7 +2132,7 @@ JS::ThrowCompletionOr<void> Element::upgrade_element(JS::NonnullGCPtr<HTML::Cust
     auto attempt_to_construct_custom_element = [&]() -> JS::ThrowCompletionOr<void> {
         // 1. If definition's disable shadow is true and element's shadow root is non-null, then throw a "NotSupportedError" DOMException.
         if (custom_element_definition->disable_shadow() && shadow_root())
-            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Custom element definition disables shadow DOM and the custom element has a shadow root"_fly_string));
+            return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Custom element definition disables shadow DOM and the custom element has a shadow root"_string));
 
         // 2. Set element's custom element state to "precustomized".
         m_custom_element_state = CustomElementState::Precustomized;

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -577,23 +577,23 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Element>> create_element(Document& document
 
                 // 5. If result’s attribute list is not empty, then throw a "NotSupportedError" DOMException.
                 if (element->has_attributes())
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have attributes"_fly_string));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have attributes"_string));
 
                 // 6. If result has children, then throw a "NotSupportedError" DOMException.
                 if (element->has_children())
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have children"_fly_string));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have children"_string));
 
                 // 7. If result’s parent is not null, then throw a "NotSupportedError" DOMException.
                 if (element->parent())
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have a parent"_fly_string));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element cannot have a parent"_string));
 
                 // 8. If result’s node document is not document, then throw a "NotSupportedError" DOMException.
                 if (&element->document() != &document)
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must be in the same document that element creation was invoked in"_fly_string));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must be in the same document that element creation was invoked in"_string));
 
                 // 9. If result’s local name is not equal to localName, then throw a "NotSupportedError" DOMException.
                 if (element->local_name() != local_name)
-                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must have the same local name that element creation was invoked with"_fly_string));
+                    return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Synchronously created custom element must have the same local name that element creation was invoked with"_string));
 
                 // 10. Set result’s namespace prefix to prefix.
                 element->set_prefix(prefix);

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -260,10 +260,10 @@ WebIDL::ExceptionOr<bool> EventTarget::dispatch_event_binding(Event& event)
 {
     // 1. If event’s dispatch flag is set, or if its initialized flag is not set, then throw an "InvalidStateError" DOMException.
     if (event.dispatched())
-        return WebIDL::InvalidStateError::create(realm(), "The event is already being dispatched."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "The event is already being dispatched."_string);
 
     if (!event.initialized())
-        return WebIDL::InvalidStateError::create(realm(), "Cannot dispatch an uninitialized event."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot dispatch an uninitialized event."_string);
 
     // 2. Initialize event’s isTrusted attribute to false.
     event.set_is_trusted(false);

--- a/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -214,7 +214,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Attr>> NamedNodeMap::set_attribute(Attr& attribute
 {
     // 1. If attr’s element is neither null nor element, throw an "InUseAttributeError" DOMException.
     if ((attribute.owner_element() != nullptr) && (attribute.owner_element() != &associated_element()))
-        return WebIDL::InUseAttributeError::create(realm(), "Attribute must not already be in use"_fly_string);
+        return WebIDL::InUseAttributeError::create(realm(), "Attribute must not already be in use"_string);
 
     // 2. Let oldAttr be the result of getting an attribute given attr’s namespace, attr’s local name, and element.
     size_t old_attribute_index = 0;
@@ -342,7 +342,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Attr>> NamedNodeMap::remove_attribute_node(
     // 1. If this’s attribute list does not contain attr, then throw a "NotFoundError" DOMException.
     auto index = m_attributes.find_first_index(attr);
     if (!index.has_value())
-        return WebIDL::NotFoundError::create(realm(), "Attribute not found"_fly_string);
+        return WebIDL::NotFoundError::create(realm(), "Attribute not found"_string);
 
     // 2. Remove attr.
     remove_attribute_at_index(index.value());

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -515,24 +515,24 @@ WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::NonnullGCPtr<N
 {
     // 1. If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError" DOMException.
     if (!is<Document>(this) && !is<DocumentFragment>(this) && !is<Element>(this))
-        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_string);
 
     // 2. If node is a host-including inclusive ancestor of parent, then throw a "HierarchyRequestError" DOMException.
     if (node->is_host_including_inclusive_ancestor_of(*this))
-        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_string);
 
     // 3. If child is non-null and its parent is not parent, then throw a "NotFoundError" DOMException.
     if (child && child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_fly_string);
+        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_string);
 
     // FIXME: All the following "Invalid node type for insertion" messages could be more descriptive.
     // 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
     if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<Text>(*node) && !is<Comment>(*node) && !is<ProcessingInstruction>(*node) && !is<CDATASection>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
 
     // 5. If either node is a Text node and parent is a document, or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
     if ((is<Text>(*node) && is<Document>(this)) || (is<DocumentType>(*node) && !is<Document>(this)))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
 
     // 6. If parent is a document, and any of the statements below, switched on the interface node implements, are true, then throw a "HierarchyRequestError" DOMException.
     if (is<Document>(this)) {
@@ -543,18 +543,18 @@ WebIDL::ExceptionOr<void> Node::ensure_pre_insertion_validity(JS::NonnullGCPtr<N
             auto node_element_child_count = verify_cast<DocumentFragment>(*node).child_element_count();
             if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
                 || (node_element_child_count == 1 && (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) || (child && child->has_following_node_of_type_in_tree_order<DocumentType>())))) {
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
             }
         } else if (is<Element>(*node)) {
             // Element
             // If parent has an element child, child is a doctype, or child is non-null and a doctype is following child.
             if (has_child_of_type<Element>() || is<DocumentType>(child.ptr()) || (child && child->has_following_node_of_type_in_tree_order<DocumentType>()))
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
         } else if (is<DocumentType>(*node)) {
             // DocumentType
             // parent has a doctype child, child is non-null and an element is preceding child, or child is null and parent has an element child.
             if (has_child_of_type<DocumentType>() || (child && child->has_preceding_node_of_type_in_tree_order<Element>()) || (!child && has_child_of_type<Element>()))
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
         }
     }
 
@@ -727,7 +727,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::pre_remove(JS::NonnullGCPtr<No
 {
     // 1. If child’s parent is not parent, then throw a "NotFoundError" DOMException.
     if (child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "Child does not belong to this node"_fly_string);
+        return WebIDL::NotFoundError::create(realm(), "Child does not belong to this node"_string);
 
     // 2. Remove child.
     child->remove();
@@ -912,25 +912,25 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::replace_child(JS::NonnullGCPtr
 {
     // If parent is not a Document, DocumentFragment, or Element node, then throw a "HierarchyRequestError" DOMException.
     if (!is<Document>(this) && !is<DocumentFragment>(this) && !is<Element>(this))
-        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Can only insert into a document, document fragment or element"_string);
 
     // 2. If node is a host-including inclusive ancestor of parent, then throw a "HierarchyRequestError" DOMException.
     if (node->is_host_including_inclusive_ancestor_of(*this))
-        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "New node is an ancestor of this node"_string);
 
     // 3. If child’s parent is not parent, then throw a "NotFoundError" DOMException.
     if (child->parent() != this)
-        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_fly_string);
+        return WebIDL::NotFoundError::create(realm(), "This node is not the parent of the given child"_string);
 
     // FIXME: All the following "Invalid node type for insertion" messages could be more descriptive.
 
     // 4. If node is not a DocumentFragment, DocumentType, Element, or CharacterData node, then throw a "HierarchyRequestError" DOMException.
     if (!is<DocumentFragment>(*node) && !is<DocumentType>(*node) && !is<Element>(*node) && !is<Text>(*node) && !is<Comment>(*node) && !is<ProcessingInstruction>(*node))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
 
     // 5. If either node is a Text node and parent is a document, or node is a doctype and parent is not a document, then throw a "HierarchyRequestError" DOMException.
     if ((is<Text>(*node) && is<Document>(this)) || (is<DocumentType>(*node) && !is<Document>(this)))
-        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
 
     // If parent is a document, and any of the statements below, switched on the interface node implements, are true, then throw a "HierarchyRequestError" DOMException.
     if (is<Document>(this)) {
@@ -941,18 +941,18 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::replace_child(JS::NonnullGCPtr
             auto node_element_child_count = verify_cast<DocumentFragment>(*node).child_element_count();
             if ((node_element_child_count > 1 || node->has_child_of_type<Text>())
                 || (node_element_child_count == 1 && (first_child_of_type<Element>() != child || child->has_following_node_of_type_in_tree_order<DocumentType>()))) {
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
             }
         } else if (is<Element>(*node)) {
             // Element
             // parent has an element child that is not child or a doctype is following child.
             if (first_child_of_type<Element>() != child || child->has_following_node_of_type_in_tree_order<DocumentType>())
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
         } else if (is<DocumentType>(*node)) {
             // DocumentType
             // parent has a doctype child that is not child, or an element is preceding child.
             if (first_child_of_type<DocumentType>() != node || child->has_preceding_node_of_type_in_tree_order<Element>())
-                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_fly_string);
+                return WebIDL::HierarchyRequestError::create(realm(), "Invalid node type for insertion"_string);
         }
     }
 
@@ -1119,7 +1119,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Node>> Node::clone_node_binding(bool deep)
 {
     // 1. If this is a shadow root, then throw a "NotSupportedError" DOMException.
     if (is<ShadowRoot>(*this))
-        return WebIDL::NotSupportedError::create(realm(), "Cannot clone shadow root"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Cannot clone shadow root"_string);
 
     // 2. Return a clone of this, with the clone children flag set if deep is true.
     return clone_node(nullptr, deep);

--- a/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeIterator.cpp
@@ -142,7 +142,7 @@ JS::ThrowCompletionOr<NodeFilter::Result> NodeIterator::filter(Node& node)
 {
     // 1. If traverser’s active flag is set, then throw an "InvalidStateError" DOMException.
     if (m_active)
-        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"_fly_string));
+        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"_string));
 
     // 2. Let n be node’s nodeType attribute value − 1.
     auto n = node.node_type() - 1;

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -36,7 +36,7 @@ WebIDL::ExceptionOr<JS::GCPtr<Element>> ParentNode::query_selector(StringView se
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_string);
 
     auto selectors = maybe_selectors.value();
 
@@ -68,7 +68,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<NodeList>> ParentNode::query_selector_all(S
 
     // 2. If s is failure, then throw a "SyntaxError" DOMException.
     if (!maybe_selectors.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Failed to parse selector"_string);
 
     auto selectors = maybe_selectors.value();
 

--- a/Userland/Libraries/LibWeb/DOM/Range.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Range.cpp
@@ -230,7 +230,7 @@ WebIDL::ExceptionOr<void> Range::set_start_or_end(Node& node, u32 offset, StartO
 
     // 1. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_string);
 
     // 2. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
     if (offset > node.length())
@@ -290,7 +290,7 @@ WebIDL::ExceptionOr<void> Range::set_start_before(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_string);
 
     // 3. Set the start of this to boundary point (parent, node’s index).
     return set_start_or_end(*parent, node.index(), StartOrEnd::Start);
@@ -304,7 +304,7 @@ WebIDL::ExceptionOr<void> Range::set_start_after(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_string);
 
     // 3. Set the start of this to boundary point (parent, node’s index plus 1).
     return set_start_or_end(*parent, node.index() + 1, StartOrEnd::Start);
@@ -318,7 +318,7 @@ WebIDL::ExceptionOr<void> Range::set_end_before(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_string);
 
     // 3. Set the end of this to boundary point (parent, node’s index).
     return set_start_or_end(*parent, node.index(), StartOrEnd::End);
@@ -332,7 +332,7 @@ WebIDL::ExceptionOr<void> Range::set_end_after(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_string);
 
     // 3. Set the end of this to boundary point (parent, node’s index plus 1).
     return set_start_or_end(*parent, node.index() + 1, StartOrEnd::End);
@@ -352,7 +352,7 @@ WebIDL::ExceptionOr<WebIDL::Short> Range::compare_boundary_points(WebIDL::Unsign
 
     // 2. If this’s root is not the same as sourceRange’s root, then throw a "WrongDocumentError" DOMException.
     if (&root() != &source_range.root())
-        return WebIDL::WrongDocumentError::create(realm(), "This range is not in the same tree as the source range."_fly_string);
+        return WebIDL::WrongDocumentError::create(realm(), "This range is not in the same tree as the source range."_string);
 
     JS::GCPtr<Node> this_point_node;
     u32 this_point_offset = 0;
@@ -433,7 +433,7 @@ WebIDL::ExceptionOr<void> Range::select(Node& node)
 
     // 2. If parent is null, then throw an "InvalidNodeTypeError" DOMException.
     if (!parent)
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Given node has no parent."_string);
 
     // 3. Let index be node’s index.
     auto index = node.index();
@@ -476,7 +476,7 @@ WebIDL::ExceptionOr<void> Range::select_node_contents(Node& node)
 {
     // 1. If node is a doctype, throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_string);
 
     // 2. Let length be the length of node.
     auto length = node.length();
@@ -570,7 +570,7 @@ WebIDL::ExceptionOr<bool> Range::is_point_in_range(Node const& node, WebIDL::Uns
 
     // 2. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_string);
 
     // 3. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
     if (offset > node.length())
@@ -591,11 +591,11 @@ WebIDL::ExceptionOr<WebIDL::Short> Range::compare_point(Node const& node, WebIDL
 {
     // 1. If node’s root is different from this’s root, then throw a "WrongDocumentError" DOMException.
     if (&node.root() != &root())
-        return WebIDL::WrongDocumentError::create(realm(), "Given node is not in the same document as the range."_fly_string);
+        return WebIDL::WrongDocumentError::create(realm(), "Given node is not in the same document as the range."_string);
 
     // 2. If node is a doctype, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(node))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Node cannot be a DocumentType."_string);
 
     // 3. If offset is greater than node’s length, then throw an "IndexSizeError" DOMException.
     if (offset > node.length())
@@ -738,7 +738,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::extract()
     // 12. If any member of contained children is a doctype, then throw a "HierarchyRequestError" DOMException.
     for (auto const& child : contained_children) {
         if (is<DocumentType>(*child))
-            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType"_fly_string);
+            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType"_string);
     }
 
     JS::GCPtr<Node> new_node;
@@ -885,7 +885,7 @@ WebIDL::ExceptionOr<void> Range::insert(JS::NonnullGCPtr<Node> node)
     if ((is<ProcessingInstruction>(*m_start_container) || is<Comment>(*m_start_container))
         || (is<Text>(*m_start_container) && !m_start_container->parent_node())
         || m_start_container.ptr() == node.ptr()) {
-        return WebIDL::HierarchyRequestError::create(realm(), "Range has inappropriate start node for insertion"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Range has inappropriate start node for insertion"_string);
     }
 
     // 2. Let referenceNode be null.
@@ -956,11 +956,11 @@ WebIDL::ExceptionOr<void> Range::surround_contents(JS::NonnullGCPtr<Node> new_pa
     if (is<Text>(*end_non_text_node))
         end_non_text_node = end_non_text_node->parent_node();
     if (start_non_text_node != end_non_text_node)
-        return WebIDL::InvalidStateError::create(realm(), "Non-Text node is partially contained in range."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Non-Text node is partially contained in range."_string);
 
     // 2. If newParent is a Document, DocumentType, or DocumentFragment node, then throw an "InvalidNodeTypeError" DOMException.
     if (is<Document>(*new_parent) || is<DocumentType>(*new_parent) || is<DocumentFragment>(*new_parent))
-        return WebIDL::InvalidNodeTypeError::create(realm(), "Invalid parent node type"_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Invalid parent node type"_string);
 
     // 3. Let fragment be the result of extracting this.
     auto fragment = TRY(extract());
@@ -1064,7 +1064,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<DocumentFragment>> Range::clone_the_content
     // 12. If any member of contained children is a doctype, then throw a "HierarchyRequestError" DOMException.
     for (auto const& child : contained_children) {
         if (is<DocumentType>(*child))
-            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType"_fly_string);
+            return WebIDL::HierarchyRequestError::create(realm(), "Contained child is a DocumentType"_string);
     }
 
     // 13. If first partially contained child is a CharacterData node, then:

--- a/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
+++ b/Userland/Libraries/LibWeb/DOM/StaticRange.cpp
@@ -29,10 +29,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<StaticRange>> StaticRange::construct_impl(J
 {
     // 1. If init["startContainer"] or init["endContainer"] is a DocumentType or Attr node, then throw an "InvalidNodeTypeError" DOMException.
     if (is<DocumentType>(*init.start_container) || is<Attr>(*init.start_container))
-        return WebIDL::InvalidNodeTypeError::create(realm, "startContainer cannot be a DocumentType or Attribute node."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm, "startContainer cannot be a DocumentType or Attribute node."_string);
 
     if (is<DocumentType>(*init.end_container) || is<Attr>(*init.end_container))
-        return WebIDL::InvalidNodeTypeError::create(realm, "endContainer cannot be a DocumentType or Attribute node."_fly_string);
+        return WebIDL::InvalidNodeTypeError::create(realm, "endContainer cannot be a DocumentType or Attribute node."_string);
 
     // 2. Set this’s start to (init["startContainer"], init["startOffset"]) and end to (init["endContainer"], init["endOffset"]).
     return realm.heap().allocate<StaticRange>(realm, *init.start_container, init.start_offset, *init.end_container, init.end_offset);

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -66,7 +66,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)
 
     // 2. If offset is greater than length, then throw an "IndexSizeError" DOMException.
     if (offset > length)
-        return WebIDL::IndexSizeError::create(realm(), "Split offset is greater than length"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Split offset is greater than length"_string);
 
     // 3. Let count be length minus offset.
     auto count = length - offset;

--- a/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
+++ b/Userland/Libraries/LibWeb/DOM/TreeWalker.cpp
@@ -247,7 +247,7 @@ JS::ThrowCompletionOr<NodeFilter::Result> TreeWalker::filter(Node& node)
 {
     // 1. If traverser’s active flag is set, then throw an "InvalidStateError" DOMException.
     if (m_active)
-        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"_fly_string));
+        return throw_completion(WebIDL::InvalidStateError::create(realm(), "NodeIterator is already active"_string));
 
     // 2. Let n be node’s nodeType attribute value − 1.
     auto n = node.node_type() - 1;

--- a/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
+++ b/Userland/Libraries/LibWeb/DOMParsing/XMLSerializer.cpp
@@ -353,7 +353,7 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
             });
 
             if (local_name_set_iterator != local_name_set.end())
-                return WebIDL::InvalidStateError::create(realm, "Element contains two attributes with identical namespaces and local names"_fly_string);
+                return WebIDL::InvalidStateError::create(realm, "Element contains two attributes with identical namespaces and local names"_string);
         }
 
         // 2. Create a new tuple consisting of attr's namespaceURI attribute and localName attribute, and add it to the localname set.
@@ -406,12 +406,12 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
                 // 2. If the require well-formed flag is set (its value is true), and the value of attr's value attribute matches the XMLNS namespace,
                 //    then throw an exception; the serialization of this attribute would produce invalid XML because the XMLNS namespace is reserved and cannot be applied as an element's namespace via XML parsing.
                 if (require_well_formed == RequireWellFormed::Yes && attribute->value() == Namespace::XMLNS)
-                    return WebIDL::InvalidStateError::create(realm, "The XMLNS namespace cannot be used as an element's namespace"_fly_string);
+                    return WebIDL::InvalidStateError::create(realm, "The XMLNS namespace cannot be used as an element's namespace"_string);
 
                 // 3. If the require well-formed flag is set (its value is true), and the value of attr's value attribute is the empty string,
                 //    then throw an exception; namespace prefix declarations cannot be used to undeclare a namespace (use a default namespace declaration instead).
                 if (require_well_formed == RequireWellFormed::Yes && attribute->value().is_empty())
-                    return WebIDL::InvalidStateError::create(realm, "Attribute's value is empty"_fly_string);
+                    return WebIDL::InvalidStateError::create(realm, "Attribute's value is empty"_string);
 
                 // 4. [If] the attr's prefix matches the string "xmlns", then let candidate prefix be the string "xmlns".
                 if (attribute->prefix() == "xmlns"sv)
@@ -454,12 +454,12 @@ static WebIDL::ExceptionOr<String> serialize_element_attributes(DOM::Element con
         //    or does not match the XML Name production or equals "xmlns" and attribute namespace is null, then throw an exception; the serialization of this attr would not be a well-formed attribute.
         if (require_well_formed == RequireWellFormed::Yes) {
             if (attribute->local_name().bytes_as_string_view().contains(':'))
-                return WebIDL::InvalidStateError::create(realm, "Attribute's local name contains a colon"_fly_string);
+                return WebIDL::InvalidStateError::create(realm, "Attribute's local name contains a colon"_string);
 
             // FIXME: Check attribute's local name against the XML Name production.
 
             if (attribute->local_name() == "xmlns"sv && !attribute->namespace_uri().has_value())
-                return WebIDL::InvalidStateError::create(realm, "Attribute's local name is 'xmlns' and the attribute has no namespace"_fly_string);
+                return WebIDL::InvalidStateError::create(realm, "Attribute's local name is 'xmlns' and the attribute has no namespace"_string);
         }
 
         // 9. Append the following strings to result, in the order listed:
@@ -489,7 +489,7 @@ static WebIDL::ExceptionOr<String> serialize_element(DOM::Element const& element
     //    then throw an exception; the serialization of this node would not be a well-formed element.
     if (require_well_formed == RequireWellFormed::Yes) {
         if (element.local_name().bytes_as_string_view().contains(':'))
-            return WebIDL::InvalidStateError::create(realm, "Element's local name contains a colon"_fly_string);
+            return WebIDL::InvalidStateError::create(realm, "Element's local name contains a colon"_string);
 
         // FIXME: Check element's local name against the XML Char production.
     }
@@ -561,7 +561,7 @@ static WebIDL::ExceptionOr<String> serialize_element(DOM::Element const& element
         if (prefix == "xmlns"sv) {
             // 1. If the require well-formed flag is set, then throw an error. An Element with prefix "xmlns" will not legally round-trip in a conforming XML parser.
             if (require_well_formed == RequireWellFormed::Yes)
-                return WebIDL::InvalidStateError::create(realm, "Elements prefix is 'xmlns'"_fly_string);
+                return WebIDL::InvalidStateError::create(realm, "Elements prefix is 'xmlns'"_string);
 
             // 2. Let candidate prefix be the value of prefix.
             candidate_prefix = prefix;
@@ -728,7 +728,7 @@ static WebIDL::ExceptionOr<String> serialize_document(DOM::Document const& docum
     // If the require well-formed flag is set (its value is true), and this node has no documentElement (the documentElement attribute's value is null),
     // then throw an exception; the serialization of this node would not be a well-formed document.
     if (require_well_formed == RequireWellFormed::Yes && !document.document_element())
-        return WebIDL::InvalidStateError::create(document.realm(), "Document has no document element"_fly_string);
+        return WebIDL::InvalidStateError::create(document.realm(), "Document has no document element"_string);
 
     // Otherwise, run the following steps:
     // 1. Let serialized document be an empty string.
@@ -752,10 +752,10 @@ static WebIDL::ExceptionOr<String> serialize_comment(DOM::Comment const& comment
         // FIXME: Check comment's data against the XML Char production.
 
         if (comment.data().contains("--"sv))
-            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data contains two adjacent hyphens"_fly_string);
+            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data contains two adjacent hyphens"_string);
 
         if (comment.data().ends_with('-'))
-            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data ends with a hyphen"_fly_string);
+            return WebIDL::InvalidStateError::create(comment.realm(), "Comment data ends with a hyphen"_string);
     }
 
     // Otherwise, return the concatenation of "<!--", node's data, and "-->".
@@ -810,7 +810,7 @@ static WebIDL::ExceptionOr<String> serialize_document_type(DOM::DocumentType con
         //    both a """ (U+0022 QUOTATION MARK) and a "'" (U+0027 APOSTROPHE), then throw an exception; the serialization of this node would not be a well-formed document type declaration.
         // FIXME: Check systemId against the XML Char production.
         if (document_type.system_id().contains('"') && document_type.system_id().contains('\''))
-            return WebIDL::InvalidStateError::create(document_type.realm(), "Document type system ID contains both a quotation mark and an apostrophe"_fly_string);
+            return WebIDL::InvalidStateError::create(document_type.realm(), "Document type system ID contains both a quotation mark and an apostrophe"_string);
     }
 
     // 3. Let markup be an empty string.
@@ -872,16 +872,16 @@ static WebIDL::ExceptionOr<String> serialize_processing_instruction(DOM::Process
         // 1. If the require well-formed flag is set (its value is true), and node's target contains a ":" (U+003A COLON) character
         //    or is an ASCII case-insensitive match for the string "xml", then throw an exception; the serialization of this node's target would not be well-formed.
         if (processing_instruction.target().contains(':'))
-            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target contains a colon"_fly_string);
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target contains a colon"_string);
 
         if (Infra::is_ascii_case_insensitive_match(processing_instruction.target(), "xml"sv))
-            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target is equal to 'xml'"_fly_string);
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction target is equal to 'xml'"_string);
 
         // 2. If the require well-formed flag is set (its value is true), and node's data contains characters that are not matched by the XML Char production or contains
         //    the string "?>" (U+003F QUESTION MARK, U+003E GREATER-THAN SIGN), then throw an exception; the serialization of this node's data would not be well-formed.
         // FIXME: Check data against the XML Char production.
         if (processing_instruction.data().contains("?>"sv))
-            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction data contains a terminator"_fly_string);
+            return WebIDL::InvalidStateError::create(processing_instruction.realm(), "Processing instruction data contains a terminator"_string);
     }
 
     // 3. Let markup be the concatenation of the following, in the order listed:
@@ -910,7 +910,7 @@ static WebIDL::ExceptionOr<String> serialize_processing_instruction(DOM::Process
 static WebIDL::ExceptionOr<String> serialize_cdata_section(DOM::CDATASection const& cdata_section, RequireWellFormed require_well_formed)
 {
     if (require_well_formed == RequireWellFormed::Yes && cdata_section.data().contains("]]>"sv))
-        return WebIDL::InvalidStateError::create(cdata_section.realm(), "CDATA section data contains a CDATA section end delimiter"_fly_string);
+        return WebIDL::InvalidStateError::create(cdata_section.realm(), "CDATA section data contains a CDATA section end delimiter"_string);
 
     StringBuilder markup;
     markup.append("<![CDATA["sv);

--- a/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Userland/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -74,7 +74,7 @@ WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<JS::Handle<WebIDL::Buff
     // FIXME: Implement the streaming stuff.
     auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input.value()->raw_object());
     if (data_buffer_or_error.is_error())
-        return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer"_fly_string);
+        return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer"_string);
     auto& data_buffer = data_buffer_or_error.value();
     auto result = TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() }));
     if (this->fatal() && result.contains(0xfffd))

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchController.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/FetchController.cpp
@@ -79,7 +79,7 @@ void FetchController::abort(JS::Realm& realm, Optional<JS::Value> error)
     m_state = State::Aborted;
 
     // 2. Let fallbackError be an "AbortError" DOMException.
-    auto fallback_error = WebIDL::AbortError::create(realm, "Fetch was aborted"_fly_string);
+    auto fallback_error = WebIDL::AbortError::create(realm, "Fetch was aborted"_string);
 
     // 3. Set error to fallbackError if it is not given.
     if (!error.has_value())

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -93,14 +93,14 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
     m_source.visit(
         [&](ByteBuffer const& byte_buffer) {
             if (auto result = success_steps(byte_buffer); result.is_error())
-                error_steps(WebIDL::UnknownError::create(realm, "Out-of-memory"_fly_string));
+                error_steps(WebIDL::UnknownError::create(realm, "Out-of-memory"_string));
         },
         [&](JS::Handle<FileAPI::Blob> const& blob) {
             if (auto result = success_steps(blob->raw_bytes()); result.is_error())
-                error_steps(WebIDL::UnknownError::create(realm, "Out-of-memory"_fly_string));
+                error_steps(WebIDL::UnknownError::create(realm, "Out-of-memory"_string));
         },
         [&](Empty) {
-            error_steps(WebIDL::DOMException::create(realm, "DOMException"_fly_string, "Reading from Blob, FormData or null source is not yet implemented"_fly_string));
+            error_steps(WebIDL::DOMException::create(realm, "DOMException"_fly_string, "Reading from Blob, FormData or null source is not yet implemented"_string));
         });
 }
 

--- a/Userland/Libraries/LibWeb/FileAPI/FileReader.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/FileReader.cpp
@@ -105,7 +105,7 @@ WebIDL::ExceptionOr<FileReader::Result> FileReader::blob_package_data(JS::Realm&
         return JS::ArrayBuffer::create(realm, move(bytes));
     case Type::BinaryString:
         // FIXME: Return bytes as a binary string, in which every byte is represented by a code unit of equal value [0..255].
-        return WebIDL::NotSupportedError::create(realm, "BinaryString not supported yet"_fly_string);
+        return WebIDL::NotSupportedError::create(realm, "BinaryString not supported yet"_string);
     }
     VERIFY_NOT_REACHED();
 }
@@ -118,7 +118,7 @@ WebIDL::ExceptionOr<void> FileReader::read_operation(Blob& blob, Type type, Opti
 
     // 1. If fr’s state is "loading", throw an InvalidStateError DOMException.
     if (m_state == State::Loading)
-        return WebIDL::InvalidStateError::create(realm, "Read already in progress"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Read already in progress"_string);
 
     // 2. Set fr’s state to "loading".
     m_state = State::Loading;

--- a/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMMatrixReadOnly.cpp
@@ -563,7 +563,7 @@ WebIDL::ExceptionOr<String> DOMMatrixReadOnly::to_string() const
         || !isfinite(m21()) || !isfinite(m22()) || !isfinite(m23()) || !isfinite(m24())
         || !isfinite(m31()) || !isfinite(m32()) || !isfinite(m33()) || !isfinite(m34())
         || !isfinite(m41()) || !isfinite(m42()) || !isfinite(m43()) || !isfinite(m44())) {
-        return WebIDL::InvalidStateError::create(realm(), "Cannot stringify non-finite matrix values"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot stringify non-finite matrix values"_string);
     }
 
     // 2. Let string be the empty string.
@@ -949,7 +949,7 @@ WebIDL::ExceptionOr<ParsedMatrix> parse_dom_matrix_init_string(JS::Realm& realm,
     auto parsing_context = CSS::Parser::ParsingContext { realm };
     auto transform_style_value = parse_css_value(parsing_context, transform_list, CSS::PropertyID::Transform);
     if (!transform_style_value)
-        return WebIDL::SyntaxError::create(realm, "Failed to parse CSS transform string."_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Failed to parse CSS transform string."_string);
     auto parsed_value = CSS::StyleProperties::transformations_for_style_value(*transform_style_value);
 
     // 3. If parsedValue is none, set parsedValue to a <transform-list> containing a single identity matrix.
@@ -981,7 +981,7 @@ WebIDL::ExceptionOr<ParsedMatrix> parse_dom_matrix_init_string(JS::Realm& realm,
     for (auto const& transform : parsed_value) {
         auto const& transform_matrix = transform.to_matrix({});
         if (transform_matrix.is_error())
-            return WebIDL::SyntaxError::create(realm, "Failed to parse CSS transform string."_fly_string);
+            return WebIDL::SyntaxError::create(realm, "Failed to parse CSS transform string."_string);
         matrix = matrix * transform_matrix.value();
     }
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasGradient.cpp
@@ -20,9 +20,9 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CanvasGradient>> CanvasGradient::create_rad
 {
     // If either of r0 or r1 are negative, then an "IndexSizeError" DOMException must be thrown.
     if (r0 < 0)
-        return WebIDL::IndexSizeError::create(realm, "The r0 passed is less than 0"_fly_string);
+        return WebIDL::IndexSizeError::create(realm, "The r0 passed is less than 0"_string);
     if (r1 < 0)
-        return WebIDL::IndexSizeError::create(realm, "The r1 passed is less than 0"_fly_string);
+        return WebIDL::IndexSizeError::create(realm, "The r1 passed is less than 0"_string);
 
     auto radial_gradient = TRY_OR_THROW_OOM(realm.vm(), Gfx::CanvasRadialGradientPaintStyle::create(Gfx::FloatPoint { x0, y0 }, r0, Gfx::FloatPoint { x1, y1 }, r1));
     return realm.heap().allocate<CanvasGradient>(realm, realm, *radial_gradient);
@@ -61,14 +61,14 @@ WebIDL::ExceptionOr<void> CanvasGradient::add_color_stop(double offset, StringVi
 {
     // 1. If the offset is less than 0 or greater than 1, then throw an "IndexSizeError" DOMException.
     if (offset < 0 || offset > 1)
-        return WebIDL::IndexSizeError::create(realm(), "CanvasGradient color stop offset out of bounds"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "CanvasGradient color stop offset out of bounds"_string);
 
     // 2. Let parsed color be the result of parsing color.
     auto parsed_color = Color::from_string(color);
 
     // 3. If parsed color is failure, throw a "SyntaxError" DOMException.
     if (!parsed_color.has_value())
-        return WebIDL::SyntaxError::create(realm(), "Could not parse color for CanvasGradient"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Could not parse color for CanvasGradient"_string);
 
     // 4. Place a new stop on the gradient, at offset offset relative to the whole gradient, and with the color parsed color.
     TRY_OR_THROW_OOM(realm().vm(), m_gradient->add_color_stop(offset, parsed_color.value()));

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -124,7 +124,7 @@ WebIDL::ExceptionOr<JS::GCPtr<CanvasPattern>> CanvasPattern::create(JS::Realm& r
     // then throw a "SyntaxError" DOMException.
     auto repetition_value = parse_repetition(repetition);
     if (!repetition_value.has_value())
-        return WebIDL::SyntaxError::create(realm, "Repetition value is not valid"_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Repetition value is not valid"_string);
 
     // Note: Bitmap won't be null here, as if it were it would have "bad" usability.
     auto const& bitmap = *image.visit([](auto const& source) -> Gfx::Bitmap const* { return source->bitmap(); });

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -48,7 +48,7 @@ CanvasRenderingContext2D::~CanvasRenderingContext2D() = default;
 void CanvasRenderingContext2D::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
-    set_prototype(&Bindings::ensure_web_prototype<Bindings::CanvasRenderingContext2DPrototype>(realm, "CanvasRenderingContext2D"_fly_string));
+    set_prototype(&Bindings::ensure_web_prototype<Bindings::CanvasRenderingContext2DPrototype>(realm, "CanvasRenderingContext2D"_string));
 }
 
 void CanvasRenderingContext2D::visit_edges(Cell::Visitor& visitor)
@@ -331,11 +331,11 @@ WebIDL::ExceptionOr<JS::GCPtr<ImageData>> CanvasRenderingContext2D::get_image_da
 {
     // 1. If either the sw or sh arguments are zero, then throw an "IndexSizeError" DOMException.
     if (width == 0 || height == 0)
-        return WebIDL::IndexSizeError::create(realm(), "Width and height must not be zero"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Width and height must not be zero"_string);
 
     // 2. If the CanvasRenderingContext2D's origin-clean flag is set to false, then throw a "SecurityError" DOMException.
     if (!m_origin_clean)
-        return WebIDL::SecurityError::create(realm(), "CanvasRenderingContext2D is not origin-clean"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "CanvasRenderingContext2D is not origin-clean"_string);
 
     // 3. Let imageData be a new ImageData object.
     // 4. Initialize imageData given sw, sh, settings set to settings, and defaultColorSpace set to this's color space.
@@ -600,7 +600,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
         [](JS::Handle<HTMLCanvasElement> const& canvas_element) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             // If image has either a horizontal dimension or a vertical dimension equal to zero, then throw an "InvalidStateError" DOMException.
             if (canvas_element->width() == 0 || canvas_element->height() == 0)
-                return WebIDL::InvalidStateError::create(canvas_element->realm(), "Canvas width or height is zero"_fly_string);
+                return WebIDL::InvalidStateError::create(canvas_element->realm(), "Canvas width or height is zero"_string);
             return Optional<CanvasImageSourceUsability> {};
         },
 
@@ -608,7 +608,7 @@ WebIDL::ExceptionOr<CanvasImageSourceUsability> check_usability_of_image(CanvasI
         // FIXME: VideoFrame
         [](JS::Handle<ImageBitmap> const& image_bitmap) -> WebIDL::ExceptionOr<Optional<CanvasImageSourceUsability>> {
             if (image_bitmap->is_detached())
-                return WebIDL::InvalidStateError::create(image_bitmap->realm(), "Image bitmap is detached"_fly_string);
+                return WebIDL::InvalidStateError::create(image_bitmap->realm(), "Image bitmap is detached"_string);
             return Optional<CanvasImageSourceUsability> {};
         }));
     if (usability.has_value())

--- a/Userland/Libraries/LibWeb/HTML/CloseWatcher.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CloseWatcher.cpp
@@ -45,7 +45,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CloseWatcher>> CloseWatcher::construct_impl
     // FIXME: Not in spec explicitly, but this should account for detached iframes too. See /close-watcher/frame-removal.html WPT.
     auto& window = verify_cast<HTML::Window>(realm.global_object());
     if (!window.associated_document().is_fully_active())
-        return WebIDL::InvalidStateError::create(realm, "The document is not fully active."_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "The document is not fully active."_string);
 
     // 2. Let close_watcher be the result of establishing a close watcher
     auto close_watcher = establish(window);

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -139,7 +139,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
     });
 
     if (existing_definition_with_constructor_iterator != m_custom_element_definitions.end())
-        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "The given constructor is already in use by another custom element"_fly_string));
+        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "The given constructor is already in use by another custom element"_string));
 
     // 5. Let localName be name.
     String local_name = name;
@@ -163,7 +163,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 
     // 8. If this CustomElementRegistry's element definition is running flag is set, then throw a "NotSupportedError" DOMException.
     if (m_element_definition_is_running)
-        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Cannot recursively define custom elements"_fly_string));
+        return JS::throw_completion(WebIDL::NotSupportedError::create(realm, "Cannot recursively define custom elements"_string));
 
     // 9. Set this CustomElementRegistry's element definition is running flag.
     m_element_definition_is_running = true;

--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -147,7 +147,7 @@ WebIDL::ExceptionOr<void> DOMStringMap::set_value_of_new_named_property(String c
         if (current_character == '-' && character_index + 1 < name_view.length()) {
             auto next_character = name_view[character_index + 1];
             if (is_ascii_lower_alpha(next_character))
-                return WebIDL::SyntaxError::create(realm(), "Name cannot contain a '-' followed by a lowercase character."_fly_string);
+                return WebIDL::SyntaxError::create(realm(), "Name cannot contain a '-' followed by a lowercase character."_string);
         }
 
         // 2. For each ASCII upper alpha in name, insert a U+002D HYPHEN-MINUS character (-) before the character and replace the character with the same character converted to ASCII lowercase.

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -281,7 +281,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_selection_start(
     if (is<HTMLInputElement>(html_element)) {
         auto& input_element = static_cast<HTMLInputElement&>(html_element);
         if (!input_element.selection_or_range_applies())
-            return WebIDL::InvalidStateError::create(html_element.realm(), "setSelectionStart does not apply to this input type"_fly_string);
+            return WebIDL::InvalidStateError::create(html_element.realm(), "setSelectionStart does not apply to this input type"_string);
     }
 
     // 2. Let end be the value of this element's selectionEnd attribute.
@@ -330,7 +330,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_selection_end(Op
     if (is<HTMLInputElement>(html_element)) {
         auto& input_element = static_cast<HTMLInputElement&>(html_element);
         if (!input_element.selection_or_range_applies())
-            return WebIDL::InvalidStateError::create(html_element.realm(), "setSelectionEnd does not apply to this input type"_fly_string);
+            return WebIDL::InvalidStateError::create(html_element.realm(), "setSelectionEnd does not apply to this input type"_string);
     }
 
     // 2. Set the selection range with the value of this element's selectionStart attribute, the
@@ -383,7 +383,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_selection_direct
     if (is<HTMLInputElement>(html_element)) {
         auto const& input_element = static_cast<HTMLInputElement const&>(html_element);
         if (!input_element.selection_direction_applies())
-            return WebIDL::InvalidStateError::create(input_element.realm(), "selectionDirection does not apply to element"_fly_string);
+            return WebIDL::InvalidStateError::create(input_element.realm(), "selectionDirection does not apply to element"_string);
     }
 
     set_the_selection_range(m_selection_start, m_selection_end, string_to_selection_direction(direction));
@@ -403,7 +403,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_range_text(Strin
     //    throw an "InvalidStateError" DOMException.
     auto& html_element = form_associated_element_to_html_element();
     if (is<HTMLInputElement>(html_element) && !static_cast<HTMLInputElement&>(html_element).selection_or_range_applies())
-        return WebIDL::InvalidStateError::create(html_element.realm(), "setRangeText does not apply to this input type"_fly_string);
+        return WebIDL::InvalidStateError::create(html_element.realm(), "setRangeText does not apply to this input type"_string);
 
     // 2. Set this element's dirty value flag to true.
     set_dirty_value_flag(true);
@@ -414,7 +414,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_range_text(Strin
 
     // 4. If start is greater than end, then throw an "IndexSizeError" DOMException.
     if (start > end)
-        return WebIDL::IndexSizeError::create(html_element.realm(), "The start argument must be less than or equal to the end argument"_fly_string);
+        return WebIDL::IndexSizeError::create(html_element.realm(), "The start argument must be less than or equal to the end argument"_string);
 
     // 5. If start is greater than the length of the relevant value of the text control, then set it to the length of the relevant value of the text control.
     auto the_relevant_value = relevant_value();
@@ -523,7 +523,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_selection_range(
     //    element, throw an "InvalidStateError" DOMException.
     auto& html_element = form_associated_element_to_html_element();
     if (is<HTMLInputElement>(html_element) && !static_cast<HTMLInputElement&>(html_element).selection_or_range_applies())
-        return WebIDL::InvalidStateError::create(html_element.realm(), "setSelectionRange does not apply to this input type"_fly_string);
+        return WebIDL::InvalidStateError::create(html_element.realm(), "setSelectionRange does not apply to this input type"_string);
 
     // 2. Set the selection range with start, end, and direction.
     set_the_selection_range(start, end, string_to_selection_direction(direction));

--- a/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -87,11 +87,11 @@ WebIDL::ExceptionOr<void> HTMLDialogElement::show_modal()
 
     // 2. If this has an open attribute, then throw an "InvalidStateError" DOMException.
     if (has_attribute(AttributeNames::open))
-        return WebIDL::InvalidStateError::create(realm(), "Dialog already open"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Dialog already open"_string);
 
     // 3. If this is not connected, then throw an "InvalidStateError" DOMException.
     if (!is_connected())
-        return WebIDL::InvalidStateError::create(realm(), "Dialog not connected"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Dialog not connected"_string);
 
     // FIXME: 4. If this is in the popover showing state, then throw an "InvalidStateError" DOMException.
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -147,7 +147,7 @@ WebIDL::ExceptionOr<void> HTMLElement::set_content_editable(StringView content_e
         MUST(set_attribute(HTML::AttributeNames::contenteditable, "false"_string));
         return {};
     }
-    return WebIDL::SyntaxError::create(realm(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'"_fly_string);
+    return WebIDL::SyntaxError::create(realm(), "Invalid contentEditable value, must be 'true', 'false', or 'inherit'"_string);
 }
 
 void HTMLElement::set_inner_text(StringView text)
@@ -651,26 +651,26 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ElementInternals>> HTMLElement::attach_inte
 {
     // 1. If this's is value is not null, then throw a "NotSupportedError" DOMException.
     if (is_value().has_value())
-        return WebIDL::NotSupportedError::create(realm(), "ElementInternals cannot be attached to a customized build-in element"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "ElementInternals cannot be attached to a customized build-in element"_string);
 
     // 2. Let definition be the result of looking up a custom element definition given this's node document, its namespace, its local name, and null as the is value.
     auto definition = document().lookup_custom_element_definition(namespace_uri(), local_name(), is_value());
 
     // 3. If definition is null, then throw an "NotSupportedError" DOMException.
     if (!definition)
-        return WebIDL::NotSupportedError::create(realm(), "ElementInternals cannot be attached to an element that is not a custom element"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "ElementInternals cannot be attached to an element that is not a custom element"_string);
 
     // 4. If definition's disable internals is true, then throw a "NotSupportedError" DOMException.
     if (definition->disable_internals())
-        return WebIDL::NotSupportedError::create(realm(), "ElementInternals are disabled for this custom element"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "ElementInternals are disabled for this custom element"_string);
 
     // 5. If this's attached internals is non-null, then throw an "NotSupportedError" DOMException.
     if (m_attached_internals)
-        return WebIDL::NotSupportedError::create(realm(), "ElementInternals already attached"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "ElementInternals already attached"_string);
 
     // 6. If this's custom element state is not "precustomized" or "custom", then throw a "NotSupportedError" DOMException.
     if (!first_is_one_of(custom_element_state(), DOM::CustomElementState::Precustomized, DOM::CustomElementState::Custom))
-        return WebIDL::NotSupportedError::create(realm(), "Custom element is in an invalid state to attach ElementInternals"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Custom element is in an invalid state to attach ElementInternals"_string);
 
     // 7. Set this's attached internals to a new ElementInternals instance whose target element is this.
     auto internals = ElementInternals::create(realm(), *this);

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -342,7 +342,7 @@ WebIDL::ExceptionOr<void> HTMLFormElement::request_submit(JS::GCPtr<Element> sub
 
         // 2. If submitter's form owner is not this form element, then throw a "NotFoundError" DOMException.
         if (form_associated_element->form() != this)
-            return WebIDL::NotFoundError::create(realm(), "The submitter is not owned by this form element"_fly_string);
+            return WebIDL::NotFoundError::create(realm(), "The submitter is not owned by this form element"_string);
     }
     // 2. Otherwise, set submitter to this form element.
     else {

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -295,7 +295,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLImageElement::decode() co
             if (this->document().is_fully_active())
                 return false;
 
-            auto exception = WebIDL::EncodingError::create(realm, "Node document not fully active"_fly_string);
+            auto exception = WebIDL::EncodingError::create(realm, "Node document not fully active"_string);
             HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*this));
             WebIDL::reject_promise(realm, promise, exception);
             return true;
@@ -305,7 +305,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLImageElement::decode() co
             if (this->current_request().state() != ImageRequest::State::Broken)
                 return false;
 
-            auto exception = WebIDL::EncodingError::create(realm, "Current request state is broken"_fly_string);
+            auto exception = WebIDL::EncodingError::create(realm, "Current request state is broken"_string);
             HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*this));
             WebIDL::reject_promise(realm, promise, exception);
             return true;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -326,7 +326,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::show_picker()
 
     // 1. If this is not mutable, then throw an "InvalidStateError" DOMException.
     if (!m_is_mutable)
-        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"_string);
 
     // 2. If this's relevant settings object's origin is not same origin with this's relevant settings object's top-level origin,
     // and this's type attribute is not in the File Upload state or Color state, then throw a "SecurityError" DOMException.
@@ -334,14 +334,14 @@ WebIDL::ExceptionOr<void> HTMLInputElement::show_picker()
     //       and has never been guarded by an origin check.
     if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin)
         && m_type != TypeAttributeState::FileUpload && m_type != TypeAttributeState::Color) {
-        return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_string);
     }
 
     // 3. If this's relevant global object does not have transient activation, then throw a "NotAllowedError" DOMException.
     // FIXME: The global object we get here should probably not need casted to Window to check for transient activation
     auto& global_object = relevant_global_object(*this);
     if (!is<HTML::Window>(global_object) || !static_cast<HTML::Window&>(global_object).has_transient_activation()) {
-        return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"_fly_string);
+        return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"_string);
     }
 
     // 4. Show the picker, if applicable, for this.
@@ -607,7 +607,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value(String const& value)
     case ValueAttributeMode::Filename:
         // On setting, if the new value is the empty string, empty the list of selected files; otherwise, throw an "InvalidStateError" DOMException.
         if (!value.is_empty())
-            return WebIDL::InvalidStateError::create(realm, "Setting value of input type file to non-empty string"_fly_string);
+            return WebIDL::InvalidStateError::create(realm, "Setting value of input type file to non-empty string"_string);
 
         m_selected_files = nullptr;
         break;
@@ -2093,7 +2093,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value_as_date(Optional<JS::Handl
 {
     // On setting, if the valueAsDate attribute does not apply, as defined for the input element's type attribute's current state, then throw an "InvalidStateError" DOMException;
     if (!value_as_date_applies())
-        return WebIDL::InvalidStateError::create(realm(), "valueAsDate: Invalid input type used"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "valueAsDate: Invalid input type used"_string);
 
     // otherwise, if the new value is not null and not a Date object throw a TypeError exception;
     if (value.has_value() && !is<JS::Date>(**value))
@@ -2136,7 +2136,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value_as_number(double value)
 
     // Otherwise, if the valueAsNumber attribute does not apply, as defined for the input element's type attribute's current state, then throw an "InvalidStateError" DOMException.
     if (!value_as_number_applies())
-        return WebIDL::InvalidStateError::create(realm(), "valueAsNumber: Invalid input type used"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "valueAsNumber: Invalid input type used"_string);
 
     // Otherwise, if the new value is a Not-a-Number (NaN) value, then set the value of the element to the empty string.
     if (value == NAN) {
@@ -2171,7 +2171,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::step_up_or_down(bool is_down, WebIDL
     // 2. If the element has no allowed value step, then throw an "InvalidStateError" DOMException.
     auto maybe_allowed_value_step = allowed_value_step();
     if (!maybe_allowed_value_step.has_value())
-        return WebIDL::InvalidStateError::create(realm(), "element has no allowed value step"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "element has no allowed value step"_string);
     double allowed_value_step = *maybe_allowed_value_step;
 
     // 3. If the element has a minimum and a maximum and the minimum is greater than the maximum, then return.

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -395,7 +395,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::set_volume(double volume)
     // set to the new value. If the new value is outside the range 0.0 to 1.0 inclusive, then, on setting, an
     // "IndexSizeError" DOMException must be thrown instead.
     if (volume < 0.0 || volume > 1.0)
-        return WebIDL::IndexSizeError::create(realm(), "Volume must be in the range 0.0 to 1.0, inclusive"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Volume must be in the range 0.0 to 1.0, inclusive"_string);
 
     m_volume = volume;
     volume_or_muted_attribute_changed();
@@ -548,7 +548,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::load_element()
 
             // 2. Take pending play promises and reject pending play promises with the result and an "AbortError" DOMException.
             auto promises = take_pending_play_promises();
-            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback was aborted"_fly_string);
+            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback was aborted"_string);
         }
 
         // 7. If seeking is true, set it to false.
@@ -1290,7 +1290,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::handle_media_source_failure(Span<JS:
     dispatch_event(DOM::Event::create(realm, HTML::EventNames::error));
 
     // 6. Reject pending play promises with promises and a "NotSupportedError" DOMException.
-    reject_pending_play_promises<WebIDL::NotSupportedError>(promises, "Media is not supported"_fly_string);
+    reject_pending_play_promises<WebIDL::NotSupportedError>(promises, "Media is not supported"_string);
 
     // 7. Set the element's delaying-the-load-event flag to false. This stops delaying the load event.
     m_delaying_the_load_event.clear();
@@ -1516,7 +1516,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::pause_element()
             dispatch_event(DOM::Event::create(realm, HTML::EventNames::pause));
 
             // 3. Reject pending play promises with promises and an "AbortError" DOMException.
-            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback was paused"_fly_string);
+            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback was paused"_string);
         });
 
         // 4. Set the official playback position to the current playback position.
@@ -1768,7 +1768,7 @@ void HTMLMediaElement::reached_end_of_media_playback()
 
             // 3. Take pending play promises and reject pending play promises with the result and an "AbortError" DOMException.
             auto promises = take_pending_play_promises();
-            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback has ended"_fly_string);
+            reject_pending_play_promises<WebIDL::AbortError>(promises, "Media playback has ended"_string);
         }
     });
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -200,11 +200,11 @@ private:
 
     // https://html.spec.whatwg.org/multipage/media.html#reject-pending-play-promises
     template<typename ErrorType>
-    void reject_pending_play_promises(ReadonlySpan<JS::NonnullGCPtr<WebIDL::Promise>> promises, FlyString const& message)
+    void reject_pending_play_promises(ReadonlySpan<JS::NonnullGCPtr<WebIDL::Promise>> promises, String message)
     {
         auto& realm = this->realm();
 
-        auto error = ErrorType::create(realm, message);
+        auto error = ErrorType::create(realm, move(message));
         reject_pending_play_promises(promises, error);
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -88,7 +88,7 @@ WebIDL::ExceptionOr<void> HTMLOptionsCollection::set_value_of_indexed_property(u
     }
 
     if (!unconverted_option.is_object() || !is<HTMLOptionElement>(unconverted_option.as_object())) {
-        return WebIDL::TypeMismatchError::create(realm(), "The value provided is not an HTMLOptionElement"_fly_string);
+        return WebIDL::TypeMismatchError::create(realm(), "The value provided is not an HTMLOptionElement"_string);
     }
 
     auto& option = static_cast<HTMLOptionElement&>(unconverted_option.as_object());
@@ -133,11 +133,11 @@ WebIDL::ExceptionOr<void> HTMLOptionsCollection::add(HTMLOptionOrOptGroupElement
 
     // 1. If element is an ancestor of the select element on which the HTMLOptionsCollection is rooted, then throw a "HierarchyRequestError" DOMException.
     if (resolved_element->is_ancestor_of(root()))
-        return WebIDL::HierarchyRequestError::create(realm(), "The provided element is an ancestor of the root select element."_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "The provided element is an ancestor of the root select element."_string);
 
     // 2. If before is an element, but that element isn't a descendant of the select element on which the HTMLOptionsCollection is rooted, then throw a "NotFoundError" DOMException.
     if (before_element && !before_element->is_descendant_of(root()))
-        return WebIDL::NotFoundError::create(realm(), "The 'before' element is not a descendant of the root select element."_fly_string);
+        return WebIDL::NotFoundError::create(realm(), "The 'before' element is not a descendant of the root select element."_string);
 
     // 3. If element and before are the same element, then return.
     if (before_element && (resolved_element.ptr() == before_element.ptr()))

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -420,19 +420,19 @@ WebIDL::ExceptionOr<void> HTMLSelectElement::show_picker()
 
     // 1. If this is not mutable, then throw an "InvalidStateError" DOMException.
     if (!enabled())
-        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Element is not mutable"_string);
 
     // 2. If this's relevant settings object's origin is not same origin with this's relevant settings object's top-level origin,
     // and this is a select element, then throw a "SecurityError" DOMException.
     if (!relevant_settings_object(*this).origin().is_same_origin(relevant_settings_object(*this).top_level_origin)) {
-        return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cross origin pickers are not allowed"_string);
     }
 
     // 3. If this's relevant global object does not have transient activation, then throw a "NotAllowedError" DOMException.
     // FIXME: The global object we get here should probably not need casted to Window to check for transient activation
     auto& global_object = relevant_global_object(*this);
     if (!is<HTML::Window>(global_object) || !static_cast<HTML::Window&>(global_object).has_transient_activation()) {
-        return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"_fly_string);
+        return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"_string);
     }
 
     // FIXME: 4. If this is a select element, and this is not being rendered, then throw a "NotSupportedError" DOMException.

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -185,7 +185,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_head(HTMLTableSectionElement* 
 {
     // If the new value is neither null nor a thead element, then a "HierarchyRequestError" DOMException must be thrown instead.
     if (thead && thead->local_name() != TagNames::thead)
-        return WebIDL::HierarchyRequestError::create(realm(), "Element is not thead"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Element is not thead"_string);
 
     // On setting, if the new value is null or a thead element, the first thead element child of the table element,
     // if any, must be removed,
@@ -283,7 +283,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::set_t_foot(HTMLTableSectionElement* 
 {
     // If the new value is neither null nor a tfoot element, then a "HierarchyRequestError" DOMException must be thrown instead.
     if (tfoot && tfoot->local_name() != TagNames::tfoot)
-        return WebIDL::HierarchyRequestError::create(realm(), "Element is not tfoot"_fly_string);
+        return WebIDL::HierarchyRequestError::create(realm(), "Element is not tfoot"_string);
 
     // On setting, if the new value is null or a tfoot element, the first tfoot element child of the table element,
     // if any, must be removed,
@@ -395,7 +395,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableElement::ins
     auto rows_length = rows->length();
 
     if (index < -1 || index > (long)rows_length) {
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows"_string);
     }
     auto& tr = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
     if (rows_length == 0 && !has_child_of_type<HTMLTableRowElement>()) {
@@ -422,7 +422,7 @@ WebIDL::ExceptionOr<void> HTMLTableElement::delete_row(WebIDL::Long index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the rows collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= (long)rows_length)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows"_string);
 
     // 2. If index is −1, then remove the last element in the rows collection from its parent, or do nothing if the rows collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -139,7 +139,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableCellElement>> HTMLTableRowElement:
 
     // 1. If index is less than −1 or greater than the number of elements in the cells collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index > cells_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of cells"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of cells"_string);
 
     // 2. Let table cell be the result of creating an element given this tr element's node document, td, and the HTML namespace.
     auto& table_cell = static_cast<HTMLTableCellElement&>(*TRY(DOM::create_element(document(), HTML::TagNames::td, Namespace::HTML)));
@@ -164,7 +164,7 @@ WebIDL::ExceptionOr<void> HTMLTableRowElement::delete_cell(i32 index)
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the cells collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= cells_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of cells"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of cells"_string);
 
     // 2. If index is −1, then remove the last element in the cells collection from its parent, or do nothing if the cells collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -62,7 +62,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<HTMLTableRowElement>> HTMLTableSectionEleme
 
     // 1. If index is less than −1 or greater than the number of elements in the rows collection, throw an "IndexSizeError" DOMException.
     if (index < -1 || index > rows_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than the number of rows"_string);
 
     // 2. Let table row be the result of creating an element given this element's node document, tr, and the HTML namespace.
     auto& table_row = static_cast<HTMLTableRowElement&>(*TRY(DOM::create_element(document(), TagNames::tr, Namespace::HTML)));
@@ -86,7 +86,7 @@ WebIDL::ExceptionOr<void> HTMLTableSectionElement::delete_row(WebIDL::Long index
 
     // 1. If index is less than −1 or greater than or equal to the number of elements in the rows collection, then throw an "IndexSizeError" DOMException.
     if (index < -1 || index >= rows_collection_size)
-        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Index is negative or greater than or equal to the number of rows"_string);
 
     // 2. If index is −1, then remove the last element in the rows collection from this element, or do nothing if the rows collection is empty.
     if (index == -1) {

--- a/Userland/Libraries/LibWeb/HTML/History.cpp
+++ b/Userland/Libraries/LibWeb/HTML/History.cpp
@@ -62,7 +62,7 @@ WebIDL::ExceptionOr<u64> History::length() const
 {
     // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform length on a document that isn't fully active."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform length on a document that isn't fully active."_string);
 
     // 2. Return this's length.
     return m_length;
@@ -73,7 +73,7 @@ WebIDL::ExceptionOr<JS::Value> History::state() const
 {
     // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform state on a document that isn't fully active."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform state on a document that isn't fully active."_string);
 
     // 2. Return this's state.
     return m_state;
@@ -91,7 +91,7 @@ WebIDL::ExceptionOr<void> History::go(WebIDL::Long delta = 0)
 
     // 2. If document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform go on a document that isn't fully active."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform go on a document that isn't fully active."_string);
 
     VERIFY(m_associated_document->navigable());
 
@@ -178,7 +178,7 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value d
 
     // 2. If document is not fully active, then throw a "SecurityError" DOMException.
     if (!document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cannot perform pushState or replaceState on a document that isn't fully active."_string);
 
     // 3. Optionally, return. (For example, the user agent might disallow calls to these methods that are invoked on a timer,
     //    or from event listeners that are not triggered in response to a clear user action, or that are invoked in rapid succession.)
@@ -200,14 +200,14 @@ WebIDL::ExceptionOr<void> History::shared_history_push_replace_state(JS::Value d
 
         // 2. If that fails, then throw a "SecurityError" DOMException.
         if (!parsed_url.is_valid())
-            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_fly_string);
+            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_string);
 
         // 3. Set newURL to the resulting URL record.
         new_url = parsed_url;
 
         // 4. If document cannot have its URL rewritten to newURL, then throw a "SecurityError" DOMException.
         if (!can_have_its_url_rewritten(document, new_url))
-            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_fly_string);
+            return WebIDL::SecurityError::create(realm(), "Cannot pushState or replaceState to incompatible URL"_string);
     }
 
     // 7. Let navigation be history's relevant global object's navigation API.
@@ -234,7 +234,7 @@ WebIDL::ExceptionOr<Bindings::ScrollRestoration> History::scroll_restoration() c
 {
     // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot obtain scroll restoration mode for a document that isn't fully active."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cannot obtain scroll restoration mode for a document that isn't fully active."_string);
 
     // 2. Return this's node navigable's active session history entry's scroll restoration mode.
     auto scroll_restoration_mode = m_associated_document->navigable()->active_session_history_entry()->scroll_restoration_mode();
@@ -252,7 +252,7 @@ WebIDL::ExceptionOr<void> History::set_scroll_restoration(Bindings::ScrollRestor
 {
     // 1. If this's relevant global object's associated Document is not fully active, then throw a "SecurityError" DOMException.
     if (!m_associated_document->is_fully_active())
-        return WebIDL::SecurityError::create(realm(), "Cannot set scroll restoration mode for a document that isn't fully active."_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Cannot set scroll restoration mode for a document that isn't fully active."_string);
 
     // 2. Set this's node navigable's active session history entry's scroll restoration mode to the given value.
     auto active_session_history_entry = m_associated_document->navigable()->active_session_history_entry();

--- a/Userland/Libraries/LibWeb/HTML/ImageData.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ImageData.cpp
@@ -25,7 +25,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ImageData>> ImageData::create(JS::Realm& re
 
     // 1. If one or both of sw and sh are zero, then throw an "IndexSizeError" DOMException.
     if (sw == 0 || sh == 0)
-        return WebIDL::IndexSizeError::create(realm, "The source width and height must be greater than zero."_fly_string);
+        return WebIDL::IndexSizeError::create(realm, "The source width and height must be greater than zero."_string);
 
     // 2. Initialize this given sw, sh, and settings set to settings.
     // 3. Initialize the image data of this to transparent black.
@@ -55,7 +55,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ImageData>> ImageData::create(JS::Realm& re
 
     // 2. If length is not a nonzero integral multiple of four, then throw an "InvalidStateError" DOMException.
     if (length == 0 || length % 4 != 0)
-        return WebIDL::InvalidStateError::create(realm, "Source data must have a non-sero length that is a multiple of four."_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Source data must have a non-sero length that is a multiple of four."_string);
 
     // 3. Let length be length divided by four.
     length = length / 4;
@@ -64,14 +64,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ImageData>> ImageData::create(JS::Realm& re
     // NOTE: At this step, the length is guaranteed to be greater than zero (otherwise the second step above would have aborted the steps),
     //       so if sw is zero, this step will throw the exception and return.
     if (sw == 0 || length % sw != 0)
-        return WebIDL::IndexSizeError::create(realm, "Source width must be a multiple of source data's length."_fly_string);
+        return WebIDL::IndexSizeError::create(realm, "Source width must be a multiple of source data's length."_string);
 
     // 5. Let height be length divided by sw.
     auto height = length / sw;
 
     // 6. If sh was given and its value is not equal to height, then throw an "IndexSizeError" DOMException.
     if (sh.has_value() && sh.value() != height)
-        return WebIDL::IndexSizeError::create(realm, "Source height must be equal to the calculated height of the data."_fly_string);
+        return WebIDL::IndexSizeError::create(realm, "Source height must be equal to the calculated height of the data."_string);
 
     // 7. Initialize this given sw, sh, settings set to settings, and source set to data.
     auto bitmap = TRY_OR_THROW_OOM(vm, Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::RGBA8888, Gfx::AlphaType::Unpremultiplied, Gfx::IntSize(sw, height), sw * sizeof(u32), uint8_clamped_array_data.data().data()));

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -100,7 +100,7 @@ WebIDL::ExceptionOr<String> Location::href() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 2. Return this's url, serialized.
     return TRY_OR_THROW_OOM(vm, String::from_byte_string(url().serialize()));
@@ -138,7 +138,7 @@ WebIDL::ExceptionOr<String> Location::origin() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 2. Return the serialization of this's url's origin.
     return TRY_OR_THROW_OOM(vm, String::from_byte_string(url().origin().serialize()));
@@ -152,7 +152,7 @@ WebIDL::ExceptionOr<String> Location::protocol() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 2. Return this's url's scheme, followed by ":".
     return TRY_OR_THROW_OOM(vm, String::formatted("{}:", url().scheme()));
@@ -169,7 +169,7 @@ WebIDL::ExceptionOr<void> Location::set_protocol(String const& value)
 
     // 2. If this's relevant Document's origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     if (!relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 3. Let copyURL be a copy of this's url.
     auto copy_url = this->url();
@@ -199,7 +199,7 @@ WebIDL::ExceptionOr<String> Location::host() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 2. Let url be this's url.
     auto url = this->url();
@@ -230,7 +230,7 @@ WebIDL::ExceptionOr<String> Location::hostname() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     auto url = this->url();
 
@@ -256,7 +256,7 @@ WebIDL::ExceptionOr<String> Location::port() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     auto url = this->url();
 
@@ -280,7 +280,7 @@ WebIDL::ExceptionOr<String> Location::pathname() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 2. Return the result of URL path serializing this Location object's url.
     return url().serialize_path();
@@ -300,7 +300,7 @@ WebIDL::ExceptionOr<String> Location::search() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     auto url = this->url();
 
@@ -324,7 +324,7 @@ WebIDL::ExceptionOr<void> Location::set_search(String const& value)
 
     // 2. If this's relevant Document's origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     if (!relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 3. Let copyURL be a copy of this's url.
     auto copy_url = this->url();
@@ -360,7 +360,7 @@ WebIDL::ExceptionOr<String> Location::hash() const
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     auto url = this->url();
 
@@ -384,7 +384,7 @@ WebIDL::ExceptionOr<void> Location::set_hash(String const& value)
 
     // 2. If this's relevant Document's origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     if (!relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 3. Let copyURL be a copy of this's url.
     auto copy_url = this->url();
@@ -452,7 +452,7 @@ WebIDL::ExceptionOr<void> Location::assign(String const& url)
 
     // 2. If this's relevant Document's origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     if (!relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
-        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 3. Parse url relative to the entry settings object. If that failed, throw a "SyntaxError" DOMException.
     auto assign_url = entry_settings_object().parse_url(url);

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -207,7 +207,7 @@ WebIDL::ExceptionOr<void> MessagePort::message_port_post_message_steps(JS::GCPtr
     // 2. If transfer contains this MessagePort, then throw a "DataCloneError" DOMException.
     for (auto const& handle : transfer) {
         if (handle == this)
-            return WebIDL::DataCloneError::create(realm, "Cannot transfer a MessagePort to itself"_fly_string);
+            return WebIDL::DataCloneError::create(realm, "Cannot transfer a MessagePort to itself"_string);
     }
 
     // 3. Let doomed be false.

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1261,7 +1261,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
     if (!source_document->navigable()->allowed_by_sandboxing_to_navigate(*this, source_snapshot_params)) {
         // 1. If exceptionsEnabled is true, then throw a "SecurityError" DOMException.
         if (exceptions_enabled) {
-            return WebIDL::SecurityError::create(realm, "Source document's node navigable is not allowed to navigate"_fly_string);
+            return WebIDL::SecurityError::create(realm, "Source document's node navigable is not allowed to navigate"_string);
         }
 
         // 2 Return.

--- a/Userland/Libraries/LibWeb/HTML/NavigateEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigateEvent.cpp
@@ -76,11 +76,11 @@ WebIDL::ExceptionOr<void> NavigateEvent::intercept(NavigationInterceptOptions co
 
     // 2. If this's canIntercept attribute was initialized to false, then throw a "SecurityError" DOMException.
     if (!m_can_intercept)
-        return WebIDL::SecurityError::create(realm, "NavigateEvent cannot be intercepted"_fly_string);
+        return WebIDL::SecurityError::create(realm, "NavigateEvent cannot be intercepted"_string);
 
     // 3. If this's dispatch flag is unset, then throw an "InvalidStateError" DOMException.
     if (!this->dispatched())
-        return WebIDL::InvalidStateError::create(realm, "NavigationEvent is not dispatched yet"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "NavigationEvent is not dispatched yet"_string);
 
     // 4. Assert: this's interception state is either "none" or "intercepted".
     VERIFY(m_interception_state == InterceptionState::None || m_interception_state == InterceptionState::Intercepted);
@@ -134,7 +134,7 @@ WebIDL::ExceptionOr<void> NavigateEvent::scroll()
 
     // 2. If this's interception state is not "committed", then throw an "InvalidStateError" DOMException.
     if (m_interception_state != InterceptionState::Committed)
-        return WebIDL::InvalidStateError::create(realm(), "Cannot scroll NavigationEvent that is not committed"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot scroll NavigationEvent that is not committed"_string);
 
     // 3. Process scroll behavior given this.
     process_scroll_behavior();
@@ -151,15 +151,15 @@ WebIDL::ExceptionOr<void> NavigateEvent::perform_shared_checks()
     //    then throw an "InvalidStateError" DOMException.
     auto& associated_document = verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document();
     if (!associated_document.is_fully_active())
-        return WebIDL::InvalidStateError::create(realm(), "Document is not fully active"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Document is not fully active"_string);
 
     // 2. If event's isTrusted attribute was initialized to false, then throw a "SecurityError" DOMException.
     if (!this->is_trusted())
-        return WebIDL::SecurityError::create(realm(), "NavigateEvent is not trusted"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "NavigateEvent is not trusted"_string);
 
     // 3. If event's canceled flag is set, then throw an "InvalidStateError" DOMException.
     if (this->cancelled())
-        return WebIDL::InvalidStateError::create(realm(), "NavigateEvent already cancelled"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "NavigateEvent already cancelled"_string);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -133,7 +133,7 @@ WebIDL::ExceptionOr<void> Navigation::update_current_entry(NavigationUpdateCurre
 
     // 2. If current is null, then throw an "InvalidStateError" DOMException.
     if (current == nullptr)
-        return WebIDL::InvalidStateError::create(realm(), "Cannot update current NavigationHistoryEntry when there is no current entry"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot update current NavigationHistoryEntry when there is no current entry"_string);
 
     // 3. Let serializedState be StructuredSerializeForStorage(options["state"]), rethrowing any exceptions.
     auto serialized_state = TRY(structured_serialize_for_storage(vm(), options.state));
@@ -230,7 +230,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     //    Otherwise, let urlRecord be the resulting URL record.
     auto url_record = relevant_settings_object(*this).parse_url(url);
     if (!url_record.is_valid())
-        return early_error_result(WebIDL::SyntaxError::create(realm, "Cannot navigate to Invalid URL"_fly_string));
+        return early_error_result(WebIDL::SyntaxError::create(realm, "Cannot navigate to Invalid URL"_string));
 
     // 2. Let document be this's relevant global object's associated Document.
     auto& document = verify_cast<HTML::Window>(relevant_global_object(*this)).associated_document();
@@ -238,7 +238,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     // 3. If options["history"] is "push", and the navigation must be a replace given urlRecord and document,
     //    then return an early error result for a "NotSupportedError" DOMException.
     if (options.history == Bindings::NavigationHistoryBehavior::Push && navigation_must_be_a_replace(url_record, document))
-        return early_error_result(WebIDL::NotSupportedError::create(realm, "Navigation must be a replace, but push was requested"_fly_string));
+        return early_error_result(WebIDL::NotSupportedError::create(realm, "Navigation must be a replace, but push was requested"_string));
 
     // 4. Let state be options["state"], if it exists; otherwise, undefined.
     auto state = options.state.value_or(JS::js_undefined());
@@ -257,11 +257,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
 
     // 6. If document is not fully active, then return an early error result for an "InvalidStateError" DOMException.
     if (!document.is_fully_active())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_string));
 
     // 7. If document's unload counter is greater than 0, then return an early error result for an "InvalidStateError" DOMException.
     if (document.unload_counter() > 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_string));
 
     // 8. Let info be options["info"], if it exists; otherwise, undefined.
     auto info = options.info.value_or(JS::js_undefined());
@@ -287,7 +287,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
     //       that upcoming API method tracker to ongoing.
     if (m_upcoming_non_traverse_api_method_tracker == api_method_tracker) {
         m_upcoming_non_traverse_api_method_tracker = nullptr;
-        return early_error_result(WebIDL::AbortError::create(realm, "Navigation aborted"_fly_string));
+        return early_error_result(WebIDL::AbortError::create(realm, "Navigation aborted"_string));
     }
 
     // 12. Return a navigation API method tracker-derived result for apiMethodTracker.
@@ -330,11 +330,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::reload(NavigationReloadOptions
 
     // 5. If document is not fully active, then return an early error result for an "InvalidStateError" DOMException.
     if (!document.is_fully_active())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_string));
 
     // 6. If document's unload counter is greater than 0, then return an early error result for an "InvalidStateError" DOMException.
     if (document.unload_counter() > 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_string));
 
     // 7. Let info be options["info"], if it exists; otherwise, undefined.
     auto info = options.info.value_or(JS::js_undefined());
@@ -357,7 +357,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::traverse_to(String key, Naviga
 
     // 1. If this's current entry index is −1, then return an early error result for an "InvalidStateError" DOMException.
     if (m_current_entry_index == -1)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: no current session history entry"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: no current session history entry"_string));
 
     // 2. If this's entry list does not contain a NavigationHistoryEntry whose session history entry's navigation API key equals key,
     //    then return an early error result for an "InvalidStateError" DOMException.
@@ -365,7 +365,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::traverse_to(String key, Naviga
         return entry->session_history_entry().navigation_api_key() == key;
     });
     if (it == m_entry_list.end())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: key not found in session history list"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot traverseTo: key not found in session history list"_string));
 
     // 3. Return the result of performing a navigation API traversal given this, key, and options.
     return perform_a_navigation_api_traversal(key, options);
@@ -379,7 +379,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::back(NavigationOptions const& 
 
     // 1. If this's current entry index is −1 or 0, then return an early error result for an "InvalidStateError" DOMException.
     if (m_current_entry_index == -1 || m_current_entry_index == 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate back: no previous session history entry"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate back: no previous session history entry"_string));
 
     // 2. Let key be this's entry list[this's current entry index − 1]'s session history entry's navigation API key.
     auto key = m_entry_list[m_current_entry_index - 1]->session_history_entry().navigation_api_key();
@@ -397,7 +397,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::forward(NavigationOptions cons
     // 1. If this's current entry index is −1 or is equal to this's entry list's size − 1,
     //    then return an early error result for an "InvalidStateError" DOMException.
     if (m_current_entry_index == -1 || m_current_entry_index == static_cast<i64>(m_entry_list.size() - 1))
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate forward: no next session history entry"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Cannot navigate forward: no next session history entry"_string));
 
     // 2. Let key be this's entry list[this's current entry index + 1]'s session history entry's navigation API key.
     auto key = m_entry_list[m_current_entry_index + 1]->session_history_entry().navigation_api_key();
@@ -626,11 +626,11 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
 
     // 2. If document is not fully active, then return an early error result for an "InvalidStateError" DOMException.
     if (!document.is_fully_active())
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document is not fully active"_string));
 
     // 3. If document's unload counter is greater than 0, then return an early error result for an "InvalidStateError" DOMException.
     if (document.unload_counter() > 0)
-        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_fly_string));
+        return early_error_result(WebIDL::InvalidStateError::create(realm, "Document already unloaded"_string));
 
     // 4. Let current be the current entry of navigation.
     auto current = current_entry();
@@ -683,7 +683,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
                 auto& reject_realm = relevant_realm(*this);
                 TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
                 WebIDL::reject_promise(reject_realm, api_method_tracker->finished_promise,
-                    WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_fly_string));
+                    WebIDL::InvalidStateError::create(reject_realm, "Cannot traverse with stale session history entry"_string));
             }));
 
             // 2. Abort these steps.
@@ -714,7 +714,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
         if (result == TraversableNavigable::HistoryStepResult::CanceledByBeforeUnload) {
             queue_global_task(Task::Source::NavigationAndTraversal, global, JS::create_heap_function(heap(), [this, api_method_tracker, &realm] {
                 TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
-                reject_the_finished_promise(api_method_tracker, WebIDL::AbortError::create(realm, "Navigation cancelled by beforeunload"_fly_string));
+                reject_the_finished_promise(api_method_tracker, WebIDL::AbortError::create(realm, "Navigation cancelled by beforeunload"_string));
             }));
         }
 
@@ -724,7 +724,7 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::perform_a_navigation_api_trave
         if (result == TraversableNavigable::HistoryStepResult::InitiatorDisallowed) {
             queue_global_task(Task::Source::NavigationAndTraversal, global, JS::create_heap_function(heap(), [this, api_method_tracker, &realm] {
                 TemporaryExecutionContext execution_context { relevant_settings_object(*this) };
-                reject_the_finished_promise(api_method_tracker, WebIDL::SecurityError::create(realm, "Navigation disallowed from this origin"_fly_string));
+                reject_the_finished_promise(api_method_tracker, WebIDL::SecurityError::create(realm, "Navigation disallowed from this origin"_string));
             }));
         }
     }));
@@ -754,7 +754,7 @@ void Navigation::abort_the_ongoing_navigation(JS::GCPtr<WebIDL::DOMException> er
 
     // 5. If error was not given, then let error be a new "AbortError" DOMException created in navigation's relevant realm.
     if (!error)
-        error = WebIDL::AbortError::create(realm, "Navigation aborted"_fly_string);
+        error = WebIDL::AbortError::create(realm, "Navigation aborted"_string);
 
     VERIFY(error);
 

--- a/Userland/Libraries/LibWeb/HTML/Numbers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Numbers.cpp
@@ -128,7 +128,7 @@ bool is_valid_floating_point_number(StringView string)
 WebIDL::ExceptionOr<String> convert_non_negative_integer_to_string(JS::Realm& realm, WebIDL::Long value)
 {
     if (value < 0)
-        return WebIDL::IndexSizeError::create(realm, "The attribute is limited to only non-negative numbers"_fly_string);
+        return WebIDL::IndexSizeError::create(realm, "The attribute is limited to only non-negative numbers"_string);
     return MUST(String::number(value));
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -121,7 +121,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::En
             settings.clean_up_after_running_script();
 
             // 2. Throw a "NetworkError" DOMException.
-            return throw_completion(WebIDL::NetworkError::create(settings.realm(), "Script error."_fly_string));
+            return throw_completion(WebIDL::NetworkError::create(settings.realm(), "Script error."_string));
         }
 
         // 3. Otherwise, rethrow errors is false. Perform the following steps:

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -520,7 +520,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ClassicScript>> fetch_a_classic_worker_impo
     if (body_bytes.template has<Empty>() || body_bytes.template has<Fetch::Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag>()
         || !Fetch::Infrastructure::is_ok_status(response->status())
         || !response->header_list()->extract_mime_type().has_value() || !response->header_list()->extract_mime_type()->is_javascript()) {
-        return WebIDL::NetworkError::create(realm, "Network error"_fly_string);
+        return WebIDL::NetworkError::create(realm, "Network error"_string);
     }
 
     // 8. Let sourceText be the result of UTF-8 decoding bodyBytes.

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -75,7 +75,7 @@ WebIDL::ExceptionOr<JS::GCPtr<JavaScriptModuleScript>> JavaScriptModuleScript::c
         for (auto const& attribute : requested.attributes) {
             if (attribute.key != "type"sv) {
                 // 1. Let error be a new SyntaxError exception.
-                auto error = JS::SyntaxError::create(settings_object.realm(), "Module request attributes must only contain a type attribute"_fly_string);
+                auto error = JS::SyntaxError::create(settings_object.realm(), "Module request attributes must only contain a type attribute"_string);
 
                 // 2. Set script's parse error to error.
                 script->set_parse_error(error);
@@ -161,7 +161,7 @@ JS::Promise* JavaScriptModuleScript::run(PreventErrorReporting)
         // then set evaluationPromise to a promise rejected with a new "QuotaExceededError" DOMException.
         if (elevation_promise_or_error.is_error()) {
             auto promise = JS::Promise::create(settings_object().realm());
-            promise->reject(WebIDL::QuotaExceededError::create(settings_object().realm(), "Failed to evaluate module script"_fly_string).ptr());
+            promise->reject(WebIDL::QuotaExceededError::create(settings_object().realm(), "Failed to evaluate module script"_string).ptr());
 
             evaluation_promise = promise;
         } else {

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -195,7 +195,7 @@ public:
 
         // 5. If Type(value) is Symbol, then throw a "DataCloneError" DOMException.
         if (value.is_symbol())
-            return WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize Symbol"_fly_string);
+            return WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize Symbol"_string);
 
         // 6. Let serialized be an uninitialized value.
 
@@ -326,12 +326,12 @@ public:
 
         // 20. Otherwise, if value is a platform object, then throw a "DataCloneError" DOMException.
         else if (value.is_object() && is<Bindings::PlatformObject>(value.as_object())) {
-            return throw_completion(WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize platform objects"_fly_string));
+            return throw_completion(WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize platform objects"_string));
         }
 
         // 21. Otherwise, if IsCallable(value) is true, then throw a "DataCloneError" DOMException.
         else if (value.is_function()) {
-            return throw_completion(WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize functions"_fly_string));
+            return throw_completion(WebIDL::DataCloneError::create(*m_vm.current_realm(), "Cannot serialize functions"_string));
         }
 
         // FIXME: 22. Otherwise, if value has any internal slot other than [[Prototype]] or [[Extensible]], then throw a "DataCloneError" DOMException.
@@ -569,11 +569,11 @@ WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, Vector<u32>& vector
         // NOTE: This check is only needed when serializing (and not when deserializing) as the cross-origin isolated capability cannot change
         //       over time and a SharedArrayBuffer cannot leave an agent cluster.
         if (current_settings_object().cross_origin_isolated_capability() == CanUseCrossOriginIsolatedAPIs::No)
-            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize SharedArrayBuffer when cross-origin isolated"_fly_string);
+            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize SharedArrayBuffer when cross-origin isolated"_string);
 
         // 2. If forStorage is true, then throw a "DataCloneError" DOMException.
         if (for_storage)
-            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize SharedArrayBuffer for storage"_fly_string);
+            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize SharedArrayBuffer for storage"_string);
 
         // FIXME: 3. If value has an [[ArrayBufferMaxByteLength]] internal slot, then set serialized to { [[Type]]: "GrowableSharedArrayBuffer",
         //           [[ArrayBufferData]]: value.[[ArrayBufferData]], [[ArrayBufferByteLengthData]]: value.[[ArrayBufferByteLengthData]],
@@ -585,7 +585,7 @@ WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, Vector<u32>& vector
     else {
         // 1. If IsDetachedBuffer(value) is true, then throw a "DataCloneError" DOMException.
         if (array_buffer.is_detached())
-            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize detached ArrayBuffer"_fly_string);
+            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize detached ArrayBuffer"_string);
 
         // 2. Let size be value.[[ArrayBufferByteLength]].
         auto size = array_buffer.byte_length();
@@ -778,7 +778,7 @@ public:
             // If this throws an exception, catch it, and then throw a "DataCloneError" DOMException.
             auto bytes_or_error = deserialize_bytes(m_vm, m_serialized, m_position);
             if (bytes_or_error.is_error())
-                return WebIDL::DataCloneError::create(*m_vm.current_realm(), "out of memory"_fly_string);
+                return WebIDL::DataCloneError::create(*m_vm.current_realm(), "out of memory"_string);
             value = JS::ArrayBuffer::create(*realm, bytes_or_error.release_value());
             break;
         }
@@ -892,7 +892,7 @@ public:
             auto interface_name = TRY(deserialize_string(m_vm, m_serialized, m_position));
             // 2. If the interface identified by interfaceName is not exposed in targetRealm, then throw a "DataCloneError" DOMException.
             if (!is_interface_exposed_on_target_realm(interface_name, realm))
-                return WebIDL::DataCloneError::create(realm, "Unsupported type"_fly_string);
+                return WebIDL::DataCloneError::create(realm, "Unsupported type"_string);
 
             // 3. Set value to a new instance of the interface identified by interfaceName, created in targetRealm.
             value = TRY(create_serialized_type(interface_name, realm));
@@ -1114,7 +1114,7 @@ WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer
         // 1. If transferable has neither an [[ArrayBufferData]] internal slot nor a [[Detached]] internal slot, then throw a "DataCloneError" DOMException.
         // FIXME: Handle transferring ArrayBufferData objects
         if (!is<Bindings::Transferable>(*transferable)) {
-            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot transfer type"_fly_string);
+            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot transfer type"_string);
         }
 
         // FIXME: 2. If transferable has an [[ArrayBufferData]] internal slot and IsSharedArrayBuffer(transferable) is true, then throw a "DataCloneError" DOMException.
@@ -1122,7 +1122,7 @@ WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer
         // 3. If memory[transferable] exists, then throw a "DataCloneError" DOMException.
         auto transferable_value = JS::Value(transferable);
         if (memory.contains(transferable_value)) {
-            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot transfer value twice"_fly_string);
+            return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot transfer value twice"_string);
         }
 
         // 4. Set memory[transferable] to { [[Type]]: an uninitialized value }.
@@ -1144,7 +1144,7 @@ WebIDL::ExceptionOr<SerializedTransferRecord> structured_serialize_with_transfer
         if (is<Bindings::Transferable>(*transferable)) {
             auto& transferable_object = dynamic_cast<Bindings::Transferable&>(*transferable);
             if (transferable_object.is_detached()) {
-                return WebIDL::DataCloneError::create(*vm.current_realm(), "Value already transferred"_fly_string);
+                return WebIDL::DataCloneError::create(*vm.current_realm(), "Value already transferred"_string);
             }
         }
 
@@ -1250,7 +1250,7 @@ WebIDL::ExceptionOr<DeserializedTransferRecord> structured_deserialize_with_tran
 
             // 2. If the interface identified by interfaceName is not exposed in targetRealm, then throw a "DataCloneError" DOMException.
             if (!is_interface_exposed_on_target_realm(interface_name, target_realm))
-                return WebIDL::DataCloneError::create(target_realm, "Unknown type transferred"_fly_string);
+                return WebIDL::DataCloneError::create(target_realm, "Unknown type transferred"_string);
 
             // 3. Set value to a new instance of the interface identified by interfaceName, created in targetRealm.
             // 4. Perform the appropriate transfer-receiving steps for the interface identified by interfaceName given transferDataHolder and value.

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -115,7 +115,7 @@ WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::btoa(String const& d
     byte_string.ensure_capacity(data.bytes().size());
     for (u32 code_point : Utf8View(data)) {
         if (code_point > 0xff)
-            return WebIDL::InvalidCharacterError::create(realm, "Data contains characters outside the range U+0000 and U+00FF"_fly_string);
+            return WebIDL::InvalidCharacterError::create(realm, "Data contains characters outside the range U+0000 and U+00FF"_string);
         byte_string.append(code_point);
     }
 
@@ -135,7 +135,7 @@ WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::atob(String const& d
 
     // 2. If decodedData is failure, then throw an "InvalidCharacterError" DOMException.
     if (decoded_data.is_error())
-        return WebIDL::InvalidCharacterError::create(realm, "Input string is not valid base64 data"_fly_string);
+        return WebIDL::InvalidCharacterError::create(realm, "Input string is not valid base64 data"_string);
 
     // 3. Return decodedData.
     // decode_base64() returns a byte buffer. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -66,7 +66,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {
         dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Invalid URL loaded '{}'.", script_url);
-        return WebIDL::SyntaxError::create(document.realm(), "url is not valid"_fly_string);
+        return WebIDL::SyntaxError::create(document.realm(), "url is not valid"_string);
     }
 
     // 5. Let worker URL be the resulting URL record.

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -104,7 +104,7 @@ WebIDL::ExceptionOr<void> WorkerGlobalScope::import_scripts(Vector<String> const
 
         // 2. If urlRecord is failure, then throw a "SyntaxError" DOMException.
         if (!url_record.is_valid())
-            return WebIDL::SyntaxError::create(realm(), "Invalid URL"_fly_string);
+            return WebIDL::SyntaxError::create(realm(), "Invalid URL"_string);
 
         // 3. Append urlRecord to urlRecords.
         url_records.unchecked_append(url_record);

--- a/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
+++ b/Userland/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
@@ -75,12 +75,12 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
     // 2. If this's observer type is "single" and options's entryTypes member is present, then throw an "InvalidModificationError".
     else if (m_observer_type == ObserverType::Single) {
         if (options.entry_types.has_value())
-            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing a single type to observing multiple types"_fly_string);
+            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing a single type to observing multiple types"_string);
     }
     // 3. If this's observer type is "multiple" and options's type member is present, then throw an "InvalidModificationError".
     else if (m_observer_type == ObserverType::Multiple) {
         if (options.type.has_value())
-            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing multiple types to observing a single type"_fly_string);
+            return WebIDL::InvalidModificationError::create(realm, "Cannot change a PerformanceObserver from observing multiple types to observing a single type"_string);
     }
 
     // 5. Set this's requires dropped entries to true.

--- a/Userland/Libraries/LibWeb/SVG/SVGTransformList.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTransformList.cpp
@@ -21,7 +21,9 @@ JS::NonnullGCPtr<SVGTransformList> SVGTransformList::create(JS::Realm& realm)
 SVGTransformList::~SVGTransformList() = default;
 
 SVGTransformList::SVGTransformList(JS::Realm& realm)
-    : PlatformObject(realm) {};
+    : PlatformObject(realm)
+{
+}
 
 // https://svgwg.org/svg2-draft/single-page.html#types-__svg__SVGNameList__length
 WebIDL::UnsignedLong SVGTransformList::length()
@@ -42,7 +44,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<SVGTransform>> SVGTransformList::get_item(W
 {
     // 1. If index is greater than or equal to the length of the list, then throw an IndexSizeError.
     if (index >= m_transforms.size())
-        return WebIDL::IndexSizeError::create(realm(), "SVGTransformList index out of bounds"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "SVGTransformList index out of bounds"_string);
     // 2. Return the element in the list at position index.
     return m_transforms.at(index);
 }

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -124,7 +124,7 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Range>> Selection::get_range_at(unsigned inde
 {
     // The method must throw an IndexSizeError exception if index is not 0, or if this is empty.
     if (index != 0 || is_empty())
-        return WebIDL::IndexSizeError::create(realm(), "Selection.getRangeAt() on empty Selection or with invalid argument"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Selection.getRangeAt() on empty Selection or with invalid argument"_string);
 
     // Otherwise, it must return a reference to (not a copy of) this's range.
     return m_range;
@@ -155,7 +155,7 @@ WebIDL::ExceptionOr<void> Selection::remove_range(JS::NonnullGCPtr<DOM::Range> r
     }
 
     // Otherwise, it must throw a NotFoundError.
-    return WebIDL::NotFoundError::create(realm(), "Selection.removeRange() with invalid argument"_fly_string);
+    return WebIDL::NotFoundError::create(realm(), "Selection.removeRange() with invalid argument"_string);
 }
 
 // https://w3c.github.io/selection-api/#dom-selection-removeallranges
@@ -183,7 +183,7 @@ WebIDL::ExceptionOr<void> Selection::collapse(JS::GCPtr<DOM::Node> node, unsigne
 
     // 2. The method must throw an IndexSizeError exception if offset is longer than node's length and abort these steps.
     if (offset > node->length()) {
-        return WebIDL::IndexSizeError::create(realm(), "Selection.collapse() with offset longer than node's length"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Selection.collapse() with offset longer than node's length"_string);
     }
 
     // 3. If document associated with this is not a shadow-including inclusive ancestor of node, abort these steps.
@@ -214,7 +214,7 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_start()
 {
     // 1. The method must throw InvalidStateError exception if the this is empty.
     if (!m_range) {
-        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_start() on empty range"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_start() on empty range"_string);
     }
 
     // 2. Otherwise, it must create a new range
@@ -234,7 +234,7 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_end()
 {
     // 1. The method must throw InvalidStateError exception if the this is empty.
     if (!m_range) {
-        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_end() on empty range"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Selection.collapse_to_end() on empty range"_string);
     }
 
     // 2. Otherwise, it must create a new range
@@ -259,7 +259,7 @@ WebIDL::ExceptionOr<void> Selection::extend(JS::NonnullGCPtr<DOM::Node> node, un
 
     // 2. If this is empty, throw an InvalidStateError exception and abort these steps.
     if (!m_range) {
-        return WebIDL::InvalidStateError::create(realm(), "Selection.extend() on empty range"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Selection.extend() on empty range"_string);
     }
 
     // 3. Let oldAnchor and oldFocus be the this's anchor and focus, and let newFocus be the boundary point (node, offset).
@@ -304,10 +304,10 @@ WebIDL::ExceptionOr<void> Selection::set_base_and_extent(JS::NonnullGCPtr<DOM::N
 {
     // 1. If anchorOffset is longer than anchorNode's length or if focusOffset is longer than focusNode's length, throw an IndexSizeError exception and abort these steps.
     if (anchor_offset > anchor_node->length())
-        return WebIDL::IndexSizeError::create(realm(), "Anchor offset points outside of the anchor node"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Anchor offset points outside of the anchor node"_string);
 
     if (focus_offset > focus_node->length())
-        return WebIDL::IndexSizeError::create(realm(), "Focus offset points outside of the focus node"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Focus offset points outside of the focus node"_string);
 
     // 2. If document associated with this is not a shadow-including inclusive ancestor of anchorNode or focusNode, abort these steps.
     if (!m_document->is_shadow_including_inclusive_ancestor_of(anchor_node) || !m_document->is_shadow_including_inclusive_ancestor_of(focus_node))

--- a/Userland/Libraries/LibWeb/ServiceWorker/Job.cpp
+++ b/Userland/Libraries/LibWeb/ServiceWorker/Job.cpp
@@ -20,7 +20,7 @@ static void run_job(JS::VM&, JobQueue&);
 static void finish_job(JS::VM&, JS::NonnullGCPtr<Job>);
 static void resolve_job_promise(JS::NonnullGCPtr<Job>, Optional<Registration const&>, JS::Value = JS::js_null());
 template<typename Error>
-static void reject_job_promise(JS::NonnullGCPtr<Job>, FlyString message);
+static void reject_job_promise(JS::NonnullGCPtr<Job>, String message);
 static void register_(JS::VM&, JS::NonnullGCPtr<Job>);
 static void update(JS::VM&, JS::NonnullGCPtr<Job>);
 static void unregister(JS::VM&, JS::NonnullGCPtr<Job>);
@@ -76,7 +76,7 @@ static void register_(JS::VM& vm, JS::NonnullGCPtr<Job> job)
     // 1. If the result of running potentially trustworthy origin with the origin of job’s script url as the argument is Not Trusted, then:
     if (SecureContexts::Trustworthiness::NotTrustworthy == SecureContexts::is_origin_potentially_trustworthy(script_origin)) {
         // 1. Invoke Reject Job Promise with job and "SecurityError" DOMException.
-        reject_job_promise<WebIDL::SecurityError>(job, "Service Worker registration has untrustworthy script origin"_fly_string);
+        reject_job_promise<WebIDL::SecurityError>(job, "Service Worker registration has untrustworthy script origin"_string);
 
         // 2. Invoke Finish Job with job and abort these steps.
         finish_job(vm, job);
@@ -86,7 +86,7 @@ static void register_(JS::VM& vm, JS::NonnullGCPtr<Job> job)
     // 2. If job’s script url's origin and job’s referrer's origin are not same origin, then:
     if (!script_origin.is_same_origin(referrer_origin)) {
         // 1. Invoke Reject Job Promise with job and "SecurityError" DOMException.
-        reject_job_promise<WebIDL::SecurityError>(job, "Service Worker registration has incompatible script and referrer origins"_fly_string);
+        reject_job_promise<WebIDL::SecurityError>(job, "Service Worker registration has incompatible script and referrer origins"_string);
 
         // 2. Invoke Finish Job with job and abort these steps.
         finish_job(vm, job);
@@ -96,7 +96,7 @@ static void register_(JS::VM& vm, JS::NonnullGCPtr<Job> job)
     // 3. If job’s scope url's origin and job’s referrer's origin are not same origin, then:
     if (!scope_origin.is_same_origin(referrer_origin)) {
         // 1. Invoke Reject Job Promise with job and "SecurityError" DOMException.
-        reject_job_promise<WebIDL::SecurityError>(job, "Service Worker registration has incompatible scope and referrer origins"_fly_string);
+        reject_job_promise<WebIDL::SecurityError>(job, "Service Worker registration has incompatible scope and referrer origins"_string);
 
         // 2. Invoke Finish Job with job and abort these steps.
         finish_job(vm, job);
@@ -252,7 +252,7 @@ static void resolve_job_promise(JS::NonnullGCPtr<Job> job, Optional<Registration
 
 // https://w3c.github.io/ServiceWorker/#reject-job-promise-algorithm
 template<typename Error>
-static void reject_job_promise(JS::NonnullGCPtr<Job> job, FlyString message)
+static void reject_job_promise(JS::NonnullGCPtr<Job> job, String message)
 {
     // 1. If job’s client is not null, queue a task, on job’s client's responsible event loop using the DOM manipulation task source,
     //    to reject job’s job promise with a new exception with errorData and a user agent-defined message, in job’s client's Realm.

--- a/Userland/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioBuffer.cpp
@@ -78,7 +78,7 @@ WebIDL::UnsignedLong AudioBuffer::number_of_channels() const
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Float32Array>> AudioBuffer::get_channel_data(WebIDL::UnsignedLong channel) const
 {
     if (channel >= m_channels.size())
-        return WebIDL::IndexSizeError::create(realm(), "Channel index is out of range"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Channel index is out of range"_string);
 
     return m_channels[channel];
 }

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -112,14 +112,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::resume()
     // 1. If this's relevant global object's associated Document is not fully active then return a promise rejected with "InvalidStateError" DOMException.
     auto const& associated_document = verify_cast<HTML::Window>(HTML::relevant_global_object(*this)).associated_document();
     if (!associated_document.is_fully_active())
-        return WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Document is not fully active"_string);
 
     // 2. Let promise be a new Promise.
     auto promise = WebIDL::create_promise(realm);
 
     // 3. If the [[control thread state]] on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
-        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_fly_string));
+        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_string));
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
     }
 
@@ -197,14 +197,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::suspend()
     // 1. If this's relevant global object's associated Document is not fully active then return a promise rejected with "InvalidStateError" DOMException.
     auto const& associated_document = verify_cast<HTML::Window>(HTML::relevant_global_object(*this)).associated_document();
     if (!associated_document.is_fully_active())
-        return WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Document is not fully active"_string);
 
     // 2. Let promise be a new Promise.
     auto promise = WebIDL::create_promise(realm);
 
     // 3. If the [[control thread state]] on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
-        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_fly_string));
+        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_string));
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
     }
 
@@ -254,14 +254,14 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
     // 1. If this's relevant global object's associated Document is not fully active then return a promise rejected with "InvalidStateError" DOMException.
     auto const& associated_document = verify_cast<HTML::Window>(HTML::relevant_global_object(*this)).associated_document();
     if (!associated_document.is_fully_active())
-        return WebIDL::InvalidStateError::create(realm, "Document is not fully active"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Document is not fully active"_string);
 
     // 2. Let promise be a new Promise.
     auto promise = WebIDL::create_promise(realm);
 
     // 3. If the [[control thread state]] flag on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
-        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_fly_string));
+        WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_string));
         return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
     }
 

--- a/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioDestinationNode.cpp
@@ -57,13 +57,13 @@ WebIDL::ExceptionOr<void> AudioDestinationNode::set_channel_count(WebIDL::Unsign
     // exception MUST be thrown for any attempt to set the count outside this range.
     if (is<AudioContext>(*context())) {
         if (channel_count < 1 || channel_count > max_channel_count())
-            return WebIDL::IndexSizeError::create(realm(), "Channel index is out of range"_fly_string);
+            return WebIDL::IndexSizeError::create(realm(), "Channel index is out of range"_string);
     }
 
     // OfflineAudioContext: The channel count cannot be changed. An InvalidStateError exception MUST
     // be thrown for any attempt to change the value.
     if (is<OfflineAudioContext>(*context()))
-        return WebIDL::InvalidStateError::create(realm(), "Cannot change channel count in an OfflineAudioContext"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot change channel count in an OfflineAudioContext"_string);
 
     return AudioNode::set_channel_count(channel_count);
 }

--- a/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioNode.cpp
@@ -29,7 +29,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioNode>> AudioNode::connect(JS::NonnullG
 
     // If the destination parameter is an AudioNode that has been created using another AudioContext, an InvalidAccessError MUST be thrown.
     if (m_context != destination_node->m_context) {
-        return WebIDL::InvalidAccessError::create(realm(), "Cannot connect to an AudioNode in a different AudioContext"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm(), "Cannot connect to an AudioNode in a different AudioContext"_string);
     }
 
     (void)output;
@@ -104,7 +104,7 @@ WebIDL::ExceptionOr<void> AudioNode::set_channel_count(WebIDL::UnsignedLong chan
     // If this value is set to zero or to a value greater than the implementation’s maximum number
     // of channels the implementation MUST throw a NotSupportedError exception.
     if (channel_count == 0 || channel_count > BaseAudioContext::MAX_NUMBER_OF_CHANNELS)
-        return WebIDL::NotSupportedError::create(realm(), "Invalid channel count"_fly_string);
+        return WebIDL::NotSupportedError::create(realm(), "Invalid channel count"_string);
 
     m_channel_count = channel_count;
     return {};

--- a/Userland/Libraries/LibWeb/WebAudio/AudioParam.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioParam.cpp
@@ -91,7 +91,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioParam>> AudioParam::linear_ramp_to_val
 {
     (void)value;
     (void)end_time;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::linear_ramp_to_value_at_time"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::linear_ramp_to_value_at_time"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-exponentialramptovalueattime
@@ -99,7 +99,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioParam>> AudioParam::exponential_ramp_t
 {
     (void)value;
     (void)end_time;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::exponential_ramp_to_value_at_time"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::exponential_ramp_to_value_at_time"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-settargetattime
@@ -108,7 +108,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioParam>> AudioParam::set_target_at_time
     (void)target;
     (void)start_time;
     (void)time_constant;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::set_target_at_time"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::set_target_at_time"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-setvaluecurveattime
@@ -117,21 +117,21 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioParam>> AudioParam::set_value_curve_at
     (void)values;
     (void)start_time;
     (void)duration;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::set_value_curve_at_time"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::set_value_curve_at_time"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelscheduledvalues
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioParam>> AudioParam::cancel_scheduled_values(double cancel_time)
 {
     (void)cancel_time;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::cancel_scheduled_values"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::cancel_scheduled_values"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioparam-cancelandholdattime
 WebIDL::ExceptionOr<JS::NonnullGCPtr<AudioParam>> AudioParam::cancel_and_hold_at_time(double cancel_time)
 {
     (void)cancel_time;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::cancel_and_hold_at_time"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioParam::cancel_and_hold_at_time"_string);
 }
 
 void AudioParam::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/WebAudio/AudioScheduledSourceNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioScheduledSourceNode.cpp
@@ -36,14 +36,14 @@ void AudioScheduledSourceNode::set_onended(JS::GCPtr<WebIDL::CallbackType> value
 WebIDL::ExceptionOr<void> AudioScheduledSourceNode::start(double when)
 {
     (void)when;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioScheduledSourceNode::start"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioScheduledSourceNode::start"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-audioscheduledsourcenode-stop
 WebIDL::ExceptionOr<void> AudioScheduledSourceNode::stop(double when)
 {
     (void)when;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioScheduledSourceNode::stop"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement AudioScheduledSourceNode::stop"_string);
 }
 
 void AudioScheduledSourceNode::initialize(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -99,16 +99,16 @@ WebIDL::ExceptionOr<void> BaseAudioContext::verify_audio_options_inside_nominal_
     // A NotSupportedError exception MUST be thrown if any of the arguments is negative, zero, or outside its nominal range.
 
     if (number_of_channels == 0)
-        return WebIDL::NotSupportedError::create(realm, "Number of channels must not be '0'"_fly_string);
+        return WebIDL::NotSupportedError::create(realm, "Number of channels must not be '0'"_string);
 
     if (number_of_channels > MAX_NUMBER_OF_CHANNELS)
-        return WebIDL::NotSupportedError::create(realm, "Number of channels is greater than allowed range"_fly_string);
+        return WebIDL::NotSupportedError::create(realm, "Number of channels is greater than allowed range"_string);
 
     if (length == 0)
-        return WebIDL::NotSupportedError::create(realm, "Length of buffer must be at least 1"_fly_string);
+        return WebIDL::NotSupportedError::create(realm, "Length of buffer must be at least 1"_string);
 
     if (sample_rate < MIN_SAMPLE_RATE || sample_rate > MAX_SAMPLE_RATE)
-        return WebIDL::NotSupportedError::create(realm, "Sample rate is outside of allowed range"_fly_string);
+        return WebIDL::NotSupportedError::create(realm, "Sample rate is outside of allowed range"_string);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
@@ -34,18 +34,18 @@ OfflineAudioContext::~OfflineAudioContext() = default;
 // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> OfflineAudioContext::start_rendering()
 {
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::start_rendering"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::start_rendering"_string);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> OfflineAudioContext::resume()
 {
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::resume"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::resume"_string);
 }
 
 WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> OfflineAudioContext::suspend(double suspend_time)
 {
     (void)suspend_time;
-    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::suspend"_fly_string);
+    return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::suspend"_string);
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-length

--- a/Userland/Libraries/LibWeb/WebAudio/OscillatorNode.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/OscillatorNode.cpp
@@ -50,7 +50,7 @@ WebIDL::ExceptionOr<void> OscillatorNode::verify_valid_type(JS::Realm& realm, Bi
     // be used to set a custom waveform, which results in this attribute being set to "custom". The default
     // value is "sine". When this attribute is set, the phase of the oscillator MUST be conserved.
     if (type == Bindings::OscillatorType::Custom)
-        return WebIDL::InvalidStateError::create(realm, "Oscillator node type cannot be set to 'custom'"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "Oscillator node type cannot be set to 'custom'"_string);
 
     return {};
 }

--- a/Userland/Libraries/LibWeb/WebAudio/PeriodicWave.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/PeriodicWave.cpp
@@ -16,7 +16,7 @@ JS_DEFINE_ALLOCATOR(PeriodicWave);
 // https://webaudio.github.io/web-audio-api/#dom-periodicwave-periodicwave
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PeriodicWave>> PeriodicWave::construct_impl(JS::Realm& realm, JS::NonnullGCPtr<BaseAudioContext>, PeriodicWaveOptions const&)
 {
-    return WebIDL::NotSupportedError::create(realm, "FIXME: Implement PeriodicWave::construct_impl"_fly_string);
+    return WebIDL::NotSupportedError::create(realm, "FIXME: Implement PeriodicWave::construct_impl"_string);
 }
 
 PeriodicWave::~PeriodicWave() = default;

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.cpp
@@ -12,20 +12,20 @@ namespace Web::WebIDL {
 
 JS_DEFINE_ALLOCATOR(DOMException);
 
-JS::NonnullGCPtr<DOMException> DOMException::create(JS::Realm& realm, FlyString const& name, FlyString const& message)
+JS::NonnullGCPtr<DOMException> DOMException::create(JS::Realm& realm, FlyString name, String message)
 {
-    return realm.heap().allocate<DOMException>(realm, realm, name, message);
+    return realm.heap().allocate<DOMException>(realm, realm, move(name), move(message));
 }
 
-JS::NonnullGCPtr<DOMException> DOMException::construct_impl(JS::Realm& realm, FlyString const& message, FlyString const& name)
+JS::NonnullGCPtr<DOMException> DOMException::construct_impl(JS::Realm& realm, String message, FlyString name)
 {
-    return realm.heap().allocate<DOMException>(realm, realm, name, message);
+    return realm.heap().allocate<DOMException>(realm, realm, move(name), move(message));
 }
 
-DOMException::DOMException(JS::Realm& realm, FlyString const& name, FlyString const& message)
+DOMException::DOMException(JS::Realm& realm, FlyString name, String message)
     : PlatformObject(realm)
-    , m_name(name)
-    , m_message(message)
+    , m_name(move(name))
+    , m_message(move(message))
 {
 }
 

--- a/Userland/Libraries/LibWeb/WebIDL/DOMException.h
+++ b/Userland/Libraries/LibWeb/WebIDL/DOMException.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Diagnostics.h>
-#include <AK/FlyString.h>
+#include <AK/String.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
 
@@ -94,11 +94,11 @@ class DOMException final : public Bindings::PlatformObject {
     JS_DECLARE_ALLOCATOR(DOMException);
 
 public:
-    static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString const& name, FlyString const& message);
+    static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString name, String message);
 
     // JS constructor has message first, name second
     // FIXME: This is a completely pointless footgun, let's use the same order for both factories.
-    static JS::NonnullGCPtr<DOMException> construct_impl(JS::Realm& realm, FlyString const& message, FlyString const& name);
+    static JS::NonnullGCPtr<DOMException> construct_impl(JS::Realm& realm, String message, FlyString name);
 
     virtual ~DOMException() override;
 
@@ -107,7 +107,7 @@ public:
     u16 code() const { return get_legacy_code_for_name(m_name); }
 
 protected:
-    DOMException(JS::Realm&, FlyString const& name, FlyString const& message);
+    DOMException(JS::Realm&, FlyString name, String message);
 
     virtual void initialize(JS::Realm&) override;
 
@@ -116,13 +116,13 @@ private:
     FlyString m_message;
 };
 
-#define __ENUMERATE(ErrorName)                                                                   \
-    class ErrorName final {                                                                      \
-    public:                                                                                      \
-        static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, FlyString const& message) \
-        {                                                                                        \
-            return DOMException::create(realm, #ErrorName##_fly_string, message);                \
-        }                                                                                        \
+#define __ENUMERATE(ErrorName)                                                                \
+    class ErrorName final {                                                                   \
+    public:                                                                                   \
+        static JS::NonnullGCPtr<DOMException> create(JS::Realm& realm, String const& message) \
+        {                                                                                     \
+            return DOMException::create(realm, #ErrorName##_fly_string, message);             \
+        }                                                                                     \
     };
 ENUMERATE_DOM_EXCEPTION_ERROR_NAMES
 #undef __ENUMERATE

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -49,7 +49,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
 
     // 3. If urlRecord is failure, then throw a "SyntaxError" DOMException.
     if (!url_record.is_valid())
-        return WebIDL::SyntaxError::create(realm, "Invalid URL"_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Invalid URL"_string);
 
     // 4. If urlRecord’s scheme is "http", then set urlRecord’s scheme to "ws".
     if (url_record.scheme() == "http"sv)
@@ -60,11 +60,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
 
     // 6. If urlRecord’s scheme is not "ws" or "wss", then throw a "SyntaxError" DOMException.
     if (!url_record.scheme().is_one_of("ws"sv, "wss"sv))
-        return WebIDL::SyntaxError::create(realm, "Invalid protocol"_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Invalid protocol"_string);
 
     // 7. If urlRecord’s fragment is non-null, then throw a "SyntaxError" DOMException.
     if (url_record.fragment().has_value())
-        return WebIDL::SyntaxError::create(realm, "Presence of URL fragment is invalid"_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Presence of URL fragment is invalid"_string);
 
     Vector<String> protocols_sequence;
     // 8. If protocols is a string, set protocols to a sequence consisting of just that string.
@@ -85,10 +85,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebSocket>> WebSocket::construct_impl(JS::R
         // separator characters as defined in [RFC2616] and MUST all be unique strings.
         auto protocol = sorted_protocols[i];
         if (i < sorted_protocols.size() - 1 && protocol == sorted_protocols[i + 1])
-            return WebIDL::SyntaxError::create(realm, "Found a duplicate protocol name in the specified list"_fly_string);
+            return WebIDL::SyntaxError::create(realm, "Found a duplicate protocol name in the specified list"_string);
         for (auto code_point : protocol.code_points()) {
             if (code_point < '\x21' || code_point > '\x7E')
-                return WebIDL::SyntaxError::create(realm, "Found invalid character in subprotocol name"_fly_string);
+                return WebIDL::SyntaxError::create(realm, "Found invalid character in subprotocol name"_string);
         }
     }
 
@@ -191,13 +191,13 @@ WebIDL::ExceptionOr<void> WebSocket::close(Optional<u16> code, Optional<String> 
 {
     // 1. If code is present, but is neither an integer equal to 1000 nor an integer in the range 3000 to 4999, inclusive, throw an "InvalidAccessError" DOMException.
     if (code.has_value() && *code != 1000 && (*code < 3000 || *code > 4099))
-        return WebIDL::InvalidAccessError::create(realm(), "The close error code is invalid"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm(), "The close error code is invalid"_string);
     // 2. If reason is present, then run these substeps:
     if (reason.has_value()) {
         // 1. Let reasonBytes be the result of encoding reason.
         // 2. If reasonBytes is longer than 123 bytes, then throw a "SyntaxError" DOMException.
         if (reason->bytes().size() > 123)
-            return WebIDL::SyntaxError::create(realm(), "The close reason is longer than 123 bytes"_fly_string);
+            return WebIDL::SyntaxError::create(realm(), "The close reason is longer than 123 bytes"_string);
     }
     // 3. Run the first matching steps from the following list:
     auto state = ready_state();
@@ -218,7 +218,7 @@ WebIDL::ExceptionOr<void> WebSocket::send(Variant<JS::Handle<WebIDL::BufferSourc
 {
     auto state = ready_state();
     if (state == Requests::WebSocket::ReadyState::Connecting)
-        return WebIDL::InvalidStateError::create(realm(), "Websocket is still CONNECTING"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Websocket is still CONNECTING"_string);
     if (state == Requests::WebSocket::ReadyState::Open) {
         TRY_OR_THROW_OOM(vm(),
             data.visit(

--- a/Userland/Libraries/LibWeb/WebVTT/VTTRegion.cpp
+++ b/Userland/Libraries/LibWeb/WebVTT/VTTRegion.cpp
@@ -62,7 +62,7 @@ WebIDL::ExceptionOr<void> VTTRegion::set_width(double width)
 {
     // On setting, if the new value is negative or greater than 100, then an IndexSizeError exception must be thrown.
     if (width < 0 || width > 100)
-        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_string);
 
     // Otherwise, the WebVTT region width must be set to the new value.
     m_width = width;
@@ -74,7 +74,7 @@ WebIDL::ExceptionOr<void> VTTRegion::set_region_anchor_x(double region_anchor_x)
 {
     // On setting, if the new value is negative or greater than 100, then an IndexSizeError exception must be thrown.
     if (region_anchor_x < 0 || region_anchor_x > 100)
-        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_string);
 
     // Otherwise, the WebVTT region anchor X distance must be set to the new value.
     m_anchor_x = region_anchor_x;
@@ -86,7 +86,7 @@ WebIDL::ExceptionOr<void> VTTRegion::set_region_anchor_y(double region_anchor_y)
 {
     // On setting, if the new value is negative or greater than 100, then an IndexSizeError exception must be thrown.
     if (region_anchor_y < 0 || region_anchor_y > 100)
-        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_string);
 
     // Otherwise, the WebVTT region anchor Y distance must be set to the new value.
     m_anchor_y = region_anchor_y;
@@ -98,7 +98,7 @@ WebIDL::ExceptionOr<void> VTTRegion::set_viewport_anchor_x(double viewport_ancho
 {
     // On setting, if the new value is negative or greater than 100, then an IndexSizeError exception must be thrown.
     if (viewport_anchor_x < 0 || viewport_anchor_x > 100)
-        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_string);
 
     // Otherwise, the WebVTT region viewport anchor X distance must be set to the new value.
     m_viewport_anchor_x = viewport_anchor_x;
@@ -110,7 +110,7 @@ WebIDL::ExceptionOr<void> VTTRegion::set_viewport_anchor_y(double viewport_ancho
 {
     // On setting, if the new value is negative or greater than 100, then an IndexSizeError exception must be thrown.
     if (viewport_anchor_y < 0 || viewport_anchor_y > 100)
-        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_fly_string);
+        return WebIDL::IndexSizeError::create(realm(), "Value is negative or greater than 100"_string);
 
     // Otherwise, the WebVTT region viewport anchor Y distance must be set to the new value.
     m_viewport_anchor_y = viewport_anchor_y;

--- a/Userland/Libraries/LibWeb/XHR/FormData.cpp
+++ b/Userland/Libraries/LibWeb/XHR/FormData.cpp
@@ -27,7 +27,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<FormData>> FormData::construct_impl(JS::Rea
         auto entry_list = TRY(construct_entry_list(realm, *form));
         // 2. If list is null, then throw an "InvalidStateError" DOMException.
         if (!entry_list.has_value())
-            return WebIDL::InvalidStateError::create(realm, "Form element does not contain any entries."_fly_string);
+            return WebIDL::InvalidStateError::create(realm, "Form element does not contain any entries."_string);
         // 3. Set this’s entry list to list.
         list = entry_list.release_value();
     }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -117,7 +117,7 @@ WebIDL::ExceptionOr<String> XMLHttpRequest::response_text() const
 {
     // 1. If this’s response type is not the empty string or "text", then throw an "InvalidStateError" DOMException.
     if (m_response_type != Bindings::XMLHttpRequestResponseType::Empty && m_response_type != Bindings::XMLHttpRequestResponseType::Text)
-        return WebIDL::InvalidStateError::create(realm(), "XHR responseText can only be used for responseType \"\" or \"text\""_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "XHR responseText can only be used for responseType \"\" or \"text\""_string);
 
     // 2. If this’s state is not loading or done, then return the empty string.
     if (m_state != State::Loading && m_state != State::Done)
@@ -132,7 +132,7 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> XMLHttpRequest::response_xml()
 {
     // 1. If this’s response type is not the empty string or "document", then throw an "InvalidStateError" DOMException.
     if (m_response_type != Bindings::XMLHttpRequestResponseType::Empty && m_response_type != Bindings::XMLHttpRequestResponseType::Document)
-        return WebIDL::InvalidStateError::create(realm(), "XHR responseXML can only be used for responseXML \"\" or \"document\""_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "XHR responseXML can only be used for responseXML \"\" or \"document\""_string);
 
     // 2. If this’s state is not done, then return null.
     if (m_state != State::Done)
@@ -163,11 +163,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_response_type(Bindings::XMLHttpReq
 
     // 2. If this’s state is loading or done, then throw an "InvalidStateError" DOMException.
     if (m_state == State::Loading || m_state == State::Done)
-        return WebIDL::InvalidStateError::create(realm(), "Can't readyState when XHR is loading or done"_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Can't readyState when XHR is loading or done"_string);
 
     // 3. If the current global object is a Window object and this’s synchronous flag is set, then throw an "InvalidAccessError" DOMException.
     if (is<HTML::Window>(HTML::current_global_object()) && m_synchronous)
-        return WebIDL::InvalidAccessError::create(realm(), "Can't set readyState on synchronous XHR in Window environment"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm(), "Can't set readyState on synchronous XHR in Window environment"_string);
 
     // 4. Set this’s response type to the given value.
     m_response_type = response_type;
@@ -421,20 +421,20 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_request_header(String const& name_
 
     // 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Opened)
-        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED"_string);
 
     // 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
     if (m_send)
-        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_string);
 
     // 3. Normalize value.
     auto normalized_value = Fetch::Infrastructure::normalize_header_value(value);
 
     // 4. If name is not a header name or value is not a header value, then throw a "SyntaxError" DOMException.
     if (!Fetch::Infrastructure::is_header_name(name))
-        return WebIDL::SyntaxError::create(realm, "Header name contains invalid characters."_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Header name contains invalid characters."_string);
     if (!Fetch::Infrastructure::is_header_value(value))
-        return WebIDL::SyntaxError::create(realm, "Header value contains invalid characters."_fly_string);
+        return WebIDL::SyntaxError::create(realm, "Header value contains invalid characters."_string);
 
     auto header = Fetch::Infrastructure::Header {
         .name = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(name)),
@@ -466,16 +466,16 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     if (is<HTML::Window>(HTML::relevant_global_object(*this))) {
         auto const& window = static_cast<HTML::Window const&>(HTML::relevant_global_object(*this));
         if (!window.associated_document().is_fully_active())
-            return WebIDL::InvalidStateError::create(realm(), "Invalid state: Window's associated document is not fully active."_fly_string);
+            return WebIDL::InvalidStateError::create(realm(), "Invalid state: Window's associated document is not fully active."_string);
     }
 
     // 2. If method is not a method, then throw a "SyntaxError" DOMException.
     if (!Fetch::Infrastructure::is_method(method))
-        return WebIDL::SyntaxError::create(realm(), "An invalid or illegal string was specified."_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "An invalid or illegal string was specified."_string);
 
     // 3. If method is a forbidden method, then throw a "SecurityError" DOMException.
     if (Fetch::Infrastructure::is_forbidden_method(method))
-        return WebIDL::SecurityError::create(realm(), "Forbidden method, must not be 'CONNECT', 'TRACE', or 'TRACK'"_fly_string);
+        return WebIDL::SecurityError::create(realm(), "Forbidden method, must not be 'CONNECT', 'TRACE', or 'TRACK'"_string);
 
     // 4. Normalize method.
     auto normalized_method = Fetch::Infrastructure::normalize_method(method);
@@ -486,7 +486,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
 
     // 6. If parsedURL is failure, then throw a "SyntaxError" DOMException.
     if (!parsed_url.is_valid())
-        return WebIDL::SyntaxError::create(realm(), "Invalid URL"_fly_string);
+        return WebIDL::SyntaxError::create(realm(), "Invalid URL"_string);
 
     // 7. If the async argument is omitted, set async to true, and set username and password to null.
     // NOTE: This is handled in the overload lacking the async argument.
@@ -506,7 +506,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     if (!async
         && is<HTML::Window>(HTML::current_global_object())
         && (m_timeout != 0 || m_response_type != Bindings::XMLHttpRequestResponseType::Empty)) {
-        return WebIDL::InvalidAccessError::create(realm(), "Synchronous XMLHttpRequests in a Window context do not support timeout or a non-empty responseType"_fly_string);
+        return WebIDL::InvalidAccessError::create(realm(), "Synchronous XMLHttpRequests in a Window context do not support timeout or a non-empty responseType"_string);
     }
 
     // 10. Terminate this’s fetch controller.
@@ -554,11 +554,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
 
     // 1. If this’s state is not opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Opened)
-        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not OPENED"_string);
 
     // 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
     if (m_send)
-        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_string);
 
     // 3. If this’s request method is `GET` or `HEAD`, then set body to null.
     if (m_request_method.is_one_of("GET"sv, "HEAD"sv))
@@ -1032,7 +1032,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::override_mime_type(String const& mime)
 
     // 1. If this’s state is loading or done, then throw an "InvalidStateError" DOMException.
     if (m_state == State::Loading || m_state == State::Done)
-        return WebIDL::InvalidStateError::create(realm(), "Cannot override MIME type when state is Loading or Done."_fly_string);
+        return WebIDL::InvalidStateError::create(realm(), "Cannot override MIME type when state is Loading or Done."_string);
 
     // 2. Set this’s override MIME type to the result of parsing mime.
     m_override_mime_type = TRY_OR_THROW_OOM(vm, MimeSniff::MimeType::parse(mime));
@@ -1050,7 +1050,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_timeout(u32 timeout)
     // 1. If the current global object is a Window object and this’s synchronous flag is set,
     //    then throw an "InvalidAccessError" DOMException.
     if (is<HTML::Window>(HTML::current_global_object()) && m_synchronous)
-        return WebIDL::InvalidAccessError::create(realm(), "Use of XMLHttpRequest's timeout attribute is not supported in the synchronous mode in window context."_fly_string);
+        return WebIDL::InvalidAccessError::create(realm(), "Use of XMLHttpRequest's timeout attribute is not supported in the synchronous mode in window context."_string);
 
     // 2. Set this’s timeout to the given value.
     m_timeout = timeout;
@@ -1075,11 +1075,11 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_with_credentials(bool with_credent
 
     // 1. If this’s state is not unsent or opened, then throw an "InvalidStateError" DOMException.
     if (m_state != State::Unsent && m_state != State::Opened)
-        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not UNSENT or OPENED"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "XHR readyState is not UNSENT or OPENED"_string);
 
     // 2. If this’s send() flag is set, then throw an "InvalidStateError" DOMException.
     if (m_send)
-        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_fly_string);
+        return WebIDL::InvalidStateError::create(realm, "XHR send() flag is already set"_string);
 
     // 3. Set this’s cross-origin credentials to the given value.
     m_cross_origin_credentials = with_credentials;
@@ -1221,15 +1221,15 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::handle_errors()
 
     // 2. If xhr’s timed out flag is set, then run the request error steps for xhr, timeout, and "TimeoutError" DOMException.
     if (m_timed_out)
-        return TRY(request_error_steps(EventNames::timeout, WebIDL::TimeoutError::create(realm(), "Timed out"_fly_string)));
+        return TRY(request_error_steps(EventNames::timeout, WebIDL::TimeoutError::create(realm(), "Timed out"_string)));
 
     // 3. Otherwise, if xhr’s response’s aborted flag is set, run the request error steps for xhr, abort, and "AbortError" DOMException.
     if (m_response->aborted())
-        return TRY(request_error_steps(EventNames::abort, WebIDL::AbortError::create(realm(), "Aborted"_fly_string)));
+        return TRY(request_error_steps(EventNames::abort, WebIDL::AbortError::create(realm(), "Aborted"_string)));
 
     // 4. Otherwise, if xhr’s response is a network error, then run the request error steps for xhr, error, and "NetworkError" DOMException.
     if (m_response->is_network_error())
-        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), "Network error"_fly_string)));
+        return TRY(request_error_steps(EventNames::error, WebIDL::NetworkError::create(realm(), "Network error"_string)));
 
     return {};
 }


### PR DESCRIPTION
There was no need to use FlyString for error messages, and it just caused a bunch of churn since these strings typically only existed during the lifetime of the error.