### PR TITLE
LibWeb: Minor adjustments relating to Navigables & fragment scrolling

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2309,6 +2309,25 @@ void Document::scroll_to_the_fragment()
     }
 }
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#try-to-scroll-to-the-fragment
+void Document::try_to_scroll_to_the_fragment()
+{
+    // FIXME: According to the spec we should only scroll here if document has no parser or parsing has stopped.
+    //        It should be ok to remove this after we implement navigation events and scrolling will happen in
+    //        "process scroll behavior".
+    //  To try to scroll to the fragment for a Document document, perform the following steps in parallel:
+    //  1. Wait for an implementation-defined amount of time. (This is intended to allow the user agent to
+    //     optimize the user experience in the face of performance concerns.)
+    //  2. Queue a global task on the navigation and traversal task source given document's relevant global
+    //     object to run these steps:
+    //      1. If document has no parser, or its parser has stopped parsing, or the user agent has reason to
+    //         believe the user is no longer interested in scrolling to the fragment, then abort these steps.
+    //      2. Scroll to the fragment given document.
+    //      3. If document's indicated part is still null, then try to scroll to the fragment for document.
+
+    scroll_to_the_fragment();
+}
+
 // https://drafts.csswg.org/cssom-view-1/#scroll-to-the-beginning-of-the-document
 void Document::scroll_to_the_beginning_of_the_document()
 {
@@ -4377,11 +4396,8 @@ void Document::update_for_history_step_application(JS::NonnullGCPtr<HTML::Sessio
 
     // 8. If documentIsNew is true, then:
     if (document_is_new) {
-        // FIXME: 1. Try to scroll to the fragment for document.
-        // FIXME: According to the spec we should only scroll here if document has no parser or parsing has stopped.
-        //        It should be ok to remove this after we implement navigation events and scrolling will happen in
-        //        "process scroll behavior".
-        scroll_to_the_fragment();
+        // 1. Try to scroll to the fragment for document.
+        try_to_scroll_to_the_fragment();
 
         // 2. At this point scripts may run for the newly-created document document.
         m_ready_to_run_scripts = true;

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -347,6 +347,7 @@ public:
     Element const* target_element() const { return m_target_element.ptr(); }
     void set_target_element(Element*);
 
+    void try_to_scroll_to_the_fragment();
     void scroll_to_the_fragment();
     void scroll_to_the_beginning_of_the_document();
 

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1178,7 +1178,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
         //            header specifying the attachment disposition type, then:
         // 6. Otherwise, if navigationParams's response's status is not 204 and is not 205, then set entry's document state's document to the result of
         //    loading a document given navigationParams, sourceSnapshotParams, and entry's document state's initiator origin.
-        else if (navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->response->status() != 204 && navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->response->status() != 205) {
+        else if (auto const& response = navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->response; response->status() != 204 && response->status() != 205) {
             auto document = load_document(navigation_params.get<JS::NonnullGCPtr<NavigationParams>>());
             entry->document_state()->set_document(document);
         }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -983,11 +983,10 @@ bool Navigation::inner_navigate_event_firing_algorithm(
         && destination->same_document()
         && (user_involvement != UserNavigationInvolvement::BrowserUI || relevant_global_object.has_history_action_activation());
 
-    // FIXME: Fix spec grammaro, extra 'the -> set'
     // 11. If either:
     //      - navigationType is not "traverse"; or
     //      - traverseCanBeCanceled is true
-    //     the initialize event's cancelable to true. Otherwise, initialize it to false.
+    //     then initialize event's cancelable to true. Otherwise, initialize it to false.
     event_init.cancelable = (navigation_type != Bindings::NavigationType::Traverse) || traverse_can_be_canceled;
 
     // 12. Initialize event's type to "navigate".

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -560,9 +560,24 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
             // 6. Let oldOrigin be targetEntry's document state's origin.
             auto old_origin = target_entry->document_state()->origin();
 
-            // FIXME: 7. If navigable is not traversable, and targetEntry is not navigable's current session history entry,
-            //    and oldOrigin is the same as navigable's current session history entry's document state's origin,
-            //    then fire a traverse navigate event given targetEntry and userInvolvementForNavigateEvents.
+            // 7. If all of the following are true:
+            //   * navigable is not traversable;
+            //   * targetEntry is not navigable's current session history entry; and
+            //   * oldOrigin is the same as navigable's current session history entry's document state's origin,
+            // then:
+            if (!navigable->is_traversable()
+                && target_entry != navigable->current_session_history_entry()
+                && old_origin == navigable->current_session_history_entry()->document_state()->origin()) {
+
+                // 1. Assert: userInvolvementForNavigateEvents is not null.
+                VERIFY(user_involvement_for_navigate_events.has_value());
+
+                // 2. Let navigation be navigable's active window's navigation API.
+                auto navigation = active_window()->navigation();
+
+                // 3. Fire a traverse navigate event at navigation given targetEntry and userInvolvementForNavigateEvents.
+                navigation->fire_a_traverse_navigate_event(*target_entry, *user_involvement_for_navigate_events);
+            }
 
             auto after_document_populated = [old_origin, changing_navigable_continuation, &changing_navigable_continuations, &vm, &navigable](bool populated_cloned_target_she, JS::NonnullGCPtr<SessionHistoryEntry> target_entry) mutable {
                 changing_navigable_continuation->populated_target_entry = target_entry;


### PR DESCRIPTION
Minor changes as I have been working towards trying to figure out how to get `scroll_to_the_fragment` to fire at the correct time to fix a WPT test I have been working on (which also included finding the same fix as https://github.com/LadybirdBrowser/ladybird/pull/1759 which sin-ack has merged in).