### PR TITLE
LibWeb: Avoid crash when animating size property

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -138,6 +138,7 @@ public:
 
     StyleProperties compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
     Optional<StyleProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
+    NonnullRefPtr<CSSStyleValue const> compute_property_value(DOM::Element&, CSS::PropertyID, NonnullRefPtr<CSSStyleValue const>) const;
 
     Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, FlyString const& qualified_layer_name = {}) const;
 

--- a/Tests/LibWeb/Layout/expected/animate-height.txt
+++ b/Tests/LibWeb/Layout/expected/animate-height.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: not-inline
+      BlockContainer <div.container> at (8,8) content-size 300x200 children: not-inline
+        BlockContainer <(anonymous)> at (8,8) content-size 300x0 children: inline
+          TextNode <#text>
+        BlockContainer <div.animate> at (8,8) content-size 300x0 children: inline
+          frag 0 from TextNode start: 0, length: 7, rect: [8,8 60.640625x17] baseline: 13.296875
+              "animate"
+          TextNode <#text>
+        BlockContainer <(anonymous)> at (8,8) content-size 300x0 children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,208) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>.container) [8,8 300x200]
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 300x0]
+        PaintableWithLines (BlockContainer<DIV>.animate) [8,8 300x0] overflow: [8,8 60.640625x17]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer(anonymous)) [8,8 300x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,208 784x0]

--- a/Tests/LibWeb/Layout/input/animate-height.html
+++ b/Tests/LibWeb/Layout/input/animate-height.html
@@ -1,0 +1,27 @@
+<style>
+  .container {
+      display: box;
+      background-color: green;
+      width: 300px;
+      height: 200px;
+  }
+  .animate {
+      background-color: brown;
+      color: white;
+      animation: 0.3s slideUp
+  }
+
+  @keyframes slideUp {
+  0% {
+    height:inherit;
+  }
+  to {
+    height:fit-content;
+  }
+}
+
+</style>
+<div class="container">
+  <div class="animate">animate</div>
+  </div>
+</div>


### PR DESCRIPTION
Avoids falling through to the default switch case and crashing when calculating a size property that is a global keyword like inherit.

Addresses #1762