### PR TITLE
LibCore: Add Windows version of DirIterator

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -1,10 +1,17 @@
 /*
  * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2023, Cameron Youell <cameronyouell@gmail.com>
+ * Copyright (c) 2024, stasoid <stasoid@yahoo.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/Error.h>
+#ifdef AK_OS_WINDOWS
+#    include <AK/ByteString.h>
+#    include <AK/HashMap.h>
+#    include <windows.h>
+#endif
 
 namespace AK {
 
@@ -12,5 +19,34 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 {
     return Error::from_string_view(string_literal);
 }
+
+#ifdef AK_OS_WINDOWS
+Error Error::from_windows_error(DWORD code)
+{
+    static HashMap<DWORD, ByteString> windows_errors;
+
+    auto string = windows_errors.get(code);
+    if (string.has_value()) {
+        return Error::from_string_view(string->view());
+    } else {
+        char* message = nullptr;
+        auto size = FormatMessageA(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+            nullptr,
+            code,
+            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+            (LPSTR)&message,
+            0,
+            nullptr);
+
+        if (size == 0)
+            return Error::from_string_view_or_print_error_and_return_errno("Unknown error"sv, code);
+
+        windows_errors.set(code, { message, size });
+        LocalFree(message);
+        return from_windows_error(code);
+    }
+}
+#endif
 
 }

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -11,6 +11,9 @@
 #include <AK/Variant.h>
 #include <errno.h>
 #include <string.h>
+#ifdef AK_OS_WINDOWS
+typedef unsigned long DWORD;
+#endif
 
 namespace AK {
 
@@ -24,6 +27,10 @@ public:
         VERIFY(code != 0);
         return Error(code);
     }
+
+#ifdef AK_OS_WINDOWS
+    static Error from_windows_error(DWORD code);
+#endif
 
     // NOTE: For calling this method from within kernel code, we will simply print
     // the error message and return the errno code.

--- a/Meta/CMake/lagom_compile_options.cmake
+++ b/Meta/CMake/lagom_compile_options.cmake
@@ -46,10 +46,12 @@ function(add_cxx_linker_flag_if_supported flag)
     endif()
 endfunction()
 
-add_cxx_linker_flag_if_supported(LINKER:--gdb-index)
+if (NOT WIN32)
+    add_cxx_linker_flag_if_supported(LINKER:--gdb-index)
 
-if (NOT ENABLE_FUZZERS)
-    add_cxx_linker_flag_if_supported(LINKER:-Bsymbolic-non-weak-functions)
+    if (NOT ENABLE_FUZZERS)
+        add_cxx_linker_flag_if_supported(LINKER:-Bsymbolic-non-weak-functions)
+    endif()
 endif()
 
 if (ENABLE_LAGOM_COVERAGE_COLLECTION)

--- a/Meta/CMake/use_linker.cmake
+++ b/Meta/CMake/use_linker.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 #
 
-if (NOT APPLE AND NOT ANDROID AND NOT LAGOM_USE_LINKER)
+if (NOT APPLE AND NOT ANDROID AND NOT WIN32 AND NOT LAGOM_USE_LINKER)
     find_program(LLD_LINKER NAMES "ld.lld")
     if (LLD_LINKER)
         message(STATUS "Using LLD to link Lagom.")

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -324,7 +324,7 @@ add_lagom_library_install_rules(JSClangPlugin)
 # Create mostly empty targets for system libraries we don't need to build for Lagom
 add_library(LibC INTERFACE)
 add_library(LibCrypt INTERFACE)
-if (NOT APPLE AND NOT ANDROID AND NOT EMSCRIPTEN AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" AND NOT HAIKU)
+if (NOT APPLE AND NOT ANDROID AND NOT EMSCRIPTEN AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD" AND NOT HAIKU AND NOT WIN32)
     target_link_libraries(LibCrypt INTERFACE crypt) # LibCore::Account uses crypt() but it's not in libcrypt on macOS
 endif()
 add_library(NoCoverage INTERFACE)

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -5,14 +5,24 @@ include(vulkan)
 set(SOURCES
     ArgsParser.cpp
     Directory.cpp
-    DirectoryEntry.cpp
-    DirIterator.cpp
     Environment.cpp
     File.cpp
     StandardPaths.cpp
     System.cpp
     Version.cpp
 )
+
+if (WIN32)
+    list(APPEND SOURCES
+        DirectoryEntryWindows.cpp
+        DirIteratorWindows.cpp
+    )
+else()
+    list(APPEND SOURCES
+        DirectoryEntry.cpp
+        DirIterator.cpp
+    )
+endif()
 
 serenity_lib(LibCoreMinimal coreminimal)
 

--- a/Userland/Libraries/LibCore/DirIterator.h
+++ b/Userland/Libraries/LibCore/DirIterator.h
@@ -8,9 +8,8 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/OwnPtr.h>
 #include <LibCore/DirectoryEntry.h>
-#include <dirent.h>
-#include <string.h>
 
 namespace Core {
 
@@ -38,7 +37,8 @@ public:
     int fd() const;
 
 private:
-    DIR* m_dir = nullptr;
+    struct Impl;
+    OwnPtr<Impl> m_impl;
     Optional<Error> m_error;
     Optional<DirectoryEntry> m_next;
     ByteString m_path;

--- a/Userland/Libraries/LibCore/DirIteratorWindows.cpp
+++ b/Userland/Libraries/LibCore/DirIteratorWindows.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023, Cameron Youell <cameronyouell@gmail.com>
+ * Copyright (c) 2024, stasoid <stasoid@yahoo.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/DirIterator.h>
+#include <windows.h>
+
+namespace Core {
+
+struct DirIterator::Impl {
+    HANDLE handle { INVALID_HANDLE_VALUE };
+    WIN32_FIND_DATA find_data;
+    bool initialized { false };
+};
+
+DirIterator::DirIterator(ByteString path, Flags flags)
+    : m_impl(make<Impl>())
+    , m_path(move(path))
+    , m_flags(flags)
+{
+}
+
+DirIterator::~DirIterator()
+{
+    if (m_impl && m_impl->handle != INVALID_HANDLE_VALUE) {
+        FindClose(m_impl->handle);
+        m_impl->handle = INVALID_HANDLE_VALUE;
+    }
+}
+
+DirIterator::DirIterator(DirIterator&& other)
+    : m_impl(move(other.m_impl))
+    , m_error(move(other.m_error))
+    , m_next(move(other.m_next))
+    , m_path(move(other.m_path))
+    , m_flags(other.m_flags)
+{
+}
+
+bool DirIterator::advance_next()
+{
+    if (!m_impl)
+        return false;
+
+    while (true) {
+        if (!m_impl->initialized) {
+            m_impl->initialized = true;
+            auto path = ByteString::formatted("{}/*", m_path);
+            m_impl->handle = FindFirstFile(path.characters(), &m_impl->find_data);
+            if (m_impl->handle == INVALID_HANDLE_VALUE) {
+                m_error = Error::from_windows_error(GetLastError());
+                return false;
+            }
+        } else {
+            if (!FindNextFile(m_impl->handle, &m_impl->find_data)) {
+                if (GetLastError() != ERROR_NO_MORE_FILES)
+                    m_error = Error::from_windows_error(GetLastError());
+                return false;
+            }
+        }
+
+        m_next = DirectoryEntry::from_find_data(m_impl->find_data);
+
+        if (m_next->name.is_empty())
+            return false;
+
+        if (m_flags & Flags::SkipDots && m_next->name.starts_with('.'))
+            continue;
+
+        if (m_flags & Flags::SkipParentAndBaseDir && (m_next->name == "." || m_next->name == ".."))
+            continue;
+
+        return !m_next->name.is_empty();
+    }
+}
+
+bool DirIterator::has_next()
+{
+    if (m_next.has_value())
+        return true;
+
+    return advance_next();
+}
+
+Optional<DirectoryEntry> DirIterator::next()
+{
+    if (!m_next.has_value())
+        advance_next();
+
+    auto result = m_next;
+    m_next.clear();
+    return result;
+}
+
+ByteString DirIterator::next_path()
+{
+    auto entry = next();
+    if (entry.has_value())
+        return entry->name;
+    return "";
+}
+
+ByteString DirIterator::next_full_path()
+{
+    StringBuilder builder;
+    builder.append(m_path);
+    if (!m_path.ends_with('/'))
+        builder.append('/');
+    builder.append(next_path());
+    return builder.to_byte_string();
+}
+
+int DirIterator::fd() const
+{
+    dbgln("DirIterator::fd() not implemented");
+    VERIFY_NOT_REACHED();
+}
+
+}

--- a/Userland/Libraries/LibCore/DirectoryEntry.h
+++ b/Userland/Libraries/LibCore/DirectoryEntry.h
@@ -8,7 +8,11 @@
 
 #include <AK/ByteString.h>
 #include <AK/StringView.h>
-#include <dirent.h>
+#ifdef AK_OS_WINDOWS
+using WIN32_FIND_DATA = struct _WIN32_FIND_DATAA;
+#else
+#    include <dirent.h>
+#endif
 
 namespace Core {
 
@@ -27,6 +31,7 @@ struct DirectoryEntry {
     Type type;
     // FIXME: Once we have a special Path string class, use that.
     ByteString name;
+#if !defined(AK_OS_WINDOWS)
     ino_t inode_number;
 
     static StringView posix_name_from_directory_entry_type(Type);
@@ -34,6 +39,9 @@ struct DirectoryEntry {
     static Type directory_entry_type_from_stat(mode_t st_mode);
     static DirectoryEntry from_dirent(dirent const&);
     static DirectoryEntry from_stat(DIR*, dirent const&);
+#else
+    static DirectoryEntry from_find_data(WIN32_FIND_DATA const&);
+#endif
 };
 
 }

--- a/Userland/Libraries/LibCore/DirectoryEntryWindows.cpp
+++ b/Userland/Libraries/LibCore/DirectoryEntryWindows.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Cameron Youell <cameronyouell@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/DirectoryEntry.h>
+#include <windows.h>
+
+namespace Core {
+
+static DirectoryEntry::Type directory_entry_type_from_win32(DWORD file_attributes)
+{
+    if (file_attributes & FILE_ATTRIBUTE_DIRECTORY)
+        return DirectoryEntry::Type::Directory;
+    if (file_attributes & FILE_ATTRIBUTE_DEVICE)
+        return DirectoryEntry::Type::CharacterDevice;
+    if (file_attributes & FILE_ATTRIBUTE_REPARSE_POINT)
+        return DirectoryEntry::Type::SymbolicLink;
+    return DirectoryEntry::Type::File;
+}
+
+DirectoryEntry DirectoryEntry::from_find_data(WIN32_FIND_DATA const& de)
+{
+    return DirectoryEntry {
+        .type = directory_entry_type_from_win32(de.dwFileAttributes),
+        .name = de.cFileName,
+    };
+}
+
+}


### PR DESCRIPTION
Split from #1794

Peculiarities:
I PIMPLed only OS-specific data in DirIterator because I don't want to access every member through m_impl->

Known problems:
* I removed `#include <windows.h>`, but there are still #ifdefs in classes in LibCore/DirectoryEntry.h and AK/Error.h
  If these are unacceptible, what approach should I use to get rid of them?
  For DirectoryEntry, I have an idea to move all platform-specific functions to DirIterator.cpp/DirIteratorWindows.cpp,
  and name them directory_entry_from_stat, etc. But this is kinda ugly? Also, inode_number is never used, can we remove it?
* <s>on Windows DirIterator::fd() works only after next() is called and it returns new descriptor every time. It is never called - can we just remove it?</s> Update: Stubbed out DirIterator::fd(), it is never used anyway.