### PR TITLE
LibJS: Count code-points instead of bytes for syntax highlight.

### DIFF
--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -59,21 +59,21 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
     Syntax::TextPosition position { 0, 0 };
     Syntax::TextPosition start { 0, 0 };
 
-    auto advance_position = [&position](char ch) {
-        if (ch == '\n') {
+    auto advance_position = [&position](u32 code_point) {
+        if (code_point == '\n') {
             position.set_line(position.line() + 1);
             position.set_column(0);
         } else
             position.set_column(position.column() + 1);
     };
 
-    auto append_token = [&](StringView str, Token const& token, bool is_trivia) {
+    auto append_token = [&](Utf8View str, Token const& token, bool is_trivia) {
         if (str.is_empty())
             return;
 
         start = position;
-        for (size_t i = 0; i < str.length(); ++i)
-            advance_position(str[i]);
+        for (auto code_point : str)
+            advance_position(code_point);
 
         Syntax::TextDocumentSpan span;
         span.range.set_start(start);
@@ -100,10 +100,10 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
 
     bool was_eof = false;
     for (auto token = lexer.next(); !was_eof; token = lexer.next()) {
-        append_token(token.trivia(), token, true);
+        append_token(Utf8View(token.trivia()), token, true);
 
         auto token_start_position = position;
-        append_token(token.value(), token, false);
+        append_token(Utf8View(token.value()), token, false);
 
         if (token.type() == TokenType::Eof)
             was_eof = true;


### PR DESCRIPTION
This fixes issue #1847, a crash on view-source sites with non-ascii characters in <script>tags, like https://chalmers.se