### PR TITLE
LibIPC+Everywhere: Introduce an IPC Transport abstraction 

### DIFF
--- a/Ladybird/AppKit/Application/Application.mm
+++ b/Ladybird/AppKit/Application/Application.mm
@@ -134,7 +134,7 @@ static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decod
     auto web_worker_paths = TRY(get_paths_for_helper_process("WebWorker"sv));
     auto worker_client = TRY(launch_web_worker_process(web_worker_paths, *m_request_server_client));
 
-    return worker_client->dup_socket();
+    return worker_client->clone_transport();
 }
 
 #pragma mark - NSApplication

--- a/Ladybird/Headless/HeadlessWebView.cpp
+++ b/Ladybird/Headless/HeadlessWebView.cpp
@@ -21,7 +21,7 @@ HeadlessWebView::HeadlessWebView(Gfx::IntSize viewport_size)
         auto web_worker_paths = MUST(get_paths_for_helper_process("WebWorker"sv));
         auto worker_client = MUST(launch_web_worker_process(web_worker_paths, Application::request_client()));
 
-        return worker_client->dup_socket();
+        return worker_client->clone_transport();
     };
 }
 

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -137,7 +137,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     on_request_worker_agent = [&]() {
         auto& request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
         auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), *request_server_client));
-        return worker_client->dup_socket();
+        return worker_client->clone_transport();
     };
 
     m_select_dropdown = new QMenu("Select Dropdown", this);

--- a/Ladybird/WebWorker/main.cpp
+++ b/Ladybird/WebWorker/main.cpp
@@ -73,10 +73,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 static ErrorOr<void> initialize_resource_loader(int request_server_socket)
 {
+    static_assert(IsSame<IPC::Transport, IPC::TransportSocket>, "Need to handle other IPC transports here");
+
     auto socket = TRY(Core::LocalSocket::adopt_fd(request_server_socket));
     TRY(socket->set_blocking(true));
 
-    auto request_client = TRY(try_make_ref_counted<Requests::RequestClient>(move(socket)));
+    auto request_client = TRY(try_make_ref_counted<Requests::RequestClient>(IPC::Transport(move(socket))));
     Web::ResourceLoader::initialize(move(request_client));
 
     return {};

--- a/Userland/Libraries/LibIPC/CMakeLists.txt
+++ b/Userland/Libraries/LibIPC/CMakeLists.txt
@@ -5,5 +5,9 @@ set(SOURCES
     Message.cpp
 )
 
+if (UNIX)
+    list(APPEND SOURCES TransportSocket.cpp)
+endif()
+
 serenity_lib(LibIPC ipc)
 target_link_libraries(LibIPC PRIVATE LibCore LibURL LibThreading)

--- a/Userland/Libraries/LibIPC/ConnectionToServer.h
+++ b/Userland/Libraries/LibIPC/ConnectionToServer.h
@@ -11,18 +11,18 @@
 
 namespace IPC {
 
-#define IPC_CLIENT_CONNECTION(klass, socket_path)                                                      \
-    C_OBJECT_ABSTRACT(klass)                                                                           \
-public:                                                                                                \
-    template<typename Klass = klass, class... Args>                                                    \
-    static ErrorOr<NonnullRefPtr<klass>> try_create(Args&&... args)                                    \
-    {                                                                                                  \
-        auto parsed_socket_path = TRY(Core::SessionManagement::parse_path_with_sid(socket_path));      \
-        auto socket = TRY(Core::LocalSocket::connect(move(parsed_socket_path)));                       \
-        /* We want to rate-limit our clients */                                                        \
-        TRY(socket->set_blocking(true));                                                               \
-                                                                                                       \
-        return adopt_nonnull_ref_or_enomem(new (nothrow) Klass(move(socket), forward<Args>(args)...)); \
+#define IPC_CLIENT_CONNECTION(klass, socket_path)                                                                      \
+    C_OBJECT_ABSTRACT(klass)                                                                                           \
+public:                                                                                                                \
+    template<typename Klass = klass, class... Args>                                                                    \
+    static ErrorOr<NonnullRefPtr<klass>> try_create(Args&&... args)                                                    \
+    {                                                                                                                  \
+        auto parsed_socket_path = TRY(Core::SessionManagement::parse_path_with_sid(socket_path));                      \
+        auto socket = TRY(Core::LocalSocket::connect(move(parsed_socket_path)));                                       \
+        /* We want to rate-limit our clients */                                                                        \
+        TRY(socket->set_blocking(true));                                                                               \
+                                                                                                                       \
+        return adopt_nonnull_ref_or_enomem(new (nothrow) Klass(IPC::Transport(move(socket)), forward<Args>(args)...)); \
     }
 
 template<typename ClientEndpoint, typename ServerEndpoint>
@@ -33,8 +33,8 @@ public:
     using ClientStub = typename ClientEndpoint::Stub;
     using IPCProxy = typename ServerEndpoint::template Proxy<ClientEndpoint>;
 
-    ConnectionToServer(ClientStub& local_endpoint, NonnullOwnPtr<Core::LocalSocket> socket)
-        : Connection<ClientEndpoint, ServerEndpoint>(local_endpoint, move(socket))
+    ConnectionToServer(ClientStub& local_endpoint, Transport transport)
+        : Connection<ClientEndpoint, ServerEndpoint>(local_endpoint, move(transport))
         , ServerEndpoint::template Proxy<ClientEndpoint>(*this, {})
     {
     }

--- a/Userland/Libraries/LibIPC/Message.h
+++ b/Userland/Libraries/LibIPC/Message.h
@@ -12,6 +12,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibCore/Forward.h>
+#include <LibIPC/Transport.h>
 #include <unistd.h>
 
 namespace IPC {
@@ -44,7 +45,7 @@ public:
 
     ErrorOr<void> append_file_descriptor(int fd);
 
-    ErrorOr<void> transfer_message(Core::LocalSocket& socket);
+    ErrorOr<void> transfer_message(Transport& socket);
 
 private:
     Vector<u8, 1024> m_data;

--- a/Userland/Libraries/LibIPC/MultiServer.h
+++ b/Userland/Libraries/LibIPC/MultiServer.h
@@ -37,7 +37,7 @@ private:
         m_server->on_accept = [&](auto client_socket) {
             auto client_id = ++m_next_client_id;
 
-            auto client = IPC::new_client_connection<ConnectionFromClientType>(move(client_socket), client_id);
+            auto client = IPC::new_client_connection<ConnectionFromClientType>(IPC::Transport(move(client_socket)), client_id);
             if (on_new_client)
                 on_new_client(*client);
         };

--- a/Userland/Libraries/LibIPC/SingleServer.h
+++ b/Userland/Libraries/LibIPC/SingleServer.h
@@ -16,7 +16,7 @@ template<typename ConnectionFromClientType>
 ErrorOr<NonnullRefPtr<ConnectionFromClientType>> take_over_accepted_client_from_system_server()
 {
     auto socket = TRY(Core::take_over_socket_from_system_server());
-    return IPC::new_client_connection<ConnectionFromClientType>(move(socket));
+    return IPC::new_client_connection<ConnectionFromClientType>(IPC::Transport(move(socket)));
 }
 
 }

--- a/Userland/Libraries/LibIPC/Transport.h
+++ b/Userland/Libraries/LibIPC/Transport.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if !defined(AK_OS_WINDOWS)
+#    include <LibIPC/TransportSocket.h>
+#endif
+
+namespace IPC {
+
+#if !defined(AK_OS_WINDOWS)
+// Unix Domain Sockets
+using Transport = TransportSocket;
+#else
+#    error "LibIPC Transport has not been ported to this platform"
+#endif
+
+}

--- a/Userland/Libraries/LibIPC/TransportSocket.cpp
+++ b/Userland/Libraries/LibIPC/TransportSocket.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/NonnullOwnPtr.h>
+#include <LibCore/Socket.h>
+#include <LibCore/System.h>
+#include <LibIPC/File.h>
+#include <LibIPC/TransportSocket.h>
+
+namespace IPC {
+
+TransportSocket::TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket)
+    : m_socket(move(socket))
+{
+    socklen_t socket_buffer_size = 128 * KiB;
+    (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_SNDBUF, &socket_buffer_size, sizeof(socket_buffer_size));
+    (void)Core::System::setsockopt(m_socket->fd().value(), SOL_SOCKET, SO_RCVBUF, &socket_buffer_size, sizeof(socket_buffer_size));
+}
+
+TransportSocket::~TransportSocket() = default;
+
+void TransportSocket::set_up_read_hook(Function<void()> hook)
+{
+    VERIFY(m_socket->is_open());
+    m_socket->on_ready_to_read = move(hook);
+}
+
+bool TransportSocket::is_open() const
+{
+    return m_socket->is_open();
+}
+
+void TransportSocket::close()
+{
+    m_socket->close();
+}
+
+void TransportSocket::wait_until_readable()
+{
+    auto maybe_did_become_readable = m_socket->can_read_without_blocking(-1);
+    if (maybe_did_become_readable.is_error()) {
+        dbgln("TransportSocket::wait_until_readable: {}", maybe_did_become_readable.error());
+        warnln("TransportSocket::wait_until_readable: {}", maybe_did_become_readable.error());
+        VERIFY_NOT_REACHED();
+    }
+
+    VERIFY(maybe_did_become_readable.value());
+}
+
+ErrorOr<void> TransportSocket::transfer(ReadonlyBytes bytes_to_write, Vector<int, 1> const& unowned_fds)
+{
+    auto num_fds_to_transfer = unowned_fds.size();
+    while (!bytes_to_write.is_empty()) {
+        ErrorOr<ssize_t> maybe_nwritten = 0;
+        if (num_fds_to_transfer > 0) {
+            maybe_nwritten = m_socket->send_message(bytes_to_write, 0, unowned_fds);
+            if (!maybe_nwritten.is_error())
+                num_fds_to_transfer = 0;
+        } else {
+            maybe_nwritten = m_socket->write_some(bytes_to_write);
+        }
+
+        if (maybe_nwritten.is_error()) {
+            if (auto error = maybe_nwritten.release_error(); error.is_errno() && (error.code() == EAGAIN || error.code() == EWOULDBLOCK)) {
+
+                // FIXME: Refactor this to pass the unwritten bytes back to the caller to send 'later'
+                //        or next time the socket is writable
+                Vector<struct pollfd, 1> pollfds;
+                if (pollfds.is_empty())
+                    pollfds.append({ .fd = m_socket->fd().value(), .events = POLLOUT, .revents = 0 });
+
+                ErrorOr<int> result { 0 };
+                do {
+                    constexpr u32 POLL_TIMEOUT_MS = 100;
+                    result = Core::System::poll(pollfds, POLL_TIMEOUT_MS);
+                } while (result.is_error() && result.error().code() == EINTR);
+
+                if (!result.is_error() && result.value() != 0)
+                    continue;
+
+                switch (error.code()) {
+                case EPIPE:
+                    return Error::from_string_literal("IPC::transfer_message: Disconnected from peer");
+                case EAGAIN:
+                    return Error::from_string_literal("IPC::transfer_message: Timed out waiting for socket to become writable");
+                default:
+                    return Error::from_syscall("IPC::transfer_message write"sv, -error.code());
+                }
+            } else {
+                return error;
+            }
+        }
+
+        bytes_to_write = bytes_to_write.slice(maybe_nwritten.value());
+    }
+    return {};
+}
+
+TransportSocket::ReadResult TransportSocket::read_as_much_as_possible_without_blocking(Function<void()> schedule_shutdown)
+{
+    u8 buffer[4096];
+
+    ReadResult result;
+    auto received_fds = Vector<int> {};
+    auto& bytes = result.bytes;
+
+    while (is_open()) {
+        auto maybe_bytes_read = m_socket->receive_message({ buffer, 4096 }, MSG_DONTWAIT, received_fds);
+        if (maybe_bytes_read.is_error()) {
+            auto error = maybe_bytes_read.release_error();
+            if (error.is_syscall() && error.code() == EAGAIN) {
+                break;
+            }
+
+            if (error.is_syscall() && error.code() == ECONNRESET) {
+                schedule_shutdown();
+                break;
+            }
+
+            dbgln("TransportSocket::read_as_much_as_possible_without_blocking: {}", error);
+            warnln("TransportSocket::read_as_much_as_possible_without_blocking: {}", error);
+            VERIFY_NOT_REACHED();
+        }
+
+        auto bytes_read = maybe_bytes_read.release_value();
+        if (bytes_read.is_empty()) {
+            schedule_shutdown();
+            break;
+        }
+
+        bytes.append(bytes_read.data(), bytes_read.size());
+        result.fds.append(received_fds.data(), received_fds.size());
+    }
+
+    return result;
+}
+
+ErrorOr<int> TransportSocket::release_underlying_transport_for_transfer()
+{
+    return m_socket->release_fd();
+}
+
+ErrorOr<IPC::File> TransportSocket::clone_for_transfer()
+{
+    return IPC::File::clone_fd(m_socket->fd().value());
+}
+
+}

--- a/Userland/Libraries/LibIPC/TransportSocket.h
+++ b/Userland/Libraries/LibIPC/TransportSocket.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/File.h>
+
+namespace IPC {
+
+class TransportSocket {
+    AK_MAKE_NONCOPYABLE(TransportSocket);
+    AK_MAKE_DEFAULT_MOVABLE(TransportSocket);
+
+public:
+    explicit TransportSocket(NonnullOwnPtr<Core::LocalSocket> socket);
+    ~TransportSocket();
+
+    void set_up_read_hook(Function<void()>);
+    bool is_open() const;
+    void close();
+
+    void wait_until_readable();
+
+    ErrorOr<void> transfer(ReadonlyBytes, Vector<int, 1> const& unowned_fds);
+
+    struct [[nodiscard]] ReadResult {
+        Vector<u8> bytes;
+        Vector<int> fds;
+    };
+    ReadResult read_as_much_as_possible_without_blocking(Function<void()> schedule_shutdown);
+
+    // Obnoxious name to make it clear that this is a dangerous operation.
+    ErrorOr<int> release_underlying_transport_for_transfer();
+
+    ErrorOr<IPC::File> clone_for_transfer();
+
+private:
+    NonnullOwnPtr<Core::LocalSocket> m_socket;
+};
+
+}

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -9,8 +9,8 @@
 
 namespace ImageDecoderClient {
 
-Client::Client(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionToServer<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(socket))
+Client::Client(IPC::Transport transport)
+    : IPC::ConnectionToServer<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(transport))
 {
 }
 

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -32,7 +32,7 @@ class Client final
     IPC_CLIENT_CONNECTION(Client, "/tmp/session/%sid/portal/image"sv);
 
 public:
-    Client(NonnullOwnPtr<Core::LocalSocket>);
+    Client(IPC::Transport);
 
     NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});
 

--- a/Userland/Libraries/LibRequests/RequestClient.cpp
+++ b/Userland/Libraries/LibRequests/RequestClient.cpp
@@ -9,8 +9,8 @@
 
 namespace Requests {
 
-RequestClient::RequestClient(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>(*this, move(socket))
+RequestClient::RequestClient(IPC::Transport transport)
+    : IPC::ConnectionToServer<RequestClientEndpoint, RequestServerEndpoint>(*this, move(transport))
 {
 }
 

--- a/Userland/Libraries/LibRequests/RequestClient.h
+++ b/Userland/Libraries/LibRequests/RequestClient.h
@@ -24,7 +24,7 @@ class RequestClient final
     IPC_CLIENT_CONNECTION(RequestClient, "/tmp/session/%sid/portal/request"sv)
 
 public:
-    explicit RequestClient(NonnullOwnPtr<Core::LocalSocket>);
+    explicit RequestClient(IPC::Transport);
     virtual ~RequestClient() override;
 
     RefPtr<Request> start_request(ByteString const& method, URL::URL const&, HTTP::HeaderMap const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -12,6 +12,7 @@
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <LibIPC/File.h>
+#include <LibIPC/Transport.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MessagePortPrototype.h>
@@ -71,6 +72,11 @@ void MessagePort::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_worker_event_target);
 }
 
+bool MessagePort::is_entangled() const
+{
+    return m_transport.has_value();
+}
+
 void MessagePort::set_worker_event_target(JS::NonnullGCPtr<DOM::EventTarget> target)
 {
     m_worker_event_target = target;
@@ -91,10 +97,14 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_steps(HTML::TransferDataHolder& 
         m_remote_port->m_has_been_shipped = true;
 
         // 2. Set dataHolder.[[RemotePort]] to remotePort.
-        auto fd = MUST(m_socket->release_fd());
-        m_socket = nullptr;
-        data_holder.fds.append(IPC::File::adopt_fd(fd));
-        data_holder.data.append(IPC_FILE_TAG);
+        if constexpr (IsSame<IPC::Transport, IPC::TransportSocket>) {
+            auto fd = MUST(m_transport->release_underlying_transport_for_transfer());
+            m_transport = {};
+            data_holder.fds.append(IPC::File::adopt_fd(fd));
+            data_holder.data.append(IPC_FILE_TAG);
+        } else {
+            VERIFY(false && "Don't know how to transfer IPC::Transport type");
+        }
     }
 
     // 4. Otherwise, set dataHolder.[[RemotePort]] to null.
@@ -118,12 +128,16 @@ WebIDL::ExceptionOr<void> MessagePort::transfer_receiving_steps(HTML::TransferDa
     //     (This will disentangle dataHolder.[[RemotePort]] from the original port that was transferred.)
     auto fd_tag = data_holder.data.take_first();
     if (fd_tag == IPC_FILE_TAG) {
-        auto fd = data_holder.fds.take_first();
-        m_socket = MUST(Core::LocalSocket::adopt_fd(fd.take_fd()));
+        if constexpr (IsSame<IPC::Transport, IPC::TransportSocket>) {
+            auto fd = data_holder.fds.take_first();
+            m_transport = IPC::Transport(MUST(Core::LocalSocket::adopt_fd(fd.take_fd())));
 
-        m_socket->on_ready_to_read = [strong_this = JS::make_handle(this)]() {
-            strong_this->read_from_socket();
-        };
+            m_transport->set_up_read_hook([strong_this = JS::make_handle(this)]() {
+                strong_this->read_from_transport();
+            });
+        } else {
+            VERIFY(false && "Don't know how to receive IPC::Transport type");
+        }
     } else if (fd_tag != 0) {
         dbgln("Unexpected byte {:x} in MessagePort transfer data", fd_tag);
         VERIFY_NOT_REACHED();
@@ -138,7 +152,7 @@ void MessagePort::disentangle()
         m_remote_port->m_remote_port = nullptr;
     m_remote_port = nullptr;
 
-    m_socket = nullptr;
+    m_transport = {};
 
     m_worker_event_target = nullptr;
 }
@@ -160,6 +174,7 @@ void MessagePort::entangle_with(MessagePort& remote_port)
     remote_port.m_remote_port = this;
     m_remote_port = &remote_port;
 
+    // FIXME: Abstract such that we can entangle different transport types
     auto create_paired_sockets = []() -> Array<NonnullOwnPtr<Core::LocalSocket>, 2> {
         int fds[2] = {};
         MUST(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, fds));
@@ -174,16 +189,16 @@ void MessagePort::entangle_with(MessagePort& remote_port)
     };
 
     auto sockets = create_paired_sockets();
-    m_socket = move(sockets[0]);
-    m_remote_port->m_socket = move(sockets[1]);
+    m_transport = IPC::Transport(move(sockets[0]));
+    m_remote_port->m_transport = IPC::Transport(move(sockets[1]));
 
-    m_socket->on_ready_to_read = [strong_this = JS::make_handle(this)]() {
-        strong_this->read_from_socket();
-    };
+    m_transport->set_up_read_hook([strong_this = JS::make_handle(this)]() {
+        strong_this->read_from_transport();
+    });
 
-    m_remote_port->m_socket->on_ready_to_read = [remote_port = JS::make_handle(m_remote_port)]() {
-        remote_port->read_from_socket();
-    };
+    m_remote_port->m_transport->set_up_read_hook([remote_port = JS::make_handle(m_remote_port)]() {
+        remote_port->read_from_transport();
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage-options
@@ -243,7 +258,7 @@ WebIDL::ExceptionOr<void> MessagePort::message_port_post_message_steps(JS::GCPtr
     // 6. If targetPort is null, or if doomed is true, then return.
     // IMPLEMENTATION DEFINED: Actually check the socket here, not the target port.
     //     If there's no target message port in the same realm, we still want to send the message over IPC
-    if (!m_socket || doomed) {
+    if (!m_transport.has_value() || doomed) {
         return {};
     }
 
@@ -253,13 +268,13 @@ WebIDL::ExceptionOr<void> MessagePort::message_port_post_message_steps(JS::GCPtr
     return {};
 }
 
-ErrorOr<void> MessagePort::send_message_on_socket(SerializedTransferRecord const& serialize_with_transfer_result)
+ErrorOr<void> MessagePort::send_message_on_transport(SerializedTransferRecord const& serialize_with_transfer_result)
 {
     IPC::MessageBuffer buffer;
     IPC::Encoder encoder(buffer);
     MUST(encoder.encode(serialize_with_transfer_result));
 
-    TRY(buffer.transfer_message(*m_socket));
+    TRY(buffer.transfer_message(*m_transport));
     return {};
 }
 
@@ -267,9 +282,9 @@ void MessagePort::post_port_message(SerializedTransferRecord serialize_with_tran
 {
     // FIXME: Use the correct task source?
     queue_global_task(Task::Source::PostedMessage, relevant_global_object(*this), JS::create_heap_function(heap(), [this, serialize_with_transfer_result = move(serialize_with_transfer_result)]() mutable {
-        if (!m_socket || !m_socket->is_open())
+        if (!m_transport.has_value() || !m_transport->is_open())
             return;
-        if (auto result = send_message_on_socket(serialize_with_transfer_result); result.is_error()) {
+        if (auto result = send_message_on_transport(serialize_with_transfer_result); result.is_error()) {
             dbgln("Failed to post message: {}", result.error());
             disentangle();
         }
@@ -320,18 +335,13 @@ ErrorOr<MessagePort::ParseDecision> MessagePort::parse_message()
     return ParseDecision::ParseNextMessage;
 }
 
-void MessagePort::read_from_socket()
+void MessagePort::read_from_transport()
 {
-    u8 buffer[4096] {};
-
-    Vector<int> fds;
-    // FIXME: What if pending bytes is > 4096? Should we loop here?
-    auto maybe_bytes = m_socket->receive_message(buffer, MSG_NOSIGNAL, fds);
-    if (maybe_bytes.is_error()) {
-        dbgln("MessagePort::read_from_socket(): Failed to receive message: {}", maybe_bytes.error());
-        return;
-    }
-    auto bytes = maybe_bytes.release_value();
+    auto&& [bytes, fds] = m_transport->read_as_much_as_possible_without_blocking([this] {
+        queue_global_task(Task::Source::PostedMessage, relevant_global_object(*this), JS::create_heap_function(heap(), [this] {
+            this->close();
+        }));
+    });
 
     m_buffered_data.append(bytes.data(), bytes.size());
 
@@ -406,7 +416,7 @@ void MessagePort::start()
     if (!is_entangled())
         return;
 
-    VERIFY(m_socket);
+    VERIFY(m_transport.has_value());
 
     // TODO: The start() method steps are to enable this's port message queue, if it is not already enabled.
 }

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.h
@@ -11,6 +11,7 @@
 #include <AK/Weakable.h>
 #include <LibCore/Socket.h>
 #include <LibIPC/File.h>
+#include <LibIPC/Transport.h>
 #include <LibWeb/Bindings/Transferable.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
@@ -69,13 +70,13 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    bool is_entangled() const { return static_cast<bool>(m_socket); }
+    bool is_entangled() const;
 
     WebIDL::ExceptionOr<void> message_port_post_message_steps(JS::GCPtr<MessagePort> target_port, JS::Value message, StructuredSerializeOptions const& options);
     void post_message_task_steps(SerializedTransferRecord&);
     void post_port_message(SerializedTransferRecord);
-    ErrorOr<void> send_message_on_socket(SerializedTransferRecord const&);
-    void read_from_socket();
+    ErrorOr<void> send_message_on_transport(SerializedTransferRecord const&);
+    void read_from_transport();
 
     enum class ParseDecision {
         NotEnoughData,
@@ -89,7 +90,7 @@ private:
     // https://html.spec.whatwg.org/multipage/web-messaging.html#has-been-shipped
     bool m_has_been_shipped { false };
 
-    OwnPtr<Core::LocalSocket> m_socket;
+    Optional<IPC::Transport> m_transport;
 
     enum class SocketState : u8 {
         Header,

--- a/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerAgent.cpp
@@ -35,10 +35,14 @@ void WorkerAgent::initialize(JS::Realm& realm)
     // NOTE: This blocking IPC call may launch another process.
     //    If spinning the event loop for this can cause other javascript to execute, we're in trouble.
     auto worker_socket_file = Bindings::host_defined_page(realm).client().request_worker_agent();
+
     auto worker_socket = MUST(Core::LocalSocket::adopt_fd(worker_socket_file.take_fd()));
     MUST(worker_socket->set_blocking(true));
+    static_assert(IsSame<IPC::Transport, IPC::TransportSocket>, "Handle other IPC::Transport types here");
 
-    m_worker_ipc = make_ref_counted<WebWorkerClient>(move(worker_socket));
+    auto transport = IPC::Transport(move(worker_socket));
+
+    m_worker_ipc = make_ref_counted<WebWorkerClient>(move(transport));
 
     m_worker_ipc->async_start_dedicated_worker(m_url, m_worker_options.type, m_worker_options.credentials, m_worker_options.name, move(data_holder), m_outside_settings->serialize());
 }

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerClient.cpp
@@ -20,14 +20,14 @@ void WebWorkerClient::did_close_worker()
         on_worker_close();
 }
 
-WebWorkerClient::WebWorkerClient(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(socket))
+WebWorkerClient::WebWorkerClient(IPC::Transport transport)
+    : IPC::ConnectionToServer<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport))
 {
 }
 
-IPC::File WebWorkerClient::dup_socket()
+IPC::File WebWorkerClient::clone_transport()
 {
-    return MUST(IPC::File::clone_fd(socket().fd().value()));
+    return MUST(m_transport.clone_for_transfer());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Worker/WebWorkerClient.h
+++ b/Userland/Libraries/LibWeb/Worker/WebWorkerClient.h
@@ -19,13 +19,13 @@ class WebWorkerClient final
     IPC_CLIENT_CONNECTION(WebWorkerClient, "/tmp/session/%sid/portal/webworker"sv);
 
 public:
-    explicit WebWorkerClient(NonnullOwnPtr<Core::LocalSocket>);
+    explicit WebWorkerClient(IPC::Transport);
 
     virtual void did_close_worker() override;
 
     Function<void()> on_worker_close;
 
-    IPC::File dup_socket();
+    IPC::File clone_transport();
 
 private:
     virtual void die() override;

--- a/Userland/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Userland/Libraries/LibWebView/ChromeProcess.cpp
@@ -29,9 +29,9 @@ ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteStr
 {
     static constexpr auto process_name = "Ladybird"sv;
 
-    auto [socket_path, pid_path] = TRY(Core::IPCProcess::paths_for_process(process_name));
+    auto [socket_path, pid_path] = TRY(Process::paths_for_process(process_name));
 
-    if (auto pid = TRY(Core::IPCProcess::get_process_pid(process_name, pid_path)); pid.has_value()) {
+    if (auto pid = TRY(Process::get_process_pid(process_name, pid_path)); pid.has_value()) {
         TRY(connect_as_client(socket_path, raw_urls, new_window));
         return ProcessDisposition::ExitProcess;
     }
@@ -63,7 +63,7 @@ ErrorOr<void> ChromeProcess::connect_as_client(ByteString const& socket_path, Ve
 
 ErrorOr<void> ChromeProcess::connect_as_server(ByteString const& socket_path)
 {
-    auto socket_fd = TRY(Core::IPCProcess::create_ipc_socket(socket_path));
+    auto socket_fd = TRY(Process::create_ipc_socket(socket_path));
     m_socket_path = socket_path;
     auto local_server = TRY(Core::LocalServer::try_create());
     TRY(local_server->take_over_fd(socket_fd));

--- a/Userland/Libraries/LibWebView/ChromeProcess.h
+++ b/Userland/Libraries/LibWebView/ChromeProcess.h
@@ -10,7 +10,6 @@
 #include <AK/Function.h>
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
-#include <LibCore/Socket.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/MultiServer.h>
@@ -33,7 +32,7 @@ public:
     Function<void(Vector<URL::URL> const&)> on_new_window;
 
 private:
-    UIProcessConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>, int client_id);
+    UIProcessConnectionFromClient(IPC::Transport, int client_id);
 
     virtual void create_new_tab(Vector<ByteString> const& urls) override;
     virtual void create_new_window(Vector<ByteString> const& urls) override;

--- a/Userland/Libraries/LibWebView/Process.cpp
+++ b/Userland/Libraries/LibWebView/Process.cpp
@@ -4,7 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Environment.h>
 #include <LibCore/Process.h>
+#include <LibCore/StandardPaths.h>
 #include <LibWebView/Process.h>
 
 namespace WebView {
@@ -20,6 +22,103 @@ Process::~Process()
 {
     if (m_connection)
         m_connection->shutdown();
+}
+
+ErrorOr<Process::ProcessAndIPCSocket> Process::spawn_and_connect_to_process(Core::ProcessSpawnOptions const& options)
+{
+    int socket_fds[2] {};
+    TRY(Core::System::socketpair(AF_LOCAL, SOCK_STREAM, 0, socket_fds));
+
+    ArmedScopeGuard guard_fd_0 { [&] { MUST(Core::System::close(socket_fds[0])); } };
+    ArmedScopeGuard guard_fd_1 { [&] { MUST(Core::System::close(socket_fds[1])); } };
+
+    auto& file_actions = const_cast<Core::ProcessSpawnOptions&>(options).file_actions;
+    file_actions.append(Core::FileAction::CloseFile { socket_fds[0] });
+
+    auto takeover_string = MUST(String::formatted("{}:{}", options.name, socket_fds[1]));
+    TRY(Core::Environment::set("SOCKET_TAKEOVER"sv, takeover_string, Core::Environment::Overwrite::Yes));
+
+    auto process = TRY(Core::Process::spawn(options));
+
+    auto ipc_socket = TRY(Core::LocalSocket::adopt_fd(socket_fds[0]));
+    guard_fd_0.disarm();
+    TRY(ipc_socket->set_blocking(true));
+
+    return ProcessAndIPCSocket { move(process), move(ipc_socket) };
+}
+
+ErrorOr<Optional<pid_t>> Process::get_process_pid(StringView process_name, StringView pid_path)
+{
+    if (Core::System::stat(pid_path).is_error())
+        return OptionalNone {};
+
+    Optional<pid_t> pid;
+    {
+        auto pid_file = Core::File::open(pid_path, Core::File::OpenMode::Read);
+        if (pid_file.is_error()) {
+            warnln("Could not open {} PID file '{}': {}", process_name, pid_path, pid_file.error());
+            return pid_file.release_error();
+        }
+
+        auto contents = pid_file.value()->read_until_eof();
+        if (contents.is_error()) {
+            warnln("Could not read {} PID file '{}': {}", process_name, pid_path, contents.error());
+            return contents.release_error();
+        }
+
+        pid = StringView { contents.value() }.to_number<pid_t>();
+    }
+
+    if (!pid.has_value()) {
+        warnln("{} PID file '{}' exists, but with an invalid PID", process_name, pid_path);
+        TRY(Core::System::unlink(pid_path));
+        return OptionalNone {};
+    }
+    if (kill(*pid, 0) < 0) {
+        warnln("{} PID file '{}' exists with PID {}, but process cannot be found", process_name, pid_path, *pid);
+        TRY(Core::System::unlink(pid_path));
+        return OptionalNone {};
+    }
+
+    return pid;
+}
+
+// This is heavily based on how SystemServer's Service creates its socket.
+ErrorOr<int> Process::create_ipc_socket(ByteString const& socket_path)
+{
+    if (!Core::System::stat(socket_path).is_error())
+        TRY(Core::System::unlink(socket_path));
+
+#ifdef SOCK_NONBLOCK
+    auto socket_fd = TRY(Core::System::socket(AF_LOCAL, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0));
+#else
+    auto socket_fd = TRY(Core::System::socket(AF_LOCAL, SOCK_STREAM, 0));
+
+    int option = 1;
+    TRY(Core::System::ioctl(socket_fd, FIONBIO, &option));
+    TRY(Core::System::fcntl(socket_fd, F_SETFD, FD_CLOEXEC));
+#endif
+
+#if !defined(AK_OS_BSD_GENERIC) && !defined(AK_OS_GNU_HURD)
+    TRY(Core::System::fchmod(socket_fd, 0600));
+#endif
+
+    auto socket_address = Core::SocketAddress::local(socket_path);
+    auto socket_address_un = socket_address.to_sockaddr_un().release_value();
+
+    TRY(Core::System::bind(socket_fd, reinterpret_cast<sockaddr*>(&socket_address_un), sizeof(socket_address_un)));
+    TRY(Core::System::listen(socket_fd, 16));
+
+    return socket_fd;
+}
+
+ErrorOr<Process::ProcessPaths> Process::paths_for_process(StringView process_name)
+{
+    auto runtime_directory = TRY(Core::StandardPaths::runtime_directory());
+    auto socket_path = ByteString::formatted("{}/{}.socket", runtime_directory, process_name);
+    auto pid_path = ByteString::formatted("{}/{}.pid", runtime_directory, process_name);
+
+    return ProcessPaths { move(socket_path), move(pid_path) };
 }
 
 }

--- a/Userland/Libraries/LibWebView/Process.h
+++ b/Userland/Libraries/LibWebView/Process.h
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Process.h>
+#include <LibCore/Socket.h>
 #include <LibIPC/Connection.h>
 #include <LibWebView/ProcessType.h>
 
@@ -21,6 +22,12 @@ class Process {
 public:
     Process(ProcessType type, RefPtr<IPC::ConnectionBase> connection, Core::Process process);
     ~Process();
+
+    template<typename ClientType>
+    struct ProcessAndClient;
+
+    template<typename ClientType, typename... ClientArguments>
+    static ErrorOr<ProcessAndClient<ClientType>> spawn(ProcessType type, Core::ProcessSpawnOptions const& options, ClientArguments&&... client_arguments);
 
     ProcessType type() const { return m_type; }
     Optional<String> const& title() const { return m_title; }
@@ -36,11 +43,40 @@ public:
 
     pid_t pid() const { return m_process.pid(); }
 
+    struct ProcessPaths {
+        ByteString socket_path;
+        ByteString pid_path;
+    };
+    static ErrorOr<ProcessPaths> paths_for_process(StringView process_name);
+    static ErrorOr<Optional<pid_t>> get_process_pid(StringView process_name, StringView pid_path);
+    static ErrorOr<int> create_ipc_socket(ByteString const& socket_path);
+
 private:
+    struct ProcessAndIPCSocket {
+        Core::Process process;
+        NonnullOwnPtr<Core::LocalSocket> socket;
+    };
+    static ErrorOr<ProcessAndIPCSocket> spawn_and_connect_to_process(Core::ProcessSpawnOptions const& options);
+
     Core::Process m_process;
     ProcessType m_type;
     Optional<String> m_title;
     WeakPtr<IPC::ConnectionBase> m_connection;
 };
+
+template<typename ClientType>
+struct Process::ProcessAndClient {
+    Process process;
+    NonnullRefPtr<ClientType> client;
+};
+
+template<typename ClientType, typename... ClientArguments>
+ErrorOr<Process::ProcessAndClient<ClientType>> Process::spawn(ProcessType type, Core::ProcessSpawnOptions const& options, ClientArguments&&... client_arguments)
+{
+    auto [core_process, socket] = TRY(spawn_and_connect_to_process(options));
+    auto client = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ClientType { move(socket), forward<ClientArguments>(client_arguments)... }));
+
+    return ProcessAndClient { Process { type, client, move(core_process) }, client };
+}
 
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -23,8 +23,8 @@ Optional<ViewImplementation&> WebContentClient::view_for_pid_and_page_id(pid_t p
     return {};
 }
 
-WebContentClient::WebContentClient(NonnullOwnPtr<Core::LocalSocket> socket, ViewImplementation& view)
-    : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(socket))
+WebContentClient::WebContentClient(IPC::Transport transport, ViewImplementation& view)
+    : IPC::ConnectionToServer<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport))
 {
     s_clients.set(this);
     m_views.set(0, &view);

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -9,6 +9,7 @@
 #include <AK/HashMap.h>
 #include <AK/SourceLocation.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibIPC/Transport.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWeb/HTML/FileFilter.h>
@@ -35,7 +36,7 @@ public:
 
     static size_t client_count() { return s_clients.size(); }
 
-    WebContentClient(NonnullOwnPtr<Core::LocalSocket>, ViewImplementation&);
+    WebContentClient(IPC::Transport, ViewImplementation&);
     ~WebContentClient();
 
     void register_view(u64 page_id, ViewImplementation&);

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -17,8 +17,8 @@ namespace ImageDecoder {
 static HashMap<int, RefPtr<ConnectionFromClient>> s_connections;
 static IDAllocator s_client_ids;
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionFromClient<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(socket), s_client_ids.allocate())
+ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+    : IPC::ConnectionFromClient<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(transport), s_client_ids.allocate())
 {
     s_connections.set(client_id(), *this);
 }
@@ -55,7 +55,7 @@ ErrorOr<IPC::File> ConnectionFromClient::connect_new_client()
 
     auto client_socket = client_socket_or_error.release_value();
     // Note: A ref is stored in the static s_connections map
-    auto client = adopt_ref(*new ConnectionFromClient(move(client_socket)));
+    auto client = adopt_ref(*new ConnectionFromClient(IPC::Transport(move(client_socket))));
 
     return IPC::File::adopt_fd(socket_fds[1]);
 }

--- a/Userland/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Userland/Services/ImageDecoder/ConnectionFromClient.h
@@ -36,7 +36,7 @@ public:
 private:
     using Job = Threading::BackgroundAction<DecodeResult>;
 
-    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
+    explicit ConnectionFromClient(IPC::Transport);
 
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&, Optional<Gfx::IntSize> const& ideal_size, Optional<ByteString> const& mime_type) override;
     virtual void cancel_decoding(i64 image_id) override;

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -30,7 +30,7 @@ public:
     void did_request_certificates(Badge<Request>, Request&);
 
 private:
-    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
+    explicit ConnectionFromClient(IPC::Transport);
 
     virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString const&) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -53,8 +53,8 @@
 
 namespace WebContent {
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionFromClient<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(socket), 1)
+ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+    : IPC::ConnectionFromClient<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(transport), 1)
     , m_page_host(PageHost::create(*this))
 {
     m_input_event_queue_timer = Web::Platform::Timer::create_single_shot(0, [this] { process_next_input_event(); });

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -42,15 +42,13 @@ public:
 
     void request_file(u64 page_id, Web::FileRequest);
 
-    Optional<int> fd() { return socket().fd(); }
-
     PageHost& page_host() { return *m_page_host; }
     PageHost const& page_host() const { return *m_page_host; }
 
     Function<void(IPC::File const&)> on_image_decoder_connection;
 
 private:
-    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
+    explicit ConnectionFromClient(IPC::Transport);
 
     Optional<PageClient&> page(u64 index, SourceLocation = SourceLocation::current());
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -14,6 +14,7 @@
 #include <AK/String.h>
 #include <LibGfx/Rect.h>
 #include <LibIPC/ConnectionToServer.h>
+#include <LibIPC/Transport.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibWeb/Forward.h>
@@ -37,7 +38,7 @@ public:
     void visit_edges(JS::Cell::Visitor&);
 
 private:
-    WebDriverConnection(NonnullOwnPtr<Core::LocalSocket> socket, Web::PageClient& page_client);
+    WebDriverConnection(IPC::Transport transport, Web::PageClient& page_client);
 
     virtual void die() override { }
 

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -9,8 +9,8 @@
 
 namespace WebDriver {
 
-WebContentConnection::WebContentConnection(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint>(*this, move(socket), 1)
+WebContentConnection::WebContentConnection(IPC::Transport transport)
+    : IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint>(*this, move(transport), 1)
 {
 }
 

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibIPC/ConnectionFromClient.h>
+#include <LibIPC/Transport.h>
 #include <WebContent/WebDriverClientEndpoint.h>
 #include <WebContent/WebDriverServerEndpoint.h>
 
@@ -18,7 +19,7 @@ class WebContentConnection
     : public IPC::ConnectionFromClient<WebDriverClientEndpoint, WebDriverServerEndpoint> {
     C_OBJECT_ABSTRACT(WebContentConnection)
 public:
-    WebContentConnection(NonnullOwnPtr<Core::LocalSocket> socket);
+    explicit WebContentConnection(IPC::Transport transport);
 
     Function<void()> on_close;
     Function<void(Web::WebDriver::Response)> on_script_executed;

--- a/Userland/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Userland/Services/WebWorker/ConnectionFromClient.cpp
@@ -45,8 +45,8 @@ void ConnectionFromClient::request_file(Web::FileRequest request)
         handle_file_return(0, IPC::File::adopt_file(file.release_value()), request_id);
 }
 
-ConnectionFromClient::ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket> socket)
-    : IPC::ConnectionFromClient<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(socket), 1)
+ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
+    : IPC::ConnectionFromClient<WebWorkerClientEndpoint, WebWorkerServerEndpoint>(*this, move(transport), 1)
     , m_page_host(PageHost::create(Web::Bindings::main_thread_vm(), *this))
 {
 }

--- a/Userland/Services/WebWorker/ConnectionFromClient.h
+++ b/Userland/Services/WebWorker/ConnectionFromClient.h
@@ -36,7 +36,7 @@ public:
     PageHost const& page_host() const { return *m_page_host; }
 
 private:
-    explicit ConnectionFromClient(NonnullOwnPtr<Core::LocalSocket>);
+    explicit ConnectionFromClient(IPC::Transport);
 
     Web::Page& page();
     Web::Page const& page() const;


### PR DESCRIPTION
This abstraction will help us to support multiple IPC transport
mechanisms going forward. For now, we only have a TransportSocket that
implements the same behavior we previously had, using Unix Sockets for
IPC.

As part of this refactor,  move Core::IPCProcess into WebView::Process.
Ladybird's HelperProcess.cpp was the only user of the IPCProcess class.
Moving the helper class from LibCore allows for some more interesting
LibIPC changes in the upcoming commits.