### PR TITLE
LibWeb/Fetch: Improve aborting fetch

### DIFF
--- a/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Fetch/Request.h>
 #include <LibWeb/Fetch/Response.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
+#include <LibWeb/Streams/AbstractOperations.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Promise.h>
 
@@ -163,8 +164,8 @@ void abort_fetch(JS::Realm& realm, WebIDL::Promise const& promise, GC::Ref<Infra
 
     // 2. If request’s body is non-null and is readable, then cancel request’s body with error.
     if (auto* body = request->body().get_pointer<GC::Ref<Infrastructure::Body>>(); body != nullptr && (*body)->stream()->is_readable()) {
-        // TODO: Implement cancelling streams
-        (void)error;
+        // NOTE: Cancel here is different than the cancel method of stream and refers to https://streams.spec.whatwg.org/#readablestream-cancel
+        Streams::readable_stream_cancel((*body)->stream(), error);
     }
 
     // 3. If responseObject is null, then return.
@@ -178,8 +179,7 @@ void abort_fetch(JS::Realm& realm, WebIDL::Promise const& promise, GC::Ref<Infra
     if (response->body()) {
         auto stream = response->body()->stream();
         if (stream->is_readable()) {
-            // TODO: Implement erroring streams
-            (void)error;
+            stream->error(error);
         }
     }
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/FetchController.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/FetchController.h
@@ -44,6 +44,7 @@ public:
     void process_next_manual_redirect() const;
     [[nodiscard]] GC::Ref<FetchTimingInfo> extract_full_timing_info() const;
     void abort(JS::Realm&, Optional<JS::Value>);
+    JS::Value deserialize_a_serialized_abort_reason(JS::Realm&);
     void terminate();
 
     void set_fetch_params(Badge<FetchParams>, GC::Ref<FetchParams> fetch_params) { m_fetch_params = fetch_params; }
@@ -77,7 +78,7 @@ private:
     // https://fetch.spec.whatwg.org/#fetch-controller-report-timing-steps
     // serialized abort reason (default null)
     //     Null or a Record (result of StructuredSerialize).
-    HTML::SerializationRecord m_serialized_abort_reason;
+    Optional<HTML::SerializationRecord> m_serialized_abort_reason;
 
     // https://fetch.spec.whatwg.org/#fetch-controller-next-manual-redirect-steps
     // next manual redirect steps (default null)
@@ -88,6 +89,24 @@ private:
 
     HashMap<u64, HTML::TaskID> m_ongoing_fetch_tasks;
     u64 m_next_fetch_task_id { 0 };
+};
+
+class FetchControllerHolder : public JS::Cell {
+    GC_CELL(FetchControllerHolder, JS::Cell);
+    GC_DECLARE_ALLOCATOR(FetchControllerHolder);
+
+public:
+    static GC::Ref<FetchControllerHolder> create(JS::VM&);
+
+    [[nodiscard]] GC::Ptr<FetchController> const& controller() const { return m_controller; }
+    void set_controller(GC::Ref<FetchController> controller) { m_controller = controller; }
+
+private:
+    FetchControllerHolder();
+
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    GC::Ptr<FetchController> m_controller;
 };
 
 }


### PR DESCRIPTION
This PR improves fetch so that the reason for an abort is returned and the request/response streams are properly handled.