### PR TITLE
LibGfx: Apply Exif orientation for PNG images

### DIFF
--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -345,10 +345,13 @@ TEST_CASE(test_exif)
     EXPECT(Gfx::PNGImageDecoderPlugin::sniff(file->bytes()));
     auto plugin_decoder = TRY_OR_FAIL(Gfx::PNGImageDecoderPlugin::create(file->bytes()));
 
-    TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 100, 200 }));
+    auto frame = TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 200, 100 }));
     EXPECT(plugin_decoder->metadata().has_value());
     auto const& exif_metadata = static_cast<Gfx::ExifMetadata const&>(plugin_decoder->metadata().value());
     EXPECT_EQ(*exif_metadata.orientation(), Gfx::TIFF::Orientation::Rotate90Clockwise);
+
+    EXPECT_EQ(frame.image->get_pixel(65, 70), Gfx::Color(0, 255, 0));
+    EXPECT_EQ(frame.image->get_pixel(190, 10), Gfx::Color(255, 0, 0));
 }
 
 TEST_CASE(test_png_malformed_frame)


### PR DESCRIPTION
Fixes wpt/png/exif-chunk.html.

At some point there should probably be some mechanism to handle this outside of the individual decoder plugins. The TIFF decoder seems to have its own version of this, and as far as I can tell, the JPEG decoder doesn't handle this at all, even though that's probably the most common use case for Exif orientations. :^)