### PR TITLE
LibWeb: Remove BrowsingContext pointer from Paintable

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -308,7 +308,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mouseup(Badge<Eve
             break;
 
         case HTML::HTMLMediaElement::MouseTrackingComponent::Volume:
-            browsing_context().page().client().page_did_stop_tooltip_override();
+            document().page().client().page_did_stop_tooltip_override();
             break;
         }
 
@@ -361,7 +361,7 @@ MediaPaintable::DispatchEventOfSameName MediaPaintable::handle_mousemove(Badge<E
                 set_volume(media_element, *cached_layout_boxes.volume_scrub_rect, position_adjusted_by_scroll_offset);
 
                 auto volume = static_cast<u8>(media_element.volume() * 100.0);
-                browsing_context().page().client().page_did_request_tooltip_override({ position_adjusted_by_scroll_offset.x(), cached_layout_boxes.volume_scrub_rect->y() + scroll_offset.y() }, ByteString::formatted("{}%", volume));
+                document().page().client().page_did_request_tooltip_override({ position_adjusted_by_scroll_offset.x(), cached_layout_boxes.volume_scrub_rect->y() + scroll_offset.y() }, ByteString::formatted("{}%", volume));
             }
 
             break;

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -14,7 +14,6 @@ namespace Web::Painting {
 
 Paintable::Paintable(Layout::Node const& layout_node)
     : m_layout_node(layout_node)
-    , m_browsing_context(const_cast<HTML::BrowsingContext&>(layout_node.browsing_context()))
 {
     auto& computed_values = layout_node.computed_values();
     if (layout_node.is_grid_item() && computed_values.z_index().has_value()) {
@@ -42,7 +41,6 @@ void Paintable::visit_edges(Cell::Visitor& visitor)
     TreeNode::visit_edges(visitor);
     visitor.visit(m_dom_node);
     visitor.visit(m_layout_node);
-    visitor.visit(m_browsing_context);
     if (m_containing_block.has_value())
         visitor.visit(m_containing_block.value());
 }
@@ -66,16 +64,6 @@ JS::GCPtr<DOM::Node> Paintable::dom_node()
 JS::GCPtr<DOM::Node const> Paintable::dom_node() const
 {
     return m_dom_node;
-}
-
-HTML::BrowsingContext const& Paintable::browsing_context() const
-{
-    return m_browsing_context;
-}
-
-HTML::BrowsingContext& Paintable::browsing_context()
-{
-    return m_browsing_context;
 }
 
 JS::GCPtr<HTML::Navigable> Paintable::navigable() const

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -198,9 +198,6 @@ public:
 
     bool visible_for_hit_testing() const { return computed_values().pointer_events() != CSS::PointerEvents::None; }
 
-    [[nodiscard]] HTML::BrowsingContext const& browsing_context() const;
-    [[nodiscard]] HTML::BrowsingContext& browsing_context();
-
     JS::GCPtr<HTML::Navigable> navigable() const;
 
     virtual void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes);
@@ -255,7 +252,6 @@ protected:
 private:
     JS::GCPtr<DOM::Node> m_dom_node;
     JS::NonnullGCPtr<Layout::Node const> m_layout_node;
-    JS::NonnullGCPtr<HTML::BrowsingContext> m_browsing_context;
     Optional<JS::GCPtr<PaintableBox>> mutable m_containing_block;
 
     OwnPtr<StackingContext> m_stacking_context;


### PR DESCRIPTION
It's no longer needed.