### PR TITLE
LibWeb+WebContent+WebDriver: Make the screenshot endpoints asynchronous

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -269,6 +269,7 @@ set(SOURCES
     Geometry/DOMRectReadOnly.cpp
     HTML/AbstractWorker.cpp
     HTML/AnimatedBitmapDecodedImageData.cpp
+    HTML/AnimationFrameCallbackDriver.cpp
     HTML/AttributeNames.cpp
     HTML/AudioTrack.cpp
     HTML/AudioTrackList.cpp

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -375,6 +375,7 @@ struct DOMPointInit;
 }
 
 namespace Web::HTML {
+class AnimationFrameCallbackDriver;
 class AudioTrack;
 class AudioTrackList;
 class BroadcastChannel;

--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.cpp
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/HTML/AnimationFrameCallbackDriver.h>
+
+namespace Web::HTML {
+
+JS_DEFINE_ALLOCATOR(AnimationFrameCallbackDriver);
+
+void AnimationFrameCallbackDriver::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_callbacks);
+}
+
+WebIDL::UnsignedLong AnimationFrameCallbackDriver::add(Callback handler)
+{
+    auto id = ++m_animation_frame_callback_identifier;
+    m_callbacks.set(id, handler);
+    return id;
+}
+
+bool AnimationFrameCallbackDriver::remove(WebIDL::UnsignedLong id)
+{
+    return m_callbacks.remove(id);
+}
+
+bool AnimationFrameCallbackDriver::has_callbacks() const
+{
+    return !m_callbacks.is_empty();
+}
+
+void AnimationFrameCallbackDriver::run(double now)
+{
+    auto taken_callbacks = move(m_callbacks);
+    for (auto& [id, callback] : taken_callbacks)
+        callback->function()(now);
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -1,52 +1,35 @@
 /*
  * Copyright (c) 2022, the SerenityOS developers.
  * Copyright (c) 2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Function.h>
 #include <AK/HashMap.h>
-#include <LibCore/Timer.h>
-#include <LibWeb/HTML/EventLoop/EventLoop.h>
+#include <LibJS/Heap/GCPtr.h>
+#include <LibJS/Heap/HeapFunction.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
-struct AnimationFrameCallbackDriver {
-    using Callback = Function<void(double)>;
+class AnimationFrameCallbackDriver final : public JS::Cell {
+    JS_CELL(AnimationFrameCallbackDriver, JS::Cell);
+    JS_DECLARE_ALLOCATOR(AnimationFrameCallbackDriver);
 
-    [[nodiscard]] WebIDL::UnsignedLong add(Callback handler)
-    {
-        auto id = ++m_animation_frame_callback_identifier;
-        m_callbacks.set(id, move(handler));
-        return id;
-    }
+    using Callback = JS::NonnullGCPtr<JS::HeapFunction<void(double)>>;
 
-    bool remove(WebIDL::UnsignedLong id)
-    {
-        auto it = m_callbacks.find(id);
-        if (it == m_callbacks.end())
-            return false;
-        m_callbacks.remove(it);
-        return true;
-    }
-
-    void run(double now)
-    {
-        auto taken_callbacks = move(m_callbacks);
-        for (auto& [id, callback] : taken_callbacks)
-            callback(now);
-    }
-
-    bool has_callbacks() const
-    {
-        return !m_callbacks.is_empty();
-    }
+public:
+    [[nodiscard]] WebIDL::UnsignedLong add(Callback handler);
+    bool remove(WebIDL::UnsignedLong);
+    bool has_callbacks() const;
+    void run(double now);
 
 private:
+    virtual void visit_edges(Cell::Visitor&) override;
+
     // https://html.spec.whatwg.org/multipage/imagebitmap-and-animations.html#animation-frame-callback-identifier
     WebIDL::UnsignedLong m_animation_frame_callback_identifier { 0 };
 

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -16,7 +16,6 @@
 #include <LibWeb/Bindings/WindowGlobalMixin.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/AnimationFrameCallbackDriver.h>
 #include <LibWeb/HTML/CrossOrigin/CrossOriginPropertyDescriptorMap.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
 #include <LibWeb/HTML/MimeType.h>
@@ -110,8 +109,6 @@ public:
     };
     WebIDL::ExceptionOr<OpenedWindow> window_open_steps_internal(StringView url, StringView target, StringView features);
 
-    bool has_animation_frame_callbacks() const { return m_animation_frame_callback_driver.has_callbacks(); }
-
     DOM::Event* current_event() { return m_current_event.ptr(); }
     DOM::Event const* current_event() const { return m_current_event.ptr(); }
     void set_current_event(DOM::Event* event);
@@ -124,8 +121,6 @@ public:
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Storage>> session_storage();
 
     void start_an_idle_period();
-
-    AnimationFrameCallbackDriver& animation_frame_callback_driver() { return m_animation_frame_callback_driver; }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#sticky-activation
     bool has_sticky_activation() const;
@@ -211,7 +206,10 @@ public:
     i32 outer_height() const;
     double device_pixel_ratio() const;
 
-    WebIDL::UnsignedLong request_animation_frame(WebIDL::CallbackType&);
+    AnimationFrameCallbackDriver& animation_frame_callback_driver();
+    bool has_animation_frame_callbacks();
+
+    WebIDL::UnsignedLong request_animation_frame(JS::NonnullGCPtr<WebIDL::CallbackType>);
     void cancel_animation_frame(WebIDL::UnsignedLong handle);
 
     u32 request_idle_callback(WebIDL::CallbackType&, RequestIdleCallback::IdleRequestOptions const&);
@@ -289,7 +287,7 @@ private:
     // Each Window object is associated with a unique instance of a CustomElementRegistry object, allocated when the Window object is created.
     JS::GCPtr<CustomElementRegistry> m_custom_element_registry;
 
-    AnimationFrameCallbackDriver m_animation_frame_callback_driver;
+    JS::GCPtr<AnimationFrameCallbackDriver> m_animation_frame_callback_driver;
 
     // https://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks
     Vector<NonnullRefPtr<IdleCallback>> m_idle_request_callbacks;

--- a/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -93,14 +93,14 @@ Response capture_element_screenshot(Painter const& painter, Page& page, DOM::Ele
         return canvas;
     };
 
-    (void)element.document().window()->animation_frame_callback_driver().add([&](auto) {
+    (void)element.document().window()->animation_frame_callback_driver().add(JS::create_heap_function(element.heap(), [&](double) {
         auto canvas_or_error = draw_bounding_box_from_the_framebuffer();
         if (canvas_or_error.is_error()) {
             encoded_string_or_error = canvas_or_error.release_error();
             return;
         }
         encoded_string_or_error = encode_canvas_element(canvas_or_error.release_value());
-    });
+    }));
 
     Platform::EventLoopPlugin::the().spin_until(JS::create_heap_function(element.document().heap(), [&]() { return encoded_string_or_error.has_value(); }));
     return encoded_string_or_error.release_value();

--- a/Userland/Libraries/LibWeb/WebDriver/Screenshot.h
+++ b/Userland/Libraries/LibWeb/WebDriver/Screenshot.h
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2022, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/Function.h>
-#include <LibGfx/Forward.h>
+#include <LibGfx/Rect.h>
+#include <LibJS/Heap/GCPtr.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/WebDriver/Response.h>
 
 namespace Web::WebDriver {
 
-using Painter = Function<void(Gfx::IntRect const&, Gfx::Bitmap&)>;
-Response capture_element_screenshot(Painter const& painter, Page& page, DOM::Element& element, Gfx::IntRect& rect);
+ErrorOr<JS::NonnullGCPtr<HTML::HTMLCanvasElement>, WebDriver::Error> draw_bounding_box_from_the_framebuffer(HTML::BrowsingContext&, DOM::Element&, Gfx::IntRect);
+Response encode_canvas_element(HTML::HTMLCanvasElement&);
 
 }

--- a/Userland/Services/WebContent/WebDriverServer.ipc
+++ b/Userland/Services/WebContent/WebDriverServer.ipc
@@ -7,4 +7,5 @@ endpoint WebDriverServer {
     script_executed(Web::WebDriver::Response response) =|
     actions_performed(Web::WebDriver::Response response) =|
     dialog_closed(Web::WebDriver::Response response) =|
+    screenshot_taken(Web::WebDriver::Response response) =|
 }

--- a/Userland/Services/WebDriver/Client.cpp
+++ b/Userland/Services/WebDriver/Client.cpp
@@ -757,7 +757,7 @@ Web::WebDriver::Response Client::take_screenshot(Web::WebDriver::Parameters para
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/screenshot");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().take_screenshot();
+    return session->take_screenshot();
 }
 
 // 17.2 Take Element Screenshot, https://w3c.github.io/webdriver/#dfn-take-element-screenshot
@@ -766,7 +766,7 @@ Web::WebDriver::Response Client::take_element_screenshot(Web::WebDriver::Paramet
 {
     dbgln_if(WEBDRIVER_DEBUG, "Handling GET /session/<session_id>/element/<element_id>/screenshot");
     auto session = TRY(find_session_with_id(parameters[0]));
-    return session->web_content_connection().take_element_screenshot(move(parameters[1]));
+    return session->take_element_screenshot(move(parameters[1]));
 }
 
 // 18.1 Print Page, https://w3c.github.io/webdriver/#dfn-print-page

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -326,4 +326,19 @@ Web::WebDriver::Response Session::accept_alert() const
         return web_content_connection().accept_alert();
     });
 }
+
+Web::WebDriver::Response Session::take_screenshot() const
+{
+    return perform_async_action(web_content_connection().on_screenshot_taken, [&]() {
+        return web_content_connection().take_screenshot();
+    });
+}
+
+Web::WebDriver::Response Session::take_element_screenshot(String element_id) const
+{
+    return perform_async_action(web_content_connection().on_screenshot_taken, [&]() {
+        return web_content_connection().take_element_screenshot(move(element_id));
+    });
+}
+
 }

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -84,6 +84,9 @@ public:
     Web::WebDriver::Response dismiss_alert() const;
     Web::WebDriver::Response accept_alert() const;
 
+    Web::WebDriver::Response take_screenshot() const;
+    Web::WebDriver::Response take_element_screenshot(String) const;
+
 private:
     using ServerPromise = Core::Promise<ErrorOr<void>>;
     ErrorOr<NonnullRefPtr<Core::LocalServer>> create_server(NonnullRefPtr<ServerPromise> promise);

--- a/Userland/Services/WebDriver/WebContentConnection.cpp
+++ b/Userland/Services/WebDriver/WebContentConnection.cpp
@@ -56,4 +56,10 @@ void WebContentConnection::dialog_closed(Web::WebDriver::Response const& respons
         on_dialog_closed(response);
 }
 
+void WebContentConnection::screenshot_taken(Web::WebDriver::Response const& response)
+{
+    if (on_screenshot_taken)
+        on_screenshot_taken(response);
+}
+
 }

--- a/Userland/Services/WebDriver/WebContentConnection.h
+++ b/Userland/Services/WebDriver/WebContentConnection.h
@@ -28,6 +28,7 @@ public:
     Function<void(Web::WebDriver::Response)> on_script_executed;
     Function<void(Web::WebDriver::Response)> on_actions_performed;
     Function<void(Web::WebDriver::Response)> on_dialog_closed;
+    Function<void(Web::WebDriver::Response)> on_screenshot_taken;
 
 private:
     virtual void die() override;
@@ -38,6 +39,7 @@ private:
     virtual void script_executed(Web::WebDriver::Response const&) override;
     virtual void actions_performed(Web::WebDriver::Response const&) override;
     virtual void dialog_closed(Web::WebDriver::Response const&) override;
+    virtual void screenshot_taken(Web::WebDriver::Response const&) override;
 };
 
 }


### PR DESCRIPTION
From what I can see, these are the last WebDriver endpoints doing any event loop spinning in the WebContent process.