### PR TITLE
LibWeb: Don't allocate a new HeapFunction 60 times per second

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -273,7 +273,7 @@ void EventLoop::update_the_rendering()
         // FIXME: doc is render-blocked;
 
         // doc's visibility state is "hidden";
-        if (document->visibility_state() == "hidden"sv)
+        if (document->hidden())
             return true;
 
         // FIXME: doc's rendering is suppressed for view transitions; or

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -81,6 +81,8 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
+    void update_the_rendering();
+
     Type m_type { Type::Window };
 
     JS::GCPtr<TaskQueue> m_task_queue;
@@ -116,6 +118,8 @@ private:
     bool m_skip_event_loop_processing_steps { false };
 
     bool m_is_running_rendering_task { false };
+
+    JS::GCPtr<JS::HeapFunction<void()>> m_rendering_task_function;
 };
 
 EventLoop& main_thread_event_loop();


### PR DESCRIPTION
We can reuse the same HeapFunction when queueing up a rendering task
on the HTML event loop. No need to create extra work for the garbage
collector like this.

Bonus commit: don't compare strings unnecessarily in the 60fps rendering task.