### PR TITLE
LibWeb: Allow CSS @import rule to import non-UTF-8 style sheets

### DIFF
--- a/Tests/LibWeb/Text/expected/css/import-rule-shift-jis.txt
+++ b/Tests/LibWeb/Text/expected/css/import-rule-shift-jis.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/import-rule-shift-jis.html
+++ b/Tests/LibWeb/Text/input/css/import-rule-shift-jis.html
@@ -1,0 +1,9 @@
+<style>
+    @import "data:text/css;charset=shift_jis;base64,77u/I2RpdjIKewogICAgY29sb3I6IGdyZWVuOwp9Cgoulb2YYQp7CiAgICBjb2xvcjogcmVkOwp9Cg==";
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
This fixes a number of WPT crashes in the /css/CSS2/syntax directory.