### PR TITLE
LibWeb: Protect animation frame callbacks from GC while they execute

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/requestAnimationFrame-gc.txt
+++ b/Tests/LibWeb/Text/expected/HTML/requestAnimationFrame-gc.txt
@@ -1,0 +1,2 @@
+Collect garbage
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/requestAnimationFrame-gc.html
+++ b/Tests/LibWeb/Text/input/HTML/requestAnimationFrame-gc.html
@@ -1,0 +1,14 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        requestAnimationFrame(() => {
+            println("Collect garbage");
+            internals.gc();
+        });
+
+        requestAnimationFrame(() => {
+            println("PASS! (Didn't crash)");
+            done();
+        });
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -34,6 +34,7 @@ private:
     WebIDL::UnsignedLong m_animation_frame_callback_identifier { 0 };
 
     OrderedHashMap<WebIDL::UnsignedLong, Callback> m_callbacks;
+    OrderedHashMap<WebIDL::UnsignedLong, Callback> m_executing_callbacks;
 };
 
 }


### PR DESCRIPTION
Stealing the callbacks from the `AnimationFrameCallbackDriver` made them no longer safe from GC. Continue to store them on the class until we have finished their execution.