### PR TITLE
LibWeb: Strip tabs before text shaping

### DIFF
--- a/Userland/Libraries/LibGfx/TextLayout.cpp
+++ b/Userland/Libraries/LibGfx/TextLayout.cpp
@@ -32,8 +32,6 @@ RefPtr<GlyphRun> shape_text(FloatPoint baseline_start, Utf8View string, Gfx::Fon
     Vector<Gfx::DrawGlyph> glyph_run;
     FloatPoint point = baseline_start;
     for (size_t i = 0; i < glyph_count; ++i) {
-        if (input_glyph_info[i].codepoint == '\t')
-            continue;
 
         auto position = point
             - FloatPoint { 0, font.pixel_metrics().ascent }

--- a/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -285,6 +285,8 @@ Optional<InlineLevelIterator::Item> InlineLevelIterator::next_without_lookahead(
             }
             tab_stop_dist = tab_stop_dist * num_of_tabs;
 
+            // remove tabs, we don't want to render them when we shape the text
+            chunk.view = chunk.view.substring_view(num_of_tabs);
             x = tab_stop_dist.to_float();
         }
 


### PR DESCRIPTION
Handling tabs during text shaping caused issues because we tried to index 'input_glyph_info' whilst iterating until 'glyph_count' and these can be different sizes.

The difference is due to when one or more characters get merged into the same glyph when calling 'input_glyph_info' (see https://lazka.github.io/pgi-docs/HarfBuzz-0.0/classes/glyph_info_t.html).

We don't want to render tabs as they come up as tofu characters so instead let's strip them out of the text chunk before starting text shaping.