### PR TITLE
AK: Revert "AK: Remove unused Complex.h"

### DIFF
--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2021, Cesar Torres <shortanemoia@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Math.h>
+
+namespace AK {
+
+template<AK::Concepts::Arithmetic T>
+class [[gnu::packed]] Complex {
+public:
+    constexpr Complex()
+        : m_real(0)
+        , m_imag(0)
+    {
+    }
+
+    constexpr Complex(T real)
+        : m_real(real)
+        , m_imag((T)0)
+    {
+    }
+
+    constexpr Complex(T real, T imaginary)
+        : m_real(real)
+        , m_imag(imaginary)
+    {
+    }
+
+    constexpr T real() const noexcept { return m_real; }
+
+    constexpr T imag() const noexcept { return m_imag; }
+
+    constexpr T magnitude_squared() const noexcept { return m_real * m_real + m_imag * m_imag; }
+
+    constexpr T magnitude() const noexcept
+    {
+        return hypot(m_real, m_imag);
+    }
+
+    constexpr T phase() const noexcept
+    {
+        return atan2(m_imag, m_real);
+    }
+
+    template<AK::Concepts::Arithmetic U, AK::Concepts::Arithmetic V>
+    static constexpr Complex<T> from_polar(U magnitude, V phase)
+    {
+        V s, c;
+        sincos(phase, s, c);
+        return Complex<T>(magnitude * c, magnitude * s);
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T>& operator=(Complex<U> const& other)
+    {
+        m_real = other.real();
+        m_imag = other.imag();
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T>& operator=(U const& x)
+    {
+        m_real = x;
+        m_imag = 0;
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator+=(Complex<U> const& x)
+    {
+        m_real += x.real();
+        m_imag += x.imag();
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator+=(U const& x)
+    {
+        m_real += x;
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator-=(Complex<U> const& x)
+    {
+        m_real -= x.real();
+        m_imag -= x.imag();
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator-=(U const& x)
+    {
+        m_real -= x;
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator*=(Complex<U> const& x)
+    {
+        T const real = m_real;
+        m_real = real * x.real() - m_imag * x.imag();
+        m_imag = real * x.imag() + m_imag * x.real();
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator*=(U const& x)
+    {
+        m_real *= x;
+        m_imag *= x;
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator/=(Complex<U> const& x)
+    {
+        T const real = m_real;
+        T const divisor = x.real() * x.real() + x.imag() * x.imag();
+        m_real = (real * x.real() + m_imag * x.imag()) / divisor;
+        m_imag = (m_imag * x.real() - x.real() * x.imag()) / divisor;
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator/=(U const& x)
+    {
+        m_real /= x;
+        m_imag /= x;
+        return *this;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator+(Complex<U> const& a)
+    {
+        Complex<T> x = *this;
+        x += a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator+(U const& a)
+    {
+        Complex<T> x = *this;
+        x += a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator-(Complex<U> const& a)
+    {
+        Complex<T> x = *this;
+        x -= a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator-(U const& a)
+    {
+        Complex<T> x = *this;
+        x -= a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator*(Complex<U> const& a)
+    {
+        Complex<T> x = *this;
+        x *= a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator*(U const& a)
+    {
+        Complex<T> x = *this;
+        x *= a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator/(Complex<U> const& a)
+    {
+        Complex<T> x = *this;
+        x /= a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr Complex<T> operator/(U const& a)
+    {
+        Complex<T> x = *this;
+        x /= a;
+        return x;
+    }
+
+    template<AK::Concepts::Arithmetic U>
+    constexpr bool operator==(Complex<U> const& a) const
+    {
+        return (this->real() == a.real()) && (this->imag() == a.imag());
+    }
+
+    constexpr Complex<T> operator+()
+    {
+        return *this;
+    }
+
+    constexpr Complex<T> operator-()
+    {
+        return Complex<T>(-m_real, -m_imag);
+    }
+
+private:
+    T m_real;
+    T m_imag;
+};
+
+// reverse associativity operators for scalars
+template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
+constexpr Complex<T> operator+(U const& a, Complex<T> const& b)
+{
+    Complex<T> x = a;
+    x += b;
+    return x;
+}
+
+template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
+constexpr Complex<T> operator-(U const& a, Complex<T> const& b)
+{
+    Complex<T> x = a;
+    x -= b;
+    return x;
+}
+
+template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
+constexpr Complex<T> operator*(U const& a, Complex<T> const& b)
+{
+    Complex<T> x = a;
+    x *= b;
+    return x;
+}
+
+template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
+constexpr Complex<T> operator/(U const& a, Complex<T> const& b)
+{
+    Complex<T> x = a;
+    x /= b;
+    return x;
+}
+
+// some identities
+template<AK::Concepts::Arithmetic T>
+static constinit Complex<T> complex_real_unit = Complex<T>((T)1, (T)0);
+template<AK::Concepts::Arithmetic T>
+static constinit Complex<T> complex_imag_unit = Complex<T>((T)0, (T)1);
+
+template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
+static constexpr bool approx_eq(Complex<T> const& a, Complex<U> const& b, double const margin = 0.000001)
+{
+    auto const x = const_cast<Complex<T>&>(a) - const_cast<Complex<U>&>(b);
+    return x.magnitude() <= margin;
+}
+
+// complex version of exp()
+template<AK::Concepts::Arithmetic T>
+static constexpr Complex<T> cexp(Complex<T> const& a)
+{
+    // FIXME: this can probably be faster and not use so many "expensive" trigonometric functions
+    return exp(a.real()) * Complex<T>(cos(a.imag()), sin(a.imag()));
+}
+}
+
+template<AK::Concepts::Arithmetic T>
+struct AK::Formatter<AK::Complex<T>> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, AK::Complex<T> c)
+    {
+        return Formatter<StringView>::format(builder, TRY(String::formatted("{}{:+}i", c.real(), c.imag())));
+    }
+};
+
+#if USING_AK_GLOBALLY
+using AK::approx_eq;
+using AK::cexp;
+using AK::Complex;
+using AK::complex_imag_unit;
+using AK::complex_real_unit;
+#endif

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -8,6 +8,7 @@
 
 #include <AK/Concepts.h>
 #include <AK/Math.h>
+#include <AK/String.h>
 
 namespace AK {
 

--- a/Meta/gn/secondary/AK/BUILD.gn
+++ b/Meta/gn/secondary/AK/BUILD.gn
@@ -50,6 +50,7 @@ shared_library("AK") {
     "CircularBuffer.cpp",
     "CircularBuffer.h",
     "CircularQueue.h",
+    "Complex.h",
     "Concepts.h",
     "ConstrainedStream.cpp",
     "ConstrainedStream.h",

--- a/Meta/gn/secondary/Tests/AK/BUILD.gn
+++ b/Meta/gn/secondary/Tests/AK/BUILD.gn
@@ -18,6 +18,7 @@ tests = [
   "TestChecked",
   "TestCircularBuffer",
   "TestCircularQueue",
+  "TestComplex",
   "TestByteString",
   "TestDisjointChunks",
   "TestDistinctNumeric",

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -17,6 +17,7 @@ set(AK_TEST_SOURCES
     TestChecked.cpp
     TestCircularBuffer.cpp
     TestCircularQueue.cpp
+    TestComplex.cpp
     TestDisjointChunks.cpp
     TestDistinctNumeric.cpp
     TestDoublyLinkedList.cpp

--- a/Tests/AK/TestComplex.cpp
+++ b/Tests/AK/TestComplex.cpp
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2021, Cesar Torres <shortanemoia@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Complex.h>
+
+using namespace Test::Randomized;
+
+namespace {
+
+Complex<f64> gen_complex()
+{
+    auto r = Gen::number_f64();
+    auto i = Gen::number_f64();
+    return Complex<f64>(r, i);
+}
+
+Complex<f64> gen_complex(f64 min, f64 max)
+{
+    auto r = Gen::number_f64(min, max);
+    auto i = Gen::number_f64(min, max);
+    return Complex<f64>(r, i);
+}
+
+}
+
+template<typename T>
+void expect_approximate_complex(Complex<T> a, Complex<T> b)
+{
+    EXPECT_APPROXIMATE(a.real(), b.real());
+    EXPECT_APPROXIMATE(a.imag(), b.imag());
+}
+
+TEST_CASE(Complex)
+{
+    auto a = Complex<float> { 1.f, 1.f };
+    auto b = complex_real_unit<double> + Complex<double> { 0, 1 } * 1;
+    EXPECT_APPROXIMATE(a.real(), b.real());
+    EXPECT_APPROXIMATE(a.imag(), b.imag());
+
+#ifdef AKCOMPLEX_CAN_USE_MATH_H
+    EXPECT_APPROXIMATE((complex_imag_unit<float> - complex_imag_unit<float>).magnitude(), 0);
+    EXPECT_APPROXIMATE((complex_imag_unit<float> + complex_real_unit<float>).magnitude(), sqrt(2));
+
+    auto c = Complex<double> { 0., 1. };
+    auto d = Complex<double>::from_polar(1., M_PI / 2.);
+    EXPECT_APPROXIMATE(c.real(), d.real());
+    EXPECT_APPROXIMATE(c.imag(), d.imag());
+
+    c = Complex<double> { -1., 1. };
+    d = Complex<double>::from_polar(sqrt(2.), 3. * M_PI / 4.);
+    EXPECT_APPROXIMATE(c.real(), d.real());
+    EXPECT_APPROXIMATE(c.imag(), d.imag());
+    EXPECT_APPROXIMATE(d.phase(), 3. * M_PI / 4.);
+    EXPECT_APPROXIMATE(c.magnitude(), d.magnitude());
+    EXPECT_APPROXIMATE(c.magnitude(), sqrt(2.));
+#endif
+    EXPECT_EQ((complex_imag_unit<double> * complex_imag_unit<double>).real(), -1.);
+    EXPECT_EQ((complex_imag_unit<double> / complex_imag_unit<double>).real(), 1.);
+
+    EXPECT_EQ(Complex(1., 10.) == (Complex<double>(1., 0.) + Complex(0., 10.)), true);
+    EXPECT_EQ(Complex(1., 10.) != (Complex<double>(1., 1.) + Complex(0., 10.)), true);
+#ifdef AKCOMPLEX_CAN_USE_MATH_H
+    EXPECT_EQ(approx_eq(Complex<int>(1), Complex<float>(1.0000004f)), true);
+    EXPECT_APPROXIMATE(cexp(Complex<double>(0., 1.) * M_PI).real(), -1.);
+#endif
+}
+
+TEST_CASE(real_operators_regression)
+{
+    {
+        auto c = Complex(0., 0.);
+        c += 1;
+        EXPECT_EQ(c.real(), 1);
+    }
+    {
+        auto c = Complex(0., 0.);
+        c -= 1;
+        EXPECT_EQ(c.real(), -1);
+    }
+    {
+        auto c1 = Complex(1., 1.);
+        auto c2 = 1 - c1;
+        EXPECT_EQ(c2.real(), 0);
+        EXPECT_EQ(c2.imag(), -1);
+    }
+    {
+        auto c1 = Complex(1., 1.);
+        auto c2 = 1 / c1;
+        EXPECT_EQ(c2.real(), 0.5);
+        EXPECT_EQ(c2.imag(), -0.5);
+    }
+}
+
+TEST_CASE(constructor_0_is_origin)
+{
+    auto c = Complex<f64>();
+    EXPECT_EQ(c.real(), 0L);
+    EXPECT_EQ(c.imag(), 0L);
+}
+
+RANDOMIZED_TEST_CASE(constructor_1)
+{
+    GEN(r, Gen::number_f64());
+    auto c = Complex<f64>(r);
+    EXPECT_EQ(c.real(), r);
+    EXPECT_EQ(c.imag(), 0L);
+}
+
+RANDOMIZED_TEST_CASE(constructor_2)
+{
+    GEN(r, Gen::number_f64());
+    GEN(i, Gen::number_f64());
+    auto c = Complex<f64>(r, i);
+    EXPECT_EQ(c.real(), r);
+    EXPECT_EQ(c.imag(), i);
+}
+
+RANDOMIZED_TEST_CASE(magnitude_squared)
+{
+    GEN(c, gen_complex());
+    auto magnitude_squared = c.magnitude_squared();
+    auto magnitude = c.magnitude();
+    EXPECT_APPROXIMATE(magnitude_squared, magnitude * magnitude);
+}
+
+RANDOMIZED_TEST_CASE(from_polar_magnitude)
+{
+    // Magnitude only makes sense non-negative, but the library allows it to be negative.
+    GEN(m, Gen::number_f64(-1000, 1000));
+    GEN(p, Gen::number_f64(-1000, 1000));
+    auto c = Complex<f64>::from_polar(m, p);
+    EXPECT_APPROXIMATE(c.magnitude(), abs(m));
+}
+
+RANDOMIZED_TEST_CASE(from_polar_phase)
+{
+    // To have a meaningful phase, magnitude needs to be >0.
+    GEN(m, Gen::number_f64(1, 1000));
+    GEN(p, Gen::number_f64(-1000, 1000));
+
+    auto c = Complex<f64>::from_polar(m, p);
+
+    // Returned phase is in the (-pi,pi] interval.
+    // We need to mod from our randomly generated [-1000,1000] interval]
+    // down to [0,2pi) or (-2pi,0] depending on our sign.
+    // Then we can adjust and get into the -pi..pi range by adding/subtracting
+    // one last 2pi.
+    auto wanted_p = fmod(p, 2 * M_PI);
+    if (wanted_p > M_PI)
+        wanted_p -= 2 * M_PI;
+    else if (wanted_p < -M_PI)
+        wanted_p += 2 * M_PI;
+
+    EXPECT_APPROXIMATE(c.phase(), wanted_p);
+}
+
+RANDOMIZED_TEST_CASE(imag_untouched_c_plus_r)
+{
+    GEN(c1, gen_complex());
+    GEN(r2, Gen::number_f64());
+    auto c2 = c1 + r2;
+    EXPECT_EQ(c2.imag(), c1.imag());
+}
+
+RANDOMIZED_TEST_CASE(imag_untouched_c_minus_r)
+{
+    GEN(c1, gen_complex());
+    GEN(r2, Gen::number_f64());
+    auto c2 = c1 - r2;
+    EXPECT_EQ(c2.imag(), c1.imag());
+}
+
+RANDOMIZED_TEST_CASE(assignment_same_as_binop_plus)
+{
+    GEN(c1, gen_complex());
+    GEN(c2, gen_complex());
+    auto out1 = c1 + c2;
+    auto out2 = c1;
+    out2 += c2;
+    EXPECT_EQ(out2, out1);
+}
+
+RANDOMIZED_TEST_CASE(assignment_same_as_binop_minus)
+{
+    GEN(c1, gen_complex());
+    GEN(c2, gen_complex());
+    auto out1 = c1 - c2;
+    auto out2 = c1;
+    out2 -= c2;
+    EXPECT_EQ(out2, out1);
+}
+
+RANDOMIZED_TEST_CASE(assignment_same_as_binop_mult)
+{
+    GEN(c1, gen_complex(-1000, 1000));
+    GEN(c2, gen_complex(-1000, 1000));
+    auto out1 = c1 * c2;
+    auto out2 = c1;
+    out2 *= c2;
+    EXPECT_EQ(out2, out1);
+}
+
+RANDOMIZED_TEST_CASE(assignment_same_as_binop_div)
+{
+    GEN(c1, gen_complex(-1000, 1000));
+    GEN(c2, gen_complex(-1000, 1000));
+    auto out1 = c1 / c2;
+    auto out2 = c1;
+    out2 /= c2;
+    EXPECT_EQ(out2, out1);
+}
+
+RANDOMIZED_TEST_CASE(commutativity_c_c)
+{
+    GEN(c1, gen_complex());
+    GEN(c2, gen_complex());
+    expect_approximate_complex(c1 + c2, c2 + c1);
+    expect_approximate_complex(c1 * c2, c2 * c1);
+}
+
+RANDOMIZED_TEST_CASE(commutativity_c_r)
+{
+    GEN(c, gen_complex());
+    GEN(r, Gen::number_f64());
+    expect_approximate_complex(r + c, c + r);
+    expect_approximate_complex(r * c, c * r);
+}
+
+RANDOMIZED_TEST_CASE(unary_plus_noop)
+{
+    GEN(c, gen_complex());
+    EXPECT_EQ(+c, c);
+}
+
+RANDOMIZED_TEST_CASE(unary_minus_inverse)
+{
+    GEN(c, gen_complex());
+    expect_approximate_complex(-(-c), c);
+}
+
+RANDOMIZED_TEST_CASE(wrapping_real)
+{
+    GEN(c, gen_complex(-1000, 1000));
+    GEN(r, Gen::number_f64(-1000, 1000));
+    auto cr = Complex<f64>(r);
+
+    expect_approximate_complex(r + c, cr + c);
+    expect_approximate_complex(r - c, cr - c);
+    expect_approximate_complex(r * c, cr * c);
+    expect_approximate_complex(r / c, cr / c);
+
+    expect_approximate_complex(c + r, c + cr);
+    expect_approximate_complex(c - r, c - cr);
+    expect_approximate_complex(c * r, c * cr);
+    expect_approximate_complex(c / r, c / cr);
+}

--- a/Tests/LibMedia/CMakeLists.txt
+++ b/Tests/LibMedia/CMakeLists.txt
@@ -2,6 +2,7 @@ set(TEST_SOURCES
     TestH264Decode.cpp
     TestParseMatroska.cpp
     TestPlaybackStream.cpp
+    TestSignalProcessing.cpp
     TestVorbisDecode.cpp
     TestVP9Decode.cpp
     TestWav.cpp

--- a/Tests/LibMedia/TestSignalProcessing.cpp
+++ b/Tests/LibMedia/TestSignalProcessing.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Noah Bright <noah.bright.1@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Complex.h>
+#include <LibTest/TestCase.h>
+
+#include <LibMedia/Audio/SignalProcessing.h>
+
+TEST_CASE(test_biquad_filter_frequency_response)
+{
+    size_t n_frequencies = 4096;
+    Vector<f64> frequencies;
+    frequencies.resize(n_frequencies);
+
+    // roughly the range of human hearing in Hz
+    auto delta_f = (20000 - 20) / n_frequencies;
+    for (size_t i = 0; i < n_frequencies; i++)
+        frequencies[i] = 20.0 + (f64)i * (f64)delta_f;
+
+    // default coefficients from https://webaudio.github.io/web-audio-api/#BiquadFilterOptions
+    f64 Q = 1.0;
+    f64 frequency = 350;
+    f64 sample_rate = 44100;
+
+    auto omega_0 = 2 * AK::Pi<f64> * frequency / sample_rate;
+    auto alpha_Q_dB = sin(omega_0) / (2 * pow(10, Q / 20));
+
+    auto lowpass_coeffs = Audio::biquad_filter_lowpass_coefficients(omega_0, alpha_Q_dB);
+
+    auto frequency_response = Audio::biquad_filter_frequency_response(frequencies, lowpass_coeffs);
+    for (auto response : frequency_response) {
+        auto phase_response = response.phase();
+        VERIFY(phase_response != AK::NaN<f64>);
+        VERIFY(phase_response != AK::Infinity<f64>);
+
+        auto magnitude_response = response.magnitude();
+        VERIFY(magnitude_response != AK::NaN<f64>);
+        VERIFY(magnitude_response != AK::Infinity<f64>);
+    }
+}

--- a/Userland/Libraries/LibMedia/Audio/SignalProcessing.h
+++ b/Userland/Libraries/LibMedia/Audio/SignalProcessing.h
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/Complex.h>
+#include <AK/Math.h>
 #include <AK/Vector.h>
 
 namespace Audio {
@@ -37,7 +38,7 @@ Vector<Complex<T>> biquad_filter_frequency_response(Vector<T> const& frequencies
     T A2 = coefficients[5] / coefficients[3];
 
     auto transfer_function = [&](Complex<T> z) {
-        auto z_inv = 1 / z;
+        auto z_inv = 1.0 / z;
         auto numerator = B0 + (B1 + B2 * z_inv) * z_inv;
         auto denominator = 1.0 + (A1 + A2 * z_inv) * z_inv;
         return numerator / denominator;
@@ -47,23 +48,123 @@ Vector<Complex<T>> biquad_filter_frequency_response(Vector<T> const& frequencies
     frequency_response.ensure_capacity(frequencies.size());
 
     for (size_t k = 0; k < frequency_response.size(); k++) {
-        auto i = Complex<T>(0, 1);
-        auto arg = cexp(2 * AK::Pi<T> * i * frequencies[k]);
+        auto i = Complex<T>(0.0, 1.0);
+        auto arg = cexp(2.0 * AK::Pi<T> * i * frequencies[k]);
         frequency_response[k] = transfer_function(arg);
     }
 
     return frequency_response;
 }
 
+using AK::cos;
+
 template<AK::Concepts::Arithmetic T>
 Array<T, 6> biquad_filter_lowpass_coefficients(T omega_0, T alpha_Q_dB)
 {
-    auto b0 = 0.5 * (1 - cos(omega_0));
-    auto b1 = 1 - cos(omega_0);
+    auto b0 = 0.5 * (1.0 - cos(omega_0));
+    auto b1 = 1.0 - cos(omega_0);
     auto b2 = b0;
-    auto a0 = 1 + alpha_Q_dB;
-    auto a1 = -2 * cos(omega_0);
-    auto a2 = 1 - alpha_Q_dB;
+    auto a0 = 1.0 + alpha_Q_dB;
+    auto a1 = -2.0 * cos(omega_0);
+    auto a2 = 1.0 - alpha_Q_dB;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_highpass_coefficients(T omega_0, T alpha_Q_dB)
+{
+    auto b0 = 0.5 * (1.0 + cos(omega_0));
+    auto b1 = (1.0 + cos(omega_0));
+    auto b2 = b0;
+    auto a0 = 1.0 + alpha_Q_dB;
+    auto a1 = -2.0 * cos(omega_0);
+    auto a2 = 1.0 - alpha_Q_dB;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_bandpass_coefficients(T omega_0, T alpha_Q)
+{
+    auto b0 = alpha_Q;
+    auto b1 = 0.0;
+    auto b2 = -alpha_Q;
+    auto a0 = 1.0 + alpha_Q;
+    auto a1 = -2.0 * cos(omega_0);
+    auto a2 = 1.0 - alpha_Q;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_notch_coefficients(T omega_0, T alpha_Q)
+{
+    auto b0 = 1.0;
+    auto b1 = -2.0 * cos(omega_0);
+    auto b2 = 1.0;
+    auto a0 = 1.0 + alpha_Q;
+    auto a1 = -2.0 * cos(omega_0);
+    auto a2 = 1.0 - alpha_Q;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_allpass_coefficients(T omega_0, T alpha_Q, T A)
+{
+    auto b0 = 1.0 + alpha_Q * A;
+    auto b1 = -2.0 * cos(omega_0);
+    auto b2 = 1.0 - alpha_Q * A;
+    auto a0 = 1.0 + alpha_Q / A;
+    auto a1 = b1;
+    auto a2 = 1.0 - alpha_Q / A;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_peaking_coefficients(T omega_0, T alpha_Q, T A)
+{
+    auto b0 = 1.0 + alpha_Q * A;
+    auto b1 = -2.0 * cos(omega_0);
+    auto b2 = 1.0 - alpha_Q * A;
+    auto a0 = 1.0 + alpha_Q / A;
+    auto a1 = b1;
+    auto a2 = 1.0 - alpha_Q / A;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_lowshelf_coefficients(T omega_0, T alpha_S, T A)
+{
+    auto cosw0 = cos(omega_0);
+    auto x = 2.0 * alpha_S * AK::sqrt(A);
+    auto a_plus_1 = A + 1.0;
+    auto a_minus_1 = A - 1.0;
+
+    auto b0 = A * (a_plus_1 - a_minus_1 * cosw0 + x);
+    auto b1 = 2.0 * A * (a_minus_1 - a_plus_1 * cosw0);
+    auto b2 = A * (a_plus_1 - a_minus_1 * cosw0 - x);
+
+    auto a0 = a_plus_1 + a_minus_1 * cosw0 + x;
+    auto a1 = -2.0 * (a_minus_1 + a_plus_1 * cosw0);
+    auto a2 = a_plus_1 + a_minus_1 * cosw0 - x;
+
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_highshelf_coefficients(T omega_0, T alpha_S, T A)
+{
+    auto cosw0 = cos(omega_0);
+    auto x = 2.0 * alpha_S * AK::sqrt(A);
+    auto a_plus_1 = A + 1.0;
+    auto a_minus_1 = A - 1.0;
+
+    auto b0 = A * (a_plus_1 + a_minus_1 * cosw0 + x);
+    auto b1 = -2.0 * A * (a_minus_1 + a_plus_1 * cosw0);
+    auto b2 = A * (a_plus_1 + a_minus_1 * cosw0 - x);
+
+    auto a0 = a_plus_1 - a_minus_1 * cosw0 + x;
+    auto a1 = -2.0 * (a_minus_1 - a_plus_1 * cosw0);
+    auto a2 = a_plus_1 - a_minus_1 * cosw0 - x;
+
     return { b0, b1, b2, a0, a1, a2 };
 }
 

--- a/Userland/Libraries/LibMedia/Audio/SignalProcessing.h
+++ b/Userland/Libraries/LibMedia/Audio/SignalProcessing.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Noah Bright <noah.bright.1@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Complex.h>
+#include <AK/Vector.h>
+
+namespace Audio {
+
+template<AK::Concepts::Arithmetic T>
+Vector<Complex<T>> biquad_filter_frequency_response(Vector<T> const& frequencies, Array<T, 6> const& coefficients)
+{
+    // frequencies is expected to be frequencies in Hz, not angular frequencies in rad/sec
+    // coefficients should be a fixed sized array of 6 containing [b0, b1, b2, a0, a1, a2]
+    //
+    // the transfer function of a biquadratic filter is
+    //      H(z) = ( b0/a0 + b1/a0 * z^-1 + b2/a0 * z^-2 ) / ( 1 + a1/a0 * z^-1 + a2/a0 * z^-2)
+    //
+    // as written, the numerator and denominator above both have 3 floating point multiplications
+    // rewriting the numerator, that can be reduced to 2:
+    // b0/a0 + (b1/a0 + b2/a0 * z) * z^-1
+    //
+    // the frequency response of a filter at frequency omega is its transfer function evaluated
+    // at z = e^{i omega}, with angular frequency omega = 2*pi*f
+    //
+    // the magnitude(phase) response of a filter is the magnitude(phase) of its frequency response
+
+    T B0 = coefficients[0] / coefficients[3];
+    T B1 = coefficients[1] / coefficients[3];
+    T B2 = coefficients[2] / coefficients[3];
+    T A1 = coefficients[4] / coefficients[3];
+    T A2 = coefficients[5] / coefficients[3];
+
+    auto transfer_function = [&](Complex<T> z) {
+        auto z_inv = 1 / z;
+        auto numerator = B0 + (B1 + B2 * z_inv) * z_inv;
+        auto denominator = 1.0 + (A1 + A2 * z_inv) * z_inv;
+        return numerator / denominator;
+    };
+
+    Vector<Complex<T>> frequency_response;
+    frequency_response.ensure_capacity(frequencies.size());
+
+    for (size_t k = 0; k < frequency_response.size(); k++) {
+        auto i = Complex<T>(0, 1);
+        auto arg = cexp(2 * AK::Pi<T> * i * frequencies[k]);
+        frequency_response[k] = transfer_function(arg);
+    }
+
+    return frequency_response;
+}
+
+template<AK::Concepts::Arithmetic T>
+Array<T, 6> biquad_filter_lowpass_coefficients(T omega_0, T alpha_Q_dB)
+{
+    auto b0 = 0.5 * (1 - cos(omega_0));
+    auto b1 = 1 - cos(omega_0);
+    auto b2 = b0;
+    auto a0 = 1 + alpha_Q_dB;
+    auto a1 = -2 * cos(omega_0);
+    auto a2 = 1 - alpha_Q_dB;
+    return { b0, b1, b2, a0, a1, a2 };
+}
+
+}


### PR DESCRIPTION
This reverts commit b88e0eb50ad4de2e786884be76a32116bf24da7a. In order to implement interfaces in the WebAudio spec, at least biquad filter and analyser node, complex numbers are needed. This brings back the previously unused Complex.h header.