### PR TITLE
Meta: Use correct certificate path when invoking WPT 

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -29,7 +29,7 @@ WEBDRIVER_BINARY=${WEBDRIVER_BINARY:-"$(default_binary_path)/WebDriver"}
 WPT_PROCESSES=${WPT_PROCESSES:-$(get_number_of_processing_units)}
 WPT_CERTIFICATES=(
   "tools/certs/cacert.pem"
-  "${LADYBIRD_SOURCE_DIR}/Build/ladybird/Lagom/cacert.pem"
+  "${BUILD_DIR}/Lagom/cacert.pem"
 )
 WPT_ARGS=( "--webdriver-binary=${WEBDRIVER_BINARY}"
            "--install-webdriver"

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -87,7 +87,7 @@ set_logging_flags()
     [ -n "${2}" ] || usage;
 
     log_type="${1}"
-    log_name="$(pwd -P)/${2}"
+    log_name="$(realpath "${2}")"
 
     WPT_ARGS+=( "${log_type}=${log_name}" )
 }


### PR DESCRIPTION
We now ensure that the directory for the currently selected build preset is used as the base certificate path. 

I've also included a change to ensure that log files are written to the correct place when an absolute path is given, previously the path was always appended to the current directory.

**NOTE:** The `-P` option can't be used with `realpath` since the option isn't available on MacOS.