### PR TITLE
LibWeb: Assert navigationParams' request and response are not null

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1071,7 +1071,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
 
     // 2. Assert: if navigationParams is non-null, then navigationParams's response is non-null.
     // NavigationParams' response field is NonnullGCPtr
-    if (!navigation_params.has<Empty>())
+    if (!navigation_params.has<Empty>() && !navigation_params.has<NullWithError>())
         VERIFY(navigation_params.has<JS::NonnullGCPtr<NavigationParams>>());
 
     // 3. Let currentBrowsingContext be navigable's active browsing context.
@@ -1081,7 +1081,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
     auto document_resource = entry->document_state()->resource();
 
     // 5. If navigationParams is null, then:
-    if (navigation_params.has<Empty>()) {
+    if (navigation_params.has<Empty>() || navigation_params.has<NullWithError>()) {
         // 1. If documentResource is a string, then set navigationParams to the result
         //    of creating navigation params from a srcdoc resource given entry, navigable,
         //    targetSnapshotParams, navigationId, and navTimingType.
@@ -1170,7 +1170,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
             saveExtraDocumentState = false;
 
             // 4. If navigationParams is not null, then:
-            if (navigation_params.has<Empty>()) {
+            if (!navigation_params.has<Empty>() && !navigation_params.has<NullWithError>()) {
                 // FIXME: 1. Run the environment discarding steps for navigationParams's reserved environment.
                 // FIXME: 2. Invoke WebDriver BiDi navigation failed with currentBrowsingContext and a new WebDriver BiDi navigation status whose id is navigationId, status is "canceled", and url is navigationParams's response's URL.
             }
@@ -1202,7 +1202,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
 
             // 3. If entry's document state's request referrer is "client", and navigationParams is a navigation params (i.e., neither null nor a non-fetch scheme navigation params), then:
             if (entry->document_state()->request_referrer() == Fetch::Infrastructure::Request::Referrer::Client
-                && (!navigation_params.has<Empty>() && Fetch::Infrastructure::is_fetch_scheme(entry->url().scheme()))) {
+                && (!navigation_params.has<Empty>() && !navigation_params.has<NullWithError>() && Fetch::Infrastructure::is_fetch_scheme(entry->url().scheme()))) {
                 // FIXME: 1. Assert: navigationParams's request is not null.
                 // FIXME: 2. Set entry's document state's request referrer to navigationParams's request's referrer.
             }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1070,9 +1070,8 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
     // FIXME: 1. Assert: this is running in parallel.
 
     // 2. Assert: if navigationParams is non-null, then navigationParams's response is non-null.
-    // NavigationParams' response field is NonnullGCPtr
     if (!navigation_params.has<Empty>() && !navigation_params.has<NullWithError>())
-        VERIFY(navigation_params.has<JS::NonnullGCPtr<NavigationParams>>());
+        VERIFY(navigation_params.has<JS::NonnullGCPtr<NavigationParams>>() && navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->response);
 
     // 3. Let currentBrowsingContext be navigable's active browsing context.
     [[maybe_unused]] auto current_browsing_context = active_browsing_context();
@@ -1202,9 +1201,12 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
 
             // 3. If entry's document state's request referrer is "client", and navigationParams is a navigation params (i.e., neither null nor a non-fetch scheme navigation params), then:
             if (entry->document_state()->request_referrer() == Fetch::Infrastructure::Request::Referrer::Client
-                && (!navigation_params.has<Empty>() && !navigation_params.has<NullWithError>() && Fetch::Infrastructure::is_fetch_scheme(entry->url().scheme()))) {
-                // FIXME: 1. Assert: navigationParams's request is not null.
-                // FIXME: 2. Set entry's document state's request referrer to navigationParams's request's referrer.
+                && (!navigation_params.has<Empty>() && !navigation_params.has<NullWithError>() && navigation_params.has<JS::NonnullGCPtr<NonFetchSchemeNavigationParams>>())) {
+                // 1. Assert: navigationParams's request is not null.
+                VERIFY(navigation_params.has<JS::NonnullGCPtr<NavigationParams>>() && navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->request);
+
+                // 2. Set entry's document state's request referrer to navigationParams's request's referrer.
+                entry->document_state()->set_request_referrer(navigation_params.get<JS::NonnullGCPtr<NavigationParams>>()->request->referrer());
             }
         }
 


### PR DESCRIPTION
There weren't checks whether `navigation_params`' response was null, since it used to be a `NonnullGCPtr`. Since it is now a `GCPtr` it's existence needs to be checked explicitly.

When checking whether `navigation_params` is null, we only check whether it contains `Empty`. After `NullWithError` was added to the variant in #209, we should also check whether `navigation_params` contains this `NullWithError`, since I believe it's equivalent to null and is just used to move along the error message.