### PR TITLE
LibWeb: Fix crash running https://wpt.live/dom/nodes/node-appendchild-crash.html

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1144,7 +1144,7 @@ void Document::update_layout()
 
     // NOTE: If our parent document needs a relayout, we must do that *first*.
     //       This is necessary as the parent layout may cause our viewport to change.
-    if (navigable->container())
+    if (navigable->container() && &navigable->container()->document() != this)
         navigable->container()->document().update_layout();
 
     update_style();

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -2679,7 +2679,7 @@ bool Document::is_fully_active() const
         return true;
 
     auto container_document = navigable->container_document();
-    if (container_document && container_document->is_fully_active())
+    if (container_document && container_document != this && container_document->is_fully_active())
         return true;
 
     return false;

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -59,7 +59,7 @@ void HTMLIFrameElement::inserted()
     HTMLElement::inserted();
 
     // When an iframe element element is inserted into a document whose browsing context is non-null, the user agent must run these steps:
-    if (in_a_document_tree() && document().browsing_context()) {
+    if (in_a_document_tree() && document().browsing_context() && document().is_fully_active()) {
         // 1. Create a new child navigable for element.
         MUST(create_new_child_navigable(JS::create_heap_function(realm().heap(), [this] {
             // 3. Process the iframe attributes for element, with initialInsertion set to true.


### PR DESCRIPTION
This makes the following WPT test pass (instead of our previous crash)  https://wpt.live/dom/nodes/node-appendchild-crash.html

I am honestly a little confused about what the expected behaviour should be here, or if this is the correct fix for this. But the changes do seem reasonable enough to me.

This seems to be a difficult test to fully execute as the appendChild(document.body) puts the document into a weird state