### PR TITLE
Verticalalign table cells

### DIFF
--- a/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
+++ b/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
@@ -1,0 +1,38 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <(anonymous)> at (0,0) content-size 800x0 children: inline
+      TextNode <#text>
+    BlockContainer <body> at (8,8) content-size 784x100 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      TableWrapper <(anonymous)> at (8,8) content-size 204x100 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 204x100 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (8,8) content-size 204x100 table-row-group children: not-inline
+            Box <tr> at (8,8) content-size 204x100 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 200x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 15, rect: [10,10 129.296875x17] baseline: 13.296875
+                    "Text at the top"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,108) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer(anonymous)) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 204x100]
+        PaintableBox (Box<TABLE>) [8,8 204x100]
+          PaintableBox (Box<TBODY>) [8,8 204x100]
+            PaintableBox (Box<TR>) [8,8 204x100]
+              PaintableWithLines (BlockContainer<TD>) [8,8 204x100]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/input/css-table-cell-verticalalign-text-top.html
+++ b/Tests/LibWeb/Layout/input/css-table-cell-verticalalign-text-top.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+        table {
+            border-collapse: collapse;
+        }
+        td {
+            border: 1px solid black;
+            width: 200px;
+            height: 100px;
+            vertical-align: text-top;
+        }
+    </style>
+</head>
+<body>
+    <table>
+        <tr>
+            <td>Text at the top</td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -1094,41 +1094,36 @@ void TableFormattingContext::position_cell_boxes()
         auto const& vertical_align = cell.box->computed_values().vertical_align();
         // The following image shows various alignment lines of a row:
         // https://www.w3.org/TR/css-tables-3/images/cell-align-explainer.png
+        // https://drafts.csswg.org/css2/#height-layout
+        // In the context of tables, values for vertical-align have the following meanings:
         if (vertical_align.has<CSS::VerticalAlign>()) {
             switch (vertical_align.get<CSS::VerticalAlign>()) {
+            // The center of the cell is aligned with the center of the rows it spans.
             case CSS::VerticalAlign::Middle: {
                 auto const height_diff = row_content_height - cell_state.border_box_height();
                 cell_state.padding_top += height_diff / 2;
                 cell_state.padding_bottom += height_diff / 2;
                 break;
             }
+            // The top of the cell box is aligned with the top of the first row it spans.
             case CSS::VerticalAlign::Top: {
                 cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
                 break;
             }
+            // The bottom of the cell box is aligned with the bottom of the last row it spans.
             case CSS::VerticalAlign::Bottom: {
                 cell_state.padding_top += row_content_height - cell_state.border_box_height();
                 break;
             }
+            // These values do not apply to cells; the cell is aligned at the baseline instead.
+            case CSS::VerticalAlign::Sub:
+            case CSS::VerticalAlign::Super:
+            case CSS::VerticalAlign::TextBottom:
+            case CSS::VerticalAlign::TextTop:
+            // The baseline of the cell is put at the same height as the baseline of the first of the rows it spans.
             case CSS::VerticalAlign::Baseline: {
                 cell_state.padding_top += m_rows[cell.row_index].baseline - cell.baseline;
                 cell_state.padding_bottom += row_content_height - cell_state.border_box_height();
-                break;
-            }
-            case CSS::VerticalAlign::Sub: {
-                dbgln("FIXME: Implement \"vertical-align: sub\" support for table cells");
-                break;
-            }
-            case CSS::VerticalAlign::Super: {
-                dbgln("FIXME: Implement \"vertical-align: super\" support for table cells");
-                break;
-            }
-            case CSS::VerticalAlign::TextBottom: {
-                dbgln("FIXME: Implement \"vertical-align: text-bottom\" support for table cells");
-                break;
-            }
-            case CSS::VerticalAlign::TextTop: {
-                dbgln("FIXME: Implement \"vertical-align: text-top\" support for table cells");
                 break;
             }
             default:


### PR DESCRIPTION
This seems to be a totally right thing to do. As per https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align
```
[baseline](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align#baseline_2) (and sub, super, text-top, text-bottom, <length>, and <percentage>)
Aligns the baseline of the cell with the baseline of all other cells in the row that are baseline-aligned.
```
I have a test that demonstates the issue
```
<!DOCTYPE html>
<html lang="en">
<head>
    <title>Vertical Align Test: text-top, text-bottom, and baseline</title>
    <style>
        table {
            width: 100%;
            border-collapse: collapse;
        }
        td {
            border: 1px solid black;
            width: 300px;
            height: 300px;
            text-align: center;
        }
    </style>
</head>
<body>
    <table>
        <tr>
            <td style="vertical-align: text-top;">
                Text aligned at the top
            </td>
            <td style="vertical-align: text-bottom;">
                Text aligned at the bottom
            </td>
            <td style="vertical-align: baseline;">
                Text aligned at the baseline
            </td>
            <td>
                Normal content for reference
            </td>
        </tr>
        <tr>
            <td style="vertical-align: text-top;">
                Short text<br>with <br>line breaks
            </td>
            <td style="vertical-align: text-bottom;">
                <div style="height: 50px;">A block element</div>
                in the cell
            </td>
            <td style="vertical-align: baseline;">
                Text aligned<br>at the baseline
            </td>
            <td>
                Reference content with normal alignment
            </td>
        </tr>
    </table>
</body>
</html>
```

However, it is quite fun that, even with my changes, the test shows ladybird table raw baseline does not correspond to that of other browsers (tested in Brave, Safari, and Firefox, that act all the same)
<img width="1178" alt="image" src="https://github.com/user-attachments/assets/7429caf9-de06-4df5-afa1-b7a0ecae4ce8">
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/5b6799b7-e64e-41d3-a037-d3be03040cf0">
While this PR is definitely a step towards getting it right, I seem to be far from getting there
For comparison, this is how it looks before this PR:
<img width="1327" alt="image" src="https://github.com/user-attachments/assets/56dbc7b7-d7a9-4e9e-b236-c144db1e663d">
