### PR TITLE
LibWeb: fallback to auto when aspect ratio is degenerate as per spec

### DIFF
--- a/Tests/LibWeb/Layout/expected/aspect-ratio-degenerate-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/aspect-ratio-degenerate-ratio.txt
@@ -1,0 +1,10 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x200 children: inline
+      frag 0 from ImageBox start: 0, length: 0, rect: [8,8 200x200] baseline: 200
+      ImageBox <img> at (8,8) content-size 200x200 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x200]
+      ImagePaintable (ImageBox<IMG>) [8,8 200x200]

--- a/Tests/LibWeb/Layout/input/aspect-ratio-degenerate-ratio.html
+++ b/Tests/LibWeb/Layout/input/aspect-ratio-degenerate-ratio.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+    img {
+        width: 200px;
+        aspect-ratio: 0/1;
+    }
+</style><img src="120.png"/>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -870,7 +870,12 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     } else if (aspect_ratio->is_keyword() && aspect_ratio->as_keyword().keyword() == CSS::Keyword::Auto) {
         computed_values.set_aspect_ratio({ true, {} });
     } else if (aspect_ratio->is_ratio()) {
-        computed_values.set_aspect_ratio({ false, aspect_ratio->as_ratio().ratio() });
+        // https://drafts.csswg.org/css-sizing-4/#aspect-ratio
+        // If the <ratio> is degenerate, the property instead behaves as auto.
+        if (aspect_ratio->as_ratio().ratio().is_degenerate())
+            computed_values.set_aspect_ratio({ true, {} });
+        else
+            computed_values.set_aspect_ratio({ false, aspect_ratio->as_ratio().ratio() });
     }
 
     auto math_shift_value = computed_style.property(CSS::PropertyID::MathShift);


### PR DESCRIPTION
When `aspect-ratio` is degenerate (e.g. 0/1 or 1/0) we should fallback to the same behaviour as `aspect-ratio: auto` according to spec (see https://drafts.csswg.org/css-sizing-4/#aspect-ratio)

This PR explicitly handles this specific, albeit very rare, case and fixes five WPT test in `css/css-sizing/aspect-ratio` (zero-or-infinity-[006-010])

This is my first ladybird PR so please have some patience with me if I've missed something obvious.

It is possible to achieve the same result with a change to `Box::preferred_aspect_ratio`, but from my understanding of the code, it's more appropriate to do the fix in `NodeWithStyle::apply_style` as otherwise we need to consider a special case for each render without much gain as far as I can tell.


