### PR TITLE
LibWeb: Shadow realm introduction part 3 - make HTML::Script accept a realm

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Userland/Libraries/LibWeb/Animations/Animation.cpp
@@ -424,7 +424,7 @@ void Animation::cancel(ShouldInvalidate should_invalidate)
 
     // 1. If animation’s play state is not idle, perform the following steps:
     if (play_state() != Bindings::AnimationPlayState::Idle) {
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+        HTML::TemporaryExecutionContext execution_context { realm };
 
         // 1. Run the procedure to reset an animation’s pending tasks on animation.
         reset_an_animations_pending_tasks();
@@ -537,7 +537,7 @@ WebIDL::ExceptionOr<void> Animation::finish()
     }
 
     if (should_resolve_ready_promise) {
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm()) };
+        HTML::TemporaryExecutionContext execution_context { realm() };
         WebIDL::resolve_promise(realm(), current_ready_promise(), this);
     }
 
@@ -1111,7 +1111,7 @@ void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify sync
                 return;
 
             // 2. Resolve animation’s current finished promise object with animation.
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+            HTML::TemporaryExecutionContext execution_context { realm };
             WebIDL::resolve_promise(realm, current_finished_promise(), this);
             m_is_finished = true;
 
@@ -1178,7 +1178,7 @@ void Animation::update_finished_state(DidSeek did_seek, SynchronouslyNotify sync
     // 6. If current finished state is false and animation’s current finished promise is already resolved, set
     //    animation’s current finished promise to a new promise in the relevant Realm of animation.
     if (!current_finished_state && m_is_finished) {
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+        HTML::TemporaryExecutionContext execution_context { realm };
         m_current_finished_promise = WebIDL::create_promise(realm);
         m_is_finished = false;
     }
@@ -1266,7 +1266,7 @@ void Animation::run_pending_play_task()
     }
 
     // 4. Resolve animation’s current ready promise with animation.
-    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm()) };
+    HTML::TemporaryExecutionContext execution_context { realm() };
     WebIDL::resolve_promise(realm(), current_ready_promise(), this);
 
     // 5. Run the procedure to update an animation’s finished state for animation with the did seek flag set to false,
@@ -1296,7 +1296,7 @@ void Animation::run_pending_pause_task()
     m_start_time = {};
 
     // 5. Resolve animation’s current ready promise with animation.
-    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm()) };
+    HTML::TemporaryExecutionContext execution_context { realm() };
     WebIDL::resolve_promise(realm(), current_ready_promise(), this);
 
     // 6. Run the procedure to update an animation’s finished state for animation with the did seek flag set to false,

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -464,7 +464,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
             auto completion = dom_exception_to_throw_completion(main_thread_vm(), url.exception());
 
             // 2. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, completion).
-            HTML::TemporaryExecutionContext context { host_defined_environment_settings_object(realm) };
+            HTML::TemporaryExecutionContext context { realm };
             JS::finish_loading_imported_module(referrer, module_request, payload, completion);
 
             // 3. Return.

--- a/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
+++ b/Userland/Libraries/LibWeb/Bindings/MainThreadVM.h
@@ -66,15 +66,15 @@ struct WebEngineCustomData final : public JS::VM::CustomData {
 };
 
 struct WebEngineCustomJobCallbackData final : public JS::JobCallback::CustomData {
-    WebEngineCustomJobCallbackData(HTML::EnvironmentSettingsObject& incumbent_settings, OwnPtr<JS::ExecutionContext> active_script_context)
-        : incumbent_settings(incumbent_settings)
+    WebEngineCustomJobCallbackData(JS::Realm& incumbent_realm, OwnPtr<JS::ExecutionContext> active_script_context)
+        : incumbent_realm(incumbent_realm)
         , active_script_context(move(active_script_context))
     {
     }
 
     virtual ~WebEngineCustomJobCallbackData() override = default;
 
-    JS::NonnullGCPtr<HTML::EnvironmentSettingsObject> incumbent_settings;
+    JS::NonnullGCPtr<JS::Realm> incumbent_realm;
     OwnPtr<JS::ExecutionContext> active_script_context;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -210,7 +210,7 @@ JS::NonnullGCPtr<WebIDL::Promise> CSSStyleSheet::replace(String text)
 
     // 4. In parallel, do these steps:
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, this, text = move(text), promise = JS::Handle(promise)] {
-        HTML::TemporaryExecutionContext execution_context { HTML::relevant_settings_object(*this), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+        HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 1. Let rules be the result of running parse a stylesheet’s contents from text.
         auto context = m_style_sheet_list ? CSS::Parser::ParsingContext { m_style_sheet_list->document() } : CSS::Parser::ParsingContext { realm };

--- a/Userland/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -120,7 +120,7 @@ CSSTransition::CSSTransition(JS::Realm& realm, DOM::Element& element, PropertyID
     element.associate_with_animation(*this);
     element.set_transition(m_transition_property, *this);
 
-    HTML::TemporaryExecutionContext context(element.document().relevant_settings_object());
+    HTML::TemporaryExecutionContext context(realm);
     play().release_value_but_fixme_should_propagate_errors();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -130,7 +130,7 @@ JS::NonnullGCPtr<FontFace> FontFace::construct_impl(JS::Realm& realm, String fam
 
         font->m_font_load_promise->when_resolved([font = JS::make_handle(font)](auto const& vector_font) -> ErrorOr<void> {
             HTML::queue_global_task(HTML::Task::Source::FontLoading, HTML::relevant_global_object(*font), JS::create_heap_function(font->heap(), [font = JS::NonnullGCPtr(*font), vector_font] {
-                HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*font), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+                HTML::TemporaryExecutionContext context(font->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
                 // 1. If the load was successful, font face now represents the parsed font;
                 //    fulfill font face’s [[FontStatusPromise]] with font face, and set its status attribute to "loaded".
 
@@ -147,7 +147,7 @@ JS::NonnullGCPtr<FontFace> FontFace::construct_impl(JS::Realm& realm, String fam
         });
         font->m_font_load_promise->when_rejected([font = JS::make_handle(font)](auto const& error) {
             HTML::queue_global_task(HTML::Task::Source::FontLoading, HTML::relevant_global_object(*font), JS::create_heap_function(font->heap(), [font = JS::NonnullGCPtr(*font), error = Error::copy(error)] {
-                HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*font), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+                HTML::TemporaryExecutionContext context(font->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
                 // 2. Otherwise, reject font face’s [[FontStatusPromise]] with a DOMException named "SyntaxError"
                 //    and set font face’s status attribute to "error".
                 font->m_status = Bindings::FontFaceLoadStatus::Error;
@@ -356,7 +356,7 @@ void FontFace::load_font_source()
         // 5. When the load operation completes, successfully or not, queue a task to run the following steps synchronously:
         auto on_error = [font] {
             HTML::queue_global_task(HTML::Task::Source::FontLoading, HTML::relevant_global_object(*font), JS::create_heap_function(font->heap(), [font = JS::NonnullGCPtr(*font)] {
-                HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*font), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+                HTML::TemporaryExecutionContext context(font->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
                 //     1. If the attempt to load fails, reject font face’s [[FontStatusPromise]] with a DOMException whose name
                 //        is "NetworkError" and set font face’s status attribute to "error".
@@ -370,7 +370,7 @@ void FontFace::load_font_source()
         auto on_load = [font](FontLoader const& loader) {
             // FIXME: We are assuming that the font loader will live as long as the document! This is an unsafe capture
             HTML::queue_global_task(HTML::Task::Source::FontLoading, HTML::relevant_global_object(*font), JS::create_heap_function(font->heap(), [font = JS::NonnullGCPtr(*font), &loader] {
-                HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*font), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+                HTML::TemporaryExecutionContext context(font->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
                 // 2. Otherwise, font face now represents the loaded font; fulfill font face’s [[FontStatusPromise]] with font face
                 //    and set font face’s status attribute to "loaded".

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -241,7 +241,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> FontFaceSet::load(Strin
         //    reject promise with a SyntaxError exception and terminate these steps.
         auto result = find_matching_font_faces(realm, font_face_set, font, text);
         if (result.is_error()) {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
             WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
             return;
         }
@@ -262,16 +262,16 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> FontFaceSet::load(Strin
 
             // 2. Resolve promise with the result of waiting for all of the [[FontStatusPromise]]s of each font face in
             //    the font face list, in order.
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             WebIDL::wait_for_all(
                 realm, promises,
                 [&realm, promise](auto const&) {
-                    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+                    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
                     WebIDL::resolve_promise(realm, promise);
                 },
                 [&realm, promise](auto error) {
-                    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+                    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
                     WebIDL::reject_promise(realm, promise, error);
                 });
         }));

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1140,10 +1140,10 @@ static void apply_animation_properties(DOM::Document& document, StyleProperties&
 
     if (play_state != effect.last_css_animation_play_state()) {
         if (play_state == CSS::AnimationPlayState::Running && animation.play_state() == Bindings::AnimationPlayState::Paused) {
-            HTML::TemporaryExecutionContext context(document.relevant_settings_object());
+            HTML::TemporaryExecutionContext context(document.realm());
             animation.play().release_value_but_fixme_should_propagate_errors();
         } else if (play_state == CSS::AnimationPlayState::Paused && animation.play_state() != Bindings::AnimationPlayState::Paused) {
-            HTML::TemporaryExecutionContext context(document.relevant_settings_object());
+            HTML::TemporaryExecutionContext context(document.realm());
             animation.pause().release_value_but_fixme_should_propagate_errors();
         }
 
@@ -1561,7 +1561,7 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
                 effect->set_target(&element);
                 element.set_cached_animation_name_animation(animation, pseudo_element);
 
-                HTML::TemporaryExecutionContext context(m_document->relevant_settings_object());
+                HTML::TemporaryExecutionContext context(realm);
                 animation->play().release_value_but_fixme_should_propagate_errors();
             } else {
                 // The animation hasn't changed, but some properties of the animation may have

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -160,7 +160,7 @@ JS::NonnullGCPtr<WebIDL::Promise> Clipboard::write_text(String data)
             // 1. Queue a global task on the permission task source, given realm’s global object, to reject p with
             //    "NotAllowedError" DOMException in realm.
             queue_global_task(HTML::Task::Source::Permissions, realm.global_object(), JS::create_heap_function(realm.heap(), [&realm, promise]() mutable {
-                HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+                HTML::TemporaryExecutionContext execution_context { realm };
                 WebIDL::reject_promise(realm, promise, WebIDL::NotAllowedError::create(realm, "Clipboard writing is only allowed through user activation"_string));
             }));
 
@@ -188,7 +188,7 @@ JS::NonnullGCPtr<WebIDL::Promise> Clipboard::write_text(String data)
             write_blobs_and_option_to_clipboard(realm, item_list, move(option));
 
             // 6. Resolve p.
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+            HTML::TemporaryExecutionContext execution_context { realm };
             WebIDL::resolve_promise(realm, promise, JS::js_undefined());
         }));
     }));

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -148,7 +148,7 @@ JS::NonnullGCPtr<WebIDL::Promise> SubtleCrypto::encrypt(AlgorithmIdentifier cons
     // 6. Return promise and perform the remaining steps in parallel.
 
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, normalized_algorithm = normalized_algorithm.release_value(), promise, key, data = move(data)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 7. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
@@ -205,7 +205,7 @@ JS::NonnullGCPtr<WebIDL::Promise> SubtleCrypto::decrypt(AlgorithmIdentifier cons
     // 6. Return promise and perform the remaining steps in parallel.
 
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, normalized_algorithm = normalized_algorithm.release_value(), promise, key, data = move(data)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 7. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
@@ -263,7 +263,7 @@ JS::NonnullGCPtr<WebIDL::Promise> SubtleCrypto::digest(AlgorithmIdentifier const
 
     // 6. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, algorithm_object = normalized_algorithm.release_value(), promise, data_buffer = move(data_buffer)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 7. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
         // FIXME: Need spec reference to https://webidl.spec.whatwg.org/#reject
 
@@ -303,7 +303,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::generate_
 
     // 5. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, normalized_algorithm = normalized_algorithm.release_value(), promise, extractable, key_usages = move(key_usages)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 6. If the following steps or referenced procedures say to throw an error, reject promise with
         //    the returned error and then terminate the algorithm.
 
@@ -385,7 +385,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::import_ke
 
     // 8. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(heap(), [&realm, real_key_data = move(real_key_data), normalized_algorithm = normalized_algorithm.release_value(), promise, format, extractable, key_usages = move(key_usages), algorithm = move(algorithm)]() mutable -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
         // 9. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
@@ -429,7 +429,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::export_ke
 
     // 3. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(heap(), [&realm, key, promise, format]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 4.  If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 5. If the name member of the [[algorithm]] internal slot of key does not identify a registered algorithm that supports the export key operation,
@@ -492,7 +492,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::sign(Algo
     // 6. Return promise and perform the remaining steps in parallel.
 
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, normalized_algorithm = normalized_algorithm.release_value(), promise, key, data = move(data)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 7. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 8. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
@@ -556,7 +556,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::verify(Al
 
     // 7. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, normalized_algorithm = normalized_algorithm.release_value(), promise, key, signature = move(signature), data = move(data)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 8. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 9. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of key then throw an InvalidAccessError.
@@ -603,7 +603,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::derive_bi
 
     // 5. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, normalized_algorithm = normalized_algorithm.release_value(), promise, base_key, length]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 6. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 7. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of baseKey then throw an InvalidAccessError.
@@ -664,7 +664,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::derive_ke
 
     // 9. Return promise and perform the remaining steps in parallel.
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, &vm, normalized_algorithm = normalized_algorithm.release_value(), promise, normalized_derived_key_algorithm_import = normalized_derived_key_algorithm_import.release_value(), normalized_derived_key_algorithm_length = normalized_derived_key_algorithm_length.release_value(), base_key = move(base_key), extractable, key_usages = move(key_usages)]() -> void {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 10. If the following steps or referenced procedures say to throw an error, reject promise with the returned error and then terminate the algorithm.
 
         // 11. If the name member of normalizedAlgorithm is not equal to the name attribute of the [[algorithm]] internal slot of baseKey then throw an InvalidAccessError.

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -190,7 +190,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> consume_body(JS::Realm& r
     // NOTE: `promise` and `realm` is protected by JS::HeapFunction.
     auto error_steps = JS::create_heap_function(realm.heap(), [promise, &realm](JS::Value error) {
         // AD-HOC: An execution context is required for Promise's reject function.
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+        HTML::TemporaryExecutionContext execution_context { realm };
         WebIDL::reject_promise(realm, promise, error);
     });
 
@@ -202,7 +202,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> consume_body(JS::Realm& r
         auto& vm = realm.vm();
 
         // AD-HOC: An execution context is required for Promise's reject function and JSON.parse.
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+        HTML::TemporaryExecutionContext execution_context { realm };
 
         auto value_or_error = Bindings::throw_dom_exception_if_needed(vm, [&]() -> WebIDL::ExceptionOr<JS::Value> {
             return package_data(realm, data, type, object.mime_type_impl());

--- a/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -38,7 +38,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> safely_extract_body(JS::Realm&
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract
 WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm, BodyInitOrReadableBytes const& object, bool keepalive)
 {
-    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
     auto& vm = realm.vm();
 
@@ -146,7 +146,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
     // 12. If action is non-null, then run these steps in parallel:
     if (action) {
         Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, stream, action = move(action)] {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             // 1. Run action.
             auto bytes = action();

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -87,7 +87,7 @@ JS::NonnullGCPtr<WebIDL::Promise> fetch(JS::VM& vm, RequestInfo const& input, Re
             return;
 
         // AD-HOC: An execution context is required for Promise functions.
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(relevant_realm) };
+        HTML::TemporaryExecutionContext execution_context { relevant_realm };
 
         // 2. If response’s aborted flag is set, then:
         if (response->aborted()) {
@@ -143,7 +143,7 @@ JS::NonnullGCPtr<WebIDL::Promise> fetch(JS::VM& vm, RequestInfo const& input, Re
         controller->abort(relevant_realm, request_object->signal()->reason());
 
         // AD-HOC: An execution context is required for Promise functions.
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(relevant_realm) };
+        HTML::TemporaryExecutionContext execution_context { relevant_realm };
 
         // 4. Abort the fetch() call with p, request, responseObject, and requestObject’s signal’s abort reason.
         abort_fetch(relevant_realm, *promise_capability, request, response_object, request_object->signal()->reason());

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -66,7 +66,7 @@ void FetchedDataReceiver::on_data_received(ReadonlyBytes bytes)
         m_fetch_params->controller(),
         m_fetch_params->task_destination().get<JS::NonnullGCPtr<JS::Object>>(),
         JS::create_heap_function(heap(), [this, bytes = MUST(ByteBuffer::copy(bytes))]() mutable {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_stream->realm()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { m_stream->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             // 1. Pull from bytes buffer into stream.
             if (auto result = Streams::readable_stream_pull_from_bytes(m_stream, move(bytes)); result.is_error()) {

--- a/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -723,7 +723,7 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
     }
     // 7. Otherwise:
     else {
-        HTML::TemporaryExecutionContext const execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+        HTML::TemporaryExecutionContext const execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 1. Let transformStream be a new TransformStream.
         auto transform_stream = realm.heap().allocate<Streams::TransformStream>(realm, realm);
@@ -2232,7 +2232,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
     //        user-agent-defined limit (or not). However, we will need to fully use stream operations throughout the
     //        fetch process to enable this (e.g. Body::fully_read must use streams for this to work).
     if (request->buffer_policy() == Infrastructure::Request::BufferPolicy::DoNotBufferResponse) {
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+        HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 12. Let stream be a new ReadableStream.
         auto stream = realm.heap().allocate<Streams::ReadableStream>(realm, realm);
@@ -2315,7 +2315,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PendingResponse>> nonstandard_resource_load
         });
 
         auto on_complete = JS::create_heap_function(vm.heap(), [&vm, &realm, pending_response, stream](bool success, Optional<StringView> error_message) {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             // 16.1.1.2. Otherwise, if the bytes transmission for response’s message body is done normally and stream is readable,
             //           then close stream, and abort these in-parallel steps.

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -49,7 +49,7 @@ void Body::visit_edges(Cell::Visitor& visitor)
 // https://fetch.spec.whatwg.org/#concept-body-clone
 JS::NonnullGCPtr<Body> Body::clone(JS::Realm& realm)
 {
-    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
     // To clone a body body, run these steps:
     // 1. Let « out1, out2 » be the result of teeing body’s stream.
@@ -107,7 +107,7 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
 // https://fetch.spec.whatwg.org/#body-incrementally-read
 void Body::incrementally_read(ProcessBodyChunkCallback process_body_chunk, ProcessEndOfBodyCallback process_end_of_body, ProcessBodyErrorCallback process_body_error, TaskDestination task_destination)
 {
-    HTML::TemporaryExecutionContext const execution_context { Bindings::host_defined_environment_settings_object(m_stream->realm()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    HTML::TemporaryExecutionContext const execution_context { m_stream->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
     VERIFY(task_destination.has<JS::NonnullGCPtr<JS::Object>>());
     // FIXME: 1. If taskDestination is null, then set taskDestination to the result of starting a new parallel queue.

--- a/Userland/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Infrastructure/IncrementalReadLoopReadRequest.cpp
@@ -33,7 +33,7 @@ void IncrementalReadLoopReadRequest::on_chunk(JS::Value chunk)
         auto bytes = MUST(ByteBuffer::copy(uint8_array.data()));
         // 2. Set continueAlgorithm to these steps:
         continue_algorithm = JS::create_heap_function(realm.heap(), [bytes = move(bytes), body = m_body, reader = m_reader, task_destination = m_task_destination, process_body_chunk = m_process_body_chunk, process_end_of_body = m_process_end_of_body, process_body_error = m_process_body_error] {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(reader->realm()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { reader->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
             // 1. Run processBodyChunk given bytes.
             process_body_chunk->function()(move(bytes));
 

--- a/Userland/Libraries/LibWeb/FileAPI/FileReader.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/FileReader.cpp
@@ -147,7 +147,7 @@ WebIDL::ExceptionOr<void> FileReader::read_operation(Blob& blob, Type type, Opti
 
     // 10. In parallel, while true:
     Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(heap(), [this, chunk_promise, reader, bytes, is_first_chunk, &realm, type, encoding_name, blobs_type]() mutable {
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+        HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
         Optional<MonotonicTime> progress_timer;
 
         while (true) {

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -397,7 +397,7 @@ void EventLoop::update_the_rendering()
 
     for (auto& document : docs) {
         if (document->readiness() == HTML::DocumentReadyState::Complete && document->style_computer().number_of_css_font_faces_with_loading_in_progress() == 0) {
-            HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*document), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+            HTML::TemporaryExecutionContext context(document->realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
             document->fonts()->resolve_ready_promise();
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -296,7 +296,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> HTMLImageElement::decode(
                 return false;
 
             auto exception = WebIDL::EncodingError::create(realm, "Node document not fully active"_string);
-            HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*this));
+            HTML::TemporaryExecutionContext context(realm);
             WebIDL::reject_promise(realm, promise, exception);
             return true;
         };
@@ -306,7 +306,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> HTMLImageElement::decode(
                 return false;
 
             auto exception = WebIDL::EncodingError::create(realm, "Current request state is broken"_string);
-            HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*this));
+            HTML::TemporaryExecutionContext context(realm);
             WebIDL::reject_promise(realm, promise, exception);
             return true;
         };
@@ -354,7 +354,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> HTMLImageElement::decode(
                 // (Typically, this would only be violated in low-memory situations that require evicting decoded image data, or when the image is too large
                 // to keep in decoded form for this period of time.)
 
-                HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*this));
+                HTML::TemporaryExecutionContext context(realm);
                 WebIDL::resolve_promise(realm, promise, JS::js_undefined());
             }
         }));

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -375,7 +375,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::pause()
 WebIDL::ExceptionOr<void> HTMLMediaElement::toggle_playback()
 {
     // AD-HOC: An execution context is required for Promise creation hooks.
-    TemporaryExecutionContext execution_context { document().relevant_settings_object() };
+    TemporaryExecutionContext execution_context { realm() };
 
     if (potentially_playing())
         TRY(pause());
@@ -1886,7 +1886,7 @@ void HTMLMediaElement::resolve_pending_play_promises(ReadonlySpan<JS::NonnullGCP
     auto& realm = this->realm();
 
     // AD-HOC: An execution context is required for Promise resolving hooks.
-    TemporaryExecutionContext execution_context { document().relevant_settings_object() };
+    TemporaryExecutionContext execution_context { realm };
 
     // To resolve pending play promises for a media element with a list of promises promises, the user agent
     // must resolve each promise in promises with undefined.
@@ -1900,7 +1900,7 @@ void HTMLMediaElement::reject_pending_play_promises(ReadonlySpan<JS::NonnullGCPt
     auto& realm = this->realm();
 
     // AD-HOC: An execution context is required for Promise rejection hooks.
-    TemporaryExecutionContext execution_context { document().relevant_settings_object() };
+    TemporaryExecutionContext execution_context { realm };
 
     // To reject pending play promises for a media element with a list of promise promises and an exception name
     // error, the user agent must reject each promise in promises with error.

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -159,6 +159,7 @@ void HTMLScriptElement::execute_script()
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#prepare-a-script
+// https://whatpr.org/html/9893/scripting.html#prepare-a-script
 void HTMLScriptElement::prepare_script()
 {
     // 1. If el's already started is true, then return.
@@ -433,9 +434,9 @@ void HTMLScriptElement::prepare_script()
         // 2. Switch on el's type:
         // -> "classic"
         if (m_script_type == ScriptType::Classic) {
-            // 1. Let script be the result of creating a classic script using source text, settings object, base URL, and options.
+            // 1. Let script be the result of creating a classic script using source text, settings object's realm, base URL, and options.
             // FIXME: Pass options.
-            auto script = ClassicScript::create(m_document->url().to_byte_string(), source_text, settings_object, base_url, m_source_line_number);
+            auto script = ClassicScript::create(m_document->url().to_byte_string(), source_text, settings_object.realm(), base_url, m_source_line_number);
 
             // 2. Mark as ready el given script.
             mark_as_ready(Result(move(script)));

--- a/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Userland/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -380,7 +380,7 @@ void MessagePort::post_message_task_steps(SerializedTransferRecord& serialize_wi
     auto& target_vm = target_realm.vm();
 
     // 3. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-    TemporaryExecutionContext context { relevant_settings_object(*final_target_port) };
+    TemporaryExecutionContext context { relevant_realm(*final_target_port) };
     auto deserialize_record_or_error = structured_deserialize_with_transfer(target_vm, serialize_with_transfer_result);
     if (deserialize_record_or_error.is_error()) {
         // If this throws an exception, catch it, fire an event named messageerror at finalTargetPort, using MessageEvent, and then return.

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1583,6 +1583,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(URL::URL const& url,
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#evaluate-a-javascript:-url
+// https://whatpr.org/html/9893/browsing-the-web.html#evaluate-a-javascript:-url
 WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> Navigable::evaluate_javascript_url(URL::URL const& url, URL::Origin const& new_document_origin, String navigation_id)
 {
     auto& vm = this->vm();
@@ -1604,8 +1605,8 @@ WebIDL::ExceptionOr<JS::GCPtr<DOM::Document>> Navigable::evaluate_javascript_url
     // 5. Let baseURL be settings's API base URL.
     auto base_url = settings.api_base_url();
 
-    // 6. Let script be the result of creating a classic script given scriptSource, settings, baseURL, and the default classic script fetch options.
-    auto script = HTML::ClassicScript::create("(javascript url)", script_source, settings, base_url);
+    // 6. Let script be the result of creating a classic script given scriptSource, settings's realm, baseURL, and the default classic script fetch options.
+    auto script = HTML::ClassicScript::create("(javascript url)", script_source, settings.realm(), base_url);
 
     // 7. Let evaluationStatus be the result of running the classic script script.
     auto evaluation_status = script->run();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -20,9 +20,8 @@ JS_DEFINE_ALLOCATOR(ClassicScript);
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-classic-script
 // https://whatpr.org/html/9893/webappapis.html#creating-a-classic-script
-JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, StringView source, EnvironmentSettingsObject& environment_settings_object, URL::URL base_url, size_t source_line_number, MutedErrors muted_errors)
+JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, StringView source, JS::Realm& realm, URL::URL base_url, size_t source_line_number, MutedErrors muted_errors)
 {
-    auto& realm = environment_settings_object.realm();
     auto& vm = realm.vm();
 
     // 1. If muted errors is true, then set baseURL to about:blank.
@@ -34,11 +33,9 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
         source = ""sv;
 
     // 3. Let script be a new classic script that this algorithm will subsequently initialize.
-    auto script = vm.heap().allocate_without_realm<ClassicScript>(move(base_url), move(filename), environment_settings_object);
-
-    // FIXME: 4. Set script's realm to realm. (NOTE: This was already done when constructing.)
-
-    // 5. Set script's base URL to baseURL. (NOTE: This was already done when constructing.)
+    // 4. Set script's realm to realm.
+    // 5. Set script's base URL to baseURL.
+    auto script = vm.heap().allocate_without_realm<ClassicScript>(move(base_url), move(filename), realm);
 
     // FIXME: 6. Set script's fetch options to options.
 
@@ -80,11 +77,10 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
 // https://whatpr.org/html/9893/webappapis.html#run-a-classic-script
 JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
 {
-    // 1. Let settings be the settings object of script.
-    auto& settings = settings_object();
-    auto& realm = settings.realm();
+    // 1. Let realm be the realm of script.
+    auto& realm = this->realm();
 
-    // 2. Check if we can run script with settings. If this returns "do not run" then return NormalCompletion(empty).
+    // 2. Check if we can run script with realm. If this returns "do not run" then return NormalCompletion(empty).
     if (can_run_script(realm) == RunScriptDecision::DoNotRun)
         return JS::normal_completion({});
 
@@ -131,8 +127,8 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
         // 3. Otherwise, rethrow errors is false. Perform the following steps:
         VERIFY(rethrow_errors == RethrowErrors::No);
 
-        // 1. Report an exception given by evaluationStatus.[[Value]] for script's settings object's global object.
-        auto* window_or_worker = dynamic_cast<WindowOrWorkerGlobalScopeMixin*>(&settings.global_object());
+        // 1. Report an exception given by evaluationStatus.[[Value]] for realms's global object.
+        auto* window_or_worker = dynamic_cast<WindowOrWorkerGlobalScopeMixin*>(&realm.global_object());
         VERIFY(window_or_worker);
         window_or_worker->report_an_exception(*evaluation_status.value());
 
@@ -154,8 +150,8 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
     //            Return Completion { [[Type]]: throw, [[Value]]: a new "QuotaExceededError" DOMException, [[Target]]: empty }.
 }
 
-ClassicScript::ClassicScript(URL::URL base_url, ByteString filename, EnvironmentSettingsObject& environment_settings_object)
-    : Script(move(base_url), move(filename), environment_settings_object)
+ClassicScript::ClassicScript(URL::URL base_url, ByteString filename, JS::Realm& realm)
+    : Script(move(base_url), move(filename), realm)
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -24,7 +24,7 @@ public:
         No,
         Yes,
     };
-    static JS::NonnullGCPtr<ClassicScript> create(ByteString filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No);
+    static JS::NonnullGCPtr<ClassicScript> create(ByteString filename, StringView source, JS::Realm&, URL::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No);
 
     JS::Script* script_record() { return m_script_record; }
     JS::Script const* script_record() const { return m_script_record; }
@@ -38,7 +38,7 @@ public:
     MutedErrors muted_errors() const { return m_muted_errors; }
 
 private:
-    ClassicScript(URL::URL base_url, ByteString filename, EnvironmentSettingsObject& environment_settings_object);
+    ClassicScript(URL::URL base_url, ByteString filename, JS::Realm&);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -286,6 +286,15 @@ void EnvironmentSettingsObject::disallow_further_import_maps()
     verify_cast<Window>(global).set_import_maps_allowed(false);
 }
 
+// https://whatpr.org/html/9893/webappapis.html#concept-realm-module-map
+ModuleMap& module_map_of_realm(JS::Realm& realm)
+{
+    // FIXME: 1. If realm is a principal realm, then return the module map of the environment settings object of realm.
+    // FIXME: 2. Assert: realm is a synthetic realm.
+    // FIXME: 3. Return the module map of the synthetic realm settings object of realm.
+    return principal_realm_settings_object(realm).module_map();
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#concept-incumbent-realm
 // https://whatpr.org/html/9893/b8ea975...df5706b/webappapis.html#concept-incumbent-realm
 JS::Realm& incumbent_realm()

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -347,12 +347,19 @@ JS::Realm& principal_realm(JS::Realm& realm)
     return realm;
 }
 
+// https://whatpr.org/html/9893/webappapis.html#concept-realm-settings-object
+EnvironmentSettingsObject& principal_realm_settings_object(JS::Realm& realm)
+{
+    // A principal realm has a [[HostDefined]] field, which contains the principal realm's settings object.
+    return Bindings::host_defined_environment_settings_object(realm);
+}
+
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object
 // https://whatpr.org/html/9893/webappapis.html#current-principal-settings-object
 EnvironmentSettingsObject& current_principal_settings_object()
 {
     // Then, the current principal settings object is the environment settings object of the current principal realm.
-    return Bindings::host_defined_environment_settings_object(current_principal_realm());
+    return principal_realm_settings_object(current_principal_realm());
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -260,23 +260,25 @@ bool is_scripting_disabled(JS::Realm const& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#module-type-allowed
-bool EnvironmentSettingsObject::module_type_allowed(StringView module_type) const
+// https://whatpr.org/html/9893/webappapis.html#module-type-allowed
+bool module_type_allowed(JS::Realm const&, StringView module_type)
 {
     // 1. If moduleType is not "javascript", "css", or "json", then return false.
     if (module_type != "javascript"sv && module_type != "css"sv && module_type != "json"sv)
         return false;
 
-    // FIXME: 2. If moduleType is "css" and the CSSStyleSheet interface is not exposed in settings's Realm, then return false.
+    // FIXME: 2. If moduleType is "css" and the CSSStyleSheet interface is not exposed in realm, then return false.
 
     // 3. Return true.
     return true;
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#disallow-further-import-maps
-void EnvironmentSettingsObject::disallow_further_import_maps()
+// https://whatpr.org/html/9893/webappapis.html#disallow-further-import-maps
+void disallow_further_import_maps(JS::Realm& realm)
 {
-    // 1. Let global be settingsObject's global object.
-    auto& global = global_object();
+    // 1. Let global be realm's global object.
+    auto& global = realm.global_object();
 
     // 2. If global does not implement Window, then return.
     if (!is<Window>(global))

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -329,11 +329,22 @@ JS::Object& incumbent_global_object()
 // https://whatpr.org/html/9893/webappapis.html#current-principal-realm
 JS::Realm& current_principal_realm()
 {
-    // FIXME: The current principal realm is the principal realm of the current realm.
     auto& event_loop = HTML::main_thread_event_loop();
     auto& vm = event_loop.vm();
 
-    return *vm.current_realm();
+    // The current principal realm is the principal realm of the current realm.
+    return principal_realm(*vm.current_realm());
+}
+
+// https://whatpr.org/html/9893/webappapis.html#concept-principal-realm-of-realm
+JS::Realm& principal_realm(JS::Realm& realm)
+{
+    // FIXME: 1. If realm.[[HostDefined]] is a synthetic realm settings object, then:
+    // FIXME: 1.1. Assert: realm is a synthetic realm.
+    // FIXME: 1.2. Set realm to the principal realm of realm.[[HostDefined]].
+    // FIXME: 2. Assert: realm.[[HostDefined]] is an environment settings object and realm is a principal realm.
+    // 3. Return realm.
+    return realm;
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -96,10 +96,6 @@ public:
     // https://fetch.spec.whatwg.org/#concept-fetch-group
     Vector<JS::NonnullGCPtr<Fetch::Infrastructure::FetchRecord>>& fetch_group() { return m_fetch_group; }
 
-    bool module_type_allowed(StringView module_type) const;
-
-    void disallow_further_import_maps();
-
     SerializedEnvironmentSettingsObject serialize();
 
     JS::NonnullGCPtr<StorageAPI::StorageManager> storage_manager();
@@ -142,6 +138,8 @@ void clean_up_after_running_script(JS::Realm const&);
 void prepare_to_run_callback(JS::Realm&);
 void clean_up_after_running_callback(JS::Realm const&);
 ModuleMap& module_map_of_realm(JS::Realm&);
+bool module_type_allowed(JS::Realm const&, StringView module_type);
+void disallow_further_import_maps(JS::Realm&);
 
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -147,6 +147,7 @@ JS::Realm& incumbent_realm();
 JS::Object& incumbent_global_object();
 
 JS::Realm& current_principal_realm();
+EnvironmentSettingsObject& principal_realm_settings_object(JS::Realm&);
 EnvironmentSettingsObject& current_principal_settings_object();
 
 JS::Realm& principal_realm(JS::Realm&);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -149,6 +149,7 @@ JS::Object& incumbent_global_object();
 JS::Realm& current_principal_realm();
 EnvironmentSettingsObject& current_principal_settings_object();
 
+JS::Realm& principal_realm(JS::Realm&);
 JS::Object& current_principal_global_object();
 JS::Realm& relevant_realm(JS::Object const&);
 EnvironmentSettingsObject& relevant_settings_object(JS::Object const&);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -141,6 +141,7 @@ void prepare_to_run_script(JS::Realm&);
 void clean_up_after_running_script(JS::Realm const&);
 void prepare_to_run_callback(JS::Realm&);
 void clean_up_after_running_callback(JS::Realm const&);
+ModuleMap& module_map_of_realm(JS::Realm&);
 
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Fetching.h
@@ -96,12 +96,12 @@ WebIDL::ExceptionOr<void> fetch_worklet_module_worker_script_graph(URL::URL cons
 void fetch_internal_module_script_graph(JS::Realm&, JS::ModuleRequest const& module_request, EnvironmentSettingsObject& fetch_client_settings_object, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, Script& referring_script, HashTable<ModuleLocationTuple> const& visited_set, PerformTheFetchHook, OnFetchScriptComplete on_complete);
 void fetch_external_module_script_graph(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& settings_object, ScriptFetchOptions const&, OnFetchScriptComplete on_complete);
 void fetch_inline_module_script_graph(JS::Realm&, ByteString const& filename, ByteString const& source_text, URL::URL const& base_url, EnvironmentSettingsObject& settings_object, OnFetchScriptComplete on_complete);
-void fetch_single_imported_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, EnvironmentSettingsObject& settings_object, Fetch::Infrastructure::Request::ReferrerType, JS::ModuleRequest const&, PerformTheFetchHook, OnFetchScriptComplete on_complete);
+void fetch_single_imported_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, JS::Realm& module_map_realm, Fetch::Infrastructure::Request::ReferrerType, JS::ModuleRequest const&, PerformTheFetchHook, OnFetchScriptComplete on_complete);
 
 void fetch_descendants_of_a_module_script(JS::Realm&, JavaScriptModuleScript& module_script, EnvironmentSettingsObject& fetch_client_settings_object, Fetch::Infrastructure::Request::Destination, HashTable<ModuleLocationTuple> visited_set, PerformTheFetchHook, OnFetchScriptComplete callback);
 void fetch_descendants_of_and_link_a_module_script(JS::Realm&, JavaScriptModuleScript&, EnvironmentSettingsObject&, Fetch::Infrastructure::Request::Destination, PerformTheFetchHook, OnFetchScriptComplete on_complete);
 
 Fetch::Infrastructure::Request::Destination fetch_destination_from_module_type(Fetch::Infrastructure::Request::Destination, ByteString const&);
 
-void fetch_single_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, EnvironmentSettingsObject& settings_object, Web::Fetch::Infrastructure::Request::ReferrerType const&, Optional<JS::ModuleRequest> const&, TopLevelModule, PerformTheFetchHook, OnFetchScriptComplete callback);
+void fetch_single_module_script(JS::Realm&, URL::URL const&, EnvironmentSettingsObject& fetch_client, Fetch::Infrastructure::Request::Destination, ScriptFetchOptions const&, JS::Realm& module_map_realm, Web::Fetch::Infrastructure::Request::ReferrerType const&, Optional<JS::ModuleRequest> const&, TopLevelModule, PerformTheFetchHook, OnFetchScriptComplete callback);
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ImportMap.cpp
@@ -18,7 +18,7 @@ namespace Web::HTML {
 // https://html.spec.whatwg.org/multipage/webappapis.html#parse-an-import-map-string
 WebIDL::ExceptionOr<ImportMap> parse_import_map_string(JS::Realm& realm, ByteString const& input, URL::URL base_url)
 {
-    HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm) };
+    HTML::TemporaryExecutionContext execution_context { realm };
 
     // 1. Let parsed be the result of parsing a JSON string to an Infra value given input.
     auto parsed = TRY(Infra::parse_json_string_to_javascript_value(realm, input));

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ModuleScript.h
@@ -19,7 +19,7 @@ public:
     virtual ~ModuleScript() override;
 
 protected:
-    ModuleScript(URL::URL base_url, ByteString filename, EnvironmentSettingsObject& environment_settings_object);
+    ModuleScript(URL::URL base_url, ByteString filename, JS::Realm&);
 };
 
 class JavaScriptModuleScript final : public ModuleScript {
@@ -29,7 +29,7 @@ class JavaScriptModuleScript final : public ModuleScript {
 public:
     virtual ~JavaScriptModuleScript() override;
 
-    static WebIDL::ExceptionOr<JS::GCPtr<JavaScriptModuleScript>> create(ByteString const& filename, StringView source, EnvironmentSettingsObject&, URL::URL base_url);
+    static WebIDL::ExceptionOr<JS::GCPtr<JavaScriptModuleScript>> create(ByteString const& filename, StringView source, JS::Realm&, URL::URL base_url);
 
     enum class PreventErrorReporting {
         Yes,
@@ -42,7 +42,7 @@ public:
     JS::SourceTextModule* record() { return m_record.ptr(); }
 
 protected:
-    JavaScriptModuleScript(URL::URL base_url, ByteString filename, EnvironmentSettingsObject& environment_settings_object);
+    JavaScriptModuleScript(URL::URL base_url, ByteString filename, JS::Realm&);
 
 private:
     virtual void visit_edges(JS::Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.cpp
@@ -11,14 +11,21 @@ namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(Script);
 
-Script::Script(URL::URL base_url, ByteString filename, EnvironmentSettingsObject& environment_settings_object)
+Script::Script(URL::URL base_url, ByteString filename, JS::Realm& realm)
     : m_base_url(move(base_url))
     , m_filename(move(filename))
-    , m_settings_object(environment_settings_object)
+    , m_realm(realm)
 {
 }
 
 Script::~Script() = default;
+
+// https://whatpr.org/html/9893/webappapis.html#settings-object
+EnvironmentSettingsObject& Script::settings_object()
+{
+    // The settings object of a script is the settings object of the principal realm of the script's realm.
+    return principal_realm_settings_object(principal_realm(realm()));
+}
 
 void Script::visit_host_defined_self(JS::Cell::Visitor& visitor)
 {
@@ -28,7 +35,7 @@ void Script::visit_host_defined_self(JS::Cell::Visitor& visitor)
 void Script::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
-    visitor.visit(m_settings_object);
+    visitor.visit(m_realm);
     visitor.visit(m_parse_error);
     visitor.visit(m_error_to_rethrow);
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Script.h
@@ -14,6 +14,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script
+// https://whatpr.org/html/9893/webappapis.html#concept-script
 class Script
     : public JS::Cell
     , public JS::Script::HostDefined {
@@ -26,7 +27,8 @@ public:
     URL::URL const& base_url() const { return m_base_url; }
     ByteString const& filename() const { return m_filename; }
 
-    EnvironmentSettingsObject& settings_object() { return m_settings_object; }
+    JS::Realm& realm() { return m_realm; }
+    EnvironmentSettingsObject& settings_object();
 
     [[nodiscard]] JS::Value error_to_rethrow() const { return m_error_to_rethrow; }
     void set_error_to_rethrow(JS::Value value) { m_error_to_rethrow = value; }
@@ -35,7 +37,7 @@ public:
     void set_parse_error(JS::Value value) { m_parse_error = value; }
 
 protected:
-    Script(URL::URL base_url, ByteString filename, EnvironmentSettingsObject& environment_settings_object);
+    Script(URL::URL base_url, ByteString filename, JS::Realm&);
 
     virtual void visit_edges(Visitor&) override;
 
@@ -44,7 +46,7 @@ private:
 
     URL::URL m_base_url;
     ByteString m_filename;
-    JS::NonnullGCPtr<EnvironmentSettingsObject> m_settings_object;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-script-parse-error
     JS::Value m_parse_error;

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.cpp
@@ -9,20 +9,20 @@
 
 namespace Web::HTML {
 
-TemporaryExecutionContext::TemporaryExecutionContext(EnvironmentSettingsObject& environment_settings, CallbacksEnabled callbacks_enabled)
-    : m_environment_settings(environment_settings)
+TemporaryExecutionContext::TemporaryExecutionContext(JS::Realm& realm, CallbacksEnabled callbacks_enabled)
+    : m_realm(realm)
     , m_callbacks_enabled(callbacks_enabled)
 {
-    prepare_to_run_script(m_environment_settings->realm());
+    prepare_to_run_script(m_realm);
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
-        prepare_to_run_callback(m_environment_settings->realm());
+        prepare_to_run_callback(m_realm);
 }
 
 TemporaryExecutionContext::~TemporaryExecutionContext()
 {
-    clean_up_after_running_script(m_environment_settings->realm());
+    clean_up_after_running_script(m_realm);
     if (m_callbacks_enabled == CallbacksEnabled::Yes)
-        clean_up_after_running_callback(m_environment_settings->realm());
+        clean_up_after_running_callback(m_realm);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
@@ -21,11 +21,11 @@ public:
         Yes,
     };
 
-    explicit TemporaryExecutionContext(EnvironmentSettingsObject&, CallbacksEnabled = CallbacksEnabled::No);
+    explicit TemporaryExecutionContext(JS::Realm&, CallbacksEnabled = CallbacksEnabled::No);
     ~TemporaryExecutionContext();
 
 private:
-    JS::NonnullGCPtr<EnvironmentSettingsObject> m_environment_settings;
+    JS::NonnullGCPtr<JS::Realm> m_realm;
     CallbacksEnabled m_callbacks_enabled { CallbacksEnabled::No };
 };
 

--- a/Userland/Libraries/LibWeb/HTML/Window.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Window.cpp
@@ -1126,8 +1126,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         auto& source = verify_cast<WindowProxy>(incumbent_settings.realm().global_environment().global_this_value());
 
         // 4. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-        auto& settings_object = Bindings::host_defined_environment_settings_object(target_realm);
-        auto temporary_execution_context = TemporaryExecutionContext { settings_object };
+        auto temporary_execution_context = TemporaryExecutionContext { target_realm };
         auto deserialize_record_or_error = structured_deserialize_with_transfer(vm(), serialize_with_transfer_result);
 
         // If this throws an exception, catch it, fire an event named messageerror at targetWindow, using MessageEvent,

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -226,7 +226,7 @@ JS::NonnullGCPtr<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_b
                     // (e.g., a vector graphic with no natural size), then reject p with an "InvalidStateError" DOMException
                     // and abort these steps.
                     auto& realm = relevant_realm(p->promise());
-                    TemporaryExecutionContext context { relevant_settings_object(p->promise()), TemporaryExecutionContext::CallbacksEnabled::Yes };
+                    TemporaryExecutionContext context { relevant_realm(p->promise()), TemporaryExecutionContext::CallbacksEnabled::Yes };
                     WebIDL::reject_promise(realm, *p, WebIDL::InvalidStateError::create(realm, "image does not contain a supported image format"_string));
                 };
 
@@ -240,7 +240,7 @@ JS::NonnullGCPtr<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_b
                     auto& realm = relevant_realm(p->promise());
 
                     // 5. Resolve p with imageBitmap.
-                    TemporaryExecutionContext context { relevant_settings_object(*image_bitmap), TemporaryExecutionContext::CallbacksEnabled::Yes };
+                    TemporaryExecutionContext context { relevant_realm(*image_bitmap), TemporaryExecutionContext::CallbacksEnabled::Yes };
                     WebIDL::resolve_promise(realm, *p, image_bitmap);
                     return {};
                 };
@@ -253,7 +253,7 @@ JS::NonnullGCPtr<WebIDL::Promise> WindowOrWorkerGlobalScopeMixin::create_image_b
             (void)sx;
             (void)sy;
             auto error = JS::Error::create(realm, "Not Implemented: createImageBitmap() for non-blob types"sv);
-            TemporaryExecutionContext context { relevant_settings_object(p->promise()), TemporaryExecutionContext::CallbacksEnabled::Yes };
+            TemporaryExecutionContext context { relevant_realm(p->promise()), TemporaryExecutionContext::CallbacksEnabled::Yes };
             WebIDL::reject_promise(realm, *p, error);
         });
 
@@ -416,7 +416,7 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
     // 11. Let completionStep be an algorithm step which queues a global task on the timer task source given global to run task.
     Function<void()> completion_step = [this, task = move(task)]() mutable {
         queue_global_task(Task::Source::TimerTask, this_impl(), JS::create_heap_function(this_impl().heap(), [this, task] {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(this_impl().realm()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { this_impl().realm(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
             task->function()();
         }));
     };
@@ -587,7 +587,7 @@ void WindowOrWorkerGlobalScopeMixin::queue_the_performance_observer_task()
     //    timeline task source.
     queue_global_task(Task::Source::PerformanceTimeline, this_impl(), JS::create_heap_function(this_impl().heap(), [this]() {
         auto& realm = this_impl().realm();
-        HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+        HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
         // 1. Unset performance observer task queued flag of relevantGlobal.
         m_performance_observer_task_queued = false;

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -384,10 +384,10 @@ i32 WindowOrWorkerGlobalScopeMixin::run_timer_initialization_steps(TimerHandler 
                     //            done by eval(). That is, module script fetches via import() will behave the same in both contexts.
                 }
 
-                // 7. Let script be the result of creating a classic script given handler, settings object, base URL, and fetch options.
+                // 7. Let script be the result of creating a classic script given handler, realm, base URL, and fetch options.
                 // FIXME: Pass fetch options.
                 auto basename = base_url.basename();
-                auto script = ClassicScript::create(basename, source, settings_object, move(base_url));
+                auto script = ClassicScript::create(basename, source, this_impl().realm(), move(base_url));
 
                 // 8. Run the classic script script.
                 (void)script->run();

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -477,7 +477,7 @@ WebIDL::ExceptionOr<void> Page::toggle_media_play_state()
         return {};
 
     // AD-HOC: An execution context is required for Promise creation hooks.
-    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
+    HTML::TemporaryExecutionContext execution_context { media_element->realm() };
 
     if (media_element->potentially_playing())
         TRY(media_element->pause());
@@ -494,7 +494,7 @@ void Page::toggle_media_mute_state()
         return;
 
     // AD-HOC: An execution context is required for Promise creation hooks.
-    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
+    HTML::TemporaryExecutionContext execution_context { media_element->realm() };
 
     media_element->set_muted(!media_element->muted());
 }
@@ -506,7 +506,7 @@ WebIDL::ExceptionOr<void> Page::toggle_media_loop_state()
         return {};
 
     // AD-HOC: An execution context is required for Promise creation hooks.
-    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
+    HTML::TemporaryExecutionContext execution_context { media_element->realm() };
 
     if (media_element->has_attribute(HTML::AttributeNames::loop))
         media_element->remove_attribute(HTML::AttributeNames::loop);
@@ -522,7 +522,7 @@ WebIDL::ExceptionOr<void> Page::toggle_media_controls_state()
     if (!media_element)
         return {};
 
-    HTML::TemporaryExecutionContext execution_context { media_element->document().relevant_settings_object() };
+    HTML::TemporaryExecutionContext execution_context { media_element->realm() };
 
     if (media_element->has_attribute(HTML::AttributeNames::controls))
         media_element->remove_attribute(HTML::AttributeNames::controls);

--- a/Userland/Libraries/LibWeb/SVG/SVGScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGScriptElement.cpp
@@ -64,10 +64,9 @@ void SVGScriptElement::process_the_script_element()
         HTML::main_thread_event_loop().spin_until(JS::create_heap_function(heap(), [&] { return m_document->ready_to_run_scripts(); }));
 
     // FIXME: Support non-inline scripts.
-    auto& settings_object = document().relevant_settings_object();
     auto base_url = document().base_url();
 
-    m_script = HTML::ClassicScript::create(m_document->url().to_byte_string(), inline_script, settings_object, base_url, m_source_line_number);
+    m_script = HTML::ClassicScript::create(m_document->url().to_byte_string(), inline_script, realm(), base_url, m_source_line_number);
     (void)m_script->run();
 }
 

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -402,7 +402,7 @@ public:
     {
         // 1. Queue a microtask to perform the following steps:
         HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk]() {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+            HTML::TemporaryExecutionContext execution_context { m_realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             auto controller1 = m_params->branch1->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>();
             auto controller2 = m_params->branch2->controller()->get<JS::NonnullGCPtr<ReadableStreamDefaultController>>();
@@ -709,7 +709,7 @@ public:
     {
         // 1. Queue a microtask to perform the following steps:
         HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk]() mutable {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm) };
+            HTML::TemporaryExecutionContext execution_context { m_realm };
 
             auto controller1 = m_params->branch1->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>();
             auto controller2 = m_params->branch2->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>();
@@ -872,7 +872,7 @@ public:
 
         // 1. Queue a microtask to perform the following steps:
         HTML::queue_a_microtask(nullptr, JS::create_heap_function(m_realm->heap(), [this, chunk = chunk_view]() {
-            HTML::TemporaryExecutionContext execution_context { Bindings::host_defined_environment_settings_object(m_realm) };
+            HTML::TemporaryExecutionContext execution_context { m_realm };
 
             auto byob_controller = m_byob_branch->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>();
             auto other_controller = m_other_branch->controller()->get<JS::NonnullGCPtr<ReadableByteStreamController>>();

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -506,14 +506,14 @@ JS::NonnullGCPtr<WebIDL::Promise> asynchronously_compile_webassembly_module(JS::
     auto promise = WebIDL::create_promise(realm);
 
     // 2. Run the following steps in parallel:
-    Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(vm.heap(), [&vm, bytes = move(bytes), promise, task_source]() mutable {
-        HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*promise->promise()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+    Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(vm.heap(), [&vm, &realm, bytes = move(bytes), promise, task_source]() mutable {
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         // 1. Compile the WebAssembly module bytes and store the result as module.
         auto module_or_error = Detail::compile_a_webassembly_module(vm, move(bytes));
 
         // 2. Queue a task to perform the following steps. If taskSource was provided, queue the task on that task source.
-        HTML::queue_a_task(task_source, nullptr, nullptr, JS::create_heap_function(vm.heap(), [&vm, promise, module_or_error = move(module_or_error)]() mutable {
-            HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*promise->promise()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::queue_a_task(task_source, nullptr, nullptr, JS::create_heap_function(vm.heap(), [&vm, &realm, promise, module_or_error = move(module_or_error)]() mutable {
+            HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
             auto& realm = HTML::relevant_realm(*promise->promise());
 
             // 1. If module is error, reject promise with a CompileError exception.
@@ -554,8 +554,8 @@ JS::NonnullGCPtr<WebIDL::Promise> asynchronously_instantiate_webassembly_module(
 
     // 4. Run the following steps in parallel:
     //   1. Queue a task to perform the following steps: Note: Implementation-specific work may be performed here.
-    HTML::queue_a_task(HTML::Task::Source::Unspecified, nullptr, nullptr, JS::create_heap_function(vm.heap(), [&vm, promise, module, import_object]() {
-        HTML::TemporaryExecutionContext context(HTML::relevant_settings_object(*promise->promise()), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+    HTML::queue_a_task(HTML::Task::Source::Unspecified, nullptr, nullptr, JS::create_heap_function(vm.heap(), [&vm, &realm, promise, module, import_object]() {
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
         auto& realm = HTML::relevant_realm(*promise->promise());
 
         // 1. Instantiate the core of a WebAssembly module module with imports, and let instance be the result.

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -146,7 +146,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::resume()
     if (!start_rendering_audio_graph()) {
         // 7.4: In case of failure, queue a media element task to execute the following steps:
         queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, this]() {
-            HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+            HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
             // 7.4.1: Reject all promises from [[pending resume promises]] in order, then clear [[pending resume promises]].
             for (auto const& promise : m_pending_resume_promises) {
@@ -163,7 +163,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::resume()
 
     // 7.5: queue a media element task to execute the following steps:
     queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, promise, this]() {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
         // 7.5.1: Resolve all promises from [[pending resume promises]] in order.
         // 7.5.2: Clear [[pending resume promises]]. Additionally, remove those promises from
@@ -233,7 +233,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::suspend()
 
     // 7.3: queue a media element task to execute the following steps:
     queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, promise, this]() {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
         // 7.3.1: Resolve promise.
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
@@ -288,7 +288,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::close()
 
     // 5.4: queue a media element task to execute the following steps:
     queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, promise, this]() {
-        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+        HTML::TemporaryExecutionContext context(realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
 
         // 5.4.1: Resolve promise.
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -340,14 +340,14 @@ void execute_script(HTML::BrowsingContext const& browsing_context, ByteString bo
     }
 
     // AD-HOC: An execution context is required for Promise creation hooks.
-    HTML::TemporaryExecutionContext execution_context { document->relevant_settings_object(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
     // 7. Let promise be a new Promise.
     auto promise = WebIDL::create_promise(realm);
 
     // 8. Run the following substeps in parallel:
-    Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, &browsing_context, promise, document, body = move(body), arguments = move(arguments)]() mutable {
-        HTML::TemporaryExecutionContext execution_context { document->relevant_settings_object() };
+    Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&realm, &browsing_context, promise, body = move(body), arguments = move(arguments)]() mutable {
+        HTML::TemporaryExecutionContext execution_context { realm };
 
         // 1. Let scriptPromise be the result of promise-calling execute a function body, with arguments body and arguments.
         auto script_result = execute_a_function_body(browsing_context, body, move(arguments));
@@ -418,15 +418,15 @@ void execute_async_script(HTML::BrowsingContext const& browsing_context, ByteStr
     }
 
     // AD-HOC: An execution context is required for Promise creation hooks.
-    HTML::TemporaryExecutionContext execution_context { document->relevant_settings_object(), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
+    HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
     // 7. Let promise be a new Promise.
     auto promise_capability = WebIDL::create_promise(realm);
     JS::NonnullGCPtr promise { verify_cast<JS::Promise>(*promise_capability->promise()) };
 
     // 8. Run the following substeps in parallel:
-    Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&vm, &realm, &browsing_context, timer, document, promise_capability, promise, body = move(body), arguments = move(arguments)]() mutable {
-        HTML::TemporaryExecutionContext execution_context { document->relevant_settings_object() };
+    Platform::EventLoopPlugin::the().deferred_invoke(JS::create_heap_function(realm.heap(), [&vm, &realm, &browsing_context, timer, promise_capability, promise, body = move(body), arguments = move(arguments)]() mutable {
+        HTML::TemporaryExecutionContext execution_context { realm };
 
         // 1. Let resolvingFunctions be CreateResolvingFunctions(promise).
         auto resolving_functions = promise->create_resolving_functions();

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -728,10 +728,10 @@ void PageClient::run_javascript(ByteString const& js_source)
     // Let baseURL be settings's API base URL.
     auto base_url = settings.api_base_url();
 
-    // Let script be the result of creating a classic script given scriptSource, settings, baseURL, and the default classic script fetch options.
+    // Let script be the result of creating a classic script given scriptSource, setting's realm, baseURL, and the default classic script fetch options.
     // FIXME: This doesn't pass in "default classic script fetch options"
     // FIXME: What should the filename be here?
-    auto script = Web::HTML::ClassicScript::create("(client connection run_javascript)", js_source, settings, move(base_url));
+    auto script = Web::HTML::ClassicScript::create("(client connection run_javascript)", js_source, settings.realm(), move(base_url));
 
     // Let evaluationStatus be the result of running the classic script script.
     auto evaluation_status = script->run();

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -504,7 +504,7 @@ Messages::WebDriverClient::NewWindowResponse WebDriverConnection::new_window(Jso
     auto* active_window = current_browsing_context().active_window();
     VERIFY(active_window);
 
-    Web::HTML::TemporaryExecutionContext execution_context { active_window->document()->relevant_settings_object() };
+    Web::HTML::TemporaryExecutionContext execution_context { active_window->document()->realm() };
     auto [target_navigable, no_opener, window_type] = MUST(active_window->window_open_steps_internal("about:blank"sv, ""sv, "noopener"sv));
 
     // 6. Let handle be the associated window handle of the newly created window.
@@ -1175,7 +1175,7 @@ Messages::WebDriverClient::GetElementPropertyResponse WebDriverConnection::get_e
     Optional<ByteString> result;
 
     // 4. Let property be the result of calling the Object.[[GetProperty]](name) on element.
-    Web::HTML::TemporaryExecutionContext execution_context { current_browsing_context().active_document()->relevant_settings_object() };
+    Web::HTML::TemporaryExecutionContext execution_context { current_browsing_context().active_document()->realm() };
 
     if (auto property_or_error = element->get(name.to_byte_string()); !property_or_error.is_throw_completion()) {
         auto property = property_or_error.release_value();
@@ -2787,7 +2787,7 @@ static ErrorOr<JS::Value, Web::WebDriver::Error> json_deserialize(JS::VM& vm, We
 ErrorOr<WebDriverConnection::ScriptArguments, Web::WebDriver::Error> WebDriverConnection::extract_the_script_arguments_from_a_request(JS::VM& vm, JsonValue const& payload)
 {
     // Creating JSON objects below requires an execution context.
-    Web::HTML::TemporaryExecutionContext execution_context { current_browsing_context().active_document()->relevant_settings_object() };
+    Web::HTML::TemporaryExecutionContext execution_context { current_browsing_context().active_document()->realm() };
 
     // 1. Let script be the result of getting a property named script from the parameters.
     // 2. If script is not a String, return error with error code invalid argument.


### PR DESCRIPTION
Sitting ontop of https://github.com/LadybirdBrowser/ladybird/pull/1932

This is the last MR / refactoring needed before introducing the concept of a 'synthetic realm' and hooking that up to [[HostDefined]].