### PR TITLE
LibWeb: Implement initial constraint validation support with ValidityState.valueMissing

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/ValidityState-valueMissing.txt
+++ b/Tests/LibWeb/Text/expected/HTML/ValidityState-valueMissing.txt
@@ -1,0 +1,25 @@
+text (required) - Initial valueMissing: true
+text (required) - After setting value - valueMissing: false
+text (required) - After clearing value - valueMissing: true
+text (optional) - Initial valueMissing: false
+text (optional) - After setting value - valueMissing: false
+text (optional) - After clearing value - valueMissing: false
+checkbox (required) - Initial valueMissing: true
+checkbox (required) - After setting value - valueMissing: false
+checkbox (required) - After clearing value - valueMissing: true
+radio (required) - Initial valueMissing: true
+radio (required) - After setting value - valueMissing: false
+radio (required) - After clearing value - valueMissing: true
+number (required) - Initial valueMissing: true
+number (required) - After setting value - valueMissing: true
+number (required) - After clearing value - valueMissing: true
+date (required) - Initial valueMissing: true
+date (required) - After setting value - valueMissing: true
+date (required) - After clearing value - valueMissing: true
+textOptional - valueMissing when empty: false
+text (required) - Disabled - valueMissing: false
+text (optional) - Disabled - valueMissing: false
+checkbox (required) - Disabled - valueMissing: true
+radio (required) - Disabled - valueMissing: true
+number (required) - Disabled - valueMissing: false
+date (required) - Disabled - valueMissing: false

--- a/Tests/LibWeb/Text/input/HTML/ValidityState-valueMissing.html
+++ b/Tests/LibWeb/Text/input/HTML/ValidityState-valueMissing.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<div id="container">
+    <input id="textRequired" type="text" required>
+    <input id="textOptional" type="text">
+    <input id="checkboxRequired" type="checkbox" required>
+    <input id="radioRequired" type="radio" name="radioGroup" required>
+    <input id="numberRequired" type="number" required>
+    <input id="dateRequired" type="date" required>
+</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const elements = [
+            { id: 'textRequired', type: 'text (required)' },
+            { id: 'textOptional', type: 'text (optional)' },
+            { id: 'checkboxRequired', type: 'checkbox (required)' },
+            { id: 'radioRequired', type: 'radio (required)' },
+            { id: 'numberRequired', type: 'number (required)' },
+            { id: 'dateRequired', type: 'date (required)' },
+        ];
+
+        function testElement(el, elementType) {
+            println(`${elementType} - Initial valueMissing: ${el.validity.valueMissing}`);
+
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                el.checked = true;
+            } else {
+                el.value = 'test';
+            }
+
+            println(`${elementType} - After setting value - valueMissing: ${el.validity.valueMissing}`);
+
+            if (el.type === 'checkbox' || el.type === 'radio') {
+                el.checked = false;
+            } else {
+                el.value = '';
+            }
+
+            println(`${elementType} - After clearing value - valueMissing: ${el.validity.valueMissing}`);
+        }
+
+        // Test all elements in normal state
+        for (let element of elements) {
+            const el = document.getElementById(element.id);
+            testElement(el, element.type);
+        }
+
+        // Test non-required elements
+        const nonRequiredElements = ['textOptional'];
+        for (let id of nonRequiredElements) {
+            const el = document.getElementById(id);
+            println(`${id} - valueMissing when empty: ${el.validity.valueMissing}`);
+        }
+
+        // Test with disabled state
+        for (let element of elements) {
+            const el = document.getElementById(element.id);
+            el.disabled = true;
+            println(`${element.type} - Disabled - valueMissing: ${el.validity.valueMissing}`);
+            el.disabled = false;
+        }
+
+        document.getElementById("container").remove();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -297,6 +297,7 @@ set(SOURCES
     HTML/DecodedImageData.cpp
     HTML/DedicatedWorkerGlobalScope.cpp
     HTML/DocumentState.cpp
+    HTML/ConstraintValidation.cpp
     HTML/DOMParser.cpp
     HTML/DOMStringList.cpp
     HTML/DOMStringMap.cpp

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -372,6 +372,7 @@ class ClassicScript;
 class CloseEvent;
 class CloseWatcher;
 class CloseWatcherManager;
+class ConstraintValidation;
 class CustomElementDefinition;
 class CustomElementRegistry;
 class DataTransfer;

--- a/Userland/Libraries/LibWeb/HTML/ConstraintValidation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ConstraintValidation.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Benjamin Bjerken <beuss-git@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/HTML/ConstraintValidation.h>
+#include <LibWeb/HTML/ValidityState.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validity
+JS::NonnullGCPtr<ValidityState const> ConstraintValidation::validity(DOM::Element const& element) const
+{
+    if (!m_validity) {
+        auto& vm = element.vm();
+        auto& realm = element.realm();
+        m_validity = vm.heap().allocate<ValidityState>(realm, realm, *this);
+    }
+
+    return *m_validity;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-willvalidate
+bool ConstraintValidation::will_validate(DOM::Element const& element) const
+{
+    dbgln("(STUBBED) ConstraintValidation::will_validate(). Called on: {}", element.debug_description());
+    return false;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-setcustomvalidity
+void ConstraintValidation::set_custom_validity(String const& error, DOM::Element const& element)
+{
+    (void)error;
+    dbgln("(STUBBED) ConstraintValidation::set_custom_validity(). Called on: {}", element.debug_description());
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
+WebIDL::ExceptionOr<bool> ConstraintValidation::check_validity(DOM::Element const& element)
+{
+    dbgln("(STUBBED) ConstraintValidation::check_validity(). Called on: {}", element.debug_description());
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity
+WebIDL::ExceptionOr<bool> ConstraintValidation::report_validity(DOM::Element const& element)
+{
+    dbgln("(STUBBED) ConstraintValidation::report_validity(). Called on: {}", element.debug_description());
+    return true;
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-validationmessage
+String ConstraintValidation::validation_message(DOM::Element const& element) const
+{
+    dbgln("(STUBBED) ConstraintValidation::validation_message(). Called on: {}", element.debug_description());
+    return {};
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#candidate-for-constraint-validation
+bool ConstraintValidation::is_candidate_for_constraint_validation(DOM::Element const& element) const
+{
+    dbgln("(STUBBED) ConstraintValidation::is_candidate_for_constraint_validation(). Called on: {}", element.debug_description());
+    return true;
+}
+}

--- a/Userland/Libraries/LibWeb/HTML/ConstraintValidation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ConstraintValidation.cpp
@@ -6,6 +6,8 @@
 
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/HTML/ConstraintValidation.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLDataListElement.h>
 #include <LibWeb/HTML/ValidityState.h>
 
 namespace Web::HTML {
@@ -60,7 +62,29 @@ String ConstraintValidation::validation_message(DOM::Element const& element) con
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#candidate-for-constraint-validation
 bool ConstraintValidation::is_candidate_for_constraint_validation(DOM::Element const& element) const
 {
-    dbgln("(STUBBED) ConstraintValidation::is_candidate_for_constraint_validation(). Called on: {}", element.debug_description());
-    return true;
+    VERIFY(is<FormAssociatedElement>(element));
+
+    auto const& form_associated_element = dynamic_cast<FormAssociatedElement const&>(element);
+
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#definitions
+    // A submittable element is a candidate for constraint validation...
+    if (!form_associated_element.is_submittable()) {
+        return false;
+    }
+
+    // NOTE: These two checks are valid for all (form associated) elements,
+    // so we write them here instead of in the specific implementation of is_barred_from_constraint_validation() for each element.
+
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute
+    if (element.is_actually_disabled()) {
+        return false;
+    }
+
+    // https://html.spec.whatwg.org/multipage/form-elements.html#the-datalist-element:barred-from-constraint-validation
+    if (element.first_ancestor_of_type<HTML::HTMLDataListElement>()) {
+        return false;
+    }
+
+    return !is_barred_from_constraint_validation();
 }
 }

--- a/Userland/Libraries/LibWeb/HTML/ConstraintValidation.h
+++ b/Userland/Libraries/LibWeb/HTML/ConstraintValidation.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024, Benjamin Bjerken <beuss-git@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Heap/GCPtr.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::HTML {
+
+#define CONSTRAINT_VALIDATION_IMPL()                                                                           \
+    JS::NonnullGCPtr<ValidityState const> validity() const { return ConstraintValidation::validity(*this); }   \
+    bool will_validate() const { return ConstraintValidation::will_validate(*this); }                          \
+    void set_custom_validity(String const& error) { ConstraintValidation::set_custom_validity(error, *this); } \
+    WebIDL::ExceptionOr<bool> check_validity() { return ConstraintValidation::check_validity(*this); }         \
+    WebIDL::ExceptionOr<bool> report_validity() { return ConstraintValidation::report_validity(*this); }       \
+    String validation_message() const { return ConstraintValidation::validation_message(*this); }
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#the-constraint-validation-api
+class ConstraintValidation {
+public:
+    virtual ~ConstraintValidation() = default;
+
+    JS::NonnullGCPtr<ValidityState const> validity(DOM::Element const&) const;
+    bool will_validate(DOM::Element const&) const;
+    void set_custom_validity(String const&, DOM::Element const&);
+    WebIDL::ExceptionOr<bool> check_validity(DOM::Element const&);
+    WebIDL::ExceptionOr<bool> report_validity(DOM::Element const&);
+    String validation_message(DOM::Element const& element) const;
+
+    friend class ValidityState;
+
+protected:
+    bool is_candidate_for_constraint_validation(DOM::Element const& element) const;
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#barred-from-constraint-validation
+    virtual bool is_barred_from_constraint_validation() const { return false; }
+
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#constraints
+    virtual bool is_value_missing() const { return false; }
+    virtual bool is_type_mismatch() const { return false; }
+    virtual bool is_pattern_mismatch() const { return false; }
+    virtual bool is_too_long() const { return false; }
+    virtual bool is_too_short() const { return false; }
+    virtual bool is_range_underflow() const { return false; }
+    virtual bool is_range_overflow() const { return false; }
+    virtual bool is_step_mismatch() const { return false; }
+    virtual bool is_bad_input() const { return false; }
+    bool has_custom_error() const { return !m_custom_validity_error_message.is_empty(); }
+    bool is_valid() const
+    {
+        return !is_value_missing()
+            && !is_type_mismatch()
+            && !is_pattern_mismatch()
+            && !is_too_long()
+            && !is_too_short()
+            && !is_range_underflow()
+            && !is_range_underflow()
+            && !is_step_mismatch()
+            && !is_bad_input()
+            && !has_custom_error();
+    }
+
+    String custom_validity_error_message() const { return m_custom_validity_error_message; }
+
+    mutable JS::GCPtr<ValidityState const> m_validity;
+
+private:
+    String m_custom_validity_error_message;
+};
+}

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -13,6 +13,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/FileAPI/FileList.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
+#include <LibWeb/HTML/ConstraintValidation.h>
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
@@ -50,6 +51,7 @@ namespace Web::HTML {
 class HTMLInputElement final
     : public HTMLElement
     , public FormAssociatedTextControlElement
+    , public ConstraintValidation
     , public DOM::EditableTextNodeOwner
     , public Layout::ImageProvider {
     WEB_PLATFORM_OBJECT(HTMLInputElement, HTMLElement);
@@ -144,9 +146,11 @@ public:
     WebIDL::ExceptionOr<void> step_up(WebIDL::Long n = 1);
     WebIDL::ExceptionOr<void> step_down(WebIDL::Long n = 1);
 
-    WebIDL::ExceptionOr<bool> check_validity();
-    WebIDL::ExceptionOr<bool> report_validity();
-    void set_custom_validity(String const&);
+    // ^ConstraintValidation
+    CONSTRAINT_VALIDATION_IMPL();
+
+    virtual bool is_barred_from_constraint_validation() const override;
+    virtual bool is_value_missing() const override;
 
     WebIDL::ExceptionOr<void> show_picker();
 
@@ -186,8 +190,6 @@ public:
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&) override;
 
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
-
-    JS::NonnullGCPtr<ValidityState const> validity() const;
 
     // ^HTMLElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-label

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <LibWeb/HTML/ConstraintValidation.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLOptionsCollection.h>
@@ -19,7 +20,8 @@ namespace Web::HTML {
 
 class HTMLSelectElement final
     : public HTMLElement
-    , public FormAssociatedElement {
+    , public FormAssociatedElement
+    , public ConstraintValidation {
     WEB_PLATFORM_OBJECT(HTMLSelectElement, HTMLElement);
     JS_DECLARE_ALLOCATOR(HTMLSelectElement);
     FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLSelectElement)
@@ -93,6 +95,10 @@ public:
     void did_select_item(Optional<u32> const& id);
 
     void update_selectedness();
+
+    CONSTRAINT_VALIDATION_IMPL();
+
+    virtual bool is_value_missing() const override;
 
 private:
     HTMLSelectElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -1,6 +1,7 @@
 #import <HTML/HTMLElement.idl>
 #import <HTML/HTMLFormElement.idl>
 #import <HTML/HTMLOptionsCollection.idl>
+#import <HTML/ValidityState.idl>
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#htmlselectelement
 [Exposed=Window]
@@ -31,7 +32,7 @@ interface HTMLSelectElement : HTMLElement {
     attribute DOMString value;
 
     [FIXME] readonly attribute boolean willValidate;
-    [FIXME] readonly attribute ValidityState validity;
+    readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
     [FIXME] boolean checkValidity();
     [FIXME] boolean reportValidity();

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.cpp
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2024, Benjamin Bjerken <beuss-git@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ValidityStatePrototype.h>
+#include <LibWeb/HTML/ConstraintValidation.h>
 #include <LibWeb/HTML/ValidityState.h>
 
 namespace Web::HTML {
@@ -22,6 +24,72 @@ void ValidityState::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(ValidityState);
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-missing
+bool ValidityState::value_missing() const
+{
+    return m_associated_element.is_value_missing();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-type-mismatch
+bool ValidityState::type_mismatch() const
+{
+    return m_associated_element.is_type_mismatch();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-pattern-mismatch
+bool ValidityState::pattern_mismatch() const
+{
+    return m_associated_element.is_pattern_mismatch();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-too-long
+bool ValidityState::too_long() const
+{
+    return m_associated_element.is_too_long();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-being-too-short
+bool ValidityState::too_short() const
+{
+    return m_associated_element.is_too_short();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-an-underflow
+bool ValidityState::range_underflow() const
+{
+    return m_associated_element.is_range_underflow();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-an-overflow
+bool ValidityState::range_overflow() const
+{
+    return m_associated_element.is_range_overflow();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-step-mismatch
+bool ValidityState::step_mismatch() const
+{
+    return m_associated_element.is_step_mismatch();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-bad-input
+bool ValidityState::bad_input() const
+{
+    return m_associated_element.is_bad_input();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-custom-error
+bool ValidityState::custom_error() const
+{
+    return m_associated_element.has_custom_error();
+}
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-valid
+bool ValidityState::valid() const
+{
+    return m_associated_element.is_valid();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.cpp
@@ -12,8 +12,9 @@ namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(ValidityState);
 
-ValidityState::ValidityState(JS::Realm& realm)
+ValidityState::ValidityState(JS::Realm& realm, ConstraintValidation const& associated_element)
     : PlatformObject(realm)
+    , m_associated_element(associated_element)
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.h
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2024, Benjamin Bjerken <beuss-git@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,6 +18,18 @@ class ValidityState final : public Bindings::PlatformObject {
 
 public:
     virtual ~ValidityState() override = default;
+
+    bool value_missing() const;
+    bool type_mismatch() const;
+    bool pattern_mismatch() const;
+    bool too_long() const;
+    bool too_short() const;
+    bool range_underflow() const;
+    bool range_overflow() const;
+    bool step_mismatch() const;
+    bool bad_input() const;
+    bool custom_error() const;
+    bool valid() const;
 
 private:
     ValidityState(JS::Realm&, ConstraintValidation const& associated_element);

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.h
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.h
@@ -19,9 +19,11 @@ public:
     virtual ~ValidityState() override = default;
 
 private:
-    ValidityState(JS::Realm&);
+    ValidityState(JS::Realm&, ConstraintValidation const& associated_element);
 
     virtual void initialize(JS::Realm&) override;
+
+    ConstraintValidation const& m_associated_element;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/ValidityState.idl
+++ b/Userland/Libraries/LibWeb/HTML/ValidityState.idl
@@ -1,7 +1,7 @@
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#validitystate
 [Exposed=Window]
 interface ValidityState {
-    [FIXME] readonly attribute boolean valueMissing;
+    readonly attribute boolean valueMissing;
     [FIXME] readonly attribute boolean typeMismatch;
     [FIXME] readonly attribute boolean patternMismatch;
     [FIXME] readonly attribute boolean tooLong;


### PR DESCRIPTION
This PR introduces basic framework for form constraint validation in LibWeb. I have implemented the `valueMissing` attribute of `ValidityState` for both `HTMLInputElement` and `HTMLSelectElement` as a proof of concept as I want to get your thoughts on the implementation before I commit to further work on it because I am not entirely sold on my `ConstraintValidation` class.

**Key changes:**
- Add `ConstraintValidation` class that form-associated elements can inherit from to implement the API
- Update `HTMLInputElement` and `HTMLSelectElement` to inherit from `ConstraintValidation`
- Implement `ValidityState`'s `valueMissing` attribute for `HTMLInputElement` and `HTMLSelectElement`
- Add tests for `ValidityState.valueMissing` behavior

**Notes and considerations:**
1. This implementation re-evaluates each attribute on every access. A future improvement would be to keep track of state and only update when the element value changes, but this adds a lot of potential complexity.

2. The `ConstraintValidation` class is introduced as a separate entity that form-associated elements implementing the constraints API will need to inherit from. A `CONSTRAINT_VALIDATION_IMPL()` macro is provided to easily implement the API methods in new elements.

3. The `m_validity` ValidityState object is part of the `ConstraintValidation` class, which requires visiting it in the implementing classes (e.g., `HTMLInputElement` and `HTMLSelectElement`).

An alternative approach could be to create a new constraint-validated `FormAssociatedElement`/`FormAssociatedTextControlElement` class instead of the current implementation. This would require more extensive changes but could lead to a cleaner architecture. I'd appreciate your thoughts on this.

This PR aims to establish a foundation for constraint validation that is easy to expand on. Support for other attributes and form-associated elements can be added incrementally in future PRs.

I tried my best to align the changes with existing code practices, but I am sure there is something I missed.
As a first-time contributor I am interested in any and all feedback! 