### PR TITLE
LibWeb: Implement indexed property support for HTML::Storage

### DIFF
--- a/Tests/LibWeb/Text/expected/localStorage.txt
+++ b/Tests/LibWeb/Text/expected/localStorage.txt
@@ -1,0 +1,6 @@
+value
+value
+other
+other
+foo
+foo

--- a/Tests/LibWeb/Text/input/localStorage.html
+++ b/Tests/LibWeb/Text/input/localStorage.html
@@ -1,0 +1,17 @@
+<script src="include.js"></script>
+<script>
+    test(() => {
+        localStorage["test"] = "value";
+        println(localStorage["test"]);
+        println(localStorage.getItem("test"));
+
+        localStorage.setItem("test", "other");
+        println(localStorage["test"]);
+        println(localStorage.getItem("test"));
+
+        // Ensure indexed properties work
+        localStorage[0] = "foo";
+        println(localStorage[0]);
+        println(localStorage.getItem("0"));
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Storage.h
+++ b/Userland/Libraries/LibWeb/HTML/Storage.h
@@ -38,9 +38,11 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^PlatformObject
+    virtual Optional<JS::Value> item_value(size_t index) const override;
     virtual JS::Value named_item_value(FlyString const&) const override;
     virtual WebIDL::ExceptionOr<DidDeletionFail> delete_value(String const&) override;
     virtual Vector<FlyString> supported_property_names() const override;
+    virtual WebIDL::ExceptionOr<void> set_value_of_indexed_property(u32, JS::Value) override;
     virtual WebIDL::ExceptionOr<void> set_value_of_named_property(String const& key, JS::Value value) override;
 
     void reorder();


### PR DESCRIPTION
We only supported named properties on Storage, and as a result `localStorage[0]` would be disconnected from the Storage's backing map.

Fixes at least 20 subtests in WPT in /webstorage.