### PR TITLE
Tests: Allow full relative or absolute pathnames for test files to run

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -122,6 +122,13 @@ done
 WPT_ARGS+=( "--binary=${LADYBIRD_BINARY}" )
 TEST_LIST=( "$@" )
 
+for i in "${!TEST_LIST[@]}"; do
+    item="${TEST_LIST[i]}"
+    item="${item#"$WPT_SOURCE_DIR"/}"
+    item="${item#*Tests/LibWeb/WPT/wpt/}"
+    TEST_LIST[i]="$item"
+done
+
 exit_if_running_as_root "Do not run WPT.sh as root"
 
 ensure_wpt_repository() {


### PR DESCRIPTION
This change allows the test list given to `WPT.sh run` to include full filesystem relative or absolute pathnames. That facilitates using tab completion in the shell to browse for pathnames, and also facilitates copy-paste of full filesystem pathnames. For example:

```
./Meta/WPT.sh run Tests/LibWeb/WPT/wpt/dom/historical.html
./Meta/WPT.sh run /opt/ladybird/Tests/LibWeb/WPT/wpt/dom/historical.html
```

Otherwise, without this change, the test list can’t include full filesystem pathnames, but is instead limited to only path fragments that specify WPT subdirectory pathnames — which doesn’t allow for tab completion on pathnames in the shell, nor copy-paste of full pathnames.