### PR TITLE
LibWeb/CSS: Add support for custom properties in CSSStyleDeclaration

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -29,9 +29,11 @@ public:
     virtual String item(size_t index) const = 0;
 
     virtual Optional<StyleProperty> property(PropertyID) const = 0;
+    virtual Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const = 0;
 
-    virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv) = 0;
-    virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) = 0;
+    // property_name only needs to be passed for custom properties.
+    virtual WebIDL::ExceptionOr<void> set_property(PropertyID, Optional<StringView> property_name, StringView css_text, StringView priority = ""sv) = 0;
+    virtual WebIDL::ExceptionOr<String> remove_property(PropertyID, StringView property_name) = 0;
 
     virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority);
     virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name);
@@ -76,12 +78,12 @@ public:
 
     virtual Optional<StyleProperty> property(PropertyID) const override;
 
-    virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority) override;
-    virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) override;
+    virtual WebIDL::ExceptionOr<void> set_property(PropertyID, Optional<StringView> property_name, StringView css_text, StringView priority) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(PropertyID, StringView) override;
 
     Vector<StyleProperty> const& properties() const { return m_properties; }
     HashMap<FlyString, StyleProperty> const& custom_properties() const { return m_custom_properties; }
-    Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const { return m_custom_properties.get(custom_property_name); }
+    virtual Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const override { return m_custom_properties.get(custom_property_name); }
     size_t custom_property_count() const { return m_custom_properties.size(); }
 
     virtual String serialized() const final override;
@@ -99,7 +101,7 @@ protected:
     void set_the_declarations(Vector<StyleProperty> properties, HashMap<FlyString, StyleProperty> custom_properties);
 
 private:
-    bool set_a_css_declaration(PropertyID, NonnullRefPtr<CSSStyleValue const>, Important);
+    bool set_a_css_declaration(PropertyID, Optional<StringView>, NonnullRefPtr<CSSStyleValue const>, Important);
 
     virtual void visit_edges(Cell::Visitor&) override;
 

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -601,13 +601,19 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     };
 }
 
+Optional<StyleProperty> ResolvedCSSStyleDeclaration::custom_property(FlyString const&) const
+{
+    dbgln("FIXME: ResolvedCSSStyleDeclaration should support custom property");
+    return {};
+}
+
 static WebIDL::ExceptionOr<void> cannot_modify_computed_property_error(JS::Realm& realm)
 {
     return WebIDL::NoModificationAllowedError::create(realm, "Cannot modify properties in result of getComputedStyle()"_string);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty
-WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(PropertyID, StringView, StringView)
+WebIDL::ExceptionOr<void> ResolvedCSSStyleDeclaration::set_property(PropertyID, Optional<StringView>, StringView, StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
     return cannot_modify_computed_property_error(realm());
@@ -626,7 +632,7 @@ static WebIDL::ExceptionOr<String> cannot_remove_computed_property_error(JS::Rea
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-removeproperty
-WebIDL::ExceptionOr<String> ResolvedCSSStyleDeclaration::remove_property(PropertyID)
+WebIDL::ExceptionOr<String> ResolvedCSSStyleDeclaration::remove_property(PropertyID, StringView)
 {
     // 1. If the computed flag is set, then throw a NoModificationAllowedError exception.
     return cannot_remove_computed_property_error(realm());

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -24,9 +24,10 @@ public:
     virtual String item(size_t index) const override;
 
     virtual Optional<StyleProperty> property(PropertyID) const override;
-    virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority) override;
+    virtual Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const override;
+    virtual WebIDL::ExceptionOr<void> set_property(PropertyID, Optional<StringView> property_name, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority) override;
-    virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) override;
+    virtual WebIDL::ExceptionOr<String> remove_property(PropertyID, StringView) override;
     virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name) override;
 
     virtual String serialized() const override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -656,9 +656,9 @@ void HTMLInputElement::update_placeholder_visibility()
     if (!m_placeholder_element)
         return;
     if (this->placeholder_value().has_value()) {
-        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "block"sv));
+        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "block"sv));
     } else {
-        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "none"sv));
+        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "none"sv));
     }
 }
 
@@ -961,7 +961,7 @@ void HTMLInputElement::create_color_input_shadow_tree()
         border: 1px solid ButtonBorder;
         box-sizing: border-box;
 )~~~"_string));
-    MUST(m_color_well_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, color));
+    MUST(m_color_well_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, {}, color));
 
     MUST(border->append_child(*m_color_well_element));
     MUST(shadow_root->append_child(border));
@@ -973,7 +973,7 @@ void HTMLInputElement::update_color_well_element()
     if (!m_color_well_element)
         return;
 
-    MUST(m_color_well_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, m_value));
+    MUST(m_color_well_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, {}, m_value));
 }
 
 void HTMLInputElement::create_file_input_shadow_tree()
@@ -1140,9 +1140,9 @@ void HTMLInputElement::computed_css_values_changed()
         accent_color = accent_color_property.to_string();
 
     if (m_slider_progress_element)
-        MUST(m_slider_progress_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));
+        MUST(m_slider_progress_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, {}, accent_color));
     if (m_slider_thumb)
-        MUST(m_slider_thumb->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));
+        MUST(m_slider_thumb->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, {}, accent_color));
 }
 
 void HTMLInputElement::user_interaction_did_change_input_value()
@@ -1170,10 +1170,10 @@ void HTMLInputElement::update_slider_shadow_tree_elements()
     double position = (value - minimum) / (maximum - minimum) * 100;
 
     if (m_slider_progress_element)
-        MUST(m_slider_progress_element->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", position))));
+        MUST(m_slider_progress_element->style_for_bindings()->set_property(CSS::PropertyID::Width, {}, MUST(String::formatted("{}%", position))));
 
     if (m_slider_thumb)
-        MUST(m_slider_thumb->style_for_bindings()->set_property(CSS::PropertyID::MarginLeft, MUST(String::formatted("{}%", position))));
+        MUST(m_slider_thumb->style_for_bindings()->set_property(CSS::PropertyID::MarginLeft, {}, MUST(String::formatted("{}%", position))));
 }
 
 void HTMLInputElement::did_receive_focus()

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -240,6 +240,6 @@ void HTMLMeterElement::update_meter_value_element()
     }
 
     double position = (value - min) / (max - min) * 100;
-    MUST(m_meter_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", position))));
+    MUST(m_meter_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, {}, MUST(String::formatted("{}%", position))));
 }
 }

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -127,7 +127,7 @@ void HTMLProgressElement::create_shadow_tree_if_needed()
 void HTMLProgressElement::update_progress_value_element()
 {
     if (m_progress_value_element)
-        MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, MUST(String::formatted("{}%", position() * 100))));
+        MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::Width, {}, MUST(String::formatted("{}%", position() * 100))));
 }
 
 void HTMLProgressElement::computed_css_values_changed()
@@ -140,7 +140,7 @@ void HTMLProgressElement::computed_css_values_changed()
         accent_color = accent_color_property.to_string();
 
     if (m_progress_value_element)
-        MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));
+        MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, {}, accent_color));
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -502,9 +502,9 @@ void HTMLSelectElement::computed_css_values_changed()
     if (m_chevron_icon_element) {
         auto appearance = computed_css_values()->appearance();
         if (appearance.has_value() && *appearance == CSS::Appearance::None) {
-            MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "none"_string));
+            MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "none"_string));
         } else {
-            MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "block"_string));
+            MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "block"_string));
         }
     }
 }

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -415,11 +415,11 @@ void HTMLTextAreaElement::update_placeholder_visibility()
         return;
     auto placeholder_text = get_attribute(AttributeNames::placeholder);
     if (placeholder_text.has_value() && m_text_node->data().is_empty()) {
-        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "block"sv));
-        MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "none"sv));
+        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "block"sv));
+        MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "none"sv));
     } else {
-        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "none"sv));
-        MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "block"sv));
+        MUST(m_placeholder_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "none"sv));
+        MUST(m_inner_text_element->style_for_bindings()->set_property(CSS::PropertyID::Display, {}, "block"sv));
     }
 }
 

--- a/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-custom-properties.txt
+++ b/Tests/LibWeb/Text/expected/css/CSSStyleDeclaration-custom-properties.txt
@@ -1,0 +1,3 @@
+--foo= bar
+--foo= baz important
+--foo= blank

--- a/Tests/LibWeb/Text/input/css/CSSStyleDeclaration-custom-properties.html
+++ b/Tests/LibWeb/Text/input/css/CSSStyleDeclaration-custom-properties.html
@@ -1,0 +1,19 @@
+<script src="../include.js"></script>
+<div id="foo"></div>
+<script>
+    test(() => {
+        const div = document.getElementById("foo");
+
+        // set property
+        div.style.setProperty("--foo", "bar");
+        println(`--foo= ${div.style.getPropertyValue("--foo")}`);
+
+        // set property with priority
+        div.style.setProperty("--foo", "baz", "important");
+        println(`--foo= ${div.style.getPropertyValue("--foo")} ${div.style.getPropertyPriority("--foo")}`);
+
+        // remove property
+        div.style.removeProperty("--foo");
+        println(`--foo= blank${div.style.getPropertyValue("--foo")}`);
+    })
+</script>


### PR DESCRIPTION
Fix for #1712 
Although I have got it working. I have a few design questions here:
1. I have added a function called `custom_property` to return a custom property. This returns a `{}` in `ResolvedCSSStyleDeclaration`. Is this a good way to do it?
2. I changed the function `set_property` to accept a `StringView` which is the property name. This is only required when the property being set is a custom property. Thus, I have passed `""sv` in the places where this function was used but a custom property was not being set.

Since I am absolutely new to this project, I might be way off in things here. Please do let me know, will fix them.