### PR TITLE
LibJS: Extend supported date string formats

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -187,6 +187,9 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%Y-%m-%e"sv,                          // "2024-1-15"
         "%Y-%m-%e%t%T%tGMT%z"sv,               // "2024-07-05 00:00:00 GMT-0800"
         "%d%t%B%t%Y"sv,                        // "01 February 2013"
+        "%d%t%B%t%Y%t%R"sv,                    // "01 February 2013 08:00"
+        "%d%t%b%t%Y"sv,                        // "01 Jan 2000"
+        "%d%t%b%t%Y%t%R"sv,                    // "01 Jan 2000 08:00"
     };
 
     for (auto const& format : extra_formats) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -27,6 +27,10 @@ test("basic functionality", () => {
     expect(Date.parse("Sun Jan 21 2024 21:11:31 GMT 0100 (Central European Standard Time)")).toBe(
         1705867891000
     );
+    expect(Date.parse("05 Jul 2024 00:00")).toBe(1720155600000);
+    expect(Date.parse("05 Jul 2024")).toBe(1720155600000);
+    expect(Date.parse("05 July 2024")).toBe(1720155600000);
+    expect(Date.parse("05 July 2024 00:00")).toBe(1720155600000);
     expect(Date.parse("2024-07-05 00:00:00 GMT-0200")).toBe(1720144800000);
     expect(Date.parse("2024-01-15 00:00:01")).toBe(1705298401000);
     expect(Date.parse("Tue Nov 07 2023 10:05:55  UTC")).toBe(1699351555000);


### PR DESCRIPTION
Found while randomly browsing a company-internal website: `Unable to parse date string: "01 Jan 2000 16:00"`