### PR TITLE
Some transform box type if needed magic

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2260,6 +2260,7 @@ void StyleComputer::transform_box_type_if_needed(StyleProperties& style, DOM::El
             // If a block box (block flow) is inlinified, its inner display type is set to flow-root so that it remains a block container.
             if (display.is_block_outside() && display.is_flow_inside()) {
                 new_display = CSS::Display { CSS::DisplayOutside::Inline, CSS::DisplayInside::FlowRoot, display.list_item() };
+                break;
             }
 
             new_display = CSS::Display { CSS::DisplayOutside::Inline, display.inside(), display.list_item() };


### PR DESCRIPTION
I'm messing around with StyleComputer.cpp
The test I'm running is
```html
<!DOCTYPE html>
<html>
<head>
    <style>
        .inline-parent {
            display: inline;
            background-color: yellow;
        }
        .block-child {
            display: block;
            background-color: lightblue;
        }
    </style>
</head>
<body>
    <div class="inline-parent">
        <div class="block-child">Block child inside inline parent.</div>
    </div>
</body>
</html>

```
This is how it's rendered in other browsers:
<img width="1077" alt="image" src="https://github.com/user-attachments/assets/144c2f66-3b35-461b-8b39-171d21d0052d">
This is ladybird master:
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/9bd04962-0701-4be2-8c98-74d7cd2b0c3f">
This is ladybird + BoxTypeTransformation::Inlinify case + condition, that was there before I modified anything + break (that appeared to be missing)
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/d83c1baa-2edd-4302-8b6d-16ddc42a10b2">
This is ladybird + BoxTypeTransformation::Inlinify case minus break, that appeared to be missing
<img width="1081" alt="image" src="https://github.com/user-attachments/assets/504b52b4-57d9-4483-87d5-f1b0b23ea687">

I don't understand a thing :(

I started to investigate it noticing original code
```
            // If a block box (block flow) is inlinified, its inner display type is set to flow-root so that it remains a block container.
            if (display.is_block_outside() && display.is_flow_inside()) {
                new_display = CSS::Display { CSS::DisplayOutside::Inline, CSS::DisplayInside::FlowRoot, display.list_item() };
            }

            new_display = CSS::Display { CSS::DisplayOutside::Inline, display.inside(), display.list_item() };
```
Rewrites new_display in this `if` scenario, rendering the whole `display.is_block_outside() && display.is_flow_inside()` check useless. Then, I noticed that this code is never actually called and went to return `BoxTypeTransformation::Inlinify` from `required_box_type_transformation`....