### PR TITLE
Meta: Use release builds as the basis for Sanitizer builds

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -100,9 +100,9 @@
     },
     {
       "name": "Sanitizer",
-      "inherits": "Debug",
+      "inherits": "default",
       "displayName": "Sanitizer Config",
-      "description": "Debug build using Sanitizers",
+      "description": "Sanitizer build using Ninja generator",
       "binaryDir": "${fileDir}/Build/ladybird-sanitizers",
       "cacheVariables": {
         "ENABLE_UNDEFINED_SANITIZER": "ON",

--- a/Meta/CMake/vcpkg/sanitizer-triplets/sanitizer.cmake
+++ b/Meta/CMake/vcpkg/sanitizer-triplets/sanitizer.cmake
@@ -1,3 +1,4 @@
+set(VCPKG_BUILD_TYPE release)
 set(VCPKG_LIBRARY_LINKAGE static)
 
 set(VCPKG_C_FLAGS "")


### PR DESCRIPTION
LLVM recommends compiling with at least -O1 to have decent performance with sanitizers enabled. Indeed, this improves CI performance of LibWeb tests as follows:

    GCC on Linux:   160.61s to 119.68s (40.93s faster)
    Clang on Linux:  65.56s to  55.64s ( 9.92s faster)