### PR TITLE
LibWeb: Prevent painting grid items twice as a stacking context

### DIFF
--- a/Tests/LibWeb/Ref/grid-item-and-css-filter.html
+++ b/Tests/LibWeb/Ref/grid-item-and-css-filter.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<link rel="match" href="reference/grid-item-and-css-filter-ref.html" />
+<style>
+    #a {
+        background-color: #000;
+        color: #fff;
+        display: grid;
+    }
+    #b {
+        filter: blur(5px);
+        padding: 15px;
+    }
+</style>
+<div id="a">
+    <div id="b">
+        Ladybird

--- a/Tests/LibWeb/Ref/reference/grid-item-and-css-filter-ref.html
+++ b/Tests/LibWeb/Ref/reference/grid-item-and-css-filter-ref.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<style>
+    #a {
+        background-color: #000;
+        color: #fff;
+    }
+    #b {
+        filter: blur(5px);
+        padding: 15px;
+    }
+</style>
+<div id="a">
+    <div id="b">
+        Ladybird

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -120,6 +120,9 @@ void StackingContext::paint_descendants(PaintContext& context, Paintable const& 
             return IterationDecision::Continue;
         }
 
+        if (stacking_context)
+            return IterationDecision::Continue;
+
         // NOTE: Grid specification https://www.w3.org/TR/css-grid-2/#z-order says that grid items should be treated
         //       the same way as CSS2 defines for inline-blocks:
         //       "For each one of these, treat the element as if it created a new stacking context, but any positioned
@@ -133,8 +136,6 @@ void StackingContext::paint_descendants(PaintContext& context, Paintable const& 
             return IterationDecision::Continue;
         }
 
-        if (stacking_context)
-            return IterationDecision::Continue;
         if (child.is_positioned() && z_index.value_or(0) == 0)
             return IterationDecision::Continue;
 

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -82,7 +82,7 @@ void StackingContext::paint_node_as_stacking_context(Paintable const& paintable,
         paint_svg(context, static_cast<PaintableBox const&>(paintable), PaintPhase::Foreground);
         return;
     }
-    VERIFY(!paintable.layout_node().is_svg_svg_box());
+
     paint_node(paintable, context, PaintPhase::Background);
     paint_node(paintable, context, PaintPhase::Border);
     paint_descendants(context, paintable, StackingContextPaintPhase::BackgroundAndBorders);


### PR DESCRIPTION
We paint grid item nodes as a stacking context when they have no
`z-index` style set. However, a grid item could already have a stacking
context established - for example, when the `filter` style is applied.
This causes these nodes to be drawn twice.

Skip painting grid item nodes if a stacking context is already present.