### PR TITLE
LibWeb/CSS: Support the xyz-d65 colorspace in the color() function

### DIFF
--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-color/greensquare-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-color/greensquare-ref.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Green square reference</title>
+<style>
+    .test { background-color: #008000; width: 12em; height: 12em;}
+</style>
+<body>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-color/xyz-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-color/xyz-001.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="../../../../expected/wpt-import/css/css-color/greensquare-ref.html">
+<meta name="assert" content="xyz with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: color(xyz 0.07719 0.15438 0.02573); } /* green (sRGB #008000) converted to xyz */
+</style>
+<body>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-color/xyz-d65-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-color/xyz-d65-001.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Color 4: xyz</title>
+<link rel="author" title="Sam Weinig" href="mailto:weinig@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-color-4/#valdef-color-xyz">
+<link rel="match" href="../../../../expected/wpt-import/css/css-color/greensquare-ref.html">
+<meta name="assert" content="xyz-d65 with no alpha">
+<style>
+    .test { background-color: red; width: 12em; height: 12em; }
+    .test { background-color: color(xyz-d65 0.07719 0.15438 0.02573); } /* green (sRGB #008000) converted to xyz-d65 */
+</style>
+<body>
+    <p>Test passes if you see a green square, and no red.</p>
+    <div class="test"></div>
+</body>

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -396,13 +396,8 @@ Vector<Color> Color::tints(u32 steps, float max) const
     return tints;
 }
 
-Color Color::from_xyz50(float x, float y, float z, float alpha)
+Color Color::from_linear_srgb(float red, float green, float blue, float alpha)
 {
-    // See commit description for these values
-    float red = 3.13397926 * x - 1.61689519 * y - 0.49070587 * z;
-    float green = -0.97840009 * x + 1.91589112 * y + 0.03339256 * z;
-    float blue = 0.07200357 * x - 0.22897505 * y + 1.40517398 * z;
-
     auto linear_to_srgb = [](float c) {
         return c >= 0.0031308f ? 1.055f * pow(c, 0.4166666f) - 0.055f : 12.92f * c;
     };
@@ -416,6 +411,16 @@ Color Color::from_xyz50(float x, float y, float z, float alpha)
         clamp(lroundf(green), 0, 255),
         clamp(lroundf(blue), 0, 255),
         clamp(lroundf(alpha * 255.f), 0, 255));
+}
+
+Color Color::from_xyz50(float x, float y, float z, float alpha)
+{
+    // See commit description for these values
+    float red = 3.13397926 * x - 1.61689519 * y - 0.49070587 * z;
+    float green = -0.97840009 * x + 1.91589112 * y + 0.03339256 * z;
+    float blue = 0.07200357 * x - 0.22897505 * y + 1.40517398 * z;
+
+    return from_linear_srgb(red, green, blue, alpha);
 }
 
 Color Color::from_lab(float L, float a, float b, float alpha)

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -423,6 +423,16 @@ Color Color::from_xyz50(float x, float y, float z, float alpha)
     return from_linear_srgb(red, green, blue, alpha);
 }
 
+Color Color::from_xyz65(float x, float y, float z, float alpha)
+{
+    // https://en.wikipedia.org/wiki/SRGB#From_CIE_XYZ_to_sRGB
+    float red = 3.2406 * x - 1.5372 * y - 0.4986 * z;
+    float green = -0.9689 * x + 1.8758 * y + 0.0415 * z;
+    float blue = 0.0557 * x - 0.2040 * y + 1.0570 * z;
+
+    return from_linear_srgb(red, green, blue, alpha);
+}
+
 Color Color::from_lab(float L, float a, float b, float alpha)
 {
     // Third edition of "Colorimetry" by the CIE

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -184,6 +184,7 @@ public:
 
     static Color from_lab(float L, float a, float b, float alpha = 1.0f);
     static Color from_xyz50(float x, float y, float z, float alpha = 1.0f);
+    static Color from_xyz65(float x, float y, float z, float alpha = 1.0f);
     static Color from_linear_srgb(float x, float y, float z, float alpha = 1.0f);
 
     // https://bottosson.github.io/posts/oklab/

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -184,14 +184,11 @@ public:
 
     static Color from_lab(float L, float a, float b, float alpha = 1.0f);
     static Color from_xyz50(float x, float y, float z, float alpha = 1.0f);
+    static Color from_linear_srgb(float x, float y, float z, float alpha = 1.0f);
 
     // https://bottosson.github.io/posts/oklab/
     static constexpr Color from_oklab(float L, float a, float b, float alpha = 1.0f)
     {
-        auto linear_to_srgb = [](float c) {
-            return c >= 0.0031308f ? 1.055f * pow(c, 0.4166666f) - 0.055f : 12.92f * c;
-        };
-
         float l = L + 0.3963377774f * a + 0.2158037573f * b;
         float m = L - 0.1055613458f * a - 0.0638541728f * b;
         float s = L - 0.0894841775f * a - 1.2914855480f * b;
@@ -204,15 +201,7 @@ public:
         float green = -1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s;
         float blue = -0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s;
 
-        red = linear_to_srgb(red) * 255.f;
-        green = linear_to_srgb(green) * 255.f;
-        blue = linear_to_srgb(blue) * 255.f;
-
-        return Color(
-            clamp(lroundf(red), 0, 255),
-            clamp(lroundf(green), 0, 255),
-            clamp(lroundf(blue), 0, 255),
-            clamp(lroundf(alpha * 255.f), 0, 255));
+        return from_linear_srgb(red, green, blue, alpha);
     }
 
     // https://bottosson.github.io/posts/oklab/

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSColor.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSColor.h
@@ -21,7 +21,7 @@ public:
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
     virtual String to_string() const override;
 
-    static constexpr Array s_supported_color_space = { "xyz-d50"sv };
+    static constexpr Array s_supported_color_space = { "xyz"sv, "xyz-d50"sv, "xyz-d65"sv };
 
 private:
     CSSColor(ColorType color_type, ValueComparingNonnullRefPtr<CSSStyleValue> c1, ValueComparingNonnullRefPtr<CSSStyleValue> c2, ValueComparingNonnullRefPtr<CSSStyleValue> c3, ValueComparingNonnullRefPtr<CSSStyleValue> alpha)

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.h
@@ -31,6 +31,7 @@ public:
         OKLab,
         OKLCH,
         XYZD50,
+        XYZD65,
     };
     ColorType color_type() const { return m_color_type; }
 


### PR DESCRIPTION
This also adds support for `xyz` as it defaults to `xyz-d65`. We now
pass the following WPT tests:
 - css/css-color/xyz-001.html
 - css/css-color/xyz-002.html
 - css/css-color/xyz-004.html
 - css/css-color/xyz-d65-001.html
 - css/css-color/xyz-d65-002.html
 - css/css-color/xyz-d65-004.html