### PR TITLE
LibWeb/CSS: Stop invalidating style when setting an animation's effect

### DIFF
--- a/Tests/LibWeb/Text/expected/css/transition-style-invalidation-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/transition-style-invalidation-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/transition-style-invalidation-crash.html
+++ b/Tests/LibWeb/Text/input/css/transition-style-invalidation-crash.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    .foo {
+        opacity: 0;
+        transition: opacity 200ms;
+    }
+</style>
+<ul>
+    <li class="foo"></li>
+    <li></li>
+</ul>
+<video src=""></video>
+<script>
+    test(() => {
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/AnimationEffect.cpp
@@ -11,7 +11,6 @@
 #include <LibWeb/Bindings/AnimationEffectPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/Parser/Parser.h>
-#include <LibWeb/DOM/Element.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::Animations {
@@ -205,8 +204,6 @@ WebIDL::ExceptionOr<void> AnimationEffect::update_timing(OptionalEffectTiming ti
 void AnimationEffect::set_associated_animation(JS::GCPtr<Animation> value)
 {
     m_associated_animation = value;
-    if (auto* target = this->target())
-        target->invalidate_style(DOM::StyleInvalidationReason::AnimationEffectSetAssociatedAnimation);
 }
 
 // https://www.w3.org/TR/web-animations-1/#animation-direction

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -54,7 +54,6 @@ enum class FragmentSerializationMode {
 
 #define ENUMERATE_STYLE_INVALIDATION_REASONS(X)     \
     X(AdoptedStyleSheetsList)                       \
-    X(AnimationEffectSetAssociatedAnimation)        \
     X(CSSFontLoaded)                                \
     X(CSSImportRule)                                \
     X(DidLoseFocus)                                 \


### PR DESCRIPTION
This reverts 6d25bf3aac3a10bd741f4193e790ab7886462b93

Invalidating the style here means that transitions can cause an element to leave style computation with its "needs style update" flag set to true. This then causes a VERIFY to fail in the TreeBuilder.

This invalidation does not otherwise seem to have any effect. The original commit suggests this was to fix a bug, but it's not clear what bug that was. If it reappears, we can try to solve the issue in a different way.

Fixes #1586.