### PR TITLE
LibWeb/CSS: Correct initial value for gaps

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -874,13 +874,13 @@
   "column-gap": {
     "animation-type": "by-computed-value",
     "inherited": false,
-    "initial": "auto",
+    "initial": "normal",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
-      "auto"
+      "normal"
     ],
     "percentages-resolve-to": "length"
   },
@@ -1274,14 +1274,14 @@
   },
   "gap": {
     "inherited": false,
-    "initial": "auto",
+    "initial": "normal",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "max-values": 2,
     "valid-identifiers": [
-      "auto"
+      "normal"
     ],
     "percentages-resolve-to": "length",
     "longhands": [
@@ -2290,13 +2290,13 @@
   "row-gap": {
     "animation-type": "by-computed-value",
     "inherited": false,
-    "initial": "auto",
+    "initial": "normal",
     "valid-types": [
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
-      "auto"
+      "normal"
     ],
     "percentages-resolve-to": "length"
   },

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -139,6 +139,13 @@ CSS::Size StyleProperties::size_value(CSS::PropertyID id) const
         switch (value->to_keyword()) {
         case Keyword::Auto:
             return CSS::Size::make_auto();
+        case Keyword::Normal:
+            if (id == CSS::PropertyID::Gap || id == CSS::PropertyID::ColumnGap || id == CSS::PropertyID::RowGap) {
+                // FIXME: Context based value, assign `1em` if container has multiple columns:
+                // https://drafts.csswg.org/css-align/#valdef-row-gap-normal
+                return CSS::Size::make_px(0);
+            }
+            VERIFY_NOT_REACHED();
         case Keyword::MinContent:
             return CSS::Size::make_min_content();
         case Keyword::MaxContent:


### PR DESCRIPTION
# Why

Should address some of the following WPT tests related to `gap`, `column-gap` and `row-gap` initial value:
* https://wpt.fyi/results/css/css-align/gaps?label=experimental&product=chrome&product=ladybird

Currently, the definition sets the initial value to `auto`, which is incorrect according to the spec:
* https://drafts.csswg.org/css-align/#gaps

# How

Sets the initial value of `gap`, `column-gap` and `row-gap` properties to `"normal"`. 

Add dedicated handler in `size_value`, but since its [value resolution is context-based](https://drafts.csswg.org/css-align/#valdef-row-gap-normal), I have set it to default variant (`0px`), and left a comment with link to the spec stating that when used in multiple-column container, the values should be set to `1em`.

Since it's my first PR, I'm not sure if such approach is correct. Please let me know if the problem should be handled differently.

# Preview

![Screenshot 2024-10-14 at 21 08 04](https://github.com/user-attachments/assets/43760236-b31b-4e60-a70b-324f0de06bb3)
