### PR TITLE
LibWeb: Make javascript mime matching more compliant with spec.

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -217,7 +217,7 @@ void HTMLScriptElement::prepare_script()
     }
 
     // 9. If the script block's type string is a JavaScript MIME type essence match,
-    if (MimeSniff::is_javascript_mime_type_essence_match(MUST(script_block_type.trim(Infra::ASCII_WHITESPACE)))) {
+    if (MimeSniff::is_javascript_mime_type_essence_match(script_block_type)) {
         // then set el's type to "classic".
         m_script_type = ScriptType::Classic;
     }

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -22,11 +22,11 @@ namespace Web::MimeSniff {
 bool is_javascript_mime_type_essence_match(StringView string)
 {
     // A string is a JavaScript MIME type essence match if it is an ASCII case-insensitive match for one of the JavaScript MIME type essence strings.
-    // NOTE: The mime type parser automatically lowercases the essence.
-    auto type = MimeType::parse(string);
-    if (!type.has_value())
-        return false;
-    return type->is_javascript();
+    for (auto const& javascript_essence : s_javascript_mime_type_essence_strings) {
+        if (string.equals_ignoring_ascii_case(javascript_essence))
+            return true;
+    }
+    return false;
 }
 
 static bool contains_only_http_quoted_string_token_code_points(StringView string)
@@ -330,40 +330,7 @@ bool MimeType::is_scriptable() const
 // https://mimesniff.spec.whatwg.org/#javascript-mime-type
 bool MimeType::is_javascript() const
 {
-    // A JavaScript MIME type is any MIME type whose essence is one of the following:
-    //    - application/ecmascript
-    //    - application/javascript
-    //    - application/x-ecmascript
-    //    - application/x-javascript
-    //    - text/ecmascript
-    //    - text/javascript
-    //    - text/javascript1.0
-    //    - text/javascript1.1
-    //    - text/javascript1.2
-    //    - text/javascript1.3
-    //    - text/javascript1.4
-    //    - text/javascript1.5
-    //    - text/jscript
-    //    - text/livescript
-    //    - text/x-ecmascript
-    //    - text/x-javascript
-    return essence().is_one_of(
-        "application/ecmascript"sv,
-        "application/javascript"sv,
-        "application/x-ecmascript"sv,
-        "application/x-javascript"sv,
-        "text/ecmascript"sv,
-        "text/javascript"sv,
-        "text/javascript1.0"sv,
-        "text/javascript1.1"sv,
-        "text/javascript1.2"sv,
-        "text/javascript1.3"sv,
-        "text/javascript1.4"sv,
-        "text/javascript1.5"sv,
-        "text/jscript"sv,
-        "text/livescript"sv,
-        "text/x-ecmascript"sv,
-        "text/x-javascript"sv);
+    return s_javascript_mime_type_essence_strings.contains_slow(essence());
 }
 
 // https://mimesniff.spec.whatwg.org/#json-mime-type

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -14,6 +14,27 @@ namespace Web::MimeSniff {
 
 bool is_javascript_mime_type_essence_match(StringView);
 
+// https://mimesniff.spec.whatwg.org/#javascript-mime-type
+// A JavaScript MIME type is any MIME type whose essence is one of the following:
+static constexpr Array s_javascript_mime_type_essence_strings = {
+    "application/ecmascript"sv,
+    "application/javascript"sv,
+    "application/x-ecmascript"sv,
+    "application/x-javascript"sv,
+    "text/ecmascript"sv,
+    "text/javascript"sv,
+    "text/javascript1.0"sv,
+    "text/javascript1.1"sv,
+    "text/javascript1.2"sv,
+    "text/javascript1.3"sv,
+    "text/javascript1.4"sv,
+    "text/javascript1.5"sv,
+    "text/jscript"sv,
+    "text/livescript"sv,
+    "text/x-ecmascript"sv,
+    "text/x-javascript"sv
+};
+
 // https://mimesniff.spec.whatwg.org/#mime-type
 class MimeType {
 public:


### PR DESCRIPTION
When mime essence matching, the spec only asks for a string comparison ignoring ascii case. The whitespace trimming and parsing of the mime produces unexpected and wrong results.

This fixes all the following tests on WPT:
[script-type-and-language-js-xhtml](https://wpt.fyi/results/html/semantics/scripting-1/the-script-element/script-type-and-language-js-xhtml.xhtml?label=master&product=ladybird)
[script-type-and-language-js](https://wpt.fyi/results/html/semantics/scripting-1/the-script-element/script-type-and-language-js.html?label=master&product=ladybird)
[script-type-and-language-with-params](https://wpt.fyi/results/html/semantics/scripting-1/the-script-element/script-type-and-language-with-params.html?label=master&product=ladybird)

I also checked that the other script-type* and script-text* kept working as before, at least to be sure there's no regressions there.

I extracted the list of javascript_mime_type_essence_strings to avoid duplication, if there's possible improvements, please tell.