### PR TITLE
Meta: Replace deprecated pre-commit stage name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
+minimum_pre_commit_version: 3.2.0
 repos:
   - repo: local
     hooks:
       - id: meta-lint-ci
         name: Running Meta/lint-ci.sh to ensure changes will pass linting on CI
         entry: bash Meta/lint-ci.sh
-        stages: [ commit ]
+        stages: [ pre-commit ]
         language: system
 
       - id: meta-lint-commit


### PR DESCRIPTION
Since [pre-commit v4.0.0](https://github.com/pre-commit/pre-commit/releases/tag/v4.0.0) The CLI warns you, that the stage name `commit` is deprecated and you should use `pre-commit`

(See also https://github.com/pre-commit/pre-commit/issues/2732)

```
[WARNING] hook id `meta-lint-ci` uses deprecated stage names (commit) which will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
```


The stage name `pre-commit` is already supported since [pre-commit v3.2.0](https://github.com/pre-commit/pre-commit/releases/tag/v3.2.0) that released in 2023-03-17

So this should be available to everyone, to be sure, I also set the  config `minimum_pre_commit_version` to `3.2.0` as this version is the first to support the `pre-commit` stage
