### PR TITLE
LibWeb: correct default ARIA Roles for few tags

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -571,6 +571,9 @@ void HTMLElement::blur()
 
 Optional<ARIA::Role> HTMLElement::default_role() const
 {
+    // https://www.w3.org/TR/html-aria/#el-address
+    if (local_name() == TagNames::address)
+        return ARIA::Role::group;
     // https://www.w3.org/TR/html-aria/#el-article
     if (local_name() == TagNames::article)
         return ARIA::Role::article;
@@ -612,7 +615,7 @@ Optional<ARIA::Role> HTMLElement::default_role() const
     }
     // https://www.w3.org/TR/html-aria/#el-hgroup
     if (local_name() == TagNames::hgroup)
-        return ARIA::Role::generic;
+        return ARIA::Role::group;
     // https://www.w3.org/TR/html-aria/#el-i
     if (local_name() == TagNames::i)
         return ARIA::Role::generic;
@@ -622,6 +625,9 @@ Optional<ARIA::Role> HTMLElement::default_role() const
     // https://www.w3.org/TR/html-aria/#el-nav
     if (local_name() == TagNames::nav)
         return ARIA::Role::navigation;
+    // https://www.w3.org/TR/html-aria/#el-s
+    if (local_name() == TagNames::s)
+        return ARIA::Role::deletion;
     // https://www.w3.org/TR/html-aria/#el-samp
     if (local_name() == TagNames::samp)
         return ARIA::Role::generic;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2311,7 +2311,7 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
         return ARIA::Role::combobox;
     // https://www.w3.org/TR/html-aria/#el-input-search
     if (type_state() == TypeAttributeState::Search && !has_attribute(AttributeNames::list))
-        return ARIA::Role::textbox;
+        return ARIA::Role::searchbox;
     // https://www.w3.org/TR/html-aria/#el-input-submit
     if (type_state() == TypeAttributeState::SubmitButton)
         return ARIA::Role::button;


### PR DESCRIPTION
# Why

Spotted in WPT tests that few elements have incorrect ARIA Roles:
* https://wpt.fyi/results/html-aam/roles.html?label=experimental&product=ladybird

# How

Update existing default roles for `hgroup` and `input type="search"`, add default role for `address` and `s` tags according to the specification:
* https://www.w3.org/TR/html-aria/#docconformance