### PR TITLE
LibJS: Parse dates like "Tuesday, October 29, 2024, 18:00 UTC"

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -190,6 +190,7 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%d%t%B%t%Y%t%R"sv,                    // "01 February 2013 08:00"
         "%d%t%b%t%Y"sv,                        // "01 Jan 2000"
         "%d%t%b%t%Y%t%R"sv,                    // "01 Jan 2000 08:00"
+        "%A,%t%B%t%e,%t%Y,%t%R%t%Z"sv,         // "Tuesday, October 29, 2024, 18:00 UTC"
     };
 
     for (auto const& format : extra_formats) {

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -39,6 +39,7 @@ test("basic functionality", () => {
     expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011000); // FIXME: support sub-second precision
     expect(Date.parse("1/27/2024, 9:28:30 AM")).toBe(1706369310000);
     expect(Date.parse("01 February 2013")).toBe(1359698400000);
+    expect(Date.parse("Tuesday, October 29, 2024, 18:00 UTC")).toBe(1730224800000);
 
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
     setTimeZone(originalTimeZone);


### PR DESCRIPTION
This format is used on https://jetbrains.com/