### PR TITLE
LibWeb: Fix CSS "filter" clamping and resolution

### DIFF
--- a/Tests/LibWeb/Text/expected/css/filter-color.txt
+++ b/Tests/LibWeb/Text/expected/css/filter-color.txt
@@ -1,0 +1,3 @@
+high: >grayscale(1) brightness(2) contrast(2) invert(1) opacity(1) saturate(2) sepia(1)<
+neg: >none<
+default: >grayscale() brightness() contrast() invert() opacity() saturate() sepia()<

--- a/Tests/LibWeb/Text/input/css/filter-color.html
+++ b/Tests/LibWeb/Text/input/css/filter-color.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #high{
+        background-color: blue;
+        height: 30px;
+        width: 30px;
+        filter: grayscale(200%) brightness(200%) contrast(200%) invert(200%) opacity(200%) saturate(200%) sepia(200%);
+    }
+    #neg{
+        background-color: blue;
+        height: 30px;
+        width: 30px;
+        filter: grayscale(-50%) brightness(-50%) contrast(-50%) invert(-50%) opacity(-50%) saturate(-50%) sepia(-50%);
+    }
+    #default{
+        background-color: blue;
+        height: 30px;
+        width: 30px;
+        filter: grayscale() brightness() contrast() invert() opacity() saturate() sepia();
+    }
+</style>
+<div id="high"></div>
+<div id="neg"></div>
+<div id="default"></div>
+<script>
+    test(() => {
+        println("high: >" + window.getComputedStyle(document.getElementById("high"))["filter"] + "<");
+        println("neg: >" + window.getComputedStyle(document.getElementById("neg"))["filter"] + "<");
+        println("default: >" + window.getComputedStyle(document.getElementById("default"))["filter"] + "<");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -36,20 +36,22 @@ float FilterOperation::Color::resolved_amount() const
     if (!amount.has_value())
         return 1;
 
-    if (amount->is_number())
-        return amount->number().value();
+    return amount.value().value();
+}
 
-    if (amount->is_percentage())
-        return amount->percentage().as_fraction();
-
-    if (amount->is_calculated()) {
-        if (amount->calculated()->resolves_to_number())
-            return amount->calculated()->resolve_number().value();
-
-        if (amount->calculated()->resolves_to_percentage())
-            return amount->calculated()->resolve_percentage()->as_fraction();
+bool FilterOperation::Color::is_clamped(FilterOperation::Color::Type type)
+{
+    switch (type) {
+    case Type::Grayscale:
+    case Type::Invert:
+    case Type::Opacity:
+    case Type::Sepia:
+        return true;
+    case Type::Brightness:
+    case Type::Contrast:
+    case Type::Saturate:
+        return false;
     }
-
     VERIFY_NOT_REACHED();
 }
 
@@ -111,7 +113,7 @@ String FilterValueListStyleValue::to_string() const
                         }
                     }());
                 if (color.amount.has_value())
-                    builder.append(color.amount->to_string());
+                    builder.appendff("{}", color.amount.value());
             });
         builder.append(')');
         first = false;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
@@ -53,9 +53,11 @@ struct Color {
         Saturate,
         Sepia
     } operation;
-    Optional<NumberPercentage> amount {};
+    Optional<Number> amount;
     float resolved_amount() const;
     bool operator==(Color const&) const = default;
+    static bool allows_negative(Type);
+    static bool is_clamped(Type);
 };
 
 };

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -513,7 +513,6 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     computed_values.set_flex_shrink(computed_style.flex_shrink());
     computed_values.set_order(computed_style.order());
     computed_values.set_clip(computed_style.clip());
-
     auto resolve_filter = [this](CSS::Filter const& computed_filter) -> CSS::ResolvedFilter {
         CSS::ResolvedFilter resolved_filter;
         for (auto const& filter : computed_filter.filters()) {


### PR DESCRIPTION
This was originally implemented in #1963. In particular, clamping was completely turned off:
6c642d168d54ced889546a88ffc0662f6d8564d2

However, *some* filter functions *do* need to be clamped, for example grayscale:
https://www.w3.org/TR/filter-effects-1/#funcdef-filter-grayscale

This made us fail at least the following test, which now passes (with this PR): http://wpt.live/css/filter-effects/filter-grayscale-005.html

Also tested against https://tweakers.net/ , like in #1963.

Ping @gmta, what do you think? You didn't include a test, so I'm not entirely sure whether this preserves all the things that you paid attention to. However, here's a screenshot of https://tweakers.net/ , just to demo that it didn't break anything obvious:

![Bildschirmfoto_2024-10-28_01-21-17](https://github.com/user-attachments/assets/b635c1b6-b3d5-49e2-be52-1cd3ebbca229)
![Bildschirmfoto_2024-10-28_01-24-41](https://github.com/user-attachments/assets/34d76319-bc13-4d6f-9ae4-0637f40498c8)

Found while investigating a very related, but ultimately different bug.