### PR TITLE
LibWeb: Layout all math elements using InternalDummy context

### DIFF
--- a/Tests/LibWeb/Text/expected/math-with-inline-child.txt
+++ b/Tests/LibWeb/Text/expected/math-with-inline-child.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/math-with-inline-child.html
+++ b/Tests/LibWeb/Text/input/math-with-inline-child.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<math>
+    <mtable></mtable>
+</math>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        println("PASS (didn't crash)");
+    
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -136,6 +136,10 @@ Optional<FormattingContext::Type> FormattingContext::formatting_context_type_cre
     if (display.is_grid_inside())
         return Type::Grid;
 
+    if (display.is_math_inside())
+        // HACK: Instead of crashing, create a dummy formatting context that does nothing.
+        return Type::InternalDummy;
+
     if (creates_block_formatting_context(box))
         return Type::Block;
 


### PR DESCRIPTION
Always create a new formatting context for <math> elements. Previously that didn't happen if they only had inline children, e.g. mtable.

This fixes a crash in the WPT MathML test mathml/crashtests/children-with-negative-block-sizes.html