### PR TITLE
LibWeb: support shorthands when setting style attribute

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/background-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/HTML/background-shorthand.txt
@@ -1,0 +1,12 @@
+style.cssText = background-color: rgb(255, 255, 0); background-image: none; background-position-x: left 0%; background-position-y: top 0%; background-size: auto auto; background-repeat: repeat repeat; background-attachment: scroll; background-origin: padding-box; background-clip: border-box;
+style.length = 9
+style[] =
+1. background-color
+2. background-image
+3. background-position-x
+4. background-position-y
+5. background-size
+6. background-repeat
+7. background-attachment
+8. background-origin
+9. background-clip

--- a/Tests/LibWeb/Text/expected/HTML/place-items-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/HTML/place-items-shorthand.txt
@@ -1,0 +1,48 @@
+=== place-items: normal
+place-items: normal normal
+align-items: normal
+justify-items: normal
+=== place-items: stretch
+place-items: stretch stretch
+align-items: stretch
+justify-items: stretch
+=== place-items: start
+place-items: start start
+align-items: start
+justify-items: start
+=== place-items: end
+place-items: end end
+align-items: end
+justify-items: end
+=== place-items: self-start
+place-items: self-start self-start
+align-items: self-start
+justify-items: self-start
+=== place-items: self-end
+place-items: self-end self-end
+align-items: self-end
+justify-items: self-end
+=== place-items: center
+place-items: center center
+align-items: center
+justify-items: center
+=== place-items: flex-start
+place-items: flex-start flex-start
+align-items: flex-start
+justify-items: flex-start
+=== place-items: flex-end
+place-items: flex-end flex-end
+align-items: flex-end
+justify-items: flex-end
+=== place-items: baseline
+place-items: baseline baseline
+align-items: baseline
+justify-items: baseline
+=== place-items: normal start
+place-items: normal start
+align-items: normal
+justify-items: start
+=== place-items: normal center
+place-items: normal center
+align-items: normal
+justify-items: center

--- a/Tests/LibWeb/Text/input/HTML/background-shorthand.html
+++ b/Tests/LibWeb/Text/input/HTML/background-shorthand.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<div id="target" style="background: yellow">Hello</div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let target = document.getElementById("target");
+        let style = target.style;
+        println(`style.cssText = ${style.cssText}`);
+        println(`style.length = ${style.length}`);
+        println(`style[] =`);
+        for (let i = 0; i < style.length; ++i) {
+            println(`${i+1}. ${style[i]}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/place-items-shorthand.html
+++ b/Tests/LibWeb/Text/input/HTML/place-items-shorthand.html
@@ -1,0 +1,34 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (const alignValue of [
+            "normal",
+            "stretch",
+            "start",
+            "end",
+            "self-start",
+            "self-end",
+            "center",
+            "flex-start",
+            "flex-end",
+            "baseline",
+            // "first baseline",
+            // "last baseline",
+            // "safe flex-end",
+            // "unsafe end",
+            // "safe end",
+            // "unsafe flex-start",
+            // "safe center",
+            "normal start",
+            "normal center",
+        ]) {
+            println("=== place-items: " + alignValue);
+            var div = document.createElement("div");
+            div.setAttribute("style", "place-items: " + alignValue + ";");
+            document.body.appendChild(div);
+            for (const prop of ["place-items", "align-items", "justify-items"]) {
+                println(prop + ": " + div.style[prop]);
+            }
+        }
+    });
+</script>


### PR DESCRIPTION
Better support for CSS shorthands when setting style attribute. This impoves some tests in WPT
/css/css-align/default-alignment/*shorthand
Small impovements in shorthand serialzaion to return shorter version when all longhands are the same.

Focus was on thist test http://wpt.live/css/css-align/default-alignment/place-items-shorthand-001.html

NOTE: this is may first contribution and I have limited C++ experience 