### PR TITLE
LibWeb: Don't crash when parsing large floating point number values

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-large-max-value.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-large-max-value.txt
@@ -1,0 +1,1 @@
+progressElement.max: 1e+21

--- a/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-large-max-value.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLProgressElement-large-max-value.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<progress max="1000000000000000000000"></progress>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const progressElement = document.querySelector("progress");
+        println(`progressElement.max: ${progressElement.max}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/Numbers.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Numbers.cpp
@@ -150,7 +150,7 @@ Optional<double> parse_floating_point_number(StringView string)
         lexer.consume_while(is_ascii_digit);
         size_t end_index = lexer.tell();
         auto digits = lexer.input().substring_view(start_index, end_index - start_index);
-        auto optional_value = AK::StringUtils::convert_to_int<i32>(digits);
+        auto optional_value = AK::StringUtils::convert_to_floating_point<double>(digits, TrimWhitespace::No);
         value *= optional_value.value();
     }
 


### PR DESCRIPTION
Previously, attempting to parse a floating point number with an integer part larger than `(2 ^ 31)  - 1` would cause the browser to crash. We now avoid this by converting the integer part of the number to a `double` rather than an `i32`.

Fixes a regression in:  http://wpt.live/html/dom/reflection-forms.html