### PR TITLE
Meta: Add a vcpkg cache to the devcontainer 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,13 @@
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
         "./features/ladybird": {
-            "llvm_version": 18,
+            "llvm_version": 18
+        },
+        "./features/vcpkg-cache": {
+            "release_triplet": true,
+            // FIXME: Figure out how to have the CI prebuilt version set both of these true
+            "debug_triplet": false,
+            "sanitizer_triplet": false
         },
         "ghcr.io/devcontainers/features/desktop-lite": {
             "password": "vscode",
@@ -44,17 +50,15 @@
                     "Toolchain/Local/**": true,
                     "Toolchain/Tarballs/**": true,
                     "Toolchain/Build/**": true,
-                    "Build/**": true,
+                    "Build/**": true
                 },
                 "search.exclude": {
                     "**/.git": true,
                     "Toolchain/Local/**": true,
                     "Toolchain/Tarballs/**": true,
                     "Toolchain/Build/**": true,
-                    "Build/**": true,
+                    "Build/**": true
                 },
-                // Force clang-format to respect Ladybird's .clang-format style file. This is not necessary if you're not using the Microsoft C++ extension.
-                "C_Cpp.clang_format_style": "file",
                 // Tab settings
                 "editor.tabSize": 4,
                 "editor.useTabStops": false,

--- a/.devcontainer/features/vcpkg-cache/devcontainer-feature.json
+++ b/.devcontainer/features/vcpkg-cache/devcontainer-feature.json
@@ -1,0 +1,27 @@
+{
+    "name": "Caches Ladybird's vcpkg dependencies",
+    "id": "vcpkg-cache",
+    "version": "1.0.0",
+    "description": "Create a prebuilt vcpkg binary cache for Ladybird developer use",
+    "installsAfter": [ "./features/ladybird" ],
+    "containerEnv": {
+        "VCPKG_BINARY_SOURCES": ";files,/usr/local/share/vcpkg-binary-cache,read"
+    },
+    "options": {
+        "release_triplet": {
+            "type": "boolean",
+            "default": true,
+            "description": "Build vcpkg dependencies with release configuration"
+        },
+        "debug_triplet": {
+            "type": "boolean",
+            "default": false,
+            "description": "Build vcpkg dependencies with debug configuration"
+        },
+        "sanitizer_triplet": {
+            "type": "boolean",
+            "default": false,
+            "description": "Build vcpkg dependencies with sanitizer configuration"
+        }
+    }
+}

--- a/.devcontainer/features/vcpkg-cache/install.sh
+++ b/.devcontainer/features/vcpkg-cache/install.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Prebuild ladybird's vcpkg dependencies
+set -e
+
+# FIXME: Add some options to make this more flexible and usable by other projects
+# FIXME: Find a way to do this without cloning ladybird
+
+cd /tmp
+
+CACHE_DIR=/usr/local/share/vcpkg-binary-cache
+mkdir -p ${CACHE_DIR}
+
+# Clone ladybird to get access to vcpkg.json and vcpkg commit id
+git clone https://github.com/LadybirdBrowser/ladybird.git --depth 1
+cd ladybird
+# Grab and bootstrap the exact commit of vcpkg that trunk is using
+python3 ./Toolchain/BuildVcpkg.py
+
+# Install the vcpkg.json in manifest mode from the root of the repo
+# Set the binary cache directory to the one we intend to use at container runtime
+export VCPKG_ROOT="${PWD}/Toolchain/Tarballs/vcpkg"
+export VCPKG_BINARY_SOURCES="clear;files,${CACHE_DIR},readwrite"
+
+# Check options to see which versions we should build
+if [ "${RELEASE_TRIPLET}" = "true" ]; then
+    ./Toolchain/Local/vcpkg/bin/vcpkg install --overlay-triplets="${PWD}/Meta/CMake/vcpkg/release-triplets"
+fi
+
+if [ "${DEBUG_TRIPLET}" = "true" ]; then
+    ./Toolchain/Local/vcpkg/bin/vcpkg install --overlay-triplets="${PWD}/Meta/CMake/vcpkg/debug-triplets"
+fi
+
+if [ "${SANITIZER_TRIPLET}" = "true" ]; then
+    ./Toolchain/Local/vcpkg/bin/vcpkg install --overlay-triplets="${PWD}/Meta/CMake/vcpkg/sanitizer-triplets"
+fi
+
+# Clean up to reduce layer size
+cd /tmp
+rm -rf ladybird

--- a/.github/workflows/dev-container.yml
+++ b/.github/workflows/dev-container.yml
@@ -6,6 +6,7 @@ on:
   push:
     paths:
       - '.devcontainer/**'
+      - 'vcpkg.json'
   schedule:
     # https://crontab.guru/#0_0_*_*_1
     - cron:  '0 0 * * 1'

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -14,14 +14,14 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo",
         "SERENITY_CACHE_DIR": "${fileDir}/Build/caches",
-        "CMAKE_TOOLCHAIN_FILE": "${fileDir}/Toolchain/Tarballs/vcpkg/scripts/buildsystems/vcpkg.cmake",
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
         "VCPKG_INSTALL_OPTIONS": "--no-print-usage",
         "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/release-triplets"
       },
       "environment": {
         "LADYBIRD_SOURCE_DIR": "${fileDir}",
         "VCPKG_ROOT": "${fileDir}/Toolchain/Tarballs/vcpkg",
-        "VCPKG_BINARY_SOURCES": "clear;files,${fileDir}/Toolchain/Build/vcpkg-binary-cache,readwrite"
+        "VCPKG_BINARY_SOURCES": "clear;files,${fileDir}/Toolchain/Build/vcpkg-binary-cache,readwrite;$penv{VCPKG_BINARY_SOURCES}"
       },
       "vendor": {
         "jetbrains.com/clion": {


### PR DESCRIPTION
This also means that the prebuilt devcontainer will have a populated
vcpkg binary cache, speeding up the first build by a lot.

It would be nice to be able to have only the prebuilt container also cache binary artifacts for a debug and sanitizer build as well, but I've left that for a future FIXME.

@joshspicer Since you added the prebuilt image for us when this was the SerenityOS devcontainer, do you know if there's a straightforward way to set different devcontainer feature flags for a devcontainer/ci action run vs a local devcontainer build? I want extra caching for the prebuilt vs a developer creating the container locally. ... preferably without duplicating the entire devcontainer.json as like, devcontainer-ci.json.


Also I'm not 100% convinced that a devcontainer feature is the most elegant way to add the vcpkg binary cache... perhaps a real Dockerfile would be a better approach, since it could(?) have the ladybird repo as context instead of just the .devcontainer folder.