### PR TITLE
LibWeb: Remove most of the copying of `CSS::Parser::ComponentValue`

### DIFF
--- a/AK/NonnullRawPtr.h
+++ b/AK/NonnullRawPtr.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/Traits.h>
+
+namespace AK {
+
+template<typename T>
+requires(!IsLvalueReference<T> && !IsRvalueReference<T>) class [[nodiscard]] NonnullRawPtr {
+public:
+    using ValueType = T;
+
+    NonnullRawPtr() = delete;
+
+    NonnullRawPtr(T& other)
+        : m_ptr(&other)
+    {
+    }
+
+    NonnullRawPtr(NonnullRawPtr const& other)
+        : m_ptr(other.m_ptr)
+    {
+    }
+
+    NonnullRawPtr(NonnullRawPtr&& other)
+        : m_ptr(other.m_ptr)
+    {
+    }
+
+    NonnullRawPtr& operator=(NonnullRawPtr const& other)
+    {
+        m_ptr = other.m_ptr;
+
+        return *this;
+    }
+
+    NonnullRawPtr& operator=(NonnullRawPtr&& other)
+    {
+        m_ptr = other.m_ptr;
+
+        return *this;
+    }
+
+    operator bool() const = delete;
+    bool operator!() const = delete;
+
+    operator T&() { return *m_ptr; }
+    operator T const&() const { return *m_ptr; }
+
+    [[nodiscard]] ALWAYS_INLINE T& value() { return *m_ptr; }
+    [[nodiscard]] ALWAYS_INLINE T const& value() const { return *m_ptr; }
+
+    [[nodiscard]] ALWAYS_INLINE T& operator*() { return value(); }
+    [[nodiscard]] ALWAYS_INLINE T const& operator*() const { return value(); }
+
+    ALWAYS_INLINE RETURNS_NONNULL T* operator->() { return &value(); }
+    ALWAYS_INLINE RETURNS_NONNULL T const* operator->() const { return &value(); }
+
+private:
+    T* m_ptr;
+};
+
+template<typename T>
+struct Traits<NonnullRawPtr<T>> : public DefaultTraits<NonnullRawPtr<T>> {
+    static unsigned hash(NonnullRawPtr<T> const& handle) { return Traits<T>::hash(handle); }
+};
+
+namespace Detail {
+template<typename T>
+inline constexpr bool IsHashCompatible<NonnullRawPtr<T>, T> = true;
+
+template<typename T>
+inline constexpr bool IsHashCompatible<T, NonnullRawPtr<T>> = true;
+
+}
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::NonnullRawPtr;
+#endif

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.cpp
@@ -14,11 +14,11 @@ ComponentValue::ComponentValue(Token token)
 {
 }
 ComponentValue::ComponentValue(Function&& function)
-    : m_value(function)
+    : m_value(move(function))
 {
 }
 ComponentValue::ComponentValue(SimpleBlock&& block)
-    : m_value(block)
+    : m_value(move(block))
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -24,12 +24,10 @@ public:
     ~ComponentValue();
 
     bool is_block() const { return m_value.has<SimpleBlock>(); }
-    SimpleBlock& block() { return m_value.get<SimpleBlock>(); }
     SimpleBlock const& block() const { return m_value.get<SimpleBlock>(); }
 
     bool is_function() const { return m_value.has<Function>(); }
     bool is_function(StringView name) const;
-    Function& function() { return m_value.get<Function>(); }
     Function const& function() const { return m_value.get<Function>(); }
 
     bool is_token() const { return m_value.has<Token>(); }

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -17,6 +17,9 @@ namespace Web::CSS::Parser {
 
 // https://drafts.csswg.org/css-syntax/#component-value
 class ComponentValue {
+    AK_MAKE_DEFAULT_COPYABLE(ComponentValue);
+    AK_MAKE_DEFAULT_MOVABLE(ComponentValue);
+
 public:
     ComponentValue(Token);
     explicit ComponentValue(Function&&);

--- a/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/NonnullRawPtr.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleValues/ConicGradientStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LinearGradientStyleValue.h>
@@ -297,13 +298,13 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
 
     // conic-gradient( [ [ from <angle> ]? [ at <position> ]? ]  ||
     // <color-interpolation-method> , <angular-color-stop-list> )
-    auto token = tokens.next_token();
+    NonnullRawPtr<ComponentValue const> token = tokens.next_token();
     bool got_from_angle = false;
     bool got_color_interpolation_method = false;
     bool got_at_position = false;
-    while (token.is(Token::Type::Ident)) {
+    while (token->is(Token::Type::Ident)) {
         auto consume_identifier = [&](auto identifier) {
-            auto token_string = token.token().ident();
+            auto token_string = token->token().ident();
             if (token_string.equals_ignoring_ascii_case(identifier)) {
                 tokens.discard_a_token();
                 tokens.discard_whitespace();
@@ -319,7 +320,7 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
             if (!tokens.has_next_token())
                 return nullptr;
 
-            auto angle_token = tokens.consume_a_token();
+            auto const& angle_token = tokens.consume_a_token();
             if (!angle_token.is(Token::Type::Dimension))
                 return nullptr;
             auto angle = angle_token.token().dimension_value();

--- a/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -121,7 +121,7 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
         return media_query;
 
     // `[ and <media-condition-without-or> ]?`
-    if (auto maybe_and = tokens.consume_a_token(); maybe_and.is_ident("and"sv)) {
+    if (auto const& maybe_and = tokens.consume_a_token(); maybe_and.is_ident("and"sv)) {
         if (auto media_condition = parse_media_condition(tokens, MediaCondition::AllowOr::No)) {
             tokens.discard_whitespace();
             if (tokens.has_next_token())

--- a/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -184,11 +184,11 @@ Optional<Selector::SimpleSelector::QualifiedName> Parser::parse_selector_qualifi
 
     auto transaction = tokens.begin_transaction();
 
-    auto first_token = tokens.consume_a_token();
+    auto const& first_token = tokens.consume_a_token();
     if (first_token.is_delim('|')) {
         // Case 1: `|<name>`
         if (is_name(tokens.next_token())) {
-            auto name_token = tokens.consume_a_token();
+            auto const& name_token = tokens.consume_a_token();
 
             if (allow_wildcard_name == AllowWildcardName::No && name_token.is_delim('*'))
                 return {};
@@ -559,7 +559,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
         case PseudoClassMetadata::ParameterType::Ident: {
             auto function_token_stream = TokenStream(pseudo_function.value);
             function_token_stream.discard_whitespace();
-            auto maybe_keyword_token = function_token_stream.consume_a_token();
+            auto const& maybe_keyword_token = function_token_stream.consume_a_token();
             function_token_stream.discard_whitespace();
             if (!maybe_keyword_token.is(Token::Type::Ident) || function_token_stream.has_next_token()) {
                 dbgln_if(CSS_PARSER_DEBUG, "Failed to parse :{}() parameter as a keyword: not an ident", pseudo_function.name);
@@ -584,10 +584,10 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
             auto function_token_stream = TokenStream(pseudo_function.value);
             auto language_token_lists = parse_a_comma_separated_list_of_component_values(function_token_stream);
 
-            for (auto language_token_list : language_token_lists) {
+            for (auto const& language_token_list : language_token_lists) {
                 auto language_token_stream = TokenStream(language_token_list);
                 language_token_stream.discard_whitespace();
-                auto language_token = language_token_stream.consume_a_token();
+                auto const& language_token = language_token_stream.consume_a_token();
                 if (!(language_token.is(Token::Type::Ident) || language_token.is(Token::Type::String))) {
                     dbgln_if(CSS_PARSER_DEBUG, "Invalid language range in :{}() - not a string/ident", pseudo_function.name);
                     return ParseError::SyntaxError;


### PR DESCRIPTION
This class was being copied all over the place, however, most of these
cases can be easily prevented with `auto const&` or `Nonnull<>`.

It also didn't have a move constructor, causing `Vector` to copy on
every resize as well.

Removing all these copies results in an almost 15% increase in
performance for CSS parsing, as measured with callgrind.