### PR TITLE
LibWeb+WebContent+WebDriver+UI: Make window rect updates asynchronous

### DIFF
--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -65,6 +65,9 @@
 - (WebView::ViewImplementation&)view;
 - (String const&)handle;
 
+- (void)setWindowPosition:(Gfx::IntPoint)position;
+- (void)setWindowSize:(Gfx::IntSize)size;
+
 - (void)handleResize;
 - (void)handleDevicePixelRatioChange;
 - (void)handleScroll;

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -184,6 +184,16 @@ struct HideCursor {
     return m_web_view_bridge->handle();
 }
 
+- (void)setWindowPosition:(Gfx::IntPoint)position
+{
+    m_web_view_bridge->set_window_position(Ladybird::compute_origin_relative_to_window([self window], position));
+}
+
+- (void)setWindowSize:(Gfx::IntSize)size
+{
+    m_web_view_bridge->set_window_size(size);
+}
+
 - (void)handleResize
 {
     [self updateViewportRect:Ladybird::WebViewBridge::ForResize::Yes];
@@ -1546,6 +1556,10 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 {
     [super viewDidMoveToWindow];
     [self handleResize];
+
+    auto window = Ladybird::ns_rect_to_gfx_rect([[self window] frame]);
+    [self setWindowPosition:window.location()];
+    [self setWindowSize:window.size()];
 }
 
 - (void)viewDidEndLiveResize

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1032,34 +1032,35 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     m_web_view_bridge->on_maximize_window = [weak_self]() {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
-            return Gfx::IntRect {};
+            return;
         }
-        auto frame = [[NSScreen mainScreen] frame];
+
+        auto frame = [[[self window] screen] frame];
         [[self window] setFrame:frame display:YES];
 
-        return Ladybird::ns_rect_to_gfx_rect([[self window] frame]);
+        m_web_view_bridge->did_update_window_rect();
     };
 
     m_web_view_bridge->on_minimize_window = [weak_self]() {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
-            return Gfx::IntRect {};
+            return;
         }
-        [[self window] setIsMiniaturized:YES];
 
-        return Ladybird::ns_rect_to_gfx_rect([[self window] frame]);
+        [[self window] setIsMiniaturized:YES];
     };
 
     m_web_view_bridge->on_fullscreen_window = [weak_self]() {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
-            return Gfx::IntRect {};
+            return;
         }
+
         if (([[self window] styleMask] & NSWindowStyleMaskFullScreen) == 0) {
             [[self window] toggleFullScreen:nil];
         }
 
-        return Ladybird::ns_rect_to_gfx_rect([[self window] frame]);
+        m_web_view_bridge->did_update_window_rect();
     };
 
     m_web_view_bridge->on_received_source = [weak_self](auto const& url, auto const& base_url, auto const& source) {

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1004,19 +1004,20 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         [[self window] orderFront:nil];
     };
 
-    m_web_view_bridge->on_reposition_window = [weak_self](auto const& position) {
+    m_web_view_bridge->on_reposition_window = [weak_self](auto position) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return Gfx::IntPoint {};
         }
-        auto frame = [[self window] frame];
-        frame.origin = Ladybird::gfx_point_to_ns_point(position);
-        [[self window] setFrame:frame display:YES];
 
-        return Ladybird::ns_point_to_gfx_point([[self window] frame].origin);
+        position = Ladybird::compute_origin_relative_to_window([self window], position);
+        [[self window] setFrameOrigin:Ladybird::gfx_point_to_ns_point(position)];
+
+        position = Ladybird::ns_point_to_gfx_point([[self window] frame].origin);
+        return Ladybird::compute_origin_relative_to_window([self window], position);
     };
 
-    m_web_view_bridge->on_resize_window = [weak_self](auto const& size) {
+    m_web_view_bridge->on_resize_window = [weak_self](auto size) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
             return Gfx::IntSize {};

--- a/Ladybird/AppKit/UI/LadybirdWebView.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebView.mm
@@ -1007,26 +1007,26 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     m_web_view_bridge->on_reposition_window = [weak_self](auto position) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
-            return Gfx::IntPoint {};
+            return;
         }
 
         position = Ladybird::compute_origin_relative_to_window([self window], position);
         [[self window] setFrameOrigin:Ladybird::gfx_point_to_ns_point(position)];
 
-        position = Ladybird::ns_point_to_gfx_point([[self window] frame].origin);
-        return Ladybird::compute_origin_relative_to_window([self window], position);
+        m_web_view_bridge->did_update_window_rect();
     };
 
     m_web_view_bridge->on_resize_window = [weak_self](auto size) {
         LadybirdWebView* self = weak_self;
         if (self == nil) {
-            return Gfx::IntSize {};
+            return;
         }
+
         auto frame = [[self window] frame];
         frame.size = Ladybird::gfx_size_to_ns_size(size);
         [[self window] setFrame:frame display:YES];
 
-        return Ladybird::ns_size_to_gfx_size([[self window] frame].size);
+        m_web_view_bridge->did_update_window_rect();
     };
 
     m_web_view_bridge->on_maximize_window = [weak_self]() {

--- a/Ladybird/AppKit/UI/TabController.mm
+++ b/Ladybird/AppKit/UI/TabController.mm
@@ -607,6 +607,12 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     [delegate removeTab:self];
 }
 
+- (void)windowDidMove:(NSNotification*)notification
+{
+    auto position = Ladybird::ns_point_to_gfx_point([[self tab] frame].origin);
+    [[[self tab] web_view] setWindowPosition:position];
+}
+
 - (void)windowDidResize:(NSNotification*)notification
 {
     if (self.location_toolbar_item_width != nil) {
@@ -620,6 +626,9 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
     if (![[self window] inLiveResize]) {
         [[[self tab] web_view] handleResize];
     }
+
+    auto size = Ladybird::ns_size_to_gfx_size([[self tab] frame].size);
+    [[[self tab] web_view] setWindowSize:size];
 }
 
 - (void)windowDidChangeBackingProperties:(NSNotification*)notification

--- a/Ladybird/AppKit/Utilities/Conversions.h
+++ b/Ladybird/AppKit/Utilities/Conversions.h
@@ -38,4 +38,6 @@ NSPoint gfx_point_to_ns_point(Gfx::IntPoint);
 Gfx::Color ns_color_to_gfx_color(NSColor*);
 NSColor* gfx_color_to_ns_color(Gfx::Color);
 
+Gfx::IntPoint compute_origin_relative_to_window(NSWindow*, Gfx::IntPoint);
+
 }

--- a/Ladybird/AppKit/Utilities/Conversions.mm
+++ b/Ladybird/AppKit/Utilities/Conversions.mm
@@ -117,4 +117,15 @@ NSColor* gfx_color_to_ns_color(Gfx::Color color)
                            alpha:(color.alpha() / 255.f)];
 }
 
+Gfx::IntPoint compute_origin_relative_to_window(NSWindow* window, Gfx::IntPoint position)
+{
+    // The origin of the NSWindow is its bottom-left corner, relative to the bottom-left of the screen. We must convert
+    // window positions sent to/from WebContent between this origin and the window's and screen's top-left corners.
+    auto screen_frame = Ladybird::ns_rect_to_gfx_rect([[window screen] frame]);
+    auto window_frame = Ladybird::ns_rect_to_gfx_rect([window frame]);
+
+    position.set_y(screen_frame.height() - window_frame.height() - position.y());
+    return position;
+}
+
 }

--- a/Ladybird/Headless/HeadlessWebView.cpp
+++ b/Ladybird/Headless/HeadlessWebView.cpp
@@ -128,6 +128,7 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
     client().async_set_window_handle(m_client_state.page_index, m_client_state.client_handle);
 
     client().async_update_system_theme(m_client_state.page_index, m_theme);
+    client().async_set_system_visibility_state(m_client_state.page_index, true);
     client().async_set_viewport_size(m_client_state.page_index, viewport_size());
     client().async_set_window_size(m_client_state.page_index, viewport_size());
 

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -1168,7 +1168,7 @@ void BrowserWindow::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
 
     for_each_tab([&](auto& tab) {
-        tab.view().set_window_size({ frameSize().width(), frameSize().height() });
+        tab.view().set_window_size({ width(), height() });
     });
 }
 
@@ -1177,7 +1177,7 @@ void BrowserWindow::moveEvent(QMoveEvent* event)
     QWidget::moveEvent(event);
 
     for_each_tab([&](auto& tab) {
-        tab.view().set_window_position({ event->pos().x(), event->pos().y() });
+        tab.view().set_window_position({ x(), y() });
     });
 }
 

--- a/Ladybird/Qt/BrowserWindow.cpp
+++ b/Ladybird/Qt/BrowserWindow.cpp
@@ -1168,7 +1168,7 @@ void BrowserWindow::resizeEvent(QResizeEvent* event)
     QWidget::resizeEvent(event);
 
     for_each_tab([&](auto& tab) {
-        tab.view().set_window_size({ frameSize().width() * m_device_pixel_ratio, frameSize().height() * m_device_pixel_ratio });
+        tab.view().set_window_size({ frameSize().width(), frameSize().height() });
     });
 }
 
@@ -1177,7 +1177,7 @@ void BrowserWindow::moveEvent(QMoveEvent* event)
     QWidget::moveEvent(event);
 
     for_each_tab([&](auto& tab) {
-        tab.view().set_window_position({ event->pos().x() * m_device_pixel_ratio, event->pos().y() * m_device_pixel_ratio });
+        tab.view().set_window_position({ event->pos().x(), event->pos().y() });
     });
 }
 

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -364,17 +364,16 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     view().on_maximize_window = [this]() {
         m_window->showMaximized();
-        return Gfx::IntRect { m_window->x(), m_window->y(), m_window->width(), m_window->height() };
+        view().did_update_window_rect();
     };
 
     view().on_minimize_window = [this]() {
         m_window->showMinimized();
-        return Gfx::IntRect { m_window->x(), m_window->y(), m_window->width(), m_window->height() };
     };
 
     view().on_fullscreen_window = [this]() {
         m_window->showFullScreen();
-        return Gfx::IntRect { m_window->x(), m_window->y(), m_window->width(), m_window->height() };
+        view().did_update_window_rect();
     };
 
     view().on_insert_clipboard_entry = [](auto const& data, auto const&, auto const& mime_type) {

--- a/Ladybird/Qt/Tab.cpp
+++ b/Ladybird/Qt/Tab.cpp
@@ -354,12 +354,12 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
 
     view().on_reposition_window = [this](auto const& position) {
         m_window->move(position.x(), position.y());
-        return Gfx::IntPoint { m_window->x(), m_window->y() };
+        view().did_update_window_rect();
     };
 
     view().on_resize_window = [this](auto const& size) {
         m_window->resize(size.width(), size.height());
-        return Gfx::IntSize { m_window->width(), m_window->height() };
+        view().did_update_window_rect();
     };
 
     view().on_maximize_window = [this]() {

--- a/Ladybird/Qt/WebContentView.cpp
+++ b/Ladybird/Qt/WebContentView.cpp
@@ -536,16 +536,6 @@ void WebContentView::set_viewport_rect(Gfx::IntRect rect)
     client().async_set_viewport_size(m_client_state.page_index, rect.size().to_type<Web::DevicePixels>());
 }
 
-void WebContentView::set_window_size(Gfx::IntSize size)
-{
-    client().async_set_window_size(m_client_state.page_index, size.to_type<Web::DevicePixels>());
-}
-
-void WebContentView::set_window_position(Gfx::IntPoint position)
-{
-    client().async_set_window_position(m_client_state.page_index, position.to_type<Web::DevicePixels>());
-}
-
 void WebContentView::set_device_pixel_ratio(double device_pixel_ratio)
 {
     m_device_pixel_ratio = device_pixel_ratio;

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -73,8 +73,6 @@ public:
     virtual bool event(QEvent*) override;
 
     void set_viewport_rect(Gfx::IntRect);
-    void set_window_size(Gfx::IntSize);
-    void set_window_position(Gfx::IntPoint);
     void set_device_pixel_ratio(double);
 
     enum class PaletteMode {

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -71,7 +71,7 @@ static bool is_primitive_type(ByteString const& type)
 static bool is_simple_type(ByteString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("AK::CaseSensitivity", "AK::Duration", "Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Core::File::OpenMode", "Web::Cookie::Source", "Web::EventResult", "Web::HTML::AllowMultipleFiles", "Web::HTML::AudioPlayState", "Web::HTML::HistoryHandlingBehavior", "WebView::PageInfoType");
+    return type.is_one_of("AK::CaseSensitivity", "AK::Duration", "Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Web::DevicePixelRect", "Core::File::OpenMode", "Web::Cookie::Source", "Web::EventResult", "Web::HTML::AllowMultipleFiles", "Web::HTML::AudioPlayState", "Web::HTML::HistoryHandlingBehavior", "WebView::PageInfoType");
 }
 
 static bool is_primitive_or_simple_type(ByteString const& type)

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2729,7 +2729,11 @@ void Document::update_the_visibility_state(HTML::VisibilityState visibility_stat
     // 2. Set document's visibility state to visibilityState.
     m_visibility_state = visibility_state;
 
-    // FIXME: 3. Run any page visibility change steps which may be defined in other specifications, with visibility state and document.
+    // 3. Run any page visibility change steps which may be defined in other specifications, with visibility state and document.
+    for (auto document_observer : m_document_observers) {
+        if (document_observer->document_visibility_state_observer())
+            document_observer->document_visibility_state_observer()->function()(m_visibility_state);
+    }
 
     // 4. Fire an event named visibilitychange at document, with its bubbles attribute initialized to true.
     auto event = DOM::Event::create(realm(), HTML::EventNames::visibilitychange);

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -430,6 +430,7 @@ public:
 
     bool hidden() const;
     StringView visibility_state() const;
+    HTML::VisibilityState visibility_state_value() const { return m_visibility_state; }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#update-the-visibility-state
     void update_the_visibility_state(HTML::VisibilityState);

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
@@ -26,6 +26,7 @@ void DocumentObserver::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_became_inactive);
     visitor.visit(m_document_completely_loaded);
     visitor.visit(m_document_readiness_observer);
+    visitor.visit(m_document_visibility_state_observer);
 }
 
 void DocumentObserver::finalize()
@@ -56,6 +57,14 @@ void DocumentObserver::set_document_readiness_observer(Function<void(HTML::Docum
         m_document_readiness_observer = JS::create_heap_function(vm().heap(), move(callback));
     else
         m_document_readiness_observer = nullptr;
+}
+
+void DocumentObserver::set_document_visibility_state_observer(Function<void(HTML::VisibilityState)> callback)
+{
+    if (callback)
+        m_document_visibility_state_observer = JS::create_heap_function(vm().heap(), move(callback));
+    else
+        m_document_visibility_state_observer = nullptr;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
@@ -12,6 +12,7 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/DocumentReadyState.h>
+#include <LibWeb/HTML/VisibilityState.h>
 
 namespace Web::DOM {
 
@@ -29,6 +30,9 @@ public:
     [[nodiscard]] JS::GCPtr<JS::HeapFunction<void(HTML::DocumentReadyState)>> document_readiness_observer() const { return m_document_readiness_observer; }
     void set_document_readiness_observer(Function<void(HTML::DocumentReadyState)>);
 
+    [[nodiscard]] JS::GCPtr<JS::HeapFunction<void(HTML::VisibilityState)>> document_visibility_state_observer() const { return m_document_visibility_state_observer; }
+    void set_document_visibility_state_observer(Function<void(HTML::VisibilityState)>);
+
 private:
     explicit DocumentObserver(JS::Realm&, DOM::Document&);
 
@@ -39,6 +43,7 @@ private:
     JS::GCPtr<JS::HeapFunction<void()>> m_document_became_inactive;
     JS::GCPtr<JS::HeapFunction<void()>> m_document_completely_loaded;
     JS::GCPtr<JS::HeapFunction<void(HTML::DocumentReadyState)>> m_document_readiness_observer;
+    JS::GCPtr<JS::HeapFunction<void(HTML::VisibilityState)>> m_document_visibility_state_observer;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Userland/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -138,7 +138,7 @@ private:
     bool m_running_nested_apply_history_step { false };
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#system-visibility-state
-    VisibilityState m_system_visibility_state { VisibilityState::Visible };
+    VisibilityState m_system_visibility_state { VisibilityState::Hidden };
 
     JS::NonnullGCPtr<SessionHistoryTraversalQueue> m_session_history_traversal_queue;
 

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -48,6 +48,7 @@ void Page::visit_edges(JS::Cell::Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_top_level_traversable);
     visitor.visit(m_client);
+    visitor.visit(m_window_rect_observer);
     visitor.visit(m_on_pending_dialog_closed);
 }
 
@@ -252,6 +253,12 @@ HTML::BrowsingContext const& Page::top_level_browsing_context() const
 JS::NonnullGCPtr<HTML::TraversableNavigable> Page::top_level_traversable() const
 {
     return *m_top_level_traversable;
+}
+
+void Page::did_update_window_rect()
+{
+    if (m_window_rect_observer)
+        m_window_rect_observer->function()({ window_position(), window_size() });
 }
 
 template<typename ResponseType>

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -127,6 +127,9 @@ public:
     DevicePixelSize window_size() const { return m_window_size; }
     void set_window_size(DevicePixelSize size) { m_window_size = size; }
 
+    void did_update_window_rect();
+    void set_window_rect_observer(JS::GCPtr<JS::HeapFunction<void(DevicePixelRect)>> window_rect_observer) { m_window_rect_observer = window_rect_observer; }
+
     void did_request_alert(String const& message);
     void alert_closed();
 
@@ -245,6 +248,7 @@ private:
 
     DevicePixelPoint m_window_position {};
     DevicePixelSize m_window_size {};
+    JS::GCPtr<JS::HeapFunction<void(DevicePixelRect)>> m_window_rect_observer;
 
     PendingDialog m_pending_dialog { PendingDialog::None };
     Optional<String> m_pending_dialog_text;
@@ -310,8 +314,8 @@ public:
     virtual void page_did_request_navigate_back() { }
     virtual void page_did_request_navigate_forward() { }
     virtual void page_did_request_refresh() { }
-    virtual Gfx::IntSize page_did_request_resize_window(Gfx::IntSize) { return {}; }
-    virtual Gfx::IntPoint page_did_request_reposition_window(Gfx::IntPoint) { return {}; }
+    virtual void page_did_request_resize_window(Gfx::IntSize) { }
+    virtual void page_did_request_reposition_window(Gfx::IntPoint) { }
     virtual void page_did_request_restore_window() { }
     virtual Gfx::IntRect page_did_request_maximize_window() { return {}; }
     virtual Gfx::IntRect page_did_request_minimize_window() { return {}; }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -317,9 +317,9 @@ public:
     virtual void page_did_request_resize_window(Gfx::IntSize) { }
     virtual void page_did_request_reposition_window(Gfx::IntPoint) { }
     virtual void page_did_request_restore_window() { }
-    virtual Gfx::IntRect page_did_request_maximize_window() { return {}; }
-    virtual Gfx::IntRect page_did_request_minimize_window() { return {}; }
-    virtual Gfx::IntRect page_did_request_fullscreen_window() { return {}; }
+    virtual void page_did_request_maximize_window() { }
+    virtual void page_did_request_minimize_window() { }
+    virtual void page_did_request_fullscreen_window() { }
     virtual void page_did_start_loading(URL::URL const&, bool is_redirect) { (void)is_redirect; }
     virtual void page_did_create_new_document(Web::DOM::Document&) { }
     virtual void page_did_change_active_document_in_top_level_browsing_context(Web::DOM::Document&) { }

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -77,6 +77,16 @@ void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id
     client().async_ready_to_paint(page_id());
 }
 
+void ViewImplementation::set_window_position(Gfx::IntPoint position)
+{
+    client().async_set_window_position(m_client_state.page_index, position.to_type<Web::DevicePixels>());
+}
+
+void ViewImplementation::set_window_size(Gfx::IntSize size)
+{
+    client().async_set_window_size(m_client_state.page_index, size.to_type<Web::DevicePixels>());
+}
+
 void ViewImplementation::load(URL::URL const& url)
 {
     m_url = url;

--- a/Userland/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Userland/Libraries/LibWebView/ViewImplementation.cpp
@@ -87,6 +87,11 @@ void ViewImplementation::set_window_size(Gfx::IntSize size)
     client().async_set_window_size(m_client_state.page_index, size.to_type<Web::DevicePixels>());
 }
 
+void ViewImplementation::did_update_window_rect()
+{
+    client().async_did_update_window_rect(m_client_state.page_index);
+}
+
 void ViewImplementation::load(URL::URL const& url)
 {
     m_url = url;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -205,9 +205,9 @@ public:
     Function<void()> on_restore_window;
     Function<void(Gfx::IntPoint)> on_reposition_window;
     Function<void(Gfx::IntSize)> on_resize_window;
-    Function<Gfx::IntRect()> on_maximize_window;
-    Function<Gfx::IntRect()> on_minimize_window;
-    Function<Gfx::IntRect()> on_fullscreen_window;
+    Function<void()> on_maximize_window;
+    Function<void()> on_minimize_window;
+    Function<void()> on_fullscreen_window;
     Function<void(Color current_color)> on_request_color_picker;
     Function<void(Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles)> on_request_file_picker;
     Function<void(Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> items)> on_request_select_dropdown;

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -50,6 +50,9 @@ public:
 
     void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size);
 
+    void set_window_position(Gfx::IntPoint);
+    void set_window_size(Gfx::IntSize);
+
     void load(URL::URL const&);
     void load_html(StringView);
     void load_empty_document();

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -52,6 +52,7 @@ public:
 
     void set_window_position(Gfx::IntPoint);
     void set_window_size(Gfx::IntSize);
+    void did_update_window_rect();
 
     void load(URL::URL const&);
     void load_html(StringView);
@@ -202,8 +203,8 @@ public:
     Function<void(i32 start_index, Vector<ByteString> const& message_types, Vector<ByteString> const& messages)> on_received_console_messages;
     Function<void(i32 count_waiting)> on_resource_status_change;
     Function<void()> on_restore_window;
-    Function<Gfx::IntPoint(Gfx::IntPoint)> on_reposition_window;
-    Function<Gfx::IntSize(Gfx::IntSize)> on_resize_window;
+    Function<void(Gfx::IntPoint)> on_reposition_window;
+    Function<void(Gfx::IntSize)> on_resize_window;
     Function<Gfx::IntRect()> on_maximize_window;
     Function<Gfx::IntRect()> on_minimize_window;
     Function<Gfx::IntRect()> on_fullscreen_window;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -492,24 +492,20 @@ void WebContentClient::did_request_restore_window(u64 page_id)
     }
 }
 
-Messages::WebContentClient::DidRequestRepositionWindowResponse WebContentClient::did_request_reposition_window(u64 page_id, Gfx::IntPoint position)
+void WebContentClient::did_request_reposition_window(u64 page_id, Gfx::IntPoint position)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_reposition_window)
-            return view->on_reposition_window(position);
+            view->on_reposition_window(position);
     }
-
-    return Gfx::IntPoint {};
 }
 
-Messages::WebContentClient::DidRequestResizeWindowResponse WebContentClient::did_request_resize_window(u64 page_id, Gfx::IntSize size)
+void WebContentClient::did_request_resize_window(u64 page_id, Gfx::IntSize size)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_resize_window)
-            return view->on_resize_window(size);
+            view->on_resize_window(size);
     }
-
-    return Gfx::IntSize {};
 }
 
 Messages::WebContentClient::DidRequestMaximizeWindowResponse WebContentClient::did_request_maximize_window(u64 page_id)

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -508,34 +508,28 @@ void WebContentClient::did_request_resize_window(u64 page_id, Gfx::IntSize size)
     }
 }
 
-Messages::WebContentClient::DidRequestMaximizeWindowResponse WebContentClient::did_request_maximize_window(u64 page_id)
+void WebContentClient::did_request_maximize_window(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_maximize_window)
-            return view->on_maximize_window();
+            view->on_maximize_window();
     }
-
-    return Gfx::IntRect {};
 }
 
-Messages::WebContentClient::DidRequestMinimizeWindowResponse WebContentClient::did_request_minimize_window(u64 page_id)
+void WebContentClient::did_request_minimize_window(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_minimize_window)
-            return view->on_minimize_window();
+            view->on_minimize_window();
     }
-
-    return Gfx::IntRect {};
 }
 
-Messages::WebContentClient::DidRequestFullscreenWindowResponse WebContentClient::did_request_fullscreen_window(u64 page_id)
+void WebContentClient::did_request_fullscreen_window(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_fullscreen_window)
-            return view->on_fullscreen_window();
+            view->on_fullscreen_window();
     }
-
-    return Gfx::IntRect {};
 }
 
 void WebContentClient::did_request_file(u64 page_id, ByteString const& path, i32 request_id)

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -100,8 +100,8 @@ private:
     virtual void did_close_browsing_context(u64 page_id) override;
     virtual void did_update_resource_count(u64 page_id, i32 count_waiting) override;
     virtual void did_request_restore_window(u64 page_id) override;
-    virtual Messages::WebContentClient::DidRequestRepositionWindowResponse did_request_reposition_window(u64 page_id, Gfx::IntPoint) override;
-    virtual Messages::WebContentClient::DidRequestResizeWindowResponse did_request_resize_window(u64 page_id, Gfx::IntSize) override;
+    virtual void did_request_reposition_window(u64 page_id, Gfx::IntPoint) override;
+    virtual void did_request_resize_window(u64 page_id, Gfx::IntSize) override;
     virtual Messages::WebContentClient::DidRequestMaximizeWindowResponse did_request_maximize_window(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestMinimizeWindowResponse did_request_minimize_window(u64 page_id) override;
     virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window(u64 page_id) override;

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -102,9 +102,9 @@ private:
     virtual void did_request_restore_window(u64 page_id) override;
     virtual void did_request_reposition_window(u64 page_id, Gfx::IntPoint) override;
     virtual void did_request_resize_window(u64 page_id, Gfx::IntSize) override;
-    virtual Messages::WebContentClient::DidRequestMaximizeWindowResponse did_request_maximize_window(u64 page_id) override;
-    virtual Messages::WebContentClient::DidRequestMinimizeWindowResponse did_request_minimize_window(u64 page_id) override;
-    virtual Messages::WebContentClient::DidRequestFullscreenWindowResponse did_request_fullscreen_window(u64 page_id) override;
+    virtual void did_request_maximize_window(u64 page_id) override;
+    virtual void did_request_minimize_window(u64 page_id) override;
+    virtual void did_request_fullscreen_window(u64 page_id) override;
     virtual void did_request_file(u64 page_id, ByteString const& path, i32) override;
     virtual void did_request_color_picker(u64 page_id, Color const& current_color) override;
     virtual void did_request_file_picker(u64 page_id, Web::HTML::FileFilter const& accepted_file_types, Web::HTML::AllowMultipleFiles) override;

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -1082,6 +1082,12 @@ void ConnectionFromClient::set_window_size(u64 page_id, Web::DevicePixelSize siz
         page->set_window_size(size);
 }
 
+void ConnectionFromClient::did_update_window_rect(u64 page_id)
+{
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().did_update_window_rect();
+}
+
 Messages::WebContentServer::GetLocalStorageEntriesResponse ConnectionFromClient::get_local_storage_entries(u64 page_id)
 {
     auto page = this->page(page_id);

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -103,6 +103,7 @@ private:
     virtual void set_device_pixels_per_css_pixel(u64 page_id, float) override;
     virtual void set_window_position(u64 page_id, Web::DevicePixelPoint) override;
     virtual void set_window_size(u64 page_id, Web::DevicePixelSize) override;
+    virtual void did_update_window_rect(u64 page_id) override;
     virtual void handle_file_return(u64 page_id, i32 error, Optional<IPC::File> const& file, i32 request_id) override;
     virtual void set_system_visibility_state(u64 page_id, bool visible) override;
 

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -261,14 +261,14 @@ void PageClient::page_did_request_refresh()
     client().async_did_request_refresh(m_id);
 }
 
-Gfx::IntSize PageClient::page_did_request_resize_window(Gfx::IntSize size)
+void PageClient::page_did_request_resize_window(Gfx::IntSize size)
 {
-    return client().did_request_resize_window(m_id, size);
+    client().async_did_request_resize_window(m_id, size);
 }
 
-Gfx::IntPoint PageClient::page_did_request_reposition_window(Gfx::IntPoint position)
+void PageClient::page_did_request_reposition_window(Gfx::IntPoint position)
 {
-    return client().did_request_reposition_window(m_id, position);
+    client().async_did_request_reposition_window(m_id, position);
 }
 
 void PageClient::page_did_request_restore_window()

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -276,19 +276,19 @@ void PageClient::page_did_request_restore_window()
     client().async_did_request_restore_window(m_id);
 }
 
-Gfx::IntRect PageClient::page_did_request_maximize_window()
+void PageClient::page_did_request_maximize_window()
 {
-    return client().did_request_maximize_window(m_id);
+    client().async_did_request_maximize_window(m_id);
 }
 
-Gfx::IntRect PageClient::page_did_request_minimize_window()
+void PageClient::page_did_request_minimize_window()
 {
-    return client().did_request_minimize_window(m_id);
+    client().async_did_request_minimize_window(m_id);
 }
 
-Gfx::IntRect PageClient::page_did_request_fullscreen_window()
+void PageClient::page_did_request_fullscreen_window()
 {
-    return client().did_request_fullscreen_window(m_id);
+    client().async_did_request_fullscreen_window(m_id);
 }
 
 void PageClient::page_did_request_tooltip_override(Web::CSSPixelPoint position, ByteString const& title)

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -112,8 +112,8 @@ private:
     virtual void page_did_request_navigate_back() override;
     virtual void page_did_request_navigate_forward() override;
     virtual void page_did_request_refresh() override;
-    virtual Gfx::IntSize page_did_request_resize_window(Gfx::IntSize) override;
-    virtual Gfx::IntPoint page_did_request_reposition_window(Gfx::IntPoint) override;
+    virtual void page_did_request_resize_window(Gfx::IntSize) override;
+    virtual void page_did_request_reposition_window(Gfx::IntPoint) override;
     virtual void page_did_request_restore_window() override;
     virtual Gfx::IntRect page_did_request_maximize_window() override;
     virtual Gfx::IntRect page_did_request_minimize_window() override;

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -115,9 +115,9 @@ private:
     virtual void page_did_request_resize_window(Gfx::IntSize) override;
     virtual void page_did_request_reposition_window(Gfx::IntPoint) override;
     virtual void page_did_request_restore_window() override;
-    virtual Gfx::IntRect page_did_request_maximize_window() override;
-    virtual Gfx::IntRect page_did_request_minimize_window() override;
-    virtual Gfx::IntRect page_did_request_fullscreen_window() override;
+    virtual void page_did_request_maximize_window() override;
+    virtual void page_did_request_minimize_window() override;
+    virtual void page_did_request_fullscreen_window() override;
     virtual void page_did_request_tooltip_override(Web::CSSPixelPoint, ByteString const&) override;
     virtual void page_did_stop_tooltip_override() override;
     virtual void page_did_enter_tooltip_area(ByteString const&) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -77,8 +77,8 @@ endpoint WebContentClient
     did_request_activate_tab(u64 page_id) =|
     did_close_browsing_context(u64 page_id) =|
     did_request_restore_window(u64 page_id) =|
-    did_request_reposition_window(u64 page_id, Gfx::IntPoint position) => (Gfx::IntPoint window_position)
-    did_request_resize_window(u64 page_id, Gfx::IntSize size) => (Gfx::IntSize window_size)
+    did_request_reposition_window(u64 page_id, Gfx::IntPoint position) =|
+    did_request_resize_window(u64 page_id, Gfx::IntSize size) =|
     did_request_maximize_window(u64 page_id) => (Gfx::IntRect window_rect)
     did_request_minimize_window(u64 page_id) => (Gfx::IntRect window_rect)
     did_request_fullscreen_window(u64 page_id) => (Gfx::IntRect window_rect)

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -79,9 +79,9 @@ endpoint WebContentClient
     did_request_restore_window(u64 page_id) =|
     did_request_reposition_window(u64 page_id, Gfx::IntPoint position) =|
     did_request_resize_window(u64 page_id, Gfx::IntSize size) =|
-    did_request_maximize_window(u64 page_id) => (Gfx::IntRect window_rect)
-    did_request_minimize_window(u64 page_id) => (Gfx::IntRect window_rect)
-    did_request_fullscreen_window(u64 page_id) => (Gfx::IntRect window_rect)
+    did_request_maximize_window(u64 page_id) =|
+    did_request_minimize_window(u64 page_id) =|
+    did_request_fullscreen_window(u64 page_id) =|
     did_request_file(u64 page_id, ByteString path, i32 request_id) =|
     did_request_color_picker(u64 page_id, Color current_color) =|
     did_request_file_picker(u64 page_id, Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles allow_multiple_files) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -90,6 +90,7 @@ endpoint WebContentServer
 
     set_window_position(u64 page_id, Web::DevicePixelPoint position) =|
     set_window_size(u64 page_id, Web::DevicePixelSize size) =|
+    did_update_window_rect(u64 page_id) =|
 
     get_local_storage_entries(u64 page_id) => (OrderedHashMap<String, String> entries)
     get_session_storage_entries(u64 page_id) => (OrderedHashMap<String, String> entries)

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -18,6 +18,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/MarkedVector.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/WebDriver/ElementLocationStrategies.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <LibWeb/WebDriver/TimeoutsConfiguration.h>
@@ -120,9 +121,11 @@ private:
     ErrorOr<void, Web::WebDriver::Error> ensure_current_top_level_browsing_context_is_open();
 
     ErrorOr<void, Web::WebDriver::Error> handle_any_user_prompts();
-    void restore_the_window();
-    Gfx::IntRect maximize_the_window();
-    Gfx::IntRect iconify_the_window();
+
+    void maximize_the_window();
+    void iconify_the_window(JS::NonnullGCPtr<JS::HeapFunction<void()>>);
+    void restore_the_window(JS::NonnullGCPtr<JS::HeapFunction<void()>>);
+    void wait_for_visibility_state(JS::NonnullGCPtr<JS::HeapFunction<void()>>, Web::HTML::VisibilityState);
 
     using OnNavigationComplete = JS::NonnullGCPtr<JS::HeapFunction<void(Web::WebDriver::Response)>>;
     void wait_for_navigation_to_complete(OnNavigationComplete);

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -161,6 +161,8 @@ private:
     // https://w3c.github.io/webdriver/#dfn-current-top-level-browsing-context
     JS::GCPtr<Web::HTML::BrowsingContext> m_current_top_level_browsing_context;
 
+    size_t m_pending_window_rect_requests { 0 };
+
     JS::GCPtr<JS::Cell> m_action_executor;
 
     JS::GCPtr<Web::DOM::DocumentObserver> m_document_observer;

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -2,6 +2,7 @@
 
 endpoint WebDriverServer {
     navigation_complete(Web::WebDriver::Response response) =|
+    window_rect_updated(Web::WebDriver::Response response) =|
     script_executed(Web::WebDriver::Response response) =|
     actions_performed(Web::WebDriver::Response response) =|
     dialog_closed(Web::WebDriver::Response response) =|

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -406,7 +406,7 @@ Web::WebDriver::Response Client::maximize_window(Web::WebDriver::Parameters para
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/maximize");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().maximize_window();
+    return session->maximize_window();
 }
 
 // 11.8.4 Minimize Window, https://w3c.github.io/webdriver/#minimize-window
@@ -415,7 +415,7 @@ Web::WebDriver::Response Client::minimize_window(Web::WebDriver::Parameters para
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/minimize");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().minimize_window();
+    return session->minimize_window();
 }
 
 // 11.8.5 Fullscreen Window, https://w3c.github.io/webdriver/#dfn-fullscreen-window
@@ -424,7 +424,7 @@ Web::WebDriver::Response Client::fullscreen_window(Web::WebDriver::Parameters pa
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/fullscreen");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().fullscreen_window();
+    return session->fullscreen_window();
 }
 
 // Extension: Consume User Activation, https://html.spec.whatwg.org/multipage/interaction.html#user-activation-user-agent-automation

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -397,7 +397,7 @@ Web::WebDriver::Response Client::set_window_rect(Web::WebDriver::Parameters para
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/window/rect");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().set_window_rect(payload);
+    return session->set_window_rect(payload);
 }
 
 // 11.8.3 Maximize Window, https://w3c.github.io/webdriver/#dfn-maximize-window

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -216,6 +216,27 @@ Web::WebDriver::Response Session::set_window_rect(JsonValue payload) const
     });
 }
 
+Web::WebDriver::Response Session::maximize_window() const
+{
+    return perform_async_action(web_content_connection().on_window_rect_updated, [&]() {
+        return web_content_connection().maximize_window();
+    });
+}
+
+Web::WebDriver::Response Session::minimize_window() const
+{
+    return perform_async_action(web_content_connection().on_window_rect_updated, [&]() {
+        return web_content_connection().minimize_window();
+    });
+}
+
+Web::WebDriver::Response Session::fullscreen_window() const
+{
+    return perform_async_action(web_content_connection().on_window_rect_updated, [&]() {
+        return web_content_connection().fullscreen_window();
+    });
+}
+
 Web::WebDriver::Response Session::execute_script(JsonValue payload, ScriptMode mode) const
 {
     return perform_async_action(web_content_connection().on_script_executed, [&]() {
@@ -263,5 +284,4 @@ Web::WebDriver::Response Session::accept_alert() const
         return web_content_connection().accept_alert();
     });
 }
-
 }

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -209,6 +209,13 @@ Web::WebDriver::Response Session::navigate_to(JsonValue payload) const
     });
 }
 
+Web::WebDriver::Response Session::set_window_rect(JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_window_rect_updated, [&]() {
+        return web_content_connection().set_window_rect(move(payload));
+    });
+}
+
 Web::WebDriver::Response Session::execute_script(JsonValue payload, ScriptMode mode) const
 {
     return perform_async_action(web_content_connection().on_script_executed, [&]() {

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -65,6 +65,8 @@ public:
     };
     Web::WebDriver::Response execute_script(JsonValue, ScriptMode) const;
 
+    Web::WebDriver::Response set_window_rect(JsonValue) const;
+
     Web::WebDriver::Response element_click(String) const;
     Web::WebDriver::Response element_send_keys(String, JsonValue) const;
     Web::WebDriver::Response perform_actions(JsonValue) const;

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -66,6 +66,9 @@ public:
     Web::WebDriver::Response execute_script(JsonValue, ScriptMode) const;
 
     Web::WebDriver::Response set_window_rect(JsonValue) const;
+    Web::WebDriver::Response maximize_window() const;
+    Web::WebDriver::Response minimize_window() const;
+    Web::WebDriver::Response fullscreen_window() const;
 
     Web::WebDriver::Response element_click(String) const;
     Web::WebDriver::Response element_send_keys(String, JsonValue) const;

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -26,6 +26,12 @@ void WebContentConnection::navigation_complete(Web::WebDriver::Response const& r
         on_navigation_complete(response);
 }
 
+void WebContentConnection::window_rect_updated(Web::WebDriver::Response const& response)
+{
+    if (on_window_rect_updated)
+        on_window_rect_updated(response);
+}
+
 void WebContentConnection::script_executed(Web::WebDriver::Response const& response)
 {
     if (on_script_executed)

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -23,6 +23,7 @@ public:
 
     Function<void()> on_close;
     Function<void(Web::WebDriver::Response)> on_navigation_complete;
+    Function<void(Web::WebDriver::Response)> on_window_rect_updated;
     Function<void(Web::WebDriver::Response)> on_script_executed;
     Function<void(Web::WebDriver::Response)> on_actions_performed;
     Function<void(Web::WebDriver::Response)> on_dialog_closed;
@@ -31,6 +32,7 @@ private:
     virtual void die() override;
 
     virtual void navigation_complete(Web::WebDriver::Response const&) override;
+    virtual void window_rect_updated(Web::WebDriver::Response const&) override;
     virtual void script_executed(Web::WebDriver::Response const&) override;
     virtual void actions_performed(Web::WebDriver::Response const&) override;
     virtual void dialog_closed(Web::WebDriver::Response const&) override;


### PR DESCRIPTION
It's currently possible for window size/position updates to hang, as the
underlying IPCs are synchronous. This updates the WebDriver endpoint to
be async, to unblock the WebContent process while the update is ongoing.
The UI process is now responsible for informing WebContent when the
update is complete.