### PR TITLE
LibWeb: Use the correct document URL in DOMParser.parseFromString()

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/DOMParser-parseFromString-document-url.txt
+++ b/Tests/LibWeb/Text/expected/HTML/DOMParser-parseFromString-document-url.txt
@@ -1,0 +1,2 @@
+PASS text/html
+PASS application/xhtml+xml

--- a/Tests/LibWeb/Text/input/HTML/DOMParser-parseFromString-document-url.html
+++ b/Tests/LibWeb/Text/input/HTML/DOMParser-parseFromString-document-url.html
@@ -1,0 +1,19 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const parser = new DOMParser();
+
+        for (const mimeType of ["text/html", "application/xhtml+xml"]) {
+            const doc = parser.parseFromString("<html><b>hello", mimeType);
+            if (doc.URL == "about:blank") {
+                println("FAIL 1 " + mimeType);
+            } else if (!doc.URL.endsWith(".html")) {
+                println("FAIL 2 " + mimeType);
+            } else if (doc.URL == document.URL) {
+                println("PASS " + mimeType);
+            } else {
+                println("FAIL 3 " + mimeType);
+            }
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5415,8 +5415,7 @@ void Document::parse_html_from_a_string(StringView html)
     auto parser = HTML::HTMLParser::create(*this, html, "UTF-8"sv);
 
     // 4. Start parser and let it run until it has consumed all the characters just inserted into the input stream.
-    // FIXME: This is to match the default URL. Instead, pass in this's relevant global object's associated Document's URL.
-    parser->run("about:blank"sv);
+    parser->run(verify_cast<HTML::Window>(HTML::relevant_global_object(*this)).associated_document().url());
 }
 
 // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-parsehtmlunsafe


### PR DESCRIPTION
We were hard-coding "about:blank" as the document URL for parsed HTML documents, which was definitely not correct.

This fixes a bunch of WPT tests under /domparsing/ :^)