### PR TITLE
LibRegex: Cache 1 MiB worth of bytecode for each parser

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -243,6 +243,12 @@ public:
         return {};
     }
 
+    V take_first()
+    requires(IsOrdered)
+    {
+        return take(begin()->key).release_value();
+    }
+
     V& ensure(K const& key)
     {
         auto it = find(key);

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -154,8 +154,11 @@ public:
     }
 
     ByteCode(ByteCode const&) = default;
+    ByteCode(ByteCode&&) = default;
+
     virtual ~ByteCode() = default;
 
+    ByteCode& operator=(ByteCode const&) = default;
     ByteCode& operator=(ByteCode&&) = default;
     ByteCode& operator=(Base&& value)
     {


### PR DESCRIPTION
While LibJS does cache regex literals, there's more than one way to
create regex objects, this cache is hit regularly just browsing the web,
though no real measurement has been done on its potential speedups.