### PR TITLE
LibWeb: Insert title as first child on setting title of svg document

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Document-svg-title-element-first-child.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-svg-title-element-first-child.txt
@@ -1,0 +1,1 @@
+title == title

--- a/Tests/LibWeb/Text/input/DOM/Document-svg-title-element-first-child.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-svg-title-element-first-child.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        var SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+        var doc = document.implementation.createDocument(SVG_NAMESPACE, "svg", null);
+        var child = doc.createElementNS(SVG_NAMESPACE, "x-child");
+        doc.documentElement.appendChild(child);
+        doc.title = "foo";
+        println(`title == ${doc.documentElement.firstChild.tagName}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -923,7 +923,7 @@ WebIDL::ExceptionOr<void> Document::set_title(String const& title)
             element = TRY(DOM::create_element(*this, HTML::TagNames::title, Namespace::SVG));
 
             // 2. Insert element as the first child of the document element.
-            document_element->insert_before(*element, nullptr);
+            document_element->insert_before(*element, document_element->first_child());
         }
 
         // 3. String replace all with the given value within element.


### PR DESCRIPTION
Makes the two failing tests pass: https://wpt.fyi/results/html/dom/documents/dom-tree-accessors/document.title-09.html?product=ladybird