### PR TITLE
LibWeb: Add temp execution context for resolving promise in AudioContext

### DIFF
--- a/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
+++ b/Userland/Libraries/LibWeb/WebAudio/AudioContext.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
+#include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebAudio/AudioContext.h>
 #include <LibWeb/WebIDL/Promise.h>
@@ -145,6 +146,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::resume()
     if (!start_rendering_audio_graph()) {
         // 7.4: In case of failure, queue a media element task to execute the following steps:
         queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, this]() {
+            HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+
             // 7.4.1: Reject all promises from [[pending resume promises]] in order, then clear [[pending resume promises]].
             for (auto const& promise : m_pending_resume_promises) {
                 WebIDL::reject_promise(realm, promise, JS::js_null());
@@ -160,6 +163,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::resume()
 
     // 7.5: queue a media element task to execute the following steps:
     queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, promise, this]() {
+        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+
         // 7.5.1: Resolve all promises from [[pending resume promises]] in order.
         // 7.5.2: Clear [[pending resume promises]]. Additionally, remove those promises from
         //        [[pending promises]].
@@ -228,6 +233,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::suspend()
 
     // 7.3: queue a media element task to execute the following steps:
     queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, promise, this]() {
+        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+
         // 7.3.1: Resolve promise.
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
 
@@ -281,6 +288,8 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<WebIDL::Promise>> AudioContext::close()
 
     // 5.4: queue a media element task to execute the following steps:
     queue_a_media_element_task(JS::create_heap_function(heap(), [&realm, promise, this]() {
+        HTML::TemporaryExecutionContext context(Bindings::host_defined_environment_settings_object(realm), HTML::TemporaryExecutionContext::CallbacksEnabled::Yes);
+
         // 5.4.1: Resolve promise.
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
 


### PR DESCRIPTION
Fixes a crash seen on twitter.com, namely from the 'resume' function.

Will unfortunately cause me some more conflcits ontop of https://github.com/LadybirdBrowser/ladybird/pull/1955 where TemporaryExecutionContext is changed to accept a Realm&