### PR TITLE
LibWeb: Revert previous attempt to fix `$0`

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -182,7 +182,7 @@ ALWAYS_INLINE Value Interpreter::do_yield(Value value, Optional<Label> continuat
 }
 
 // 16.1.6 ScriptEvaluation ( scriptRecord ), https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
-ThrowCompletionOr<Value> Interpreter::run(Script& script_record)
+ThrowCompletionOr<Value> Interpreter::run(Script& script_record, JS::GCPtr<Environment> lexical_environment_override)
 {
     auto& vm = this->vm();
 
@@ -206,6 +206,10 @@ ThrowCompletionOr<Value> Interpreter::run(Script& script_record)
 
     // 7. Set the LexicalEnvironment of scriptContext to globalEnv.
     script_context->lexical_environment = &global_environment;
+
+    // Non-standard: Override the lexical environment if requested.
+    if (lexical_environment_override)
+        script_context->lexical_environment = lexical_environment_override;
 
     // 8. Set the PrivateEnvironment of scriptContext to null.
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -30,7 +30,7 @@ public:
     VM& vm() { return m_vm; }
     VM const& vm() const { return m_vm; }
 
-    ThrowCompletionOr<Value> run(Script&);
+    ThrowCompletionOr<Value> run(Script&, JS::GCPtr<Environment> lexical_environment_override = nullptr);
     ThrowCompletionOr<Value> run(SourceTextModule&);
 
     ThrowCompletionOr<Value> run(Bytecode::Executable& executable, Optional<size_t> entry_point = {}, Value initial_accumulator_value = {})

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -75,7 +75,7 @@ JS::NonnullGCPtr<ClassicScript> ClassicScript::create(ByteString filename, Strin
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#run-a-classic-script
 // https://whatpr.org/html/9893/webappapis.html#run-a-classic-script
-JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
+JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, JS::GCPtr<JS::Environment> lexical_environment_override)
 {
     // 1. Let realm be the realm of script.
     auto& realm = this->realm();
@@ -97,7 +97,7 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors)
         auto timer = Core::ElapsedTimer::start_new();
 
         // 6. Otherwise, set evaluationStatus to ScriptEvaluation(script's record).
-        evaluation_status = vm().bytecode_interpreter().run(*m_script_record);
+        evaluation_status = vm().bytecode_interpreter().run(*m_script_record, lexical_environment_override);
 
         // FIXME: If ScriptEvaluation does not complete because the user agent has aborted the running script, leave evaluationStatus as null.
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -33,7 +33,7 @@ public:
         No,
         Yes,
     };
-    JS::Completion run(RethrowErrors = RethrowErrors::No);
+    JS::Completion run(RethrowErrors = RethrowErrors::No, JS::GCPtr<JS::Environment> lexical_environment_override = {});
 
     MutedErrors muted_errors() const { return m_muted_errors; }
 

--- a/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.h
+++ b/Userland/Libraries/LibWeb/WebDriver/ExecuteScript.h
@@ -23,9 +23,6 @@ struct ExecutionResult {
 
 using OnScriptComplete = JS::HeapFunction<void(ExecutionResult)>;
 
-JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingContext const&, ByteString const& body, ReadonlySpan<JS::Value> parameters);
-JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::Window const&, ByteString const& body, ReadonlySpan<JS::Value> parameters, JS::GCPtr<JS::Object> environment_override_object = {});
-
 void execute_script(HTML::BrowsingContext const&, ByteString body, JS::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, JS::NonnullGCPtr<OnScriptComplete> on_complete);
 void execute_async_script(HTML::BrowsingContext const&, ByteString body, JS::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, JS::NonnullGCPtr<OnScriptComplete> on_complete);
 


### PR DESCRIPTION
The previous fix essentially generated a script of the form:
```js
function() {
    // ... the script entered into the console ...
}
```

Thus, any `let` expressions would not escape the function scope. This PR reverts that attempt, and instead fixes `$0` by avoiding global binding bytecode generation when we've overridden the lexical environment with a `with` object at runtime. We already use this same avoidance at parse time, i.e. the following script:

```js
with (foo) {
    console.log(x);
}
```

will not generate a global binding lookup for the variable `x`. Our environment override is a completely ad-hoc feature, and is a run time feature - so we must employ the same tactic as `with` statement at run time.

<img width="987" alt="Screenshot 2024-10-31 at 9 45 20 AM" src="https://github.com/user-attachments/assets/18263e1e-0ca7-4b8a-95f7-9ceb2372d37c">

CC @gmta	