### PR TITLE
LibWeb: Remove variable self-assignment

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -313,7 +313,6 @@ void DisplayListRecorder::apply_backdrop_filter(Gfx::IntRect const& backdrop_reg
 
 void DisplayListRecorder::paint_outer_box_shadow_params(PaintBoxShadowParams params)
 {
-    params.device_content_rect = params.device_content_rect;
     append(PaintOuterBoxShadow { .box_shadow_params = params });
 }
 


### PR DESCRIPTION
As per Jelle Raaijmakers at discord, this is a leftover from coordinate/rect translation from the code