### PR TITLE
LibWeb: Fix infinite loop in `Storage::internal_own_property_keys`

### DIFF
--- a/Tests/LibWeb/Text/expected/iterating-over-storage.txt
+++ b/Tests/LibWeb/Text/expected/iterating-over-storage.txt
@@ -1,0 +1,1 @@
+PASS (didn't loop forever)

--- a/Tests/LibWeb/Text/input/iterating-over-storage.html
+++ b/Tests/LibWeb/Text/input/iterating-over-storage.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        for (_ in window.localStorage);
+        println("PASS (didn't loop forever)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Storage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Storage.cpp
@@ -175,7 +175,10 @@ Optional<JS::Value> Storage::item_value(size_t index) const
 {
     // Handle index as a string since that's our key type
     auto key = String::number(index);
-    return named_item_value(key);
+    auto value = get_item(key);
+    if (!value.has_value())
+        return {};
+    return JS::PrimitiveString::create(vm(), value.release_value());
 }
 
 JS::Value Storage::named_item_value(FlyString const& name) const


### PR DESCRIPTION
Since `Storage::item_value` never returns an empty Optional, and since `PlatformObject::is_supported_property_index` only returns false when `item_value` returns an empty Optional, the loop in `PlatformObject::internal_own_property_keys` will never terminate when executed on a `Storage` instance.

This fix allows youtube.com to load successfully :^)