### PR TITLE
LibWeb: Remove save() call in DisplayListPlayerSkia::add_mask()

### DIFF
--- a/Tests/LibWeb/Ref/background-clip-text.html
+++ b/Tests/LibWeb/Ref/background-clip-text.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<link rel="match" href="reference/background-clip-text-ref.html" />
+<style>
+* { outline: 1px solid black; font-size: 100px; }
+.overflow-hidden {
+    overflow: hidden;
+}
+.background-clip-text {
+    background-clip: text;
+}
+</style><body><div>hello</div><div class="overflow-hidden"><div class="background-clip-text">x

--- a/Tests/LibWeb/Ref/reference/background-clip-text-ref.html
+++ b/Tests/LibWeb/Ref/reference/background-clip-text-ref.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<style>
+* { outline: 1px solid black; font-size: 100px; }
+.overflow-hidden {
+    overflow: hidden;
+}
+</style><body><div>hello</div><div class="overflow-hidden"><div>x

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1233,7 +1233,6 @@ void DisplayListPlayerSkia::add_mask(AddMask const& command)
     mask_matrix.setTranslate(rect.x(), rect.y());
     auto image = mask_surface->makeImageSnapshot();
     auto shader = image->makeShader(SkSamplingOptions(), mask_matrix);
-    surface().canvas().save();
     surface().canvas().clipShader(shader);
 }
 


### PR DESCRIPTION
This save() call did not have matching restore(). For mask application it's display list builder responsibility to emit save() and restore() so mask is applied only to relevant portion.

Progress on https://www.jetbrains.com/