### PR TITLE
LibWeb+WebContent: Implement missing cookie validation steps

### DIFF
--- a/Tests/LibWeb/Text/expected/cookie.txt
+++ b/Tests/LibWeb/Text/expected/cookie.txt
@@ -1,3 +1,4 @@
+Cookie averse test: ""
 Basic test: "cookie=value"
 Multiple cookies: "cookie1=value1; cookie2=value2; cookie3=value3"
 Nameless cookie: "value"

--- a/Tests/LibWeb/Text/input/cookie.html
+++ b/Tests/LibWeb/Text/input/cookie.html
@@ -12,6 +12,11 @@
         document.cookie = `${name}=""; max-age=-9999`;
     };
 
+    const cookieAverseTest = () => {
+        document.cookie = "cookie=value";
+        printCookies("Cookie averse test");
+    };
+
     const basicTest = () => {
         document.cookie = "cookie=value";
         printCookies("Basic test");
@@ -178,6 +183,10 @@
     };
 
     test(() => {
+        cookieAverseTest();
+
+        internals.enableCookiesOnFileDomains();
+
         basicTest();
         multipleCookiesTest();
 

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -468,6 +468,30 @@ Optional<UnixDateTime> parse_date_time(StringView date_string)
     return parsed_cookie_date;
 }
 
+// https://www.ietf.org/archive/id/draft-ietf-httpbis-rfc6265bis-15.html#section-5.1.3
+bool domain_matches(StringView string, StringView domain_string)
+{
+    // A string domain-matches a given domain string if at least one of the following conditions hold:
+
+    // * The domain string and the string are identical. (Note that both the domain string and the string will have been
+    //   canonicalized to lower case at this point.)
+    if (string == domain_string)
+        return true;
+
+    // * All of the following conditions hold:
+    //   - The domain string is a suffix of the string.
+    if (!string.ends_with(domain_string))
+        return false;
+    //   - The last character of the string that is not included in the domain string is a %x2E (".") character.
+    if (string[string.length() - domain_string.length() - 1] != '.')
+        return false;
+    //   - The string is a host name (i.e., not an IP address).
+    if (AK::IPv4Address::from_string(string).has_value())
+        return false;
+
+    return true;
+}
+
 // https://www.ietf.org/archive/id/draft-ietf-httpbis-rfc6265bis-15.html#section-5.1.4
 String default_path(URL::URL const& url)
 {

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -29,6 +29,7 @@ struct ParsedCookie {
 
 Optional<ParsedCookie> parse_cookie(URL::URL const&, StringView cookie_string);
 bool cookie_contains_invalid_control_character(StringView);
+bool domain_matches(StringView string, StringView domain_string);
 String default_path(URL::URL const&);
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -116,8 +116,10 @@ public:
 
     JS::GCPtr<Selection::Selection> get_selection() const;
 
-    String cookie(Cookie::Source = Cookie::Source::NonHttp);
-    void set_cookie(StringView, Cookie::Source = Cookie::Source::NonHttp);
+    WebIDL::ExceptionOr<String> cookie(Cookie::Source = Cookie::Source::NonHttp);
+    WebIDL::ExceptionOr<void> set_cookie(StringView, Cookie::Source = Cookie::Source::NonHttp);
+    bool is_cookie_averse() const;
+    void enable_cookies_on_file_domains(Badge<Internals::Internals>) { m_enable_cookies_on_file_domains = true; }
 
     String fg_color() const;
     void set_fg_color(String const&);
@@ -1019,6 +1021,8 @@ private:
     WeakPtr<HTML::Navigable> m_cached_navigable;
 
     bool m_needs_repaint { false };
+
+    bool m_enable_cookies_on_file_domains { false };
 
     Optional<PaintConfig> m_cached_display_list_paint_config;
     RefPtr<Painting::DisplayList> m_cached_display_list;

--- a/Userland/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Userland/Libraries/LibWeb/Internals/Internals.cpp
@@ -183,6 +183,11 @@ void Internals::simulate_drop(double x, double y)
     page.handle_drag_and_drop_event(DragEvent::Type::Drop, position, position, UIEvents::MouseButton::Primary, 0, 0, {});
 }
 
+void Internals::enable_cookies_on_file_domains()
+{
+    internals_window().associated_document().enable_cookies_on_file_domains({});
+}
+
 void Internals::expire_cookies_with_time_offset(WebIDL::LongLong seconds)
 {
     internals_page().client().page_did_expire_cookies_with_time_offset(AK::Duration::from_seconds(seconds));

--- a/Userland/Libraries/LibWeb/Internals/Internals.h
+++ b/Userland/Libraries/LibWeb/Internals/Internals.h
@@ -44,6 +44,7 @@ public:
     void simulate_drag_move(double x, double y);
     void simulate_drop(double x, double y);
 
+    void enable_cookies_on_file_domains();
     void expire_cookies_with_time_offset(WebIDL::LongLong seconds);
 
 private:

--- a/Userland/Libraries/LibWeb/Internals/Internals.idl
+++ b/Userland/Libraries/LibWeb/Internals/Internals.idl
@@ -34,5 +34,6 @@ interface Internals {
     undefined simulateDragMove(double x, double y);
     undefined simulateDrop(double x, double y);
 
+    undefined enableCookiesOnFileDomains();
     undefined expireCookiesWithTimeOffset(long long seconds);
 };

--- a/Userland/Libraries/LibWebView/CookieJar.h
+++ b/Userland/Libraries/LibWebView/CookieJar.h
@@ -103,7 +103,6 @@ private:
     AK_MAKE_NONMOVABLE(CookieJar);
 
     static Optional<String> canonicalize_domain(const URL::URL& url);
-    static bool domain_matches(StringView string, StringView domain_string);
     static bool path_matches(StringView request_path, StringView cookie_path);
 
     enum class MatchingCookiesSpecMode {


### PR DESCRIPTION
Contains missing steps from both the `document.cookie` and WebDriver steps.