### PR TITLE
LibWeb/HTML: Use IDL Enumerated for form{Enctype, Method}, method attributes

### DIFF
--- a/Tests/LibWeb/Text/expected/form-formEnctype-attribute.txt
+++ b/Tests/LibWeb/Text/expected/form-formEnctype-attribute.txt
@@ -49,3 +49,55 @@ button.formEnctype == 'application/x-www-form-urlencoded'
 button.setAttribute('formEnctype', '5%')
 button.getAttribute('formEnctype') == '5%'
 button.formEnctype == 'application/x-www-form-urlencoded'
+
+input: unset
+input.getAttribute('formEnctype') == 'null'
+input.formEnctype == ''
+
+input.setAttribute('formEnctype', '')
+input.getAttribute('formEnctype') == ''
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', 'undefined')
+input.getAttribute('formEnctype') == 'undefined'
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', 'null')
+input.getAttribute('formEnctype') == 'null'
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', 'application/x-www-form-urlencoded')
+input.getAttribute('formEnctype') == 'application/x-www-form-urlencoded'
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', 'multipart/form-data')
+input.getAttribute('formEnctype') == 'multipart/form-data'
+input.formEnctype == 'multipart/form-data'
+
+input.setAttribute('formEnctype', 'text/plain')
+input.getAttribute('formEnctype') == 'text/plain'
+input.formEnctype == 'text/plain'
+
+input.setAttribute('formEnctype', 'APPLICATION/X-WWW-FORM-URLENCODED')
+input.getAttribute('formEnctype') == 'APPLICATION/X-WWW-FORM-URLENCODED'
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', 'MULTIPART/FORM-DATA')
+input.getAttribute('formEnctype') == 'MULTIPART/FORM-DATA'
+input.formEnctype == 'multipart/form-data'
+
+input.setAttribute('formEnctype', 'tEXt/PlAIn')
+input.getAttribute('formEnctype') == 'tEXt/PlAIn'
+input.formEnctype == 'text/plain'
+
+input.setAttribute('formEnctype', 'text/plain ')
+input.getAttribute('formEnctype') == 'text/plain '
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', '7')
+input.getAttribute('formEnctype') == '7'
+input.formEnctype == 'application/x-www-form-urlencoded'
+
+input.setAttribute('formEnctype', '5%')
+input.getAttribute('formEnctype') == '5%'
+input.formEnctype == 'application/x-www-form-urlencoded'

--- a/Tests/LibWeb/Text/expected/form-formEnctype-attribute.txt
+++ b/Tests/LibWeb/Text/expected/form-formEnctype-attribute.txt
@@ -1,0 +1,51 @@
+button: unset
+button.getAttribute('formEnctype') == 'null'
+button.formEnctype == ''
+
+button.setAttribute('formEnctype', '')
+button.getAttribute('formEnctype') == ''
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', 'undefined')
+button.getAttribute('formEnctype') == 'undefined'
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', 'null')
+button.getAttribute('formEnctype') == 'null'
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', 'application/x-www-form-urlencoded')
+button.getAttribute('formEnctype') == 'application/x-www-form-urlencoded'
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', 'multipart/form-data')
+button.getAttribute('formEnctype') == 'multipart/form-data'
+button.formEnctype == 'multipart/form-data'
+
+button.setAttribute('formEnctype', 'text/plain')
+button.getAttribute('formEnctype') == 'text/plain'
+button.formEnctype == 'text/plain'
+
+button.setAttribute('formEnctype', 'APPLICATION/X-WWW-FORM-URLENCODED')
+button.getAttribute('formEnctype') == 'APPLICATION/X-WWW-FORM-URLENCODED'
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', 'MULTIPART/FORM-DATA')
+button.getAttribute('formEnctype') == 'MULTIPART/FORM-DATA'
+button.formEnctype == 'multipart/form-data'
+
+button.setAttribute('formEnctype', 'tEXt/PlAIn')
+button.getAttribute('formEnctype') == 'tEXt/PlAIn'
+button.formEnctype == 'text/plain'
+
+button.setAttribute('formEnctype', 'text/plain ')
+button.getAttribute('formEnctype') == 'text/plain '
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', '7')
+button.getAttribute('formEnctype') == '7'
+button.formEnctype == 'application/x-www-form-urlencoded'
+
+button.setAttribute('formEnctype', '5%')
+button.getAttribute('formEnctype') == '5%'
+button.formEnctype == 'application/x-www-form-urlencoded'

--- a/Tests/LibWeb/Text/expected/form-formMethod-attribute.txt
+++ b/Tests/LibWeb/Text/expected/form-formMethod-attribute.txt
@@ -1,0 +1,51 @@
+button: unset
+button.getAttribute('formMethod') == 'null'
+button.formMethod == ''
+
+button.setAttribute('formMethod', '')
+button.getAttribute('formMethod') == ''
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', 'undefined')
+button.getAttribute('formMethod') == 'undefined'
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', 'null')
+button.getAttribute('formMethod') == 'null'
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', 'get')
+button.getAttribute('formMethod') == 'get'
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', 'post')
+button.getAttribute('formMethod') == 'post'
+button.formMethod == 'post'
+
+button.setAttribute('formMethod', 'dialog')
+button.getAttribute('formMethod') == 'dialog'
+button.formMethod == 'dialog'
+
+button.setAttribute('formMethod', 'GeT')
+button.getAttribute('formMethod') == 'GeT'
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', 'POST')
+button.getAttribute('formMethod') == 'POST'
+button.formMethod == 'post'
+
+button.setAttribute('formMethod', 'DIAlog')
+button.getAttribute('formMethod') == 'DIAlog'
+button.formMethod == 'dialog'
+
+button.setAttribute('formMethod', 'foo')
+button.getAttribute('formMethod') == 'foo'
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', 'xpost')
+button.getAttribute('formMethod') == 'xpost'
+button.formMethod == 'get'
+
+button.setAttribute('formMethod', '5%')
+button.getAttribute('formMethod') == '5%'
+button.formMethod == 'get'

--- a/Tests/LibWeb/Text/expected/form-formMethod-attribute.txt
+++ b/Tests/LibWeb/Text/expected/form-formMethod-attribute.txt
@@ -49,3 +49,55 @@ button.formMethod == 'get'
 button.setAttribute('formMethod', '5%')
 button.getAttribute('formMethod') == '5%'
 button.formMethod == 'get'
+
+input: unset
+input.getAttribute('formMethod') == 'null'
+input.formMethod == ''
+
+input.setAttribute('formMethod', '')
+input.getAttribute('formMethod') == ''
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', 'undefined')
+input.getAttribute('formMethod') == 'undefined'
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', 'null')
+input.getAttribute('formMethod') == 'null'
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', 'get')
+input.getAttribute('formMethod') == 'get'
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', 'post')
+input.getAttribute('formMethod') == 'post'
+input.formMethod == 'post'
+
+input.setAttribute('formMethod', 'dialog')
+input.getAttribute('formMethod') == 'dialog'
+input.formMethod == 'dialog'
+
+input.setAttribute('formMethod', 'GeT')
+input.getAttribute('formMethod') == 'GeT'
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', 'POST')
+input.getAttribute('formMethod') == 'POST'
+input.formMethod == 'post'
+
+input.setAttribute('formMethod', 'DIAlog')
+input.getAttribute('formMethod') == 'DIAlog'
+input.formMethod == 'dialog'
+
+input.setAttribute('formMethod', 'foo')
+input.getAttribute('formMethod') == 'foo'
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', 'xpost')
+input.getAttribute('formMethod') == 'xpost'
+input.formMethod == 'get'
+
+input.setAttribute('formMethod', '5%')
+input.getAttribute('formMethod') == '5%'
+input.formMethod == 'get'

--- a/Tests/LibWeb/Text/expected/form-method-attribute.txt
+++ b/Tests/LibWeb/Text/expected/form-method-attribute.txt
@@ -1,0 +1,51 @@
+form: unset
+form.getAttribute('method') == 'null'
+form.method == 'get'
+
+form.setAttribute('method', '')
+form.getAttribute('method') == ''
+form.method == 'get'
+
+form.setAttribute('method', 'undefined')
+form.getAttribute('method') == 'undefined'
+form.method == 'get'
+
+form.setAttribute('method', 'null')
+form.getAttribute('method') == 'null'
+form.method == 'get'
+
+form.setAttribute('method', 'get')
+form.getAttribute('method') == 'get'
+form.method == 'get'
+
+form.setAttribute('method', 'post')
+form.getAttribute('method') == 'post'
+form.method == 'post'
+
+form.setAttribute('method', 'dialog')
+form.getAttribute('method') == 'dialog'
+form.method == 'dialog'
+
+form.setAttribute('method', 'GeT')
+form.getAttribute('method') == 'GeT'
+form.method == 'get'
+
+form.setAttribute('method', 'POST')
+form.getAttribute('method') == 'POST'
+form.method == 'post'
+
+form.setAttribute('method', 'DIAlog')
+form.getAttribute('method') == 'DIAlog'
+form.method == 'dialog'
+
+form.setAttribute('method', 'foo')
+form.getAttribute('method') == 'foo'
+form.method == 'get'
+
+form.setAttribute('method', 'xpost')
+form.getAttribute('method') == 'xpost'
+form.method == 'get'
+
+form.setAttribute('method', '5%')
+form.getAttribute('method') == '5%'
+form.method == 'get'

--- a/Tests/LibWeb/Text/input/form-formEnctype-attribute.html
+++ b/Tests/LibWeb/Text/input/form-formEnctype-attribute.html
@@ -2,6 +2,7 @@
 <script>
     test(() => {
         const btn = document.createElement('button');
+        const input = document.createElement('input');
         const values = [
             '', undefined, null,
             'application/x-www-form-urlencoded',
@@ -22,6 +23,18 @@
             println(`button.setAttribute('formEnctype', '${value}')`);
             println(`button.getAttribute('formEnctype') == '${btn.getAttribute('formEnctype')}'`);
             println(`button.formEnctype == '${btn.formEnctype}'`);
+        }
+
+        println('');
+        println('input: unset');
+        println(`input.getAttribute('formEnctype') == '${input.getAttribute('formEnctype')}'`);
+        println(`input.formEnctype == '${input.formEnctype}'`);
+        for (value of values) {
+            input.setAttribute('formEnctype', value);
+            println('');
+            println(`input.setAttribute('formEnctype', '${value}')`);
+            println(`input.getAttribute('formEnctype') == '${input.getAttribute('formEnctype')}'`);
+            println(`input.formEnctype == '${input.formEnctype}'`);
         }
     });
 </script>

--- a/Tests/LibWeb/Text/input/form-formEnctype-attribute.html
+++ b/Tests/LibWeb/Text/input/form-formEnctype-attribute.html
@@ -1,0 +1,27 @@
+<script src="./include.js"></script>
+<script>
+    test(() => {
+        const btn = document.createElement('button');
+        const values = [
+            '', undefined, null,
+            'application/x-www-form-urlencoded',
+            'multipart/form-data',
+            'text/plain',
+            'APPLICATION/X-WWW-FORM-URLENCODED',
+            'MULTIPART/FORM-DATA',
+            'tEXt/PlAIn',
+            'text/plain ', '7', '5%'
+        ];
+
+        println('button: unset');
+        println(`button.getAttribute('formEnctype') == '${btn.getAttribute('formEnctype')}'`);
+        println(`button.formEnctype == '${btn.formEnctype}'`);
+        for (value of values) {
+            btn.setAttribute('formEnctype', value);
+            println('');
+            println(`button.setAttribute('formEnctype', '${value}')`);
+            println(`button.getAttribute('formEnctype') == '${btn.getAttribute('formEnctype')}'`);
+            println(`button.formEnctype == '${btn.formEnctype}'`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/form-formMethod-attribute.html
+++ b/Tests/LibWeb/Text/input/form-formMethod-attribute.html
@@ -1,0 +1,23 @@
+<script src="./include.js"></script>
+<script>
+    test(() => {
+        const btn = document.createElement('button');
+        const values = [
+            '', undefined, null,
+            'get', 'post', 'dialog',
+            'GeT', 'POST', 'DIAlog',
+            'foo', 'xpost', '5%'
+        ];
+
+        println('button: unset');
+        println(`button.getAttribute('formMethod') == '${btn.getAttribute('formMethod')}'`);
+        println(`button.formMethod == '${btn.formMethod}'`);
+        for (value of values) {
+            btn.setAttribute('formMethod', value);
+            println('');
+            println(`button.setAttribute('formMethod', '${value}')`);
+            println(`button.getAttribute('formMethod') == '${btn.getAttribute('formMethod')}'`);
+            println(`button.formMethod == '${btn.formMethod}'`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/form-formMethod-attribute.html
+++ b/Tests/LibWeb/Text/input/form-formMethod-attribute.html
@@ -2,6 +2,7 @@
 <script>
     test(() => {
         const btn = document.createElement('button');
+        const input = document.createElement('input');
         const values = [
             '', undefined, null,
             'get', 'post', 'dialog',
@@ -18,6 +19,18 @@
             println(`button.setAttribute('formMethod', '${value}')`);
             println(`button.getAttribute('formMethod') == '${btn.getAttribute('formMethod')}'`);
             println(`button.formMethod == '${btn.formMethod}'`);
+        }
+
+        println('');
+        println('input: unset')
+        println(`input.getAttribute('formMethod') == '${input.getAttribute('formMethod')}'`);
+        println(`input.formMethod == '${input.formMethod}'`);
+        for (value of values) {
+            input.setAttribute('formMethod', value);
+            println('');
+            println(`input.setAttribute('formMethod', '${value}')`);
+            println(`input.getAttribute('formMethod') == '${input.getAttribute('formMethod')}'`);
+            println(`input.formMethod == '${input.formMethod}'`);
         }
     });
 </script>

--- a/Tests/LibWeb/Text/input/form-method-attribute.html
+++ b/Tests/LibWeb/Text/input/form-method-attribute.html
@@ -1,0 +1,23 @@
+<script src="./include.js"></script>
+<script>
+    test(() => {
+        const form = document.createElement('form');
+        const values = [
+            '', undefined, null,
+            'get', 'post', 'dialog',
+            'GeT', 'POST', 'DIAlog',
+            'foo', 'xpost', '5%'
+        ];
+
+        println('form: unset');
+        println(`form.getAttribute('method') == '${form.getAttribute('method')}'`);
+        println(`form.method == '${form.method}'`);
+        for (value of values) {
+            form.setAttribute('method', value);
+            println('');
+            println(`form.setAttribute('method', '${value}')`);
+            println(`form.getAttribute('method') == '${form.getAttribute('method')}'`);
+            println(`form.method == '${form.method}'`);
+        }
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -16,8 +16,8 @@ interface HTMLButtonElement : HTMLElement {
     [CEReactions, Reflect] attribute boolean disabled;
     readonly attribute HTMLFormElement? form;
     [CEReactions] attribute USVString formAction;
-    [CEReactions, Reflect=formenctype] attribute DOMString formEnctype;
-    [CEReactions, Reflect=formmethod] attribute DOMString formMethod;
+    [CEReactions, Reflect=formenctype, Enumerated=FormEnctypeAttribute] attribute DOMString formEnctype;
+    [CEReactions, Reflect=formmethod, Enumerated=FormMethodAttribute] attribute DOMString formMethod;
     [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
     [CEReactions, Reflect=formtarget] attribute DOMString formTarget;
     [CEReactions, Reflect] attribute DOMString name;

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -565,23 +565,6 @@ Vector<JS::NonnullGCPtr<DOM::Element>> HTMLFormElement::get_submittable_elements
     return submittable_elements;
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-method
-StringView HTMLFormElement::method() const
-{
-    // The method and enctype IDL attributes must reflect the respective content attributes of the same name, limited to only known values.
-    // FIXME: This should probably be `Reflect` in the IDL.
-    auto method_state = method_state_from_form_element(*this);
-    switch (method_state) {
-    case MethodAttributeState::GET:
-        return "get"sv;
-    case MethodAttributeState::POST:
-        return "post"sv;
-    case MethodAttributeState::Dialog:
-        return "dialog"sv;
-    }
-    VERIFY_NOT_REACHED();
-}
-
 // https://html.spec.whatwg.org/multipage/forms.html#dom-form-rellist
 JS::NonnullGCPtr<DOM::DOMTokenList> HTMLFormElement::rel_list()
 {

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -88,7 +88,6 @@ public:
     bool constructing_entry_list() const { return m_constructing_entry_list; }
     void set_constructing_entry_list(bool value) { m_constructing_entry_list = value; }
 
-    StringView method() const;
     WebIDL::ExceptionOr<void> set_method(String const&);
 
     JS::NonnullGCPtr<DOM::DOMTokenList> rel_list();

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -24,6 +24,22 @@ enum MethodAttribute {
     "dialog"
 };
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formenctype
+[InvalidValueDefault=application/x-www-form-urlencoded]
+enum FormEnctypeAttribute {
+    "application/x-www-form-urlencoded",
+    "multipart/form-data",
+    "text/plain"
+};
+
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-formmethod
+[InvalidValueDefault=get]
+enum FormMethodAttribute {
+    "get",
+    "post",
+    "dialog"
+};
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#selectionmode
 enum SelectionMode {
     "select",

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.idl
@@ -16,6 +16,14 @@ enum EnctypeAttribute {
     "text/plain"
 };
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
+[MissingValueDefault=get, InvalidValueDefault=get]
+enum MethodAttribute {
+    "get",
+    "post",
+    "dialog"
+};
+
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#selectionmode
 enum SelectionMode {
     "select",
@@ -35,7 +43,7 @@ interface HTMLFormElement : HTMLElement {
     [CEReactions, Enumerated=Autocomplete, Reflect] attribute DOMString autocomplete;
     [CEReactions, Enumerated=EnctypeAttribute, Reflect] attribute DOMString enctype;
     [CEReactions, Enumerated=EnctypeAttribute, Reflect=enctype] attribute DOMString encoding;
-    [CEReactions] attribute DOMString method;
+    [CEReactions, Enumerated=MethodAttribute, Reflect] attribute DOMString method;
     [CEReactions, Reflect] attribute DOMString name;
     [CEReactions, Reflect=novalidate] attribute boolean noValidate;
     [CEReactions, Reflect] attribute DOMString target;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -18,8 +18,8 @@ interface HTMLInputElement : HTMLElement {
     readonly attribute HTMLFormElement? form;
     attribute FileList? files;
     [CEReactions] attribute USVString formAction;
-    [FIXME, CEReactions] attribute DOMString formEnctype;
-    [FIXME, CEReactions] attribute DOMString formMethod;
+    [CEReactions, Reflect=formenctype, Enumerated=FormEnctypeAttribute] attribute DOMString formEnctype;
+    [CEReactions, Reflect=formmethod, Enumerated=FormMethodAttribute] attribute DOMString formMethod;
     [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
     [CEReactions, Reflect=formtarget] attribute DOMString formTarget;
     [FIXME, CEReactions] attribute unsigned long height;


### PR DESCRIPTION
The values of these attributes must be [limited to only known values](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-action), updated the IDL to enforce this.

This PR fixes many test in [this](https://wpt.fyi/results/html/dom/reflection-forms.html?product=ladybird) WPT test

- [x] Fix #1890