### PR TITLE
LibWeb: Don't crash when input with no associated text node loses focus

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-blur.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLInputElement-blur.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/HTML/HTMLInputElement-blur.html
+++ b/Tests/LibWeb/Text/input/HTML/HTMLInputElement-blur.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<input type="checkbox">
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const input = document.querySelector("input");
+        input.focus();
+        input.blur();
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1187,11 +1187,12 @@ void HTMLInputElement::did_receive_focus()
 
 void HTMLInputElement::did_lose_focus()
 {
-    if (m_text_node)
+    if (m_text_node) {
         m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
 
-    if (auto* paintable = m_text_node->paintable())
-        paintable->set_selected(false);
+        if (auto* paintable = m_text_node->paintable())
+            paintable->set_selected(false);
+    }
 
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);


### PR DESCRIPTION
Fixes a crash seen on http://wpt.live when attempting to filter passing or failing tests.