### PR TITLE
UI/Qt: Ignore auto-repeated keyRelease events

### DIFF
--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -20,7 +20,6 @@
 #include <LibCore/Resource.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/DeprecatedPainter.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibGfx/Palette.h>
@@ -29,7 +28,6 @@
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
-#include <LibWeb/Worker/WebWorkerClient.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/WebContentClient.h>
 #include <QApplication>

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -391,6 +391,12 @@ void WebContentView::keyPressEvent(QKeyEvent* event)
 
 void WebContentView::keyReleaseEvent(QKeyEvent* event)
 {
+    // NOTE: Prevent auto-repeated keyRelease events from being enqueued, as they should not result
+    //       in a keyup event down the line.
+    //       See: https://w3c.github.io/uievents/#events-keyboard-event-order
+    if (event->isAutoRepeat())
+        return;
+
     enqueue_native_event(Web::KeyEvent::Type::KeyUp, *event);
 }
 


### PR DESCRIPTION
X11 applications typically receive the following events on a long key press:

  - KeyPress (initial)
  - KeyRelease (repeat)
  - KeyPress (repeat)
  - KeyRelease (repeat)
  - ad infinitum

We directly translate KeyPress to keyup and KeyRelease to keydown, which is not to spec. We should only repeat the keydown, beforeinput and input events.

Since there is very little use to receiving both KeyPress and KeyRelease events for an auto-repeat, skip auto-repeated KeyReleases altogether.

This fixes keeping the arrow keys pressed on https://playbiolab.com/.