### PR TITLE
LibWeb: Fix `selectionchange` event dispatch on text control elements

### DIFF
--- a/Tests/LibWeb/Text/expected/selectionchange-on-textarea.txt
+++ b/Tests/LibWeb/Text/expected/selectionchange-on-textarea.txt
@@ -1,0 +1,2 @@
+selectionchange event dispatched on textarea should bubble: true
+Selected range: 6 - 10

--- a/Tests/LibWeb/Text/input/selectionchange-on-textarea.html
+++ b/Tests/LibWeb/Text/input/selectionchange-on-textarea.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<textarea id="textarea">hello hmmm</textarea>
+<script>
+    asyncTest(done => {
+        const textarea = document.getElementById("textarea");
+        textarea.addEventListener("selectionchange", event => {
+            const start = textarea.selectionStart;
+            const end = textarea.selectionEnd;
+            println(`selectionchange event dispatched on textarea should bubble: ${event.bubbles}`);
+            println(`Selected range: ${start} - ${end}`);
+            done();
+        });
+        textarea.setSelectionRange(6, 10);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/DOM/Range.h
+++ b/Userland/Libraries/LibWeb/DOM/Range.h
@@ -23,13 +23,6 @@ enum class RelativeBoundaryPointPosition {
 // https://dom.spec.whatwg.org/#concept-range-bp-position
 RelativeBoundaryPointPosition position_of_boundary_point_relative_to_other_boundary_point(Node const& node_a, u32 offset_a, Node const& node_b, u32 offset_b);
 
-// https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event
-template<typename T>
-concept SelectionChangeTarget = DerivedFrom<T, EventTarget> && requires(T t) {
-    { t.has_scheduled_selectionchange_event() } -> SameAs<bool>;
-    { t.set_scheduled_selectionchange_event(bool()) } -> SameAs<void>;
-};
-
 class Range final : public AbstractRange {
     WEB_PLATFORM_OBJECT(Range, AbstractRange);
     JS_DECLARE_ALLOCATOR(Range);
@@ -115,10 +108,6 @@ private:
     Node const& root() const;
 
     void update_associated_selection();
-    template<SelectionChangeTarget T>
-    void schedule_a_selectionchange_event(T&);
-    template<SelectionChangeTarget T>
-    void fire_a_selectionchange_event(T&);
 
     enum class StartOrEnd {
         Start,

--- a/Userland/Libraries/LibWeb/DOM/SelectionchangeEventDispatching.h
+++ b/Userland/Libraries/LibWeb/DOM/SelectionchangeEventDispatching.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Event.h>
+#include <LibWeb/DOM/EventTarget.h>
+
+namespace Web::DOM {
+
+// https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event
+template<typename T>
+concept SelectionChangeTarget = DerivedFrom<T, EventTarget> && requires(T t) {
+    { t.has_scheduled_selectionchange_event() } -> SameAs<bool>;
+    { t.set_scheduled_selectionchange_event(bool()) } -> SameAs<void>;
+};
+
+// https://w3c.github.io/selection-api/#scheduling-selectionhange-event
+template<SelectionChangeTarget T>
+void schedule_a_selectionchange_event(T& target, Document& document)
+{
+    // 1. If target's has scheduled selectionchange event is true, abort these steps.
+    if (target.has_scheduled_selectionchange_event())
+        return;
+
+    // AD-HOC (https://github.com/w3c/selection-api/issues/338):
+    // Set target's has scheduled selectionchange event to true
+    target.set_scheduled_selectionchange_event(true);
+
+    // 2. Queue a task on the user interaction task source to fire a selectionchange event on
+    //    target.
+    queue_global_task(HTML::Task::Source::UserInteraction, relevant_global_object(document), JS::create_heap_function(document.heap(), [&] {
+        fire_a_selectionchange_event(target, document);
+    }));
+}
+
+// https://w3c.github.io/selection-api/#firing-selectionhange-event
+template<SelectionChangeTarget T>
+void fire_a_selectionchange_event(T& target, Document& document)
+{
+    // 1. Set target's has scheduled selectionchange event to false.
+    target.set_scheduled_selectionchange_event(false);
+
+    // 2. If target is an element, fire an event named selectionchange, which bubbles and not
+    //    cancelable, at target.
+    // 3. Otherwise, if target is a document, fire an event named selectionchange, which does not
+    //    bubble and not cancelable, at target.
+    EventInit event_init;
+    event_init.bubbles = DerivedFrom<T, Element>;
+    event_init.cancelable = false;
+
+    auto event = DOM::Event::create(document.realm(), HTML::EventNames::selectionchange, event_init);
+    target.dispatch_event(event);
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -192,8 +192,6 @@ protected:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
     void relevant_value_was_changed();
 
-    virtual void selection_was_changed([[maybe_unused]] size_t selection_start, [[maybe_unused]] size_t selection_end) { }
-
 private:
     void collapse_selection_to_offset(size_t);
     void selection_was_changed();


### PR DESCRIPTION
With a8077f79cc65a37f82078a6249f161e469e96c3a Selection object is no longer aware of selection state inside text controls (<textarea> and <input>), so this change makes them responsible for dispatching `selectionchange` if their selection state was changed.