### PR TITLE
LibWebView: Fix ProcessAndClient template deduction causing build error

### DIFF
--- a/Userland/Libraries/LibWebView/Process.h
+++ b/Userland/Libraries/LibWebView/Process.h
@@ -76,7 +76,7 @@ ErrorOr<Process::ProcessAndClient<ClientType>> Process::spawn(ProcessType type, 
     auto [core_process, transport] = TRY(spawn_and_connect_to_process(options));
     auto client = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ClientType { move(transport), forward<ClientArguments>(client_arguments)... }));
 
-    return ProcessAndClient { Process { type, client, move(core_process) }, client };
+    return ProcessAndClient<ClientType> { Process { type, client, move(core_process) }, client };
 }
 
 }


### PR DESCRIPTION
## Problem
The compiler is unable to deduce template arguments during aggregate initialization of `ProcessAndClient`, causing build failures in `HelperProcess.cpp`.

## Solution
Explicitly specify the `ClientType` template parameter when constructing `ProcessAndClient` in the `Process::spawn()` function. This allows proper template argument deduction without requiring changes to the struct definition.