### PR TITLE
UI/AppKit: Use round rect bezel style on older SDKs

### DIFF
--- a/Ladybird/AppKit/UI/SearchPanel.mm
+++ b/Ladybird/AppKit/UI/SearchPanel.mm
@@ -63,7 +63,11 @@ static constexpr CGFloat const SEARCH_FIELD_WIDTH = 300;
                                                target:self
                                                action:@selector(cancelSearch:)];
         [search_done setToolTip:@"Close Search Bar"];
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000
         [search_done setBezelStyle:NSBezelStyleAccessoryBarAction];
+#else
+        [search_done setBezelStyle:NSBezelStyleRoundRect];
+#endif
 
         [self addView:self.search_field inGravity:NSStackViewGravityLeading];
         [self addView:search_previous inGravity:NSStackViewGravityLeading];


### PR DESCRIPTION
This fixes #1378 by adding a fallback for a bezel style that is unavailable in older macOS SDK versions.