### PR TITLE
LibJS: Cache UTF-16 strings on the VM

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.cpp
@@ -55,6 +55,13 @@ Utf16View Utf16StringImpl::view() const
     return Utf16View { m_string };
 }
 
+u32 Utf16StringImpl::compute_hash() const
+{
+    if (m_string.is_empty())
+        return 0;
+    return string_hash((char const*)m_string.data(), m_string.size() * sizeof(u16));
+}
+
 }
 
 Utf16String Utf16String::create()

--- a/Userland/Libraries/LibJS/Runtime/Utf16String.h
+++ b/Userland/Libraries/LibJS/Runtime/Utf16String.h
@@ -29,10 +29,24 @@ public:
     Utf16Data const& string() const;
     Utf16View view() const;
 
+    [[nodiscard]] u32 hash() const
+    {
+        if (!m_has_hash) {
+            m_hash = compute_hash();
+            m_has_hash = true;
+        }
+        return m_hash;
+    }
+    [[nodiscard]] bool operator==(Utf16StringImpl const& other) const { return string() == other.string(); }
+
 private:
     Utf16StringImpl() = default;
     explicit Utf16StringImpl(Utf16Data string);
 
+    [[nodiscard]] u32 compute_hash() const;
+
+    mutable bool m_has_hash { false };
+    mutable u32 m_hash { 0 };
     Utf16Data m_string;
 };
 
@@ -57,10 +71,27 @@ public:
     size_t length_in_code_units() const;
     bool is_empty() const;
 
+    [[nodiscard]] u32 hash() const { return m_string->hash(); }
+    [[nodiscard]] bool operator==(Utf16String const& other) const
+    {
+        if (m_string == other.m_string)
+            return true;
+        return *m_string == *other.m_string;
+    }
+
 private:
     explicit Utf16String(NonnullRefPtr<Detail::Utf16StringImpl>);
 
     NonnullRefPtr<Detail::Utf16StringImpl> m_string;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<JS::Utf16String> : public DefaultTraits<JS::Utf16String> {
+    static unsigned hash(JS::Utf16String const& s) { return s.hash(); }
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -75,6 +75,11 @@ public:
         return m_byte_string_cache;
     }
 
+    HashMap<Utf16String, GCPtr<PrimitiveString>>& utf16_string_cache()
+    {
+        return m_utf16_string_cache;
+    }
+
     PrimitiveString& empty_string() { return *m_empty_string; }
 
     PrimitiveString& single_ascii_character_string(u8 character)
@@ -298,6 +303,7 @@ private:
 
     HashMap<String, GCPtr<PrimitiveString>> m_string_cache;
     HashMap<ByteString, GCPtr<PrimitiveString>> m_byte_string_cache;
+    HashMap<Utf16String, GCPtr<PrimitiveString>> m_utf16_string_cache;
 
     Heap m_heap;
 


### PR DESCRIPTION
We were already caching UTF-8 and byte strings, so let's add a cache for UTF-16 strings as well. This is particularly profitable whenever we run regular expressions, since the output of regex execution is a set of UTF-16 strings.

Note that this is a weak cache like the other JS string caches, meaning that strings are removed from the cache as they are garbage collected.

This avoids billions of PrimitiveString allocations across a run of WPT, significantly reducing GC activity.