### PR TITLE
LibWeb: Compare navigable active_url with fragments included

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1289,7 +1289,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         // 1. If url equals navigable's active document's URL,
         //     and initiatorOriginSnapshot is same origin with targetNavigable's active document's origin,
         //     then set historyHandling to "replace".
-        if (url.equals(active_document.url(), URL::ExcludeFragment::Yes) && initiator_origin_snapshot.is_same_origin(active_document.origin()))
+        if (url == active_document.url() && initiator_origin_snapshot.is_same_origin(active_document.origin()))
             history_handling = Bindings::NavigationHistoryBehavior::Replace;
 
         // 2. Otherwise, set historyHandling to "push".


### PR DESCRIPTION
This was previously negated due to a misread of https://url.spec.whatwg.org/#concept-url-equals. This change fixes a bunch of WPT crashes such as "/html/browsers/history/the-history-interface/001".

No regression test because this requires the HTTP protocol to manifest the crash.