### PR TITLE
LibWeb: Make `CSSRule::type()` non-virtual

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.cpp
@@ -11,8 +11,8 @@
 
 namespace Web::CSS {
 
-CSSConditionRule::CSSConditionRule(JS::Realm& realm, CSSRuleList& rules)
-    : CSSGroupingRule(realm, rules)
+CSSConditionRule::CSSConditionRule(JS::Realm& realm, CSSRuleList& rules, Type type)
+    : CSSGroupingRule(realm, rules, type)
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSConditionRule.h
@@ -24,7 +24,7 @@ public:
     virtual void for_each_effective_rule(TraversalOrder, Function<void(CSSRule const&)> const& callback) const override;
 
 protected:
-    CSSConditionRule(JS::Realm&, CSSRuleList&);
+    CSSConditionRule(JS::Realm&, CSSRuleList&, Type);
 
     virtual void initialize(JS::Realm&) override;
 };

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.cpp
@@ -23,7 +23,7 @@ JS::NonnullGCPtr<CSSFontFaceRule> CSSFontFaceRule::create(JS::Realm& realm, Pars
 }
 
 CSSFontFaceRule::CSSFontFaceRule(JS::Realm& realm, ParsedFontFace&& font_face)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::FontFace)
     , m_font_face(move(font_face))
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSFontFaceRule.h
@@ -21,8 +21,6 @@ public:
 
     virtual ~CSSFontFaceRule() override = default;
 
-    virtual Type type() const override { return Type::FontFace; }
-
     ParsedFontFace const& font_face() const { return m_font_face; }
     CSSStyleDeclaration* style();
 

--- a/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.cpp
@@ -14,8 +14,8 @@
 
 namespace Web::CSS {
 
-CSSGroupingRule::CSSGroupingRule(JS::Realm& realm, CSSRuleList& rules)
-    : CSSRule(realm)
+CSSGroupingRule::CSSGroupingRule(JS::Realm& realm, CSSRuleList& rules, Type type)
+    : CSSRule(realm, type)
     , m_rules(rules)
 {
     for (auto& rule : *m_rules)

--- a/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSGroupingRule.h
@@ -31,7 +31,7 @@ public:
     virtual void set_parent_style_sheet(CSSStyleSheet*) override;
 
 protected:
-    CSSGroupingRule(JS::Realm&, CSSRuleList&);
+    CSSGroupingRule(JS::Realm&, CSSRuleList&, Type);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -29,7 +29,7 @@ JS::NonnullGCPtr<CSSImportRule> CSSImportRule::create(URL::URL url, DOM::Documen
 }
 
 CSSImportRule::CSSImportRule(URL::URL url, DOM::Document& document)
-    : CSSRule(document.realm())
+    : CSSRule(document.realm(), Type::Import)
     , m_url(move(url))
     , m_document(document)
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -36,8 +36,6 @@ public:
     CSSStyleSheet* style_sheet_for_bindings() { return m_style_sheet; }
     void set_style_sheet(CSSStyleSheet* style_sheet) { m_style_sheet = style_sheet; }
 
-    virtual Type type() const override { return Type::Import; }
-
 private:
     CSSImportRule(URL::URL, DOM::Document&);
 

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.cpp
@@ -19,7 +19,7 @@ JS::NonnullGCPtr<CSSKeyframeRule> CSSKeyframeRule::create(JS::Realm& realm, CSS:
 }
 
 CSSKeyframeRule::CSSKeyframeRule(JS::Realm& realm, CSS::Percentage key, PropertyOwningCSSStyleDeclaration& declarations)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::Keyframe)
     , m_key(key)
     , m_declarations(declarations)
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframeRule.h
@@ -25,8 +25,6 @@ public:
 
     virtual ~CSSKeyframeRule() = default;
 
-    virtual Type type() const override { return Type::Keyframe; }
-
     CSS::Percentage key() const { return m_key; }
     JS::NonnullGCPtr<CSSStyleDeclaration> style() const { return m_declarations; }
     JS::NonnullGCPtr<PropertyOwningCSSStyleDeclaration> style_as_property_owning_style_declaration() const { return m_declarations; }

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.cpp
@@ -20,7 +20,7 @@ JS::NonnullGCPtr<CSSKeyframesRule> CSSKeyframesRule::create(JS::Realm& realm, Fl
 }
 
 CSSKeyframesRule::CSSKeyframesRule(JS::Realm& realm, FlyString name, JS::NonnullGCPtr<CSSRuleList> keyframes)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::Keyframes)
     , m_name(move(name))
     , m_rules(move(keyframes))
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSKeyframesRule.h
@@ -28,8 +28,6 @@ public:
 
     virtual ~CSSKeyframesRule() = default;
 
-    virtual Type type() const override { return Type::Keyframes; }
-
     auto const& css_rules() const { return m_rules; }
     FlyString const& name() const { return m_name; }
     [[nodiscard]] WebIDL::UnsignedLong length() const;

--- a/Userland/Libraries/LibWeb/CSS/CSSLayerBlockRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSLayerBlockRule.cpp
@@ -25,7 +25,7 @@ FlyString CSSLayerBlockRule::next_unique_anonymous_layer_name()
 }
 
 CSSLayerBlockRule::CSSLayerBlockRule(JS::Realm& realm, FlyString name, CSSRuleList& rules)
-    : CSSGroupingRule(realm, rules)
+    : CSSGroupingRule(realm, rules, Type::LayerBlock)
     , m_name(move(name))
 {
     if (m_name.is_empty()) {

--- a/Userland/Libraries/LibWeb/CSS/CSSLayerBlockRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSLayerBlockRule.h
@@ -22,8 +22,6 @@ public:
 
     virtual ~CSSLayerBlockRule() = default;
 
-    virtual Type type() const override { return Type::LayerBlock; }
-
     FlyString const& name() const { return m_name; }
     FlyString const& internal_name() const { return m_name_internal; }
     FlyString internal_qualified_name(Badge<StyleComputer>) const;

--- a/Userland/Libraries/LibWeb/CSS/CSSLayerStatementRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSLayerStatementRule.cpp
@@ -19,7 +19,7 @@ JS::NonnullGCPtr<CSSLayerStatementRule> CSSLayerStatementRule::create(JS::Realm&
 }
 
 CSSLayerStatementRule::CSSLayerStatementRule(JS::Realm& realm, Vector<FlyString> name_list)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::LayerStatement)
     , m_name_list(move(name_list))
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSLayerStatementRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSLayerStatementRule.h
@@ -20,8 +20,6 @@ public:
 
     virtual ~CSSLayerStatementRule() = default;
 
-    virtual Type type() const override { return Type::LayerStatement; }
-
     // FIXME: Should be FrozenArray
     ReadonlySpan<FlyString> name_list() const { return m_name_list; }
     Vector<FlyString> internal_qualified_name_list(Badge<StyleComputer>) const;

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.cpp
@@ -20,7 +20,7 @@ JS::NonnullGCPtr<CSSMediaRule> CSSMediaRule::create(JS::Realm& realm, MediaList&
 }
 
 CSSMediaRule::CSSMediaRule(JS::Realm& realm, MediaList& media, CSSRuleList& rules)
-    : CSSConditionRule(realm, rules)
+    : CSSConditionRule(realm, rules, Type::Media)
     , m_media(media)
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSMediaRule.h
@@ -23,8 +23,6 @@ public:
 
     virtual ~CSSMediaRule() = default;
 
-    virtual Type type() const override { return Type::Media; }
-
     virtual String condition_text() const override;
     virtual bool condition_matches() const override { return m_media->matches(); }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.cpp
@@ -17,7 +17,7 @@ namespace Web::CSS {
 JS_DEFINE_ALLOCATOR(CSSNamespaceRule);
 
 CSSNamespaceRule::CSSNamespaceRule(JS::Realm& realm, Optional<FlyString> prefix, FlyString namespace_uri)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::Namespace)
     , m_namespace_uri(move(namespace_uri))
     , m_prefix(prefix.value_or(""_fly_string))
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNamespaceRule.h
@@ -23,7 +23,6 @@ public:
     FlyString const& namespace_uri() const { return m_namespace_uri; }
     void set_prefix(FlyString value) { m_prefix = move(value); }
     FlyString const& prefix() const { return m_prefix; }
-    virtual Type type() const override { return Type::Namespace; }
 
 private:
     CSSNamespaceRule(JS::Realm&, Optional<FlyString> prefix, FlyString namespace_uri);

--- a/Userland/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSNestedDeclarations.cpp
@@ -18,7 +18,7 @@ JS::NonnullGCPtr<CSSNestedDeclarations> CSSNestedDeclarations::create(JS::Realm&
 }
 
 CSSNestedDeclarations::CSSNestedDeclarations(JS::Realm& realm, PropertyOwningCSSStyleDeclaration& declaration)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::NestedDeclarations)
     , m_declaration(declaration)
 {
     m_declaration->set_parent_rule(*this);

--- a/Userland/Libraries/LibWeb/CSS/CSSNestedDeclarations.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSNestedDeclarations.h
@@ -19,7 +19,6 @@ public:
 
     virtual ~CSSNestedDeclarations() override = default;
 
-    virtual Type type() const override { return Type::NestedDeclarations; }
     PropertyOwningCSSStyleDeclaration const& declaration() const { return m_declaration; }
 
     CSSStyleDeclaration* style();

--- a/Userland/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSPropertyRule.cpp
@@ -19,7 +19,7 @@ JS::NonnullGCPtr<CSSPropertyRule> CSSPropertyRule::create(JS::Realm& realm, FlyS
 }
 
 CSSPropertyRule::CSSPropertyRule(JS::Realm& realm, FlyString name, FlyString syntax, bool inherits, Optional<String> initial_value)
-    : CSSRule(realm)
+    : CSSRule(realm, Type::Property)
     , m_name(move(name))
     , m_syntax(move(syntax))
     , m_inherits(inherits)

--- a/Userland/Libraries/LibWeb/CSS/CSSPropertyRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSPropertyRule.h
@@ -25,7 +25,6 @@ public:
 
     virtual ~CSSPropertyRule() = default;
 
-    virtual Type type() const override { return Type::Property; }
     FlyString const& name() const { return m_name; }
     FlyString const& syntax() const { return m_syntax; }
     bool inherits() const { return m_inherits; }

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.cpp
@@ -13,8 +13,9 @@
 
 namespace Web::CSS {
 
-CSSRule::CSSRule(JS::Realm& realm)
+CSSRule::CSSRule(JS::Realm& realm, Type type)
     : PlatformObject(realm)
+    , m_type(type)
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSRule.h
@@ -38,7 +38,7 @@ public:
         Property = 103, // FIXME: This should return `0` as a type, but type is used for a lot of dispatching
     };
 
-    virtual Type type() const = 0;
+    Type type() const { return m_type; }
 
     String css_text() const;
     void set_css_text(StringView);
@@ -57,7 +57,7 @@ public:
     virtual String serialized() const = 0;
 
 protected:
-    explicit CSSRule(JS::Realm&);
+    explicit CSSRule(JS::Realm&, Type);
 
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -72,6 +72,7 @@ protected:
 
     [[nodiscard]] FlyString const& parent_layer_internal_qualified_name_slow_case() const;
 
+    Type m_type;
     JS::GCPtr<CSSRule> m_parent_rule;
     JS::GCPtr<CSSStyleSheet> m_parent_style_sheet;
 

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -22,7 +22,7 @@ JS::NonnullGCPtr<CSSStyleRule> CSSStyleRule::create(JS::Realm& realm, SelectorLi
 }
 
 CSSStyleRule::CSSStyleRule(JS::Realm& realm, SelectorList&& selectors, PropertyOwningCSSStyleDeclaration& declaration, CSSRuleList& nested_rules)
-    : CSSGroupingRule(realm, nested_rules)
+    : CSSGroupingRule(realm, nested_rules, Type::Style)
     , m_selectors(move(selectors))
     , m_declaration(declaration)
 {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleRule.h
@@ -27,8 +27,6 @@ public:
     SelectorList const& absolutized_selectors() const;
     PropertyOwningCSSStyleDeclaration const& declaration() const { return m_declaration; }
 
-    virtual Type type() const override { return Type::Style; }
-
     String selector_text() const;
     void set_selector_text(StringView);
 

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.cpp
@@ -19,7 +19,7 @@ JS::NonnullGCPtr<CSSSupportsRule> CSSSupportsRule::create(JS::Realm& realm, Nonn
 }
 
 CSSSupportsRule::CSSSupportsRule(JS::Realm& realm, NonnullRefPtr<Supports>&& supports, CSSRuleList& rules)
-    : CSSConditionRule(realm, rules)
+    : CSSConditionRule(realm, rules, Type::Supports)
     , m_supports(move(supports))
 {
 }

--- a/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSSupportsRule.h
@@ -24,8 +24,6 @@ public:
 
     virtual ~CSSSupportsRule() = default;
 
-    virtual Type type() const override { return Type::Supports; }
-
     String condition_text() const override;
     virtual bool condition_matches() const override { return m_supports->matches(); }
 


### PR DESCRIPTION
All its overrides return constants, and without virtual dispatch the `qualified_layer_name` and `absolutized_selectors` functions can benefit from slightly better optimizations.

`CSSRule`s aren't allocated that often, so the memory impact is minimal.