### PR TITLE
LibWeb: Scale up "inspected node" hint text to match screen DPI

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -432,7 +432,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         auto size_text_device_rect = context.enclosing_device_rect(size_text_rect).to_type<int>();
         context.display_list_recorder().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
         context.display_list_recorder().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
-        context.display_list_recorder().draw_text(size_text_device_rect, size_text, font, Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
+        context.display_list_recorder().draw_text(size_text_device_rect, size_text, font.with_size(font.point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
     }
 }
 


### PR DESCRIPTION
This fixes an issue where the text would look very small on macOS.

Before:
<img width="417" alt="Screenshot 2024-10-21 at 14 35 18" src="https://github.com/user-attachments/assets/d0531ac0-3dbd-425a-828d-c2b760aa0c6f">

After:
<img width="417" alt="Screenshot 2024-10-21 at 14 33 05" src="https://github.com/user-attachments/assets/cb4be583-a4c5-489e-84dd-d6e958d3069a">
