### PR TITLE
LibJS: Extend supported date string formats

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -182,6 +182,7 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%a%t%b%t%e%t%Y%t%T%t%Z"sv,            // "Tue Nov 07 2023 10:05:55  UTC"
         "%a%t%b%t%e%t%T%t%Y"sv,                // "Wed Apr 17 23:08:53 2019"
         "%a%t%b%t%e%t%Y%t%T"sv,                // "Wed Apr 17 2019 23:08:53"
+        "%Y-%m-%eT%T%z"sv,                     // "2024-10-19T11:22:00+0000"
         "%Y-%m-%eT%T%X%z"sv,                   // "2024-01-26T22:10:11.306+0000"
         "%m/%e/%Y,%t%T%t%p"sv,                 // "1/27/2024, 9:28:30 AM"
         "%Y-%m-%e"sv,                          // "2024-1-15"

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -37,6 +37,7 @@ test("basic functionality", () => {
     expect(Date.parse("Wed Apr 17 23:08:53 2019")).toBe(1555560533000);
     expect(Date.parse("Wed Apr 17 2019 23:08:53")).toBe(1555560533000);
     expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011000); // FIXME: support sub-second precision
+    expect(Date.parse("2024-10-19T11:22:00+0000")).toBe(1729336920000);
     expect(Date.parse("1/27/2024, 9:28:30 AM")).toBe(1706369310000);
     expect(Date.parse("01 February 2013")).toBe(1359698400000);
 


### PR DESCRIPTION
Adds support for dates like:
2024-10-18T15:46:00+0000