### PR TITLE
LibWeb: Skip DedicatedWorkerGlobalScope-instanceof test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -1,8 +1,12 @@
 [Skipped]
-Text/input/HTML/cross-origin-window-properties.html
+Ref/css-keyframe-fill-forwards.html
+Ref/unicode-range.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
+Text/input/HTML/cross-origin-window-properties.html
+Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
 Text/input/WebAnimations/misc/DocumentTimeline.html
+Text/input/window-scrollTo.html
 Text/input/Worker/Worker-blob.html
 Text/input/Worker/Worker-close-after-postMessage.html
 Text/input/Worker/Worker-crypto.html
@@ -11,6 +15,3 @@ Text/input/Worker/Worker-importScripts.html
 Text/input/Worker/Worker-location.html
 Text/input/Worker/Worker-module.html
 Text/input/Worker/Worker-performance.html
-Text/input/window-scrollTo.html
-Ref/unicode-range.html
-Ref/css-keyframe-fill-forwards.html


### PR DESCRIPTION
It is consistently hanging on mac, which makes running the test suite locally quite annoying. See #1306 for details.