### PR TITLE
LibJS: Cache symbolicated stack frames on ExecutionContext

### DIFF
--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
@@ -43,7 +44,7 @@ public:
     // If your code relies on the decoded character being equivalent to the re-encoded character, use the `UTF8View::validate()`
     // method on the view prior to using its iterator.
     size_t underlying_code_point_length_in_bytes() const;
-    ReadonlyBytes underlying_code_point_bytes() const;
+    ReadonlyBytes underlying_code_point_bytes() const { return { m_ptr, underlying_code_point_length_in_bytes() }; }
     bool done() const { return m_length == 0; }
 
 private:
@@ -92,7 +93,15 @@ public:
 
     unsigned char const* bytes() const { return begin_ptr(); }
     size_t byte_length() const { return m_string.length(); }
-    size_t byte_offset_of(Utf8CodePointIterator const&) const;
+
+    [[nodiscard]] size_t byte_offset_of(Utf8CodePointIterator const& it) const
+    {
+        VERIFY(it.m_ptr >= begin_ptr());
+        VERIFY(it.m_ptr <= end_ptr());
+
+        return it.m_ptr - begin_ptr();
+    }
+
     size_t byte_offset_of(size_t code_point_offset) const;
 
     Utf8View substring_view(size_t byte_offset, size_t byte_length) const { return Utf8View { m_string.substring_view(byte_offset, byte_length) }; }
@@ -213,6 +222,92 @@ template<>
 struct Formatter<Utf8View> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder&, Utf8View const&);
 };
+
+inline Utf8CodePointIterator& Utf8CodePointIterator::operator++()
+{
+    VERIFY(m_length > 0);
+
+    // OPTIMIZATION: Fast path for ASCII characters.
+    if (*m_ptr <= 0x7F) {
+        m_ptr += 1;
+        m_length -= 1;
+        return *this;
+    }
+
+    size_t code_point_length_in_bytes = underlying_code_point_length_in_bytes();
+    if (code_point_length_in_bytes > m_length) {
+        // We don't have enough data for the next code point. Skip one character and try again.
+        // The rest of the code will output replacement characters as needed for any eventual extension bytes we might encounter afterwards.
+        dbgln_if(UTF8_DEBUG, "Expected code point size {} is too big for the remaining length {}. Moving forward one byte.", code_point_length_in_bytes, m_length);
+        m_ptr += 1;
+        m_length -= 1;
+        return *this;
+    }
+
+    m_ptr += code_point_length_in_bytes;
+    m_length -= code_point_length_in_bytes;
+    return *this;
+}
+
+inline size_t Utf8CodePointIterator::underlying_code_point_length_in_bytes() const
+{
+    VERIFY(m_length > 0);
+    auto [code_point_length_in_bytes, value, first_byte_makes_sense] = Utf8View::decode_leading_byte(*m_ptr);
+
+    // If any of these tests fail, we will output a replacement character for this byte and treat it as a code point of size 1.
+    if (!first_byte_makes_sense)
+        return 1;
+
+    if (code_point_length_in_bytes > m_length)
+        return 1;
+
+    for (size_t offset = 1; offset < code_point_length_in_bytes; offset++) {
+        if (m_ptr[offset] >> 6 != 2)
+            return 1;
+    }
+
+    return code_point_length_in_bytes;
+}
+
+inline u32 Utf8CodePointIterator::operator*() const
+{
+    VERIFY(m_length > 0);
+
+    // OPTIMIZATION: Fast path for ASCII characters.
+    if (*m_ptr <= 0x7F)
+        return *m_ptr;
+
+    auto [code_point_length_in_bytes, code_point_value_so_far, first_byte_makes_sense] = Utf8View::decode_leading_byte(*m_ptr);
+
+    if (!first_byte_makes_sense) {
+        // The first byte of the code point doesn't make sense: output a replacement character
+        dbgln_if(UTF8_DEBUG, "First byte doesn't make sense: {:#02x}.", m_ptr[0]);
+        return 0xFFFD;
+    }
+
+    if (code_point_length_in_bytes > m_length) {
+        // There is not enough data left for the full code point: output a replacement character
+        dbgln_if(UTF8_DEBUG, "Not enough bytes (need {}, have {}), first byte is: {:#02x}.", code_point_length_in_bytes, m_length, m_ptr[0]);
+        return 0xFFFD;
+    }
+
+    for (size_t offset = 1; offset < code_point_length_in_bytes; offset++) {
+        if (m_ptr[offset] >> 6 != 2) {
+            // One of the extension bytes of the code point doesn't make sense: output a replacement character
+            dbgln_if(UTF8_DEBUG, "Extension byte {:#02x} in {} position after first byte {:#02x} doesn't make sense.", m_ptr[offset], offset, m_ptr[0]);
+            return 0xFFFD;
+        }
+
+        code_point_value_so_far <<= 6;
+        code_point_value_so_far |= m_ptr[offset] & 63;
+    }
+
+    if (code_point_value_so_far > 0x10FFFF) {
+        dbgln_if(UTF8_DEBUG, "Multi-byte sequence is otherwise valid, but code point {:#x} is not permissible.", code_point_value_so_far);
+        return 0xFFFD;
+    }
+    return code_point_value_so_far;
+}
 
 }
 

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -156,6 +156,7 @@ class Accessor;
 struct AsyncGeneratorRequest;
 class BigInt;
 class BoundFunction;
+struct CachedSourceRange;
 class Cell;
 class CellAllocator;
 class ClassExpression;

--- a/Userland/Libraries/LibJS/Runtime/Error.h
+++ b/Userland/Libraries/LibJS/Runtime/Error.h
@@ -19,7 +19,7 @@ struct TracebackFrame {
     DeprecatedFlyString function_name;
     [[nodiscard]] SourceRange const& source_range() const;
 
-    mutable Variant<SourceRange, UnrealizedSourceRange> source_range_storage;
+    RefPtr<CachedSourceRange> cached_source_range;
 };
 
 enum CompactTraceback {

--- a/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
+++ b/Userland/Libraries/LibJS/Runtime/ExecutionContext.h
@@ -21,6 +21,16 @@ namespace JS {
 
 using ScriptOrModule = Variant<Empty, NonnullGCPtr<Script>, NonnullGCPtr<Module>>;
 
+struct CachedSourceRange : public RefCounted<CachedSourceRange> {
+    CachedSourceRange(size_t program_counter, Variant<UnrealizedSourceRange, SourceRange> source_range)
+        : program_counter(program_counter)
+        , source_range(move(source_range))
+    {
+    }
+    size_t program_counter { 0 };
+    Variant<UnrealizedSourceRange, SourceRange> source_range;
+};
+
 // 9.4 Execution Contexts, https://tc39.es/ecma262/#sec-execution-contexts
 struct ExecutionContext {
     static NonnullOwnPtr<ExecutionContext> create();
@@ -49,6 +59,9 @@ public:
     GCPtr<Cell> context_owner;
 
     Optional<size_t> program_counter;
+
+    mutable RefPtr<CachedSourceRange> cached_source_range;
+
     GCPtr<PrimitiveString> function_name;
     Value this_value;
 
@@ -82,7 +95,7 @@ public:
 
 struct StackTraceElement {
     ExecutionContext* execution_context;
-    Optional<UnrealizedSourceRange> source_range;
+    RefPtr<CachedSourceRange> source_range;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -731,7 +731,7 @@ struct [[gnu::packed]] NativeStackFrame {
 };
 #endif
 
-static Optional<UnrealizedSourceRange> get_source_range(ExecutionContext const* context)
+static RefPtr<CachedSourceRange> get_source_range(ExecutionContext const* context)
 {
     // native function
     if (!context->executable)
@@ -740,7 +740,14 @@ static Optional<UnrealizedSourceRange> get_source_range(ExecutionContext const* 
     if (!context->program_counter.has_value())
         return {};
 
-    return context->executable->source_range_at(context->program_counter.value());
+    if (!context->cached_source_range
+        || context->cached_source_range->program_counter != context->program_counter.value()) {
+        auto unrealized_source_range = context->executable->source_range_at(context->program_counter.value());
+        context->cached_source_range = adopt_ref(*new CachedSourceRange(
+            context->program_counter.value(),
+            move(unrealized_source_range)));
+    }
+    return context->cached_source_range;
 }
 
 Vector<StackTraceElement> VM::stack_trace() const
@@ -750,7 +757,7 @@ Vector<StackTraceElement> VM::stack_trace() const
         auto* context = m_execution_context_stack[i];
         stack_trace.append({
             .execution_context = context,
-            .source_range = get_source_range(context).value_or({}),
+            .source_range = get_source_range(context),
         });
     }
 


### PR DESCRIPTION
Instead of re-symbolicating entire stacks from scratch every time
we want a JS VM backtrace, we now use the ExecutionContext object as
cache storage via a new CachedSourceRange object.
    
This means that once a stack frame has been symbolicated, we don't
have to resymbolicate it again (unless the program counter moves
within that stack frame).
    
This drastically reduces time spent in symbolication in some WPT tests.

(+bonus commit making the hot parts of Utf8View inline)