### PR TITLE
LibWeb: Handle calculations without a context better

### DIFF
--- a/Tests/LibWeb/Text/expected/css/calc-missing-context.txt
+++ b/Tests/LibWeb/Text/expected/css/calc-missing-context.txt
@@ -1,0 +1,1 @@
+NO CRASH

--- a/Tests/LibWeb/Text/input/css/calc-missing-context.html
+++ b/Tests/LibWeb/Text/input/css/calc-missing-context.html
@@ -1,0 +1,15 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const testElement = document.getElementById('target');
+        testElement.style = "";
+
+        testElement.style.transform = 'rotate(atan2(1rem, -1rem))';
+
+        getComputedStyle(testElement).transform;
+
+        println("NO CRASH");
+
+    });
+</script>
+<div id="target"></div>

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -178,11 +178,14 @@ public:
     {
         if (is_auto())
             return 0;
+        if (is_absolute())
+            return absolute_length_to_px();
         if (is_font_relative())
             return font_relative_length_to_px(font_metrics, root_font_metrics);
         if (is_viewport_relative())
             return viewport_relative_length_to_px(viewport_rect);
-        return absolute_length_to_px();
+
+        VERIFY_NOT_REACHED();
     }
 
     ALWAYS_INLINE CSSPixels absolute_length_to_px() const


### PR DESCRIPTION
We dont always have a valid context when trying to resolve a calculation, this mitigates that somewhat
I'm not sure if this is the correct fix, since we should(?) have a context at this point, but it stops it from crashing atleast

Fixes a crash on https://wpt.live/css/css-values/acos-asin-atan-atan2-computed.html after we [parse the rotate property](https://github.com/LadybirdBrowser/ladybird/pull/1823)