### PR TITLE
Toolchain: Fix path to BuildVcpkg.py in BuildVcpkg.sh

### DIFF
--- a/Toolchain/BuildVcpkg.sh
+++ b/Toolchain/BuildVcpkg.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-python3 ./Toolchain/BuildVcpkg.py
+python3 ./BuildVcpkg.py


### PR DESCRIPTION
The relative path to *.py script was incorrect. Fixed.