### PR TITLE
LibWeb: Use the correct locale when applying titlecase in TextNode

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/Element-to_titlecase-lang.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Element-to_titlecase-lang.txt
@@ -1,0 +1,2 @@
+IJsland
+Ijsland

--- a/Tests/LibWeb/Text/input/DOM/Element-to_titlecase-lang.html
+++ b/Tests/LibWeb/Text/input/DOM/Element-to_titlecase-lang.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<style type='text/css'>
+.test { text-transform: capitalize; }
+</style>
+</head>
+
+<script src="../include.js"></script>
+<body>
+<div class="test" lang="nl">ijsland</div>
+<div class="test" lang="en">ijsland</div>
+<div>IJsland</div>
+
+<script>
+    test(() => {
+        var elements = document.getElementsByClassName('test');
+        for (var i = 0; i < elements.length; i++) {
+            println(elements[i].innerText);
+        }
+    });
+</script>
+</body>
+
+</html>

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -9,6 +9,7 @@
 #include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <LibUnicode/CharacterTypes.h>
+#include <LibUnicode/Locale.h>
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
@@ -2902,6 +2903,45 @@ void Element::inherit_counters()
 
     VERIFY(!element_counters || !element_counters->is_empty());
     m_counters_set = move(element_counters);
+}
+
+// https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes
+Optional<String> Element::lang() const
+{
+    // 1. If the node is an element that has a lang attribute in the XML namespace set
+    //      Use the value of that attribute.
+    auto maybe_xml_lang = get_attribute_ns(Namespace::XML, HTML::AttributeNames::lang);
+    if (maybe_xml_lang.has_value())
+        return maybe_xml_lang.release_value();
+
+    // 2. If the node is an HTML element or an element in the SVG namespace, and it has a lang in no namespace attribute set
+    //      Use the value of that attribute.
+    if (is_html_element() || namespace_uri() == Namespace::SVG) {
+        auto maybe_lang = get_attribute(HTML::AttributeNames::lang);
+        if (maybe_lang.has_value())
+            return maybe_lang.release_value();
+    }
+
+    // 3. If the node's parent is a shadow root
+    //      Use the language of that shadow root's host.
+    if (auto const* parent = parent_element()) {
+        if (parent->is_shadow_root())
+            return parent->shadow_root()->host()->lang();
+    }
+
+    // 4. If the node's parent element is not null
+    //      Use the language of that parent element.
+    if (auto const* parent = parent_element())
+        return parent->lang();
+
+    // 5. Otherwise
+    //      - If there is a pragma-set default language set, then that is the language of the node.
+    //      - If there is no pragma-set default language set, then language information from a higher-level protocol (such as HTTP),
+    //        if any, must be used as the final fallback language instead.
+    //      - In the absence of any such language information, and in cases where the higher-level protocol reports multiple languages,
+    //        the language of the node is unknown, and the corresponding language tag is the empty string.
+    // Default locale sounds like a reasonable fallback here.
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -123,6 +123,8 @@ public:
     Optional<String> get_attribute_ns(Optional<FlyString> const& namespace_, FlyString const& name) const;
     String get_attribute_value(FlyString const& local_name, Optional<FlyString> const& namespace_ = {}) const;
 
+    Optional<String> lang() const;
+
     WebIDL::ExceptionOr<void> set_attribute(FlyString const& name, String const& value);
 
     WebIDL::ExceptionOr<void> set_attribute_ns(Optional<FlyString> const& namespace_, FlyString const& qualified_name, String const& value);


### PR DESCRIPTION
This fixes: https://wpt.fyi/results/css/css-text/text-transform/text-transform-tailoring-001.html
Also, implemented a `lang()` member function in `DOM::Element` in accordance with the spec: https://html.spec.whatwg.org/multipage/dom.html#the-lang-and-xml:lang-attributes