### PR TITLE
AK: Pass `(Deprecated)FlyString::is_one_of` arguments by reference

### DIFF
--- a/AK/DeprecatedFlyString.h
+++ b/AK/DeprecatedFlyString.h
@@ -84,7 +84,7 @@ public:
     static void did_destroy_impl(Badge<StringImpl>, StringImpl&);
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -74,7 +74,7 @@ public:
     [[nodiscard]] bool ends_with_bytes(StringView, CaseSensitivity = CaseSensitivity::CaseSensitive) const;
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }


### PR DESCRIPTION
This avoid unnecessairy reference counting.