### PR TITLE
LibWeb/HTML: Add missing HTMLElement IDL `autocorrect` as a stub

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -25,6 +25,7 @@ interface HTMLElement : Element {
     [FIXME, CEReactions] attribute boolean draggable;
     [FIXME, CEReactions] attribute boolean spellcheck;
     [FIXME, CEReactions] attribute DOMString autocapitalize;
+    [FIXME, CEReactions] attribute boolean autocorrect;
 
     [LegacyNullToEmptyString, CEReactions] attribute DOMString innerText;
     [LegacyNullToEmptyString, CEReactions] attribute DOMString outerText;


### PR DESCRIPTION
This adds an IDL stub for the autocorrect HTMLElement attribute.

Related commit: https://github.com/whatwg/html/commit/7bab05ac69e7992be25b23b2017b03d2ef4f7869
Spec: https://html.spec.whatwg.org/#htmlelement