### PR TITLE
LibWeb: Visit the MessagePort's associated Worker target

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3308,22 +3308,26 @@ void Document::run_unloading_cleanup_steps()
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#destroy-a-document
 void Document::destroy()
 {
-    // NOTE: Abort needs to happen before destory. There is currently bug in the spec: https://github.com/whatwg/html/issues/9148
-    // 4. Abort document.
+    // FIXME: 1. Assert: this is running as part of a task queued on document's relevant agent's event loop.
+
+    // 2. Abort document.
     abort();
 
-    // 2. Set document's salvageable state to false.
+    // 3. Set document's salvageable state to false.
     m_salvageable = false;
 
-    // 3. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
+    // FIXME: 4. Let ports be the list of MessagePorts whose relevant global object's associated Document is document.
+    // FIXME: 5. For each port in ports, disentangle port.
+
+    // 6. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
     run_unloading_cleanup_steps();
 
-    // 5. Remove any tasks whose document is document from any task queue (without running those tasks).
+    // 7. Remove any tasks whose document is document from any task queue (without running those tasks).
     HTML::main_thread_event_loop().task_queue().remove_tasks_matching([this](auto& task) {
         return task.document() == this;
     });
 
-    // 6. Set document's browsing context to null.
+    // 8. Set document's browsing context to null.
     m_browsing_context = nullptr;
 
     // Not in the spec:
@@ -3332,14 +3336,12 @@ void Document::destroy()
             HTML::all_navigables().remove(navigable_container->content_navigable());
     }
 
-    // 7. Set document's node navigable's active session history entry's document state's document to null.
-    if (navigable()) {
-        navigable()->active_session_history_entry()->document_state()->set_document(nullptr);
-    }
+    // 9. Set document's node navigable's active session history entry's document state's document to null.
+    if (auto navigable = this->navigable())
+        navigable->active_session_history_entry()->document_state()->set_document(nullptr);
 
-    // FIXME: 8. Remove document from the owner set of each WorkerGlobalScope object whose set contains document.
-
-    // FIXME: 9. For each workletGlobalScope in document's worklet global scopes, terminate workletGlobalScope.
+    // FIXME: 10. Remove document from the owner set of each WorkerGlobalScope object whose set contains document.
+    // FIXME: 11. For each workletGlobalScope in document's worklet global scopes, terminate workletGlobalScope.
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#make-document-unsalvageable

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -96,6 +96,7 @@
 #include <LibWeb/HTML/ListOfAvailableImages.h>
 #include <LibWeb/HTML/Location.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/NavigationParams.h>
@@ -3316,8 +3317,17 @@ void Document::destroy()
     // 3. Set document's salvageable state to false.
     m_salvageable = false;
 
-    // FIXME: 4. Let ports be the list of MessagePorts whose relevant global object's associated Document is document.
-    // FIXME: 5. For each port in ports, disentangle port.
+    // 4. Let ports be the list of MessagePorts whose relevant global object's associated Document is document.
+    // 5. For each port in ports, disentangle port.
+    HTML::MessagePort::for_each_message_port([&](HTML::MessagePort& port) {
+        auto& global = HTML::relevant_global_object(port);
+        if (!is<HTML::Window>(global))
+            return;
+
+        auto& window = static_cast<HTML::Window&>(global);
+        if (&window.associated_document() == this)
+            port.disentangle();
+    });
 
     // 6. Run any unloading document cleanup steps for document that are defined by this specification and other applicable specifications.
     run_unloading_cleanup_steps();

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -14,15 +14,16 @@ namespace Web {
 class DragAndDropEventHandler;
 class EditEventHandler;
 class EventHandler;
-enum class InvalidateDisplayList;
 class LoadRequest;
 class Page;
 class PageClient;
 class PaintContext;
 class Resource;
 class ResourceLoader;
-enum class TraversalDecision;
 class XMLDocumentBuilder;
+
+enum class InvalidateDisplayList;
+enum class TraversalDecision;
 }
 
 namespace Web::Painting {
@@ -46,6 +47,7 @@ class KeyframeEffect;
 namespace Web::ARIA {
 class AriaData;
 class ARIAMixin;
+
 enum class StateAndProperties;
 }
 
@@ -102,6 +104,11 @@ class BackgroundRepeatStyleValue;
 class BackgroundSizeStyleValue;
 class BasicShapeStyleValue;
 class BorderRadiusStyleValue;
+class Clip;
+class ConicGradientStyleValue;
+class ContentStyleValue;
+class CounterDefinitionsStyleValue;
+class CounterStyleValue;
 class CSSAnimation;
 class CSSColorValue;
 class CSSConditionRule;
@@ -125,14 +132,8 @@ class CSSRuleList;
 class CSSStyleDeclaration;
 class CSSStyleRule;
 class CSSStyleSheet;
-struct CSSStyleSheetInit;
 class CSSStyleValue;
 class CSSSupportsRule;
-class Clip;
-class ConicGradientStyleValue;
-class ContentStyleValue;
-class CounterStyleValue;
-class CounterDefinitionsStyleValue;
 class CustomIdentStyleValue;
 class Display;
 class DisplayStyleValue;
@@ -203,7 +204,6 @@ class StringStyleValue;
 class StyleComputer;
 class StyleProperties;
 class StyleSheet;
-struct StyleSheetIdentifier;
 class StyleSheetList;
 class StyleValueList;
 class Supports;
@@ -215,8 +215,8 @@ class TimeStyleValue;
 class Transformation;
 class TransformationStyleValue;
 class TransitionStyleValue;
-class URLStyleValue;
 class UnresolvedStyleValue;
+class URLStyleValue;
 class VisualViewport;
 
 enum class Keyword;
@@ -224,18 +224,21 @@ enum class MediaFeatureID;
 enum class PropertyID;
 
 struct BackgroundLayerData;
+struct CSSStyleSheetInit;
+struct StyleSheetIdentifier;
 }
 
 namespace Web::CSS::Parser {
-struct AtRule;
 class ComponentValue;
-struct Declaration;
-struct Function;
 class Parser;
-struct QualifiedRule;
-struct SimpleBlock;
 class Token;
 class Tokenizer;
+
+struct AtRule;
+struct Declaration;
+struct Function;
+struct QualifiedRule;
+struct SimpleBlock;
 }
 
 namespace Web::DOM {
@@ -275,8 +278,8 @@ class NodeList;
 class ParentNode;
 class Position;
 class ProcessingInstruction;
-class Range;
 class RadioNodeList;
+class Range;
 class RegisteredObserver;
 class ShadowRoot;
 class StaticNodeList;
@@ -296,10 +299,11 @@ class XMLSerializer;
 }
 
 namespace Web::Encoding {
-struct TextDecodeOptions;
 class TextDecoder;
-struct TextDecoderOptions;
 class TextEncoder;
+
+struct TextDecodeOptions;
+struct TextDecoderOptions;
 struct TextEncoderEncodeIntoResult;
 }
 
@@ -330,8 +334,8 @@ class ConnectionTimingInfo;
 class FetchAlgorithms;
 class FetchController;
 class FetchParams;
-class FetchTimingInfo;
 class FetchRecord;
+class FetchTimingInfo;
 class HeaderList;
 class IncrementalReadLoopReadRequest;
 class Request;
@@ -349,16 +353,17 @@ class FileList;
 
 namespace Web::Geometry {
 class DOMMatrix;
-struct DOMMatrix2DInit;
-struct DOMMatrixInit;
 class DOMMatrixReadOnly;
 class DOMPoint;
-struct DOMPointInit;
 class DOMPointReadOnly;
 class DOMQuad;
 class DOMRect;
 class DOMRectList;
 class DOMRectReadOnly;
+
+struct DOMMatrix2DInit;
+struct DOMMatrixInit;
+struct DOMPointInit;
 }
 
 namespace Web::HTML {
@@ -385,7 +390,6 @@ class DOMStringMap;
 class DragDataStore;
 class DragEvent;
 class ElementInternals;
-struct EmbedderPolicy;
 class ErrorEvent;
 class EventHandler;
 class EventLoop;
@@ -496,6 +500,7 @@ class PromiseRejectionEvent;
 class SelectedFile;
 class ServiceWorkerContainer;
 class ServiceWorkerRegistration;
+class SessionHistoryEntry;
 class SharedResourceRequest;
 class Storage;
 class SubmitEvent;
@@ -508,7 +513,6 @@ class Timer;
 class TimeRanges;
 class ToggleEvent;
 class TrackEvent;
-struct TransferDataHolder;
 class TraversableNavigable;
 class UserActivation;
 class ValidityState;
@@ -529,18 +533,19 @@ enum class AllowMultipleFiles;
 enum class MediaSeekMode;
 enum class SandboxingFlagSet;
 
-struct OpenerPolicy;
-struct OpenerPolicyEnforcementResult;
+struct EmbedderPolicy;
 struct Environment;
 struct EnvironmentSettingsObject;
 struct NavigationParams;
+struct OpenerPolicy;
+struct OpenerPolicyEnforcementResult;
 struct PolicyContainer;
 struct POSTResource;
 struct ScrollOptions;
 struct ScrollToOptions;
 struct SerializedFormData;
-class SessionHistoryEntry;
 struct ToggleTaskTracker;
+struct TransferDataHolder;
 }
 
 namespace Web::HighResolutionTime {
@@ -561,6 +566,7 @@ class Internals;
 namespace Web::IntersectionObserver {
 class IntersectionObserver;
 class IntersectionObserverEntry;
+
 struct IntersectionObserverRegistration;
 }
 
@@ -574,8 +580,8 @@ class CheckBox;
 class FlexFormattingContext;
 class FormattingContext;
 class ImageBox;
-class InlineNode;
 class InlineFormattingContext;
+class InlineNode;
 class Label;
 class LabelableNode;
 class LineBox;
@@ -640,6 +646,7 @@ namespace Web::PerformanceTimeline {
 class PerformanceEntry;
 class PerformanceObserver;
 class PerformanceObserverEntryList;
+
 struct PerformanceObserverInit;
 }
 
@@ -757,7 +764,6 @@ class Table;
 namespace Web::WebAudio {
 class AudioBuffer;
 class AudioBufferSourceNode;
-class AudioDestinationNode;
 class AudioContext;
 class AudioDestinationNode;
 class AudioNode;
@@ -817,5 +823,6 @@ class ProgressEvent;
 class XMLHttpRequest;
 class XMLHttpRequestEventTarget;
 class XMLHttpRequestUpload;
+
 struct FormDataEntry;
 }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -544,6 +544,7 @@ struct POSTResource;
 struct ScrollOptions;
 struct ScrollToOptions;
 struct SerializedFormData;
+struct StructuredSerializeOptions;
 struct ToggleTaskTracker;
 struct TransferDataHolder;
 }

--- a/Userland/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DedicatedWorkerGlobalScope.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -128,6 +128,8 @@ void MessagePort::disentangle()
     m_remote_port = nullptr;
 
     m_socket = nullptr;
+
+    m_worker_event_target = nullptr;
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#entangle

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/HTML/MessageEvent.h>
 #include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/StructuredSerializeOptions.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -68,10 +68,7 @@ void MessagePort::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_remote_port);
-
-    // FIXME: This is incorrect!! We *should* be visiting the worker event target,
-    //        but CI hangs if we do: https://github.com/SerenityOS/serenity/issues/23899
-    visitor.ignore(m_worker_event_target);
+    visitor.visit(m_worker_event_target);
 }
 
 void MessagePort::set_worker_event_target(JS::NonnullGCPtr<DOM::EventTarget> target)

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -30,10 +30,14 @@ class MessagePort final : public DOM::EventTarget
 public:
     [[nodiscard]] static JS::NonnullGCPtr<MessagePort> create(JS::Realm&);
 
+    static void for_each_message_port(Function<void(MessagePort&)>);
+
     virtual ~MessagePort() override;
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#entangle
     void entangle_with(MessagePort&);
+
+    void disentangle();
 
     // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Vector<JS::Handle<JS::Object>> const& transfer);
@@ -66,7 +70,6 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     bool is_entangled() const { return static_cast<bool>(m_socket); }
-    void disentangle();
 
     WebIDL::ExceptionOr<void> message_port_post_message_steps(JS::GCPtr<MessagePort> target_port, JS::Value message, StructuredSerializeOptions const& options);
     void post_message_task_steps(SerializedTransferRecord&);

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -21,11 +21,6 @@ namespace Web::HTML {
     E(onmessage, HTML::EventNames::message)      \
     E(onmessageerror, HTML::EventNames::messageerror)
 
-// https://html.spec.whatwg.org/multipage/web-messaging.html#structuredserializeoptions
-struct StructuredSerializeOptions {
-    Vector<JS::Handle<JS::Object>> transfer;
-};
-
 // https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports
 class MessagePort final : public DOM::EventTarget
     , public Bindings::Transferable {

--- a/Userland/Libraries/LibWeb/HTML/ServiceWorker.h
+++ b/Userland/Libraries/LibWeb/HTML/ServiceWorker.h
@@ -8,7 +8,6 @@
 
 #include <LibWeb/Bindings/ServiceWorkerPrototype.h>
 #include <LibWeb/DOM/EventTarget.h>
-#include <LibWeb/HTML/MessagePort.h>
 
 #define ENUMERATE_SERVICE_WORKER_EVENT_HANDLERS(E)  \
     E(onstatechange, HTML::EventNames::statechange) \

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerializeOptions.h
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerializeOptions.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibJS/Runtime/Object.h>
+
+namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#structuredserializeoptions
+struct StructuredSerializeOptions {
+    Vector<JS::Handle<JS::Object>> transfer;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -44,6 +44,7 @@
 #include <LibWeb/HTML/HTMLObjectElement.h>
 #include <LibWeb/HTML/Location.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Navigation.h>
 #include <LibWeb/HTML/Navigator.h>
 #include <LibWeb/HTML/PageTransitionEvent.h>

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -24,6 +24,7 @@
 #include <LibWeb/HTML/Plugin.h>
 #include <LibWeb/HTML/Scripting/ImportMap.h>
 #include <LibWeb/HTML/ScrollOptions.h>
+#include <LibWeb/HTML/StructuredSerializeOptions.h>
 #include <LibWeb/HTML/WindowEventHandlers.h>
 #include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>
 #include <LibWeb/RequestIdleCallback/IdleRequest.h>

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -27,6 +27,7 @@
 #include <LibWeb/HTML/Scripting/ExceptionReporter.h>
 #include <LibWeb/HTML/Scripting/Fetching.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
+#include <LibWeb/HTML/StructuredSerializeOptions.h>
 #include <LibWeb/HTML/Timer.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowOrWorkerGlobalScope.h>

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -16,7 +16,6 @@
 #include <LibWeb/Fetch/Request.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ImageBitmap.h>
-#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/PerformanceTimeline/PerformanceEntry.h>
 #include <LibWeb/PerformanceTimeline/PerformanceEntryTuple.h>
 

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -5,14 +5,12 @@
  */
 
 #include <AK/Debug.h>
-#include <LibJS/Runtime/ConsoleObject.h>
 #include <LibJS/Runtime/Realm.h>
-#include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Bindings/WorkerPrototype.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Scripting/Environments.h>
-#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/Worker.h>
-#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {
 

--- a/Userland/Libraries/LibWeb/HTML/Worker.h
+++ b/Userland/Libraries/LibWeb/HTML/Worker.h
@@ -6,20 +6,11 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
-#include <LibURL/Parser.h>
-#include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/AbstractWorker.h>
-#include <LibWeb/HTML/MessageEvent.h>
-#include <LibWeb/HTML/MessagePort.h>
-#include <LibWeb/HTML/Scripting/ClassicScript.h>
-#include <LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h>
-#include <LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WorkerAgent.h>
-#include <LibWeb/HTML/WorkerDebugConsoleClient.h>
-#include <LibWeb/Loader/ResourceLoader.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 #define ENUMERATE_WORKER_EVENT_HANDLERS(E)  \
     E(onmessage, HTML::EventNames::message) \

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/HostDefined.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/WorkerAgent.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Worker/WebWorkerClient.h>

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.h
@@ -9,7 +9,6 @@
 #include <LibWeb/Bindings/RequestPrototype.h>
 #include <LibWeb/Bindings/WorkerPrototype.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/StructuredSerialize.h>
 #include <LibWeb/HTML/WorkerGlobalScope.h>

--- a/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
+++ b/Userland/Services/WebWorker/DedicatedWorkerHost.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/HTML/DedicatedWorkerGlobalScope.h>
+#include <LibWeb/HTML/MessagePort.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
 #include <LibWeb/HTML/Scripting/EnvironmentSettingsSnapshot.h>
 #include <LibWeb/HTML/Scripting/Fetching.h>


### PR DESCRIPTION
Without this, a worker can be GC'd in a very simple script such as:

```js
const worker = new Worker("script.js");
worker.onmessage = () => {};
```

Where script.js attempts to post a message back to the parent window.

When the Worker is GC'd, the IPC connection from the WebContent process to the WebWorker process is closed. When this occurs, the WebWorker will exit() from LibIPC, and any message from the worker to its parent does not have a chance to run.