### PR TITLE
Meta+Documentation: Require clang-format 18 (not greater)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 **Do:**
 
 * Write in idiomatic project-style C++23, using the `AK` containers in all code.
-* Conform to the project coding style found in [CodingStyle.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 18 or later) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-18.
+* Conform to the project coding style found in [CodingStyle.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 18) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-18.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits (i.e. A commit per feature or fix, where the build, tests and the system are all functioning).
 * Make sure your commits are rebased on the master branch.

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -126,7 +126,7 @@ brew install autoconf autoconf-archive automake ccache cmake ffmpeg nasm ninja p
 
 If you wish to use clang from homebrew instead:
 ```
-brew install llvm
+brew install llvm@18
 ```
 
 If you also plan to use the Qt chrome on macOS:

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 18 or later!**
+**Important: Make sure you use `clang-format` version 18!**
 
 This document describes the coding style used for C++ code in the Ladybird Browser project. All new code should conform to this style.
 

--- a/Documentation/QtCreatorConfiguration.md
+++ b/Documentation/QtCreatorConfiguration.md
@@ -38,7 +38,7 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 ## Auto-Formatting
 
-You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 18, as some OSes will ship older clang-format versions by default.
+You can use `clang-format` to help you with the [style guide](CodingStyle.md). Before you proceed, check that you're actually using clang-format version 18, as some OSes will ship other clang-format versions by default.
 
 - In QtCreator, go to "Help > About Plugins…"
 - Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)

--- a/Documentation/SelfHostedRunners.md
+++ b/Documentation/SelfHostedRunners.md
@@ -22,7 +22,7 @@ sudo add-apt-repository ppa:canonical-server/server-backports
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
 sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main'
 apt update
-apt install git build-essential make cmake clang-format-16 gcc-13 g++-13 libstdc++-13-dev libgmp-dev ccache libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 wabt
+apt install git build-essential make cmake clang-format-18 gcc-13 g++-13 libstdc++-13-dev libgmp-dev ccache libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 wabt
 ```
 ### Force usage of GCC 13
 ```shell

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -39,13 +39,13 @@ if (( ${#files[@]} )); then
         CLANG_FORMAT=$TOOLCHAIN_DIR/clang-format
     elif command -v clang-format >/dev/null 2>&1 ; then
         CLANG_FORMAT=clang-format
-        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) < 18) exit 1; }'; then
-            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 18 or later."
+        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) != 18) exit 1; }'; then
+            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 18."
             echo "It is very likely that the resulting changes are not what you wanted."
         fi
     else
         echo "clang-format-18 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-18."
-        echo "(If you install a package 'clang-format', please make sure it's version 18 or later.)"
+        echo "(If you install a package 'clang-format', please make sure it's version 18.)"
         exit 1
     fi
 


### PR DESCRIPTION
The clang-format version released with llvm 19 will format many files differently than clang-format-18.

These changes should help to avoid accidental usage of version 19 (or greater) before this issue has been resolved.

Fixes #1750 

