### PR TITLE
LibWeb: Shadow Realm integration - part 2

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2441,7 +2441,7 @@ static void generate_html_constructor(SourceGenerator& generator, IDL::Construct
     }
 
     constructor_generator.append(R"~~~(
-    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
 
     // 1. Let registry be the current global object's CustomElementRegistry object.
     auto registry = TRY(throw_dom_exception_if_needed(vm, [&] { return window.custom_elements(); }));

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -48,6 +48,8 @@ public:
     }
 
     HostDefined* host_defined() { return m_host_defined; }
+    HostDefined const* host_defined() const { return m_host_defined; }
+
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
     void define_builtin(Bytecode::Builtin builtin, NonnullGCPtr<NativeFunction> value)

--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -34,7 +34,7 @@ JS::NonnullGCPtr<Animation> Animation::create(JS::Realm& realm, JS::GCPtr<Animat
     //    a timeline argument is missing, passing the default document timeline of the Document associated with the
     //    Window that is the current global object.
     if (!timeline.has_value()) {
-        auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+        auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
         timeline = window.associated_document().timeline();
     }
     animation->set_timeline(timeline.release_value());

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
@@ -41,7 +41,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> AudioConstructor::construct(
     auto& vm = this->vm();
 
     // 1. Let document be the current global object's associated Document.
-    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
     auto& document = window.associated_document();
 
     // 2. Let audio be the result of creating an element given document, audio, and the HTML namespace.

--- a/Userland/Libraries/LibWeb/Bindings/HostDefined.h
+++ b/Userland/Libraries/LibWeb/Bindings/HostDefined.h
@@ -33,6 +33,11 @@ struct HostDefined : public JS::Realm::HostDefined {
     return *verify_cast<HostDefined>(realm.host_defined())->environment_settings_object;
 }
 
+[[nodiscard]] inline HTML::EnvironmentSettingsObject const& host_defined_environment_settings_object(JS::Realm const& realm)
+{
+    return *verify_cast<HostDefined>(realm.host_defined())->environment_settings_object;
+}
+
 [[nodiscard]] inline Page& host_defined_page(JS::Realm& realm)
 {
     return *verify_cast<HostDefined>(realm.host_defined())->page;

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -36,12 +36,13 @@ JS::ThrowCompletionOr<JS::Value> ImageConstructor::call()
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-image
+// https://whatpr.org/html/9893/embedded-content.html#dom-image
 JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> ImageConstructor::construct(FunctionObject&)
 {
     auto& vm = this->vm();
 
-    // 1. Let document be the current global object's associated Document.
-    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    // 1. Let document be the current principal global object's associated Document.
+    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
     auto& document = window.associated_document();
 
     // 2. Let img be the result of creating an element given document, img, and the HTML namespace.

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -250,7 +250,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
             auto result = finalization_registry.cleanup();
 
             // 5. Clean up after running script with entry.
-            entry.clean_up_after_running_script();
+            HTML::clean_up_after_running_script(realm);
 
             // 6. If result is an abrupt completion, then report the exception given by result.[[Value]].
             if (result.is_error())
@@ -309,15 +309,15 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
             // 3. Let result be job().
             auto result = job->function()();
 
-            // 4. If job settings is not null, then clean up after running script with job settings.
-            if (job_settings) {
+            // 4. If realm is not null, then clean up after running script with job settings.
+            if (realm) {
                 // IMPLEMENTATION DEFINED: Disassociate the realm execution context from the script or module.
                 job_settings->realm_execution_context().script_or_module = Empty {};
 
                 // IMPLEMENTATION DEFINED: See comment above, we need to clean up the non-standard prepare_to_run_callback() call.
                 job_settings->clean_up_after_running_callback();
 
-                job_settings->clean_up_after_running_script();
+                HTML::clean_up_after_running_script(*realm);
             } else {
                 // Pop off the dummy execution context. See the above FIXME block about why this is done.
                 s_main_thread_vm->pop_execution_context();

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -124,6 +124,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
     // FIXME: Implement 8.1.5.2 HostEnsureCanCompileStrings(callerRealm, calleeRealm), https://html.spec.whatwg.org/multipage/webappapis.html#hostensurecancompilestrings(callerrealm,-calleerealm)
 
     // 8.1.5.3 HostPromiseRejectionTracker(promise, operation), https://html.spec.whatwg.org/multipage/webappapis.html#the-hostpromiserejectiontracker-implementation
+    // https://whatpr.org/html/9893/webappapis.html#the-hostpromiserejectiontracker-implementation
     s_main_thread_vm->host_promise_rejection_tracker = [](JS::Promise& promise, JS::Promise::RejectionOperation operation) {
         // 1. Let script be the running script.
         //    The running script is the script in the [[HostDefined]] field in the ScriptOrModule component of the running JavaScript execution context.
@@ -147,8 +148,8 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
         }
 
         // 3. Let settings object be the current settings object.
-        // 4. If script is not null, then set settings object to script's settings object.
-        auto& settings_object = script ? script->settings_object() : HTML::current_settings_object();
+        // 4. If script is not null, then set settings object to script's principal settings object.
+        auto& settings_object = script ? script->settings_object() : HTML::current_principal_settings_object();
 
         // 5. Let global be settingsObject's global object.
         auto* global_mixin = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&settings_object.global_object());
@@ -414,12 +415,13 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
     };
 
     // 8.1.6.7.3 HostLoadImportedModule(referrer, moduleRequest, loadState, payload), https://html.spec.whatwg.org/multipage/webappapis.html#hostloadimportedmodule
+    // https://whatpr.org/html/9893/webappapis.html#hostloadimportedmodule
     s_main_thread_vm->host_load_imported_module = [](JS::ImportedModuleReferrer referrer, JS::ModuleRequest const& module_request, JS::GCPtr<JS::GraphLoadingState::HostDefined> load_state, JS::ImportedModulePayload payload) -> void {
         auto& vm = *s_main_thread_vm;
         auto& realm = *vm.current_realm();
 
-        // 1. Let settingsObject be the current settings object.
-        Optional<HTML::EnvironmentSettingsObject&> settings_object = HTML::current_settings_object();
+        // 1. Let settingsObject be the current principal settings object.
+        Optional<HTML::EnvironmentSettingsObject&> settings_object = HTML::current_principal_settings_object();
 
         // FIXME: 2. If settingsObject's global object implements WorkletGlobalScope or ServiceWorkerGlobalScope and loadState is undefined, then:
 

--- a/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/OptionConstructor.cpp
@@ -39,13 +39,14 @@ JS::ThrowCompletionOr<JS::Value> OptionConstructor::call()
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option
+// https://whatpr.org/html/9893/form-elements.html#dom-option
 JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Object>> OptionConstructor::construct(FunctionObject&)
 {
     auto& vm = this->vm();
     auto& realm = *vm.current_realm();
 
-    // 1. Let document be the current global object's associated Document.
-    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    // 1. Let document be the current principal global object's associated Document.
+    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
     auto& document = window.associated_document();
 
     // 2. Let option be the result of creating an element given document, option, and the HTML namespace.

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -34,8 +34,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CSSStyleSheet>> CSSStyleSheet::construct_im
     // 1. Construct a new CSSStyleSheet object sheet.
     auto sheet = create(realm, CSSRuleList::create_empty(realm), CSS::MediaList::create(realm, {}), {});
 
-    // 2. Set sheet’s location to the base URL of the associated Document for the current global object.
-    auto associated_document = verify_cast<HTML::Window>(HTML::current_global_object()).document();
+    // 2. Set sheet’s location to the base URL of the associated Document for the current principal global object.
+    auto associated_document = verify_cast<HTML::Window>(HTML::current_principal_global_object()).document();
     sheet->set_location(MUST(associated_document->base_url().to_string()));
 
     // 3. Set sheet’s stylesheet base URL to the baseURL attribute value from options.

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -1450,16 +1450,18 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-script
+// https://whatpr.org/html/9893/webappapis.html#concept-n-script
 bool Node::is_scripting_enabled() const
 {
-    // Scripting is enabled for a node node if node's node document's browsing context is non-null, and scripting is enabled for node's relevant settings object.
-    return document().browsing_context() && const_cast<Document&>(document()).relevant_settings_object().is_scripting_enabled();
+    // Scripting is enabled for a node node if node's node document's browsing context is non-null, and scripting is enabled for node's relevant realm.
+    return document().browsing_context() && HTML::is_scripting_enabled(HTML::relevant_realm(*this));
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#concept-n-noscript
+// https://whatpr.org/html/9893/webappapis.html#concept-n-script
 bool Node::is_scripting_disabled() const
 {
-    // Scripting is disabled for a node when scripting is not enabled, i.e., when its node document's browsing context is null or when scripting is disabled for its relevant settings object.
+    // Scripting is disabled for a node when scripting is not enabled, i.e., when its node document's browsing context is null or when scripting is disabled for its relevant realm.
     return !is_scripting_enabled();
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -44,7 +44,7 @@ void Text::visit_edges(Cell::Visitor& visitor)
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& realm, String const& data)
 {
     // The new Text(data) constructor steps are to set this’s data to data and this’s node document to current global object’s associated Document.
-    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
     return realm.heap().allocate<Text>(realm, window.associated_document(), data);
 }
 

--- a/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Userland/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -144,7 +144,7 @@ WebIDL::ExceptionOr<void> DOMURL::revoke_object_url(JS::VM& vm, StringView url)
     auto origin = url_record.origin();
 
     // 4. Let settings be the current settings object.
-    auto& settings = HTML::current_settings_object();
+    auto& settings = HTML::current_principal_settings_object();
 
     // 5. If origin is not same origin with settings’s origin, return.
     if (!origin.is_same_origin(settings.origin()))

--- a/Userland/Libraries/LibWeb/Fetch/Response.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Response.cpp
@@ -168,7 +168,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Response>> Response::redirect(JS::VM& vm, S
     auto& realm = *vm.current_realm();
 
     // 1. Let parsedURL be the result of parsing url with current settings object’s API base URL.
-    auto api_base_url = HTML::current_settings_object().api_base_url();
+    auto api_base_url = HTML::current_principal_settings_object().api_base_url();
     auto parsed_url = DOMURL::parse(url, api_base_url);
 
     // 2. If parsedURL is failure, then throw a TypeError.

--- a/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
@@ -33,7 +33,7 @@ ErrorOr<String> generate_new_blob_url()
     TRY(result.try_append("blob:"sv));
 
     // 3. Let settings be the current settings object
-    auto& settings = HTML::current_settings_object();
+    auto& settings = HTML::current_principal_settings_object();
 
     // 4. Let origin be settings’s origin.
     auto origin = settings.origin();
@@ -69,7 +69,7 @@ ErrorOr<String> add_entry_to_blob_url_store(JS::NonnullGCPtr<Blob> object)
     auto url = TRY(generate_new_blob_url());
 
     // 3. Let entry be a new blob URL entry consisting of object and the current settings object.
-    BlobURLEntry entry { object, HTML::current_settings_object() };
+    BlobURLEntry entry { object, HTML::current_principal_settings_object() };
 
     // 4. Set store[url] to entry.
     TRY(store.try_set(url, move(entry)));

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/AbstractOperations.cpp
@@ -81,23 +81,25 @@ JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS:
     return throw_completion(WebIDL::SecurityError::create(*vm.current_realm(), MUST(String::formatted("Can't access property '{}' on cross-origin object", property_key))));
 }
 
-// 7.2.3.3 IsPlatformObjectSameOrigin ( O ), https://html.spec.whatwg.org/multipage/browsers.html#isplatformobjectsameorigin-(-o-)
+// 7.2.3.3 IsPlatformObjectSameOrigin ( O ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#isplatformobjectsameorigin-(-o-)
+// https://whatpr.org/html/9893/nav-history-apis.html#isplatformobjectsameorigin-(-o-)
 bool is_platform_object_same_origin(JS::Object const& object)
 {
-    // 1. Return true if the current settings object's origin is same origin-domain with O's relevant settings object's origin, and false otherwise.
-    return HTML::current_settings_object().origin().is_same_origin_domain(HTML::relevant_settings_object(object).origin());
+    // 1. Return true if the current principal settings object's origin is same origin-domain with O's relevant settings object's origin, and false otherwise.
+    return HTML::current_principal_settings_object().origin().is_same_origin_domain(HTML::relevant_settings_object(object).origin());
 }
 
-// 7.2.3.4 CrossOriginGetOwnPropertyHelper ( O, P ), https://html.spec.whatwg.org/multipage/browsers.html#crossorigingetownpropertyhelper-(-o,-p-)
+// 7.2.3.4 CrossOriginGetOwnPropertyHelper ( O, P ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#crossorigingetownpropertyhelper-(-o,-p-)
+// https://whatpr.org/html/9893/nav-history-apis.html#crossorigingetownpropertyhelper-(-o,-p-)
 Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<HTML::Location*, HTML::Window*> const& object, JS::PropertyKey const& property_key)
 {
     auto& realm = *Bindings::main_thread_vm().current_realm();
     auto const* object_ptr = object.visit([](auto* o) { return static_cast<JS::Object const*>(o); });
     auto const object_const_variant = object.visit([](auto* o) { return Variant<HTML::Location const*, HTML::Window const*> { o }; });
 
-    // 1. Let crossOriginKey be a tuple consisting of the current settings object, O's relevant settings object, and P.
+    // 1. Let crossOriginKey be a tuple consisting of the current principal settings object, O's relevant settings object, and P.
     auto cross_origin_key = CrossOriginKey {
-        .current_settings_object = (FlatPtr)&HTML::current_settings_object(),
+        .current_principal_settings_object = (FlatPtr)&HTML::current_principal_settings_object(),
         .relevant_settings_object = (FlatPtr)&HTML::relevant_settings_object(*object_ptr),
         .property_key = property_key,
     };

--- a/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h
+++ b/Userland/Libraries/LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h
@@ -22,7 +22,7 @@ struct CrossOriginProperty {
 };
 
 struct CrossOriginKey {
-    FlatPtr current_settings_object;
+    FlatPtr current_principal_settings_object;
     FlatPtr relevant_settings_object;
     JS::PropertyKey property_key;
 };
@@ -39,12 +39,12 @@ struct Traits<Web::HTML::CrossOriginKey> : public DefaultTraits<Web::HTML::Cross
     {
         return pair_int_hash(
             Traits<JS::PropertyKey>::hash(key.property_key),
-            pair_int_hash(ptr_hash(key.current_settings_object), ptr_hash(key.relevant_settings_object)));
+            pair_int_hash(ptr_hash(key.current_principal_settings_object), ptr_hash(key.relevant_settings_object)));
     }
 
     static bool equals(Web::HTML::CrossOriginKey const& a, Web::HTML::CrossOriginKey const& b)
     {
-        return a.current_settings_object == b.current_settings_object
+        return a.current_principal_settings_object == b.current_principal_settings_object
             && a.relevant_settings_object == b.relevant_settings_object
             && Traits<JS::PropertyKey>::equals(a.property_key, b.property_key);
     }

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -46,7 +46,7 @@ void EventLoop::visit_edges(Visitor& visitor)
     visitor.visit(m_task_queue);
     visitor.visit(m_microtask_queue);
     visitor.visit(m_currently_running_task);
-    visitor.visit(m_backup_incumbent_settings_object_stack);
+    visitor.visit(m_backup_incumbent_realm_stack);
     visitor.visit(m_rendering_task_function);
     visitor.visit(m_system_event_loop_timer);
 }
@@ -538,19 +538,19 @@ void EventLoop::unregister_document(Badge<DOM::Document>, DOM::Document& documen
     VERIFY(did_remove);
 }
 
-void EventLoop::push_onto_backup_incumbent_settings_object_stack(Badge<EnvironmentSettingsObject>, EnvironmentSettingsObject& environment_settings_object)
+void EventLoop::push_onto_backup_incumbent_realm_stack(JS::Realm& realm)
 {
-    m_backup_incumbent_settings_object_stack.append(environment_settings_object);
+    m_backup_incumbent_realm_stack.append(realm);
 }
 
-void EventLoop::pop_backup_incumbent_settings_object_stack(Badge<EnvironmentSettingsObject>)
+void EventLoop::pop_backup_incumbent_realm_stack()
 {
-    m_backup_incumbent_settings_object_stack.take_last();
+    m_backup_incumbent_realm_stack.take_last();
 }
 
-EnvironmentSettingsObject& EventLoop::top_of_backup_incumbent_settings_object_stack()
+JS::Realm& EventLoop::top_of_backup_incumbent_realm_stack()
 {
-    return m_backup_incumbent_settings_object_stack.last();
+    return m_backup_incumbent_realm_stack.last();
 }
 
 void EventLoop::register_environment_settings_object(Badge<EnvironmentSettingsObject>, EnvironmentSettingsObject& environment_settings_object)

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -61,10 +61,10 @@ public:
 
     Vector<JS::Handle<HTML::Window>> same_loop_windows() const;
 
-    void push_onto_backup_incumbent_settings_object_stack(Badge<EnvironmentSettingsObject>, EnvironmentSettingsObject& environment_settings_object);
-    void pop_backup_incumbent_settings_object_stack(Badge<EnvironmentSettingsObject>);
-    EnvironmentSettingsObject& top_of_backup_incumbent_settings_object_stack();
-    bool is_backup_incumbent_settings_object_stack_empty() const { return m_backup_incumbent_settings_object_stack.is_empty(); }
+    void push_onto_backup_incumbent_realm_stack(JS::Realm&);
+    void pop_backup_incumbent_realm_stack();
+    JS::Realm& top_of_backup_incumbent_realm_stack();
+    bool is_backup_incumbent_realm_stack_empty() const { return m_backup_incumbent_realm_stack.is_empty(); }
 
     void register_environment_settings_object(Badge<EnvironmentSettingsObject>, EnvironmentSettingsObject&);
     void unregister_environment_settings_object(Badge<EnvironmentSettingsObject>, EnvironmentSettingsObject&);
@@ -107,7 +107,8 @@ private:
     Vector<RawPtr<EnvironmentSettingsObject>> m_related_environment_settings_objects;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#backup-incumbent-settings-object-stack
-    Vector<JS::NonnullGCPtr<EnvironmentSettingsObject>> m_backup_incumbent_settings_object_stack;
+    // https://whatpr.org/html/9893/webappapis.html#backup-incumbent-realm-stack
+    Vector<JS::NonnullGCPtr<JS::Realm>> m_backup_incumbent_realm_stack;
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#termination-nesting-level
     size_t m_termination_nesting_level { 0 };

--- a/Userland/Libraries/LibWeb/HTML/Location.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Location.cpp
@@ -110,7 +110,7 @@ WebIDL::ExceptionOr<String> Location::href() const
 WebIDL::ExceptionOr<void> Location::set_href(String const& new_href)
 {
     auto& realm = this->realm();
-    auto& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
 
     // 1. If this's relevant Document is null, then return.
     auto const relevant_document = this->relevant_document();

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -1498,8 +1498,8 @@ void Navigation::update_the_navigation_api_entries_for_a_same_document_navigatio
         disposed_nhe->dispatch_event(DOM::Event::create(realm, EventNames::dispose, {}));
     }
 
-    // 12. Clean up after running script given navigation's relevant settings object.
-    relevant_settings_object(*this).clean_up_after_running_script();
+    // 12. Clean up after running script given navigation's relevant realm.
+    clean_up_after_running_script(relevant_realm(*this));
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.cpp
@@ -1402,6 +1402,7 @@ void Navigation::initialize_the_navigation_api_entries_for_a_new_document(Vector
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation
+// https://whatpr.org/html/9893/nav-history-apis.html#update-the-navigation-api-entries-for-a-same-document-navigation
 void Navigation::update_the_navigation_api_entries_for_a_same_document_navigation(JS::NonnullGCPtr<SessionHistoryEntry> destination_she, Bindings::NavigationType navigation_type)
 {
     auto& realm = relevant_realm(*this);
@@ -1482,8 +1483,8 @@ void Navigation::update_the_navigation_api_entries_for_a_same_document_navigatio
     if (m_ongoing_api_method_tracker != nullptr)
         notify_about_the_committed_to_entry(*m_ongoing_api_method_tracker, *current_entry());
 
-    // 9. Prepare to run script given navigation's relevant settings object.
-    relevant_settings_object(*this).prepare_to_run_script();
+    // 9. Prepare to run script given navigation's relevant realm.
+    prepare_to_run_script(realm);
 
     // 10. Fire an event named currententrychange at navigation using NavigationCurrentEntryChangeEvent,
     //     with its navigationType attribute initialized to navigationType and its from initialized to oldCurrentNHE.

--- a/Userland/Libraries/LibWeb/HTML/Navigator.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigator.cpp
@@ -45,7 +45,7 @@ bool Navigator::pdf_viewer_enabled() const
 {
     // The NavigatorPlugins mixin's pdfViewerEnabled getter steps are to return the user agent's PDF viewer supported.
     // NOTE: The NavigatorPlugins mixin should only be exposed on the Window object.
-    auto const& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    auto const& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
     return window.page().pdf_viewer_supported();
 }
 
@@ -55,7 +55,7 @@ bool Navigator::webdriver() const
     // Returns true if webdriver-active flag is set, false otherwise.
 
     // NOTE: The NavigatorAutomationInformation interface should not be exposed on WorkerNavigator.
-    auto const& window = verify_cast<HTML::Window>(HTML::current_global_object());
+    auto const& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
     return window.page().is_webdriver_active();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -88,8 +88,8 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
     if (can_run_script(realm) == RunScriptDecision::DoNotRun)
         return JS::normal_completion({});
 
-    // 3. Prepare to run script given settings.
-    settings.prepare_to_run_script();
+    // 3. Prepare to run script given realm.
+    prepare_to_run_script(realm);
 
     // 4. Let evaluationStatus be null.
     JS::Completion evaluation_status;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -23,31 +23,31 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
 {
     auto& vm = environment_settings_object.realm().vm();
 
-    // 1. If muted errors was not provided, let it be false. (NOTE: This is taken care of by the default argument.)
-
-    // 2. If muted errors is true, then set baseURL to about:blank.
+    // 1. If muted errors is true, then set baseURL to about:blank.
     if (muted_errors == MutedErrors::Yes)
         base_url = "about:blank"sv;
 
-    // 3. If scripting is disabled for settings, then set source to the empty string.
+    // 2. If scripting is disabled for settings object, then set source to the empty string.
     if (environment_settings_object.is_scripting_disabled())
         source = ""sv;
 
-    // 4. Let script be a new classic script that this algorithm will subsequently initialize.
+    // 3. Let script be a new classic script that this algorithm will subsequently initialize.
     auto script = vm.heap().allocate_without_realm<ClassicScript>(move(base_url), move(filename), environment_settings_object);
 
-    // 5. Set script's settings object to settings. (NOTE: This was already done when constructing.)
+    // 4. Set script's settings object to settings. (NOTE: This was already done when constructing.)
 
-    // 6. Set script's base URL to baseURL. (NOTE: This was already done when constructing.)
+    // 5. Set script's base URL to baseURL. (NOTE: This was already done when constructing.)
 
-    // FIXME: 7. Set script's fetch options to options.
+    // FIXME: 6. Set script's fetch options to options.
 
-    // 8. Set script's muted errors to muted errors.
+    // 7. Set script's muted errors to muted errors.
     script->m_muted_errors = muted_errors;
 
-    // 9. Set script's parse error and error to rethrow to null.
+    // 8. Set script's parse error and error to rethrow to null.
     script->set_parse_error(JS::js_null());
     script->set_error_to_rethrow(JS::js_null());
+
+    // FIXME: 9. Record classic script creation time given script and sourceURLForWindowScripts .
 
     // 10. Let result be ParseScript(source, settings's Realm, script).
     auto parse_timer = Core::ElapsedTimer::start_new();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -112,8 +112,8 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
     if (evaluation_status.is_abrupt()) {
         // 1. If rethrow errors is true and script's muted errors is false, then:
         if (rethrow_errors == RethrowErrors::Yes && m_muted_errors == MutedErrors::No) {
-            // 1. Clean up after running script with settings.
-            settings.clean_up_after_running_script();
+            // 1. Clean up after running script with realm.
+            clean_up_after_running_script(realm);
 
             // 2. Rethrow evaluationStatus.[[Value]].
             return JS::throw_completion(*evaluation_status.value());
@@ -121,8 +121,8 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
 
         // 2. If rethrow errors is true and script's muted errors is true, then:
         if (rethrow_errors == RethrowErrors::Yes && m_muted_errors == MutedErrors::Yes) {
-            // 1. Clean up after running script with settings.
-            settings.clean_up_after_running_script();
+            // 1. Clean up after running script with realm.
+            clean_up_after_running_script(realm);
 
             // 2. Throw a "NetworkError" DOMException.
             return throw_completion(WebIDL::NetworkError::create(realm, "Script error."_string));
@@ -136,15 +136,15 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
         VERIFY(window_or_worker);
         window_or_worker->report_an_exception(*evaluation_status.value());
 
-        // 2. Clean up after running script with settings.
-        settings.clean_up_after_running_script();
+        // 2. Clean up after running script with realm.
+        clean_up_after_running_script(realm);
 
         // 3. Return evaluationStatus.
         return evaluation_status;
     }
 
-    // 8. Clean up after running script with settings.
-    settings.clean_up_after_running_script();
+    // 8. Clean up after running script with realm.
+    clean_up_after_running_script(realm);
 
     // 9. If evaluationStatus is a normal completion, then return evaluationStatus.
     VERIFY(!evaluation_status.is_abrupt());

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -65,6 +65,12 @@ JS::ExecutionContext& EnvironmentSettingsObject::realm_execution_context()
     return *m_realm_execution_context;
 }
 
+JS::ExecutionContext const& EnvironmentSettingsObject::realm_execution_context() const
+{
+    // NOTE: All environment settings objects are created with a realm execution context, so it's stored and returned here in the base class.
+    return *m_realm_execution_context;
+}
+
 ModuleMap& EnvironmentSettingsObject::module_map()
 {
     return *m_module_map;
@@ -122,6 +128,15 @@ void EnvironmentSettingsObject::prepare_to_run_script()
     global_object().vm().push_execution_context(realm_execution_context());
 
     // FIXME: 2. Add settings to the currently running task's script evaluation environment settings object set.
+}
+
+// https://whatpr.org/html/9893/b8ea975...df5706b/webappapis.html#concept-realm-execution-context
+JS::ExecutionContext const& execution_context_of_realm(JS::Realm const& realm)
+{
+    // FIXME: 1. If realm is a principal realm, then return the realm execution context of the environment settings object of realm.
+    // FIXME: 2. Assert: realm is a synthetic realm.
+    // FIXME: 3. Return the execution context of the synthetic realm settings object of realm.
+    return Bindings::host_defined_environment_settings_object(realm).realm_execution_context();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#clean-up-after-running-script

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -319,13 +319,11 @@ EnvironmentSettingsObject& current_principal_settings_object()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object
+// https://whatpr.org/html/9893/webappapis.html#current-principal-global-object
 JS::Object& current_principal_global_object()
 {
-    auto& event_loop = HTML::main_thread_event_loop();
-    auto& vm = event_loop.vm();
-
-    // Similarly, the current global object is the global object of the current Realm Record.
-    return vm.current_realm()->global_object();
+    // Similarly, the current principal global object is the global object of the current principal realm.
+    return current_principal_realm().global_object();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -300,14 +300,22 @@ JS::Object& incumbent_global_object()
     return incumbent_settings_object().global_object();
 }
 
-// https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object
-EnvironmentSettingsObject& current_principal_settings_object()
+// https://whatpr.org/html/9893/webappapis.html#current-principal-realm
+JS::Realm& current_principal_realm()
 {
+    // FIXME: The current principal realm is the principal realm of the current realm.
     auto& event_loop = HTML::main_thread_event_loop();
     auto& vm = event_loop.vm();
 
-    // Then, the current settings object is the environment settings object of the current Realm Record.
-    return Bindings::host_defined_environment_settings_object(*vm.current_realm());
+    return *vm.current_realm();
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object
+// https://whatpr.org/html/9893/webappapis.html#current-principal-settings-object
+EnvironmentSettingsObject& current_principal_settings_object()
+{
+    // Then, the current principal settings object is the environment settings object of the current principal realm.
+    return Bindings::host_defined_environment_settings_object(current_principal_realm());
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -319,7 +319,7 @@ EnvironmentSettingsObject& current_principal_settings_object()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object
-JS::Object& current_global_object()
+JS::Object& current_principal_global_object()
 {
     auto& event_loop = HTML::main_thread_event_loop();
     auto& vm = event_loop.vm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -123,12 +123,15 @@ RunScriptDecision can_run_script(JS::Realm const& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#prepare-to-run-script
-void EnvironmentSettingsObject::prepare_to_run_script()
+// https://whatpr.org/html/9893/b8ea975...df5706b/webappapis.html#prepare-to-run-script
+void prepare_to_run_script(JS::Realm& realm)
 {
-    // 1. Push settings's realm execution context onto the JavaScript execution context stack; it is now the running JavaScript execution context.
-    global_object().vm().push_execution_context(realm_execution_context());
+    // 1. Push realms's execution context onto the JavaScript execution context stack; it is now the running JavaScript execution context.
+    realm.global_object().vm().push_execution_context(execution_context_of_realm(realm));
 
-    // FIXME: 2. Add settings to the currently running task's script evaluation environment settings object set.
+    // FIXME: 2. If realm is a principal realm, then:
+    // FIXME: 2.1 Let settings be realm's settings object.
+    // FIXME: 2.2 Add settings to the currently running task's script evaluation environment settings object set.
 }
 
 // https://whatpr.org/html/9893/b8ea975...df5706b/webappapis.html#concept-realm-execution-context

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -301,7 +301,7 @@ JS::Object& incumbent_global_object()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object
-EnvironmentSettingsObject& current_settings_object()
+EnvironmentSettingsObject& current_principal_settings_object()
 {
     auto& event_loop = HTML::main_thread_event_loop();
     auto& vm = event_loop.vm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -96,8 +96,6 @@ public:
     // https://fetch.spec.whatwg.org/#concept-fetch-group
     Vector<JS::NonnullGCPtr<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
 
-    void prepare_to_run_script();
-
     void prepare_to_run_callback();
     void clean_up_after_running_callback();
 
@@ -137,10 +135,12 @@ private:
 };
 
 JS::ExecutionContext const& execution_context_of_realm(JS::Realm const&);
+inline JS::ExecutionContext& execution_context_of_realm(JS::Realm& realm) { return const_cast<JS::ExecutionContext&>(execution_context_of_realm(const_cast<JS::Realm const&>(realm))); }
 
 RunScriptDecision can_run_script(JS::Realm const&);
 bool is_scripting_enabled(JS::Realm const&);
 bool is_scripting_disabled(JS::Realm const&);
+void prepare_to_run_script(JS::Realm&);
 void clean_up_after_running_script(JS::Realm const&);
 
 EnvironmentSettingsObject& incumbent_settings_object();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -96,9 +96,6 @@ public:
     // https://fetch.spec.whatwg.org/#concept-fetch-group
     Vector<JS::NonnullGCPtr<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
 
-    void prepare_to_run_callback();
-    void clean_up_after_running_callback();
-
     bool module_type_allowed(StringView module_type) const;
 
     void disallow_further_import_maps();
@@ -142,6 +139,8 @@ bool is_scripting_enabled(JS::Realm const&);
 bool is_scripting_disabled(JS::Realm const&);
 void prepare_to_run_script(JS::Realm&);
 void clean_up_after_running_script(JS::Realm const&);
+void prepare_to_run_callback(JS::Realm&);
+void clean_up_after_running_callback(JS::Realm const&);
 
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -146,7 +146,7 @@ JS::Object& incumbent_global_object();
 JS::Realm& current_principal_realm();
 EnvironmentSettingsObject& current_principal_settings_object();
 
-JS::Object& current_global_object();
+JS::Object& current_principal_global_object();
 JS::Realm& relevant_realm(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(DOM::Node const&);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -142,7 +142,7 @@ private:
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();
 JS::Object& incumbent_global_object();
-EnvironmentSettingsObject& current_settings_object();
+EnvironmentSettingsObject& current_principal_settings_object();
 JS::Object& current_global_object();
 JS::Realm& relevant_realm(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(JS::Object const&);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -94,15 +94,11 @@ public:
     // https://fetch.spec.whatwg.org/#concept-fetch-group
     Vector<JS::NonnullGCPtr<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
 
-    RunScriptDecision can_run_script();
     void prepare_to_run_script();
     void clean_up_after_running_script();
 
     void prepare_to_run_callback();
     void clean_up_after_running_callback();
-
-    bool is_scripting_enabled() const;
-    bool is_scripting_disabled() const;
 
     bool module_type_allowed(StringView module_type) const;
 
@@ -138,6 +134,10 @@ private:
     // A service worker client has an associated discarded flag. It is initially unset.
     bool m_discarded { false };
 };
+
+RunScriptDecision can_run_script(JS::Realm const&);
+bool is_scripting_enabled(JS::Realm const&);
+bool is_scripting_disabled(JS::Realm const&);
 
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -96,7 +97,6 @@ public:
     Vector<JS::NonnullGCPtr<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
 
     void prepare_to_run_script();
-    void clean_up_after_running_script();
 
     void prepare_to_run_callback();
     void clean_up_after_running_callback();
@@ -141,6 +141,7 @@ JS::ExecutionContext const& execution_context_of_realm(JS::Realm const&);
 RunScriptDecision can_run_script(JS::Realm const&);
 bool is_scripting_enabled(JS::Realm const&);
 bool is_scripting_disabled(JS::Realm const&);
+void clean_up_after_running_script(JS::Realm const&);
 
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -142,7 +142,10 @@ private:
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();
 JS::Object& incumbent_global_object();
+
+JS::Realm& current_principal_realm();
 EnvironmentSettingsObject& current_principal_settings_object();
+
 JS::Object& current_global_object();
 JS::Realm& relevant_realm(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(JS::Object const&);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -63,6 +63,7 @@ public:
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-environment-target-browsing-context
     JS::ExecutionContext& realm_execution_context();
+    JS::ExecutionContext const& realm_execution_context() const;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-module-map
     ModuleMap& module_map();
@@ -134,6 +135,8 @@ private:
     // A service worker client has an associated discarded flag. It is initially unset.
     bool m_discarded { false };
 };
+
+JS::ExecutionContext const& execution_context_of_realm(JS::Realm const&);
 
 RunScriptDecision can_run_script(JS::Realm const&);
 bool is_scripting_enabled(JS::Realm const&);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -81,6 +81,7 @@ ByteString module_type_from_module_request(JS::ModuleRequest const& module_reque
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier
+// https://whatpr.org/html/9893/webappapis.html#resolve-a-module-specifier
 WebIDL::ExceptionOr<URL::URL> resolve_module_specifier(Optional<Script&> referring_script, ByteString const& specifier)
 {
     // 1. Let settingsObject and baseURL be null.
@@ -97,11 +98,11 @@ WebIDL::ExceptionOr<URL::URL> resolve_module_specifier(Optional<Script&> referri
     }
     // 3. Otherwise:
     else {
-        // 1. Assert: there is a current settings object.
-        // NOTE: This is handled by the current_settings_object() accessor.
+        // 1. Assert: there is a current principal settings object.
+        // NOTE: This is handled by the current_principal_settings_object() accessor.
 
-        // 2. Set settingsObject to the current settings object.
-        settings_object = current_settings_object();
+        // 2. Set settingsObject to the current principal settings object.
+        settings_object = current_principal_settings_object();
 
         // 3. Set baseURL to settingsObject's API base URL.
         base_url = settings_object->api_base_url();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -958,7 +958,7 @@ void fetch_descendants_of_and_link_a_module_script(JS::Realm& realm,
     //       resulting in the event loop hanging forever awaiting for the script to be ready for parser
     //       execution.
     realm.vm().push_execution_context(fetch_client.realm_execution_context());
-    fetch_client.prepare_to_run_callback();
+    prepare_to_run_callback(realm);
 
     // 5. Let loadingPromise be record.LoadRequestedModules(state).
     auto& loading_promise = record->load_requested_modules(state);
@@ -995,7 +995,8 @@ void fetch_descendants_of_and_link_a_module_script(JS::Realm& realm,
         return JS::js_undefined();
     }));
 
-    fetch_client.clean_up_after_running_callback();
+    clean_up_after_running_callback(realm);
+
     realm.vm().pop_execution_context();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -133,8 +133,8 @@ JS::Promise* JavaScriptModuleScript::run(PreventErrorReporting)
         return promise;
     }
 
-    // 3. Prepare to run script given settings.
-    settings.prepare_to_run_script();
+    // 3. Prepare to run script given realm.
+    prepare_to_run_script(realm);
 
     // 4. Let evaluationPromise be null.
     JS::Promise* evaluation_promise = nullptr;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -177,8 +177,8 @@ JS::Promise* JavaScriptModuleScript::run(PreventErrorReporting)
 
     // FIXME: 7. If preventErrorReporting is false, then upon rejection of evaluationPromise with reason, report the exception given by reason for script.
 
-    // 8. Clean up after running script with settings.
-    settings.clean_up_after_running_script();
+    // 8. Clean up after running script with realm.
+    clean_up_after_running_script(realm);
 
     // 9. Return evaluationPromise.
     return evaluation_promise;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
@@ -13,7 +13,7 @@ TemporaryExecutionContext::TemporaryExecutionContext(EnvironmentSettingsObject& 
     : m_environment_settings(environment_settings)
     , m_callbacks_enabled(callbacks_enabled)
 {
-    m_environment_settings->prepare_to_run_script();
+    prepare_to_run_script(m_environment_settings->realm());
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
         m_environment_settings->prepare_to_run_callback();
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
@@ -20,7 +20,7 @@ TemporaryExecutionContext::TemporaryExecutionContext(EnvironmentSettingsObject& 
 
 TemporaryExecutionContext::~TemporaryExecutionContext()
 {
-    m_environment_settings->clean_up_after_running_script();
+    clean_up_after_running_script(m_environment_settings->realm());
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
         m_environment_settings->clean_up_after_running_callback();
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
@@ -15,14 +15,14 @@ TemporaryExecutionContext::TemporaryExecutionContext(EnvironmentSettingsObject& 
 {
     prepare_to_run_script(m_environment_settings->realm());
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
-        m_environment_settings->prepare_to_run_callback();
+        prepare_to_run_callback(m_environment_settings->realm());
 }
 
 TemporaryExecutionContext::~TemporaryExecutionContext()
 {
     clean_up_after_running_script(m_environment_settings->realm());
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
-        m_environment_settings->clean_up_after_running_callback();
+        clean_up_after_running_callback(m_environment_settings->realm());
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -1305,8 +1305,7 @@ WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationR
         memory = DeserializationMemory { vm.heap() };
 
     // IMPLEMENTATION DEFINED: We need to make sure there's an execution context for target_realm on the stack before constructing these JS objects
-    auto& target_settings = Bindings::host_defined_environment_settings_object(target_realm);
-    target_settings.prepare_to_run_script();
+    prepare_to_run_script(target_realm);
 
     auto result = TRY(structured_deserialize_internal(vm, serialized.span(), target_realm, *memory));
 

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -1310,7 +1310,7 @@ WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationR
 
     auto result = TRY(structured_deserialize_internal(vm, serialized.span(), target_realm, *memory));
 
-    target_settings.clean_up_after_running_script();
+    clean_up_after_running_script(target_realm);
     VERIFY(result.value.has_value());
     return *result.value;
 }

--- a/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
+++ b/Userland/Libraries/LibWeb/HTML/StructuredSerialize.cpp
@@ -157,6 +157,7 @@ public:
     }
 
     // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializeinternal
+    // https://whatpr.org/html/9893/structured-data.html#structuredserializeinternal
     WebIDL::ExceptionOr<SerializationRecord> serialize(JS::Value value)
     {
         // 2. If memory[value] exists, then return memory[value].
@@ -565,10 +566,10 @@ WebIDL::ExceptionOr<void> serialize_array_buffer(JS::VM& vm, Vector<u32>& vector
 
     // FIXME: 1.  If IsSharedArrayBuffer(value) is true, then:
     if (false) {
-        // 1. If the current settings object's cross-origin isolated capability is false, then throw a "DataCloneError" DOMException.
+        // 1. If the current principal settings object's cross-origin isolated capability is false, then throw a "DataCloneError" DOMException.
         // NOTE: This check is only needed when serializing (and not when deserializing) as the cross-origin isolated capability cannot change
         //       over time and a SharedArrayBuffer cannot leave an agent cluster.
-        if (current_settings_object().cross_origin_isolated_capability() == CanUseCrossOriginIsolatedAPIs::No)
+        if (current_principal_settings_object().cross_origin_isolated_capability() == CanUseCrossOriginIsolatedAPIs::No)
             return WebIDL::DataCloneError::create(*vm.current_realm(), "Cannot serialize SharedArrayBuffer when cross-origin isolated"_string);
 
         // 2. If forStorage is true, then throw a "DataCloneError" DOMException.

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -994,6 +994,7 @@ JS::GCPtr<WindowProxy const> Window::parent() const
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-frameelement
+// https://whatpr.org/html/9893/nav-history-apis.html#dom-frameelement
 JS::GCPtr<DOM::Element const> Window::frame_element() const
 {
     // 1. Let current be this's node navigable.
@@ -1010,8 +1011,8 @@ JS::GCPtr<DOM::Element const> Window::frame_element() const
     if (!container)
         return {};
 
-    // 5. If container's node document's origin is not same origin-domain with the current settings object's origin, then return null.
-    if (!container->document().origin().is_same_origin_domain(current_settings_object().origin()))
+    // 5. If container's node document's origin is not same origin-domain with the current principal settings object's origin, then return null.
+    if (!container->document().origin().is_same_origin_domain(current_principal_settings_object().origin()))
         return {};
 
     // 6. Return container.

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -160,8 +160,8 @@ JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const
 
     // 1. Let W be the value of the [[Window]] internal slot of this.
 
-    // 2. Check if an access between two browsing contexts should be reported, given the current global object's browsing context, W's browsing context, P, and the current principal settings object.
-    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_principal_settings_object());
+    // 2. Check if an access between two browsing contexts should be reported, given the current principal global object's browsing context, W's browsing context, P, and the current principal settings object.
+    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_principal_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_principal_settings_object());
 
     // 3. If IsPlatformObjectSameOrigin(W) is true, then return ? OrdinaryGet(this, P, Receiver).
     // NOTE: this is passed rather than W as OrdinaryGet and CrossOriginGet will invoke the [[GetOwnProperty]] internal method.
@@ -181,8 +181,8 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& pro
 
     // 1. Let W be the value of the [[Window]] internal slot of this.
 
-    // 2. Check if an access between two browsing contexts should be reported, given the current global object's browsing context, W's browsing context, P, and the current principal settings object.
-    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_principal_settings_object());
+    // 2. Check if an access between two browsing contexts should be reported, given the current principal global object's browsing context, W's browsing context, P, and the current principal settings object.
+    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_principal_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_principal_settings_object());
 
     // 3. If IsPlatformObjectSameOrigin(W) is true, then:
     if (is_platform_object_same_origin(*m_window)) {

--- a/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowProxy.cpp
@@ -152,15 +152,16 @@ JS::ThrowCompletionOr<bool> WindowProxy::internal_define_own_property(JS::Proper
     return throw_completion(WebIDL::SecurityError::create(m_window->realm(), MUST(String::formatted("Can't define property '{}' on cross-origin object", property_key))));
 }
 
-// 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-get
+// 7.4.7 [[Get]] ( P, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-get
 JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const& property_key, JS::Value receiver, JS::CacheablePropertyMetadata*, PropertyLookupPhase) const
 {
     auto& vm = this->vm();
 
     // 1. Let W be the value of the [[Window]] internal slot of this.
 
-    // 2. Check if an access between two browsing contexts should be reported, given the current global object's browsing context, W's browsing context, P, and the current settings object.
-    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_settings_object());
+    // 2. Check if an access between two browsing contexts should be reported, given the current global object's browsing context, W's browsing context, P, and the current principal settings object.
+    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_principal_settings_object());
 
     // 3. If IsPlatformObjectSameOrigin(W) is true, then return ? OrdinaryGet(this, P, Receiver).
     // NOTE: this is passed rather than W as OrdinaryGet and CrossOriginGet will invoke the [[GetOwnProperty]] internal method.
@@ -172,15 +173,16 @@ JS::ThrowCompletionOr<JS::Value> WindowProxy::internal_get(JS::PropertyKey const
     return cross_origin_get(vm, *this, property_key, receiver);
 }
 
-// 7.4.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/window-object.html#windowproxy-set
+// 7.4.8 [[Set]] ( P, V, Receiver ), https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
+// https://html.spec.whatwg.org/multipage/nav-history-apis.html#windowproxy-set
 JS::ThrowCompletionOr<bool> WindowProxy::internal_set(JS::PropertyKey const& property_key, JS::Value value, JS::Value receiver, JS::CacheablePropertyMetadata*)
 {
     auto& vm = this->vm();
 
     // 1. Let W be the value of the [[Window]] internal slot of this.
 
-    // 2. Check if an access between two browsing contexts should be reported, given the current global object's browsing context, W's browsing context, P, and the current settings object.
-    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_settings_object());
+    // 2. Check if an access between two browsing contexts should be reported, given the current global object's browsing context, W's browsing context, P, and the current principal settings object.
+    check_if_access_between_two_browsing_contexts_should_be_reported(*verify_cast<Window>(current_global_object()).browsing_context(), m_window->browsing_context(), property_key, current_principal_settings_object());
 
     // 3. If IsPlatformObjectSameOrigin(W) is true, then:
     if (is_platform_object_same_origin(*m_window)) {

--- a/Userland/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Worker.cpp
@@ -40,6 +40,7 @@ void Worker::visit_edges(Cell::Visitor& visitor)
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-worker
+// https://whatpr.org/html/9893/workers.html#dom-worker
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& script_url, WorkerOptions const& options, DOM::Document& document)
 {
     dbgln_if(WEB_WORKER_DEBUG, "WebWorker: Creating worker with script_url = {}", script_url);
@@ -55,8 +56,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Worker>> Worker::create(String const& scrip
     // a policy decision (e.g. if the user agent is configured to not allow the page to start dedicated workers).
     // Technically not a fixme if our policy is not to throw errors :^)
 
-    // 2. Let outside settings be the current settings object.
-    auto& outside_settings = current_settings_object();
+    // 2. Let outside settings be the current principal settings object.
+    auto& outside_settings = current_principal_settings_object();
 
     // 3. Parse the scriptURL argument relative to outside settings.
     auto url = document.parse_url(script_url);

--- a/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -79,6 +79,7 @@ void WorkerGlobalScope::close_a_worker()
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#importing-scripts-and-libraries
+// https://whatpr.org/html/9893/workers.html#importing-scripts-and-libraries
 WebIDL::ExceptionOr<void> WorkerGlobalScope::import_scripts(Vector<String> const& urls, PerformTheFetchHook perform_fetch)
 {
     // The algorithm may optionally be customized by supplying custom perform the fetch hooks,
@@ -87,8 +88,8 @@ WebIDL::ExceptionOr<void> WorkerGlobalScope::import_scripts(Vector<String> const
 
     // FIXME: 1. If worker global scope's type is "module", throw a TypeError exception.
 
-    // 2. Let settings object be the current settings object.
-    auto& settings_object = HTML::current_settings_object();
+    // 2. Let settings object be the current principal settings object.
+    auto& settings_object = HTML::current_principal_settings_object();
 
     // 3. If urls is empty, return.
     if (urls.is_empty())

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -264,7 +264,7 @@ void Page::did_update_window_rect()
 template<typename ResponseType>
 static ResponseType spin_event_loop_until_dialog_closed(PageClient& client, Optional<ResponseType>& response, SourceLocation location = SourceLocation::current())
 {
-    auto& event_loop = Web::HTML::current_settings_object().responsible_event_loop();
+    auto& event_loop = Web::HTML::current_principal_settings_object().responsible_event_loop();
 
     ScopeGuard guard { [&] { event_loop.set_execution_paused(false); } };
     event_loop.set_execution_paused(true);

--- a/Userland/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
+++ b/Userland/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
@@ -29,11 +29,11 @@ PerformanceMark::~PerformanceMark() = default;
 // https://w3c.github.io/user-timing/#dfn-performancemark-constructor
 WebIDL::ExceptionOr<JS::NonnullGCPtr<PerformanceMark>> PerformanceMark::construct_impl(JS::Realm& realm, String const& mark_name, Web::UserTiming::PerformanceMarkOptions const& mark_options)
 {
-    auto& current_global_object = realm.global_object();
+    auto& current_principal_global_object = HTML::current_principal_global_object();
     auto& vm = realm.vm();
 
     // 1. If the current global object is a Window object and markName uses the same name as a read only attribute in the PerformanceTiming interface, throw a SyntaxError.
-    if (is<HTML::Window>(current_global_object)) {
+    if (is<HTML::Window>(current_principal_global_object)) {
         bool matched = false;
 
 #define __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(name, _) \

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -123,7 +123,7 @@ WebIDL::ExceptionOr<void> BaseAudioContext::verify_audio_options_inside_nominal_
 
 void BaseAudioContext::queue_a_media_element_task(JS::NonnullGCPtr<JS::HeapFunction<void()>> steps)
 {
-    auto task = HTML::Task::create(vm(), m_media_element_event_task_source.source, HTML::current_settings_object().responsible_document(), steps);
+    auto task = HTML::Task::create(vm(), m_media_element_event_task_source.source, HTML::current_principal_settings_object().responsible_document(), steps);
     HTML::main_thread_event_loop().task_queue().add(task);
 }
 

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -306,8 +306,8 @@ JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::Window const& win
     // 10. Clean up after running a callback with environment settings.
     environment_settings.clean_up_after_running_callback();
 
-    // 11. Clean up after running a script with environment settings.
-    environment_settings.clean_up_after_running_script();
+    // 11. Clean up after running a script with realm.
+    HTML::clean_up_after_running_script(realm);
 
     // 12. Return completion.
     return completion;

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -279,8 +279,8 @@ JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::Window const& win
     // 5. If body begins with a directive prologue that contains a use strict directive then let strict be true, otherwise let strict be false.
     // NOTE: Handled in step 8 below.
 
-    // 6. Prepare to run a script with environment settings.
-    environment_settings.prepare_to_run_script();
+    // 6. Prepare to run a script with realm.
+    HTML::prepare_to_run_script(realm);
 
     // 7. Prepare to run a callback with environment settings.
     environment_settings.prepare_to_run_callback();

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -283,7 +283,7 @@ JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::Window const& win
     HTML::prepare_to_run_script(realm);
 
     // 7. Prepare to run a callback with environment settings.
-    environment_settings.prepare_to_run_callback();
+    HTML::prepare_to_run_callback(realm);
 
     // 8. Let function be the result of calling FunctionCreate, with arguments:
     // kind
@@ -304,7 +304,7 @@ JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::Window const& win
     auto completion = function->internal_call(&window, parameters);
 
     // 10. Clean up after running a callback with environment settings.
-    environment_settings.clean_up_after_running_callback();
+    HTML::clean_up_after_running_callback(realm);
 
     // 11. Clean up after running a script with realm.
     HTML::clean_up_after_running_script(realm);

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -101,6 +101,7 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
 }
 
 // https://webidl.spec.whatwg.org/#call-user-object-operation-return
+// https://whatpr.org/webidl/1437.html#call-user-object-operation-return
 inline JS::Completion clean_up_on_return(HTML::EnvironmentSettingsObject& stored_settings, HTML::EnvironmentSettingsObject& relevant_settings, JS::Completion& completion, OperationReturnsPromise operation_returns_promise)
 {
     auto& realm = stored_settings.realm();
@@ -110,8 +111,8 @@ inline JS::Completion clean_up_on_return(HTML::EnvironmentSettingsObject& stored
     // 1. Clean up after running a callback with stored settings.
     stored_settings.clean_up_after_running_callback();
 
-    // 2. Clean up after running script with relevant settings.
-    relevant_settings.clean_up_after_running_script();
+    // 2. Clean up after running script with relevant realm.
+    HTML::clean_up_after_running_script(relevant_settings.realm());
 
     // 3. If completion is a normal completion, return completion.
     if (completion.type() == JS::Completion::Type::Normal)
@@ -312,8 +313,8 @@ JS::Completion construct(WebIDL::CallbackType& callback, JS::MarkedVector<JS::Va
     // 1. Clean up after running a callback with stored settings.
     stored_settings->clean_up_after_running_callback();
 
-    // 2. Clean up after running script with relevant settings.
-    relevant_settings.clean_up_after_running_script();
+    // 2. Clean up after running script with relevant realm.
+    HTML::clean_up_after_running_script(realm);
 
     // 3. Return completion.
     return completion;

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -130,6 +130,8 @@ inline JS::Completion clean_up_on_return(HTML::EnvironmentSettingsObject& stored
     return JS::Value { rejected_promise->promise() };
 }
 
+// https://webidl.spec.whatwg.org/#call-a-user-objects-operation
+// https://whatpr.org/webidl/1437.html#call-a-user-objects-operation
 JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String const& operation_name, Optional<JS::Value> this_argument, JS::MarkedVector<JS::Value> args)
 {
     // 1. Let completion be an uninitialized variable.
@@ -142,17 +144,17 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
     // 3. Let O be the ECMAScript object corresponding to value.
     auto& object = callback.callback;
 
-    // 4. Let realm be O’s associated Realm.
-    auto& realm = object->shape().realm();
+    // 4. Let relevant realm be O’s associated Realm.
+    auto& relevant_realm = object->shape().realm();
 
-    // 5. Let relevant settings be realm’s settings object.
-    auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
+    // 5. Let relevant settings be relvant realm’s settings object.
+    auto& relevant_settings = Bindings::host_defined_environment_settings_object(relevant_realm);
 
     // 6. Let stored settings be value’s callback context.
     auto& stored_settings = callback.callback_context;
 
-    // 7. Prepare to run script with relevant settings.
-    relevant_settings.prepare_to_run_script();
+    // 7. Prepare to run script with relevant realm.
+    HTML::prepare_to_run_script(relevant_realm);
 
     // 8. Prepare to run a callback with stored settings.
     stored_settings->prepare_to_run_callback();
@@ -173,7 +175,7 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
 
         // 4. If ! IsCallable(X) is false, then set completion to a new Completion{[[Type]]: throw, [[Value]]: a newly created TypeError object, [[Target]]: empty}, and jump to the step labeled return.
         if (!get_result.value().is_function()) {
-            completion = realm.vm().template throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, get_result.value().to_string_without_side_effects());
+            completion = relevant_realm.vm().template throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, get_result.value().to_string_without_side_effects());
             return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
         }
 
@@ -239,7 +241,7 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     auto& stored_settings = callback.callback_context;
 
     // 8. Prepare to run script with relevant settings.
-    relevant_settings.prepare_to_run_script();
+    HTML::prepare_to_run_script(realm);
 
     // 9. Prepare to run a callback with stored settings.
     stored_settings->prepare_to_run_callback();
@@ -280,13 +282,13 @@ JS::Completion construct(WebIDL::CallbackType& callback, JS::MarkedVector<JS::Va
         return realm.vm().template throw_completion<JS::TypeError>(JS::ErrorType::NotAConstructor, JS::Value(function_object).to_string_without_side_effects());
 
     // 5. Let relevant settings be realm’s settings object.
-    auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
+    // NOTE: Not needed after ShadowRealm implementation.
 
     // 6. Let stored settings be callable’s callback context.
     auto& stored_settings = callback.callback_context;
 
     // 7. Prepare to run script with relevant settings.
-    relevant_settings.prepare_to_run_script();
+    HTML::prepare_to_run_script(realm);
 
     // 8. Prepare to run a callback with stored settings.
     stored_settings->prepare_to_run_callback();

--- a/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -102,17 +102,15 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
 
 // https://webidl.spec.whatwg.org/#call-user-object-operation-return
 // https://whatpr.org/webidl/1437.html#call-user-object-operation-return
-inline JS::Completion clean_up_on_return(HTML::EnvironmentSettingsObject& stored_settings, HTML::EnvironmentSettingsObject& relevant_settings, JS::Completion& completion, OperationReturnsPromise operation_returns_promise)
+inline JS::Completion clean_up_on_return(JS::Realm& stored_realm, JS::Realm& relevant_realm, JS::Completion& completion, OperationReturnsPromise operation_returns_promise)
 {
-    auto& realm = stored_settings.realm();
-
     // Return: at this point completion will be set to an ECMAScript completion value.
 
-    // 1. Clean up after running a callback with stored settings.
-    stored_settings.clean_up_after_running_callback();
+    // 1. Clean up after running a callback with stored realm.
+    HTML::clean_up_after_running_callback(stored_realm);
 
     // 2. Clean up after running script with relevant realm.
-    HTML::clean_up_after_running_script(relevant_settings.realm());
+    HTML::clean_up_after_running_script(relevant_realm);
 
     // 3. If completion is a normal completion, return completion.
     if (completion.type() == JS::Completion::Type::Normal)
@@ -123,7 +121,7 @@ inline JS::Completion clean_up_on_return(HTML::EnvironmentSettingsObject& stored
         return completion;
 
     // 5. Let rejectedPromise be ! Call(%Promise.reject%, %Promise%, «completion.[[Value]]»).
-    auto rejected_promise = create_rejected_promise(realm, *completion.release_value());
+    auto rejected_promise = create_rejected_promise(relevant_realm, *completion.release_value());
 
     // 6. Return the result of converting rejectedPromise to the operation’s return type.
     // Note: The operation must return a promise, so no conversion is necessary
@@ -147,22 +145,20 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
     // 4. Let relevant realm be O’s associated Realm.
     auto& relevant_realm = object->shape().realm();
 
-    // 5. Let relevant settings be relvant realm’s settings object.
-    auto& relevant_settings = Bindings::host_defined_environment_settings_object(relevant_realm);
+    // FIXME: We should get the realm directly from the callback context.
+    // 5. Let stored realm be value’s callback context.
+    auto& stored_realm = callback.callback_context->realm();
 
-    // 6. Let stored settings be value’s callback context.
-    auto& stored_settings = callback.callback_context;
-
-    // 7. Prepare to run script with relevant realm.
+    // 6. Prepare to run script with relevant realm.
     HTML::prepare_to_run_script(relevant_realm);
 
-    // 8. Prepare to run a callback with stored settings.
-    stored_settings->prepare_to_run_callback();
+    // 7. Prepare to run a callback with stored realm.
+    HTML::prepare_to_run_callback(stored_realm);
 
-    // 9. Let X be O.
+    // 8. Let X be O.
     auto actual_function_object = object;
 
-    // 10. If ! IsCallable(O) is false, then:
+    // 9. If ! IsCallable(O) is false, then:
     if (!object->is_function()) {
         // 1. Let getResult be Get(O, opName).
         auto get_result = object->get(operation_name.to_byte_string());
@@ -170,13 +166,13 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
         // 2. If getResult is an abrupt completion, set completion to getResult and jump to the step labeled return.
         if (get_result.is_throw_completion()) {
             completion = get_result.throw_completion();
-            return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
+            return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
         }
 
         // 4. If ! IsCallable(X) is false, then set completion to a new Completion{[[Type]]: throw, [[Value]]: a newly created TypeError object, [[Target]]: empty}, and jump to the step labeled return.
         if (!get_result.value().is_function()) {
             completion = relevant_realm.vm().template throw_completion<JS::TypeError>(JS::ErrorType::NotAFunction, get_result.value().to_string_without_side_effects());
-            return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
+            return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
         }
 
         // 3. Set X to getResult.[[Value]].
@@ -187,28 +183,29 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
         this_argument = object;
     }
 
-    // FIXME: 11. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
+    // FIXME: 10. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
     //        For simplicity, we currently make the caller do this. However, this means we can't throw exceptions at this point like the spec wants us to.
 
-    // 12. Let callResult be Call(X, thisArg, esArgs).
+    // 11. Let callResult be Call(X, thisArg, esArgs).
     VERIFY(actual_function_object);
     auto& vm = object->vm();
     auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*actual_function_object), this_argument.value(), args.span());
 
-    // 13. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
+    // 12. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {
         completion = call_result.throw_completion();
-        return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
+        return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
     }
 
-    // 14. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as the operation’s return type.
+    // 13. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as the operation’s return type.
     // FIXME: This does no conversion.
     completion = call_result.value();
 
-    return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
+    return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
 }
 
 // https://webidl.spec.whatwg.org/#invoke-a-callback-function
+// https://whatpr.org/webidl/1437.html#invoke-a-callback-function
 JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, JS::MarkedVector<JS::Value> args)
 {
     // 1. Let completion be an uninitialized variable.
@@ -230,21 +227,18 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
         return { JS::js_undefined() };
     }
 
-    // 5. Let realm be F’s associated Realm.
-    // See the comment about associated realm on step 4 of call_user_object_operation.
-    auto& realm = function_object->shape().realm();
+    // 5. Let relevant realm be F’s associated Realm.
+    auto& relevant_realm = function_object->shape().realm();
 
-    // 6. Let relevant settings be realm’s settings object.
-    auto& relevant_settings = Bindings::host_defined_environment_settings_object(realm);
+    // FIXME: We should get the realm directly from the callback context.
+    // 6. Let stored realm be value’s callback context.
+    auto& stored_realm = callback.callback_context->realm();
 
-    // 7. Let stored settings be value’s callback context.
-    auto& stored_settings = callback.callback_context;
+    // 8. Prepare to run script with relevant realm.
+    HTML::prepare_to_run_script(relevant_realm);
 
-    // 8. Prepare to run script with relevant settings.
-    HTML::prepare_to_run_script(realm);
-
-    // 9. Prepare to run a callback with stored settings.
-    stored_settings->prepare_to_run_callback();
+    // 9. Prepare to run a callback with stored realm.
+    HTML::prepare_to_run_callback(stored_realm);
 
     // FIXME: 10. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
     //        For simplicity, we currently make the caller do this. However, this means we can't throw exceptions at this point like the spec wants us to.
@@ -256,14 +250,14 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
     // 12. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {
         completion = call_result.throw_completion();
-        return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
+        return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
     }
 
     // 13. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as the operation’s return type.
     // FIXME: This does no conversion.
     completion = call_result.value();
 
-    return clean_up_on_return(stored_settings, relevant_settings, completion, callback.operation_returns_promise);
+    return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
 }
 
 JS::Completion construct(WebIDL::CallbackType& callback, JS::MarkedVector<JS::Value> args)
@@ -274,49 +268,46 @@ JS::Completion construct(WebIDL::CallbackType& callback, JS::MarkedVector<JS::Va
     // 2. Let F be the ECMAScript object corresponding to callable.
     auto& function_object = callback.callback;
 
-    // 4. Let realm be F’s associated Realm.
-    auto& realm = function_object->shape().realm();
+    // 4. Let relevant realm be F’s associated Realm.
+    auto& relevant_realm = function_object->shape().realm();
 
     // 3. If IsConstructor(F) is false, throw a TypeError exception.
     if (!JS::Value(function_object).is_constructor())
-        return realm.vm().template throw_completion<JS::TypeError>(JS::ErrorType::NotAConstructor, JS::Value(function_object).to_string_without_side_effects());
+        return relevant_realm.vm().template throw_completion<JS::TypeError>(JS::ErrorType::NotAConstructor, JS::Value(function_object).to_string_without_side_effects());
 
-    // 5. Let relevant settings be realm’s settings object.
-    // NOTE: Not needed after ShadowRealm implementation.
+    // FIXME: We should get the realm directly from the callback context.
+    // 4. Let stored realm be callable’s callback context.
+    auto& stored_realm = callback.callback_context->realm();
 
-    // 6. Let stored settings be callable’s callback context.
-    auto& stored_settings = callback.callback_context;
+    // 5. Prepare to run script with relevant realm.
+    HTML::prepare_to_run_script(relevant_realm);
 
-    // 7. Prepare to run script with relevant settings.
-    HTML::prepare_to_run_script(realm);
+    // 6. Prepare to run a callback with stored realm.
+    HTML::prepare_to_run_callback(stored_realm);
 
-    // 8. Prepare to run a callback with stored settings.
-    stored_settings->prepare_to_run_callback();
-
-    // FIXME: 9. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
+    // FIXME: 7. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
     //        For simplicity, we currently make the caller do this. However, this means we can't throw exceptions at this point like the spec wants us to.
 
-    // 10. Let callResult be Completion(Construct(F, esArgs)).
+    // 8. Let callResult be Completion(Construct(F, esArgs)).
     auto& vm = function_object->vm();
     auto call_result = JS::construct(vm, verify_cast<JS::FunctionObject>(*function_object), args.span());
 
-    // 11. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
+    // 9. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {
         completion = call_result.throw_completion();
     }
-
-    // 12. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as the operation’s return type.
+    // 10. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as the operation’s return type.
     else {
         // FIXME: This does no conversion.
         completion = JS::Value(call_result.value());
     }
 
-    // 13. Return: at this point completion will be set to an ECMAScript completion value.
-    // 1. Clean up after running a callback with stored settings.
-    stored_settings->clean_up_after_running_callback();
+    // 11. Return: at this point completion will be set to an ECMAScript completion value.
+    // 1. Clean up after running a callback with stored realm.
+    HTML::clean_up_after_running_callback(stored_realm);
 
     // 2. Clean up after running script with relevant realm.
-    HTML::clean_up_after_running_script(realm);
+    HTML::clean_up_after_running_script(relevant_realm);
 
     // 3. Return completion.
     return completion;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -159,7 +159,7 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> XMLHttpRequest::response_xml()
 WebIDL::ExceptionOr<void> XMLHttpRequest::set_response_type(Bindings::XMLHttpRequestResponseType response_type)
 {
     // 1. If the current global object is not a Window object and the given value is "document", then return.
-    if (!is<HTML::Window>(HTML::current_global_object()) && response_type == Bindings::XMLHttpRequestResponseType::Document)
+    if (!is<HTML::Window>(HTML::current_principal_global_object()) && response_type == Bindings::XMLHttpRequestResponseType::Document)
         return {};
 
     // 2. If this’s state is loading or done, then throw an "InvalidStateError" DOMException.
@@ -167,7 +167,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_response_type(Bindings::XMLHttpReq
         return WebIDL::InvalidStateError::create(realm(), "Can't readyState when XHR is loading or done"_string);
 
     // 3. If the current global object is a Window object and this’s synchronous flag is set, then throw an "InvalidAccessError" DOMException.
-    if (is<HTML::Window>(HTML::current_global_object()) && m_synchronous)
+    if (is<HTML::Window>(HTML::current_principal_global_object()) && m_synchronous)
         return WebIDL::InvalidAccessError::create(realm(), "Can't set readyState on synchronous XHR in Window environment"_string);
 
     // 4. Set this’s response type to the given value.
@@ -506,7 +506,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::open(String const& method_string, Stri
     // 9. If async is false, the current global object is a Window object, and either this’s timeout is
     //     not 0 or this’s response type is not the empty string, then throw an "InvalidAccessError" DOMException.
     if (!async
-        && is<HTML::Window>(HTML::current_global_object())
+        && is<HTML::Window>(HTML::current_principal_global_object())
         && (m_timeout != 0 || m_response_type != Bindings::XMLHttpRequestResponseType::Empty)) {
         return WebIDL::InvalidAccessError::create(realm(), "Synchronous XMLHttpRequests in a Window context do not support timeout or a non-empty responseType"_string);
     }
@@ -1051,7 +1051,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::set_timeout(u32 timeout)
 {
     // 1. If the current global object is a Window object and this’s synchronous flag is set,
     //    then throw an "InvalidAccessError" DOMException.
-    if (is<HTML::Window>(HTML::current_global_object()) && m_synchronous)
+    if (is<HTML::Window>(HTML::current_principal_global_object()) && m_synchronous)
         return WebIDL::InvalidAccessError::create(realm(), "Use of XMLHttpRequest's timeout attribute is not supported in the synchronous mode in window context."_string);
 
     // 2. Set this’s timeout to the given value.


### PR DESCRIPTION
Second stage of shadow realm integration into LibWeb sitting ontop of https://github.com/LadybirdBrowser/ladybird/pull/1927

The step after this is to change HTML::Script to operate on realm's instead of environment setting objects. After that, we should then be able to hook up the VM hook to actually initialize the shadow realm global object - which is enough for the test case of:

```html
<script>
async function test() {
    const realm = new ShadowRealm()
    const aSync = realm.evaluate(`async () => 1 + 1`)
    aSync()
}

test();
</script>
```

To not crash :^)

Edit: For a mostly-working implementation, see: https://github.com/LadybirdBrowser/ladybird/pull/1993