### PR TITLE
LibWeb: Do not allow focusing "actually disabled" elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -107,4 +107,9 @@ void HTMLButtonElement::activation_behavior(DOM::Event const& event)
     // 4. FIXME: Run the popover target attribute activation behavior given element.
 }
 
+bool HTMLButtonElement::is_focusable() const
+{
+    return enabled();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -40,7 +40,9 @@ public:
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-button-element
-    virtual bool is_focusable() const override { return true; }
+    // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+    // https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled
+    virtual bool is_focusable() const override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2587,4 +2587,9 @@ HTMLInputElement::ValueAttributeMode HTMLInputElement::value_attribute_mode() co
     return value_attribute_mode_for_type_state(type_state());
 }
 
+bool HTMLInputElement::is_focusable() const
+{
+    return m_type != TypeAttributeState::Hidden && enabled();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -155,7 +155,9 @@ public:
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-input-element
-    virtual bool is_focusable() const override { return m_type != TypeAttributeState::Hidden; }
+    // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+    // https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled
+    virtual bool is_focusable() const override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -613,4 +613,10 @@ void HTMLSelectElement::update_selectedness(JS::GCPtr<HTML::HTMLOptionElement> l
     }
     update_inner_text_element();
 }
+
+bool HTMLSelectElement::is_focusable() const
+{
+    return enabled();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -59,7 +59,9 @@ public:
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element
-    virtual bool is_focusable() const override { return true; }
+    // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+    // https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled
+    virtual bool is_focusable() const override;
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -478,4 +478,9 @@ void HTMLTextAreaElement::queue_firing_input_event()
     });
 }
 
+bool HTMLTextAreaElement::is_focusable() const
+{
+    return enabled();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -42,7 +42,10 @@ public:
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-textarea-element
-    virtual bool is_focusable() const override { return true; }
+    // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
+    // https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled
+    virtual bool is_focusable() const override;
+
     virtual void did_lose_focus() override;
     virtual void did_receive_focus() override;
 


### PR DESCRIPTION
# Why

According to the specification "actually disabled" elements should not be focusable:
* https://html.spec.whatwg.org/multipage/interaction.html#focusable-area

The definition of "actually disabled" elements:
* https://html.spec.whatwg.org/multipage/semantics-other.html#concept-element-disabled

Should fix most of the following tests:
* https://wpt.fyi/results/html/semantics/disabled-elements/disabledElement.html?label=experimental&product=ladybird

# How

This PR changes the `is_focusable` implementations for the few form elements to account for the `disabled` state using already inherited `FormAssociatedElement::enabled()` method.

# Preview

https://github.com/user-attachments/assets/5b4eaa2c-eab4-4ade-98c2-a15289235fed