### PR TITLE
AK: Add ASCII fast path in StringBuilder::append(Utf16View)

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -224,7 +224,19 @@ void StringBuilder::append_code_point(u32 code_point)
 
 ErrorOr<void> StringBuilder::try_append(Utf16View const& utf16_view)
 {
+    // NOTE: This may under-allocate in the presence of surrogate pairs.
+    //       That's okay, appending will still grow the buffer as needed.
+    TRY(will_append(utf16_view.length_in_code_units()));
+
     for (size_t i = 0; i < utf16_view.length_in_code_units();) {
+        // OPTIMIZATION: Fast path for ASCII characters.
+        auto code_unit = utf16_view.data()[i];
+        if (code_unit <= 0x7f) {
+            append(static_cast<char>(code_unit));
+            ++i;
+            continue;
+        }
+
         auto code_point = utf16_view.code_point_at(i);
         TRY(try_append_code_point(code_point));
 


### PR DESCRIPTION
And let's at least try to pre-allocate an appropriate amount of buffer space in the builder instead of appending and growing one code point at a time.