### PR TITLE
AK: Add ASCII fast path for `Utf8View::contains`

### DIFF
--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -104,10 +104,19 @@ bool Utf8View::starts_with(Utf8View const& start) const
 
 bool Utf8View::contains(u32 needle) const
 {
-    for (u32 code_point : *this) {
-        if (code_point == needle)
-            return true;
+    if (needle <= 0x7f) {
+        // OPTIMIZATION: Fast path for ASCII
+        for (u8 code_point : as_string()) {
+            if (code_point == needle)
+                return true;
+        }
+    } else {
+        for (u32 code_point : *this) {
+            if (code_point == needle)
+                return true;
+        }
     }
+
     return false;
 }
 


### PR DESCRIPTION
This also makes `Utf8View::trim` significantly faster, since most strings start and end with ASCII.