### PR TITLE
headless-browser: Implement dialog-related WebView callbacks

### DIFF
--- a/Ladybird/Headless/HeadlessWebView.cpp
+++ b/Ladybird/Headless/HeadlessWebView.cpp
@@ -75,6 +75,9 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
     client().async_set_viewport_size(m_client_state.page_index, viewport_size());
     client().async_set_window_size(m_client_state.page_index, viewport_size());
 
+    Vector<Web::DevicePixelRect> screen_rects { Web::DevicePixelRect { 0, 0, 1920, 1080 } };
+    client().async_update_screen_rects(m_client_state.page_index, move(screen_rects), 0);
+
     if (Application::chrome_options().allow_popups == WebView::AllowPopups::Yes)
         client().async_debug_request(m_client_state.page_index, "block-pop-ups"sv, "off"sv);
 

--- a/Ladybird/Headless/HeadlessWebView.h
+++ b/Ladybird/Headless/HeadlessWebView.h
@@ -13,6 +13,7 @@
 #include <LibCore/Promise.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Size.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/ViewImplementation.h>
 
@@ -48,6 +49,9 @@ private:
     RefPtr<Core::Promise<RefPtr<Gfx::Bitmap>>> m_pending_screenshot;
 
     NonnullRefPtr<TestPromise> m_test_promise;
+
+    Web::Page::PendingDialog m_pending_dialog { Web::Page::PendingDialog::None };
+    Optional<String> m_pending_prompt_text;
 };
 
 }


### PR DESCRIPTION
This allows us to headlessly run WPT tests which involve dialogs.