### PR TITLE
LibGfx: Use actual vector size as indicated by HarfBuzz

### DIFF
--- a/Tests/LibWeb/Layout/expected/tab-size-chars-should-vertically-align.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-chars-should-vertically-align.txt
@@ -3,7 +3,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x68 children: not-inline
       BlockContainer <div> at (8,8) content-size 784x17 children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 60x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [68,8 82.265625x17] baseline: 13.296875
+        frag 1 from TextNode start: 0, length: 2, rect: [68,8 88.109375x17] baseline: 13.296875
             "	A"
         BlockContainer <span#s1> at (8,21) content-size 60x0 inline-block [BFC] children: not-inline
         TextNode <#text>
@@ -11,7 +11,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,25) content-size 784x17 children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 70x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [78,25 72.265625x17] baseline: 13.296875
+        frag 1 from TextNode start: 0, length: 2, rect: [78,25 78.109375x17] baseline: 13.296875
             "	A"
         BlockContainer <span#s2> at (8,38) content-size 70x0 inline-block [BFC] children: not-inline
         TextNode <#text>
@@ -19,7 +19,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
       BlockContainer <div> at (8,42) content-size 784x17 children: inline
         frag 0 from BlockContainer start: 0, length: 0, rect: [8,55 73x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [81,42 69.265625x17] baseline: 13.296875
+        frag 1 from TextNode start: 0, length: 2, rect: [81,42 75.109375x17] baseline: 13.296875
             "	A"
         BlockContainer <span#s3> at (8,55) content-size 73x0 inline-block [BFC] children: not-inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
@@ -2,19 +2,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x67 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
       BlockContainer <div> at (8,8) content-size 100x51 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 114.265625x17] baseline: 13.296875
-        frag 1 from BlockContainer start: 0, length: 0, rect: [8,25 123.609375x17] baseline: 13.296875
-        frag 2 from BlockContainer start: 0, length: 0, rect: [8,42 133.921875x17] baseline: 13.296875
-        BlockContainer <span> at (8,8) content-size 114.265625x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 2, rect: [8,8 114.265625x17] baseline: 13.296875
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 120.109375x17] baseline: 13.296875
+        frag 1 from BlockContainer start: 0, length: 0, rect: [8,25 129.453125x17] baseline: 13.296875
+        frag 2 from BlockContainer start: 0, length: 0, rect: [8,42 139.765625x17] baseline: 13.296875
+        BlockContainer <span> at (8,8) content-size 120.109375x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 2, rect: [8,8 120.109375x17] baseline: 13.296875
               "	A"
           TextNode <#text>
-        BlockContainer <span> at (8,25) content-size 123.609375x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [8,25 123.609375x17] baseline: 13.296875
+        BlockContainer <span> at (8,25) content-size 129.453125x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,25 129.453125x17] baseline: 13.296875
               "	AB"
           TextNode <#text>
-        BlockContainer <span> at (8,42) content-size 133.921875x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 4, rect: [8,42 133.921875x17] baseline: 13.296875
+        BlockContainer <span> at (8,42) content-size 139.765625x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,42 139.765625x17] baseline: 13.296875
               "	ABC"
           TextNode <#text>
       BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
@@ -23,11 +23,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x67]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x51]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 100x51] overflow: [8,8 133.921875x51]
-        PaintableWithLines (BlockContainer<SPAN>) [8,8 114.265625x17]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x51] overflow: [8,8 139.765625x51]
+        PaintableWithLines (BlockContainer<SPAN>) [8,8 120.109375x17]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<SPAN>) [8,25 123.609375x17]
+        PaintableWithLines (BlockContainer<SPAN>) [8,25 129.453125x17]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<SPAN>) [8,42 133.921875x17]
+        PaintableWithLines (BlockContainer<SPAN>) [8,42 139.765625x17]
           TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,59 784x0]

--- a/Tests/LibWeb/Text/expected/regress/recursive-glyph-miscount-dont-crash.txt
+++ b/Tests/LibWeb/Text/expected/regress/recursive-glyph-miscount-dont-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/regress/recursive-glyph-miscount-dont-crash.html
+++ b/Tests/LibWeb/Text/input/regress/recursive-glyph-miscount-dont-crash.html
@@ -1,0 +1,7 @@
+<script src="../include.js"></script>
+&ne;
+<script>
+    test(() => {
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -21,7 +21,6 @@ RefPtr<GlyphRun> shape_text(FloatPoint baseline_start, Utf8View string, Gfx::Fon
 
     u32 glyph_count;
     auto* glyph_info = hb_buffer_get_glyph_infos(buffer, &glyph_count);
-    Vector<hb_glyph_info_t> const input_glyph_info({ glyph_info, glyph_count });
 
     auto* hb_font = font.harfbuzz_font();
     hb_shape(hb_font, buffer, nullptr, 0);
@@ -29,6 +28,7 @@ RefPtr<GlyphRun> shape_text(FloatPoint baseline_start, Utf8View string, Gfx::Fon
     glyph_info = hb_buffer_get_glyph_infos(buffer, &glyph_count);
     auto* positions = hb_buffer_get_glyph_positions(buffer, &glyph_count);
 
+    Vector<hb_glyph_info_t> const input_glyph_info({ glyph_info, glyph_count });
     Vector<Gfx::DrawGlyph> glyph_run;
     FloatPoint point = baseline_start;
     for (size_t i = 0; i < glyph_count; ++i) {


### PR DESCRIPTION
This fixes a browser crash as experienced on Wikipedia when encountering the `&ne;` entity. As a side-effect, this also affects some tab-align and -wrap tests.

In particular, harfbuzz keeps changing the internal buffer array around, and writes to `glyph_count` in the later calls, so it's a bad idea to use the first value and use it forever.

CC @kostyafarber, as I this seems to change(?) or break(?) a test that you recently added in #1691. I don't know what's going on, so I have a few stupid questions: Do your tests intentionally check for these exact values? If yes, how do we fix this?