### PR TITLE
LibWeb: Handle unpaired surrogates in File and Blob constructors

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1414,19 +1414,23 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
         }
 
-        bool includes_string = false;
+        RefPtr<IDL::Type const> string_type;
         for (auto& type : types) {
             if (type->is_string()) {
-                includes_string = true;
+                string_type = type;
                 break;
             }
         }
 
-        if (includes_string) {
+        if (string_type) {
             // 14. If types includes a string type, then return the result of converting V to that type.
             // NOTE: Currently all string types are converted to String.
+
+            IDL::Parameter parameter { .type = *string_type, .name = ByteString::empty(), .optional_default_value = {}, .extended_attributes = {} };
+            generate_to_cpp(union_generator, parameter, js_name, js_suffix, ByteString::formatted("{}{}_string", js_name, js_suffix), interface, false, false, {}, false, recursion_depth + 1);
+
             union_generator.append(R"~~~(
-        return TRY(@js_name@@js_suffix@.to_string(vm));
+        return { @js_name@@js_suffix@_string };
 )~~~");
         } else if (numeric_type && includes_bigint) {
             // 15. If types includes a numeric type and bigint, then return the result of converting V to either that numeric type or bigint.

--- a/Tests/LibWeb/Text/expected/FileAPI/unpaired-surrogates-in-constructor.txt
+++ b/Tests/LibWeb/Text/expected/FileAPI/unpaired-surrogates-in-constructor.txt
@@ -1,0 +1,2 @@
+PASS
+PASS

--- a/Tests/LibWeb/Text/input/FileAPI/unpaired-surrogates-in-constructor.html
+++ b/Tests/LibWeb/Text/input/FileAPI/unpaired-surrogates-in-constructor.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const unpairedSurrogates = "hello\uDC00friends\uD800:)";
+        const replacedSurrogates = "hello\uFFFDfriends\uFFFD:)";
+
+        const blob = new Blob([unpairedSurrogates]);
+        println(await blob.text() === replacedSurrogates ? "PASS" : "FAIL")
+
+        const file = new File([unpairedSurrogates], "someFileName");
+        println(await file.text() === replacedSurrogates ? "PASS" : "FAIL")
+
+        done();
+    });
+</script>


### PR DESCRIPTION
This should fix the last two remaining WPT test failures in FileAPI/unicode.html.