### PR TITLE
LibWeb: Make default monospace font size 13px

### DIFF
--- a/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,16) content-size 784x19 children: not-inline
-      BlockContainer <pre> at (9,17) content-size 782x17 children: inline
+    BlockContainer <body> at (8,13) content-size 784x16 children: not-inline
+      BlockContainer <pre> at (9,14) content-size 782x14 children: inline
         InlineNode <span>
-          frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17] baseline: 13.296875
+          frag 0 from TextNode start: 0, length: 1, rect: [9,14 6.5x14] baseline: 10.890625
               " "
           TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,16 784x19]
-      PaintableWithLines (BlockContainer<PRE>) [8,16 784x19]
+    PaintableWithLines (BlockContainer<BODY>) [8,13 784x16]
+      PaintableWithLines (BlockContainer<PRE>) [8,13 784x16]
         PaintableWithLines (InlineNode<SPAN>)
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x152 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x140 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
         InlineNode <span>
           frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17] baseline: 13.296875
@@ -15,27 +15,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "friends"
               TextNode <#text>
         TextNode <#text>
-      BlockContainer <div> at (8,25) content-size 784x135 children: not-inline
+      BlockContainer <div> at (8,25) content-size 784x123 children: not-inline
         BlockContainer <(anonymous)> at (8,25) content-size 784x68 children: inline
           BreakNode <br>
           BreakNode <br>
           BreakNode <br>
           BreakNode <br>
-        BlockContainer <pre#out> at (8,109) content-size 784x51 children: inline
-          frag 0 from TextNode start: 0, length: 10, rect: [8,109 72.203125x17] baseline: 13.296875
+        BlockContainer <pre#out> at (8,106) content-size 784x42 children: inline
+          frag 0 from TextNode start: 0, length: 10, rect: [8,106 58.640625x14] baseline: 10.890625
               "well: 8, 8"
-          frag 1 from TextNode start: 11, length: 13, rect: [8,126 95.359375x17] baseline: 13.296875
+          frag 1 from TextNode start: 11, length: 13, rect: [8,120 77.46875x14] baseline: 10.890625
               "hello: 44, 33"
-          frag 2 from TextNode start: 25, length: 15, rect: [8,143 113.65625x17] baseline: 13.296875
+          frag 2 from TextNode start: 25, length: 15, rect: [8,134 92.359375x14] baseline: 10.890625
               "friends: 45, 25"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,176) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,161) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x152] overflow: [8,8 784x168]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x140] overflow: [8,8 784x153]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
         PaintableWithLines (InlineNode<SPAN>)
           TextPaintable (TextNode<#text>)
@@ -43,8 +43,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             TextPaintable (TextNode<#text>)
             PaintableWithLines (InlineNode<I>)
               TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>) [8,25 784x135]
+      PaintableWithLines (BlockContainer<DIV>) [8,25 784x123]
         PaintableWithLines (BlockContainer(anonymous)) [8,25 784x68]
-        PaintableWithLines (BlockContainer<PRE>#out) [8,109 784x51]
+        PaintableWithLines (BlockContainer<PRE>#out) [8,106 784x42]
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,176 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,161 784x0]

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
       InlineNode <pre>
-        frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17] baseline: 13.296875
+        frag 0 from TextNode start: 0, length: 3, rect: [9,10 16.15625x14] baseline: 10.890625
             " | "
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/tab-size-chars-should-vertically-align.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-chars-should-vertically-align.txt
@@ -1,52 +1,52 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x84 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x68 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x17 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 60x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [68,8 82.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x72 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x56 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x14 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,18 48x0] baseline: 0
+        frag 1 from TextNode start: 0, length: 2, rect: [56,8 15.59375x14] baseline: 10.890625
             "	A"
-        BlockContainer <span#s1> at (8,21) content-size 60x0 inline-block [BFC] children: not-inline
+        BlockContainer <span#s1> at (8,18) content-size 48x0 inline-block [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,22) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,25) content-size 784x17 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 70x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [78,25 72.265625x17] baseline: 13.296875
+      BlockContainer <div> at (8,22) content-size 784x14 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,32 56x0] baseline: 0
+        frag 1 from TextNode start: 0, length: 2, rect: [64,22 59.59375x14] baseline: 10.890625
             "	A"
-        BlockContainer <span#s2> at (8,38) content-size 70x0 inline-block [BFC] children: not-inline
+        BlockContainer <span#s2> at (8,32) content-size 56x0 inline-block [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,36) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,42) content-size 784x17 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,55 73x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [81,42 69.265625x17] baseline: 13.296875
+      BlockContainer <div> at (8,36) content-size 784x14 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,46 58.40625x0] baseline: 0
+        frag 1 from TextNode start: 0, length: 2, rect: [66,36 57.1875x14] baseline: 10.890625
             "	A"
-        BlockContainer <span#s3> at (8,55) content-size 73x0 inline-block [BFC] children: not-inline
+        BlockContainer <span#s3> at (8,46) content-size 58.40625x0 inline-block [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,50) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,59) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 9, rect: [8,59 78.265625x17] baseline: 13.296875
+      BlockContainer <div> at (8,50) content-size 784x14 children: inline
+        frag 0 from TextNode start: 0, length: 9, rect: [8,50 63.59375x14] baseline: 10.890625
             "        A"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,76) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,64) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x84]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x68]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
-        PaintableWithLines (BlockContainer<SPAN>#s1) [8,21 60x0]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x56]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x14]
+        PaintableWithLines (BlockContainer<SPAN>#s1) [8,18 48x0]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,25 784x17]
-        PaintableWithLines (BlockContainer<SPAN>#s2) [8,38 70x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,22 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,22 784x14]
+        PaintableWithLines (BlockContainer<SPAN>#s2) [8,32 56x0]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,42 784x17]
-        PaintableWithLines (BlockContainer<SPAN>#s3) [8,55 73x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,36 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,36 784x14]
+        PaintableWithLines (BlockContainer<SPAN>#s3) [8,46 58.40625x0]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,59 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,59 784x17]
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,50 784x14]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,76 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,64 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-letter-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-letter-spacing.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 1, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x30 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x14 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x14 children: inline
+        frag 0 from TextNode start: 1, length: 1, rect: [8,8 11.59375x14] baseline: 10.890625
             "A"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,22) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x14]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x14]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,22 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
@@ -1,33 +1,33 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x67 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
-      BlockContainer <div> at (8,8) content-size 100x51 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 114.265625x17] baseline: 13.296875
-        frag 1 from BlockContainer start: 0, length: 0, rect: [8,25 123.609375x17] baseline: 13.296875
-        frag 2 from BlockContainer start: 0, length: 0, rect: [8,42 133.921875x17] baseline: 13.296875
-        BlockContainer <span> at (8,8) content-size 114.265625x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 2, rect: [8,8 114.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x58 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x42 children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x42 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 111.59375x14] baseline: 10.890625
+        frag 1 from BlockContainer start: 0, length: 0, rect: [8,22 119.1875x14] baseline: 10.890625
+        frag 2 from BlockContainer start: 0, length: 0, rect: [8,36 127.5625x14] baseline: 10.890625
+        BlockContainer <span> at (8,8) content-size 111.59375x14 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 2, rect: [8,8 111.59375x14] baseline: 10.890625
               "	A"
           TextNode <#text>
-        BlockContainer <span> at (8,25) content-size 123.609375x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [8,25 123.609375x17] baseline: 13.296875
+        BlockContainer <span> at (8,22) content-size 119.1875x14 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,22 119.1875x14] baseline: 10.890625
               "	AB"
           TextNode <#text>
-        BlockContainer <span> at (8,42) content-size 133.921875x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 4, rect: [8,42 133.921875x17] baseline: 13.296875
+        BlockContainer <span> at (8,36) content-size 127.5625x14 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,36 127.5625x14] baseline: 10.890625
               "	ABC"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,50) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x67]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x51]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 100x51] overflow: [8,8 133.921875x51]
-        PaintableWithLines (BlockContainer<SPAN>) [8,8 114.265625x17]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x42]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x42] overflow: [8,8 127.5625x42]
+        PaintableWithLines (BlockContainer<SPAN>) [8,8 111.59375x14]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<SPAN>) [8,25 123.609375x17]
+        PaintableWithLines (BlockContainer<SPAN>) [8,22 119.1875x14]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<SPAN>) [8,42 133.921875x17]
+        PaintableWithLines (BlockContainer<SPAN>) [8,36 127.5625x14]
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,59 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-word-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-word-spacing.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 1, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x30 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x14 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x14 children: inline
+        frag 0 from TextNode start: 1, length: 1, rect: [8,8 11.59375x14] baseline: 10.890625
             "A"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,22) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x14]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x14]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,22 784x0]

--- a/Tests/LibWeb/Layout/expected/textarea-reset.txt
+++ b/Tests/LibWeb/Layout/expected/textarea-reset.txt
@@ -1,26 +1,26 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
-      BlockContainer <form#form> at (8,8) content-size 784x34 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 194x28] baseline: 16.296875
+    BlockContainer <body> at (8,8) content-size 784x28 children: not-inline
+      BlockContainer <form#form> at (8,8) content-size 784x28 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 154x22] baseline: 13.890625
         TextNode <#text>
-        BlockContainer <textarea#textarea> at (11,11) content-size 194x28 inline-block [BFC] children: not-inline
-          BlockContainer <div> at (11,11) content-size 194x17 children: not-inline
-            BlockContainer <div> at (11,11) content-size 194x17 children: inline
-              frag 0 from TextNode start: 0, length: 14, rect: [11,11 108.453125x17] baseline: 13.296875
+        BlockContainer <textarea#textarea> at (11,11) content-size 154x22 inline-block [BFC] children: not-inline
+          BlockContainer <div> at (11,11) content-size 154x14 children: not-inline
+            BlockContainer <div> at (11,11) content-size 154x14 children: inline
+              frag 0 from TextNode start: 0, length: 14, rect: [11,11 88.109375x14] baseline: 10.890625
                   "Original value"
               TextNode <#text>
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,58) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,52) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34] overflow: [8,8 784x50]
-      PaintableWithLines (BlockContainer<FORM>#form) [8,8 784x34]
-        PaintableWithLines (BlockContainer<TEXTAREA>#textarea) [8,8 200x34]
-          PaintableWithLines (BlockContainer<DIV>) [11,11 194x17]
-            PaintableWithLines (BlockContainer<DIV>) [11,11 194x17]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x28] overflow: [8,8 784x44]
+      PaintableWithLines (BlockContainer<FORM>#form) [8,8 784x28]
+        PaintableWithLines (BlockContainer<TEXTAREA>#textarea) [8,8 160x28]
+          PaintableWithLines (BlockContainer<DIV>) [11,11 154x14]
+            PaintableWithLines (BlockContainer<DIV>) [11,11 154x14]
               TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,58 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]

--- a/Tests/LibWeb/Text/expected/DOM/Offset-of-empty-inline-element.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Offset-of-empty-inline-element.txt
@@ -1,2 +1,2 @@
-Top: 16
+Top: 13
 Left: 8

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -121,7 +121,7 @@ grid-row-start: auto
 grid-template-areas: none
 grid-template-columns: auto
 grid-template-rows: auto
-height: 2091px
+height: 1722px
 inline-size: auto
 inset-block-end: auto
 inset-block-start: auto

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1949,7 +1949,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
     // Note: This is modified by the find_font() lambda
     bool monospace = false;
 
-    float const font_size_in_pt = font_size_in_px * 0.75f;
+    float font_size_in_pt = font_size_in_px * 0.75f;
 
     auto find_font = [&](FlyString const& family) -> RefPtr<Gfx::FontCascadeList const> {
         FontFaceKey key {
@@ -1986,6 +1986,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
         case Keyword::Monospace:
         case Keyword::UiMonospace:
             generic_font = Platform::GenericFont::Monospace;
+            font_size_in_pt = 13 * 0.75f;
             monospace = true;
             break;
         case Keyword::Serif:


### PR DESCRIPTION
This is the default font size used in Chrome and Firefox and my theory is some WPT tests make the same assumption. As an example, https://wpt.live/css/css-text/tab-size/tab-size-spacing-001.html will pass once PR #1999 is merged if we explicitly set the `font-size` to be `13px`.

I figured this out when comparing the size of the space character across Chrome and Ladybird, which we were sizing to large and hence overshooting the
red square in the aforementioned WPT test. I'd like to think that this is true across all WPT tests that measure pixels and use monospace as their font-family :^) but this is unsubstantiated.