### PR TITLE
LibWeb: Defer handling of WebDriver endpoint invocations

### DIFF
--- a/Userland/Libraries/LibHTTP/HttpRequest.h
+++ b/Userland/Libraries/LibHTTP/HttpRequest.h
@@ -9,6 +9,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/ByteString.h>
+#include <AK/Noncopyable.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibCore/Forward.h>
@@ -63,6 +64,8 @@ public:
 
     HttpRequest() = default;
     ~HttpRequest() = default;
+
+    AK_MAKE_DEFAULT_MOVABLE(HttpRequest);
 
     ByteString const& resource() const { return m_resource; }
     HeaderMap const& headers() const { return m_headers; }

--- a/Userland/Libraries/LibWeb/WebDriver/Client.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Client.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2022, Florent Castelli <florent.castelli@gmail.com>
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -123,15 +123,18 @@ private:
     using WrappedError = Variant<AK::Error, HTTP::HttpRequest::ParseError, WebDriver::Error>;
 
     void die();
+
     ErrorOr<void, WrappedError> on_ready_to_read();
-    ErrorOr<JsonValue, WrappedError> read_body_as_json();
-    ErrorOr<void, WrappedError> handle_request(JsonValue body);
-    ErrorOr<void, WrappedError> send_success_response(JsonValue result);
-    ErrorOr<void, WrappedError> send_error_response(Error const& error);
-    void log_response(unsigned code);
+    static ErrorOr<JsonValue, WrappedError> read_body_as_json(HTTP::HttpRequest const&);
+
+    ErrorOr<void, WrappedError> handle_request(HTTP::HttpRequest const&, JsonValue body);
+    void handle_error(HTTP::HttpRequest const&, WrappedError const&);
+
+    ErrorOr<void, WrappedError> send_success_response(HTTP::HttpRequest const&, JsonValue result);
+    ErrorOr<void, WrappedError> send_error_response(HTTP::HttpRequest const&, Error const& error);
+    static void log_response(HTTP::HttpRequest const&, unsigned code);
 
     NonnullOwnPtr<Core::BufferedTCPSocket> m_socket;
-    Optional<HTTP::HttpRequest> m_request;
     StringBuilder m_remaining_request;
 };
 


### PR DESCRIPTION
We can currently crash on WebDriver session shutdown when we receive a
Delete Session command. This destroys the WebDriver client while we are
inside the client's socket's on_ready_to_read callback. This is not
allowed by AK::Function.

To avoid this, we now only read data from the socket in the callback. We
then defer handling the message to break out of the callback.