### PR TITLE
LibWeb: Fix crash when importing malformed RSAOAEP key

### DIFF
--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-import-rsaoaep-minimal_jwk.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-import-rsaoaep-minimal_jwk.txt
@@ -1,0 +1,4 @@
+true
+RSA-OAEP
+SHA-1
+1,0,1

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-rsaoaep-minimal_jwk.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-import-rsaoaep-minimal_jwk.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        var subtle = self.crypto.subtle;
+        var key = await subtle.importKey(
+            "jwk",
+            {
+                kty: "RSA",
+                n: "zZn4sRGfjQos56yL_Qy1R9NI-THMnFynn94g5RxA6wGrJh4BJT3x6I9x0IbpS3q-d4ORA6R2vuDMh8dDFRr9RDH6XY-gUScc9U5Jz3UA2KmVfsCbnUPvcAmMV_ENA7_TF0ivVjuIFodyDTx7EKHNVTrHHSlrbt7spbmcivs23Zc",
+                e: "AQAB",
+            },
+            { name: "RSA-OAEP", hash: "SHA-1" },
+            true,
+            ["encrypt", "wrapKey"]
+        );
+        println(key.extractable);
+        println(key.algorithm.name);
+        println(key.algorithm.hash);
+        println(key.algorithm.publicExponent);
+        done();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -660,9 +660,11 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
 
         // 6. If the key_ops field of jwk is present, and is invalid according to the requirements of JSON Web Key [JWK]
         //    or does not contain all of the specified usages values, then throw a DataError.
-        for (auto const& usage : usages) {
-            if (!jwk.key_ops->contains_slow(Bindings::idl_enum_to_string(usage)))
-                return WebIDL::DataError::create(m_realm, MUST(String::formatted("Missing key_ops field: {}", Bindings::idl_enum_to_string(usage))));
+        if (jwk.key_ops.has_value()) {
+            for (auto const& usage : usages) {
+                if (!jwk.key_ops->contains_slow(Bindings::idl_enum_to_string(usage)))
+                    return WebIDL::DataError::create(m_realm, MUST(String::formatted("Missing key_ops field: {}", Bindings::idl_enum_to_string(usage))));
+            }
         }
         // FIXME: Validate jwk.key_ops against requirements in https://www.rfc-editor.org/rfc/rfc7517#section-4.3
 
@@ -676,7 +678,7 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<CryptoKey>> RSAOAEP::import_key(Web::Crypto
             //     Let hash be undefined.
         }
         //    ->  If the alg field of jwk is equal to "RSA-OAEP":
-        if (jwk.alg == "RSA-OAEP"sv) {
+        else if (jwk.alg == "RSA-OAEP"sv) {
             //     Let hash be the string "SHA-1".
             hash = "SHA-1"_string;
         }


### PR DESCRIPTION
This fixes a crash in WPT:
[WebCryptoAPI/import_export/rsa_importKey.https.any](https://wpt.fyi/results/WebCryptoAPI/import_export/rsa_importKey.https.any.html?product=ladybird)

This allows us to pass 240 tests!