### PR TITLE
LibJS: calendarId getters within Temporal

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -93,6 +93,7 @@ namespace JS {
     P(byteLength)                            \
     P(byteOffset)                            \
     P(calendar)                              \
+    P(calendarId)                            \
     P(calendarName)                          \
     P(call)                                  \
     P(callee)                                \

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.cpp
@@ -52,6 +52,7 @@ void PlainDatePrototype::initialize(Realm& realm)
     define_native_accessor(realm, vm.names.inLeapYear, in_leap_year_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.era, era_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.eraYear, era_year_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.calendarId, calendar_id_getter, {}, Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(realm, vm.names.toPlainYearMonth, to_plain_year_month, 0, attr);
@@ -647,6 +648,18 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::value_of)
 {
     // 1. Throw a TypeError exception.
     return vm.throw_completion<TypeError>(ErrorType::Convert, "Temporal.PlainDate", "a primitive value");
+}
+
+// 3.3.3 get Temporal.PlainDate.prototype.calendarId, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindate.prototype.calendarid
+JS_DEFINE_NATIVE_FUNCTION(PlainDatePrototype::calendar_id_getter)
+{
+    // 1. Let temporalDate be the this value.
+    // 2. Perform ? RequireInternalSlot(temporalDate, [[InitializedTemporalDate]]).
+    auto temporal_date = TRY(typed_this_object(vm));
+
+    // 3. Return temporalDate.[[Calendar]].
+    auto& calendar = static_cast<Calendar&>(temporal_date->calendar());
+    return PrimitiveString::create(vm, calendar.identifier());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDatePrototype.h
@@ -23,6 +23,7 @@ private:
     explicit PlainDatePrototype(Realm&);
 
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(calendar_id_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -38,6 +38,7 @@ void PlainDateTimePrototype::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainDateTime"_string), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.calendarId, calendar_id_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.month, month_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
@@ -804,6 +805,18 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::get_iso_fields)
 
     // 14. Return fields.
     return fields;
+}
+
+// 5.3.3 get Temporal.PlainDateTime.prototype.calendarId, https://tc39.es/proposal-temporal/#sec-get-temporal.plaindatetime.prototype.calendarid
+JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::calendar_id_getter)
+{
+    // 1. Let dateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]).
+    auto temporal_date = TRY(typed_this_object(vm));
+
+    // 3. Return dateTime.[[Calendar]].
+    auto& calendar = static_cast<Calendar&>(temporal_date->calendar());
+    return PrimitiveString::create(vm, calendar.identifier());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.h
@@ -23,6 +23,7 @@ private:
     explicit PlainDateTimePrototype(Realm&);
 
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(calendar_id_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.cpp
@@ -32,6 +32,7 @@ void PlainMonthDayPrototype::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainMonthDay"_string), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.calendarId, calendar_id_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.day, day_getter, {}, Attribute::Configurable);
 
@@ -278,6 +279,18 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::get_iso_fields)
 
     // 8. Return fields.
     return fields;
+}
+
+// 10.3.3 get Temporal.PlainMonthDay.prototype.calendarId
+JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayPrototype::calendar_id_getter)
+{
+    // Step 1: Let monthDay be the this value
+    // Step 2: Perform ? RequireInternalSlot(monthDay, [[InitializedTemporalMonthDay]]).
+    auto month_day = TRY(typed_this_object(vm));
+
+    // Step 3: Return monthDay.[[Calendar]].
+    auto& calendar = static_cast<Calendar&>(month_day->calendar());
+    return PrimitiveString::create(vm, calendar.identifier());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayPrototype.h
@@ -23,6 +23,7 @@ private:
     explicit PlainMonthDayPrototype(Realm&);
 
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(calendar_id_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);
     JS_DECLARE_NATIVE_FUNCTION(day_getter);
     JS_DECLARE_NATIVE_FUNCTION(with);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.cpp
@@ -34,6 +34,7 @@ void PlainYearMonthPrototype::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.PlainYearMonth"_string), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.calendarId, calendar_id_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.month, month_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.monthCode, month_code_getter, {}, Attribute::Configurable);
@@ -445,6 +446,18 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::get_iso_fields)
 
     // 8. Return fields.
     return fields;
+}
+
+// 9.3.3 get Temporal.PlainYearMonth.prototype.calendarId
+JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthPrototype::calendar_id_getter)
+{
+    // Step 1: Let yearMonth be the this value
+    // Step 2: Perform ? RequireInternalSlot(yearMonth, [[InitializedTemporalYearMonth]]).
+    auto year_month = TRY(typed_this_object(vm));
+
+    // Step 3: Return yearMonth.[[Calendar]].identifier
+    auto& calendar = static_cast<Calendar&>(year_month->calendar());
+    return PrimitiveString::create(vm, calendar.identifier());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthPrototype.h
@@ -23,6 +23,7 @@ private:
     explicit PlainYearMonthPrototype(Realm&);
 
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(calendar_id_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_code_getter);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -38,6 +38,7 @@ void ZonedDateTimePrototype::initialize(Realm& realm)
     define_direct_property(vm.well_known_symbol_to_string_tag(), PrimitiveString::create(vm, "Temporal.ZonedDateTime"_string), Attribute::Configurable);
 
     define_native_accessor(realm, vm.names.calendar, calendar_getter, {}, Attribute::Configurable);
+    define_native_accessor(realm, vm.names.calendarId, calendar_id_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.timeZone, time_zone_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.year, year_getter, {}, Attribute::Configurable);
     define_native_accessor(realm, vm.names.month, month_getter, {}, Attribute::Configurable);
@@ -1399,6 +1400,19 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::get_iso_fields)
 
     // 21. Return fields.
     return fields;
+}
+
+// 6.3.3 get Temporal.ZonedDateTime.prototype.calendarId
+// https://tc39.es/proposal-temporal/#sec-get-temporal.zoneddatetime.prototype.calendarid
+JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::calendar_id_getter)
+{
+    // 1. Let zonedDateTime be the this value.
+    // 2. Perform ? RequireInternalSlot(zonedDateTime, [[InitializedTemporalZonedDateTime]]).
+    auto zoned_date_time = TRY(typed_this_object(vm));
+
+    // 3. Return zonedDateTime.[[Calendar]].identifier
+    auto& calendar = static_cast<Calendar&>(zoned_date_time->calendar());
+    return PrimitiveString::create(vm, calendar.identifier());
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.h
@@ -23,6 +23,7 @@ private:
     explicit ZonedDateTimePrototype(Realm&);
 
     JS_DECLARE_NATIVE_FUNCTION(calendar_getter);
+    JS_DECLARE_NATIVE_FUNCTION(calendar_id_getter);
     JS_DECLARE_NATIVE_FUNCTION(time_zone_getter);
     JS_DECLARE_NATIVE_FUNCTION(year_getter);
     JS_DECLARE_NATIVE_FUNCTION(month_getter);

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.calendarId.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.calendarId.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("calendarId basic functionality", () => {
+        const calendar = "iso8601";
+        const plainDate = new Temporal.PlainDate(2000, 5, 1, calendar);
+        expect(plainDate.calendarId).toBe("iso8601");
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainDate object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDate.prototype, "calendarId", "foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainDate");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.calendarId.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.calendarId.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("calendarId basic functionality", () => {
+        const calendar = "iso8601";
+        const plainDateTime = new Temporal.PlainDateTime(2000, 5, 1, 12, 30, 0, calendar);
+        expect(plainDateTime.calendarId).toBe("iso8601");
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainDateTime.prototype, "calendarId", "foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainDateTime");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainMonthDay/PlainMonthDay.prototype.calendarId.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainMonthDay/PlainMonthDay.prototype.calendarId.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("calendarId basic functionality", () => {
+        const calendar = "iso8601";
+        const plainMonthDay = new Temporal.PlainMonthDay(5, 1, calendar);
+        expect(plainMonthDay.calendarId).toBe("iso8601");
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainMonthDay object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainMonthDay.prototype, "calendarId", "foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainMonthDay");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.calendarId.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainYearMonth/PlainYearMonth.prototype.calendarId.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("calendarId basic functionality", () => {
+        const calendar = "iso8601";
+        const plainYearMonth = new Temporal.PlainYearMonth(2000, 5, calendar);
+        expect(plainYearMonth.calendarId).toBe("iso8601");
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.PlainYearMonth object", () => {
+        expect(() => {
+            Reflect.get(Temporal.PlainYearMonth.prototype, "calendarId", "foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.PlainYearMonth");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.calendarId.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/ZonedDateTime/ZonedDateTime.prototype.calendarId.js
@@ -1,0 +1,19 @@
+describe("correct behavior", () => {
+    test("calendarId basic functionality", () => {
+        const calendar = "iso8601";
+        const zonedDateTime = new Temporal.ZonedDateTime(
+            0n,
+            Temporal.TimeZone.from("UTC"),
+            Temporal.Calendar.from(calendar)
+        );
+        expect(zonedDateTime.calendarId).toBe("iso8601");
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Temporal.ZonedDateTime object", () => {
+        expect(() => {
+            Reflect.get(Temporal.ZonedDateTime.prototype, "calendarId", "foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.ZonedDateTime");
+    });
+});


### PR DESCRIPTION
Implementations:

- [x] Temporal.PlainDate
- [x] Temporal.PlainDateTime
- [x] Temporal.PlainYearMonth
- [x] Temporal.PlainMonthDay
- [x] Temporal.ZonedDateTime

Tests:

- [x] Temporal.PlainDate
- [x] Temporal.PlainDateTime
- [x] Temporal.PlainYearMonth
- [x] Temporal.PlainMonthDay
- [x] Temporal.ZonedDateTime