### PR TITLE
WebAudio: Initialize BiquadFilterNode properly

### DIFF
--- a/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.h
+++ b/Userland/Libraries/LibWeb/WebAudio/BiquadFilterNode.h
@@ -32,7 +32,7 @@ public:
     WebIDL::UnsignedLong number_of_inputs() override { return 1; }
     WebIDL::UnsignedLong number_of_outputs() override { return 1; }
 
-    WebIDL::ExceptionOr<void> set_type(Bindings::BiquadFilterType);
+    void set_type(Bindings::BiquadFilterType);
     Bindings::BiquadFilterType type() const;
     JS::NonnullGCPtr<AudioParam> frequency() const;
     JS::NonnullGCPtr<AudioParam> detune() const;


### PR DESCRIPTION
That helps to pass WPT tests
under webaudio/the-audio-api/the-biquadfilternode-interface/ctor-biquadfilter.html