### PR TITLE
LibWeb: Remove reference counting for `CSS::StyleProperties`

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -171,7 +171,7 @@ public:
     }
 
     ALWAYS_INLINE ~Optional()
-    requires(!IsTriviallyDestructible<T>)
+    requires(!IsTriviallyDestructible<T> && IsDestructible<T>)
     {
         clear();
     }

--- a/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Userland/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -954,13 +954,13 @@ void KeyframeEffect::update_style_properties()
     if (!target)
         return;
 
-    CSS::StyleProperties* style = nullptr;
+    Optional<CSS::StyleProperties&> style = {};
     if (!pseudo_element_type().has_value())
         style = target->computed_css_values();
     else
         style = target->pseudo_element_computed_css_values(pseudo_element_type().value());
 
-    if (!style)
+    if (!style.has_value())
         return;
 
     auto animated_properties_before_update = style->animated_property_values();
@@ -970,8 +970,8 @@ void KeyframeEffect::update_style_properties()
 
     // Traversal of the subtree is necessary to update the animated properties inherited from the target element.
     target->for_each_in_subtree_of_type<DOM::Element>([&](auto& element) {
-        auto* element_style = element.computed_css_values();
-        if (!element_style || !element.layout_node())
+        auto element_style = element.computed_css_values();
+        if (!element_style.has_value() || !element.layout_node())
             return TraversalDecision::Continue;
 
         for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -520,8 +520,7 @@ WebIDL::ExceptionOr<void> ElementInlineCSSStyleDeclaration::set_css_text(StringV
 
     // 3. Parse the given value and, if the return value is not the empty list, insert the items in the list into the declarations, in specified order.
     auto style = parse_css_style_attribute(CSS::Parser::ParsingContext(m_element->document()), css_text, *m_element.ptr());
-    auto custom_properties = TRY_OR_THROW_OOM(vm(), style->custom_properties().clone());
-    set_the_declarations(style->properties(), move(custom_properties));
+    set_the_declarations(style->properties(), style->custom_properties());
 
     // 4. Update style attribute for the CSS declaration block.
     update_style_attribute();

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -581,7 +581,7 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
         auto style = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element), m_pseudo_element);
 
         // FIXME: This is a stopgap until we implement shorthand -> longhand conversion.
-        auto value = style->maybe_null_property(property_id);
+        auto value = style.maybe_null_property(property_id);
         if (!value) {
             dbgln("FIXME: ResolvedCSSStyleDeclaration::property(property_id={:#x}) No value for property ID in newly computed style case.", to_underlying(property_id));
             return {};

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -134,10 +134,10 @@ public:
     void push_ancestor(DOM::Element const&);
     void pop_ancestor(DOM::Element const&);
 
-    NonnullRefPtr<StyleProperties> create_document_style() const;
+    StyleProperties create_document_style() const;
 
-    NonnullRefPtr<StyleProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
-    RefPtr<StyleProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
+    StyleProperties compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
+    Optional<StyleProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
 
     Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, FlyString const& qualified_layer_name = {}) const;
 
@@ -176,7 +176,7 @@ private:
 
     [[nodiscard]] bool should_reject_with_ancestor_filter(Selector const&) const;
 
-    RefPtr<StyleProperties> compute_style_impl(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, ComputeStyleMode) const;
+    Optional<StyleProperties> compute_style_impl(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, ComputeStyleMode) const;
     void compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -53,13 +53,6 @@ NonnullRefPtr<StyleProperties::Data> StyleProperties::Data::clone() const
     return clone;
 }
 
-NonnullRefPtr<StyleProperties> StyleProperties::clone() const
-{
-    auto cloned = adopt_ref(*new StyleProperties);
-    cloned->m_data = m_data;
-    return cloned;
-}
-
 bool StyleProperties::is_property_important(CSS::PropertyID property_id) const
 {
     size_t n = to_underlying(property_id);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -19,7 +19,7 @@
 
 namespace Web::CSS {
 
-class StyleProperties : public RefCounted<StyleProperties> {
+class StyleProperties {
 public:
     static constexpr size_t number_of_properties = to_underlying(CSS::last_property_id) + 1;
 
@@ -47,9 +47,6 @@ private:
 
 public:
     StyleProperties() = default;
-
-    static NonnullRefPtr<StyleProperties> create() { return adopt_ref(*new StyleProperties); }
-    NonnullRefPtr<StyleProperties> clone() const;
 
     template<typename Callback>
     inline void for_each_property(Callback callback) const

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <LibWeb/ARIA/ARIAMixin.h>
 #include <LibWeb/Animations/Animatable.h>
 #include <LibWeb/Bindings/ElementPrototype.h>
@@ -14,6 +15,7 @@
 #include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
+#include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/DOM/ChildNode.h>
 #include <LibWeb/DOM/NonDocumentTypeChildNode.h>
@@ -183,13 +185,13 @@ public:
     JS::GCPtr<Layout::NodeWithStyle> layout_node();
     JS::GCPtr<Layout::NodeWithStyle const> layout_node() const;
 
-    CSS::StyleProperties* computed_css_values() { return m_computed_css_values.ptr(); }
-    CSS::StyleProperties const* computed_css_values() const { return m_computed_css_values.ptr(); }
-    void set_computed_css_values(RefPtr<CSS::StyleProperties>);
-    NonnullRefPtr<CSS::StyleProperties> resolved_css_values(Optional<CSS::Selector::PseudoElement::Type> = {});
+    Optional<CSS::StyleProperties>& computed_css_values() { return m_computed_css_values; }
+    Optional<CSS::StyleProperties> const& computed_css_values() const { return m_computed_css_values; }
+    void set_computed_css_values(Optional<CSS::StyleProperties>);
+    CSS::StyleProperties resolved_css_values(Optional<CSS::Selector::PseudoElement::Type> = {});
 
-    void set_pseudo_element_computed_css_values(CSS::Selector::PseudoElement::Type, RefPtr<CSS::StyleProperties>);
-    RefPtr<CSS::StyleProperties> pseudo_element_computed_css_values(CSS::Selector::PseudoElement::Type);
+    void set_pseudo_element_computed_css_values(CSS::Selector::PseudoElement::Type, Optional<CSS::StyleProperties>);
+    Optional<CSS::StyleProperties&> pseudo_element_computed_css_values(CSS::Selector::PseudoElement::Type);
 
     void reset_animated_css_properties();
 
@@ -235,13 +237,13 @@ public:
     JS::NonnullGCPtr<Geometry::DOMRect> get_bounding_client_rect() const;
     JS::NonnullGCPtr<Geometry::DOMRectList> get_client_rects() const;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>);
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties);
     virtual void adjust_computed_style(CSS::StyleProperties&) { }
 
     virtual void did_receive_focus() { }
     virtual void did_lose_focus() { }
 
-    static JS::GCPtr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, NonnullRefPtr<CSS::StyleProperties>, Element*);
+    static JS::GCPtr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, CSS::StyleProperties, Element*);
 
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, JS::GCPtr<Layout::NodeWithStyle>);
     JS::GCPtr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
@@ -456,12 +458,12 @@ private:
     JS::GCPtr<DOMTokenList> m_class_list;
     JS::GCPtr<ShadowRoot> m_shadow_root;
 
-    RefPtr<CSS::StyleProperties> m_computed_css_values;
+    Optional<CSS::StyleProperties> m_computed_css_values;
     HashMap<FlyString, CSS::StyleProperty> m_custom_properties;
 
     struct PseudoElement {
         JS::GCPtr<Layout::NodeWithStyle> layout_node;
-        RefPtr<CSS::StyleProperties> computed_css_values;
+        Optional<CSS::StyleProperties> computed_css_values;
         HashMap<FlyString, CSS::StyleProperty> custom_properties;
     };
     // TODO: CSS::Selector::PseudoElement::Type includes a lot of pseudo-elements that exist in shadow trees,

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -394,7 +394,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         }
     }
 
-    if (show_specified_style && layout_node.dom_node() && layout_node.dom_node()->is_element() && verify_cast<DOM::Element>(layout_node.dom_node())->computed_css_values()) {
+    if (show_specified_style && layout_node.dom_node() && layout_node.dom_node()->is_element() && verify_cast<DOM::Element>(layout_node.dom_node())->computed_css_values().has_value()) {
         struct NameAndValue {
             FlyString name;
             String value;

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -28,7 +28,7 @@ void HTMLAudioElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLAudioElement);
 }
 
-JS::GCPtr<Layout::Node> HTMLAudioElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLAudioElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::AudioBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAudioElement.h
@@ -25,7 +25,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     virtual void on_playing() override;
     virtual void on_paused() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -26,7 +26,7 @@ void HTMLBRElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLBRElement);
 }
 
-JS::GCPtr<Layout::Node> HTMLBRElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLBRElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::BreakNode>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLBRElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBRElement.h
@@ -17,7 +17,7 @@ class HTMLBRElement final : public HTMLElement {
 public:
     virtual ~HTMLBRElement() override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
 private:
     virtual bool is_html_br_element() const override { return true; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -128,7 +128,7 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::set_height(unsigned value)
     return {};
 }
 
-JS::GCPtr<Layout::Node> HTMLCanvasElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLCanvasElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::CanvasBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -47,7 +47,7 @@ private:
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     enum class HasOrCreatedContext {
         No,

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -32,7 +32,7 @@ void HTMLIFrameElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLIFrameElement);
 }
 
-JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLIFrameElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::FrameBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -23,7 +23,7 @@ class HTMLIFrameElement final
 public:
     virtual ~HTMLIFrameElement() override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     void set_current_navigation_was_lazy_loaded(bool value);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -110,7 +110,7 @@ void HTMLImageElement::form_associated_element_attribute_changed(FlyString const
     }
 }
 
-JS::GCPtr<Layout::Node> HTMLImageElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLImageElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::ImageBox>(document(), *this, move(style), *this);
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -123,7 +123,7 @@ private:
     // https://html.spec.whatwg.org/multipage/embedded-content.html#the-img-element:dimension-attributes
     virtual bool supports_dimension_attributes() const override { return true; }
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     virtual void did_set_viewport_rect(CSSPixelRect const&) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -98,7 +98,7 @@ JS::NonnullGCPtr<ValidityState const> HTMLInputElement::validity() const
     return vm.heap().allocate<ValidityState>(realm, realm);
 }
 
-JS::GCPtr<Layout::Node> HTMLInputElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLInputElement::create_layout_node(CSS::StyleProperties style)
 {
     if (type_state() == TypeAttributeState::Hidden)
         return nullptr;
@@ -113,8 +113,8 @@ JS::GCPtr<Layout::Node> HTMLInputElement::create_layout_node(NonnullRefPtr<CSS::
     // This specification introduces the appearance property to provide some control over this behavior.
     // In particular, using appearance: none allows authors to suppress the native appearance of widgets,
     // giving them a primitive appearance where CSS can be used to restyle them.
-    if (style->appearance() == CSS::Appearance::None) {
-        return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
+    if (style.appearance() == CSS::Appearance::None) {
+        return Element::create_layout_node_for_display_type(document(), style.display(), style, this);
     }
 
     if (type_state() == TypeAttributeState::SubmitButton || type_state() == TypeAttributeState::Button || type_state() == TypeAttributeState::ResetButton)
@@ -126,7 +126,7 @@ JS::GCPtr<Layout::Node> HTMLInputElement::create_layout_node(NonnullRefPtr<CSS::
     if (type_state() == TypeAttributeState::RadioButton)
         return heap().allocate_without_realm<Layout::RadioButton>(document(), *this, move(style));
 
-    return Element::create_layout_node_for_display_type(document(), style->display(), style, this);
+    return Element::create_layout_node_for_display_type(document(), style.display(), style, this);
 }
 
 void HTMLInputElement::adjust_computed_style(CSS::StyleProperties& style)

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -59,7 +59,7 @@ class HTMLInputElement final
 public:
     virtual ~HTMLInputElement() override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
     virtual void adjust_computed_style(CSS::StyleProperties&) override;
 
     enum class TypeAttributeState {

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -27,7 +27,7 @@ void HTMLLabelElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLLabelElement);
 }
 
-JS::GCPtr<Layout::Node> HTMLLabelElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLLabelElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::Label>(document(), this, move(style));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLabelElement.h
@@ -17,7 +17,7 @@ class HTMLLabelElement final : public HTMLElement {
 public:
     virtual ~HTMLLabelElement() override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     Optional<String> for_() const { return attribute(HTML::AttributeNames::for_); }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -136,7 +136,7 @@ String HTMLObjectElement::data() const
     return MUST(document().parse_url(*data).to_string());
 }
 
-JS::GCPtr<Layout::Node> HTMLObjectElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLObjectElement::create_layout_node(CSS::StyleProperties style)
 {
     switch (m_representation) {
     case Representation::Children:

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -58,7 +58,7 @@ private:
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     bool has_ancestor_media_element_or_object_element_not_showing_fallback_content() const;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -62,7 +62,7 @@ void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<String>
     }
 }
 
-JS::GCPtr<Layout::Node> HTMLVideoElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> HTMLVideoElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::VideoBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -60,7 +60,7 @@ private:
     // https://html.spec.whatwg.org/multipage/media.html#the-video-element:dimension-attributes
     virtual bool supports_dimension_attributes() const override { return true; }
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     virtual void on_playing() override;
     virtual void on_paused() override;

--- a/Userland/Libraries/LibWeb/Layout/AudioBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/AudioBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(AudioBox);
 
-AudioBox::AudioBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
+AudioBox::AudioBox(DOM::Document& document, DOM::Element& element, CSS::StyleProperties style)
     : ReplacedBox(document, element, move(style))
 {
     set_natural_width(300);

--- a/Userland/Libraries/LibWeb/Layout/AudioBox.h
+++ b/Userland/Libraries/LibWeb/Layout/AudioBox.h
@@ -23,7 +23,7 @@ public:
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
 private:
-    AudioBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    AudioBox(DOM::Document&, DOM::Element&, CSS::StyleProperties);
 };
 
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::Layout {
 
-BlockContainer::BlockContainer(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
+BlockContainer::BlockContainer(DOM::Document& document, DOM::Node* node, CSS::StyleProperties style)
     : Box(document, node, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.h
@@ -16,7 +16,7 @@ class BlockContainer : public Box {
     JS_CELL(BlockContainer, Box);
 
 public:
-    BlockContainer(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);
+    BlockContainer(DOM::Document&, DOM::Node*, CSS::StyleProperties);
     BlockContainer(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
     virtual ~BlockContainer() override;
 

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -14,7 +14,7 @@
 
 namespace Web::Layout {
 
-Box::Box(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
+Box::Box(DOM::Document& document, DOM::Node* node, CSS::StyleProperties style)
     : NodeWithStyleAndBoxModelMetrics(document, node, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/Box.h
+++ b/Userland/Libraries/LibWeb/Layout/Box.h
@@ -55,7 +55,7 @@ public:
     virtual void visit_edges(Cell::Visitor&) override;
 
 protected:
-    Box(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);
+    Box(DOM::Document&, DOM::Node*, CSS::StyleProperties);
     Box(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
 
 private:

--- a/Userland/Libraries/LibWeb/Layout/BreakNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(BreakNode);
 
-BreakNode::BreakNode(DOM::Document& document, HTML::HTMLBRElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+BreakNode::BreakNode(DOM::Document& document, HTML::HTMLBRElement& element, CSS::StyleProperties style)
     : Layout::NodeWithStyleAndBoxModelMetrics(document, &element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/BreakNode.h
+++ b/Userland/Libraries/LibWeb/Layout/BreakNode.h
@@ -16,7 +16,7 @@ class BreakNode final : public NodeWithStyleAndBoxModelMetrics {
     JS_DECLARE_ALLOCATOR(BreakNode);
 
 public:
-    BreakNode(DOM::Document&, HTML::HTMLBRElement&, NonnullRefPtr<CSS::StyleProperties>);
+    BreakNode(DOM::Document&, HTML::HTMLBRElement&, CSS::StyleProperties);
     virtual ~BreakNode() override;
 
     const HTML::HTMLBRElement& dom_node() const { return verify_cast<HTML::HTMLBRElement>(*Node::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CanvasBox.cpp
@@ -11,7 +11,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(CanvasBox);
 
-CanvasBox::CanvasBox(DOM::Document& document, HTML::HTMLCanvasElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+CanvasBox::CanvasBox(DOM::Document& document, HTML::HTMLCanvasElement& element, CSS::StyleProperties style)
     : ReplacedBox(document, element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/CanvasBox.h
+++ b/Userland/Libraries/LibWeb/Layout/CanvasBox.h
@@ -16,7 +16,7 @@ class CanvasBox final : public ReplacedBox {
     JS_DECLARE_ALLOCATOR(CanvasBox);
 
 public:
-    CanvasBox(DOM::Document&, HTML::HTMLCanvasElement&, NonnullRefPtr<CSS::StyleProperties>);
+    CanvasBox(DOM::Document&, HTML::HTMLCanvasElement&, CSS::StyleProperties);
     virtual ~CanvasBox() override;
 
     virtual void prepare_for_replaced_layout() override;

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.cpp
@@ -13,7 +13,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(CheckBox);
 
-CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+CheckBox::CheckBox(DOM::Document& document, HTML::HTMLInputElement& element, CSS::StyleProperties style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {
     set_natural_width(13);

--- a/Userland/Libraries/LibWeb/Layout/CheckBox.h
+++ b/Userland/Libraries/LibWeb/Layout/CheckBox.h
@@ -16,7 +16,7 @@ class CheckBox final : public FormAssociatedLabelableNode {
     JS_DECLARE_ALLOCATOR(CheckBox);
 
 public:
-    CheckBox(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);
+    CheckBox(DOM::Document&, HTML::HTMLInputElement&, CSS::StyleProperties);
     virtual ~CheckBox() override;
 
 private:

--- a/Userland/Libraries/LibWeb/Layout/FormAssociatedLabelableNode.h
+++ b/Userland/Libraries/LibWeb/Layout/FormAssociatedLabelableNode.h
@@ -21,7 +21,7 @@ public:
     HTML::FormAssociatedElement& dom_node() { return dynamic_cast<HTML::FormAssociatedElement&>(LabelableNode::dom_node()); }
 
 protected:
-    FormAssociatedLabelableNode(DOM::Document& document, HTML::FormAssociatedElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+    FormAssociatedLabelableNode(DOM::Document& document, HTML::FormAssociatedElement& element, CSS::StyleProperties style)
         : LabelableNode(document, element.form_associated_element_to_html_element(), move(style))
     {
     }

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.cpp
@@ -13,7 +13,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(FrameBox);
 
-FrameBox::FrameBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
+FrameBox::FrameBox(DOM::Document& document, DOM::Element& element, CSS::StyleProperties style)
     : ReplacedBox(document, element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/FrameBox.h
+++ b/Userland/Libraries/LibWeb/Layout/FrameBox.h
@@ -16,7 +16,7 @@ class FrameBox final : public ReplacedBox {
     JS_DECLARE_ALLOCATOR(FrameBox);
 
 public:
-    FrameBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    FrameBox(DOM::Document&, DOM::Element&, CSS::StyleProperties);
     virtual ~FrameBox() override;
 
     virtual void prepare_for_replaced_layout() override;

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -15,7 +15,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(ImageBox);
 
-ImageBox::ImageBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style, ImageProvider const& image_provider)
+ImageBox::ImageBox(DOM::Document& document, DOM::Element& element, CSS::StyleProperties style, ImageProvider const& image_provider)
     : ReplacedBox(document, element, move(style))
     , m_image_provider(image_provider)
 {

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.h
@@ -16,7 +16,7 @@ class ImageBox final : public ReplacedBox {
     JS_DECLARE_ALLOCATOR(ImageBox);
 
 public:
-    ImageBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>, ImageProvider const&);
+    ImageBox(DOM::Document&, DOM::Element&, CSS::StyleProperties, ImageProvider const&);
     virtual ~ImageBox() override;
 
     virtual void prepare_for_replaced_layout() override;

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -16,7 +16,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(InlineNode);
 
-InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
+InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, CSS::StyleProperties style)
     : Layout::NodeWithStyleAndBoxModelMetrics(document, element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.h
@@ -15,7 +15,7 @@ class InlineNode final : public NodeWithStyleAndBoxModelMetrics {
     JS_DECLARE_ALLOCATOR(InlineNode);
 
 public:
-    InlineNode(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);
+    InlineNode(DOM::Document&, DOM::Element*, CSS::StyleProperties);
     virtual ~InlineNode() override;
 
     JS::GCPtr<Painting::PaintableWithLines> create_paintable_for_line_with_index(size_t line_index) const;

--- a/Userland/Libraries/LibWeb/Layout/Label.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Label.cpp
@@ -17,7 +17,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(Label);
 
-Label::Label(DOM::Document& document, HTML::HTMLLabelElement* element, NonnullRefPtr<CSS::StyleProperties> style)
+Label::Label(DOM::Document& document, HTML::HTMLLabelElement* element, CSS::StyleProperties style)
     : BlockContainer(document, element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/Label.h
+++ b/Userland/Libraries/LibWeb/Layout/Label.h
@@ -16,7 +16,7 @@ class Label final : public BlockContainer {
     JS_DECLARE_ALLOCATOR(Label);
 
 public:
-    Label(DOM::Document&, HTML::HTMLLabelElement*, NonnullRefPtr<CSS::StyleProperties>);
+    Label(DOM::Document&, HTML::HTMLLabelElement*, CSS::StyleProperties);
     virtual ~Label() override;
 
     static bool is_inside_associated_label(LabelableNode const&, CSSPixelPoint);

--- a/Userland/Libraries/LibWeb/Layout/LabelableNode.h
+++ b/Userland/Libraries/LibWeb/Layout/LabelableNode.h
@@ -19,7 +19,7 @@ public:
     Painting::LabelablePaintable const* paintable() const;
 
 protected:
-    LabelableNode(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
+    LabelableNode(DOM::Document& document, DOM::Element& element, CSS::StyleProperties style)
         : ReplacedBox(document, element, move(style))
     {
     }

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(ListItemBox);
 
-ListItemBox::ListItemBox(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
+ListItemBox::ListItemBox(DOM::Document& document, DOM::Element* element, CSS::StyleProperties style)
     : Layout::BlockContainer(document, element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.h
@@ -16,7 +16,7 @@ class ListItemBox final : public BlockContainer {
     JS_DECLARE_ALLOCATOR(ListItemBox);
 
 public:
-    ListItemBox(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);
+    ListItemBox(DOM::Document&, DOM::Element*, CSS::StyleProperties);
     virtual ~ListItemBox() override;
 
     DOM::Element& dom_node() { return static_cast<DOM::Element&>(*BlockContainer::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(ListItemMarkerBox);
 
-ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, CSS::ListStylePosition style_position, size_t index, NonnullRefPtr<CSS::StyleProperties> style)
+ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType style_type, CSS::ListStylePosition style_position, size_t index, CSS::StyleProperties style)
     : Box(document, nullptr, move(style))
     , m_list_style_type(style_type)
     , m_list_style_position(style_position)

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -16,7 +16,7 @@ class ListItemMarkerBox final : public Box {
     JS_DECLARE_ALLOCATOR(ListItemMarkerBox);
 
 public:
-    explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, size_t index, NonnullRefPtr<CSS::StyleProperties>);
+    explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, size_t index, CSS::StyleProperties);
     virtual ~ListItemMarkerBox() override;
 
     Optional<ByteString> const& text() const { return m_text; }

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -261,12 +261,12 @@ bool Node::is_sticky_position() const
     return position == CSS::Positioning::Sticky;
 }
 
-NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> computed_style)
+NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, CSS::StyleProperties computed_style)
     : Node(document, node)
     , m_computed_values(make<CSS::ComputedValues>())
 {
     m_has_style = true;
-    apply_style(*computed_style);
+    apply_style(computed_style);
 }
 
 NodeWithStyle::NodeWithStyle(DOM::Document& document, DOM::Node* node, NonnullOwnPtr<CSS::ComputedValues> computed_values)

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -228,7 +228,7 @@ public:
     virtual void visit_edges(Cell::Visitor& visitor) override;
 
 protected:
-    NodeWithStyle(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);
+    NodeWithStyle(DOM::Document&, DOM::Node*, CSS::StyleProperties);
     NodeWithStyle(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
 
 private:
@@ -247,7 +247,7 @@ public:
     BoxModelMetrics const& box_model() const { return m_box_model; }
 
 protected:
-    NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
+    NodeWithStyleAndBoxModelMetrics(DOM::Document& document, DOM::Node* node, CSS::StyleProperties style)
         : NodeWithStyle(document, node, move(style))
     {
     }

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.cpp
@@ -14,7 +14,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(RadioButton);
 
-RadioButton::RadioButton(DOM::Document& document, HTML::HTMLInputElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+RadioButton::RadioButton(DOM::Document& document, HTML::HTMLInputElement& element, CSS::StyleProperties style)
     : FormAssociatedLabelableNode(document, element, move(style))
 {
     set_natural_width(12);

--- a/Userland/Libraries/LibWeb/Layout/RadioButton.h
+++ b/Userland/Libraries/LibWeb/Layout/RadioButton.h
@@ -16,7 +16,7 @@ class RadioButton final : public FormAssociatedLabelableNode {
     JS_DECLARE_ALLOCATOR(RadioButton);
 
 public:
-    RadioButton(DOM::Document&, HTML::HTMLInputElement&, NonnullRefPtr<CSS::StyleProperties>);
+    RadioButton(DOM::Document&, HTML::HTMLInputElement&, CSS::StyleProperties);
     virtual ~RadioButton() override;
 
 private:

--- a/Userland/Libraries/LibWeb/Layout/ReplacedBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ReplacedBox.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::Layout {
 
-ReplacedBox::ReplacedBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
+ReplacedBox::ReplacedBox(DOM::Document& document, DOM::Element& element, CSS::StyleProperties style)
     : Box(document, &element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/ReplacedBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ReplacedBox.h
@@ -15,7 +15,7 @@ class ReplacedBox : public Box {
     JS_CELL(ReplacedBox, Box);
 
 public:
-    ReplacedBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    ReplacedBox(DOM::Document&, DOM::Element&, CSS::StyleProperties);
     virtual ~ReplacedBox() override;
 
     DOM::Element const& dom_node() const { return verify_cast<DOM::Element>(*Node::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGBox.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::Layout {
 
-SVGBox::SVGBox(DOM::Document& document, SVG::SVGElement& element, NonnullRefPtr<CSS::StyleProperties> style)
+SVGBox::SVGBox(DOM::Document& document, SVG::SVGElement& element, CSS::StyleProperties style)
     : Box(document, &element, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGBox.h
@@ -16,7 +16,7 @@ class SVGBox : public Box {
     JS_CELL(SVGBox, Box);
 
 public:
-    SVGBox(DOM::Document&, SVG::SVGElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGBox(DOM::Document&, SVG::SVGElement&, CSS::StyleProperties);
     virtual ~SVGBox() override = default;
 
     SVG::SVGElement& dom_node() { return verify_cast<SVG::SVGElement>(*Box::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGClipBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGClipBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGClipBox);
 
-SVGClipBox::SVGClipBox(DOM::Document& document, SVG::SVGClipPathElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGClipBox::SVGClipBox(DOM::Document& document, SVG::SVGClipPathElement& element, CSS::StyleProperties properties)
     : SVGBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGClipBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGClipBox.h
@@ -17,7 +17,7 @@ class SVGClipBox : public SVGBox {
     JS_DECLARE_ALLOCATOR(SVGClipBox);
 
 public:
-    SVGClipBox(DOM::Document&, SVG::SVGClipPathElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGClipBox(DOM::Document&, SVG::SVGClipPathElement&, CSS::StyleProperties);
     virtual ~SVGClipBox() override = default;
 
     SVG::SVGClipPathElement& dom_node() { return verify_cast<SVG::SVGClipPathElement>(SVGBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGForeignObjectBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGForeignObjectBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGForeignObjectBox);
 
-SVGForeignObjectBox::SVGForeignObjectBox(DOM::Document& document, SVG::SVGForeignObjectElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGForeignObjectBox::SVGForeignObjectBox(DOM::Document& document, SVG::SVGForeignObjectElement& element, CSS::StyleProperties properties)
     : BlockContainer(document, &element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGForeignObjectBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGForeignObjectBox.h
@@ -18,7 +18,7 @@ class SVGForeignObjectBox final : public BlockContainer {
     JS_DECLARE_ALLOCATOR(SVGForeignObjectBox);
 
 public:
-    SVGForeignObjectBox(DOM::Document&, SVG::SVGForeignObjectElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGForeignObjectBox(DOM::Document&, SVG::SVGForeignObjectElement&, CSS::StyleProperties);
     virtual ~SVGForeignObjectBox() override = default;
 
     SVG::SVGForeignObjectElement& dom_node() { return static_cast<SVG::SVGForeignObjectElement&>(*BlockContainer::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -14,7 +14,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGGeometryBox);
 
-SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGGeometryBox::SVGGeometryBox(DOM::Document& document, SVG::SVGGeometryElement& element, CSS::StyleProperties properties)
     : SVGGraphicsBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.h
@@ -17,7 +17,7 @@ class SVGGeometryBox final : public SVGGraphicsBox {
     JS_DECLARE_ALLOCATOR(SVGGeometryBox);
 
 public:
-    SVGGeometryBox(DOM::Document&, SVG::SVGGeometryElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGGeometryBox(DOM::Document&, SVG::SVGGeometryElement&, CSS::StyleProperties);
     virtual ~SVGGeometryBox() override = default;
 
     SVG::SVGGeometryElement& dom_node() { return static_cast<SVG::SVGGeometryElement&>(SVGGraphicsBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.cpp
@@ -10,7 +10,7 @@
 
 namespace Web::Layout {
 
-SVGGraphicsBox::SVGGraphicsBox(DOM::Document& document, SVG::SVGGraphicsElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGGraphicsBox::SVGGraphicsBox(DOM::Document& document, SVG::SVGGraphicsElement& element, CSS::StyleProperties properties)
     : SVGBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGGraphicsBox.h
@@ -16,7 +16,7 @@ class SVGGraphicsBox : public SVGBox {
     JS_CELL(SVGGraphicsBox, SVGBox);
 
 public:
-    SVGGraphicsBox(DOM::Document&, SVG::SVGGraphicsElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGGraphicsBox(DOM::Document&, SVG::SVGGraphicsElement&, CSS::StyleProperties);
     virtual ~SVGGraphicsBox() override = default;
 
     SVG::SVGGraphicsElement& dom_node() { return verify_cast<SVG::SVGGraphicsElement>(SVGBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGImageBox.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::Layout {
 
-SVGImageBox::SVGImageBox(DOM::Document& document, SVG::SVGGraphicsElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGImageBox::SVGImageBox(DOM::Document& document, SVG::SVGGraphicsElement& element, CSS::StyleProperties properties)
     : SVGGraphicsBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGImageBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGImageBox.h
@@ -16,7 +16,7 @@ class SVGImageBox : public SVGGraphicsBox {
     JS_CELL(SVGImageBox, SVGGraphicsBox);
 
 public:
-    SVGImageBox(DOM::Document&, SVG::SVGGraphicsElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGImageBox(DOM::Document&, SVG::SVGGraphicsElement&, CSS::StyleProperties);
     virtual ~SVGImageBox() override = default;
 
     SVG::SVGImageElement& dom_node() { return static_cast<SVG::SVGImageElement&>(SVGGraphicsBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGMaskBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGMaskBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGMaskBox);
 
-SVGMaskBox::SVGMaskBox(DOM::Document& document, SVG::SVGMaskElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGMaskBox::SVGMaskBox(DOM::Document& document, SVG::SVGMaskElement& element, CSS::StyleProperties properties)
     : SVGGraphicsBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGMaskBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGMaskBox.h
@@ -17,7 +17,7 @@ class SVGMaskBox : public SVGGraphicsBox {
     JS_DECLARE_ALLOCATOR(SVGMaskBox);
 
 public:
-    SVGMaskBox(DOM::Document&, SVG::SVGMaskElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGMaskBox(DOM::Document&, SVG::SVGMaskElement&, CSS::StyleProperties);
     virtual ~SVGMaskBox() override = default;
 
     virtual bool is_svg_mask_box() const override { return true; }

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -15,7 +15,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGSVGBox);
 
-SVGSVGBox::SVGSVGBox(DOM::Document& document, SVG::SVGSVGElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGSVGBox::SVGSVGBox(DOM::Document& document, SVG::SVGSVGElement& element, CSS::StyleProperties properties)
     : ReplacedBox(document, element, move(properties))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.h
@@ -16,7 +16,7 @@ class SVGSVGBox final : public ReplacedBox {
     JS_DECLARE_ALLOCATOR(SVGSVGBox);
 
 public:
-    SVGSVGBox(DOM::Document&, SVG::SVGSVGElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGSVGBox(DOM::Document&, SVG::SVGSVGElement&, CSS::StyleProperties);
     virtual ~SVGSVGBox() override = default;
 
     SVG::SVGSVGElement& dom_node() { return verify_cast<SVG::SVGSVGElement>(ReplacedBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGTextBox);
 
-SVGTextBox::SVGTextBox(DOM::Document& document, SVG::SVGTextPositioningElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGTextBox::SVGTextBox(DOM::Document& document, SVG::SVGTextPositioningElement& element, CSS::StyleProperties properties)
     : SVGGraphicsBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGTextBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextBox.h
@@ -17,7 +17,7 @@ class SVGTextBox final : public SVGGraphicsBox {
     JS_DECLARE_ALLOCATOR(SVGTextBox);
 
 public:
-    SVGTextBox(DOM::Document&, SVG::SVGTextPositioningElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGTextBox(DOM::Document&, SVG::SVGTextPositioningElement&, CSS::StyleProperties);
     virtual ~SVGTextBox() override = default;
 
     SVG::SVGTextPositioningElement& dom_node() { return static_cast<SVG::SVGTextPositioningElement&>(SVGGraphicsBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.cpp
@@ -11,7 +11,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(SVGTextPathBox);
 
-SVGTextPathBox::SVGTextPathBox(DOM::Document& document, SVG::SVGTextPathElement& element, NonnullRefPtr<CSS::StyleProperties> properties)
+SVGTextPathBox::SVGTextPathBox(DOM::Document& document, SVG::SVGTextPathElement& element, CSS::StyleProperties properties)
     : SVGGraphicsBox(document, element, properties)
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.h
+++ b/Userland/Libraries/LibWeb/Layout/SVGTextPathBox.h
@@ -16,7 +16,7 @@ class SVGTextPathBox final : public SVGGraphicsBox {
     JS_DECLARE_ALLOCATOR(SVGTextPathBox);
 
 public:
-    SVGTextPathBox(DOM::Document&, SVG::SVGTextPathElement&, NonnullRefPtr<CSS::StyleProperties>);
+    SVGTextPathBox(DOM::Document&, SVG::SVGTextPathElement&, CSS::StyleProperties);
     virtual ~SVGTextPathBox() override = default;
 
     SVG::SVGTextPathElement& dom_node() { return static_cast<SVG::SVGTextPathElement&>(SVGGraphicsBox::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/TableWrapper.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableWrapper.cpp
@@ -10,7 +10,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(TableWrapper);
 
-TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, NonnullRefPtr<CSS::StyleProperties> style)
+TableWrapper::TableWrapper(DOM::Document& document, DOM::Node* node, CSS::StyleProperties style)
     : BlockContainer(document, node, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/TableWrapper.h
+++ b/Userland/Libraries/LibWeb/Layout/TableWrapper.h
@@ -15,7 +15,7 @@ class TableWrapper : public BlockContainer {
     JS_DECLARE_ALLOCATOR(TableWrapper);
 
 public:
-    TableWrapper(DOM::Document&, DOM::Node*, NonnullRefPtr<CSS::StyleProperties>);
+    TableWrapper(DOM::Document&, DOM::Node*, CSS::StyleProperties);
     TableWrapper(DOM::Document&, DOM::Node*, NonnullOwnPtr<CSS::ComputedValues>);
     virtual ~TableWrapper() override;
 

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -193,7 +193,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Se
     auto& document = element.document();
 
     auto pseudo_element_style = element.pseudo_element_computed_css_values(pseudo_element);
-    if (!pseudo_element_style)
+    if (!pseudo_element_style.has_value())
         return;
 
     auto initial_quote_nesting_level = m_quote_nesting_level;
@@ -221,7 +221,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Se
             pseudo_element_node->computed_values().list_style_type(),
             pseudo_element_node->computed_values().list_style_position(),
             0,
-            *marker_style);
+            marker_style);
         static_cast<ListItemBox&>(*pseudo_element_node).set_marker(list_item_marker);
         element.set_pseudo_element_node({}, CSS::Selector::PseudoElement::Type::Marker, list_item_marker);
         pseudo_element_node->append_child(*list_item_marker);
@@ -341,7 +341,7 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
     auto& document = dom_node.document();
     auto& style_computer = document.style_computer();
-    RefPtr<CSS::StyleProperties> style;
+    Optional<CSS::StyleProperties> style;
     CSS::Display display;
 
     if (is<DOM::Element>(dom_node)) {
@@ -429,7 +429,7 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     if (is<ListItemBox>(*layout_node)) {
         auto& element = static_cast<DOM::Element&>(dom_node);
         auto marker_style = style_computer.compute_style(element, CSS::Selector::PseudoElement::Type::Marker);
-        auto list_item_marker = document.heap().allocate_without_realm<ListItemMarkerBox>(document, layout_node->computed_values().list_style_type(), layout_node->computed_values().list_style_position(), calculate_list_item_index(dom_node), *marker_style);
+        auto list_item_marker = document.heap().allocate_without_realm<ListItemMarkerBox>(document, layout_node->computed_values().list_style_type(), layout_node->computed_values().list_style_position(), calculate_list_item_index(dom_node), marker_style);
         static_cast<ListItemBox&>(*layout_node).set_marker(list_item_marker);
         element.set_pseudo_element_node({}, CSS::Selector::PseudoElement::Type::Marker, list_item_marker);
         layout_node->append_child(*list_item_marker);

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.cpp
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(VideoBox);
 
-VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
+VideoBox::VideoBox(DOM::Document& document, DOM::Element& element, CSS::StyleProperties style)
     : ReplacedBox(document, element, move(style))
 {
     document.register_viewport_client(*this);

--- a/Userland/Libraries/LibWeb/Layout/VideoBox.h
+++ b/Userland/Libraries/LibWeb/Layout/VideoBox.h
@@ -27,7 +27,7 @@ public:
     virtual JS::GCPtr<Painting::Paintable> create_paintable() const override;
 
 private:
-    VideoBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    VideoBox(DOM::Document&, DOM::Element&, CSS::StyleProperties);
 
     // ^Document::ViewportClient
     virtual void did_set_viewport_rect(CSSPixelRect const&) final;

--- a/Userland/Libraries/LibWeb/Layout/Viewport.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.cpp
@@ -16,7 +16,7 @@ namespace Web::Layout {
 
 JS_DEFINE_ALLOCATOR(Viewport);
 
-Viewport::Viewport(DOM::Document& document, NonnullRefPtr<CSS::StyleProperties> style)
+Viewport::Viewport(DOM::Document& document, CSS::StyleProperties style)
     : BlockContainer(document, &document, move(style))
 {
 }

--- a/Userland/Libraries/LibWeb/Layout/Viewport.h
+++ b/Userland/Libraries/LibWeb/Layout/Viewport.h
@@ -16,7 +16,7 @@ class Viewport final : public BlockContainer {
     JS_DECLARE_ALLOCATOR(Viewport);
 
 public:
-    explicit Viewport(DOM::Document&, NonnullRefPtr<CSS::StyleProperties>);
+    explicit Viewport(DOM::Document&, CSS::StyleProperties);
     virtual ~Viewport() override;
 
     struct TextPosition {

--- a/Userland/Libraries/LibWeb/SVG/SVGAElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGAElement.cpp
@@ -59,7 +59,7 @@ JS::NonnullGCPtr<DOM::DOMTokenList> SVGAElement::rel_list()
     return *m_rel_list;
 }
 
-JS::GCPtr<Layout::Node> SVGAElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGAElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGAElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGAElement.h
@@ -23,7 +23,7 @@ public:
 
     JS::NonnullGCPtr<DOM::DOMTokenList> rel_list();
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
 private:
     SVGAElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -35,7 +35,7 @@ void SVGClipPathElement::attribute_changed(FlyString const& name, Optional<Strin
         m_clip_path_units = AttributeParser::parse_units(value.value_or(String {}));
 }
 
-JS::GCPtr<Layout::Node> SVGClipPathElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties>)
+JS::GCPtr<Layout::Node> SVGClipPathElement::create_layout_node(CSS::StyleProperties)
 {
     // Clip paths are handled as a special case in the TreeBuilder.
     return nullptr;

--- a/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGClipPathElement.h
@@ -40,7 +40,7 @@ public:
         return m_clip_path_units.value_or(ClipPathUnits::UserSpaceOnUse);
     }
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
 private:
     SVGClipPathElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -133,8 +133,8 @@ Optional<CSSPixels> SVGDecodedImageData::intrinsic_width() const
 {
     // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
     m_document->update_style();
-    auto const* root_element_style = m_root_element->computed_css_values();
-    VERIFY(root_element_style);
+    auto const root_element_style = m_root_element->computed_css_values();
+    VERIFY(root_element_style.has_value());
     auto const& width_value = root_element_style->size_value(CSS::PropertyID::Width);
     if (width_value.is_length() && width_value.length().is_absolute())
         return width_value.length().absolute_length_to_px();
@@ -145,8 +145,8 @@ Optional<CSSPixels> SVGDecodedImageData::intrinsic_height() const
 {
     // https://www.w3.org/TR/SVG2/coords.html#SizingSVGInCSS
     m_document->update_style();
-    auto const* root_element_style = m_root_element->computed_css_values();
-    VERIFY(root_element_style);
+    auto const root_element_style = m_root_element->computed_css_values();
+    VERIFY(root_element_style.has_value());
     auto const& height_value = root_element_style->size_value(CSS::PropertyID::Height);
     if (height_value.is_length() && height_value.length().is_absolute())
         return height_value.length().absolute_length_to_px();

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.h
@@ -17,7 +17,7 @@ class SVGDefsElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGDefsElement();
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override
     {
         return nullptr;
     }

--- a/Userland/Libraries/LibWeb/SVG/SVGDescElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDescElement.cpp
@@ -25,7 +25,7 @@ void SVGDescElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGDescElement);
 }
 
-JS::GCPtr<Layout::Node> SVGDescElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties>)
+JS::GCPtr<Layout::Node> SVGDescElement::create_layout_node(CSS::StyleProperties)
 {
     return nullptr;
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGDescElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDescElement.h
@@ -19,7 +19,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -139,7 +139,7 @@ JS::NonnullGCPtr<SVGAnimatedLength> SVGElement::svg_animated_length_for_property
 {
     // FIXME: Create a proper animated value when animations are supported.
     auto make_length = [&] {
-        if (auto const* style = computed_css_values(); style) {
+        if (auto const style = computed_css_values(); style.has_value()) {
             if (auto length = style->length_percentage(property); length.has_value())
                 return SVGLength::from_length_percentage(realm(), *length);
         }

--- a/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.cpp
@@ -47,7 +47,7 @@ void SVGForeignObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_height);
 }
 
-JS::GCPtr<Layout::Node> SVGForeignObjectElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGForeignObjectElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGForeignObjectBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGForeignObjectElement.h
@@ -18,7 +18,7 @@ class SVGForeignObjectElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGForeignObjectElement() override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     JS::NonnullGCPtr<SVG::SVGAnimatedLength> x();
     JS::NonnullGCPtr<SVG::SVGAnimatedLength> y();

--- a/Userland/Libraries/LibWeb/SVG/SVGGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGElement.cpp
@@ -26,7 +26,7 @@ void SVGGElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGGElement);
 }
 
-JS::GCPtr<Layout::Node> SVGGElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGGElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGElement.h
@@ -17,7 +17,7 @@ class SVGGElement final : public SVGGraphicsElement {
 public:
     virtual ~SVGGElement() override = default;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
 private:
     SVGGElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.cpp
@@ -22,7 +22,7 @@ void SVGGeometryElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGGeometryElement);
 }
 
-JS::GCPtr<Layout::Node> SVGGeometryElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGGeometryElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGGeometryBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGeometryElement.h
@@ -16,7 +16,7 @@ class SVGGeometryElement : public SVGGraphicsElement {
     WEB_PLATFORM_OBJECT(SVGGeometryElement, SVGGraphicsElement);
 
 public:
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) = 0;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -178,7 +178,7 @@ void SVGImageElement::fetch_the_document(URL::URL const& url)
     }
 }
 
-JS::GCPtr<Layout::Node> SVGImageElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGImageElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGImageBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -57,7 +57,7 @@ protected:
     void fetch_the_document(URL::URL const& url);
 
 private:
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
     void animate();
 
     JS::GCPtr<SVG::SVGAnimatedLength> m_x;

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -27,7 +27,7 @@ void SVGMaskElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGMaskElement);
 }
 
-JS::GCPtr<Layout::Node> SVGMaskElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties>)
+JS::GCPtr<Layout::Node> SVGMaskElement::create_layout_node(CSS::StyleProperties)
 {
     // Masks are handled as a special case in the TreeBuilder.
     return nullptr;

--- a/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -38,7 +38,7 @@ public:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     CSSPixelRect resolve_masking_area(CSSPixelRect const& mask_target) const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGMetadataElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGMetadataElement.cpp
@@ -25,7 +25,7 @@ void SVGMetadataElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGMetadataElement);
 }
 
-JS::GCPtr<Layout::Node> SVGMetadataElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties>)
+JS::GCPtr<Layout::Node> SVGMetadataElement::create_layout_node(CSS::StyleProperties)
 {
     return nullptr;
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGMetadataElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGMetadataElement.h
@@ -20,7 +20,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -42,7 +42,7 @@ void SVGSVGElement::visit_edges(Visitor& visitor)
     visitor.visit(m_view_box_for_bindings);
 }
 
-JS::GCPtr<Layout::Node> SVGSVGElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGSVGElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGSVGBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -29,7 +29,7 @@ class SVGSVGElement final : public SVGGraphicsElement
     JS_DECLARE_ALLOCATOR(SVGSVGElement);
 
 public:
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -48,14 +48,14 @@ void SVGStopElement::apply_presentational_hints(CSS::StyleProperties& style) con
 
 Gfx::Color SVGStopElement::stop_color() const
 {
-    if (auto css_values = computed_css_values())
+    if (auto css_values = computed_css_values(); css_values.has_value())
         return css_values->stop_color();
     return Color::Black;
 }
 
 float SVGStopElement::stop_opacity() const
 {
-    if (auto css_values = computed_css_values())
+    if (auto css_values = computed_css_values(); css_values.has_value())
         return css_values->stop_opacity();
     return 1;
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -74,7 +74,7 @@ bool SVGSymbolElement::is_direct_child_of_use_shadow_tree() const
     return is<SVGUseElement>(host);
 }
 
-JS::GCPtr<Layout::Node> SVGSymbolElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGSymbolElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -36,7 +36,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     bool is_direct_child_of_use_shadow_tree() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTSpanElement.cpp
@@ -24,7 +24,7 @@ void SVGTSpanElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGTSpanElement);
 }
 
-JS::GCPtr<Layout::Node> SVGTSpanElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGTSpanElement::create_layout_node(CSS::StyleProperties style)
 {
     // Text must be within an SVG <text> element.
     if (shadow_including_first_ancestor_of_type<SVGTextElement>())

--- a/Userland/Libraries/LibWeb/SVG/SVGTSpanElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTSpanElement.h
@@ -17,7 +17,7 @@ class SVGTSpanElement : public SVGTextPositioningElement {
     JS_DECLARE_ALLOCATOR(SVGTSpanElement);
 
 public:
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
 protected:
     SVGTSpanElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/SVG/SVGTextElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextElement.cpp
@@ -23,7 +23,7 @@ void SVGTextElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGTextElement);
 }
 
-JS::GCPtr<Layout::Node> SVGTextElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGTextElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGTextBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGTextElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextElement.h
@@ -17,7 +17,7 @@ class SVGTextElement : public SVGTextPositioningElement {
     JS_DECLARE_ALLOCATOR(SVGTextElement);
 
 public:
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
 protected:
     SVGTextElement(DOM::Document&, DOM::QualifiedName);

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
@@ -40,7 +40,7 @@ void SVGTextPathElement::visit_edges(Cell::Visitor& visitor)
     SVGURIReferenceMixin::visit_edges(visitor);
 }
 
-JS::GCPtr<Layout::Node> SVGTextPathElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGTextPathElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGTextPathBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTextPathElement.h
@@ -20,7 +20,7 @@ class SVGTextPathElement
     JS_DECLARE_ALLOCATOR(SVGTextPathElement);
 
 public:
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     JS::GCPtr<SVGGeometryElement const> path_or_shape() const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -25,7 +25,7 @@ void SVGTitleElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGTitleElement);
 }
 
-JS::GCPtr<Layout::Node> SVGTitleElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties>)
+JS::GCPtr<Layout::Node> SVGTitleElement::create_layout_node(CSS::StyleProperties)
 {
     return nullptr;
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGTitleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGTitleElement.h
@@ -19,7 +19,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
     virtual void children_changed() override;
 };
 

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -235,7 +235,7 @@ JS::GCPtr<SVGElement> SVGUseElement::animated_instance_root() const
     return instance_root();
 }
 
-JS::GCPtr<Layout::Node> SVGUseElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties> style)
+JS::GCPtr<Layout::Node> SVGUseElement::create_layout_node(CSS::StyleProperties style)
 {
     return heap().allocate_without_realm<Layout::SVGGraphicsBox>(document(), *this, move(style));
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -49,7 +49,7 @@ private:
 
     virtual bool is_svg_use_element() const override { return true; }
 
-    virtual JS::GCPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+    virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 
     void process_the_url(Optional<String> const& href);
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -342,7 +342,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
                     auto styles = doc->style_computer().compute_style(*static_cast<Web::DOM::Element*>(element));
                     dbgln("+ Element {}", element->debug_description());
                     for (size_t i = 0; i < Web::CSS::StyleProperties::number_of_properties; ++i) {
-                        auto property = styles->maybe_null_property(static_cast<Web::CSS::PropertyID>(i));
+                        auto property = styles.maybe_null_property(static_cast<Web::CSS::PropertyID>(i));
                         dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string() : ""_string);
                     }
                     dbgln("---");
@@ -470,7 +470,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
 
     if (node->is_element()) {
         auto& element = verify_cast<Web::DOM::Element>(*node);
-        if (!element.computed_css_values()) {
+        if (!element.computed_css_values().has_value()) {
             async_did_inspect_dom_node(page_id, false, {}, {}, {}, {}, {}, {});
             return;
         }
@@ -581,7 +581,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
 
             auto pseudo_element_style = element.pseudo_element_computed_css_values(pseudo_element.value());
             ByteString computed_values = serialize_json(*pseudo_element_style);
-            ByteString resolved_values = serialize_json(*element.resolved_css_values(pseudo_element.value()));
+            ByteString resolved_values = serialize_json(element.resolved_css_values(pseudo_element.value()));
             ByteString custom_properties_json = serialize_custom_properties_json(element, pseudo_element);
             ByteString node_box_sizing_json = serialize_node_box_sizing_json(pseudo_element_node.ptr());
             ByteString fonts_json = serialize_fonts_json(*pseudo_element_style);

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1184,7 +1184,7 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
     if (!current_browsing_context().active_document()->is_xml_document()) {
         // computed value of parameter property name from element’s style declarations. property name is obtained from url variables.
         if (auto property = Web::CSS::property_id_from_string(name); property.has_value()) {
-            if (auto* computed_values = element->computed_css_values())
+            if (auto computed_values = element->computed_css_values(); computed_values.has_value())
                 computed_value = computed_values->property(property.value())->to_string().to_byte_string();
         }
     }


### PR DESCRIPTION
`AK::CopyOnWrite` already does reference counting, so there is no need to do it again.