### PR TITLE
Meta: Use the correct organization name for the devcontainer base

### DIFF
--- a/.devcontainer/optimized/devcontainer.json
+++ b/.devcontainer/optimized/devcontainer.json
@@ -7,5 +7,5 @@
 // getting you into your development environment faster!
 {
     "name": "Ladybird (Pre-Built Image)",
-    "image": "ghcr.io/ladybirdwebbrowser/ladybird-devcontainer:base"
+    "image": "ghcr.io/ladybirdbrowser/ladybird-devcontainer:base"
 }


### PR DESCRIPTION
The optimized devcontainer workflow downloads an image from the GitHub container registry. Now that we've made that image, which is built in CI, public, it would help to have the correct org name.