### PR TITLE
LibWeb: Implement and use "isomorphic decoding"

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -347,7 +347,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Document>> Document::create_and_initialize(
     // 16. If navigationParams's response has a `Refresh` header, then:
     if (auto maybe_refresh = navigation_params.response->header_list()->get("Refresh"sv.bytes()); maybe_refresh.has_value()) {
         // 1. Let value be the isomorphic decoding of the value of the header.
-        auto const& value = maybe_refresh.value();
+        auto value = Infra::isomorphic_decode(maybe_refresh.value());
 
         // 2. Run the shared declarative refresh steps with document and value.
         document->shared_declarative_refresh_steps(value, nullptr);

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/URL.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/URL.cpp
@@ -9,6 +9,7 @@
 #include <AK/Base64.h>
 #include <LibURL/URL.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
+#include <LibWeb/Infra/Strings.h>
 #include <LibWeb/MimeSniff/MimeType.h>
 
 namespace Web::Fetch::Infrastructure {
@@ -75,7 +76,7 @@ ErrorOr<DataURL> process_data_url(URL::URL const& data_url)
         trimmed_substring_view = trimmed_substring_view.trim(" "sv, TrimMode::Right);
         if (trimmed_substring_view.ends_with(';')) {
             // 1. Let stringBody be the isomorphic decode of body.
-            auto string_body = StringView(body);
+            auto string_body = Infra::isomorphic_decode(body);
 
             // 2. Set body to the forgiving-base64 decode of stringBody.
             // 3. If body is failure, then return failure.

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -13,7 +13,6 @@
 #include <AK/Vector.h>
 #include <LibJS/Heap/HeapFunction.h>
 #include <LibJS/Runtime/Array.h>
-#include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/Fetch/FetchMethod.h>
@@ -36,6 +35,7 @@
 #include <LibWeb/HighResolutionTime/Performance.h>
 #include <LibWeb/HighResolutionTime/SupportedPerformanceTypes.h>
 #include <LibWeb/IndexedDB/IDBFactory.h>
+#include <LibWeb/Infra/Strings.h>
 #include <LibWeb/PerformanceTimeline/EntryTypes.h>
 #include <LibWeb/PerformanceTimeline/PerformanceObserver.h>
 #include <LibWeb/PerformanceTimeline/PerformanceObserverEntryList.h>
@@ -142,10 +142,8 @@ WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::atob(String const& d
         return WebIDL::InvalidCharacterError::create(realm, "Input string is not valid base64 data"_string);
 
     // 3. Return decodedData.
-    // decode_base64() returns a byte buffer. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.
-    auto decoder = TextCodec::decoder_for_exact_name("ISO-8859-1"sv);
-    VERIFY(decoder.has_value());
-    return TRY_OR_THROW_OOM(vm, decoder->to_utf8(decoded_data.value()));
+    // decode_base64() returns a byte buffer. LibJS uses UTF-8 for strings. Use isomorphic decoding to convert bytes to UTF-8.
+    return Infra::isomorphic_decode(decoded_data.value());
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-queuemicrotask

--- a/Userland/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Userland/Libraries/LibWeb/Infra/Strings.cpp
@@ -144,4 +144,27 @@ ErrorOr<String> to_ascii_uppercase(StringView string)
     return string_builder.to_string();
 }
 
+// https://infra.spec.whatwg.org/#isomorphic-encode
+ByteBuffer isomorphic_encode(StringView input)
+{
+    ByteBuffer buf = {};
+    for (auto code_point : Utf8View { input }) {
+        // VERIFY(code_point <= 0xFF);
+        if (code_point > 0xFF)
+            dbgln("FIXME: Trying to isomorphic encode a string with code points > U+00FF.");
+        buf.append((u8)code_point);
+    }
+    return buf;
+}
+
+// https://infra.spec.whatwg.org/#isomorphic-decode
+String isomorphic_decode(ReadonlyBytes input)
+{
+    StringBuilder builder(input.size());
+    for (u8 code_point : input) {
+        builder.append_code_point(code_point);
+    }
+    return builder.to_string_without_validation();
+}
+
 }

--- a/Userland/Libraries/LibWeb/Infra/Strings.h
+++ b/Userland/Libraries/LibWeb/Infra/Strings.h
@@ -20,5 +20,7 @@ bool is_code_unit_prefix(StringView potential_prefix, StringView input);
 ErrorOr<String> convert_to_scalar_value_string(StringView string);
 ErrorOr<String> to_ascii_lowercase(StringView string);
 ErrorOr<String> to_ascii_uppercase(StringView string);
+ByteBuffer isomorphic_encode(StringView input);
+String isomorphic_decode(ReadonlyBytes input);
 
 }


### PR DESCRIPTION
> To [isomorphic decode](https://infra.spec.whatwg.org/#isomorphic-decode) a [byte sequence](https://infra.spec.whatwg.org/#byte-sequence) input, return a [string](https://infra.spec.whatwg.org/#string) whose [code point length](https://infra.spec.whatwg.org/#string-code-point-length) is equal to input’s [length](https://infra.spec.whatwg.org/#byte-sequence-length) and whose [code points](https://infra.spec.whatwg.org/#code-point) have the same [values](https://infra.spec.whatwg.org/#code-point-value) as the [values](https://infra.spec.whatwg.org/#byte-value) of input’s [bytes](https://infra.spec.whatwg.org/#byte), in the same order.

This is essentially spec-speak for "Decode as ISO-8859-1 / Latin-1", but existing code interpreted it as "Transparently interpret as UTF-8" which is only correct for ASCII characters (< 0x80).

This change fixes a crash in http://wpt.live/mimesniff/mime-types/charset-parameter.window.html when parsing a non-ascii header value. The test now fully passes when combining these changes with #1879.