### PR TITLE
LibWeb: Handle language attributes without a '-'

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-008.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-008.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	If an element contains a lang attribute with an empty value, the value of a lang attribute higher up the document tree will no longer be applied to the content of that element.	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-009.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-009.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	If the HTTP header contains a language declaration but the html element uses an empty lang value, the UA will not recognize the language declared in the HTTP header.	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-010.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-010.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	If the meta Content-Language element contains a language declaration but the html element uses an empty lang value, the UA will not recognize the language declared in the meta Content-Language element.	

--- a/Tests/LibWeb/Text/input/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-008.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-008.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html   >
+<head>
+<meta charset="utf-8"/>
+<title>lang="..." vs lang=""</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='https://html.spec.whatwg.org/multipage/#the-lang-and-xml:lang-attributes'>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='dom'>
+<style type='text/css'>
+    #colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+    #colonlangcontroltest:lang(xx) { display:none; }
+.test div { width: 50px; }
+#box:lang(ko) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test" lang="ko"><div id="box" lang="">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.</p>
+
+
+<!--Notes:
+
+This test uses :lang to detect whether the language has been set. If :lang is not supported, a message will appear and the test will fail.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "If an element contains a lang attribute with an empty value, the value of a lang attribute higher up the document tree will no longer be applied to the content of that element.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-009.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-009.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html   lang="" >
+<head>
+<meta charset="utf-8"/>
+<title>lang="" vs HTTP</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='https://html.spec.whatwg.org/multipage/#the-lang-and-xml:lang-attributes'>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='http dom'>
+<style type='text/css'>
+    #colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+    #colonlangcontroltest:lang(xx) { display:none; }
+.test div { width: 50px; }
+#box:lang(ko) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.</p>
+
+
+<!--Notes:
+
+This test uses :lang to detect whether the language has been set. If :lang is not supported, a message will appear and the test will fail.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "If the HTTP header contains a language declaration but the html element uses an empty lang value, the UA will not recognize the language declared in the HTTP header.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-010.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/dom/elements/global-attributes/the-lang-attribute-010.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html   lang="" >
+<head>
+<meta charset="utf-8"/>
+ <meta http-equiv="Content-Language" content="ko" >
+<title>lang="" vs meta Content-Language</title>
+<link rel='author' title='Richard Ishida' href='mailto:ishida@w3.org'>
+<link rel='help' href='https://html.spec.whatwg.org/multipage/#the-lang-and-xml:lang-attributes'>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<meta name='flags' content='dom'>
+<style type='text/css'>
+    #colonlangcontroltest { color: red; font-weight: bold; width: 400px; }
+    #colonlangcontroltest:lang(xx) { display:none; }
+.test div { width: 50px; }
+#box:lang(ko) { width: 100px; }
+</style>
+</head>
+<body>
+
+
+
+<div class="test"><div id="box">&#xA0;</div></div>
+<p lang='xx' id='colonlangcontroltest'>This test failed because it relies on :lang for results, but :lang is not supported by this browser.</p>
+
+
+<!--Notes:
+
+This test uses :lang to detect whether the language has been set. If :lang is not supported, a message will appear and the test will fail.
+
+-->
+<script>
+test(function() {
+assert_equals(document.getElementById('colonlangcontroltest').offsetWidth, 0)
+assert_equals(document.getElementById('box').offsetWidth, 50);
+}, "If the meta Content-Language element contains a language declaration but the html element uses an empty lang value, the UA will not recognize the language declared in the meta Content-Language element.");
+</script>
+
+<div id='log'></div>
+
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -72,7 +72,7 @@ static inline bool matches_lang_pseudo_class(DOM::Element const& element, Vector
         if (!element_language.contains('-') && Infra::is_ascii_case_insensitive_match(element_language, language))
             return true;
         auto parts = element_language.split_limit('-', 2).release_value_but_fixme_should_propagate_errors();
-        if (Infra::is_ascii_case_insensitive_match(parts[0], language))
+        if (!parts.is_empty() && Infra::is_ascii_case_insensitive_match(parts[0], language))
             return true;
     }
     return false;


### PR DESCRIPTION
Where we would previously index out of bounds.