### PR TITLE
LibWasm: Reject indirect calls to external function references

### DIFF
--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.cpp
@@ -2109,8 +2109,8 @@ VALIDATE_INSTRUCTION(call_indirect)
     TRY(validate(args.type));
 
     auto& table = m_context.tables[args.table.value()];
-    if (!table.element_type().is_reference())
-        return Errors::invalid("table element type for call.indirect"sv, "a reference type"sv, table.element_type());
+    if (table.element_type().kind() != ValueType::FunctionReference)
+        return Errors::invalid("table element type for call.indirect"sv, "a function reference"sv, table.element_type());
 
     auto& type = m_context.types[args.type.value()];
 


### PR DESCRIPTION
This fixes a test in the WebAssembly spec test suite that was added in https://github.com/WebAssembly/spec/commit/924c1f816d30c760bd4b66a9cf8d8f83f7f9ac2c