### PR TITLE
Tests: Use Swift.String extension instead of manual conversion

### DIFF
--- a/Tests/LibWeb/TestLibWebSwiftBindings.swift
+++ b/Tests/LibWeb/TestLibWebSwiftBindings.swift
@@ -17,8 +17,7 @@ struct TestLibWebSwiftBindings {
         #expect(Web.Bindings.NavigationType.Push.rawValue == 0)
 
         let end = Web.Bindings.idl_enum_to_string(Web.Bindings.ScrollLogicalPosition.End)
-        let end_view = end.__bytes_as_string_viewUnsafe().bytes()
-        let end_string = Swift.String(bytes: end_view, encoding: .utf8)!
+        let end_string = Swift.String(akString: end)!
 
         #expect(end_string == "end")
     }


### PR DESCRIPTION
This fixes a build error with Swift 6.0 on macOS.