### PR TITLE
LibWeb: Improve support for resolutions when parsing CSS

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7,6 +7,7 @@
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
  * Copyright (c) 2024, Tommy van der Vorst <tommy@pixelspark.nl>
  * Copyright (c) 2024, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2024, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8437,7 +8438,8 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
                 values.append({ NumericCalculationNode::create(dimension->length()) });
             else if (dimension->is_percentage())
                 values.append({ NumericCalculationNode::create(dimension->percentage()) });
-            // FIXME: Resolutions, once calc() supports them.
+            else if (dimension->is_resolution())
+                values.append({ NumericCalculationNode::create(dimension->resolution()) });
             else if (dimension->is_time())
                 values.append({ NumericCalculationNode::create(dimension->time()) });
             else if (dimension->is_flex()) {

--- a/Userland/Libraries/LibWeb/CSS/Resolution.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Resolution.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2024, Glenn Skrzypczak <glenn.skrzypczak@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -56,7 +57,7 @@ Optional<Resolution::Type> Resolution::unit_from_name(StringView name)
         return Type::Dpi;
     } else if (name.equals_ignoring_ascii_case("dpcm"sv)) {
         return Type::Dpcm;
-    } else if (name.equals_ignoring_ascii_case("dppx"sv)) {
+    } else if (name.equals_ignoring_ascii_case("dppx"sv) || name.equals_ignoring_ascii_case("x"sv)) {
         return Type::Dppx;
     }
     return {};


### PR DESCRIPTION
This adds support for the 'x' unit and parsing a calculation with resolutions. 

As a result http://wpt.live/css/css-values/round-mod-rem-invalid.html passes.