### PR TITLE
LibJS: Early return from Date string parsing on empty string

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -152,6 +152,9 @@ static double parse_simplified_iso8601(ByteString const& iso_8601)
 
 static double parse_date_string(VM& vm, ByteString const& date_string)
 {
+    if (date_string.is_empty())
+        return NAN;
+
     auto value = parse_simplified_iso8601(date_string);
     if (isfinite(value))
         return value;


### PR DESCRIPTION
Loading Ladybird on Github results in 37 debug logs about being unable to parse an empty Date string. This log is intended to catch Date formats we do not support to detect web compatability problems, which makes this case not particuarly useful to log.

Instead of trying to parse all of the different date formats and logging that the string is not valid, let's just return NAN immediately.