### PR TITLE
LibWeb: Implement some missing WebDriver features

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -144,6 +144,7 @@ public:
 
     ErrorOr<String> trim(Utf8View const& code_points_to_trim, TrimMode mode = TrimMode::Both) const;
     ErrorOr<String> trim(StringView code_points_to_trim, TrimMode mode = TrimMode::Both) const;
+    ErrorOr<String> trim_whitespace(TrimMode mode = TrimMode::Both) const;
     ErrorOr<String> trim_ascii_whitespace(TrimMode mode = TrimMode::Both) const;
 
     ErrorOr<Vector<String>> split_limit(u32 separator, size_t limit, SplitBehavior = SplitBehavior::Nothing) const;

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -1289,6 +1289,82 @@ TEST_CASE(trim)
     }
 }
 
+TEST_CASE(trim_whitespace)
+{
+    {
+        String string {};
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), String {});
+    }
+    {
+        auto string = " "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), String {});
+    }
+    {
+        auto string = "   "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), String {});
+    }
+    {
+        auto string = " \t \n \r \u00A0 \u202F "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), String {});
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), String {});
+    }
+    {
+        auto string = "abcdef"_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "abcdef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "abcdef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), "abcdef"_string);
+    }
+    {
+        auto string = " \u00A0 abcdef"_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "abcdef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "abcdef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), " \u00A0 abcdef"_string);
+    }
+    {
+        auto string = "abcdef \u202F "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "abcdef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "abcdef \u202F "_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), "abcdef"_string);
+    }
+    {
+        auto string = " \u00A0 abcdef \u202F "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "abcdef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "abcdef \u202F "_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), " \u00A0 abcdef"_string);
+    }
+    {
+        auto string = "ab \t cd \n ef"_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "ab \t cd \n ef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "ab \t cd \n ef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), "ab \t cd \n ef"_string);
+    }
+    {
+        auto string = " \u00A0 ab \t cd \n ef"_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "ab \t cd \n ef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "ab \t cd \n ef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), " \u00A0 ab \t cd \n ef"_string);
+    }
+    {
+        auto string = "ab \t cd \n ef \u202F "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "ab \t cd \n ef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "ab \t cd \n ef \u202F "_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), "ab \t cd \n ef"_string);
+    }
+    {
+        auto string = " \u00A0 ab \t cd \n ef \u202F "_string;
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Both)), "ab \t cd \n ef"_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Left)), "ab \t cd \n ef \u202F "_string);
+        EXPECT_EQ(MUST(string.trim_whitespace(TrimMode::Right)), " \u00A0 ab \t cd \n ef"_string);
+    }
+}
+
 TEST_CASE(contains)
 {
     EXPECT(!String {}.contains({}));

--- a/Userland/Libraries/LibUnicode/CharacterTypes.cpp
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.cpp
@@ -231,6 +231,11 @@ bool code_point_has_variation_selector_property(u32 code_point)
     return code_point_has_property(code_point, UCHAR_VARIATION_SELECTOR);
 }
 
+bool code_point_has_white_space_property(u32 code_point)
+{
+    return code_point_has_property(code_point, UCHAR_WHITE_SPACE);
+}
+
 // https://tc39.es/ecma262/#table-binary-unicode-properties
 bool is_ecma262_property(Property property)
 {

--- a/Userland/Libraries/LibUnicode/CharacterTypes.h
+++ b/Userland/Libraries/LibUnicode/CharacterTypes.h
@@ -36,6 +36,7 @@ bool code_point_has_identifier_start_property(u32 code_point);
 bool code_point_has_identifier_continue_property(u32 code_point);
 bool code_point_has_regional_indicator_property(u32 code_point);
 bool code_point_has_variation_selector_property(u32 code_point);
+bool code_point_has_white_space_property(u32 code_point);
 
 bool is_ecma262_property(Property);
 

--- a/Userland/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -516,6 +516,18 @@ bool is_shadow_root_detached(Web::DOM::ShadowRoot const& shadow_root)
     return !shadow_root.document().is_active() || !shadow_root.host() || is_element_stale(*shadow_root.host());
 }
 
+// https://w3c.github.io/webdriver/#dfn-bot-dom-getvisibletext
+String element_rendered_text(DOM::Node& node)
+{
+    // FIXME: The spec does not define how to get the element's rendered text, other than to do exactly as Selenium does.
+    //        This implementation is not sufficient, as we must also at least consider the shadow DOM.
+    if (!is<HTML::HTMLElement>(node))
+        return node.text_content().value_or(String {});
+
+    auto& element = static_cast<HTML::HTMLElement&>(node);
+    return element.inner_text();
+}
+
 // https://w3c.github.io/webdriver/#dfn-center-point
 CSSPixelPoint in_view_center_point(DOM::Element const& element, CSSPixelRect viewport)
 {

--- a/Userland/Libraries/LibWeb/WebDriver/ElementReference.h
+++ b/Userland/Libraries/LibWeb/WebDriver/ElementReference.h
@@ -55,6 +55,8 @@ ErrorOr<JS::NonnullGCPtr<Web::DOM::ShadowRoot>, WebDriver::Error> deserialize_sh
 ErrorOr<JS::NonnullGCPtr<Web::DOM::ShadowRoot>, Web::WebDriver::Error> get_known_shadow_root(HTML::BrowsingContext const&, StringView reference);
 bool is_shadow_root_detached(Web::DOM::ShadowRoot const&);
 
+String element_rendered_text(DOM::Node&);
+
 CSSPixelPoint in_view_center_point(DOM::Element const& element, CSSPixelRect viewport);
 
 }

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -1322,11 +1322,12 @@ Messages::WebDriverClient::GetElementTextResponse WebDriverConnection::get_eleme
         // 3. Let element be the result of trying to get a known connected element with url variable element id.
         auto element = WEBDRIVER_TRY(Web::WebDriver::get_known_element(current_browsing_context(), element_id));
 
-        // 4. Let rendered text be the result of performing implementation-specific steps whose result is exactly the same as the result of a Function.[[Call]](null, element) with bot.dom.getVisibleText as the this value.
-        auto rendered_text = element->text_content();
+        // 4. Let rendered text be the result of performing implementation-specific steps whose result is exactly the
+        //    same as the result of a Function.[[Call]](null, element) with bot.dom.getVisibleText as the this value.
+        auto rendered_text = Web::WebDriver::element_rendered_text(element);
 
         // 5. Return success with data rendered text.
-        async_driver_execution_complete({ rendered_text.value_or(String {}).to_byte_string() });
+        async_driver_execution_complete({ rendered_text.to_byte_string() });
     });
 
     return JsonValue {};


### PR DESCRIPTION
This implements:
* Switching frames via numeric IDs
* Non-XPath element locators
* A step towards a spec-compliant method of getting rendered text