### PR TITLE
LibWeb: Implement HTMLFrameElement as a NavigableContainer

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLFrameElement-add-remove.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLFrameElement-add-remove.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/expected/HTML/HTMLFrameElement-load.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLFrameElement-load.txt
@@ -1,0 +1,1 @@
+frame load: blank.html

--- a/Tests/LibWeb/Text/input/HTML/HTMLFrameElement-add-remove.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLFrameElement-add-remove.html
@@ -1,0 +1,20 @@
+<head>
+    <script src="../include.js"></script>
+    <script>
+        asyncTest(done => {
+            let frameset = document.getElementById("frameset");
+
+            let frame = document.createElement("frame");
+            frameset.appendChild(frame);
+            frame.remove();
+
+            // Attempting to load the frame will happen in a task on the event loop, so defer completing this test until
+            // the event loop has spun once.
+            setTimeout(() => {
+                println("PASS! (Didn't crash)");
+                done();
+            })
+        });
+    </script>
+</head>
+<frameset id="frameset"></frameset>

--- a/Tests/LibWeb/Text/input/HTML/HTMLFrameElement-load.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLFrameElement-load.html
@@ -1,0 +1,18 @@
+<head>
+    <script src="../include.js"></script>
+    <script>
+        asyncTest(done => {
+            let frame = document.getElementById("frame");
+
+            frame.addEventListener("load", e => {
+                println(`frame load: ${e.target.src.split("/").pop()}`);
+                done();
+            });
+
+            frame.src = "../../data/blank.html";
+        });
+    </script>
+</head>
+<frameset>
+    <frame id="frame" />
+</frameset>

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -6,15 +6,23 @@
 
 #include <LibWeb/Bindings/HTMLFrameElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Event.h>
+#include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/HTMLFrameElement.h>
+#include <LibWeb/ReferrerPolicy/ReferrerPolicy.h>
 
 namespace Web::HTML {
 
 JS_DEFINE_ALLOCATOR(HTMLFrameElement);
 
 HTMLFrameElement::HTMLFrameElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : HTMLElement(document, move(qualified_name))
+    : NavigableContainer(document, move(qualified_name))
 {
+    // https://html.spec.whatwg.org/multipage/obsolete.html#frames:potentially-delays-the-load-event
+    // The frame element potentially delays the load event.
+    set_potentially_delays_the_load_event(true);
 }
 
 HTMLFrameElement::~HTMLFrameElement() = default;
@@ -25,11 +33,76 @@ void HTMLFrameElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLFrameElement);
 }
 
+// https://html.spec.whatwg.org/multipage/obsolete.html#frames:html-element-insertion-steps
+void HTMLFrameElement::inserted()
+{
+    Base::inserted();
+
+    // 1. If insertedNode is not in a document tree, then return.
+    if (!in_a_document_tree())
+        return;
+
+    // 2. If insertedNode's root's browsing context is null, then return.
+    if (root().document().browsing_context() == nullptr)
+        return;
+
+    // 3. Create a new child navigable for insertedNode.
+    MUST(create_new_child_navigable(JS::create_heap_function(realm().heap(), [this] {
+        // 4. Process the frame attributes for insertedNode, with initialInsertion set to true.
+        process_the_frame_attributes(true);
+        set_content_navigable_initialized();
+    })));
+}
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#frames:html-element-removing-steps
+void HTMLFrameElement::removed_from(DOM::Node* node)
+{
+    Base::removed_from(node);
+
+    // The frame HTML element removing steps, given removedNode, are to destroy a child navigable given removedNode.
+    destroy_the_child_navigable();
+}
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#frames:frame-3
+void HTMLFrameElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+{
+    Base::attribute_changed(name, old_value, value);
+
+    // Whenever a frame element with a non-null content navigable has its src attribute set, changed, or removed, the
+    // user agent must process the frame attributes.
+    if (content_navigable() && name == HTML::AttributeNames::src)
+        process_the_frame_attributes();
+}
+
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-tabindex
 i32 HTMLFrameElement::default_tab_index_value() const
 {
     // See the base function for the spec comments.
     return 0;
+}
+
+// https://html.spec.whatwg.org/multipage/obsolete.html#process-the-frame-attributes
+void HTMLFrameElement::process_the_frame_attributes(bool initial_insertion)
+{
+    // 1. Let url be the result of running the shared attribute processing steps for iframe and frame elements given
+    //    element and initialInsertion.
+    auto url = shared_attribute_processing_steps_for_iframe_and_frame(initial_insertion);
+
+    // 2. If url is null, then return.
+    if (!url.has_value())
+        return;
+
+    // 3. If url matches about:blank and initialInsertion is true, then:
+    if (url_matches_about_blank(*url) && initial_insertion) {
+        // 1. Fire an event named load at element.
+        dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
+
+        // 2. Return.
+        return;
+    }
+
+    // 3. Navigate an iframe or frame given element, url, and the empty string.
+    navigate_an_iframe_or_frame(*url, ReferrerPolicy::ReferrerPolicy::EmptyString);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/HTML/NavigableContainer.h>
 
 namespace Web::HTML {
 
 // NOTE: This element is marked as obsolete, but is still listed as required by the specification.
-class HTMLFrameElement final : public HTMLElement {
-    WEB_PLATFORM_OBJECT(HTMLFrameElement, HTMLElement);
+class HTMLFrameElement final : public NavigableContainer {
+    WEB_PLATFORM_OBJECT(HTMLFrameElement, NavigableContainer);
     JS_DECLARE_ALLOCATOR(HTMLFrameElement);
 
 public:
@@ -24,7 +24,12 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     // ^DOM::Element
+    virtual void inserted() override;
+    virtual void removed_from(Node*) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
     virtual i32 default_tab_index_value() const override;
+
+    void process_the_frame_attributes(bool initial_insertion = false);
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFrameElement.idl
@@ -12,8 +12,8 @@ interface HTMLFrameElement : HTMLElement {
     [CEReactions, Reflect=frameborder] attribute DOMString frameBorder;
     [CEReactions, Reflect=longdesc, URL] attribute USVString longDesc;
     [CEReactions, Reflect=noresize] attribute boolean noResize;
-    [FIXME] readonly attribute Document? contentDocument;
-    [FIXME] readonly attribute WindowProxy? contentWindow;
+    readonly attribute Document? contentDocument;
+    readonly attribute WindowProxy? contentWindow;
 
     [CEReactions, LegacyNullToEmptyString, Reflect=marginheight] attribute DOMString marginHeight;
     [CEReactions, LegacyNullToEmptyString, Reflect=marginwidth] attribute DOMString marginWidth;

--- a/Userland/Libraries/LibWebView/InspectorClient.cpp
+++ b/Userland/Libraries/LibWebView/InspectorClient.cpp
@@ -313,7 +313,7 @@ void InspectorClient::reset()
     static constexpr auto script = "inspector.reset();"sv;
     m_inspector_web_view.run_javascript(script);
 
-    m_body_node_id.clear();
+    m_body_or_frameset_node_id.clear();
     m_pending_selection.clear();
     m_dom_tree_loaded = false;
 
@@ -331,8 +331,8 @@ void InspectorClient::select_hovered_node()
 
 void InspectorClient::select_default_node()
 {
-    if (m_body_node_id.has_value())
-        select_node(*m_body_node_id);
+    if (m_body_or_frameset_node_id.has_value())
+        select_node(*m_body_or_frameset_node_id);
 }
 
 void InspectorClient::clear_selection()
@@ -633,8 +633,8 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             return;
         }
 
-        if (name.equals_ignoring_ascii_case("BODY"sv))
-            m_body_node_id = node_id;
+        if (name.equals_ignoring_ascii_case("BODY"sv) || name.equals_ignoring_ascii_case("FRAMESET"sv))
+            m_body_or_frameset_node_id = node_id;
 
         auto tag = name.to_lowercase();
 

--- a/Userland/Libraries/LibWebView/InspectorClient.h
+++ b/Userland/Libraries/LibWebView/InspectorClient.h
@@ -72,7 +72,7 @@ private:
     ViewImplementation& m_content_web_view;
     ViewImplementation& m_inspector_web_view;
 
-    Optional<Web::UniqueNodeID> m_body_node_id;
+    Optional<Web::UniqueNodeID> m_body_or_frameset_node_id;
     Optional<Web::UniqueNodeID> m_pending_selection;
 
     bool m_inspector_loaded { false };

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -631,22 +631,14 @@ Messages::WebDriverClient::SwitchToFrameResponse WebDriverConnection::switch_to_
             auto element = WEBDRIVER_TRY(Web::WebDriver::get_known_element(current_browsing_context(), element_id));
 
             // 4. If element is not a frame or iframe element, return error with error code no such frame.
-            bool is_frame = is<Web::HTML::HTMLFrameElement>(*element);
-            bool is_iframe = is<Web::HTML::HTMLIFrameElement>(*element);
-
-            if (!is_frame && !is_iframe) {
+            if (!is<Web::HTML::HTMLFrameElement>(*element) && !is<Web::HTML::HTMLIFrameElement>(*element)) {
                 async_driver_execution_complete(Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchFrame, "element is not a frame"sv));
                 return;
             }
 
             // 5. Set the current browsing context with session and element's content navigable's active browsing context.
-            if (is_frame) {
-                // FIXME: Should HTMLFrameElement also be a NavigableContainer?
-                set_current_browsing_context(*element->navigable()->active_browsing_context());
-            } else {
-                auto& navigable_container = static_cast<Web::HTML::NavigableContainer&>(*element);
-                set_current_browsing_context(*navigable_container.content_navigable()->active_browsing_context());
-            }
+            auto& navigable_container = static_cast<Web::HTML::NavigableContainer&>(*element);
+            set_current_browsing_context(*navigable_container.content_navigable()->active_browsing_context());
 
             async_driver_execution_complete(JsonValue {});
         });


### PR DESCRIPTION
NavigableContainer is our home grown concept which already contains the
AOs needed for `frame` and `iframe` elements. This patch simply aligns our
HTMLFrameElement implementation with this class.

A couple of notes:

1. The `<script>` in the `<head>` element is intentional. The `<frameset>`
   element effectively takes the place of the `<body>` element, and we
   cannot add a `<script>` to a `<frameset>` element.

2. We don't render `<frameset>` or `<frame>` at all. Rendering is defined
   in the following spec:
   https://html.spec.whatwg.org/multipage/rendering.html#frames-and-framesets

3. If you load the test page in your browser, you won't see anything,
   regardless of (2). Our test infra adds a `<pre>` element to the "body"
   element (which is the `<frameset>` element here). Such children will
   never be rendered. In the future, we could come up with something
   better for our test infra to do, but this isn't important anyways
   for this test - we can still grab the `<pre>` element's `innerText`.