### PR TITLE
LibWeb: Implement KeyboardEvent.charCode according to spec

### DIFF
--- a/Tests/LibWeb/Text/expected/UIEvents/KeyEvent-keypress.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/KeyEvent-keypress.txt
@@ -1,5 +1,5 @@
-keydown A
-keypress A
-keydown Shift
-keydown B
-keypress B
+keydown key=A charCode=0
+keypress key=A charCode=65
+keydown key=Shift charCode=0
+keydown key=B charCode=0
+keypress key=B charCode=66

--- a/Tests/LibWeb/Text/input/UIEvents/KeyEvent-keypress.html
+++ b/Tests/LibWeb/Text/input/UIEvents/KeyEvent-keypress.html
@@ -5,10 +5,10 @@
         let input = document.getElementById("input");
 
         input.addEventListener("keydown", e => {
-            println(`keydown ${e.key}`);
+            println(`keydown key=${e.key} charCode=${e.charCode}`);
         });
         input.addEventListener("keypress", e => {
-            println(`keypress ${e.key}`);
+            println(`keypress key=${e.key} charCode=${e.charCode}`);
         });
 
         internals.sendText(input, "A");

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -108,6 +108,11 @@ bool code_point_has_general_category(u32 code_point, GeneralCategory general_cat
     return u_charType(icu_code_point) == icu_general_category;
 }
 
+bool code_point_is_printable(u32 code_point)
+{
+    return static_cast<bool>(u_isprint(static_cast<UChar32>(code_point)));
+}
+
 bool code_point_has_control_general_category(u32 code_point)
 {
     return code_point_has_general_category(code_point, U_CONTROL_CHAR);

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -17,6 +17,7 @@ namespace Unicode {
 Optional<GeneralCategory> general_category_from_string(StringView);
 bool code_point_has_general_category(u32 code_point, GeneralCategory general_category);
 
+bool code_point_is_printable(u32 code_point);
 bool code_point_has_control_general_category(u32 code_point);
 bool code_point_has_letter_general_category(u32 code_point);
 bool code_point_has_number_general_category(u32 code_point);


### PR DESCRIPTION
It should be 0 for `keydown`/`keyup` events.