### PR TITLE
Meta: Add an option to `WPT.sh` to import WPT tests

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -32,6 +32,7 @@ ladybird_git_hash() {
 
 LADYBIRD_BINARY=${LADYBIRD_BINARY:-"$(default_binary_path)/Ladybird"}
 WEBDRIVER_BINARY=${WEBDRIVER_BINARY:-"$(default_binary_path)/WebDriver"}
+HEADLESS_BROWSER_BINARY=${HEADLESS_BROWSER_BINARY:-"$(default_binary_path)/headless-browser"}
 WPT_PROCESSES=${WPT_PROCESSES:-$(get_number_of_processing_units)}
 WPT_CERTIFICATES=(
   "tools/certs/cacert.pem"
@@ -57,6 +58,8 @@ print_help() {
                       Run the Web Platform Tests.
       compare:    $NAME compare [OPTIONS...] LOG_FILE [TESTS...]
                       Run the Web Platform Tests comparing the results to the expectations in LOG_FILE.
+      import:     $NAME import [TESTS...]
+                      Fetch the given test file(s) from https://wpt.live/ and create an in-tree test and expectation files.
 
     Examples:
       $NAME update
@@ -71,6 +74,8 @@ print_help() {
           Run all of the Web Platform Tests comparing the results to the expectations in before.log.
       $NAME compare --log results.log expectations.log css/CSS2
           Run the Web Platform Tests in the 'css/CSS2' directory, comparing the results to the expectations in expectations.log; output the results to results.log.
+      $NAME import html/dom/aria-attribute-reflection.html
+          Import the test from https://wpt.live/html/dom/aria-attribute-reflection.html into the Ladybird test suite.
 EOF
 }
 
@@ -179,6 +184,18 @@ serve_wpt()
     popd > /dev/null
 }
 
+import_wpt()
+{
+    pushd "${LADYBIRD_SOURCE_DIR}" > /dev/null
+        ./Meta/ladybird.sh build headless-browser
+        for path in "${INPUT_PATHS[@]}"; do
+            echo "Importing test from ${path}"
+            ./Meta/import-wpt-test.py https://wpt.live/"${path}"
+            "${HEADLESS_BROWSER_BINARY}" --run-tests ./Tests/LibWeb --rebaseline -f "$path"
+        done
+    popd > /dev/null
+}
+
 compare_wpt() {
     ensure_wpt_repository
     METADATA_DIR=$(mktemp -d)
@@ -191,7 +208,7 @@ compare_wpt() {
     rm -rf "${METADATA_DIR}"
 }
 
-if [[ "$CMD" =~ ^(update|run|serve|compare)$ ]]; then
+if [[ "$CMD" =~ ^(update|run|serve|compare|import)$ ]]; then
     case "$CMD" in
         update)
             update_wpt
@@ -202,6 +219,14 @@ if [[ "$CMD" =~ ^(update|run|serve|compare)$ ]]; then
         serve)
             serve_wpt
             ;;
+        import)
+            if [ $# -eq 0 ]; then
+                usage
+            fi
+            INPUT_PATHS=( "$@" )
+            import_wpt
+            ;;
+
         compare)
             INPUT_LOG_NAME="$(pwd -P)/$1"
             if [ ! -f "$INPUT_LOG_NAME" ]; then


### PR DESCRIPTION
This invokes the existing `import-wpt-test.py` script, then uses `headless-browser` to create an expectation file.