### PR TITLE
LibJS: Add HashMap for finding Bindings by name

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -69,6 +69,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_mutable_binding(VM&, Depr
     // NOTE: We skip this to avoid O(n) traversal of m_bindings.
 
     // 2. Create a mutable binding in envRec for N and record that it is uninitialized. If D is true, record that the newly created binding may be deleted by a subsequent DeleteBinding call.
+    m_bindings_assoc.set(name, m_bindings.size());
     m_bindings.append(Binding {
         .name = name,
         .value = {},
@@ -91,6 +92,7 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(VM&, De
     // NOTE: We skip this to avoid O(n) traversal of m_bindings.
 
     // 2. Create an immutable binding in envRec for N and record that it is uninitialized. If S is true, record that the newly created binding is a strict binding.
+    m_bindings_assoc.set(name, m_bindings.size());
     m_bindings.append(Binding {
         .name = name,
         .value = {},

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -115,18 +115,16 @@ protected:
 
     virtual Optional<BindingAndIndex> find_binding_and_index(DeprecatedFlyString const& name) const
     {
-        auto it = m_bindings.find_if([&](auto const& binding) {
-            return binding.name == name;
-        });
+        if (auto it = m_bindings_assoc.find(name); it != m_bindings_assoc.end()) {
+            return BindingAndIndex { const_cast<Binding*>(&m_bindings.at(it->value)), it->value };
+        }
 
-        if (it == m_bindings.end())
-            return {};
-
-        return BindingAndIndex { const_cast<Binding*>(&(*it)), it.index() };
+        return {};
     }
 
 private:
     Vector<Binding> m_bindings;
+    HashMap<DeprecatedFlyString, size_t> m_bindings_assoc;
     Vector<DisposableResource> m_disposable_resource_stack;
 
     u64 m_environment_serial_number { 0 };


### PR DESCRIPTION
`find_binding_and_index` was doing a linear search, and while most environments are small, websites using JavaScript bundlers can have functions with very large environments, like youtube.com, which has environments with over 13K bindings, causing environment lookups to take a noticeable amount of time, showing up high while profiling.

Adding a HashMap significantly increases performance on such websites.