### PR TITLE
Meta: Add cross-platform function for absolutizing paths and use it in `WPT.sh`

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -87,7 +87,7 @@ set_logging_flags()
     [ -n "${2}" ] || usage;
 
     log_type="${1}"
-    log_name="$(realpath "${2}")"
+    log_name="$(absolutize_path "${2}")"
 
     WPT_ARGS+=( "${log_type}=${log_name}" )
 }

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -83,3 +83,14 @@ get_build_dir() {
 
     echo "${BUILD_DIR}"
 }
+
+absolutize_path() {
+    directory="$(eval echo "$(dirname "$1")")"
+    if [ -d "$directory" ]; then
+        resolved_directory="$(cd "$directory" && pwd)"
+        echo "${resolved_directory%/}/$(basename "$1")"
+    else
+        echo "No such directory: '$directory'" >&2
+        return 1
+    fi
+}


### PR DESCRIPTION
Previously, `realpath` was being used to absolutize log file paths in `WPT.sh`, but this doesn't work as expected on MacOS, where `realpath` returns an error if the given path doesn't exist.