### PR TITLE
LibWeb: Use machine epsilon when approximating cubic bezier

### DIFF
--- a/Tests/LibWeb/Text/expected/css/cubic-bezier-infinite-slope-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/cubic-bezier-infinite-slope-crash.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/css/cubic-bezier-infinite-slope-crash.html
+++ b/Tests/LibWeb/Text/input/css/cubic-bezier-infinite-slope-crash.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<style>
+    #foo {
+        animation-name: anim;
+        animation-play-state: paused;
+        animation-fill-mode: forwards;
+        animation-timing-function: cubic-bezier(0.4, 0.1, 1, 0);
+    }
+
+    @keyframes anim {}
+</style>
+<div id="foo"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const foo = document.getElementById("foo");
+        const anim = foo.getAnimations()[0];
+        anim.onfinish = function () {
+            println("PASS! (Didn't crash)");
+            done();
+        };
+        anim.play();
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
@@ -126,9 +126,9 @@ double EasingStyleValue::Function::evaluate_at(double input_progress, bool befor
 
             size_t nearby_index = 0;
             if (auto found = binary_search(cached_x_samples, x, &nearby_index, [](auto x, auto& sample) {
-                    if (x > sample.x)
+                    if (x - sample.x >= NumericLimits<double>::epsilon())
                         return 1;
-                    if (x < sample.x)
+                    if (x - sample.x <= NumericLimits<double>::epsilon())
                         return -1;
                     return 0;
                 }))
@@ -146,9 +146,9 @@ double EasingStyleValue::Function::evaluate_at(double input_progress, bool befor
                 }
 
                 if (auto found = binary_search(cached_x_samples, x, &nearby_index, [](auto x, auto& sample) {
-                        if (x > sample.x)
+                        if (x - sample.x >= NumericLimits<double>::epsilon())
                             return 1;
-                        if (x < sample.x)
+                        if (x - sample.x <= NumericLimits<double>::epsilon())
                             return -1;
                         return 0;
                     }))


### PR DESCRIPTION
In some cases floating point imprecision can cause a cubic bezier with an infinite slope at the end to never reach exactly x=1.

Fixes a crash on https://comp.anu.edu.au/sapling/index.html when a dropdown animation finishes.
Also includes a crash test.