### PR TITLE
WebContent: Restore ability to use Inspector accessors like `$0`

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -182,7 +182,7 @@ ALWAYS_INLINE Value Interpreter::do_yield(Value value, Optional<Label> continuat
 }
 
 // 16.1.6 ScriptEvaluation ( scriptRecord ), https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
-ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Environment> lexical_environment_override)
+ThrowCompletionOr<Value> Interpreter::run(Script& script_record)
 {
     auto& vm = this->vm();
 
@@ -206,10 +206,6 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Envir
 
     // 7. Set the LexicalEnvironment of scriptContext to globalEnv.
     script_context->lexical_environment = &global_environment;
-
-    // Non-standard: Override the lexical environment if requested.
-    if (lexical_environment_override)
-        script_context->lexical_environment = lexical_environment_override;
 
     // 8. Set the PrivateEnvironment of scriptContext to null.
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -30,7 +30,7 @@ public:
     VM& vm() { return m_vm; }
     VM const& vm() const { return m_vm; }
 
-    ThrowCompletionOr<Value> run(Script&, JS::GCPtr<Environment> lexical_environment_override = nullptr);
+    ThrowCompletionOr<Value> run(Script&);
     ThrowCompletionOr<Value> run(SourceTextModule&);
 
     ThrowCompletionOr<Value> run(Bytecode::Executable& executable, Optional<size_t> entry_point = {}, Value initial_accumulator_value = {})

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -75,7 +75,7 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script
-JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::Environment> lexical_environment_override)
+JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
 {
     // 1. Let settings be the settings object of script.
     auto& settings = settings_object();
@@ -97,7 +97,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::En
         auto timer = Core::ElapsedTimer::start_new();
 
         // 6. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
-        evaluation_status = vm().bytecode_interpreter().run(*m_script_record, lexical_environment_override);
+        evaluation_status = vm().bytecode_interpreter().run(*m_script_record);
 
         // FIXME: If ScriptEvaluation does not complete because the user agent has aborted the running script, leave evaluationStatus as null.
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -33,7 +33,7 @@ public:
         No,
         Yes,
     };
-    JS::Completion run(RethrowErrors = RethrowErrors::No, JS::GCPtr<JS::Environment> lexical_environment_override = {});
+    JS::Completion run(RethrowErrors = RethrowErrors::No);
 
     MutedErrors muted_errors() const { return m_muted_errors; }
 

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.h
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.h
@@ -36,6 +36,9 @@ struct ExecuteScriptResultSerialized {
 
 using OnScriptComplete = JS::HeapFunction<void(ExecuteScriptResultSerialized)>;
 
+JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingContext const&, ByteString const& body, ReadonlySpan<JS::Value> parameters);
+JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::Window const&, ByteString const& body, ReadonlySpan<JS::Value> parameters, JS::GCPtr<JS::Object> environment_override_object = {});
+
 void execute_script(HTML::BrowsingContext const&, ByteString body, JS::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, JS::NonnullGCPtr<OnScriptComplete> on_complete);
 void execute_async_script(HTML::BrowsingContext const&, ByteString body, JS::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, JS::NonnullGCPtr<OnScriptComplete> on_complete);
 


### PR DESCRIPTION
We implement these built-in accessors via a lexical environment override
on the inspected document's global scope. However, ClassicScript will
parse the script we provide as a JS program, in which any evaluated
bindings will be interpreted as global bindings. Our global binding
lookup in the bytecode interpreter does not search the lexical env for
the binding, thus scripts like "$0" fail to evaluate.

Instead, we can create an ECMAScriptFunctionObject to evaluate scripts
entered into the Inspector. These are not evaluated as JS programs, and
thus any evaluated bindings are interpreted as non-global bindings. The
lexical environment override we set will then be considered.

CC @AtkinsSJ 

<img width="987" alt="Screenshot 2024-10-29 at 1 43 39 PM" src="https://github.com/user-attachments/assets/aa974348-00ef-4724-bd5d-3c82cc8da375">

