### PR TITLE
UI/AppKit: Extract bare minimum WebView functionality into its own class

### DIFF
--- a/Ladybird/AppKit/CMakeLists.txt
+++ b/Ladybird/AppKit/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(ladybird_impl STATIC
     UI/InspectorController.mm
     UI/LadybirdWebView.mm
     UI/LadybirdWebViewBridge.cpp
+    UI/LadybirdWebViewWindow.mm
     UI/Palette.mm
     UI/SearchPanel.mm
     UI/Tab.mm

--- a/Ladybird/AppKit/UI/Inspector.h
+++ b/Ladybird/AppKit/UI/Inspector.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,11 +7,12 @@
 #pragma once
 
 #import <Cocoa/Cocoa.h>
+#import <Ladybird/AppKit/UI/LadybirdWebViewWindow.h>
 
 @class LadybirdWebView;
 @class Tab;
 
-@interface Inspector : NSWindow
+@interface Inspector : LadybirdWebViewWindow
 
 - (instancetype)init:(Tab*)tab;
 
@@ -19,7 +20,5 @@
 - (void)reset;
 
 - (void)selectHoveredElement;
-
-@property (nonatomic, strong) LadybirdWebView* web_view;
 
 @end

--- a/Ladybird/AppKit/UI/Inspector.mm
+++ b/Ladybird/AppKit/UI/Inspector.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -54,20 +54,10 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
     auto tab_rect = [tab frame];
     auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
     auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
-
     auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
-    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
 
-    self = [super initWithContentRect:window_rect
-                            styleMask:style_mask
-                              backing:NSBackingStoreBuffered
-                                defer:NO];
-
-    if (self) {
+    if (self = [super initWithWebView:nil windowRect:window_rect]) {
         self.tab = tab;
-
-        self.web_view = [[LadybirdWebView alloc] init:nil];
-        [self.web_view setPostsBoundsChangedNotifications:YES];
 
         m_inspector_client = make<WebView::InspectorClient>([[tab web_view] view], [[self web_view] view]);
         __weak Inspector* weak_self = self;
@@ -139,15 +129,7 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
             [NSMenu popUpContextMenu:strong_self.cookie_context_menu withEvent:event forView:strong_self.web_view];
         };
 
-        auto* scroll_view = [[NSScrollView alloc] init];
-        [scroll_view setHasVerticalScroller:YES];
-        [scroll_view setHasHorizontalScroller:YES];
-        [scroll_view setLineScroll:24];
-
-        [scroll_view setContentView:self.web_view];
-        [scroll_view setDocumentView:[[NSView alloc] init]];
-
-        [self setContentView:scroll_view];
+        [self setContentView:self.web_view.enclosingScrollView];
         [self setTitle:@"Inspector"];
         [self setIsVisible:YES];
     }

--- a/Ladybird/AppKit/UI/LadybirdWebViewWindow.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewWindow.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#import <Cocoa/Cocoa.h>
+
+@class LadybirdWebView;
+
+@interface LadybirdWebViewWindow : NSWindow
+
+- (instancetype)initWithWebView:(LadybirdWebView*)web_view
+                     windowRect:(NSRect)window_rect;
+
+@property (nonatomic, strong) LadybirdWebView* web_view;
+
+@end

--- a/Ladybird/AppKit/UI/LadybirdWebViewWindow.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebViewWindow.mm
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#import <UI/LadybirdWebView.h>
+#import <UI/LadybirdWebViewWindow.h>
+
+#if !__has_feature(objc_arc)
+#    error "This project requires ARC"
+#endif
+
+@interface LadybirdWebViewWindow ()
+@end
+
+@implementation LadybirdWebViewWindow
+
+- (instancetype)initWithWebView:(LadybirdWebView*)web_view
+                     windowRect:(NSRect)window_rect
+{
+    static constexpr auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
+
+    self = [super initWithContentRect:window_rect
+                            styleMask:style_mask
+                              backing:NSBackingStoreBuffered
+                                defer:NO];
+
+    if (self) {
+        self.web_view = web_view;
+        if (self.web_view == nil)
+            self.web_view = [[LadybirdWebView alloc] init:nil];
+
+        [self.web_view setPostsBoundsChangedNotifications:YES];
+
+        auto* scroll_view = [[NSScrollView alloc] init];
+        [scroll_view setHasVerticalScroller:NO];
+        [scroll_view setHasHorizontalScroller:NO];
+        [scroll_view setLineScroll:24];
+
+        [scroll_view setContentView:self.web_view];
+        [scroll_view setDocumentView:[[NSView alloc] init]];
+
+        [[NSNotificationCenter defaultCenter]
+            addObserver:self
+               selector:@selector(onContentScroll:)
+                   name:NSViewBoundsDidChangeNotification
+                 object:[scroll_view contentView]];
+    }
+
+    return self;
+}
+
+#pragma mark - Private methods
+
+- (void)onContentScroll:(NSNotification*)notification
+{
+    [self.web_view handleScroll];
+}
+
+#pragma mark - NSWindow
+
+- (void)setIsVisible:(BOOL)flag
+{
+    [self.web_view handleVisibility:flag];
+    [super setIsVisible:flag];
+}
+
+- (void)setIsMiniaturized:(BOOL)flag
+{
+    [self.web_view handleVisibility:!flag];
+    [super setIsMiniaturized:flag];
+}
+
+@end

--- a/Ladybird/AppKit/UI/Tab.h
+++ b/Ladybird/AppKit/UI/Tab.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,10 +9,11 @@
 #include <AK/Types.h>
 
 #import <Cocoa/Cocoa.h>
+#import <Ladybird/AppKit/UI/LadybirdWebViewWindow.h>
 
 @class LadybirdWebView;
 
-@interface Tab : NSWindow
+@interface Tab : LadybirdWebViewWindow
 
 - (instancetype)init;
 - (instancetype)initAsChild:(Tab*)parent
@@ -22,7 +23,5 @@
 
 - (void)openInspector:(id)sender;
 - (void)onInspectorClosed;
-
-@property (nonatomic, strong) LadybirdWebView* web_view;
 
 @end

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -77,21 +77,11 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     auto screen_rect = [[NSScreen mainScreen] frame];
     auto position_x = (NSWidth(screen_rect) - WINDOW_WIDTH) / 2;
     auto position_y = (NSHeight(screen_rect) - WINDOW_HEIGHT) / 2;
-
     auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
-    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
 
-    self = [super initWithContentRect:window_rect
-                            styleMask:style_mask
-                              backing:NSBackingStoreBuffered
-                                defer:NO];
-
-    if (self) {
+    if (self = [super initWithWebView:web_view windowRect:window_rect]) {
         // Remember last window position
         self.frameAutosaveName = @"window";
-
-        self.web_view = web_view;
-        [self.web_view setPostsBoundsChangedNotifications:YES];
 
         self.favicon = [Tab defaultFavicon];
         self.title = @"New Tab";
@@ -103,27 +93,13 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
         self.search_panel = [[SearchPanel alloc] init];
         [self.search_panel setHidden:YES];
 
-        auto* scroll_view = [[NSScrollView alloc] init];
-        [scroll_view setHasVerticalScroller:NO];
-        [scroll_view setHasHorizontalScroller:NO];
-        [scroll_view setLineScroll:24];
-
-        [scroll_view setContentView:self.web_view];
-        [scroll_view setDocumentView:[[NSView alloc] init]];
-
         auto* stack_view = [NSStackView stackViewWithViews:@[
             self.search_panel,
-            scroll_view,
+            self.web_view.enclosingScrollView,
         ]];
 
         [stack_view setOrientation:NSUserInterfaceLayoutOrientationVertical];
         [stack_view setSpacing:0];
-
-        [[NSNotificationCenter defaultCenter]
-            addObserver:self
-               selector:@selector(onContentScroll:)
-                   name:NSViewBoundsDidChangeNotification
-                 object:[scroll_view contentView]];
 
         [self setContentView:stack_view];
 
@@ -279,11 +255,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
     VERIFY_NOT_REACHED();
 }
 
-- (void)onContentScroll:(NSNotification*)notification
-{
-    [[self web_view] handleScroll];
-}
-
 #pragma mark - LadybirdWebViewObserver
 
 - (String const&)onCreateNewTab:(Optional<URL::URL> const&)url
@@ -420,20 +391,6 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 {
     [self.search_panel onFindInPageResult:current_match_index
                           totalMatchCount:total_match_count];
-}
-
-#pragma mark - NSWindow
-
-- (void)setIsVisible:(BOOL)flag
-{
-    [[self web_view] handleVisibility:flag];
-    [super setIsVisible:flag];
-}
-
-- (void)setIsMiniaturized:(BOOL)flag
-{
-    [[self web_view] handleVisibility:!flag];
-    [super setIsMiniaturized:flag];
 }
 
 @end

--- a/Ladybird/AppKit/UI/TaskManager.h
+++ b/Ladybird/AppKit/UI/TaskManager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,13 +7,12 @@
 #pragma once
 
 #import <Cocoa/Cocoa.h>
+#import <Ladybird/AppKit/UI/LadybirdWebViewWindow.h>
 
 @class LadybirdWebView;
 
-@interface TaskManager : NSWindow
+@interface TaskManager : LadybirdWebViewWindow
 
 - (instancetype)init;
-
-@property (nonatomic, strong) LadybirdWebView* web_view;
 
 @end

--- a/Ladybird/AppKit/UI/TaskManager.mm
+++ b/Ladybird/AppKit/UI/TaskManager.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -32,27 +32,9 @@ static constexpr CGFloat const WINDOW_HEIGHT = 400;
     auto tab_rect = [[NSApp keyWindow] frame];
     auto position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2;
     auto position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2;
-
     auto window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT);
-    auto style_mask = NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable;
 
-    self = [super initWithContentRect:window_rect
-                            styleMask:style_mask
-                              backing:NSBackingStoreBuffered
-                                defer:NO];
-
-    if (self) {
-        self.web_view = [[LadybirdWebView alloc] init:nil];
-        [self.web_view setPostsBoundsChangedNotifications:YES];
-
-        auto* scroll_view = [[NSScrollView alloc] init];
-        [scroll_view setHasVerticalScroller:YES];
-        [scroll_view setHasHorizontalScroller:YES];
-        [scroll_view setLineScroll:24];
-
-        [scroll_view setContentView:self.web_view];
-        [scroll_view setDocumentView:[[NSView alloc] init]];
-
+    if (self = [super initWithWebView:nil windowRect:window_rect]) {
         __weak TaskManager* weak_self = self;
 
         m_update_timer = Core::Timer::create_repeating(1000, [weak_self] {
@@ -64,7 +46,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 400;
             [strong_self updateStatistics];
         });
 
-        [self setContentView:scroll_view];
+        [self setContentView:self.web_view.enclosingScrollView];
         [self setTitle:@"Task Manager"];
         [self setIsVisible:YES];
 


### PR DESCRIPTION
When a window containing a WebView becomes visibile, we have to inform WebContent. This was only implemented for the Tab class (not Inspector or Task Manaager).

This patch adds LadybirdWebViewWindow to contain the bare minimum needed to render a LadybirdWebView. All windows containing a WebView inherit from this class, to ensure their WebContent processes know they became visible.