### PR TITLE
LibWeb: Avoid a weird reparse of style attributes for pseudo elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2310,8 +2310,7 @@ RefPtr<StyleProperties> StyleComputer::compute_style_impl(DOM::Element& element,
         auto style = compute_style(parent_element, *element.use_pseudo_element());
 
         // Merge back inline styles
-        if (element.has_attribute(HTML::AttributeNames::style)) {
-            auto* inline_style = parse_css_style_attribute(CSS::Parser::ParsingContext(document()), *element.get_attribute(HTML::AttributeNames::style), element);
+        if (auto inline_style = element.inline_style()) {
             for (auto const& property : inline_style->properties())
                 style->set_property(property.property_id, property.value);
         }

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1174,6 +1174,8 @@ void Node::set_needs_style_update(bool value)
 
     if (m_needs_style_update) {
         for (auto* ancestor = parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host()) {
+            if (ancestor->m_child_needs_style_update)
+                break;
             ancestor->m_child_needs_style_update = true;
         }
         document().schedule_style_update();


### PR DESCRIPTION
For pseudo elements that represent a browser-generated shadow tree
element, such as ::placeholder, we were reparsing their style attribute
in StyleComputer for some reason.

Instead of doing this, just access the already-parsed version via
Element::inline_style().

Bonus commit: abort ancestor traversal earlier in `Node::set_needs_style_recalc()`