### PR TITLE
LibWeb/CSS: If possible, simplify `min()` and `max()` calculations

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
@@ -667,6 +667,10 @@ MinCalculationNode::~MinCalculationNode() = default;
 
 String MinCalculationNode::to_string() const
 {
+    if (m_values.size() == 1) {
+        return m_values[0]->to_string();
+    }
+
     StringBuilder builder;
     builder.append("min("sv);
     for (size_t i = 0; i < m_values.size(); ++i) {
@@ -764,6 +768,10 @@ MaxCalculationNode::~MaxCalculationNode() = default;
 
 String MaxCalculationNode::to_string() const
 {
+    if (m_values.size() == 1) {
+        return m_values[0]->to_string();
+    }
+
     StringBuilder builder;
     builder.append("max("sv);
     for (size_t i = 0; i < m_values.size(); ++i) {


### PR DESCRIPTION
# Why

According to the spec, the `min()` and `max()` calculation can be simplified, if there is only one child:
* https://www.w3.org/TR/css-values-4/#calc-simplification (see 5.2)

Should fix few WPT tests, for example:
* https://wpt.fyi/results/css/css-values/minmax-length-percent-computed.html?label=experimental&product=chrome&product=ladybird

# How

Return the sole child string value directly in `to_string` calls on `MinCalculationNode` and `MaxCalculationNode` nodes.

# Preview

![Screenshot 2024-10-14 at 23 14 19](https://github.com/user-attachments/assets/ee4fff4b-61d1-43cc-8b62-e6d15388d935)
