### PR TITLE
LibWeb: Do not resolve inline block height early if height is definite

### DIFF
--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-inline-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-inline-block.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x66 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x50 children: not-inline
+      BlockContainer <div#a> at (8,8) content-size 100x50 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 100x50] baseline: 50
+        TextNode <#text>
+        BlockContainer <div#b> at (8,8) content-size 100x50 inline-block [BFC] children: inline
+          frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x50] baseline: 50
+          TextNode <#text>
+          SVGSVGBox <svg> at (8,8) content-size 100x50 [SVG] children: inline
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x66]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x50]
+      PaintableWithLines (BlockContainer<DIV>#a) [8,8 100x50]
+        PaintableWithLines (BlockContainer<DIV>#b) [8,8 100x50]
+          SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x50]

--- a/Tests/LibWeb/Layout/input/svg/svg-inside-inline-block.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-inside-inline-block.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<style>
+    #a {
+        background-color: #f00;
+        height: 50px;
+        width: 100px;
+    }
+    #b {
+        display: inline-block;
+        height: 100%;
+    }
+    svg {
+        background-color: #0f0;
+        height: 100%;
+    }
+</style>
+<div id="a">
+    <div id="b">
+        <svg viewBox="0 0 100 50">

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -180,7 +180,7 @@ void InlineFormattingContext::dimension_box_on_line(Box const& box, LayoutMode l
     parent().resolve_used_height_if_not_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()));
 
     // NOTE: Flex containers with `auto` height are treated as `max-content`, so we can compute their height early.
-    if (box_state.has_definite_height() || box.display().is_flex_inside())
+    if (box.display().is_flex_inside())
         parent().resolve_used_height_if_treated_as_auto(box, AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_indefinite()));
 
     auto independent_formatting_context = layout_inside(box, layout_mode, box_state.available_inner_space_or_constraints_from(*m_available_space));


### PR DESCRIPTION
This condition was included to implement flex containers with auto height, but it actually can reset the definitive height to 0 for inline blocks with only replaced elements such as an SVG. Removing the condition does not break any in-tree test, so let's improve the situation on the SVG side of things for now.

Fixes the https://tweakers.net logo:

| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/6969e57a-2761-4a3d-8efa-c3ec8dbd9f1a) | ![image](https://github.com/user-attachments/assets/bd49b936-3d93-4e64-bb5d-a312f9376e06) |
