### PR TITLE
LibJS: fix base64 decoder typo

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Uint8Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Uint8Array.cpp
@@ -729,7 +729,7 @@ DecodeResult from_base64(VM& vm, StringView string, Alphabet alphabet, LastChunk
                 ch = '+';
             }
             // iii. Else if char is "_", then
-            else if (ch == '-') {
+            else if (ch == '_') {
                 // 1. Set char to "/".
                 ch = '/';
             }

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/Uint8Array.fromBase64.js
@@ -108,6 +108,25 @@ describe("correct behavior", () => {
 
         decodeEqual("8J-kkw==", "🤓", options);
         decodeEqual("8J-kk2Zvb_CflpY=", "🤓foo🖖", options);
+
+        decodeEqual("b2g_", "oh?", options);
+    });
+
+    test("strict mode with base64url alphabet", () => {
+        const options = { alphabet: "base64url", lastChunkHandling: "strict" };
+
+        decodeEqual("", "", options);
+        decodeEqual("Zg==", "f", options);
+        decodeEqual("Zm8=", "fo", options);
+        decodeEqual("Zm9v", "foo", options);
+        decodeEqual("Zm9vYg==", "foob", options);
+        decodeEqual("Zm9vYmE=", "fooba", options);
+        decodeEqual("Zm9vYmFy", "foobar", options);
+
+        decodeEqual("8J-kkw==", "🤓", options);
+        decodeEqual("8J-kk2Zvb_CflpY=", "🤓foo🖖", options);
+
+        decodeEqual("b2g_", "oh?", options);
     });
 
     test("stop-before-partial lastChunkHandling", () => {


### PR DESCRIPTION
As the comments suggest, `_` is supposed to be translated into `/` but `-` is translated twice instead
I don't have a bug reproduction scenario at hand, as I was chasing a totally different issue and just came by these lines...

It's draft as it seems it breaks some tests, I gotta dig deeper 