### PR TITLE
LibWeb:Storage: Change getNamedItem default value

### DIFF
--- a/Tests/LibWeb/Text/expected/localStorage.txt
+++ b/Tests/LibWeb/Text/expected/localStorage.txt
@@ -1,6 +1,10 @@
+undefined
+null
 value
 value
 other
 other
+undefined
+null
 foo
 foo

--- a/Tests/LibWeb/Text/input/localStorage.html
+++ b/Tests/LibWeb/Text/input/localStorage.html
@@ -1,6 +1,10 @@
 <script src="include.js"></script>
 <script>
     test(() => {
+
+        println(localStorage["test"])
+        println(localStorage.getItem("test"))
+
         localStorage["test"] = "value";
         println(localStorage["test"]);
         println(localStorage.getItem("test"));
@@ -10,6 +14,9 @@
         println(localStorage.getItem("test"));
 
         // Ensure indexed properties work
+        println(localStorage[0])
+        println(localStorage.getItem(0))
+
         localStorage[0] = "foo";
         println(localStorage[0]);
         println(localStorage.getItem("0"));

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -182,7 +182,9 @@ JS::Value Storage::named_item_value(FlyString const& name) const
 {
     auto value = get_item(name);
     if (!value.has_value())
-        return JS::js_null();
+        // AD-HOC: Spec leaves open to a description at: https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-interface
+        // However correct behavior expected here: https://github.com/whatwg/html/issues/8684
+        return JS::js_undefined();
     return JS::PrimitiveString::create(vm(), value.release_value());
 }
 


### PR DESCRIPTION
All tests at now pass: http://wpt.live/webstorage/defineProperty.window.html.
Uncertain whether this is actually the correct change:
https://html.spec.whatwg.org/multipage/webstorage.html#the-storage-interface indicates that the two getter methods storage[name] and storage.getItem(name) should return null when the name is not present. However the tests assert on this behaviour. 
