### PR TITLE
UI/mac: Fix mac tab title layout

### DIFF
--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -205,15 +205,19 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     [favicon_attribute addAttribute:NSForegroundColorAttributeName
                               value:[NSColor clearColor]
                               range:NSMakeRange(0, [favicon_attribute length])];
+    // Add a offset to make the icon vertical center, maybe have better solution
+    [favicon_attribute addAttribute:NSBaselineOffsetAttributeName
+                              value:@-2
+                              range:NSMakeRange(0, [favicon_attribute length])];
 
     // By default, the text attachment will be aligned to the bottom of the string. We have to manually
     // try to center it vertically.
-    // FIXME: Figure out a way to programmatically arrive at a good NSBaselineOffsetAttributeName. Using
-    //        half the distance between the font's line height and the height of the favicon produces a
-    //        value that results in the title being aligned too low still.
+    CGFloat titleFontSize = 12;
+    CGFloat baselineOffset = (self.favicon.size.height - titleFontSize) / 2;
     auto* title_attributes = @{
         NSForegroundColorAttributeName : [NSColor textColor],
-        NSBaselineOffsetAttributeName : @3
+        NSBaselineOffsetAttributeName : @(baselineOffset),
+        NSFontAttributeName : [NSFont systemFontOfSize:titleFontSize]
     };
 
     auto* title_attribute = [[NSAttributedString alloc] initWithString:self.title

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -59,7 +59,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     bool m_can_navigate_forward;
 }
 
-@property (nonatomic, strong) Tab* parent;
+@property (nonatomic, weak) Tab* parent;
 
 @property (nonatomic, strong) NSToolbar* toolbar;
 @property (nonatomic, strong) NSArray* toolbar_identifiers;


### PR DESCRIPTION
Make the tab title icon and text vertical center
<img width="1126" alt="image" src="https://github.com/user-attachments/assets/f496b053-d4e6-4d5c-add5-1574d10bf8dc">
