### PR TITLE
LibWeb+WebContent+WebDriver: Make the element locator endpoints async, implement shadow references correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,10 @@ output/
 .exrc
 .helix/
 
+# Environments
+.venv*/
+venv*/
+
 # Gradle/AndroidStudio
 .gradle/
 .cxx/

--- a/Userland/Libraries/LibWeb/WebDriver/ElementReference.h
+++ b/Userland/Libraries/LibWeb/WebDriver/ElementReference.h
@@ -42,9 +42,10 @@ bool is_element_in_view(ReadonlySpan<JS::NonnullGCPtr<Web::DOM::Element>> paint_
 bool is_element_obscured(ReadonlySpan<JS::NonnullGCPtr<Web::DOM::Element>> paint_tree, Web::DOM::Element&);
 JS::MarkedVector<JS::NonnullGCPtr<Web::DOM::Element>> pointer_interactable_tree(Web::HTML::BrowsingContext&, Web::DOM::Element&);
 
-ByteString get_or_create_a_shadow_root_reference(Web::DOM::ShadowRoot const& shadow_root);
-JsonObject shadow_root_reference_object(Web::DOM::ShadowRoot const& shadow_root);
-ErrorOr<JS::NonnullGCPtr<Web::DOM::ShadowRoot>, Web::WebDriver::Error> get_known_shadow_root(StringView shadow_id);
+ByteString get_or_create_a_shadow_root_reference(HTML::BrowsingContext const&, Web::DOM::ShadowRoot const&);
+JsonObject shadow_root_reference_object(HTML::BrowsingContext const&, Web::DOM::ShadowRoot const&);
+ErrorOr<JS::NonnullGCPtr<Web::DOM::ShadowRoot>, Web::WebDriver::Error> get_known_shadow_root(HTML::BrowsingContext const&, StringView reference);
+bool is_shadow_root_detached(Web::DOM::ShadowRoot const&);
 
 CSSPixelPoint in_view_center_point(DOM::Element const& element, CSSPixelRect viewport);
 

--- a/Userland/Services/WebContent/WebDriverConnection.h
+++ b/Userland/Services/WebContent/WebDriverConnection.h
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <AK/ByteString.h>
-#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
 #include <LibGfx/Rect.h>
@@ -27,6 +26,8 @@
 #include <WebContent/WebDriverServerEndpoint.h>
 
 namespace WebContent {
+
+class ElementLocator;
 
 class WebDriverConnection final
     : public IPC::ConnectionToServer<WebDriverClientEndpoint, WebDriverServerEndpoint> {
@@ -133,8 +134,9 @@ private:
     Gfx::IntPoint calculate_absolute_position_of_element(JS::NonnullGCPtr<Web::Geometry::DOMRect> rect);
     Gfx::IntRect calculate_absolute_rect_of_element(Web::DOM::Element const& element);
 
-    using StartNodeGetter = Function<ErrorOr<JS::NonnullGCPtr<Web::DOM::ParentNode>, Web::WebDriver::Error>()>;
-    ErrorOr<JsonArray, Web::WebDriver::Error> find(StartNodeGetter&& start_node_getter, Web::WebDriver::LocationStrategy using_, StringView value);
+    using GetStartNode = JS::NonnullGCPtr<JS::HeapFunction<ErrorOr<JS::NonnullGCPtr<Web::DOM::ParentNode>, Web::WebDriver::Error>()>>;
+    using OnFindComplete = JS::NonnullGCPtr<JS::HeapFunction<void(Web::WebDriver::Response)>>;
+    void find(Web::WebDriver::LocationStrategy, ByteString, GetStartNode, OnFindComplete);
 
     struct ScriptArguments {
         ByteString script;
@@ -165,6 +167,9 @@ private:
     JS::GCPtr<Web::HTML::BrowsingContext> m_current_top_level_browsing_context;
 
     size_t m_pending_window_rect_requests { 0 };
+
+    friend class ElementLocator;
+    JS::GCPtr<ElementLocator> m_element_locator;
 
     JS::GCPtr<JS::Cell> m_action_executor;
 

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -3,6 +3,7 @@
 endpoint WebDriverServer {
     navigation_complete(Web::WebDriver::Response response) =|
     window_rect_updated(Web::WebDriver::Response response) =|
+    find_elements_complete(Web::WebDriver::Response response) =|
     script_executed(Web::WebDriver::Response response) =|
     actions_performed(Web::WebDriver::Response response) =|
     dialog_closed(Web::WebDriver::Response response) =|

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -442,7 +442,7 @@ Web::WebDriver::Response Client::find_element(Web::WebDriver::Parameters paramet
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/element");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().find_element(payload);
+    return session->find_element(payload);
 }
 
 // 12.3.3 Find Elements, https://w3c.github.io/webdriver/#dfn-find-elements
@@ -451,7 +451,7 @@ Web::WebDriver::Response Client::find_elements(Web::WebDriver::Parameters parame
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/elements");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().find_elements(payload);
+    return session->find_elements(payload);
 }
 
 // 12.3.4 Find Element From Element, https://w3c.github.io/webdriver/#dfn-find-element-from-element
@@ -460,7 +460,7 @@ Web::WebDriver::Response Client::find_element_from_element(Web::WebDriver::Param
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/element/<element_id>/element");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().find_element_from_element(payload, move(parameters[1]));
+    return session->find_element_from_element(move(parameters[1]), move(payload));
 }
 
 // 12.3.5 Find Elements From Element, https://w3c.github.io/webdriver/#dfn-find-elements-from-element
@@ -469,7 +469,7 @@ Web::WebDriver::Response Client::find_elements_from_element(Web::WebDriver::Para
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/element/<element_id>/elements");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().find_elements_from_element(payload, move(parameters[1]));
+    return session->find_elements_from_element(move(parameters[1]), move(payload));
 }
 
 // 12.3.6 Find Element From Shadow Root, https://w3c.github.io/webdriver/#find-element-from-shadow-root
@@ -478,7 +478,7 @@ Web::WebDriver::Response Client::find_element_from_shadow_root(Web::WebDriver::P
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/shadow/<shadow_id>/element");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().find_element_from_shadow_root(payload, move(parameters[1]));
+    return session->find_element_from_shadow_root(move(parameters[1]), move(payload));
 }
 
 // 12.3.7 Find Elements From Shadow Root, https://w3c.github.io/webdriver/#find-elements-from-shadow-root
@@ -487,7 +487,7 @@ Web::WebDriver::Response Client::find_elements_from_shadow_root(Web::WebDriver::
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling POST /session/<session_id>/shadow/<shadow_id>/elements");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().find_elements_from_shadow_root(payload, move(parameters[1]));
+    return session->find_elements_from_shadow_root(move(parameters[1]), move(payload));
 }
 
 // 12.3.8 Get Active Element, https://w3c.github.io/webdriver/#get-active-element

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -237,6 +237,48 @@ Web::WebDriver::Response Session::fullscreen_window() const
     });
 }
 
+Web::WebDriver::Response Session::find_element(JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_find_elements_complete, [&]() {
+        return web_content_connection().find_element(move(payload));
+    });
+}
+
+Web::WebDriver::Response Session::find_elements(JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_find_elements_complete, [&]() {
+        return web_content_connection().find_elements(move(payload));
+    });
+}
+
+Web::WebDriver::Response Session::find_element_from_element(String element_id, JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_find_elements_complete, [&]() {
+        return web_content_connection().find_element_from_element(move(payload), move(element_id));
+    });
+}
+
+Web::WebDriver::Response Session::find_elements_from_element(String element_id, JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_find_elements_complete, [&]() {
+        return web_content_connection().find_elements_from_element(move(payload), move(element_id));
+    });
+}
+
+Web::WebDriver::Response Session::find_element_from_shadow_root(String shadow_id, JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_find_elements_complete, [&]() {
+        return web_content_connection().find_element_from_shadow_root(move(payload), move(shadow_id));
+    });
+}
+
+Web::WebDriver::Response Session::find_elements_from_shadow_root(String shadow_id, JsonValue payload) const
+{
+    return perform_async_action(web_content_connection().on_find_elements_complete, [&]() {
+        return web_content_connection().find_elements_from_shadow_root(move(payload), move(shadow_id));
+    });
+}
+
 Web::WebDriver::Response Session::execute_script(JsonValue payload, ScriptMode mode) const
 {
     return perform_async_action(web_content_connection().on_script_executed, [&]() {

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -70,6 +70,13 @@ public:
     Web::WebDriver::Response minimize_window() const;
     Web::WebDriver::Response fullscreen_window() const;
 
+    Web::WebDriver::Response find_element(JsonValue) const;
+    Web::WebDriver::Response find_elements(JsonValue) const;
+    Web::WebDriver::Response find_element_from_element(String, JsonValue) const;
+    Web::WebDriver::Response find_elements_from_element(String, JsonValue) const;
+    Web::WebDriver::Response find_element_from_shadow_root(String, JsonValue) const;
+    Web::WebDriver::Response find_elements_from_shadow_root(String, JsonValue) const;
+
     Web::WebDriver::Response element_click(String) const;
     Web::WebDriver::Response element_send_keys(String, JsonValue) const;
     Web::WebDriver::Response perform_actions(JsonValue) const;

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -32,6 +32,12 @@ void WebContentConnection::window_rect_updated(Web::WebDriver::Response const& r
         on_window_rect_updated(response);
 }
 
+void WebContentConnection::find_elements_complete(Web::WebDriver::Response const& response)
+{
+    if (on_find_elements_complete)
+        on_find_elements_complete(response);
+}
+
 void WebContentConnection::script_executed(Web::WebDriver::Response const& response)
 {
     if (on_script_executed)

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -24,6 +24,7 @@ public:
     Function<void()> on_close;
     Function<void(Web::WebDriver::Response)> on_navigation_complete;
     Function<void(Web::WebDriver::Response)> on_window_rect_updated;
+    Function<void(Web::WebDriver::Response)> on_find_elements_complete;
     Function<void(Web::WebDriver::Response)> on_script_executed;
     Function<void(Web::WebDriver::Response)> on_actions_performed;
     Function<void(Web::WebDriver::Response)> on_dialog_closed;
@@ -33,6 +34,7 @@ private:
 
     virtual void navigation_complete(Web::WebDriver::Response const&) override;
     virtual void window_rect_updated(Web::WebDriver::Response const&) override;
+    virtual void find_elements_complete(Web::WebDriver::Response const&) override;
     virtual void script_executed(Web::WebDriver::Response const&) override;
     virtual void actions_performed(Web::WebDriver::Response const&) override;
     virtual void dialog_closed(Web::WebDriver::Response const&) override;


### PR DESCRIPTION
Removes the last instance of `spin_until` from WebDriverConnection.cpp.