### PR TITLE
LibWeb/Fetch: Update cached responses when revalidating 

### DIFF
--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.cpp
@@ -42,6 +42,13 @@ requires(IsSameIgnoringCV<T, u8>) struct CaseInsensitiveBytesTraits : public Tra
     }
 };
 
+Header Header::copy(Header const& header)
+{
+    return Header {
+        .name = MUST(ByteBuffer::copy(header.name)),
+        .value = MUST(ByteBuffer::copy(header.value)),
+    };
+}
 Header Header::from_string_pair(StringView name, StringView value)
 {
     return Header {

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Headers.h
@@ -26,7 +26,8 @@ struct Header {
     ByteBuffer name;
     ByteBuffer value;
 
-    static Header from_string_pair(StringView, StringView);
+    [[nodiscard]] static Header copy(Header const&);
+    [[nodiscard]] static Header from_string_pair(StringView, StringView);
 };
 
 // https://fetch.spec.whatwg.org/#concept-header-list

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -197,9 +197,14 @@ private:
     u64 stale_while_revalidate_lifetime() const;
 
     // Non-standard
+    ByteBuffer m_method;
     UnixDateTime m_response_time;
 
     Optional<Variant<String, StringView>> m_network_error_message;
+
+public:
+    [[nodiscard]] ByteBuffer const& method() const { return m_method; }
+    void set_method(ByteBuffer method) { m_method = method; }
 };
 
 // https://fetch.spec.whatwg.org/#concept-filtered-response


### PR DESCRIPTION
The old code was cloning the cached response, but after a second reading of RFC9111, I have come to the conclusion that the spec expects the cached response to be passed around by (mutable) reference. Cloning causes some changes to not be propagated on revalidation, which may result in CORS violations and missing headers.

This fixes WPT test [wpt/cors/304.htm](http://wpt.live/cors/304.htm).