### PR TITLE
LibWeb/Crypto: Fix sizes being passed into `generate_aes_key()`

### DIFF
--- a/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-aesgcm.txt
+++ b/Tests/LibWeb/Text/expected/Crypto/SubtleCrypto-aesgcm.txt
@@ -1,0 +1,3 @@
+exported 128 bit key length: 16
+exported 192 bit key length: 24
+exported 256 bit key length: 32

--- a/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-aesgcm.html
+++ b/Tests/LibWeb/Text/input/Crypto/SubtleCrypto-aesgcm.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const algorithm = "AES-GCM";
+
+        // Generate keys and export them, verify length
+        const aesGcm128bitKey = await crypto.subtle.generateKey({ name: algorithm, length: 128 }, true, ["encrypt"]);
+        const aesGcm192bitKey = await crypto.subtle.generateKey({ name: algorithm, length: 192 }, true, ["encrypt"]);
+        const aesGcm256bitKey = await crypto.subtle.generateKey({ name: algorithm, length: 256 }, true, ["encrypt"]);
+
+        const exported128bitKey = await crypto.subtle.exportKey("raw", aesGcm128bitKey);
+        const exported192bitKey = await crypto.subtle.exportKey("raw", aesGcm192bitKey);
+        const exported256bitKey = await crypto.subtle.exportKey("raw", aesGcm256bitKey);
+
+        println("exported 128 bit key length: " + exported128bitKey.byteLength);
+        println("exported 192 bit key length: " + exported192bitKey.byteLength);
+        println("exported 256 bit key length: " + exported256bitKey.byteLength);
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Previously, callers were passing the size in bytes, but the method expected bits. This caused a crash in LibCrypto when verifying the key size later on.

Also make the naming of local variables and parameters a little more clear between the different AES algorithms :^)

cc: @BenWiederhake 