### PR TITLE
LibWeb: Add most of ServiceWorker Update algorithm

### DIFF
--- a/Tests/LibWeb/Text/expected/ServiceWorker/service-worker-register.txt
+++ b/Tests/LibWeb/Text/expected/ServiceWorker/service-worker-register.txt
@@ -1,1 +1,1 @@
-ServiceWorker registration failed: InternalError: TODO(Service Worker update is not implemented in LibJS)
+ServiceWorker registration failed: SecurityError: Service Worker script response is not a JavaScript MIME type

--- a/Tests/LibWeb/Text/input/ServiceWorker/service-worker-register.html
+++ b/Tests/LibWeb/Text/input/ServiceWorker/service-worker-register.html
@@ -5,6 +5,9 @@
         setTimeout(() => {
             // We need to do this spoofing later in the event loop so that we don't end up
             // telling the test runner the wrong URL in page_did_finish_loading.
+
+            // FIXME: We need to use an actual https:// domain here in order to
+            //        actually fetch() our js file.
             spoofCurrentURL("https://example.com/service-worker-register.html");
 
             let swPromise = navigator.serviceWorker.register("service-worker.js");

--- a/Userland/Libraries/LibWeb/ServiceWorker/Registration.h
+++ b/Userland/Libraries/LibWeb/ServiceWorker/Registration.h
@@ -31,13 +31,18 @@ public:
     // https://w3c.github.io/ServiceWorker/#set-registration-algorithm
     static Registration& set(StorageAPI::StorageKey const&, URL::URL const&, Bindings::ServiceWorkerUpdateViaCache);
 
+    static void remove(StorageAPI::StorageKey const&, URL::URL const&);
+
     bool is_unregistered();
 
     StorageAPI::StorageKey const& storage_key() const { return m_storage_key; }
     URL::URL const& scope_url() const { return m_scope_url; }
     Bindings::ServiceWorkerUpdateViaCache update_via_cache() const { return m_update_via_cache_mode; }
 
+    void set_last_update_check_time(MonotonicTime time) { m_last_update_check_time = time; }
+
     ServiceWorker* newest_worker() const;
+    bool is_stale() const;
 
 private:
     Registration(StorageAPI::StorageKey, URL::URL, Bindings::ServiceWorkerUpdateViaCache);


### PR DESCRIPTION
This misses the final, most important part of actually creating a service worker object and sending the script over to it in a WebWorker process.