### PR TITLE
Meta: Add build instructions for Void Linux

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -93,6 +93,12 @@ sudo zypper install autoconf-archive automake ccache cmake curl ffmpeg-7-libavco
 ```
 The build process requires at least python3.7; openSUSE Leap only features Python 3.6 as default, so it is recommendable to install package python311 and create a virtual environment (venv) in this case.
 
+### Void Linux:
+```
+sudo xbps-install -Su # (optional) ensure packages are up to date to avoid "Transaction aborted due to unresolved dependencies."
+sudo xbps-install -S git bash gcc python3 curl cmake zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm MesaLib-devel ninja ffmpeg-devel qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel
+```
+
 ### NixOS or with Nix:
 
 > [!NOTE]


### PR DESCRIPTION
`git` and `bash` are most likely already installed, `bash` is part of `base-system`, and `git` is required to pull the repository in the first place, but they are not included in `base-minimal` or `base-container`, and they ARE required for a successful build, so I have added them regardless.

`qt6-tools-devel` and `qt6-wayland-devel` were not required to compile and link Ladybird on my machine, but I have included them as they are installed on the other Linux distributions.