### PR TITLE
LibGfx: Use `FlyString` for family name

### DIFF
--- a/Userland/Libraries/LibGfx/Font/Font.h
+++ b/Userland/Libraries/LibGfx/Font/Font.h
@@ -85,7 +85,7 @@ public:
     virtual float width(StringView) const = 0;
     virtual float width(Utf8View const&) const = 0;
 
-    virtual String family() const = 0;
+    virtual FlyString family() const = 0;
 
     virtual NonnullRefPtr<Font> with_size(float point_size) const = 0;
 

--- a/Userland/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Userland/Libraries/LibGfx/Font/ScaledFont.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Font.h>
@@ -36,7 +37,7 @@ public:
     virtual u8 baseline() const override { return m_point_height; }  // FIXME: Read from font
     virtual float width(StringView) const override;
     virtual float width(Utf8View const&) const override;
-    virtual String family() const override { return m_typeface->family(); }
+    virtual FlyString family() const override { return m_typeface->family(); }
 
     virtual NonnullRefPtr<ScaledFont> scaled_with_size(float point_size) const;
     virtual NonnullRefPtr<Font> with_size(float point_size) const override;

--- a/Userland/Libraries/LibGfx/Font/Typeface.h
+++ b/Userland/Libraries/LibGfx/Font/Typeface.h
@@ -47,7 +47,7 @@ public:
     virtual u32 glyph_count() const = 0;
     virtual u16 units_per_em() const = 0;
     virtual u32 glyph_id_for_code_point(u32 code_point) const = 0;
-    virtual String family() const = 0;
+    virtual FlyString family() const = 0;
     virtual u16 weight() const = 0;
     virtual u16 width() const = 0;
     virtual u8 slope() const = 0;

--- a/Userland/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Userland/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -114,12 +114,12 @@ void TypefaceSkia::populate_glyph_page(GlyphPage& glyph_page, size_t page_index)
     }
 }
 
-String TypefaceSkia::family() const
+FlyString TypefaceSkia::family() const
 {
     if (!m_family.has_value()) {
         SkString family_name;
         impl().skia_typeface->getFamilyName(&family_name);
-        m_family = String::from_utf8_without_validation(ReadonlyBytes { family_name.c_str(), family_name.size() });
+        m_family = FlyString::from_utf8_without_validation(ReadonlyBytes { family_name.c_str(), family_name.size() });
     }
     return m_family.value();
 }

--- a/Userland/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Userland/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -19,7 +19,7 @@ public:
     virtual u32 glyph_count() const override;
     virtual u16 units_per_em() const override;
     virtual u32 glyph_id_for_code_point(u32 code_point) const override;
-    virtual String family() const override;
+    virtual FlyString family() const override;
     virtual u16 weight() const override;
     virtual u16 width() const override;
     virtual u8 slope() const override;
@@ -39,7 +39,7 @@ private:
     ReadonlyBytes m_buffer;
     unsigned m_ttc_index { 0 };
 
-    mutable Optional<String> m_family;
+    mutable Optional<FlyString> m_family;
 
     // This cache stores information per code point.
     // It's segmented into pages with data about 256 code points each.


### PR DESCRIPTION
This value gets converted to FlyString a lot, so let's just make it a FlyString in the first place!