### PR TITLE
LibWeb: Disable css/transition-basics.html test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -3,6 +3,7 @@ Ref/css-keyframe-fill-forwards.html
 Ref/unicode-range.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
+Text/input/css/transition-basics.html
 Text/input/HTML/cross-origin-window-properties.html
 Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
 Text/input/WebAnimations/misc/DocumentTimeline.html


### PR DESCRIPTION
This is flaky in CI.