### PR TITLE
Documentation: Change in name from Serenity to Ladybird

### DIFF
--- a/Documentation/EditorConfiguration/VSCodeConfiguration.md
+++ b/Documentation/EditorConfiguration/VSCodeConfiguration.md
@@ -105,7 +105,7 @@ clangd provides code formatting out of the box using the ``clang-format`` engine
 
 ## Settings
 
-These belong in the `.vscode/settings.json` of Serenity.
+These belong in the `.vscode/settings.json` of Ladybird.
 
 ```json
 {


### PR DESCRIPTION
Probably a remnant from Ladybird being in Serenity :^).