### PR TITLE
headless-browser: Force-enable font config via code rather than CMake

### DIFF
--- a/Ladybird/Headless/Application.cpp
+++ b/Ladybird/Headless/Application.cpp
@@ -47,6 +47,9 @@ void Application::create_platform_options(WebView::ChromeOptions& chrome_options
     if (is_layout_test_mode) {
         // Allow window.open() to succeed for tests.
         chrome_options.allow_popups = WebView::AllowPopups::Yes;
+
+        // Ensure consistent font rendering between operating systems.
+        web_content_options.force_fontconfig = WebView::ForceFontconfig::Yes;
     }
 
     if (dump_gc_graph) {

--- a/Ladybird/Headless/CMakeLists.txt
+++ b/Ladybird/Headless/CMakeLists.txt
@@ -14,6 +14,6 @@ target_link_libraries(headless-browser PRIVATE ${LADYBIRD_LIBS} LibDiff)
 if (BUILD_TESTING)
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:headless-browser> --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests --force-fontconfig
+        COMMAND $<TARGET_FILE:headless-browser> --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --dump-failed-ref-tests
     )
 endif()

--- a/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-of-sticky.txt
+++ b/Tests/LibWeb/Text/expected/element-get-bounding-client-rect-of-sticky.txt
@@ -1,1 +1,1 @@
-  Sticky Element      Bounding Client Rect: top=50, left=10, width=500, height=57
+Bounding Client Rect: top=50, left=10, width=500, height=57

--- a/Tests/LibWeb/Text/input/element-get-bounding-client-rect-of-sticky.html
+++ b/Tests/LibWeb/Text/input/element-get-bounding-client-rect-of-sticky.html
@@ -40,10 +40,6 @@
         const stickyElement = document.getElementById("sticky-element");
         const boundingRect = stickyElement.getBoundingClientRect();
 
-        const result = document.createElement("p");
-        result.textContent = `Bounding Client Rect: top=${boundingRect.top}, left=${boundingRect.left}, width=${boundingRect.width}, height=${boundingRect.height}`;
-        document.body.appendChild(result);
-
-        println(document.body.innerText);
+        println(`Bounding Client Rect: top=${boundingRect.top}, left=${boundingRect.left}, width=${boundingRect.width}, height=${boundingRect.height}`);
     });
 </script>


### PR DESCRIPTION
It is easy to forget to set this flag on macOS, where doing so causes
many tests to fail. So let's just set it via code along with other
options to make it a bit more foolproof.