### PR TITLE
LibWebSocket: Don't send closing frame if connection is already closed

### DIFF
--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -483,8 +483,6 @@ void WebSocket::read_frame()
     }
 
     if (op_code == WebSocket::OpCode::ConnectionClose) {
-        send_frame(WebSocket::OpCode::ConnectionClose, {}, true);
-        set_state(WebSocket::InternalState::Closing);
         if (payload.size() > 1) {
             m_last_close_code = (((u16)(payload[0] & 0xff) << 8) | ((u16)(payload[1] & 0xff)));
             m_last_close_message = ByteString(ReadonlyBytes(payload.offset_pointer(2), payload.size() - 2));
@@ -492,6 +490,7 @@ void WebSocket::read_frame()
             m_last_close_code = 1000;
             m_last_close_message = {};
         }
+        close(m_last_close_code, m_last_close_message);
         return;
     }
     if (op_code == WebSocket::OpCode::Ping) {


### PR DESCRIPTION
This fixes a regression introduced in #1826.

Results of running: `./Meta/WPT.sh run websockets`:

Before:
```
Ran 758 tests finished in 227.5 seconds.
  • 243 ran as expected. 0 tests skipped.
  • 45 tests had errors unexpectedly
  • 306 tests timed out unexpectedly
  • 436 tests had unexpected subtest results
```

After:
```
After:
Ran 758 tests finished in 188.8 seconds.
  • 369 ran as expected. 0 tests skipped.
  • 45 tests had errors unexpectedly
  • 156 tests timed out unexpectedly
  • 327 tests had unexpected subtest results
```

Fixes: #2041