### PR TITLE
Meta: Make WPT.sh echo the “wpt run” invocation

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -153,6 +153,7 @@ execute_wpt() {
             fi
             WPT_ARGS+=( "--webdriver-arg=--certificate=${certificate_path}" )
         done
+        echo QT_QPA_PLATFORM="offscreen" ./wpt run "${WPT_ARGS[@]}" ladybird "${TEST_LIST[@]}"
         QT_QPA_PLATFORM="offscreen" ./wpt run "${WPT_ARGS[@]}" ladybird "${TEST_LIST[@]}"
     popd > /dev/null
 }


### PR DESCRIPTION
To help people in troubleshooting problems when running the WPT.sh script, this change makes the script echo to stdout the complete `wpt run` invocation (including all the flags and path args).

For context, see https://discord.com/channels/1247070541085671459/1247090166909374474/1299207453212151891.

I don’t feel strongly that this needs to be added — so I’m fine with this PR just being closed if this seems not necessary. I just figured going ahead and doing a patch for it would be quicker than first having a discussion about whether or not to actually do it…