### PR TITLE
LibWeb/CSS: Allowing CSS Pseudo Element Nesting

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-pseudo-element-display-list-item.txt
+++ b/Tests/LibWeb/Layout/expected/css-pseudo-element-display-list-item.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x34 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [8,8 83.265625x17] baseline: 13.296875
+              "Filler text"
+          TextNode <#text>
+        ListItemBox <(anonymous)> at (24,25) content-size 768x17 children: inline
+          frag 0 from TextNode start: 0, length: 11, rect: [24,25 88.703125x17] baseline: 13.296875
+              "Filler Text"
+          ListItemMarkerBox <(anonymous)> at (0,25) content-size 12x17 children: not-inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x34]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (ListItemBox(anonymous)) [24,25 768x17]
+          MarkerPaintable (ListItemMarkerBox(anonymous)) [0,25 12x17]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]

--- a/Tests/LibWeb/Layout/input/css-pseudo-element-display-list-item.html
+++ b/Tests/LibWeb/Layout/input/css-pseudo-element-display-list-item.html
@@ -1,0 +1,9 @@
+<style>
+div::after {
+    content: "Filler Text";
+    display: list-item;
+    margin-left: 1em;
+}  
+</style>
+
+<div>Filler text</div>

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -211,6 +211,22 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Se
     if (!pseudo_element_node)
         return;
 
+    auto& style_computer = document.style_computer();
+
+    // FIXME: This code actually computes style for element::marker, and shouldn't for element::pseudo::marker
+    if (is<ListItemBox>(*pseudo_element_node)) {
+        auto marker_style = style_computer.compute_style(element, CSS::Selector::PseudoElement::Type::Marker);
+        auto list_item_marker = document.heap().allocate_without_realm<ListItemMarkerBox>(
+            document,
+            pseudo_element_node->computed_values().list_style_type(),
+            pseudo_element_node->computed_values().list_style_position(),
+            0,
+            *marker_style);
+        static_cast<ListItemBox&>(*pseudo_element_node).set_marker(list_item_marker);
+        element.set_pseudo_element_node({}, CSS::Selector::PseudoElement::Type::Marker, list_item_marker);
+        pseudo_element_node->append_child(*list_item_marker);
+    }
+
     auto generated_for = Node::GeneratedFor::NotGenerated;
     if (pseudo_element == CSS::Selector::PseudoElement::Type::Before) {
         generated_for = Node::GeneratedFor::PseudoBefore;


### PR DESCRIPTION
This change is required to not crash on the following WPT test:
[http://wpt.live/css/CSS2/generated-content/after-content-display-003.xht](http://wpt.live/css/CSS2/generated-content/after-content-display-003.xht)

It makes a CSS pseudo element display: list-item, which in turn requires the creation of a ::marker pseudo element, leading to the nesting of pseudo elements.
In its current state, TreeBuilder::create_pseudo_element_if_needed creates a ListItemBox, but doesn't create and assign the corresponding ::marker pseudo element. As a result, ListItemBox.m_marker remains a null pointer, leading to a crash.

I've just added a simple check for `is<ListItemBox>(...)` creating the marker directly in `create_pseudo_element_if_needed` to handle this case. However, there may be a need for an additional function to handle similar cases in the future.