### PR TITLE
LibWeb: Compare font keys by reference 

### DIFF
--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -85,7 +85,7 @@ public:
     virtual float width(StringView) const = 0;
     virtual float width(Utf8View const&) const = 0;
 
-    virtual FlyString family() const = 0;
+    virtual FlyString const& family() const = 0;
 
     virtual NonnullRefPtr<Font> with_size(float point_size) const = 0;
 

--- a/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Libraries/LibGfx/Font/ScaledFont.h
@@ -37,7 +37,7 @@ public:
     virtual u8 baseline() const override { return m_point_height; }  // FIXME: Read from font
     virtual float width(StringView) const override;
     virtual float width(Utf8View const&) const override;
-    virtual FlyString family() const override { return m_typeface->family(); }
+    virtual FlyString const& family() const override { return m_typeface->family(); }
 
     virtual NonnullRefPtr<ScaledFont> scaled_with_size(float point_size) const;
     virtual NonnullRefPtr<Font> with_size(float point_size) const override;

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -47,7 +47,7 @@ public:
     virtual u32 glyph_count() const = 0;
     virtual u16 units_per_em() const = 0;
     virtual u32 glyph_id_for_code_point(u32 code_point) const = 0;
-    virtual FlyString family() const = 0;
+    virtual FlyString const& family() const = 0;
     virtual u16 weight() const = 0;
     virtual u16 width() const = 0;
     virtual u8 slope() const = 0;

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -114,7 +114,7 @@ void TypefaceSkia::populate_glyph_page(GlyphPage& glyph_page, size_t page_index)
     }
 }
 
-FlyString TypefaceSkia::family() const
+FlyString const& TypefaceSkia::family() const
 {
     if (!m_family.has_value()) {
         SkString family_name;

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -19,7 +19,7 @@ public:
     virtual u32 glyph_count() const override;
     virtual u16 units_per_em() const override;
     virtual u32 glyph_id_for_code_point(u32 code_point) const override;
-    virtual FlyString family() const override;
+    virtual FlyString const& family() const override;
     virtual u16 weight() const override;
     virtual u16 width() const override;
     virtual u8 slope() const override;

--- a/Libraries/LibWeb/CSS/ParsedFontFace.h
+++ b/Libraries/LibWeb/CSS/ParsedFontFace.h
@@ -30,7 +30,7 @@ public:
     Optional<Percentage> ascent_override() const { return m_ascent_override; }
     Optional<Percentage> descent_override() const { return m_descent_override; }
     FontDisplay font_display() const { return m_font_display; }
-    FlyString font_family() const { return m_font_family; }
+    FlyString const& font_family() const { return m_font_family; }
     Optional<OrderedHashMap<FlyString, i64>> font_feature_settings() const { return m_font_feature_settings; }
     Optional<FlyString> font_language_override() const { return m_font_language_override; }
     Optional<FlyString> font_named_instance() const { return m_font_named_instance; }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -101,13 +101,20 @@ struct MatchingRule {
     FlyString const& qualified_layer_name() const;
 };
 
-struct FontFaceKey {
+struct FontFaceKey;
+
+struct OwnFontFaceKey {
+    explicit OwnFontFaceKey(FontFaceKey const& other);
+
+    operator FontFaceKey() const;
+
+    [[nodiscard]] u32 hash() const { return pair_int_hash(family_name.hash(), pair_int_hash(weight, slope)); }
+    [[nodiscard]] bool operator==(OwnFontFaceKey const& other) const = default;
+    [[nodiscard]] bool operator==(FontFaceKey const& other) const;
+
     FlyString family_name;
     int weight { 0 };
     int slope { 0 };
-
-    [[nodiscard]] u32 hash() const { return pair_int_hash(family_name.hash(), pair_int_hash(weight, slope)); }
-    [[nodiscard]] bool operator==(FontFaceKey const&) const = default;
 };
 
 class FontLoader;
@@ -180,7 +187,7 @@ private:
     void compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
-    RefPtr<Gfx::FontCascadeList const> font_matching_algorithm(FontFaceKey const& key, float font_size_in_pt) const;
+    RefPtr<Gfx::FontCascadeList const> font_matching_algorithm(FlyString const& family_name, int weight, int slope, float font_size_in_pt) const;
     void compute_font(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void compute_math_depth(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void compute_defaulted_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
@@ -246,7 +253,7 @@ private:
     GC::Root<CSSStyleSheet> m_user_style_sheet;
 
     using FontLoaderList = Vector<NonnullOwnPtr<FontLoader>>;
-    HashMap<FontFaceKey, FontLoaderList> m_loaded_fonts;
+    HashMap<OwnFontFaceKey, FontLoaderList> m_loaded_fonts;
 
     Length::FontMetrics m_default_font_metrics;
     Length::FontMetrics m_root_element_font_metrics;


### PR DESCRIPTION
`StyleComputer::font_matching_algorithm` was creating a copy of a
`FlyString` every time a `MatchingFontCandidate` was constructed or
copied, causing millions of unnecessairy reference updates when a
lot of fonts are loaded.

While a more permanent solution would be to not load so many unused
fonts, let's do the right thing and remove the unnecessairy copies of
`FlyString`.