### PR TITLE
LibMedia: Handle EOF as end of stream in FFmpegLoader

### DIFF
--- a/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
+++ b/Userland/Libraries/LibWeb/Platform/AudioCodecPluginAgnostic.cpp
@@ -46,8 +46,8 @@ ErrorOr<NonnullOwnPtr<AudioCodecPluginAgnostic>> AudioCodecPluginAgnostic::creat
             VERIFY(format == Audio::PcmSampleFormat::Float32);
 
             auto samples_result = loader->get_more_samples(sample_count);
-
             if (samples_result.is_error()) {
+                dbgln("Error while loading samples: {}", samples_result.error());
                 plugin.on_decoder_error(MUST(String::formatted("Decoding failure: {}", samples_result.error())));
                 return buffer.trim(0);
             }


### PR DESCRIPTION
This makes https://playbiolab.com/ a bit more stable!