### PR TITLE
LibWeb: Add missing check if scrollable overflow defined for paintable

### DIFF
--- a/Tests/LibWeb/Text/expected/query-scroll-size-of-inline-node.txt
+++ b/Tests/LibWeb/Text/expected/query-scroll-size-of-inline-node.txt
@@ -1,0 +1,1 @@
+Scroll Height: 0px, Scroll Width: 0px

--- a/Tests/LibWeb/Text/input/query-scroll-size-of-inline-node.html
+++ b/Tests/LibWeb/Text/input/query-scroll-size-of-inline-node.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<span id="empty-span"></span>
+<script src="include.js"></script>
+<script>
+test(() => {
+    const hiddenDiv = document.getElementById('empty-span');
+    const scrollHeight = hiddenDiv.scrollHeight;
+    const scrollWidth = hiddenDiv.scrollWidth;
+    println(`Scroll Height: ${scrollHeight}px, Scroll Width: ${scrollWidth}px`);
+});
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -1455,7 +1455,10 @@ int Element::scroll_width() const
         return 0;
 
     // 7. Return the width of the element’s scrolling area.
-    return paintable_box()->scrollable_overflow_rect()->width().to_int();
+    if (auto scrollable_overflow_rect = paintable_box()->scrollable_overflow_rect(); scrollable_overflow_rect.has_value()) {
+        return scrollable_overflow_rect->width().to_int();
+    }
+    return 0;
 }
 
 // https://drafts.csswg.org/cssom-view/#dom-element-scrollheight
@@ -1491,7 +1494,10 @@ int Element::scroll_height() const
         return 0;
 
     // 7. Return the height of the element’s scrolling area.
-    return paintable_box()->scrollable_overflow_rect()->height().to_int();
+    if (auto scrollable_overflow_rect = paintable_box()->scrollable_overflow_rect(); scrollable_overflow_rect.has_value()) {
+        return scrollable_overflow_rect->height().to_int();
+    }
+    return 0;
 }
 
 // https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled


### PR DESCRIPTION
With 6a549f62702e8b733dd4fc0caf1fa3e114243070 we need to check if optional scrollable overflow exists for paintable box, because it's not computed for inline nodes.

Fixes crashing after navigating into direct messages screen on Discord.