### PR TITLE
Qt: Disable deprecated-declarations flag on Qt >= 6.8

### DIFF
--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -62,7 +62,11 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     m_match_case = new QCheckBox(this);
     m_match_case->setText("Match &Case");
     m_match_case->setChecked(false);
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_match_case, &QCheckBox::checkStateChanged, this, [this] {
+#else
     connect(m_match_case, &QCheckBox::stateChanged, this, [this] {
+#endif
         find_text_changed();
     });
 

--- a/Ladybird/Qt/SettingsDialog.cpp
+++ b/Ladybird/Qt/SettingsDialog.cpp
@@ -62,7 +62,11 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
 
     m_enable_do_not_track = new QCheckBox(this);
     m_enable_do_not_track->setChecked(Settings::the()->enable_do_not_track());
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    QObject::connect(m_enable_do_not_track, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     QObject::connect(m_enable_do_not_track, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_do_not_track(state == Qt::Checked);
     });
 
@@ -73,7 +77,11 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
         m_enable_autoplay->setChecked(Settings::the()->enable_autoplay());
     }
 
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    QObject::connect(m_enable_autoplay, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     QObject::connect(m_enable_autoplay, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_autoplay(state == Qt::Checked);
     });
 
@@ -129,12 +137,20 @@ void SettingsDialog::setup_search_engines()
     m_autocomplete_engine_dropdown->setMenu(autocomplete_engine_menu);
     m_autocomplete_engine_dropdown->setEnabled(Settings::the()->enable_autocomplete());
 
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_enable_search, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     connect(m_enable_search, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_search(state == Qt::Checked);
         m_search_engine_dropdown->setEnabled(state == Qt::Checked);
     });
 
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    connect(m_enable_autocomplete, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
     connect(m_enable_autocomplete, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
         Settings::the()->set_enable_autocomplete(state == Qt::Checked);
         m_autocomplete_engine_dropdown->setEnabled(state == Qt::Checked);
     });


### PR DESCRIPTION
Qt 6.8 deprecated `QCheckbox::stateChanged` function and some distros like Arch Linux updated the qt6-base package to this version causing an error during the build with `-Wno-error=deprecated-declarations` flag.

```
ninja: Entering directory `/home/gear/sources/ladybird/Build/ladybird'
[0/2] Re-checking globbed directories...
[1/4] Building CXX object Ladybird/Qt/CMakeFiles/ladybird.dir/SettingsDialog.cpp.o
FAILED: Ladybird/Qt/CMakeFiles/ladybird.dir/SettingsDialog.cpp.o
/usr/bin/ccache /usr/bin/c++ -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_WIDGETS_LIB -D_FILE_OFFSET_BITS=64 -I/home/gear/sources/ladybird/Build/ladybird/Ladybird/Qt/ladybird_autogen/include -I/home/gear/sources/ladybird -I/home/gear/sources/ladybird/Userland/Services -I/home/gear/sources/ladybird/Userland/Libraries -I/home/gear/sources/ladybird/Build/ladybird/Lagom -I/home/gear/sources/ladybird/Build/ladybird/Lagom/Userland/Services -I/home/gear/sources/ladybird/Build/ladybird/Lagom/Userland/Libraries -I/home/gear/sources/ladybird/Build/ladybird/Ladybird -I/home/gear/sources/ladybird/Userland -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /home/gear/sources/ladybird/Build/ladybird/vcpkg_installed/x64-linux/include -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtWidgets -O2 -g -DNDEBUG -std=c++23 -fdiagnostics-color=always -Wall -Wextra -fno-exceptions -ffp-contract=off -Wcast-qual -Wformat=2 -Wimplicit-fallthrough -Wmissing-declarations -Wsuggest-override -Wno-invalid-offsetof -Wno-unknown-warning-option -Wno-unused-command-line-argument -Werror -Wno-expansion-to-defined -Wno-literal-suffix -Wno-dangling-reference -fno-semantic-interposition -fvisibility-inlines-hidden -fstack-protector-strong -fstrict-flex-arrays=2 -Wno-maybe-uninitialized -Wno-shorten-64-to-32 -fsigned-char -ggnu-pubnames -fPIC -O2 -g1 -Wno-user-defined-literals -mno-direct-extern-access -MD -MT Ladybird/Qt/CMakeFiles/ladybird.dir/SettingsDialog.cpp.o -MF Ladybird/Qt/CMakeFiles/ladybird.dir/SettingsDialog.cpp.o.d -o Ladybird/Qt/CMakeFiles/ladybird.dir/SettingsDialog.cpp.o -c /home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp
/home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp: In constructor ‘Ladybird::SettingsDialog::SettingsDialog(QMainWindow*)’:
/home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp:65:57: error: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Werror=deprecated-declarations]
   65 |     QObject::connect(m_enable_do_not_track, &QCheckBox::stateChanged, this, [&](int state) {
      |                                                         ^~~~~~~~~~~~
In file included from /usr/include/qt6/QtWidgets/QCheckBox:1,
                 from /home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.h:8,
                 from /home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp:8:
/usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
   41 |     void stateChanged(int);
      |          ^~~~~~~~~~~~
/home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp:76:53: error: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Werror=deprecated-declarations]
   76 |     QObject::connect(m_enable_autoplay, &QCheckBox::stateChanged, this, [&](int state) {
      |                                                     ^~~~~~~~~~~~
/usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
   41 |     void stateChanged(int);
      |          ^~~~~~~~~~~~
/home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp: In member function ‘void Ladybird::SettingsDialog::setup_search_engines()’:
/home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp:132:42: error: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Werror=deprecated-declarations]
  132 |     connect(m_enable_search, &QCheckBox::stateChanged, this, [&](int state) {
      |                                          ^~~~~~~~~~~~
/usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
   41 |     void stateChanged(int);
      |          ^~~~~~~~~~~~
/home/gear/sources/ladybird/Ladybird/Qt/SettingsDialog.cpp:137:48: error: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Werror=deprecated-declarations]
  137 |     connect(m_enable_autocomplete, &QCheckBox::stateChanged, this, [&](int state) {
      |                                                ^~~~~~~~~~~~
/usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
   41 |     void stateChanged(int);
      |          ^~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-user-defined-literals’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-shorten-64-to-32’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-unused-command-line-argument’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
[2/4] Building CXX object Ladybird/Qt/CMakeFiles/ladybird.dir/FindInPageWidget.cpp.o
FAILED: Ladybird/Qt/CMakeFiles/ladybird.dir/FindInPageWidget.cpp.o
/usr/bin/ccache /usr/bin/c++ -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_DEBUG -DQT_WIDGETS_LIB -D_FILE_OFFSET_BITS=64 -I/home/gear/sources/ladybird/Build/ladybird/Ladybird/Qt/ladybird_autogen/include -I/home/gear/sources/ladybird -I/home/gear/sources/ladybird/Userland/Services -I/home/gear/sources/ladybird/Userland/Libraries -I/home/gear/sources/ladybird/Build/ladybird/Lagom -I/home/gear/sources/ladybird/Build/ladybird/Lagom/Userland/Services -I/home/gear/sources/ladybird/Build/ladybird/Lagom/Userland/Libraries -I/home/gear/sources/ladybird/Build/ladybird/Ladybird -I/home/gear/sources/ladybird/Userland -isystem /usr/include/qt6/QtCore -isystem /usr/include/qt6 -isystem /usr/lib/qt6/mkspecs/linux-g++ -isystem /usr/include/qt6/QtGui -isystem /home/gear/sources/ladybird/Build/ladybird/vcpkg_installed/x64-linux/include -isystem /usr/include/qt6/QtNetwork -isystem /usr/include/qt6/QtWidgets -O2 -g -DNDEBUG -std=c++23 -fdiagnostics-color=always -Wall -Wextra -fno-exceptions -ffp-contract=off -Wcast-qual -Wformat=2 -Wimplicit-fallthrough -Wmissing-declarations -Wsuggest-override -Wno-invalid-offsetof -Wno-unknown-warning-option -Wno-unused-command-line-argument -Werror -Wno-expansion-to-defined -Wno-literal-suffix -Wno-dangling-reference -fno-semantic-interposition -fvisibility-inlines-hidden -fstack-protector-strong -fstrict-flex-arrays=2 -Wno-maybe-uninitialized -Wno-shorten-64-to-32 -fsigned-char -ggnu-pubnames -fPIC -O2 -g1 -Wno-user-defined-literals -mno-direct-extern-access -MD -MT Ladybird/Qt/CMakeFiles/ladybird.dir/FindInPageWidget.cpp.o -MF Ladybird/Qt/CMakeFiles/ladybird.dir/FindInPageWidget.cpp.o.d -o Ladybird/Qt/CMakeFiles/ladybird.dir/FindInPageWidget.cpp.o -c /home/gear/sources/ladybird/Ladybird/Qt/FindInPageWidget.cpp
/home/gear/sources/ladybird/Ladybird/Qt/FindInPageWidget.cpp: In constructor ‘Ladybird::FindInPageWidget::FindInPageWidget(Ladybird::Tab*, Ladybird::WebContentView*)’:
/home/gear/sources/ladybird/Ladybird/Qt/FindInPageWidget.cpp:65:39: error: ‘void QCheckBox::stateChanged(int)’ is deprecated: Use checkStateChanged() instead [-Werror=deprecated-declarations]
   65 |     connect(m_match_case, &QCheckBox::stateChanged, this, [this] {
      |                                       ^~~~~~~~~~~~
In file included from /usr/include/qt6/QtWidgets/QCheckBox:1,
                 from /home/gear/sources/ladybird/Ladybird/Qt/FindInPageWidget.h:11,
                 from /home/gear/sources/ladybird/Ladybird/Qt/FindInPageWidget.cpp:7:
/usr/include/qt6/QtWidgets/qcheckbox.h:41:10: note: declared here
   41 |     void stateChanged(int);
      |          ^~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-user-defined-literals’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-shorten-64-to-32’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-unused-command-line-argument’ may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
ninja: build stopped: subcommand failed.
```
