### PR TITLE
LibWeb: Substring by code units instead of bytes in `EditEventHandler`

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -254,6 +254,22 @@ ErrorOr<String> String::substring_from_byte_offset(size_t start) const
     return substring_from_byte_offset(start, bytes_as_string_view().length() - start);
 }
 
+ErrorOr<String> String::substring_from_code_unit_offset(size_t offset, size_t count) const
+{
+    auto const utf16_data = TRY(utf8_to_utf16(bytes_as_string_view()));
+    Utf16View const utf16_view { utf16_data };
+
+    return TRY(utf16_view.substring_view(offset, count).to_utf8());
+}
+
+ErrorOr<String> String::substring_from_code_unit_offset(size_t offset) const
+{
+    auto const utf16_data = TRY(utf8_to_utf16(bytes_as_string_view()));
+    Utf16View const utf16_view { utf16_data };
+
+    return TRY(utf16_view.substring_view(offset, utf16_view.length_in_code_units() - offset).to_utf8());
+}
+
 ErrorOr<String> String::substring_from_byte_offset_with_shared_superstring(size_t start, size_t byte_count) const
 {
     return String { TRY(StringBase::substring_from_byte_offset_with_shared_superstring(start, byte_count)) };

--- a/AK/String.h
+++ b/AK/String.h
@@ -121,6 +121,10 @@ public:
     ErrorOr<String> substring_from_byte_offset(size_t start, size_t byte_count) const;
     ErrorOr<String> substring_from_byte_offset(size_t start) const;
 
+    // UTF-16 substring helpers
+    ErrorOr<String> substring_from_code_unit_offset(size_t offset, size_t count) const;
+    ErrorOr<String> substring_from_code_unit_offset(size_t offset) const;
+
     // Creates a substring that strongly references the origin superstring instead of making a deep copy of the data.
     ErrorOr<String> substring_from_byte_offset_with_shared_superstring(size_t start, size_t byte_count) const;
     ErrorOr<String> substring_from_byte_offset_with_shared_superstring(size_t start) const;

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -5459,6 +5459,7 @@ void Document::set_cursor_position(JS::NonnullGCPtr<DOM::Position> position)
         m_cursor_position->node()->paintable()->set_needs_display();
 
     m_cursor_position = position;
+    m_cursor_position->set_offset(position->offset());
 
     if (m_cursor_position && m_cursor_position->node()->paintable())
         m_cursor_position->node()->paintable()->set_needs_display();

--- a/Userland/Libraries/LibWeb/DOM/Position.h
+++ b/Userland/Libraries/LibWeb/DOM/Position.h
@@ -32,7 +32,7 @@ public:
 
     unsigned offset() const { return m_offset; }
     bool offset_is_at_end_of_node() const;
-    void set_offset(unsigned value) { m_offset = value; }
+    void set_offset(unsigned const value) { m_offset = value; }
     bool increment_offset();
     bool decrement_offset();
 

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -198,8 +198,8 @@ WebIDL::ExceptionOr<void> FormAssociatedElement::set_form_action(String const& v
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
 void FormAssociatedTextControlElement::relevant_value_was_changed(JS::GCPtr<DOM::Text> text_node)
 {
-    auto the_relevant_value = relevant_value();
-    auto relevant_value_length = the_relevant_value.code_points().length();
+    auto const the_relevant_value = relevant_value();
+    auto const relevant_value_length = Utf16View { MUST(AK::utf8_to_utf16(the_relevant_value)) }.length_in_code_units();
 
     // 1. If the element has a selection:
     if (m_selection_start < m_selection_end) {
@@ -418,7 +418,7 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_range_text(Strin
 
     // 5. If start is greater than the length of the relevant value of the text control, then set it to the length of the relevant value of the text control.
     auto the_relevant_value = relevant_value();
-    auto relevant_value_length = the_relevant_value.code_points().length();
+    auto relevant_value_length = Utf16View { MUST(AK::utf8_to_utf16(the_relevant_value)) }.length_in_code_units();
     if (start > relevant_value_length)
         start = relevant_value_length;
 
@@ -436,25 +436,25 @@ WebIDL::ExceptionOr<void> FormAssociatedTextControlElement::set_range_text(Strin
     //    the code unit at the startth position and ending with the code unit at the (end-1)th position.
     if (start < end) {
         StringBuilder builder;
-        auto before_removal_point_view = the_relevant_value.code_points().unicode_substring_view(0, start);
-        builder.append(before_removal_point_view.as_string());
-        auto after_removal_point_view = the_relevant_value.code_points().unicode_substring_view(end);
-        builder.append(after_removal_point_view.as_string());
+        auto before_removal_point_view = MUST(the_relevant_value.substring_from_code_unit_offset(0, start));
+        builder.append(before_removal_point_view);
+        auto after_removal_point_view = MUST(the_relevant_value.substring_from_code_unit_offset(end));
+        builder.append(after_removal_point_view);
         the_relevant_value = MUST(builder.to_string());
     }
 
     // 10. Insert the value of the first argument into the text of the relevant value of the text control, immediately before the startth code unit.
     StringBuilder builder;
-    auto before_insertion_point_view = the_relevant_value.code_points().unicode_substring_view(0, start);
-    builder.append(before_insertion_point_view.as_string());
+    auto before_insertion_point_view = MUST(the_relevant_value.substring_from_code_unit_offset(0, start));
+    builder.append(before_insertion_point_view);
     builder.append(replacement);
-    auto after_insertion_point_view = the_relevant_value.code_points().unicode_substring_view(start);
-    builder.append(after_insertion_point_view.as_string());
+    auto after_insertion_point_view = MUST(the_relevant_value.substring_from_code_unit_offset(start));
+    builder.append(after_insertion_point_view);
     the_relevant_value = MUST(builder.to_string());
     TRY(set_relevant_value(the_relevant_value));
 
     // 11. Let new length be the length of the value of the first argument.
-    i64 new_length = replacement.code_points().length();
+    size_t new_length = Utf16View { MUST(AK::utf8_to_utf16(replacement)) }.length_in_code_units();
 
     // 12. Let new end be the sum of start and new length.
     auto new_end = start + new_length;
@@ -545,7 +545,7 @@ void FormAssociatedTextControlElement::set_the_selection_range(Optional<WebIDL::
     //    relevant value of the text control (including the special value infinity) must be treated
     //    as pointing at the end of the text control.
     auto the_relevant_value = relevant_value();
-    auto relevant_value_length = the_relevant_value.code_points().length();
+    auto relevant_value_length = Utf16View { MUST(AK::utf8_to_utf16(the_relevant_value)) }.length_in_code_units();
     auto new_selection_start = AK::min(start.value(), relevant_value_length);
     auto new_selection_end = AK::min(end.value(), relevant_value_length);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -586,7 +586,8 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_value(String const& value)
                 m_text_node->set_data(m_value);
                 update_placeholder_visibility();
 
-                set_the_selection_range(m_text_node->length(), m_text_node->length());
+                auto const text_node_length = m_text_node->length_in_utf16_code_units();
+                set_the_selection_range(text_node_length, text_node_length);
             }
 
             update_shadow_tree();
@@ -1177,8 +1178,10 @@ void HTMLInputElement::did_receive_focus()
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
 
-    if (auto cursor = document().cursor_position(); !cursor || m_text_node != cursor->node())
-        document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, m_text_node->length()));
+    if (auto cursor = document().cursor_position(); !cursor || m_text_node != cursor->node()) {
+        auto const code_unit_length = m_text_node->length_in_utf16_code_units();
+        document().set_cursor_position(DOM::Position::create(realm(), *m_text_node, code_unit_length));
+    }
 }
 
 void HTMLInputElement::did_lose_focus()

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -194,7 +194,8 @@ void HTMLTextAreaElement::set_value(String const& value)
             m_text_node->set_data(m_raw_value);
             update_placeholder_visibility();
 
-            set_the_selection_range(m_text_node->length(), m_text_node->length());
+            auto const text_node_length = m_text_node->length_in_utf16_code_units();
+            set_the_selection_range(text_node_length, text_node_length);
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Page/EditEventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EditEventHandler.h
@@ -24,7 +24,7 @@ public:
     void handle_delete_character_after(JS::NonnullGCPtr<DOM::Document>, JS::NonnullGCPtr<DOM::Position>);
     void handle_delete(JS::NonnullGCPtr<DOM::Document>, DOM::Range&);
     void handle_insert(JS::NonnullGCPtr<DOM::Document>, JS::NonnullGCPtr<DOM::Position>, u32 code_point);
-    void handle_insert(JS::NonnullGCPtr<DOM::Document>, JS::NonnullGCPtr<DOM::Position>, String);
+    void handle_insert(JS::NonnullGCPtr<DOM::Document>, JS::NonnullGCPtr<DOM::Position>, String const&);
 };
 
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1727,11 +1727,8 @@ Messages::WebDriverClient::ElementSendKeysResponse WebDriverConnection::element_
             Optional<Web::WebIDL::UnsignedLong> current_text_length;
 
             if (element->is_focused()) {
-                auto api_value = target->relevant_value();
-
-                // FIXME: This should be a UTF-16 code unit length, but `set_the_selection_range` is also currently
-                //        implemented in terms of code point length.
-                current_text_length = api_value.code_points().length();
+                auto const api_value = target->relevant_value();
+                current_text_length = Utf16View { MUST(AK::utf8_to_utf16(api_value)) }.length_in_code_units();
             }
 
             // 2. Set the text insertion caret using set selection range using current text length for both the start


### PR DESCRIPTION
Fixes #1815 