### PR TITLE
LibWeb/XHR: Progess event handle empty length

### DIFF
--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -105,7 +105,7 @@ static void fire_progress_event(XMLHttpRequestEventTarget& target, FlyString con
     // with the loaded attribute initialized to transmitted, and if length is not 0, with the lengthComputable attribute initialized to true
     // and the total attribute initialized to length.
     ProgressEventInit event_init {};
-    event_init.length_computable = true;
+    event_init.length_computable = length;
     event_init.loaded = transmitted;
     event_init.total = length;
     // FIXME: If we're in an async context, this will propagate to a callback context which can't propagate it anywhere else and does not expect this to fail.


### PR DESCRIPTION
Spec comment included asserts on this behaviour implicitly.
Fixes WPT test here: http://wpt.live/xhr/firing-events-http-no-content-length.html.