### PR TITLE
LibCore: Respect system hard limit in `set_resource_limits`

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -992,7 +992,7 @@ ErrorOr<rlimit> get_resource_limits(int resource)
 ErrorOr<void> set_resource_limits(int resource, rlim_t limit)
 {
     auto limits = TRY(get_resource_limits(resource));
-    limits.rlim_cur = limit;
+    limits.rlim_cur = min(limit, limits.rlim_max);
 
     if (::setrlimit(resource, &limits) != 0)
         return Error::from_syscall("setrlimit"sv, -errno);


### PR DESCRIPTION
This avoids an "Invalid argument (errno=22)" error on systems with lower hard limits.