### PR TITLE
LibWeb+WebContent+WebDriver: Asynchronously wait for navigations to complete

### DIFF
--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -180,34 +180,46 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     view().on_request_alert = [this](auto const& message) {
         m_dialog = new QMessageBox(QMessageBox::Icon::Warning, "Ladybird", qstring_from_ak_string(message), QMessageBox::StandardButton::Ok, &view());
-        m_dialog->exec();
 
-        view().alert_closed();
-        m_dialog = nullptr;
+        QObject::connect(m_dialog, &QDialog::finished, this, [this]() {
+            view().alert_closed();
+            m_dialog = nullptr;
+        });
+
+        m_dialog->open();
     };
 
     view().on_request_confirm = [this](auto const& message) {
         m_dialog = new QMessageBox(QMessageBox::Icon::Question, "Ladybird", qstring_from_ak_string(message), QMessageBox::StandardButton::Ok | QMessageBox::StandardButton::Cancel, &view());
-        auto result = m_dialog->exec();
 
-        view().confirm_closed(result == QMessageBox::StandardButton::Ok || result == QDialog::Accepted);
-        m_dialog = nullptr;
+        QObject::connect(m_dialog, &QDialog::finished, this, [this](auto result) {
+            view().confirm_closed(result == QMessageBox::StandardButton::Ok || result == QDialog::Accepted);
+            m_dialog = nullptr;
+        });
+
+        m_dialog->open();
     };
 
     view().on_request_prompt = [this](auto const& message, auto const& default_) {
         m_dialog = new QInputDialog(&view());
-        auto& dialog = static_cast<QInputDialog&>(*m_dialog);
 
+        auto& dialog = static_cast<QInputDialog&>(*m_dialog);
         dialog.setWindowTitle("Ladybird");
         dialog.setLabelText(qstring_from_ak_string(message));
         dialog.setTextValue(qstring_from_ak_string(default_));
 
-        if (dialog.exec() == QDialog::Accepted)
-            view().prompt_closed(ak_string_from_qstring(dialog.textValue()));
-        else
-            view().prompt_closed({});
+        QObject::connect(m_dialog, &QDialog::finished, this, [this](auto result) {
+            if (result == QDialog::Accepted) {
+                auto& dialog = static_cast<QInputDialog&>(*m_dialog);
+                view().prompt_closed(ak_string_from_qstring(dialog.textValue()));
+            } else {
+                view().prompt_closed({});
+            }
 
-        m_dialog = nullptr;
+            m_dialog = nullptr;
+        });
+
+        m_dialog->open();
     };
 
     view().on_request_set_prompt_text = [this](auto const& message) {
@@ -227,20 +239,26 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     view().on_request_color_picker = [this](Color current_color) {
         m_dialog = new QColorDialog(QColor(current_color.red(), current_color.green(), current_color.blue()), &view());
-        auto& dialog = static_cast<QColorDialog&>(*m_dialog);
 
+        auto& dialog = static_cast<QColorDialog&>(*m_dialog);
         dialog.setWindowTitle("Ladybird");
         dialog.setOption(QColorDialog::ShowAlphaChannel, false);
         QObject::connect(&dialog, &QColorDialog::currentColorChanged, this, [this](QColor const& color) {
             view().color_picker_update(Color(color.red(), color.green(), color.blue()), Web::HTML::ColorPickerUpdateState::Update);
         });
 
-        if (dialog.exec() == QDialog::Accepted)
-            view().color_picker_update(Color(dialog.selectedColor().red(), dialog.selectedColor().green(), dialog.selectedColor().blue()), Web::HTML::ColorPickerUpdateState::Closed);
-        else
-            view().color_picker_update({}, Web::HTML::ColorPickerUpdateState::Closed);
+        QObject::connect(m_dialog, &QDialog::finished, this, [this](auto result) {
+            if (result == QDialog::Accepted) {
+                auto& dialog = static_cast<QColorDialog&>(*m_dialog);
+                view().color_picker_update(Color(dialog.selectedColor().red(), dialog.selectedColor().green(), dialog.selectedColor().blue()), Web::HTML::ColorPickerUpdateState::Closed);
+            } else {
+                view().color_picker_update({}, Web::HTML::ColorPickerUpdateState::Closed);
+            }
 
-        m_dialog = nullptr;
+            m_dialog = nullptr;
+        });
+
+        m_dialog->open();
     };
 
     view().on_request_file_picker = [this](auto const& accepted_file_types, auto allow_multiple_files) {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -747,6 +747,7 @@ set(SOURCES
     WebDriver/ElementReference.cpp
     WebDriver/Error.cpp
     WebDriver/ExecuteScript.cpp
+    WebDriver/HeapTimer.cpp
     WebDriver/InputSource.cpp
     WebDriver/InputState.cpp
     WebDriver/Response.cpp

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -411,6 +411,7 @@ set(SOURCES
     HTML/NavigationDestination.cpp
     HTML/NavigationCurrentEntryChangeEvent.cpp
     HTML/NavigationHistoryEntry.cpp
+    HTML/NavigationObserver.cpp
     HTML/NavigationParams.cpp
     HTML/NavigationTransition.cpp
     HTML/Navigator.cpp

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2392,6 +2392,11 @@ void Document::update_readiness(HTML::DocumentReadyState readiness_value)
             m_needs_to_call_page_did_load = true;
         }
     }
+
+    for (auto document_observer : m_document_observers) {
+        if (document_observer->document_readiness_observer())
+            document_observer->document_readiness_observer()->function()(m_readiness);
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#dom-document-lastmodified

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,6 +25,7 @@ void DocumentObserver::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document);
     visitor.visit(m_document_became_inactive);
     visitor.visit(m_document_completely_loaded);
+    visitor.visit(m_document_readiness_observer);
 }
 
 void DocumentObserver::finalize()
@@ -41,6 +42,11 @@ void DocumentObserver::set_document_became_inactive(Function<void()> callback)
 void DocumentObserver::set_document_completely_loaded(Function<void()> callback)
 {
     m_document_completely_loaded = JS::create_heap_function(vm().heap(), move(callback));
+}
+
+void DocumentObserver::set_document_readiness_observer(Function<void(HTML::DocumentReadyState)> callback)
+{
+    m_document_readiness_observer = JS::create_heap_function(vm().heap(), move(callback));
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
@@ -36,17 +36,26 @@ void DocumentObserver::finalize()
 
 void DocumentObserver::set_document_became_inactive(Function<void()> callback)
 {
-    m_document_became_inactive = JS::create_heap_function(vm().heap(), move(callback));
+    if (callback)
+        m_document_became_inactive = JS::create_heap_function(vm().heap(), move(callback));
+    else
+        m_document_became_inactive = nullptr;
 }
 
 void DocumentObserver::set_document_completely_loaded(Function<void()> callback)
 {
-    m_document_completely_loaded = JS::create_heap_function(vm().heap(), move(callback));
+    if (callback)
+        m_document_completely_loaded = JS::create_heap_function(vm().heap(), move(callback));
+    else
+        m_document_completely_loaded = nullptr;
 }
 
 void DocumentObserver::set_document_readiness_observer(Function<void(HTML::DocumentReadyState)> callback)
 {
-    m_document_readiness_observer = JS::create_heap_function(vm().heap(), move(callback));
+    if (callback)
+        m_document_readiness_observer = JS::create_heap_function(vm().heap(), move(callback));
+    else
+        m_document_readiness_observer = nullptr;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,6 +11,7 @@
 #include <LibJS/SafeFunction.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/DocumentReadyState.h>
 
 namespace Web::DOM {
 
@@ -25,6 +26,9 @@ public:
     [[nodiscard]] JS::GCPtr<JS::HeapFunction<void()>> document_completely_loaded() const { return m_document_completely_loaded; }
     void set_document_completely_loaded(Function<void()>);
 
+    [[nodiscard]] JS::GCPtr<JS::HeapFunction<void(HTML::DocumentReadyState)>> document_readiness_observer() const { return m_document_readiness_observer; }
+    void set_document_readiness_observer(Function<void(HTML::DocumentReadyState)>);
+
 private:
     explicit DocumentObserver(JS::Realm&, DOM::Document&);
 
@@ -34,6 +38,7 @@ private:
     JS::NonnullGCPtr<DOM::Document> m_document;
     JS::GCPtr<JS::HeapFunction<void()>> m_document_became_inactive;
     JS::GCPtr<JS::HeapFunction<void()>> m_document_completely_loaded;
+    JS::GCPtr<JS::HeapFunction<void(HTML::DocumentReadyState)>> m_document_readiness_observer;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -812,6 +812,8 @@ using Promise = JS::PromiseCapability;
 }
 
 namespace Web::WebDriver {
+class HeapTimer;
+
 struct ActionObject;
 struct InputState;
 };

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -496,6 +496,7 @@ class Navigation;
 class NavigationCurrentEntryChangeEvent;
 class NavigationDestination;
 class NavigationHistoryEntry;
+class NavigationObserver;
 class NavigationTransition;
 class Navigator;
 class PageTransitionEvent;

--- a/Userland/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.cpp
@@ -23,6 +23,7 @@
 #include <LibWeb/HTML/HistoryHandlingBehavior.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/Navigation.h>
+#include <LibWeb/HTML/NavigationObserver.h>
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/POSTResource.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
@@ -126,6 +127,7 @@ void Navigable::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_current_session_history_entry);
     visitor.visit(m_active_session_history_entry);
     visitor.visit(m_container);
+    visitor.visit(m_navigation_observers);
     m_event_handler.visit_edges(visitor);
 }
 
@@ -230,6 +232,13 @@ void Navigable::activate_history_entry(JS::GCPtr<SessionHistoryEntry> entry)
 
     // 5. Make active newDocument.
     new_document->make_active();
+
+    if (m_ongoing_navigation.has<Empty>()) {
+        for (auto navigation_observer : m_navigation_observers) {
+            if (navigation_observer->navigation_complete())
+                navigation_observer->navigation_complete()->function()();
+        }
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#nav-document
@@ -2198,6 +2207,18 @@ void Navigable::paste(String const& text)
         return;
 
     m_event_handler.handle_paste(text);
+}
+
+void Navigable::register_navigation_observer(Badge<NavigationObserver>, NavigationObserver& navigation_observer)
+{
+    auto result = m_navigation_observers.set(navigation_observer);
+    VERIFY(result == AK::HashSetResult::InsertedNewEntry);
+}
+
+void Navigable::unregister_navigation_observer(Badge<NavigationObserver>, NavigationObserver& navigation_observer)
+{
+    bool was_removed = m_navigation_observers.remove(navigation_observer);
+    VERIFY(was_removed);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Navigable.h
+++ b/Userland/Libraries/LibWeb/HTML/Navigable.h
@@ -59,6 +59,9 @@ public:
 
     ErrorOr<void> initialize_navigable(JS::NonnullGCPtr<DocumentState> document_state, JS::GCPtr<Navigable> parent);
 
+    void register_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);
+    void unregister_navigation_observer(Badge<NavigationObserver>, NavigationObserver&);
+
     Vector<JS::Handle<Navigable>> child_navigables() const;
 
     bool is_traversable() const;
@@ -231,6 +234,8 @@ private:
     JS::GCPtr<NavigableContainer> m_container;
 
     JS::NonnullGCPtr<Page> m_page;
+
+    HashTable<JS::NonnullGCPtr<NavigationObserver>> m_navigation_observers;
 
     bool m_has_been_destroyed { false };
 

--- a/Userland/Libraries/LibWeb/HTML/NavigationObserver.cpp
+++ b/Userland/Libraries/LibWeb/HTML/NavigationObserver.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Realm.h>
+#include <LibWeb/HTML/Navigable.h>
+#include <LibWeb/HTML/NavigationObserver.h>
+
+namespace Web::HTML {
+
+JS_DEFINE_ALLOCATOR(NavigationObserver);
+
+NavigationObserver::NavigationObserver(JS::Realm& realm, Navigable& navigable)
+    : Bindings::PlatformObject(realm)
+    , m_navigable(navigable)
+{
+    m_navigable->register_navigation_observer({}, *this);
+}
+
+void NavigationObserver::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_navigable);
+    visitor.visit(m_navigation_complete);
+}
+
+void NavigationObserver::finalize()
+{
+    Base::finalize();
+    m_navigable->unregister_navigation_observer({}, *this);
+}
+
+void NavigationObserver::set_navigation_complete(Function<void()> callback)
+{
+    if (callback)
+        m_navigation_complete = JS::create_heap_function(vm().heap(), move(callback));
+    else
+        m_navigation_complete = nullptr;
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/NavigationObserver.h
+++ b/Userland/Libraries/LibWeb/HTML/NavigationObserver.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Heap/HeapFunction.h>
+#include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::HTML {
+
+class NavigationObserver final : public Bindings::PlatformObject {
+    WEB_PLATFORM_OBJECT(NavigationObserver, Bindings::PlatformObject);
+    JS_DECLARE_ALLOCATOR(NavigationObserver);
+
+public:
+    [[nodiscard]] JS::GCPtr<JS::HeapFunction<void()>> navigation_complete() const { return m_navigation_complete; }
+    void set_navigation_complete(Function<void()>);
+
+private:
+    NavigationObserver(JS::Realm&, Navigable&);
+
+    virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
+
+    JS::NonnullGCPtr<Navigable> m_navigable;
+    JS::GCPtr<JS::HeapFunction<void()>> m_navigation_complete;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -145,8 +145,8 @@ public:
     bool has_pending_dialog() const { return m_pending_dialog != PendingDialog::None; }
     PendingDialog pending_dialog() const { return m_pending_dialog; }
     Optional<String> const& pending_dialog_text() const { return m_pending_dialog_text; }
-    void dismiss_dialog();
-    void accept_dialog();
+    void dismiss_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed = nullptr);
+    void accept_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed = nullptr);
 
     void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
     void color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUpdateState state);
@@ -224,6 +224,8 @@ private:
     FindInPageResult perform_find_in_page_query(FindInPageQuery const&, Optional<SearchDirection> = {});
     void update_find_in_page_selection(Vector<JS::Handle<DOM::Range>> matches);
 
+    void on_pending_dialog_closed();
+
     JS::NonnullGCPtr<PageClient> m_client;
 
     WeakPtr<HTML::Navigable> m_focused_navigable;
@@ -249,6 +251,7 @@ private:
     Optional<Empty> m_pending_alert_response;
     Optional<bool> m_pending_confirm_response;
     Optional<Optional<String>> m_pending_prompt_response;
+    JS::GCPtr<JS::HeapFunction<void()>> m_on_pending_dialog_closed;
 
     PendingNonBlockingDialog m_pending_non_blocking_dialog { PendingNonBlockingDialog::None };
     WeakPtr<HTML::HTMLElement> m_pending_non_blocking_dialog_target;

--- a/Userland/Libraries/LibWeb/WebDriver/HeapTimer.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/HeapTimer.cpp
@@ -42,6 +42,15 @@ void HeapTimer::start(u64 timeout_ms, JS::NonnullGCPtr<JS::HeapFunction<void()>>
     m_timer->start();
 }
 
+void HeapTimer::stop_and_fire_timeout_handler()
+{
+    auto on_timeout = m_on_timeout;
+    stop();
+
+    if (on_timeout)
+        on_timeout->function()();
+}
+
 void HeapTimer::stop()
 {
     m_on_timeout = nullptr;

--- a/Userland/Libraries/LibWeb/WebDriver/HeapTimer.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/HeapTimer.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/Timer.h>
+#include <LibWeb/WebDriver/HeapTimer.h>
+
+namespace Web::WebDriver {
+
+JS_DEFINE_ALLOCATOR(HeapTimer);
+
+HeapTimer::HeapTimer()
+    : m_timer(Core::Timer::create())
+{
+}
+
+HeapTimer::~HeapTimer() = default;
+
+void HeapTimer::visit_edges(JS::Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_on_timeout);
+}
+
+void HeapTimer::start(u64 timeout_ms, JS::NonnullGCPtr<JS::HeapFunction<void()>> on_timeout)
+{
+    m_on_timeout = on_timeout;
+
+    m_timer->on_timeout = [this]() {
+        m_timed_out = true;
+
+        if (m_on_timeout) {
+            m_on_timeout->function()();
+            m_on_timeout = nullptr;
+        }
+    };
+
+    m_timer->set_interval(static_cast<int>(timeout_ms));
+    m_timer->set_single_shot(true);
+    m_timer->start();
+}
+
+void HeapTimer::stop()
+{
+    m_on_timeout = nullptr;
+    m_timer->stop();
+}
+
+}

--- a/Userland/Libraries/LibWeb/WebDriver/HeapTimer.h
+++ b/Userland/Libraries/LibWeb/WebDriver/HeapTimer.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Forward.h>
+#include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Heap/HeapFunction.h>
+
+namespace Web::WebDriver {
+
+class HeapTimer : public JS::Cell {
+    JS_CELL(HeapTimer, JS::Cell);
+    JS_DECLARE_ALLOCATOR(HeapTimer);
+
+public:
+    explicit HeapTimer();
+    virtual ~HeapTimer() override;
+
+    void start(u64 timeout_ms, JS::NonnullGCPtr<JS::HeapFunction<void()>> on_timeout);
+    void stop();
+
+    bool is_timed_out() const { return m_timed_out; }
+
+private:
+    virtual void visit_edges(JS::Cell::Visitor& visitor) override;
+
+    NonnullRefPtr<Core::Timer> m_timer;
+    JS::GCPtr<JS::HeapFunction<void()>> m_on_timeout;
+    bool m_timed_out { false };
+};
+
+}

--- a/Userland/Libraries/LibWeb/WebDriver/HeapTimer.h
+++ b/Userland/Libraries/LibWeb/WebDriver/HeapTimer.h
@@ -21,6 +21,7 @@ public:
     virtual ~HeapTimer() override;
 
     void start(u64 timeout_ms, JS::NonnullGCPtr<JS::HeapFunction<void()>> on_timeout);
+    void stop_and_fire_timeout_handler();
     void stop();
 
     bool is_timed_out() const { return m_timed_out; }

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -389,6 +389,9 @@ void PageClient::page_did_request_media_context_menu(Web::CSSPixelPoint content_
 void PageClient::page_did_request_alert(String const& message)
 {
     client().async_did_request_alert(m_id, message);
+
+    if (m_webdriver)
+        m_webdriver->page_did_open_dialog({});
 }
 
 void PageClient::alert_closed()
@@ -399,6 +402,9 @@ void PageClient::alert_closed()
 void PageClient::page_did_request_confirm(String const& message)
 {
     client().async_did_request_confirm(m_id, message);
+
+    if (m_webdriver)
+        m_webdriver->page_did_open_dialog({});
 }
 
 void PageClient::confirm_closed(bool accepted)
@@ -409,6 +415,9 @@ void PageClient::confirm_closed(bool accepted)
 void PageClient::page_did_request_prompt(String const& message, String const& default_)
 {
     client().async_did_request_prompt(m_id, message, default_);
+
+    if (m_webdriver)
+        m_webdriver->page_did_open_dialog({});
 }
 
 void PageClient::page_did_request_set_prompt_text(String const& text)

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -2162,7 +2162,9 @@ Messages::WebDriverClient::DismissAlertResponse WebDriverConnection::dismiss_ale
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchAlert, "No user dialog is currently open"sv);
 
     // 3. Dismiss the current user prompt.
-    current_browsing_context().page().dismiss_dialog();
+    current_browsing_context().page().dismiss_dialog(JS::create_heap_function(current_browsing_context().heap(), [this]() {
+        async_dialog_closed(JsonValue {});
+    }));
 
     // 4. Return success with data null.
     return JsonValue {};
@@ -2179,7 +2181,9 @@ Messages::WebDriverClient::AcceptAlertResponse WebDriverConnection::accept_alert
         return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchAlert, "No user dialog is currently open"sv);
 
     // 3. Accept the current user prompt.
-    current_browsing_context().page().accept_dialog();
+    current_browsing_context().page().accept_dialog(JS::create_heap_function(current_browsing_context().heap(), [this]() {
+        async_dialog_closed(JsonValue {});
+    }));
 
     // 4. Return success with data null.
     return JsonValue {};

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -23,6 +23,7 @@
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/DocumentObserver.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/Position.h>
@@ -40,6 +41,7 @@
 #include <LibWeb/HTML/HTMLOptionElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
+#include <LibWeb/HTML/NavigationObserver.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
@@ -52,6 +54,7 @@
 #include <LibWeb/WebDriver/Actions.h>
 #include <LibWeb/WebDriver/ElementReference.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
+#include <LibWeb/WebDriver/HeapTimer.h>
 #include <LibWeb/WebDriver/InputState.h>
 #include <LibWeb/WebDriver/Properties.h>
 #include <LibWeb/WebDriver/Screenshot.h>
@@ -201,6 +204,9 @@ void WebDriverConnection::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_current_parent_browsing_context);
     visitor.visit(m_current_top_level_browsing_context);
     visitor.visit(m_action_executor);
+    visitor.visit(m_document_observer);
+    visitor.visit(m_navigation_observer);
+    visitor.visit(m_navigation_timer);
 }
 
 // https://w3c.github.io/webdriver/#dfn-close-the-session
@@ -288,21 +294,27 @@ Messages::WebDriverClient::NavigateToResponse WebDriverConnection::navigate_to(J
     // 7. Navigate the current top-level browsing context to url.
     current_top_level_browsing_context()->page().load(url);
 
+    auto navigation_complete = JS::create_heap_function(current_top_level_browsing_context()->heap(), [this](Web::WebDriver::Response result) {
+        // 9. Set the current browsing context with the current top-level browsing context.
+        set_current_browsing_context(*current_top_level_browsing_context());
+
+        // FIXME: 10. If the current top-level browsing context contains a refresh state pragma directive of time 1 second or less, wait until the refresh timeout has elapsed, a new navigate has begun, and return to the first step of this algorithm.
+
+        async_navigation_complete(move(result));
+    });
+
     // 8. If url is special except for file and current URL and URL do not have the same absolute URL:
     // AD-HOC: We wait for the navigation to complete regardless of whether the current URL differs from the provided
     //         URL. Even if they're the same, the navigation queues a tasks that we must await, otherwise subsequent
     //         endpoint invocations will attempt to operate on the wrong page.
     if (url.is_special() && url.scheme() != "file"sv) {
         // a. Try to wait for navigation to complete.
-        TRY(wait_for_navigation_to_complete());
+        wait_for_navigation_to_complete(navigation_complete);
 
         // FIXME: b. Try to run the post-navigation checks.
+    } else {
+        navigation_complete->function()(JsonValue {});
     }
-
-    // 9. Set the current browsing context with the current top-level browsing context.
-    set_current_browsing_context(*current_top_level_browsing_context());
-
-    // FIXME: 10. If the current top-level browsing context contains a refresh state pragma directive of time 1 second or less, wait until the refresh timeout has elapsed, a new navigate has begun, and return to the first step of this algorithm.
 
     // 11. Return success with data null.
     return JsonValue {};
@@ -1365,14 +1377,14 @@ Messages::WebDriverClient::ElementClickResponse WebDriverConnection::element_cli
         // FIXME: 10. Perform implementation-defined steps to allow any navigations triggered by the click to start.
 
         // 11. Try to wait for navigation to complete.
-        if (auto navigation_result = wait_for_navigation_to_complete(); navigation_result.is_error()) {
-            async_actions_performed(navigation_result.release_error());
-            return;
-        }
+        wait_for_navigation_to_complete(JS::create_heap_function(current_browsing_context().heap(), [this, result = move(result)](Web::WebDriver::Response navigation_result) mutable {
+            // FIXME: 12. Try to run the post-navigation checks.
 
-        // FIXME: 12. Try to run the post-navigation checks.
-
-        async_actions_performed(move(result));
+            if (navigation_result.is_error())
+                async_actions_performed(move(navigation_result));
+            else
+                async_actions_performed(move(result));
+        }));
     });
 
     // 8. Matching on element:
@@ -2394,57 +2406,105 @@ ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::handle_any_user_prompt
     return {};
 }
 
-// https://w3c.github.io/webdriver/#dfn-waiting-for-the-navigation-to-complete
+// https://w3c.github.io/webdriver/#dfn-wait-for-navigation-to-complete
 // FIXME: Update this AO to the latest spec steps.
-ErrorOr<void, Web::WebDriver::Error> WebDriverConnection::wait_for_navigation_to_complete()
+void WebDriverConnection::wait_for_navigation_to_complete(OnNavigationComplete on_complete)
 {
     // 1. If the current session has a page loading strategy of none, return success with data null.
-    if (m_page_load_strategy == Web::WebDriver::PageLoadStrategy::None)
-        return {};
+    if (m_page_load_strategy == Web::WebDriver::PageLoadStrategy::None) {
+        on_complete->function()(JsonValue {});
+        return;
+    }
 
     // 2. If the current browsing context is no longer open, return success with data null.
-    if (ensure_browsing_context_is_open(current_browsing_context()).is_error())
-        return {};
+    if (ensure_browsing_context_is_open(current_browsing_context()).is_error()) {
+        on_complete->function()(JsonValue {});
+        return;
+    }
 
+    auto& realm = current_browsing_context().active_document()->realm();
     auto navigable = current_browsing_context().active_document()->navigable();
-    if (!navigable || navigable->ongoing_navigation().has<Empty>())
-        return {};
 
-    // 3. Start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout in milliseconds, return an error with error code timeout.
-    auto page_load_timeout_fired = false;
-    auto timer = Core::Timer::create_single_shot(m_timeouts_configuration.page_load_timeout.value_or(300'000), [&] {
-        page_load_timeout_fired = true;
+    if (!navigable || navigable->ongoing_navigation().has<Empty>()) {
+        on_complete->function()(JsonValue {});
+        return;
+    }
+
+    auto reset_observers = [](auto& self) {
+        if (self.m_navigation_observer) {
+            self.m_navigation_observer->set_navigation_complete({});
+            self.m_navigation_observer = nullptr;
+        }
+        if (self.m_document_observer) {
+            self.m_document_observer->set_document_readiness_observer({});
+            self.m_document_observer = nullptr;
+        }
+    };
+
+    // 3. Start a timer. If this algorithm has not completed before timer reaches the session’s session page load timeout
+    //    in milliseconds, return an error with error code timeout.
+    m_navigation_timer = realm.heap().allocate<Web::WebDriver::HeapTimer>(realm);
+
+    // 4. If there is an ongoing attempt to navigate the current browsing context that has not yet matured, wait for
+    //    navigation to mature.
+    m_navigation_observer = realm.heap().allocate<Web::HTML::NavigationObserver>(realm, realm, *navigable);
+
+    m_navigation_observer->set_navigation_complete([this, &realm, reset_observers]() {
+        reset_observers(*this);
+
+        // 5. Let readiness target be the document readiness state associated with the current session’s page loading
+        //    strategy, which can be found in the table of page load strategies.
+        auto readiness_target = [this]() {
+            switch (m_page_load_strategy) {
+            case Web::WebDriver::PageLoadStrategy::Normal:
+                return Web::HTML::DocumentReadyState::Complete;
+            case Web::WebDriver::PageLoadStrategy::Eager:
+                return Web::HTML::DocumentReadyState::Interactive;
+            default:
+                VERIFY_NOT_REACHED();
+            };
+        }();
+
+        // 6. Wait for the current browsing context’s document readiness state to reach readiness target,
+        //    or for the session page load timeout to pass, whichever occurs sooner.
+        if (auto* document = current_browsing_context().active_document(); document->readiness() != readiness_target) {
+            m_document_observer = realm.heap().allocate<Web::DOM::DocumentObserver>(realm, realm, *document);
+
+            m_document_observer->set_document_readiness_observer([this, readiness_target](Web::HTML::DocumentReadyState readiness) {
+                if (readiness == readiness_target)
+                    m_navigation_timer->stop_and_fire_timeout_handler();
+            });
+        } else {
+            m_navigation_timer->stop_and_fire_timeout_handler();
+        }
     });
-    timer->start();
-    // 4. If there is an ongoing attempt to navigate the current browsing context that has not yet matured, wait for navigation to mature.
-    Web::Platform::EventLoopPlugin::the().spin_until([&] {
-        return page_load_timeout_fired || navigable->ongoing_navigation().has<Empty>();
-    });
 
-    // 5. Let readiness target be the document readiness state associated with the current session’s page loading strategy, which can be found in the table of page load strategies.
-    auto readiness_target = [this]() {
-        switch (m_page_load_strategy) {
-        case Web::WebDriver::PageLoadStrategy::Normal:
-            return Web::HTML::DocumentReadyState::Complete;
-        case Web::WebDriver::PageLoadStrategy::Eager:
-            return Web::HTML::DocumentReadyState::Interactive;
-        default:
-            VERIFY_NOT_REACHED();
-        };
-    }();
+    m_navigation_timer->start(m_timeouts_configuration.page_load_timeout.value_or(300'000), JS::create_heap_function(realm.heap(), [this, on_complete, reset_observers]() {
+        reset_observers(*this);
 
-    // 6. Wait for the current browsing context’s document readiness state to reach readiness target,
-    //    or for the session page load timeout to pass, whichever occurs sooner.
-    Web::Platform::EventLoopPlugin::the().spin_until([&]() {
-        return page_load_timeout_fired || current_browsing_context().active_document()->readiness() == readiness_target;
-    });
+        auto did_time_out = m_navigation_timer->is_timed_out();
+        m_navigation_timer = nullptr;
 
-    // 7. If the previous step completed by the session page load timeout being reached and the browser does not have an active user prompt, return error with error code timeout.
-    if (page_load_timeout_fired && !current_browsing_context().page().has_pending_dialog())
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::Timeout, "Navigation timed out"sv);
+        // 7. If the previous step completed by the session page load timeout being reached and the browser does
+        //    not have an active user prompt, return error with error code timeout.
+        if (did_time_out && !current_browsing_context().active_document()->page().has_pending_dialog()) {
+            on_complete->function()(Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::Timeout, "Navigation timed out"sv));
+            return;
+        }
 
-    // 8. Return success with data null.
-    return {};
+        // 8. Return success with data null.
+        on_complete->function()(JsonValue {});
+    }));
+}
+
+void WebDriverConnection::page_did_open_dialog(Badge<PageClient>)
+{
+    // OPTMIZATION: If a dialog is opened while we are awaiting a specific document readiness state, that state will
+    //              never be reached, as the dialog will block the HTML event loop from any further processing. Instead
+    //              of waiting for the session's page load timeout to expire, unblock the waiter immediately. This also
+    //              seems to match how other browsers behave.
+    if (m_navigation_timer)
+        m_navigation_timer->stop_and_fire_timeout_handler();
 }
 
 // https://w3c.github.io/webdriver/#dfn-restore-the-window

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -37,6 +37,8 @@ public:
 
     void visit_edges(JS::Cell::Visitor&);
 
+    void page_did_open_dialog(Badge<PageClient>);
+
 private:
     WebDriverConnection(IPC::Transport transport, Web::PageClient& page_client);
 
@@ -122,7 +124,8 @@ private:
     Gfx::IntRect maximize_the_window();
     Gfx::IntRect iconify_the_window();
 
-    ErrorOr<void, Web::WebDriver::Error> wait_for_navigation_to_complete();
+    using OnNavigationComplete = JS::NonnullGCPtr<JS::HeapFunction<void(Web::WebDriver::Response)>>;
+    void wait_for_navigation_to_complete(OnNavigationComplete);
 
     Gfx::IntPoint calculate_absolute_position_of_element(JS::NonnullGCPtr<Web::Geometry::DOMRect> rect);
     Gfx::IntRect calculate_absolute_rect_of_element(Web::DOM::Element const& element);
@@ -159,6 +162,10 @@ private:
     JS::GCPtr<Web::HTML::BrowsingContext> m_current_top_level_browsing_context;
 
     JS::GCPtr<JS::Cell> m_action_executor;
+
+    JS::GCPtr<Web::DOM::DocumentObserver> m_document_observer;
+    JS::GCPtr<Web::HTML::NavigationObserver> m_navigation_observer;
+    JS::GCPtr<Web::WebDriver::HeapTimer> m_navigation_timer;
 };
 
 }

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -4,4 +4,5 @@ endpoint WebDriverServer {
     navigation_complete(Web::WebDriver::Response response) =|
     script_executed(Web::WebDriver::Response response) =|
     actions_performed(Web::WebDriver::Response response) =|
+    dialog_closed(Web::WebDriver::Response response) =|
 }

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -1,6 +1,7 @@
 #include <LibWeb/WebDriver/Response.h>
 
 endpoint WebDriverServer {
+    navigation_complete(Web::WebDriver::Response response) =|
     script_executed(Web::WebDriver::Response response) =|
     actions_performed(Web::WebDriver::Response response) =|
 }

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -241,7 +241,7 @@ Web::WebDriver::Response Client::navigate_to(Web::WebDriver::Parameters paramete
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/url");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().navigate_to(payload);
+    return session->navigate_to(payload);
 }
 
 // 10.2 Get Current URL, https://w3c.github.io/webdriver/#dfn-get-current-url

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -721,7 +721,7 @@ Web::WebDriver::Response Client::dismiss_alert(Web::WebDriver::Parameters parame
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/alert/dismiss");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().dismiss_alert();
+    return session->dismiss_alert();
 }
 
 // 16.2 Accept Alert, https://w3c.github.io/webdriver/#accept-alert
@@ -730,7 +730,7 @@ Web::WebDriver::Response Client::accept_alert(Web::WebDriver::Parameters paramet
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/alert/accept");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().accept_alert();
+    return session->accept_alert();
 }
 
 // 16.3 Get Alert Text, https://w3c.github.io/webdriver/#get-alert-text

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -202,6 +202,13 @@ static Web::WebDriver::Response perform_async_action(Handler& handler, Action&& 
     return response.release_value();
 }
 
+Web::WebDriver::Response Session::navigate_to(JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_navigation_complete, [&]() {
+        return web_content_connection().navigate_to(move(payload));
+    });
+}
+
 Web::WebDriver::Response Session::execute_script(JsonValue payload, ScriptMode mode) const
 {
     return perform_async_action(web_content_connection().on_script_executed, [&]() {

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -243,4 +243,18 @@ Web::WebDriver::Response Session::perform_actions(JsonValue payload) const
     });
 }
 
+Web::WebDriver::Response Session::dismiss_alert() const
+{
+    return perform_async_action(web_content_connection().on_dialog_closed, [&]() {
+        return web_content_connection().dismiss_alert();
+    });
+}
+
+Web::WebDriver::Response Session::accept_alert() const
+{
+    return perform_async_action(web_content_connection().on_dialog_closed, [&]() {
+        return web_content_connection().accept_alert();
+    });
+}
+
 }

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -57,6 +57,8 @@ public:
     Web::WebDriver::Response get_window_handles() const;
     ErrorOr<void, Web::WebDriver::Error> ensure_current_window_handle_is_valid() const;
 
+    Web::WebDriver::Response navigate_to(JsonValue) const;
+
     enum class ScriptMode {
         Sync,
         Async,

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -69,6 +69,9 @@ public:
     Web::WebDriver::Response element_send_keys(String, JsonValue) const;
     Web::WebDriver::Response perform_actions(JsonValue) const;
 
+    Web::WebDriver::Response dismiss_alert() const;
+    Web::WebDriver::Response accept_alert() const;
+
 private:
     using ServerPromise = Core::Promise<ErrorOr<void>>;
     ErrorOr<NonnullRefPtr<Core::LocalServer>> create_server(NonnullRefPtr<ServerPromise> promise);

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -38,4 +38,10 @@ void WebContentConnection::actions_performed(Web::WebDriver::Response const& res
         on_actions_performed(response);
 }
 
+void WebContentConnection::dialog_closed(Web::WebDriver::Response const& response)
+{
+    if (on_dialog_closed)
+        on_dialog_closed(response);
+}
+
 }

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -20,6 +20,12 @@ void WebContentConnection::die()
         on_close();
 }
 
+void WebContentConnection::navigation_complete(Web::WebDriver::Response const& response)
+{
+    if (on_navigation_complete)
+        on_navigation_complete(response);
+}
+
 void WebContentConnection::script_executed(Web::WebDriver::Response const& response)
 {
     if (on_script_executed)

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -25,6 +25,7 @@ public:
     Function<void(Web::WebDriver::Response)> on_navigation_complete;
     Function<void(Web::WebDriver::Response)> on_script_executed;
     Function<void(Web::WebDriver::Response)> on_actions_performed;
+    Function<void(Web::WebDriver::Response)> on_dialog_closed;
 
 private:
     virtual void die() override;
@@ -32,6 +33,7 @@ private:
     virtual void navigation_complete(Web::WebDriver::Response const&) override;
     virtual void script_executed(Web::WebDriver::Response const&) override;
     virtual void actions_performed(Web::WebDriver::Response const&) override;
+    virtual void dialog_closed(Web::WebDriver::Response const&) override;
 };
 
 }

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -22,12 +22,14 @@ public:
     explicit WebContentConnection(IPC::Transport transport);
 
     Function<void()> on_close;
+    Function<void(Web::WebDriver::Response)> on_navigation_complete;
     Function<void(Web::WebDriver::Response)> on_script_executed;
     Function<void(Web::WebDriver::Response)> on_actions_performed;
 
 private:
     virtual void die() override;
 
+    virtual void navigation_complete(Web::WebDriver::Response const&) override;
     virtual void script_executed(Web::WebDriver::Response const&) override;
     virtual void actions_performed(Web::WebDriver::Response const&) override;
 };


### PR DESCRIPTION
Similar to commit c2cf65adac78912883996153fb608dafe389b6e0, we should avoid spinning the event loop from the WebContent-side of the WebDriver connection. This can result in deadlocks if another component in LibWeb also spins the event loop.

The AO to await navigations has two event loop spinners - waiting for the navigation to complete and for the document to reach the target readiness state. We now use NavigationObserver and DocumentObserver to be notified when these conditions are met. And we use the same async IPC mechanism as script execution to notify the WebDriver process when all conditions are met (or timed out).

This lets us pass `/webdriver/tests/classic/accept_alert/accept.py`. This should also eliminate a bunch of timeouts related to navigation / alert handling.