### PR TITLE
LibWeb: Move JS::Promise <-> WebIDL conversion into IDL 

### DIFF
--- a/Userland/Libraries/LibWeb/Animations/Animation.h
+++ b/Userland/Libraries/LibWeb/Animations/Animation.h
@@ -60,10 +60,10 @@ public:
     bool pending() const { return m_pending_play_task == TaskState::Scheduled || m_pending_pause_task == TaskState::Scheduled; }
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-ready
-    JS::NonnullGCPtr<JS::Object> ready() const { return *current_ready_promise()->promise(); }
+    JS::NonnullGCPtr<WebIDL::Promise> ready() const { return current_ready_promise(); }
 
     // https://www.w3.org/TR/web-animations-1/#dom-animation-finished
-    JS::NonnullGCPtr<JS::Object> finished() const { return *current_finished_promise()->promise(); }
+    JS::NonnullGCPtr<WebIDL::Promise> finished() const { return current_finished_promise(); }
     bool is_finished() const { return m_is_finished; }
 
     JS::GCPtr<WebIDL::CallbackType> onfinish();

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -53,7 +53,7 @@ public:
     WebIDL::ExceptionOr<void> remove_rule(Optional<WebIDL::UnsignedLong> index);
     WebIDL::ExceptionOr<void> delete_rule(unsigned index);
 
-    JS::NonnullGCPtr<JS::Promise> replace(String text);
+    JS::NonnullGCPtr<WebIDL::Promise> replace(String text);
     WebIDL::ExceptionOr<void> replace_sync(StringView text);
 
     void for_each_effective_rule(TraversalOrder, Function<void(CSSRule const&)> const& callback) const;

--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -205,9 +205,9 @@ void FontFace::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_font_status_promise);
 }
 
-JS::NonnullGCPtr<JS::Promise> FontFace::loaded() const
+JS::NonnullGCPtr<WebIDL::Promise> FontFace::loaded() const
 {
-    return verify_cast<JS::Promise>(*m_font_status_promise->promise());
+    return m_font_status_promise;
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-family
@@ -320,7 +320,7 @@ WebIDL::ExceptionOr<void> FontFace::set_line_gap_override(String const&)
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontface-load
-JS::NonnullGCPtr<JS::Promise> FontFace::load()
+JS::NonnullGCPtr<WebIDL::Promise> FontFace::load()
 {
     //  1. Let font face be the FontFace object on which this method was called.
     auto& font_face = *this;

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -74,8 +74,8 @@ public:
 
     Bindings::FontFaceLoadStatus status() const { return m_status; }
 
-    JS::NonnullGCPtr<JS::Promise> load();
-    JS::NonnullGCPtr<JS::Promise> loaded() const;
+    JS::NonnullGCPtr<WebIDL::Promise> load();
+    JS::NonnullGCPtr<WebIDL::Promise> loaded() const;
 
     void load_font_source();
 

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -227,7 +227,7 @@ static WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Set>> find_matching_font_faces(J
 }
 
 // https://drafts.csswg.org/css-font-loading/#dom-fontfaceset-load
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> FontFaceSet::load(String const& font, String const& text)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> FontFaceSet::load(String const& font, String const& text)
 {
     auto& realm = this->realm();
 
@@ -278,18 +278,18 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> FontFaceSet::load(String co
     });
 
     // 2. Return promise. Complete the rest of these steps asynchronously.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 // https://drafts.csswg.org/css-font-loading/#font-face-set-ready
-JS::NonnullGCPtr<JS::Promise> FontFaceSet::ready() const
+JS::NonnullGCPtr<WebIDL::Promise> FontFaceSet::ready() const
 {
-    return verify_cast<JS::Promise>(*m_ready_promise->promise());
+    return m_ready_promise;
 }
 
 void FontFaceSet::resolve_ready_promise()
 {
-    WebIDL::resolve_promise(realm(), *m_ready_promise);
+    WebIDL::resolve_promise(realm(), m_ready_promise);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/FontFaceSet.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFaceSet.h
@@ -38,9 +38,9 @@ public:
     void set_onloadingerror(WebIDL::CallbackType*);
     WebIDL::CallbackType* onloadingerror();
 
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> load(String const& font, String const& text);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> load(String const& font, String const& text);
 
-    JS::NonnullGCPtr<JS::Promise> ready() const;
+    JS::NonnullGCPtr<WebIDL::Promise> ready() const;
     Bindings::FontFaceSetLoadStatus status() const { return m_status; }
 
     void resolve_ready_promise();
@@ -52,7 +52,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     JS::NonnullGCPtr<JS::Set> m_set_entries;
-    JS::GCPtr<WebIDL::Promise> m_ready_promise; // [[ReadyPromise]]
+    JS::NonnullGCPtr<WebIDL::Promise> m_ready_promise; // [[ReadyPromise]]
 
     Vector<JS::NonnullGCPtr<FontFace>> m_loading_fonts {}; // [[LoadingFonts]]
     Vector<JS::NonnullGCPtr<FontFace>> m_loaded_fonts {};  // [[LoadedFonts]]

--- a/Userland/Libraries/LibWeb/CSS/ScreenOrientation.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ScreenOrientation.cpp
@@ -30,7 +30,7 @@ JS::NonnullGCPtr<ScreenOrientation> ScreenOrientation::create(JS::Realm& realm)
 }
 
 // https://w3c.github.io/screen-orientation/#lock-method
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> ScreenOrientation::lock(Bindings::OrientationLockType)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> ScreenOrientation::lock(Bindings::OrientationLockType)
 {
     return WebIDL::NotSupportedError::create(realm(), "FIXME: ScreenOrientation::lock() is not implemented"_string);
 }

--- a/Userland/Libraries/LibWeb/CSS/ScreenOrientation.h
+++ b/Userland/Libraries/LibWeb/CSS/ScreenOrientation.h
@@ -20,7 +20,7 @@ class ScreenOrientation final : public DOM::EventTarget {
 public:
     [[nodiscard]] static JS::NonnullGCPtr<ScreenOrientation> create(JS::Realm&);
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> lock(Bindings::OrientationLockType);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> lock(Bindings::OrientationLockType);
     void unlock();
     Bindings::OrientationType type() const;
     WebIDL::UnsignedShort angle() const;

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -142,7 +142,7 @@ static bool check_clipboard_write_permission(JS::Realm& realm)
 }
 
 // https://w3c.github.io/clipboard-apis/#dom-clipboard-writetext
-JS::NonnullGCPtr<JS::Promise> Clipboard::write_text(String data)
+JS::NonnullGCPtr<WebIDL::Promise> Clipboard::write_text(String data)
 {
     // 1. Let realm be this's relevant realm.
     auto& realm = HTML::relevant_realm(*this);
@@ -194,7 +194,7 @@ JS::NonnullGCPtr<JS::Promise> Clipboard::write_text(String data)
     });
 
     // 4. Return p.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Clipboard/Clipboard.h
+++ b/Userland/Libraries/LibWeb/Clipboard/Clipboard.h
@@ -23,7 +23,7 @@ public:
     static WebIDL::ExceptionOr<JS::NonnullGCPtr<Clipboard>> construct_impl(JS::Realm&);
     virtual ~Clipboard() override;
 
-    JS::NonnullGCPtr<JS::Promise> write_text(String);
+    JS::NonnullGCPtr<WebIDL::Promise> write_text(String);
 
 private:
     Clipboard(JS::Realm&);

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -121,7 +121,7 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-encrypt
-JS::NonnullGCPtr<JS::Promise> SubtleCrypto::encrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter)
+JS::NonnullGCPtr<WebIDL::Promise> SubtleCrypto::encrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter)
 {
     auto& realm = this->realm();
     auto& vm = this->vm();
@@ -174,11 +174,11 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::encrypt(AlgorithmIdentifier const& a
         WebIDL::resolve_promise(realm, promise, cipher_text.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-decrypt
-JS::NonnullGCPtr<JS::Promise> SubtleCrypto::decrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter)
+JS::NonnullGCPtr<WebIDL::Promise> SubtleCrypto::decrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter)
 {
     auto& realm = this->realm();
     auto& vm = this->vm();
@@ -231,11 +231,11 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::decrypt(AlgorithmIdentifier const& a
         WebIDL::resolve_promise(realm, promise, plain_text.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-digest
-JS::NonnullGCPtr<JS::Promise> SubtleCrypto::digest(AlgorithmIdentifier const& algorithm, JS::Handle<WebIDL::BufferSource> const& data)
+JS::NonnullGCPtr<WebIDL::Promise> SubtleCrypto::digest(AlgorithmIdentifier const& algorithm, JS::Handle<WebIDL::BufferSource> const& data)
 {
     auto& realm = this->realm();
     auto& vm = this->vm();
@@ -279,11 +279,11 @@ JS::NonnullGCPtr<JS::Promise> SubtleCrypto::digest(AlgorithmIdentifier const& al
         WebIDL::resolve_promise(realm, promise, result.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-generateKey
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::generate_key(AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::generate_key(AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages)
 {
     auto& realm = this->realm();
 
@@ -339,11 +339,11 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::generate_key(
             });
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#SubtleCrypto-method-importKey
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::import_key(Bindings::KeyFormat format, KeyDataType key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::import_key(Bindings::KeyFormat format, KeyDataType key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages)
 {
     auto& realm = this->realm();
 
@@ -415,11 +415,11 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::import_key(Bi
         WebIDL::resolve_promise(realm, promise, result);
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-exportKey
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::export_key(Bindings::KeyFormat format, JS::NonnullGCPtr<CryptoKey> key)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::export_key(Bindings::KeyFormat format, JS::NonnullGCPtr<CryptoKey> key)
 {
     auto& realm = this->realm();
     // 1. Let format and key be the format and key parameters passed to the exportKey() method, respectively.
@@ -461,11 +461,11 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::export_key(Bi
         WebIDL::resolve_promise(realm, promise, result_or_error.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-sign
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::sign(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::sign(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter)
 {
     auto& realm = this->realm();
     auto& vm = this->vm();
@@ -518,11 +518,11 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::sign(Algorith
         WebIDL::resolve_promise(realm, promise, result.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#dfn-SubtleCrypto-method-verify
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::verify(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& signature_data, JS::Handle<WebIDL::BufferSource> const& data_parameter)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::verify(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& signature_data, JS::Handle<WebIDL::BufferSource> const& data_parameter)
 {
     auto& realm = this->realm();
     auto& vm = this->vm();
@@ -582,11 +582,11 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::verify(Algori
         WebIDL::resolve_promise(realm, promise, result.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://w3c.github.io/webcrypto/#SubtleCrypto-method-deriveBits
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_bits(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, u32 length)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::derive_bits(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, u32 length)
 {
     auto& realm = this->realm();
     // 1. Let algorithm, baseKey and length, be the algorithm, baseKey and length parameters passed to the deriveBits() method, respectively.
@@ -629,10 +629,10 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_bits(A
         WebIDL::resolve_promise(realm, promise, result.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
-JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_key(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, AlgorithmIdentifier derived_key_type, bool extractable, Vector<Bindings::KeyUsage> key_usages)
+JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> SubtleCrypto::derive_key(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, AlgorithmIdentifier derived_key_type, bool extractable, Vector<Bindings::KeyUsage> key_usages)
 {
     auto& realm = this->realm();
     auto& vm = this->vm();
@@ -722,7 +722,7 @@ JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> SubtleCrypto::derive_key(Al
         WebIDL::resolve_promise(realm, promise, result.release_value());
     });
 
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 SupportedAlgorithmsMap& supported_algorithms_internal()

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.h
@@ -27,19 +27,19 @@ public:
 
     virtual ~SubtleCrypto() override;
 
-    JS::NonnullGCPtr<JS::Promise> encrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter);
-    JS::NonnullGCPtr<JS::Promise> decrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter);
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> sign(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter);
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> verify(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& signature, JS::Handle<WebIDL::BufferSource> const& data_parameter);
+    JS::NonnullGCPtr<WebIDL::Promise> encrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter);
+    JS::NonnullGCPtr<WebIDL::Promise> decrypt(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> sign(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& data_parameter);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> verify(AlgorithmIdentifier const& algorithm, JS::NonnullGCPtr<CryptoKey> key, JS::Handle<WebIDL::BufferSource> const& signature, JS::Handle<WebIDL::BufferSource> const& data_parameter);
 
-    JS::NonnullGCPtr<JS::Promise> digest(AlgorithmIdentifier const& algorithm, JS::Handle<WebIDL::BufferSource> const& data);
+    JS::NonnullGCPtr<WebIDL::Promise> digest(AlgorithmIdentifier const& algorithm, JS::Handle<WebIDL::BufferSource> const& data);
 
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> generate_key(AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> derive_bits(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, u32 length);
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> derive_key(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, AlgorithmIdentifier derived_key_type, bool extractable, Vector<Bindings::KeyUsage> key_usages);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> generate_key(AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> derive_bits(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, u32 length);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> derive_key(AlgorithmIdentifier algorithm, JS::NonnullGCPtr<CryptoKey> base_key, AlgorithmIdentifier derived_key_type, bool extractable, Vector<Bindings::KeyUsage> key_usages);
 
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> import_key(Bindings::KeyFormat format, KeyDataType key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
-    JS::ThrowCompletionOr<JS::NonnullGCPtr<JS::Promise>> export_key(Bindings::KeyFormat format, JS::NonnullGCPtr<CryptoKey> key);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> import_key(Bindings::KeyFormat format, KeyDataType key_data, AlgorithmIdentifier algorithm, bool extractable, Vector<Bindings::KeyUsage> key_usages);
+    JS::ThrowCompletionOr<JS::NonnullGCPtr<WebIDL::Promise>> export_key(Bindings::KeyFormat format, JS::NonnullGCPtr<CryptoKey> key);
 
 private:
     explicit SubtleCrypto(JS::Realm&);

--- a/Userland/Libraries/LibWeb/Fetch/Body.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/Body.cpp
@@ -55,7 +55,7 @@ bool BodyMixin::body_used() const
 }
 
 // https://fetch.spec.whatwg.org/#dom-body-arraybuffer
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::array_buffer() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> BodyMixin::array_buffer() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
@@ -65,7 +65,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::array_buffer() con
 }
 
 // https://fetch.spec.whatwg.org/#dom-body-blob
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::blob() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> BodyMixin::blob() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
@@ -75,7 +75,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::blob() const
 }
 
 // https://fetch.spec.whatwg.org/#dom-body-bytes
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::bytes() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> BodyMixin::bytes() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
@@ -85,7 +85,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::bytes() const
 }
 
 // https://fetch.spec.whatwg.org/#dom-body-formdata
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::form_data() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> BodyMixin::form_data() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
@@ -95,7 +95,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::form_data() const
 }
 
 // https://fetch.spec.whatwg.org/#dom-body-json
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::json() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> BodyMixin::json() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
@@ -105,7 +105,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::json() const
 }
 
 // https://fetch.spec.whatwg.org/#dom-body-text
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> BodyMixin::text() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> BodyMixin::text() const
 {
     auto& vm = Bindings::main_thread_vm();
     auto& realm = *vm.current_realm();
@@ -175,7 +175,7 @@ WebIDL::ExceptionOr<JS::Value> package_data(JS::Realm& realm, ByteBuffer bytes, 
 }
 
 // https://fetch.spec.whatwg.org/#concept-body-consume-body
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm& realm, BodyMixin const& object, PackageDataType type)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> consume_body(JS::Realm& realm, BodyMixin const& object, PackageDataType type)
 {
     // 1. If object is unusable, then return a promise rejected with a TypeError.
     if (object.is_unusable()) {
@@ -229,7 +229,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm& realm
     }
 
     // 7. Return promise.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise().ptr()) };
+    return promise;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/Body.h
+++ b/Userland/Libraries/LibWeb/Fetch/Body.h
@@ -39,15 +39,15 @@ public:
     [[nodiscard]] bool body_used() const;
 
     // JS API functions
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> array_buffer() const;
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> blob() const;
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> bytes() const;
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> form_data() const;
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> json() const;
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> text() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> array_buffer() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> blob() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> bytes() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> form_data() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> json() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> text() const;
 };
 
 [[nodiscard]] WebIDL::ExceptionOr<JS::Value> package_data(JS::Realm&, ByteBuffer, PackageDataType, Optional<MimeSniff::MimeType> const&);
-[[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> consume_body(JS::Realm&, BodyMixin const&, PackageDataType);
+[[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> consume_body(JS::Realm&, BodyMixin const&, PackageDataType);
 
 }

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -26,7 +26,7 @@
 namespace Web::Fetch {
 
 // https://fetch.spec.whatwg.org/#dom-global-fetch
-JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, RequestInit const& init)
+JS::NonnullGCPtr<WebIDL::Promise> fetch(JS::VM& vm, RequestInfo const& input, RequestInit const& init)
 {
     auto& realm = *vm.current_realm();
 
@@ -39,7 +39,7 @@ JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, Reques
     if (exception_or_request_object.is_exception()) {
         auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, exception_or_request_object.exception());
         WebIDL::reject_promise(realm, promise_capability, *throw_completion.value());
-        return verify_cast<JS::Promise>(*promise_capability->promise().ptr());
+        return promise_capability;
     }
     auto request_object = exception_or_request_object.release_value();
 
@@ -52,7 +52,7 @@ JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, Reques
         abort_fetch(realm, promise_capability, request, nullptr, request_object->signal()->reason());
 
         // 2. Return p.
-        return verify_cast<JS::Promise>(*promise_capability->promise().ptr());
+        return promise_capability;
     }
 
     // 5. Let globalObject be request’s client’s global object.
@@ -150,7 +150,7 @@ JS::NonnullGCPtr<JS::Promise> fetch(JS::VM& vm, RequestInfo const& input, Reques
     });
 
     // 13. Return p.
-    return verify_cast<JS::Promise>(*promise_capability->promise().ptr());
+    return promise_capability;
 }
 
 // https://fetch.spec.whatwg.org/#abort-fetch

--- a/Userland/Libraries/LibWeb/Fetch/FetchMethod.h
+++ b/Userland/Libraries/LibWeb/Fetch/FetchMethod.h
@@ -14,7 +14,7 @@
 
 namespace Web::Fetch {
 
-JS::NonnullGCPtr<JS::Promise> fetch(JS::VM&, RequestInfo const& input, RequestInit const& init = {});
+JS::NonnullGCPtr<WebIDL::Promise> fetch(JS::VM&, RequestInfo const& input, RequestInit const& init = {});
 void abort_fetch(JS::Realm&, WebIDL::Promise const&, JS::NonnullGCPtr<Infrastructure::Request>, JS::GCPtr<Response>, JS::Value error);
 
 }

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -377,7 +377,7 @@ JS::NonnullGCPtr<Streams::ReadableStream> Blob::get_stream()
 }
 
 // https://w3c.github.io/FileAPI/#dom-blob-text
-JS::NonnullGCPtr<JS::Promise> Blob::text()
+JS::NonnullGCPtr<WebIDL::Promise> Blob::text()
 {
     auto& realm = this->realm();
     auto& vm = realm.vm();
@@ -407,7 +407,7 @@ JS::NonnullGCPtr<JS::Promise> Blob::text()
 }
 
 // https://w3c.github.io/FileAPI/#dom-blob-arraybuffer
-JS::NonnullGCPtr<JS::Promise> Blob::array_buffer()
+JS::NonnullGCPtr<WebIDL::Promise> Blob::array_buffer()
 {
     auto& realm = this->realm();
 
@@ -434,7 +434,7 @@ JS::NonnullGCPtr<JS::Promise> Blob::array_buffer()
 }
 
 // https://w3c.github.io/FileAPI/#dom-blob-bytes
-JS::NonnullGCPtr<JS::Promise> Blob::bytes()
+JS::NonnullGCPtr<WebIDL::Promise> Blob::bytes()
 {
     auto& realm = this->realm();
 

--- a/Userland/Libraries/LibWeb/FileAPI/Blob.h
+++ b/Userland/Libraries/LibWeb/FileAPI/Blob.h
@@ -48,9 +48,9 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Blob>> slice(Optional<i64> start = {}, Optional<i64> end = {}, Optional<String> const& content_type = {});
 
     JS::NonnullGCPtr<Streams::ReadableStream> stream();
-    JS::NonnullGCPtr<JS::Promise> text();
-    JS::NonnullGCPtr<JS::Promise> array_buffer();
-    JS::NonnullGCPtr<JS::Promise> bytes();
+    JS::NonnullGCPtr<WebIDL::Promise> text();
+    JS::NonnullGCPtr<WebIDL::Promise> array_buffer();
+    JS::NonnullGCPtr<WebIDL::Promise> bytes();
 
     ReadonlyBytes raw_bytes() const { return m_byte_buffer.bytes(); }
 

--- a/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
+++ b/Userland/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.h
@@ -27,7 +27,7 @@ public:
     JS::ThrowCompletionOr<void> define(String const& name, WebIDL::CallbackType* constructor, ElementDefinitionOptions options);
     Variant<JS::Handle<WebIDL::CallbackType>, JS::Value> get(String const& name) const;
     Optional<String> get_name(JS::Handle<WebIDL::CallbackType> const& constructor) const;
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> when_defined(String const& name);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> when_defined(String const& name);
     void upgrade(JS::NonnullGCPtr<DOM::Node> root) const;
 
     JS::GCPtr<CustomElementDefinition> get_definition_with_name_and_local_name(String const& name, String const& local_name) const;
@@ -48,7 +48,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/custom-elements.html#when-defined-promise-map
     // Every CustomElementRegistry also has a when-defined promise map, mapping valid custom element names to promises. It is used to implement the whenDefined() method.
-    OrderedHashMap<String, JS::NonnullGCPtr<JS::Promise>> m_when_defined_promise_map;
+    OrderedHashMap<String, JS::NonnullGCPtr<WebIDL::Promise>> m_when_defined_promise_map;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -282,7 +282,7 @@ String HTMLImageElement::current_src() const
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLImageElement::decode() const
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> HTMLImageElement::decode() const
 {
     auto& realm = this->realm();
 
@@ -360,7 +360,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLImageElement::decode() co
         });
     }));
 
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 Optional<ARIA::Role> HTMLImageElement::default_role() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -61,7 +61,7 @@ public:
     String current_src() const;
 
     // https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-decode
-    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> decode() const;
+    [[nodiscard]] WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> decode() const;
 
     virtual Optional<ARIA::Role> default_role() const override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -334,7 +334,7 @@ void HTMLMediaElement::set_duration(double duration)
         paintable->set_needs_display();
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLMediaElement::play()
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> HTMLMediaElement::play()
 {
     auto& realm = this->realm();
 
@@ -355,7 +355,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> HTMLMediaElement::play()
     TRY(play_element());
 
     // 5. Return promise.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-media-pause

--- a/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -89,7 +89,7 @@ public:
     bool paused() const { return m_paused; }
     bool ended() const;
     bool potentially_playing() const;
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> play();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> play();
     WebIDL::ExceptionOr<void> pause();
     WebIDL::ExceptionOr<void> toggle_playback();
 

--- a/Userland/Libraries/LibWeb/HTML/Navigation.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigation.h
@@ -39,9 +39,8 @@ struct NavigationReloadOptions : public NavigationOptions {
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationresult
 struct NavigationResult {
-    // FIXME: Are we supposed to return a PromiseCapability (WebIDL::Promise) here?
-    JS::NonnullGCPtr<JS::Object> committed;
-    JS::NonnullGCPtr<JS::Object> finished;
+    JS::NonnullGCPtr<WebIDL::Promise> committed;
+    JS::NonnullGCPtr<WebIDL::Promise> finished;
 };
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigation-api-method-tracker

--- a/Userland/Libraries/LibWeb/HTML/NavigationTransition.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigationTransition.cpp
@@ -5,23 +5,23 @@
  */
 
 #include <LibJS/Heap/Heap.h>
-#include <LibJS/Runtime/Promise.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/NavigationTransitionPrototype.h>
 #include <LibWeb/HTML/NavigationHistoryEntry.h>
 #include <LibWeb/HTML/NavigationTransition.h>
+#include <LibWeb/WebIDL/Promise.h>
 
 namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(NavigationTransition);
 
-JS::NonnullGCPtr<NavigationTransition> NavigationTransition::create(JS::Realm& realm, Bindings::NavigationType navigation_type, JS::NonnullGCPtr<NavigationHistoryEntry> from_entry, JS::GCPtr<JS::Promise> finished_promise)
+JS::NonnullGCPtr<NavigationTransition> NavigationTransition::create(JS::Realm& realm, Bindings::NavigationType navigation_type, JS::NonnullGCPtr<NavigationHistoryEntry> from_entry, JS::NonnullGCPtr<WebIDL::Promise> finished_promise)
 {
     return realm.heap().allocate<NavigationTransition>(realm, realm, navigation_type, from_entry, finished_promise);
 }
 
-NavigationTransition::NavigationTransition(JS::Realm& realm, Bindings::NavigationType navigation_type, JS::NonnullGCPtr<NavigationHistoryEntry> from_entry, JS::GCPtr<JS::Promise> finished_promise)
+NavigationTransition::NavigationTransition(JS::Realm& realm, Bindings::NavigationType navigation_type, JS::NonnullGCPtr<NavigationHistoryEntry> from_entry, JS::NonnullGCPtr<WebIDL::Promise> finished_promise)
     : Bindings::PlatformObject(realm)
     , m_navigation_type(navigation_type)
     , m_from_entry(from_entry)

--- a/Userland/Libraries/LibWeb/HTML/NavigationTransition.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigationTransition.h
@@ -17,7 +17,7 @@ class NavigationTransition : public Bindings::PlatformObject {
     JS_DECLARE_ALLOCATOR(NavigationTransition);
 
 public:
-    [[nodiscard]] static JS::NonnullGCPtr<NavigationTransition> create(JS::Realm&, Bindings::NavigationType, JS::NonnullGCPtr<NavigationHistoryEntry>, JS::GCPtr<JS::Promise>);
+    [[nodiscard]] static JS::NonnullGCPtr<NavigationTransition> create(JS::Realm&, Bindings::NavigationType, JS::NonnullGCPtr<NavigationHistoryEntry>, JS::NonnullGCPtr<WebIDL::Promise>);
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationtransition-navigationtype
     Bindings::NavigationType navigation_type() const { return m_navigation_type; }
@@ -26,12 +26,12 @@ public:
     JS::NonnullGCPtr<NavigationHistoryEntry> from() const { return m_from_entry; }
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigationtransition-finished
-    JS::GCPtr<JS::Promise> finished() const { return m_finished_promise; }
+    JS::NonnullGCPtr<WebIDL::Promise> finished() const { return m_finished_promise; }
 
     virtual ~NavigationTransition() override;
 
 private:
-    NavigationTransition(JS::Realm&, Bindings::NavigationType, JS::NonnullGCPtr<NavigationHistoryEntry>, JS::GCPtr<JS::Promise>);
+    NavigationTransition(JS::Realm&, Bindings::NavigationType, JS::NonnullGCPtr<NavigationHistoryEntry>, JS::NonnullGCPtr<WebIDL::Promise>);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
@@ -43,7 +43,7 @@ private:
     JS::NonnullGCPtr<NavigationHistoryEntry> m_from_entry;
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#concept-navigationtransition-finished
-    JS::GCPtr<JS::Promise> m_finished_promise;
+    JS::NonnullGCPtr<WebIDL::Promise> m_finished_promise;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.cpp
@@ -24,7 +24,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<PromiseRejectionEvent>> PromiseRejectionEve
 
 PromiseRejectionEvent::PromiseRejectionEvent(JS::Realm& realm, FlyString const& event_name, PromiseRejectionEventInit const& event_init)
     : DOM::Event(realm, event_name, event_init)
-    , m_promise(const_cast<JS::Promise*>(event_init.promise.cell()))
+    , m_promise(*event_init.promise)
     , m_reason(event_init.reason)
 {
 }

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -16,7 +16,7 @@
 namespace Web::HTML {
 
 struct PromiseRejectionEventInit : public DOM::EventInit {
-    JS::Handle<JS::Promise> promise;
+    JS::Handle<JS::Object> promise;
     JS::Value reason;
 };
 
@@ -31,7 +31,7 @@ public:
     virtual ~PromiseRejectionEvent() override;
 
     // Needs to return a pointer for the generated JS bindings to work.
-    JS::Promise const* promise() const { return m_promise; }
+    JS::Object const* promise() const { return m_promise; }
     JS::Value reason() const { return m_reason; }
 
 private:
@@ -40,7 +40,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    JS::GCPtr<JS::Promise> m_promise;
+    JS::NonnullGCPtr<JS::Object> m_promise;
     JS::Value m_reason;
 };
 

--- a/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.idl
+++ b/Userland/Libraries/LibWeb/HTML/PromiseRejectionEvent.idl
@@ -1,15 +1,15 @@
 #import <DOM/Event.idl>
 
-// https://html.spec.whatwg.org/#promiserejectionevent
-[Exposed=(Window,Worker)]
+// https://html.spec.whatwg.org/multipage/webappapis.html#promiserejectionevent
+[Exposed=*]
 interface PromiseRejectionEvent : Event {
     constructor(DOMString type, PromiseRejectionEventInit eventInitDict);
 
-    readonly attribute Promise<any> promise;
+    readonly attribute object promise;
     readonly attribute any reason;
 };
 
 dictionary PromiseRejectionEventInit : EventInit {
-    required Promise<any> promise;
+    required object promise;
     any reason;
 };

--- a/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/HTML/ServiceWorkerContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/ServiceWorkerContainer.cpp
@@ -44,7 +44,7 @@ JS::NonnullGCPtr<ServiceWorkerContainer> ServiceWorkerContainer::create(JS::Real
 }
 
 // https://w3c.github.io/ServiceWorker/#navigator-service-worker-register
-JS::NonnullGCPtr<JS::Promise> ServiceWorkerContainer::register_(String script_url, RegistrationOptions const& options)
+JS::NonnullGCPtr<WebIDL::Promise> ServiceWorkerContainer::register_(String script_url, RegistrationOptions const& options)
 {
     auto& realm = this->realm();
     // Note: The register(scriptURL, options) method creates or updates a service worker registration for the given scope url.
@@ -76,7 +76,7 @@ JS::NonnullGCPtr<JS::Promise> ServiceWorkerContainer::register_(String script_ur
     start_register(scope_url, parsed_script_url, p, client, client->creation_url, options.type, options.update_via_cache);
 
     // 8. Return p.
-    return verify_cast<JS::Promise>(*p->promise());
+    return p;
 }
 
 // https://w3c.github.io/ServiceWorker/#start-register-algorithm

--- a/Userland/Libraries/LibWeb/HTML/ServiceWorkerContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/ServiceWorkerContainer.h
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] static JS::NonnullGCPtr<ServiceWorkerContainer> create(JS::Realm& realm);
     virtual ~ServiceWorkerContainer() override;
 
-    JS::NonnullGCPtr<JS::Promise> register_(String script_url, RegistrationOptions const& options);
+    JS::NonnullGCPtr<WebIDL::Promise> register_(String script_url, RegistrationOptions const& options);
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)       \

--- a/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Userland/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -39,10 +39,10 @@ public:
     WebIDL::ExceptionOr<String> btoa(String const& data) const;
     WebIDL::ExceptionOr<String> atob(String const& data) const;
     void queue_microtask(WebIDL::CallbackType&);
-    JS::NonnullGCPtr<JS::Promise> create_image_bitmap(ImageBitmapSource image, Optional<ImageBitmapOptions> options = {}) const;
-    JS::NonnullGCPtr<JS::Promise> create_image_bitmap(ImageBitmapSource image, WebIDL::Long sx, WebIDL::Long sy, WebIDL::Long sw, WebIDL::Long sh, Optional<ImageBitmapOptions> options = {}) const;
+    JS::NonnullGCPtr<WebIDL::Promise> create_image_bitmap(ImageBitmapSource image, Optional<ImageBitmapOptions> options = {}) const;
+    JS::NonnullGCPtr<WebIDL::Promise> create_image_bitmap(ImageBitmapSource image, WebIDL::Long sx, WebIDL::Long sy, WebIDL::Long sw, WebIDL::Long sh, Optional<ImageBitmapOptions> options = {}) const;
     WebIDL::ExceptionOr<JS::Value> structured_clone(JS::Value, StructuredSerializeOptions const&) const;
-    JS::NonnullGCPtr<JS::Promise> fetch(Fetch::RequestInfo const&, Fetch::RequestInit const&) const;
+    JS::NonnullGCPtr<WebIDL::Promise> fetch(Fetch::RequestInfo const&, Fetch::RequestInit const&) const;
 
     i32 set_timeout(TimerHandler, i32 timeout, JS::MarkedVector<JS::Value> arguments);
     i32 set_interval(TimerHandler, i32 timeout, JS::MarkedVector<JS::Value> arguments);
@@ -105,7 +105,7 @@ private:
     i32 run_timer_initialization_steps(TimerHandler handler, i32 timeout, JS::MarkedVector<JS::Value> arguments, Repeat repeat, Optional<i32> previous_id = {});
     void run_steps_after_a_timeout_impl(i32 timeout, Function<void()> completion_step, Optional<i32> timer_key = {});
 
-    JS::NonnullGCPtr<JS::Promise> create_image_bitmap_impl(ImageBitmapSource& image, Optional<WebIDL::Long> sx, Optional<WebIDL::Long> sy, Optional<WebIDL::Long> sw, Optional<WebIDL::Long> sh, Optional<ImageBitmapOptions>& options) const;
+    JS::NonnullGCPtr<WebIDL::Promise> create_image_bitmap_impl(ImageBitmapSource& image, Optional<WebIDL::Long> sx, Optional<WebIDL::Long> sy, Optional<WebIDL::Long> sw, Optional<WebIDL::Long> sh, Optional<ImageBitmapOptions>& options) const;
 
     IDAllocator m_timer_id_allocator;
     HashMap<int, JS::NonnullGCPtr<Timer>> m_timers;

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -131,7 +131,7 @@ JS::NonnullGCPtr<WebIDL::Promise> readable_stream_cancel(ReadableStream& stream,
         JS::create_heap_function(stream.heap(), [](JS::Value) -> WebIDL::ExceptionOr<JS::Value> { return JS::js_undefined(); }),
         {});
 
-    return WebIDL::create_resolved_promise(realm, react_result);
+    return react_result;
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-fulfill-read-into-request
@@ -431,9 +431,9 @@ public:
 
                     // 3. Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
                     auto cancel_result = readable_stream_cancel(m_stream, completion.value().value());
-                    JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
 
-                    WebIDL::resolve_promise(m_realm, m_cancel_promise, cancel_value);
+                    // Note: We need to manually convert the result to an ECMAScript value here, by extracting its [[Promise]] slot.
+                    WebIDL::resolve_promise(m_realm, m_cancel_promise, cancel_result->promise());
 
                     // 4. Return.
                     return;
@@ -584,8 +584,7 @@ WebIDL::ExceptionOr<ReadableStreamPair> readable_stream_default_tee(JS::Realm& r
             auto cancel_result = readable_stream_cancel(stream, composite_reason);
 
             // 3. Resolve cancelPromise with cancelResult.
-            JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
-            WebIDL::resolve_promise(realm, cancel_promise, cancel_value);
+            WebIDL::resolve_promise(realm, cancel_promise, cancel_result->promise());
         }
 
         // 4. Return cancelPromise.
@@ -609,8 +608,7 @@ WebIDL::ExceptionOr<ReadableStreamPair> readable_stream_default_tee(JS::Realm& r
             auto cancel_result = readable_stream_cancel(stream, composite_reason);
 
             // 3. Resolve cancelPromise with cancelResult.
-            JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
-            WebIDL::resolve_promise(realm, cancel_promise, cancel_value);
+            WebIDL::resolve_promise(realm, cancel_promise, cancel_result->promise());
         }
 
         // 4. Return cancelPromise.
@@ -744,9 +742,8 @@ public:
 
                     // 3. Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
                     auto cancel_result = readable_stream_cancel(m_stream, completion.value().value());
-                    JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
 
-                    WebIDL::resolve_promise(m_realm, m_cancel_promise, cancel_value);
+                    WebIDL::resolve_promise(m_realm, m_cancel_promise, cancel_result->promise());
 
                     // 4. Return.
                     return;
@@ -909,9 +906,8 @@ public:
 
                     // 3. Resolve cancelPromise with ! ReadableStreamCancel(stream, cloneResult.[[Value]]).
                     auto cancel_result = readable_stream_cancel(m_stream, completion.value().value());
-                    JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
 
-                    WebIDL::resolve_promise(m_realm, m_cancel_promise, cancel_value);
+                    WebIDL::resolve_promise(m_realm, m_cancel_promise, cancel_result->promise());
 
                     // 4. Return.
                     return;
@@ -1221,8 +1217,7 @@ WebIDL::ExceptionOr<ReadableStreamPair> readable_byte_stream_tee(JS::Realm& real
             auto cancel_result = readable_stream_cancel(stream, composite_reason);
 
             // 3. Resolve cancelPromise with cancelResult.
-            JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
-            WebIDL::resolve_promise(realm, cancel_promise, cancel_value);
+            WebIDL::resolve_promise(realm, cancel_promise, cancel_result->promise());
         }
 
         // 4. Return cancelPromise.
@@ -1246,8 +1241,7 @@ WebIDL::ExceptionOr<ReadableStreamPair> readable_byte_stream_tee(JS::Realm& real
             auto cancel_result = readable_stream_cancel(stream, composite_reason);
 
             // 3. Resolve cancelPromise with cancelResult.
-            JS::NonnullGCPtr cancel_value = verify_cast<JS::Promise>(*cancel_result->promise().ptr());
-            WebIDL::resolve_promise(realm, cancel_promise, cancel_value);
+            WebIDL::resolve_promise(realm, cancel_promise, cancel_result->promise());
         }
 
         // 4. Return cancelPromise.
@@ -1442,7 +1436,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> readable_stream_from_itera
             }),
             {});
 
-        return WebIDL::create_resolved_promise(realm, react_result);
+        return react_result;
     });
 
     // 5. Let cancelAlgorithm be the following steps, given reason:
@@ -1483,7 +1477,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> readable_stream_from_itera
             }),
             {});
 
-        return WebIDL::create_resolved_promise(realm, react_result);
+        return react_result;
     });
 
     // 6. Set stream to ! CreateReadableStream(startAlgorithm, pullAlgorithm, cancelAlgorithm, 0).
@@ -4711,7 +4705,7 @@ void writable_stream_default_controller_write(WritableStreamDefaultController& c
 }
 
 // https://streams.spec.whatwg.org/#initialize-transform-stream
-void initialize_transform_stream(TransformStream& stream, JS::NonnullGCPtr<JS::PromiseCapability> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm)
+void initialize_transform_stream(TransformStream& stream, JS::NonnullGCPtr<WebIDL::Promise> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm)
 {
     auto& realm = stream.realm();
 
@@ -4970,7 +4964,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_controller_perform_tr
             return JS::throw_completion(reason);
         }));
 
-    return WebIDL::create_resolved_promise(realm, react_result);
+    return react_result;
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-default-sink-abort-algorithm
@@ -5031,7 +5025,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_abort_algorithm(
         }));
 
     // 8. Return controller.[[finishPromise]].
-    return JS::NonnullGCPtr { *controller->finish_promise() };
+    return *controller->finish_promise();
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-default-sink-close-algorithm
@@ -5075,7 +5069,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_close_algorithm(
             return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, readable->stored_error().as_string().utf8_string() };
         }));
 
-    return WebIDL::create_resolved_promise(realm, react_result);
+    return react_result;
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-default-sink-write-algorithm
@@ -5118,7 +5112,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_sink_write_algorithm(
             }),
             {});
 
-        return WebIDL::create_resolved_promise(realm, react_result);
+        return react_result;
     }
 
     // 4. Return ! TransformStreamDefaultControllerPerformTransform(controller, chunk).
@@ -5196,7 +5190,7 @@ JS::NonnullGCPtr<WebIDL::Promise> transform_stream_default_source_cancel_algorit
         }));
 
     // 8. Return controller.[[finishPromise]].
-    return JS::NonnullGCPtr { *controller->finish_promise() };
+    return *controller->finish_promise();
 }
 
 // https://streams.spec.whatwg.org/#transform-stream-error

--- a/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -168,7 +168,7 @@ void writable_stream_default_controller_process_close(WritableStreamDefaultContr
 void writable_stream_default_controller_process_write(WritableStreamDefaultController&, JS::Value chunk);
 void writable_stream_default_controller_write(WritableStreamDefaultController&, JS::Value chunk, JS::Value chunk_size);
 
-void initialize_transform_stream(TransformStream&, JS::NonnullGCPtr<JS::PromiseCapability> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm);
+void initialize_transform_stream(TransformStream&, JS::NonnullGCPtr<WebIDL::Promise> start_promise, double writable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> writable_size_algorithm, double readable_high_water_mark, JS::NonnullGCPtr<SizeAlgorithm> readable_size_algorithm);
 void set_up_transform_stream_default_controller(TransformStream&, TransformStreamDefaultController&, JS::NonnullGCPtr<TransformAlgorithm>, JS::NonnullGCPtr<FlushAlgorithm>, JS::NonnullGCPtr<CancelAlgorithm>);
 void set_up_transform_stream_default_controller_from_transformer(TransformStream&, JS::Value transformer, Transformer&);
 void transform_stream_default_controller_clear_algorithms(TransformStreamDefaultController&);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStream.h
@@ -75,10 +75,10 @@ public:
     virtual ~ReadableStream() override;
 
     bool locked() const;
-    JS::NonnullGCPtr<JS::Object> cancel(JS::Value reason);
+    JS::NonnullGCPtr<WebIDL::Promise> cancel(JS::Value reason);
     WebIDL::ExceptionOr<ReadableStreamReader> get_reader(ReadableStreamGetReaderOptions const& = {});
     WebIDL::ExceptionOr<JS::NonnullGCPtr<ReadableStream>> pipe_through(ReadableWritablePair transform, StreamPipeOptions const& = {});
-    JS::NonnullGCPtr<JS::Object> pipe_to(WritableStream& destination, StreamPipeOptions const& = {});
+    JS::NonnullGCPtr<WebIDL::Promise> pipe_to(WritableStream& destination, StreamPipeOptions const& = {});
     WebIDL::ExceptionOr<ReadableStreamPair> tee();
 
     void close();

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.cpp
@@ -107,7 +107,7 @@ private:
 JS_DEFINE_ALLOCATOR(BYOBReaderReadIntoRequest);
 
 // https://streams.spec.whatwg.org/#byob-reader-read
-JS::NonnullGCPtr<JS::Promise> ReadableStreamBYOBReader::read(JS::Handle<WebIDL::ArrayBufferView>& view, ReadableStreamBYOBReaderReadOptions options)
+JS::NonnullGCPtr<WebIDL::Promise> ReadableStreamBYOBReader::read(JS::Handle<WebIDL::ArrayBufferView>& view, ReadableStreamBYOBReaderReadOptions options)
 {
     auto& realm = this->realm();
 
@@ -177,6 +177,6 @@ JS::NonnullGCPtr<JS::Promise> ReadableStreamBYOBReader::read(JS::Handle<WebIDL::
     readable_stream_byob_reader_read(*this, *view, options.min, *read_into_request);
 
     // 11. Return promise.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+    return promise_capability;
 }
 }

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamBYOBReader.h
@@ -51,7 +51,7 @@ public:
 
     virtual ~ReadableStreamBYOBReader() override = default;
 
-    JS::NonnullGCPtr<JS::Promise> read(JS::Handle<WebIDL::ArrayBufferView>&, ReadableStreamBYOBReaderReadOptions options = {});
+    JS::NonnullGCPtr<WebIDL::Promise> read(JS::Handle<WebIDL::ArrayBufferView>&, ReadableStreamBYOBReaderReadOptions options = {});
 
     void release_lock();
 

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.cpp
@@ -162,7 +162,7 @@ private:
 JS_DEFINE_ALLOCATOR(DefaultReaderReadRequest);
 
 // https://streams.spec.whatwg.org/#default-reader-read
-JS::NonnullGCPtr<JS::Promise> ReadableStreamDefaultReader::read()
+JS::NonnullGCPtr<WebIDL::Promise> ReadableStreamDefaultReader::read()
 {
     auto& realm = this->realm();
 
@@ -188,7 +188,7 @@ JS::NonnullGCPtr<JS::Promise> ReadableStreamDefaultReader::read()
     readable_stream_default_reader_read(*this, read_request);
 
     // 5. Return promise.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise()) };
+    return promise_capability;
 }
 
 void ReadableStreamDefaultReader::read_a_chunk(Fetch::Infrastructure::IncrementalReadLoopReadRequest& read_request)

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamDefaultReader.h
@@ -77,7 +77,7 @@ public:
 
     virtual ~ReadableStreamDefaultReader() override = default;
 
-    JS::NonnullGCPtr<JS::Promise> read();
+    JS::NonnullGCPtr<WebIDL::Promise> read();
 
     void read_a_chunk(Fetch::Infrastructure::IncrementalReadLoopReadRequest& read_request);
     void read_all_bytes(JS::NonnullGCPtr<ReadLoopReadRequest::SuccessSteps>, JS::NonnullGCPtr<ReadLoopReadRequest::FailureSteps>);

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.cpp
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.cpp
@@ -14,14 +14,14 @@
 namespace Web::Streams {
 
 // https://streams.spec.whatwg.org/#generic-reader-closed
-JS::GCPtr<JS::Promise> ReadableStreamGenericReaderMixin::closed()
+JS::GCPtr<WebIDL::Promise> ReadableStreamGenericReaderMixin::closed()
 {
     // 1. Return this.[[closedPromise]].
-    return JS::GCPtr { verify_cast<JS::Promise>(*m_closed_promise->promise()) };
+    return m_closed_promise;
 }
 
 // https://streams.spec.whatwg.org/#generic-reader-cancel
-JS::NonnullGCPtr<JS::Promise> ReadableStreamGenericReaderMixin::cancel(JS::Value reason)
+JS::NonnullGCPtr<WebIDL::Promise> ReadableStreamGenericReaderMixin::cancel(JS::Value reason)
 {
     // 1. If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
     if (!m_stream) {
@@ -30,8 +30,7 @@ JS::NonnullGCPtr<JS::Promise> ReadableStreamGenericReaderMixin::cancel(JS::Value
     }
 
     // 2. Return ! ReadableStreamReaderGenericCancel(this, reason).
-    auto promise_capability = readable_stream_reader_generic_cancel(*this, reason);
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise_capability->promise().ptr()) };
+    return readable_stream_reader_generic_cancel(*this, reason);
 }
 
 ReadableStreamGenericReaderMixin::ReadableStreamGenericReaderMixin(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.h
+++ b/Userland/Libraries/LibWeb/Streams/ReadableStreamGenericReader.h
@@ -19,9 +19,9 @@ class ReadableStreamGenericReaderMixin {
 public:
     virtual ~ReadableStreamGenericReaderMixin() = default;
 
-    JS::GCPtr<JS::Promise> closed();
+    JS::GCPtr<WebIDL::Promise> closed();
 
-    JS::NonnullGCPtr<JS::Promise> cancel(JS::Value reason);
+    JS::NonnullGCPtr<WebIDL::Promise> cancel(JS::Value reason);
 
     JS::GCPtr<ReadableStream> stream() const { return m_stream; }
     void set_stream(JS::GCPtr<ReadableStream> stream) { m_stream = stream; }

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -58,39 +58,39 @@ bool WritableStream::locked() const
 }
 
 // https://streams.spec.whatwg.org/#ws-close
-JS::GCPtr<JS::Object> WritableStream::close()
+JS::GCPtr<WebIDL::Promise> WritableStream::close()
 {
     auto& realm = this->realm();
 
     // 1. If ! IsWritableStreamLocked(this) is true, return a promise rejected with a TypeError exception.
     if (is_writable_stream_locked(*this)) {
         auto exception = JS::TypeError::create(realm, "Cannot close a locked stream"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 2. If ! WritableStreamCloseQueuedOrInFlight(this) is true, return a promise rejected with a TypeError exception.
     if (writable_stream_close_queued_or_in_flight(*this)) {
         auto exception = JS::TypeError::create(realm, "Cannot close a stream that is already closed or errored"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 3. Return ! WritableStreamClose(this).
-    return writable_stream_close(*this)->promise();
+    return writable_stream_close(*this);
 }
 
 // https://streams.spec.whatwg.org/#ws-abort
-JS::GCPtr<JS::Object> WritableStream::abort(JS::Value reason)
+JS::GCPtr<WebIDL::Promise> WritableStream::abort(JS::Value reason)
 {
     auto& realm = this->realm();
 
     // 1. If ! IsWritableStreamLocked(this) is true, return a promise rejected with a TypeError exception.
     if (is_writable_stream_locked(*this)) {
         auto exception = JS::TypeError::create(realm, "Cannot abort a locked stream"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 2. Return ! WritableStreamAbort(this, reason).
-    return writable_stream_abort(*this, reason)->promise();
+    return writable_stream_abort(*this, reason);
 }
 
 // https://streams.spec.whatwg.org/#ws-get-writer

--- a/Userland/Libraries/LibWeb/Streams/WritableStream.h
+++ b/Userland/Libraries/LibWeb/Streams/WritableStream.h
@@ -49,8 +49,8 @@ public:
     virtual ~WritableStream() = default;
 
     bool locked() const;
-    JS::GCPtr<JS::Object> abort(JS::Value reason);
-    JS::GCPtr<JS::Object> close();
+    JS::GCPtr<WebIDL::Promise> abort(JS::Value reason);
+    JS::GCPtr<WebIDL::Promise> close();
     WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStreamDefaultWriter>> get_writer();
 
     bool backpressure() const { return m_backpressure; }

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
@@ -27,10 +27,10 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WritableStreamDefaultWriter>> WritableStrea
 }
 
 // https://streams.spec.whatwg.org/#default-writer-closed
-JS::GCPtr<JS::Object> WritableStreamDefaultWriter::closed()
+JS::GCPtr<WebIDL::Promise> WritableStreamDefaultWriter::closed()
 {
     // 1. Return this.[[closedPromise]].
-    return m_closed_promise->promise();
+    return m_closed_promise;
 }
 
 // https://streams.spec.whatwg.org/#default-writer-desired-size
@@ -45,29 +45,29 @@ WebIDL::ExceptionOr<Optional<double>> WritableStreamDefaultWriter::desired_size(
 }
 
 // https://streams.spec.whatwg.org/#default-writer-ready
-JS::GCPtr<JS::Object> WritableStreamDefaultWriter::ready()
+JS::GCPtr<WebIDL::Promise> WritableStreamDefaultWriter::ready()
 {
     // 1. Return this.[[readyPromise]].
-    return m_ready_promise->promise();
+    return m_ready_promise;
 }
 
 // https://streams.spec.whatwg.org/#default-writer-abort
-JS::GCPtr<JS::Object> WritableStreamDefaultWriter::abort(JS::Value reason)
+JS::GCPtr<WebIDL::Promise> WritableStreamDefaultWriter::abort(JS::Value reason)
 {
     auto& realm = this->realm();
 
     // 1. If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
     if (!m_stream) {
         auto exception = JS::TypeError::create(realm, "Cannot abort a writer that has no locked stream"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 2. Return ! WritableStreamDefaultWriterAbort(this, reason).
-    return writable_stream_default_writer_abort(*this, reason)->promise();
+    return writable_stream_default_writer_abort(*this, reason);
 }
 
 // https://streams.spec.whatwg.org/#default-writer-close
-JS::GCPtr<JS::Object> WritableStreamDefaultWriter::close()
+JS::GCPtr<WebIDL::Promise> WritableStreamDefaultWriter::close()
 {
     auto& realm = this->realm();
 
@@ -76,17 +76,17 @@ JS::GCPtr<JS::Object> WritableStreamDefaultWriter::close()
     // 2. If stream is undefined, return a promise rejected with a TypeError exception.
     if (!m_stream) {
         auto exception = JS::TypeError::create(realm, "Cannot close a writer that has no locked stream"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 3. If ! WritableStreamCloseQueuedOrInFlight(stream) is true, return a promise rejected with a TypeError exception.
     if (writable_stream_close_queued_or_in_flight(*m_stream)) {
         auto exception = JS::TypeError::create(realm, "Cannot close a stream that is already closed or errored"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 4. Return ! WritableStreamDefaultWriterClose(this).
-    return writable_stream_default_writer_close(*this)->promise();
+    return writable_stream_default_writer_close(*this);
 }
 
 // https://streams.spec.whatwg.org/#default-writer-release-lock
@@ -106,18 +106,18 @@ void WritableStreamDefaultWriter::release_lock()
 }
 
 // https://streams.spec.whatwg.org/#default-writer-write
-JS::GCPtr<JS::Object> WritableStreamDefaultWriter::write(JS::Value chunk)
+JS::GCPtr<WebIDL::Promise> WritableStreamDefaultWriter::write(JS::Value chunk)
 {
     auto& realm = this->realm();
 
     // 1. If this.[[stream]] is undefined, return a promise rejected with a TypeError exception.
     if (!m_stream) {
         auto exception = JS::TypeError::create(realm, "Cannot write to a writer that has no locked stream"sv);
-        return WebIDL::create_rejected_promise(realm, exception)->promise();
+        return WebIDL::create_rejected_promise(realm, exception);
     }
 
     // 2. Return ! WritableStreamDefaultWriterWrite(this, chunk).
-    return writable_stream_default_writer_write(*this, chunk)->promise();
+    return writable_stream_default_writer_write(*this, chunk);
 }
 
 WritableStreamDefaultWriter::WritableStreamDefaultWriter(JS::Realm& realm)

--- a/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.h
+++ b/Userland/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.h
@@ -25,13 +25,13 @@ public:
 
     virtual ~WritableStreamDefaultWriter() override = default;
 
-    JS::GCPtr<JS::Object> closed();
+    JS::GCPtr<WebIDL::Promise> closed();
     WebIDL::ExceptionOr<Optional<double>> desired_size() const;
-    JS::GCPtr<JS::Object> ready();
-    JS::GCPtr<JS::Object> abort(JS::Value reason);
-    JS::GCPtr<JS::Object> close();
+    JS::GCPtr<WebIDL::Promise> ready();
+    JS::GCPtr<WebIDL::Promise> abort(JS::Value reason);
+    JS::GCPtr<WebIDL::Promise> close();
     void release_lock();
-    JS::GCPtr<JS::Object> write(JS::Value chunk);
+    JS::GCPtr<WebIDL::Promise> write(JS::Value chunk);
 
     JS::GCPtr<WebIDL::Promise> closed_promise() { return m_closed_promise; }
     void set_closed_promise(JS::GCPtr<WebIDL::Promise> value) { m_closed_promise = value; }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.h
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssembly.h
@@ -22,10 +22,10 @@ void visit_edges(JS::Object&, JS::Cell::Visitor&);
 void finalize(JS::Object&);
 
 bool validate(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes);
-WebIDL::ExceptionOr<JS::Value> compile(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> compile(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes);
 
-WebIDL::ExceptionOr<JS::Value> instantiate(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes, Optional<JS::Handle<JS::Object>>& import_object);
-WebIDL::ExceptionOr<JS::Value> instantiate(JS::VM&, Module const& module_object, Optional<JS::Handle<JS::Object>>& import_object);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> instantiate(JS::VM&, JS::Handle<WebIDL::BufferSource>& bytes, Optional<JS::Handle<JS::Object>>& import_object);
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> instantiate(JS::VM&, Module const& module_object, Optional<JS::Handle<JS::Object>>& import_object);
 
 namespace Detail {
 struct CompiledWebAssemblyModule : public RefCounted<CompiledWebAssemblyModule> {

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -103,7 +103,7 @@ AudioTimestamp AudioContext::get_output_timestamp()
 }
 
 // https://www.w3.org/TR/webaudio/#dom-audiocontext-resume
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::resume()
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::resume()
 {
     auto& realm = this->realm();
 
@@ -118,7 +118,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::resume()
     // 3. If the [[control thread state]] on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
         WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_string));
-        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+        return promise;
     }
 
     // 4. Set [[suspended by user]] to true.
@@ -187,11 +187,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::resume()
     }));
 
     // 8. Return promise.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 // https://www.w3.org/TR/webaudio/#dom-audiocontext-suspend
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::suspend()
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::suspend()
 {
     auto& realm = this->realm();
 
@@ -206,7 +206,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::suspend()
     // 3. If the [[control thread state]] on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
         WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_string));
-        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+        return promise;
     }
 
     // 4. Append promise to [[pending promises]].
@@ -244,11 +244,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::suspend()
     }));
 
     // 8. Return promise.
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 // https://www.w3.org/TR/webaudio/#dom-audiocontext-close
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::close()
 {
     auto& realm = this->realm();
 
@@ -263,7 +263,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
     // 3. If the [[control thread state]] flag on the AudioContext is closed reject the promise with InvalidStateError, abort these steps, returning promise.
     if (state() == Bindings::AudioContextState::Closed) {
         WebIDL::reject_promise(realm, promise, WebIDL::InvalidStateError::create(realm, "Audio context is already closed."_string));
-        return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+        return promise;
     }
 
     // 4. Set the [[control thread state]] flag on the AudioContext to closed.
@@ -296,7 +296,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> AudioContext::close()
     }));
 
     // 6. Return promise
-    return JS::NonnullGCPtr { verify_cast<JS::Promise>(*promise->promise()) };
+    return promise;
 }
 
 // FIXME: Actually implement the rendering thread

--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.h
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.h
@@ -35,9 +35,9 @@ public:
     double base_latency() const { return m_base_latency; }
     double output_latency() const { return m_output_latency; }
     AudioTimestamp get_output_timestamp();
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> resume();
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> suspend();
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> close();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> resume();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> suspend();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> close();
 
 private:
     explicit AudioContext(JS::Realm&, AudioContextOptions const& context_options);

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -128,7 +128,7 @@ void BaseAudioContext::queue_a_media_element_task(JS::NonnullGCPtr<JS::HeapFunct
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata
-JS::NonnullGCPtr<JS::Promise> BaseAudioContext::decode_audio_data(JS::Handle<WebIDL::BufferSource> audio_data, JS::GCPtr<WebIDL::CallbackType> success_callback, JS::GCPtr<WebIDL::CallbackType> error_callback)
+JS::NonnullGCPtr<WebIDL::Promise> BaseAudioContext::decode_audio_data(JS::Handle<WebIDL::BufferSource> audio_data, JS::GCPtr<WebIDL::CallbackType> success_callback, JS::GCPtr<WebIDL::CallbackType> error_callback)
 {
     auto& realm = this->realm();
 
@@ -178,7 +178,7 @@ JS::NonnullGCPtr<JS::Promise> BaseAudioContext::decode_audio_data(JS::Handle<Web
     }
 
     // 5. Return promise.
-    return verify_cast<JS::Promise>(*promise->promise());
+    return promise;
 }
 
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-decodeaudiodata

--- a/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.h
+++ b/Userland/Libraries/LibWeb/WebAudio/BaseAudioContext.h
@@ -61,7 +61,7 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<DynamicsCompressorNode>> create_dynamics_compressor();
     JS::NonnullGCPtr<GainNode> create_gain();
 
-    JS::NonnullGCPtr<JS::Promise> decode_audio_data(JS::Handle<WebIDL::BufferSource>, JS::GCPtr<WebIDL::CallbackType>, JS::GCPtr<WebIDL::CallbackType>);
+    JS::NonnullGCPtr<WebIDL::Promise> decode_audio_data(JS::Handle<WebIDL::BufferSource>, JS::GCPtr<WebIDL::CallbackType>, JS::GCPtr<WebIDL::CallbackType>);
 
 protected:
     explicit BaseAudioContext(JS::Realm&, float m_sample_rate = 0);

--- a/Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.cpp
@@ -32,17 +32,17 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<OfflineAudioContext>> OfflineAudioContext::
 OfflineAudioContext::~OfflineAudioContext() = default;
 
 // https://webaudio.github.io/web-audio-api/#dom-offlineaudiocontext-startrendering
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> OfflineAudioContext::start_rendering()
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> OfflineAudioContext::start_rendering()
 {
     return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::start_rendering"_string);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> OfflineAudioContext::resume()
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> OfflineAudioContext::resume()
 {
     return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::resume"_string);
 }
 
-WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> OfflineAudioContext::suspend(double suspend_time)
+WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> OfflineAudioContext::suspend(double suspend_time)
 {
     (void)suspend_time;
     return WebIDL::NotSupportedError::create(realm(), "FIXME: Implement OfflineAudioContext::suspend"_string);

--- a/Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.h
+++ b/Userland/Libraries/LibWeb/WebAudio/OfflineAudioContext.h
@@ -32,9 +32,9 @@ public:
 
     virtual ~OfflineAudioContext() override;
 
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> start_rendering();
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> resume();
-    WebIDL::ExceptionOr<JS::NonnullGCPtr<JS::Promise>> suspend(double suspend_time);
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> start_rendering();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> resume();
+    WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> suspend(double suspend_time);
 
     WebIDL::UnsignedLong length() const;
 

--- a/Userland/Libraries/LibWeb/WebIDL/Promise.h
+++ b/Userland/Libraries/LibWeb/WebIDL/Promise.h
@@ -27,13 +27,13 @@ JS::NonnullGCPtr<Promise> create_resolved_promise(JS::Realm&, JS::Value);
 JS::NonnullGCPtr<Promise> create_rejected_promise(JS::Realm&, JS::Value);
 void resolve_promise(JS::Realm&, Promise const&, JS::Value = JS::js_undefined());
 void reject_promise(JS::Realm&, Promise const&, JS::Value);
-JS::NonnullGCPtr<JS::Promise> react_to_promise(Promise const&, JS::GCPtr<ReactionSteps> on_fulfilled_callback, JS::GCPtr<ReactionSteps> on_rejected_callback);
-JS::NonnullGCPtr<JS::Promise> upon_fulfillment(Promise const&, JS::NonnullGCPtr<ReactionSteps>);
-JS::NonnullGCPtr<JS::Promise> upon_rejection(Promise const&, JS::NonnullGCPtr<ReactionSteps>);
+JS::NonnullGCPtr<Promise> react_to_promise(Promise const&, JS::GCPtr<ReactionSteps> on_fulfilled_callback, JS::GCPtr<ReactionSteps> on_rejected_callback);
+JS::NonnullGCPtr<Promise> upon_fulfillment(Promise const&, JS::NonnullGCPtr<ReactionSteps>);
+JS::NonnullGCPtr<Promise> upon_rejection(Promise const&, JS::NonnullGCPtr<ReactionSteps>);
 void mark_promise_as_handled(Promise const&);
 void wait_for_all(JS::Realm&, Vector<JS::NonnullGCPtr<Promise>> const& promises, Function<void(Vector<JS::Value> const&)> success_steps, Function<void(JS::Value)> failure_steps);
 
 // Non-spec, convenience method.
-JS::NonnullGCPtr<JS::Promise> create_rejected_promise_from_exception(JS::Realm&, Exception);
+JS::NonnullGCPtr<Promise> create_rejected_promise_from_exception(JS::Realm&, Exception);
 
 }


### PR DESCRIPTION
This change also removes as much direct use of JS::Promise in LibWeb
as possible. When specs refer to `Promise<T>` they should be assumed
to be referring to the WebIDL Promise type, not the JS::Promise type.

The one exception is the HostPromiseRejectionTracker hook on the JS
VM. This facility and its associated sets and events are intended to
expose the exact opaque object handles that were rejected to author
code. This is not possible with the WebIDL Promise type, so we have
to use JS::Promise or JS::Object to hold onto the promises.

It also exposes which specs need some updates in the area of
promises. WebDriver stands out in this regard. WebAudio could use
some more cross-references to WebIDL as well to clarify things.