### PR TITLE
LibJS: Remember the position into the cached indices

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -210,10 +210,12 @@ bool IndexedPropertyIterator::operator!=(IndexedPropertyIterator const& other) c
 
 void IndexedPropertyIterator::skip_empty_indices()
 {
-    for (auto i : m_cached_indices) {
-        if (i < m_index)
+    for (size_t i = m_next_cached_index; i < m_cached_indices.size(); i++) {
+        auto index = m_cached_indices[i];
+        if (index < m_index)
             continue;
-        m_index = i;
+        m_index = index;
+        m_next_cached_index = i + 1;
         return;
     }
     m_index = m_indexed_properties.array_like_size();

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -135,6 +135,7 @@ private:
 
     IndexedProperties const& m_indexed_properties;
     Vector<u32> m_cached_indices;
+    size_t m_next_cached_index { 0 };
     u32 m_index { 0 };
     bool m_skip_empty { false };
 };


### PR DESCRIPTION
There is no need to do a full linear search from start to end when we can just remember the position and continue where we left off.