### PR TITLE
LibWeb: Implement Web::Fetch::Body::fully_read() closer to spec

### DIFF
--- a/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
+++ b/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
@@ -58,7 +58,7 @@ struct ExtractExceptionOrValueType<WebIDL::ExceptionOr<void>> {
 
 }
 
-ALWAYS_INLINE JS::Completion dom_exception_to_throw_completion(JS::VM& vm, auto&& exception)
+ALWAYS_INLINE JS::Completion exception_to_throw_completion(JS::VM& vm, auto&& exception)
 {
     return exception.visit(
         [&](WebIDL::SimpleException const& exception) {
@@ -97,7 +97,7 @@ JS::ThrowCompletionOr<Ret> throw_dom_exception_if_needed(JS::VM& vm, F&& fn)
         auto&& result = fn();
 
         if (result.is_exception())
-            return dom_exception_to_throw_completion(vm, result.exception());
+            return exception_to_throw_completion(vm, result.exception());
 
         if constexpr (requires(T v) { v.value(); })
             return result.value();

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -499,7 +499,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
                 // 3. If the previous step threw an exception, then:
                 if (maybe_exception.is_exception()) {
                     // 1. Let completion be Completion Record { [[Type]]: throw, [[Value]]: resolutionError, [[Target]]: empty }.
-                    auto completion = dom_exception_to_throw_completion(main_thread_vm(), maybe_exception.exception());
+                    auto completion = exception_to_throw_completion(main_thread_vm(), maybe_exception.exception());
 
                     // 2. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, completion).
                     JS::finish_loading_imported_module(referrer, module_request, payload, completion);
@@ -542,7 +542,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
         // 10. If the previous step threw an exception, then:
         if (url.is_exception()) {
             // 1. Let completion be Completion Record { [[Type]]: throw, [[Value]]: resolutionError, [[Target]]: empty }.
-            auto completion = dom_exception_to_throw_completion(main_thread_vm(), url.exception());
+            auto completion = exception_to_throw_completion(main_thread_vm(), url.exception());
 
             // 2. Perform FinishLoadingImportedModule(referrer, moduleRequest, payload, completion).
             HTML::TemporaryExecutionContext context { *module_map_realm };

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -241,7 +241,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> FontFaceSet::load(String const& 
         auto result = find_matching_font_faces(realm, font_face_set, font, text);
         if (result.is_error()) {
             HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
             return;
         }
 

--- a/Libraries/LibWeb/Compression/CompressionStream.cpp
+++ b/Libraries/LibWeb/Compression/CompressionStream.cpp
@@ -55,7 +55,7 @@ WebIDL::ExceptionOr<GC::Ref<CompressionStream>> CompressionStream::construct_imp
         auto& vm = realm.vm();
 
         if (auto result = stream->compress_and_enqueue_chunk(chunk); result.is_error()) {
-            auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, result.exception());
+            auto throw_completion = Bindings::exception_to_throw_completion(vm, result.exception());
             return WebIDL::create_rejected_promise(realm, *throw_completion.release_value());
         }
 
@@ -68,7 +68,7 @@ WebIDL::ExceptionOr<GC::Ref<CompressionStream>> CompressionStream::construct_imp
         auto& vm = realm.vm();
 
         if (auto result = stream->compress_flush_and_enqueue(); result.is_error()) {
-            auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, result.exception());
+            auto throw_completion = Bindings::exception_to_throw_completion(vm, result.exception());
             return WebIDL::create_rejected_promise(realm, *throw_completion.release_value());
         }
 

--- a/Libraries/LibWeb/Compression/DecompressionStream.cpp
+++ b/Libraries/LibWeb/Compression/DecompressionStream.cpp
@@ -56,7 +56,7 @@ WebIDL::ExceptionOr<GC::Ref<DecompressionStream>> DecompressionStream::construct
         auto& vm = realm.vm();
 
         if (auto result = stream->decompress_and_enqueue_chunk(chunk); result.is_error()) {
-            auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, result.exception());
+            auto throw_completion = Bindings::exception_to_throw_completion(vm, result.exception());
             return WebIDL::create_rejected_promise(realm, *throw_completion.release_value());
         }
 
@@ -69,7 +69,7 @@ WebIDL::ExceptionOr<GC::Ref<DecompressionStream>> DecompressionStream::construct
         auto& vm = realm.vm();
 
         if (auto result = stream->decompress_flush_and_enqueue(); result.is_error()) {
-            auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, result.exception());
+            auto throw_completion = Bindings::exception_to_throw_completion(vm, result.exception());
             return WebIDL::create_rejected_promise(realm, *throw_completion.release_value());
         }
 

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -176,7 +176,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::encrypt(AlgorithmIdentifier const& algori
         // 10. Let ciphertext be the result of performing the encrypt operation specified by normalizedAlgorithm using algorithm and key and with data as plaintext.
         auto cipher_text = normalized_algorithm.methods->encrypt(*normalized_algorithm.parameter, key, data);
         if (cipher_text.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), cipher_text.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), cipher_text.release_error()).release_value().value());
             return;
         }
 
@@ -233,7 +233,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::decrypt(AlgorithmIdentifier const& algori
         // 10. Let plaintext be the result of performing the decrypt operation specified by normalizedAlgorithm using algorithm and key and with data as ciphertext.
         auto plain_text = normalized_algorithm.methods->decrypt(*normalized_algorithm.parameter, key, data);
         if (plain_text.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), plain_text.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), plain_text.release_error()).release_value().value());
             return;
         }
 
@@ -281,7 +281,7 @@ GC::Ref<WebIDL::Promise> SubtleCrypto::digest(AlgorithmIdentifier const& algorit
         auto result = algorithm_object.methods->digest(*algorithm_object.parameter, data_buffer);
 
         if (result.is_exception()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
             return;
         }
 
@@ -322,7 +322,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::generate_key(Algor
         auto result_or_error = normalized_algorithm.methods->generate_key(*normalized_algorithm.parameter, extractable, key_usages);
 
         if (result_or_error.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value().value());
             return;
         }
         auto result = result_or_error.release_value();
@@ -403,7 +403,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::import_key(Binding
         // specified by normalizedAlgorithm using keyData, algorithm, format, extractable and usages.
         auto maybe_result = normalized_algorithm.methods->import_key(*normalized_algorithm.parameter, format, real_key_data.downcast<CryptoKey::InternalKeyData>(), extractable, key_usages);
         if (maybe_result.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), maybe_result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), maybe_result.release_error()).release_value().value());
             return;
         }
         auto result = maybe_result.release_value();
@@ -449,7 +449,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::export_key(Binding
         // FIXME: Stash the AlgorithmMethods on the KeyAlgorithm
         auto normalized_algorithm_or_error = normalize_an_algorithm(realm, algorithm.name(), "exportKey"_string);
         if (normalized_algorithm_or_error.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), normalized_algorithm_or_error.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), normalized_algorithm_or_error.release_error()).release_value().value());
             return;
         }
         auto normalized_algorithm = normalized_algorithm_or_error.release_value();
@@ -463,7 +463,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::export_key(Binding
         // 7. Let result be the result of performing the export key operation specified by the [[algorithm]] internal slot of key using key and format.
         auto result_or_error = normalized_algorithm.methods->export_key(format, key);
         if (result_or_error.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value().value());
             return;
         }
 
@@ -520,7 +520,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::sign(AlgorithmIden
         // 10. Let result be the result of performing the sign operation specified by normalizedAlgorithm using key and algorithm and with data as message.
         auto result = normalized_algorithm.methods->sign(*normalized_algorithm.parameter, key, data);
         if (result.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
             return;
         }
 
@@ -584,7 +584,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::verify(AlgorithmId
         // 11. Let result be the result of performing the verify operation specified by normalizedAlgorithm using key, algorithm and signature and with data as message.
         auto result = normalized_algorithm.methods->verify(*normalized_algorithm.parameter, key, signature, data);
         if (result.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
             return;
         }
 
@@ -631,7 +631,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::derive_bits(Algori
         // 9. Let result be the result of creating an ArrayBuffer containing the result of performing the derive bits operation specified by normalizedAlgorithm using baseKey, algorithm and length.
         auto result = normalized_algorithm.methods->derive_bits(*normalized_algorithm.parameter, base_key, length);
         if (result.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result.release_error()).release_value().value());
             return;
         }
 
@@ -693,7 +693,7 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::derive_key(Algorit
         // 13. Let length be the result of performing the get key length algorithm specified by normalizedDerivedKeyAlgorithmLength using derivedKeyType.
         auto length_result = normalized_derived_key_algorithm_length.methods->get_key_length(*normalized_derived_key_algorithm_length.parameter);
         if (length_result.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), length_result.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), length_result.release_error()).release_value().value());
             return;
         }
 
@@ -712,14 +712,14 @@ JS::ThrowCompletionOr<GC::Ref<WebIDL::Promise>> SubtleCrypto::derive_key(Algorit
         // 14. Let secret be the result of performing the derive bits operation specified by normalizedAlgorithm using key, algorithm and length.
         auto secret = normalized_algorithm.methods->derive_bits(*normalized_algorithm.parameter, base_key, length);
         if (secret.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), secret.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), secret.release_error()).release_value().value());
             return;
         }
 
         // 15. Let result be the result of performing the import key operation specified by normalizedDerivedKeyAlgorithmImport using "raw" as format, secret as keyData, derivedKeyType as algorithm and using extractable and usages.
         auto result_or_error = normalized_derived_key_algorithm_import.methods->import_key(*normalized_derived_key_algorithm_import.parameter, Bindings::KeyFormat::Raw, secret.release_value()->buffer(), extractable, key_usages);
         if (result_or_error.is_error()) {
-            WebIDL::reject_promise(realm, promise, Bindings::dom_exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value().value());
+            WebIDL::reject_promise(realm, promise, Bindings::exception_to_throw_completion(realm.vm(), result_or_error.release_error()).release_value().value());
             return;
         }
         auto result = result_or_error.release_value();

--- a/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -135,7 +135,6 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm& realm,
         }));
 
     // 11. If source is a byte sequence, then set action to a step that returns source and length to source’s length.
-    // For now, do it synchronously.
     if (source.has<ByteBuffer>()) {
         action = [source = MUST(ByteBuffer::copy(source.get<ByteBuffer>()))]() mutable {
             return move(source);

--- a/Libraries/LibWeb/Fetch/BodyInit.cpp
+++ b/Libraries/LibWeb/Fetch/BodyInit.cpp
@@ -23,7 +23,7 @@
 namespace Web::Fetch {
 
 // https://fetch.spec.whatwg.org/#bodyinit-safely-extract
-WebIDL::ExceptionOr<Infrastructure::BodyWithType> safely_extract_body(JS::Realm& realm, BodyInitOrReadableBytes const& object)
+Infrastructure::BodyWithType safely_extract_body(JS::Realm& realm, BodyInitOrReadableBytes const& object)
 {
     // 1. If object is a ReadableStream object, then:
     if (auto const* stream = object.get_pointer<GC::Root<Streams::ReadableStream>>()) {
@@ -32,7 +32,7 @@ WebIDL::ExceptionOr<Infrastructure::BodyWithType> safely_extract_body(JS::Realm&
     }
 
     // 2. Return the result of extracting object.
-    return extract_body(realm, object);
+    return MUST(extract_body(realm, object));
 }
 
 // https://fetch.spec.whatwg.org/#concept-bodyinit-extract

--- a/Libraries/LibWeb/Fetch/BodyInit.h
+++ b/Libraries/LibWeb/Fetch/BodyInit.h
@@ -17,7 +17,7 @@ namespace Web::Fetch {
 using BodyInit = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String>;
 
 using BodyInitOrReadableBytes = Variant<GC::Root<Streams::ReadableStream>, GC::Root<FileAPI::Blob>, GC::Root<WebIDL::BufferSource>, GC::Root<XHR::FormData>, GC::Root<DOMURL::URLSearchParams>, String, ReadonlyBytes>;
-WebIDL::ExceptionOr<Infrastructure::BodyWithType> safely_extract_body(JS::Realm&, BodyInitOrReadableBytes const&);
+Infrastructure::BodyWithType safely_extract_body(JS::Realm&, BodyInitOrReadableBytes const&);
 WebIDL::ExceptionOr<Infrastructure::BodyWithType> extract_body(JS::Realm&, BodyInitOrReadableBytes const&, bool keepalive = false);
 
 }

--- a/Libraries/LibWeb/Fetch/FetchMethod.cpp
+++ b/Libraries/LibWeb/Fetch/FetchMethod.cpp
@@ -36,7 +36,7 @@ GC::Ref<WebIDL::Promise> fetch(JS::VM& vm, RequestInfo const& input, RequestInit
     //    as arguments. If this throws an exception, reject p with it and return p.
     auto exception_or_request_object = Request::construct_impl(realm, input, init);
     if (exception_or_request_object.is_exception()) {
-        auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, exception_or_request_object.exception());
+        auto throw_completion = Bindings::exception_to_throw_completion(vm, exception_or_request_object.exception());
         WebIDL::reject_promise(realm, promise_capability, *throw_completion.value());
         return promise_capability;
     }

--- a/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/FetchedDataReceiver.cpp
@@ -69,7 +69,7 @@ void FetchedDataReceiver::on_data_received(ReadonlyBytes bytes)
 
             // 1. Pull from bytes buffer into stream.
             if (auto result = Streams::readable_stream_pull_from_bytes(m_stream, move(bytes)); result.is_error()) {
-                auto throw_completion = Bindings::dom_exception_to_throw_completion(m_stream->vm(), result.release_error());
+                auto throw_completion = Bindings::exception_to_throw_completion(m_stream->vm(), result.release_error());
 
                 dbgln("FetchedDataReceiver: Stream error pulling bytes");
                 HTML::report_exception(throw_completion, m_stream->realm());

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -122,7 +122,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
 
     // 8. If request’s body is a byte sequence, then set request’s body to request’s body as a body.
     if (auto const* buffer = request.body().get_pointer<ByteBuffer>())
-        request.set_body(TRY(Infrastructure::byte_sequence_as_body(realm, buffer->bytes())));
+        request.set_body(Infrastructure::byte_sequence_as_body(realm, buffer->bytes()));
 
     // 9. If request’s window is "client", then set request’s window to request’s client, if request’s client’s global
     //    object is a Window object; otherwise "no-window".
@@ -576,7 +576,7 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                     }
 
                     // 2. Set response’s body to bytes as a body.
-                    response->set_body(TRY_OR_IGNORE(Infrastructure::byte_sequence_as_body(realm, bytes)));
+                    response->set_body(Infrastructure::byte_sequence_as_body(realm, bytes));
 
                     // 3. Run fetch response handover given fetchParams and response.
                     fetch_response_handover(realm, fetch_params, *response);
@@ -807,7 +807,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
             auto header = Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html;charset=utf-8"sv);
             response->header_list()->append(move(header));
 
-            response->set_body(MUST(Infrastructure::byte_sequence_as_body(realm, ""sv.bytes())));
+            response->set_body(Infrastructure::byte_sequence_as_body(realm, ""sv.bytes()));
             return PendingResponse::create(vm, request, response);
         }
 
@@ -845,13 +845,13 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
         // 8. If request’s header list does not contain `Range`:
         if (!request->header_list()->contains("Range"sv.bytes())) {
             // 1. Let bodyWithType be the result of safely extracting blob.
-            auto body_with_type = TRY(safely_extract_body(realm, blob->raw_bytes()));
+            auto body_with_type = safely_extract_body(realm, blob->raw_bytes());
 
             // 2. Set response’s status message to `OK`.
             response->set_status_message(MUST(ByteBuffer::copy("OK"sv.bytes())));
 
             // 3. Set response’s body to bodyWithType’s body.
-            response->set_body(move(body_with_type.body));
+            response->set_body(body_with_type.body);
 
             // 4. Set response’s header list to « (`Content-Length`, serializedFullLength), (`Content-Type`, type) ».
             auto content_length_header = Infrastructure::Header::from_string_pair("Content-Length"sv, serialized_full_length);
@@ -903,7 +903,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
             auto sliced_blob = TRY(blob->slice(*range_start, *range_end + 1, type));
 
             // 9. Let slicedBodyWithType be the result of safely extracting slicedBlob.
-            auto sliced_body_with_type = TRY(safely_extract_body(realm, sliced_blob->raw_bytes()));
+            auto sliced_body_with_type = safely_extract_body(realm, sliced_blob->raw_bytes());
 
             // 10. Set response’s body to slicedBodyWithType’s body.
             response->set_body(sliced_body_with_type.body);
@@ -958,7 +958,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
         auto header = Infrastructure::Header::from_string_pair("Content-Type"sv, mime_type);
         response->header_list()->append(move(header));
 
-        response->set_body(TRY(Infrastructure::byte_sequence_as_body(realm, data_url_struct.value().body)));
+        response->set_body(Infrastructure::byte_sequence_as_body(realm, data_url_struct.value().body));
         return PendingResponse::create(vm, request, response);
     }
     // -> "file"
@@ -1308,8 +1308,8 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
         auto converted_source = source.has<ByteBuffer>()
             ? BodyInitOrReadableBytes { source.get<ByteBuffer>() }
             : BodyInitOrReadableBytes { source.get<GC::Root<FileAPI::Blob>>() };
-        auto [body, _] = TRY(safely_extract_body(realm, converted_source));
-        request->set_body(move(body));
+        auto [body, _] = safely_extract_body(realm, converted_source);
+        request->set_body(body);
     }
 
     // 15. Let timingInfo be fetchParams’s timing info.
@@ -2107,8 +2107,8 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 auto converted_source = source.has<ByteBuffer>()
                     ? BodyInitOrReadableBytes { source.get<ByteBuffer>() }
                     : BodyInitOrReadableBytes { source.get<GC::Root<FileAPI::Blob>>() };
-                auto [body, _] = TRY_OR_IGNORE(safely_extract_body(realm, converted_source));
-                request->set_body(move(body));
+                auto [body, _] = safely_extract_body(realm, converted_source);
+                request->set_body(body);
             }
 
             // 3. If request’s use-URL-credentials flag is unset or isAuthenticationFetch is true, then:

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -568,7 +568,7 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                 }
 
                 // 3. Let processBody given bytes be these steps:
-                auto process_body = GC::create_function(vm.heap(), [&realm, request, response, &fetch_params, process_body_error = move(process_body_error)](ByteBuffer bytes) {
+                auto process_body = GC::create_function(vm.heap(), [&realm, request, response, &fetch_params, process_body_error](ByteBuffer bytes) {
                     // 1. If bytes do not match request’s integrity metadata, then run processBodyError and abort these steps.
                     if (!TRY_OR_IGNORE(SRI::do_bytes_match_metadata_list(bytes, request->integrity_metadata()))) {
                         process_body_error->function()({});
@@ -766,7 +766,7 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         // 3. If internalResponse's body is null, then queue a fetch task to run processBody given null, with
         //    fetchParams’s task destination.
         if (!internal_response->body()) {
-            Infrastructure::queue_fetch_task(fetch_params.controller(), task_destination, GC::create_function(vm.heap(), [process_body = move(process_body)]() {
+            Infrastructure::queue_fetch_task(fetch_params.controller(), task_destination, GC::create_function(vm.heap(), [process_body]() {
                 process_body->function()({});
             }));
         }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -93,7 +93,7 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
     auto reader = Streams::acquire_readable_stream_default_reader(m_stream);
 
     if (reader.is_exception()) {
-        auto throw_completion = Bindings::dom_exception_to_throw_completion(realm.vm(), reader.release_error());
+        auto throw_completion = Bindings::exception_to_throw_completion(realm.vm(), reader.release_error());
         error_steps(throw_completion.release_value().value());
         return;
     }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -134,10 +134,10 @@ void Body::incrementally_read_loop(Streams::ReadableStreamDefaultReader& reader,
 }
 
 // https://fetch.spec.whatwg.org/#byte-sequence-as-a-body
-WebIDL::ExceptionOr<GC::Ref<Body>> byte_sequence_as_body(JS::Realm& realm, ReadonlyBytes bytes)
+GC::Ref<Body> byte_sequence_as_body(JS::Realm& realm, ReadonlyBytes bytes)
 {
     // To get a byte sequence bytes as a body, return the body of the result of safely extracting bytes.
-    auto [body, _] = TRY(safely_extract_body(realm, bytes));
+    auto [body, _] = safely_extract_body(realm, bytes);
     return body;
 }
 

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.h
@@ -76,6 +76,6 @@ struct BodyWithType {
     Optional<ByteBuffer> type;
 };
 
-WebIDL::ExceptionOr<GC::Ref<Body>> byte_sequence_as_body(JS::Realm&, ReadonlyBytes);
+GC::Ref<Body> byte_sequence_as_body(JS::Realm&, ReadonlyBytes);
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -422,7 +422,6 @@ void OpaqueFilteredResponse::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_header_list);
-    visitor.visit(m_body);
 }
 
 GC::Ref<OpaqueRedirectFilteredResponse> OpaqueRedirectFilteredResponse::create(JS::VM& vm, GC::Ref<Response> internal_response)
@@ -442,7 +441,6 @@ void OpaqueRedirectFilteredResponse::visit_edges(JS::Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(m_header_list);
-    visitor.visit(m_body);
 }
 
 }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -67,42 +67,41 @@ public:
     void set_type(Type type) { m_type = type; }
 
     [[nodiscard]] virtual bool aborted() const { return m_aborted; }
-    void set_aborted(bool aborted) { m_aborted = aborted; }
+    virtual void set_aborted(bool aborted) { m_aborted = aborted; }
 
     [[nodiscard]] virtual Vector<URL::URL> const& url_list() const { return m_url_list; }
     [[nodiscard]] virtual Vector<URL::URL>& url_list() { return m_url_list; }
-    void set_url_list(Vector<URL::URL> url_list) { m_url_list = move(url_list); }
+    virtual void set_url_list(Vector<URL::URL> url_list) { m_url_list = move(url_list); }
 
     [[nodiscard]] virtual Status status() const { return m_status; }
-    void set_status(Status status) { m_status = status; }
+    virtual void set_status(Status status) { m_status = status; }
 
     [[nodiscard]] virtual ReadonlyBytes status_message() const { return m_status_message; }
-    void set_status_message(ByteBuffer status_message) { m_status_message = move(status_message); }
+    virtual void set_status_message(ByteBuffer status_message) { m_status_message = move(status_message); }
 
     [[nodiscard]] virtual GC::Ref<HeaderList> header_list() const { return m_header_list; }
-    void set_header_list(GC::Ref<HeaderList> header_list) { m_header_list = header_list; }
+    virtual void set_header_list(GC::Ref<HeaderList> header_list) { m_header_list = header_list; }
 
-    [[nodiscard]] virtual GC::Ptr<Body> const& body() const { return m_body; }
-    [[nodiscard]] virtual GC::Ptr<Body>& body() { return m_body; }
-    void set_body(GC::Ptr<Body> body) { m_body = move(body); }
+    [[nodiscard]] virtual GC::Ptr<Body> body() const { return m_body; }
+    virtual void set_body(GC::Ptr<Body> body) { m_body = body; }
 
     [[nodiscard]] virtual Optional<CacheState> const& cache_state() const { return m_cache_state; }
-    void set_cache_state(Optional<CacheState> cache_state) { m_cache_state = move(cache_state); }
+    virtual void set_cache_state(Optional<CacheState> cache_state) { m_cache_state = move(cache_state); }
 
     [[nodiscard]] virtual Vector<ByteBuffer> const& cors_exposed_header_name_list() const { return m_cors_exposed_header_name_list; }
-    void set_cors_exposed_header_name_list(Vector<ByteBuffer> cors_exposed_header_name_list) { m_cors_exposed_header_name_list = move(cors_exposed_header_name_list); }
+    virtual void set_cors_exposed_header_name_list(Vector<ByteBuffer> cors_exposed_header_name_list) { m_cors_exposed_header_name_list = move(cors_exposed_header_name_list); }
 
     [[nodiscard]] virtual bool range_requested() const { return m_range_requested; }
-    void set_range_requested(bool range_requested) { m_range_requested = range_requested; }
+    virtual void set_range_requested(bool range_requested) { m_range_requested = range_requested; }
 
     [[nodiscard]] virtual bool request_includes_credentials() const { return m_request_includes_credentials; }
-    void set_request_includes_credentials(bool request_includes_credentials) { m_request_includes_credentials = request_includes_credentials; }
+    virtual void set_request_includes_credentials(bool request_includes_credentials) { m_request_includes_credentials = request_includes_credentials; }
 
     [[nodiscard]] virtual bool timing_allow_passed() const { return m_timing_allow_passed; }
-    void set_timing_allow_passed(bool timing_allow_passed) { m_timing_allow_passed = timing_allow_passed; }
+    virtual void set_timing_allow_passed(bool timing_allow_passed) { m_timing_allow_passed = timing_allow_passed; }
 
     [[nodiscard]] virtual BodyInfo const& body_info() const { return m_body_info; }
-    void set_body_info(BodyInfo body_info) { m_body_info = body_info; }
+    virtual void set_body_info(BodyInfo body_info) { m_body_info = body_info; }
 
     [[nodiscard]] bool has_cross_origin_redirects() const { return m_has_cross_origin_redirects; }
     void set_has_cross_origin_redirects(bool has_cross_origin_redirects) { m_has_cross_origin_redirects = has_cross_origin_redirects; }
@@ -216,20 +215,43 @@ public:
     virtual ~FilteredResponse() = 0;
 
     [[nodiscard]] virtual Type type() const override { return m_internal_response->type(); }
+
     [[nodiscard]] virtual bool aborted() const override { return m_internal_response->aborted(); }
+    virtual void set_aborted(bool aborted) override { m_internal_response->set_aborted(aborted); }
+
     [[nodiscard]] virtual Vector<URL::URL> const& url_list() const override { return m_internal_response->url_list(); }
     [[nodiscard]] virtual Vector<URL::URL>& url_list() override { return m_internal_response->url_list(); }
+    virtual void set_url_list(Vector<URL::URL> url_list) override { m_internal_response->set_url_list(move(url_list)); }
+
     [[nodiscard]] virtual Status status() const override { return m_internal_response->status(); }
+    virtual void set_status(Status status) override { m_internal_response->set_status(status); }
+
     [[nodiscard]] virtual ReadonlyBytes status_message() const override { return m_internal_response->status_message(); }
+    virtual void set_status_message(ByteBuffer status_message) override { m_internal_response->set_status_message(move(status_message)); }
+
     [[nodiscard]] virtual GC::Ref<HeaderList> header_list() const override { return m_internal_response->header_list(); }
-    [[nodiscard]] virtual GC::Ptr<Body> const& body() const override { return m_internal_response->body(); }
-    [[nodiscard]] virtual GC::Ptr<Body>& body() override { return m_internal_response->body(); }
+    virtual void set_header_list(GC::Ref<HeaderList> header_list) override { m_internal_response->set_header_list(header_list); }
+
+    [[nodiscard]] virtual GC::Ptr<Body> body() const override { return m_internal_response->body(); }
+    virtual void set_body(GC::Ptr<Body> body) override { m_internal_response->set_body(body); }
+
     [[nodiscard]] virtual Optional<CacheState> const& cache_state() const override { return m_internal_response->cache_state(); }
+    virtual void set_cache_state(Optional<CacheState> cache_state) override { m_internal_response->set_cache_state(move(cache_state)); }
+
     [[nodiscard]] virtual Vector<ByteBuffer> const& cors_exposed_header_name_list() const override { return m_internal_response->cors_exposed_header_name_list(); }
+    virtual void set_cors_exposed_header_name_list(Vector<ByteBuffer> cors_exposed_header_name_list) override { m_internal_response->set_cors_exposed_header_name_list(move(cors_exposed_header_name_list)); }
+
     [[nodiscard]] virtual bool range_requested() const override { return m_internal_response->range_requested(); }
+    virtual void set_range_requested(bool range_requested) override { m_internal_response->set_range_requested(range_requested); }
+
     [[nodiscard]] virtual bool request_includes_credentials() const override { return m_internal_response->request_includes_credentials(); }
+    virtual void set_request_includes_credentials(bool request_includes_credentials) override { m_internal_response->set_request_includes_credentials(request_includes_credentials); }
+
     [[nodiscard]] virtual bool timing_allow_passed() const override { return m_internal_response->timing_allow_passed(); }
+    virtual void set_timing_allow_passed(bool timing_allow_passed) override { m_internal_response->set_timing_allow_passed(timing_allow_passed); }
+
     [[nodiscard]] virtual BodyInfo const& body_info() const override { return m_internal_response->body_info(); }
+    virtual void set_body_info(BodyInfo body_info) override { m_internal_response->set_body_info(move(body_info)); }
 
     [[nodiscard]] GC::Ref<Response> internal_response() const { return m_internal_response; }
 
@@ -293,8 +315,7 @@ public:
     [[nodiscard]] virtual Status status() const override { return 0; }
     [[nodiscard]] virtual ReadonlyBytes status_message() const override { return {}; }
     [[nodiscard]] virtual GC::Ref<HeaderList> header_list() const override { return m_header_list; }
-    [[nodiscard]] virtual GC::Ptr<Body> const& body() const override { return m_body; }
-    [[nodiscard]] virtual GC::Ptr<Body>& body() override { return m_body; }
+    [[nodiscard]] virtual GC::Ptr<Body> body() const override { return nullptr; }
 
 private:
     OpaqueFilteredResponse(GC::Ref<Response>, GC::Ref<HeaderList>);
@@ -303,7 +324,6 @@ private:
 
     Vector<URL::URL> m_url_list;
     GC::Ref<HeaderList> m_header_list;
-    GC::Ptr<Body> m_body;
 };
 
 // https://fetch.spec.whatwg.org/#concept-filtered-response-opaque-redirect
@@ -318,8 +338,7 @@ public:
     [[nodiscard]] virtual Status status() const override { return 0; }
     [[nodiscard]] virtual ReadonlyBytes status_message() const override { return {}; }
     [[nodiscard]] virtual GC::Ref<HeaderList> header_list() const override { return m_header_list; }
-    [[nodiscard]] virtual GC::Ptr<Body> const& body() const override { return m_body; }
-    [[nodiscard]] virtual GC::Ptr<Body>& body() override { return m_body; }
+    [[nodiscard]] virtual GC::Ptr<Body> body() const override { return nullptr; }
 
 private:
     OpaqueRedirectFilteredResponse(GC::Ref<Response>, GC::Ref<HeaderList>);
@@ -327,6 +346,5 @@ private:
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
     GC::Ref<HeaderList> m_header_list;
-    GC::Ptr<Body> m_body;
 };
 }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -618,7 +618,8 @@ static GC::Ptr<DOM::Document> attempt_to_create_a_non_fetch_scheme_document(NonF
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-from-a-srcdoc-resource
-static WebIDL::ExceptionOr<GC::Ref<NavigationParams>> create_navigation_params_from_a_srcdoc_resource(GC::Ptr<SessionHistoryEntry> entry, GC::Ptr<Navigable> navigable, TargetSnapshotParams const& target_snapshot_params, Optional<String> navigation_id)
+
+static GC::Ref<NavigationParams> create_navigation_params_from_a_srcdoc_resource(GC::Ptr<SessionHistoryEntry> entry, GC::Ptr<Navigable> navigable, TargetSnapshotParams const& target_snapshot_params, Optional<String> navigation_id)
 {
     auto& vm = navigable->vm();
     VERIFY(navigable->active_window());
@@ -638,7 +639,7 @@ static WebIDL::ExceptionOr<GC::Ref<NavigationParams>> create_navigation_params_f
     auto header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv);
     response->header_list()->append(move(header));
 
-    response->set_body(TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, document_resource.get<String>().bytes())));
+    response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, document_resource.get<String>().bytes()));
 
     // 3. Let responseOrigin be the result of determining the origin given response's URL, targetSnapshotParams's sandboxing flags, and entry's document state's origin.
     auto response_origin = determine_the_origin(response->url(), target_snapshot_params.sandboxing_flags, entry->document_state()->origin());
@@ -1100,7 +1101,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
         //    of creating navigation params from a srcdoc resource given entry, navigable,
         //    targetSnapshotParams, navigationId, and navTimingType.
         if (document_resource.has<String>()) {
-            navigation_params = TRY(create_navigation_params_from_a_srcdoc_resource(entry, this, target_snapshot_params, navigation_id));
+            navigation_params = create_navigation_params_from_a_srcdoc_resource(entry, this, target_snapshot_params, navigation_id);
         }
         // 2. Otherwise, if all of the following are true:
         //    - entry's URL's scheme is a fetch scheme; and
@@ -1377,7 +1378,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         // 1. Queue a global task on the navigation and traversal task source given navigable's active window to navigate to a javascript: URL given navigable, url, historyHandling, initiatorOriginSnapshot, and cspNavigationType.
         VERIFY(active_window());
         queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(heap(), [this, url, history_handling, initiator_origin_snapshot, csp_navigation_type, navigation_id] {
-            (void)navigate_to_a_javascript_url(url, to_history_handling_behavior(history_handling), initiator_origin_snapshot, csp_navigation_type, navigation_id);
+            navigate_to_a_javascript_url(url, to_history_handling_behavior(history_handling), initiator_origin_snapshot, csp_navigation_type, navigation_id);
         }));
 
         // 2. Return.
@@ -1604,7 +1605,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_fragment(URL::URL const& url,
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#evaluate-a-javascript:-url
 // https://whatpr.org/html/9893/browsing-the-web.html#evaluate-a-javascript:-url
-WebIDL::ExceptionOr<GC::Ptr<DOM::Document>> Navigable::evaluate_javascript_url(URL::URL const& url, URL::Origin const& new_document_origin, String navigation_id)
+GC::Ptr<DOM::Document> Navigable::evaluate_javascript_url(URL::URL const& url, URL::Origin const& new_document_origin, String navigation_id)
 {
     auto& vm = this->vm();
     VERIFY(active_window());
@@ -1652,7 +1653,7 @@ WebIDL::ExceptionOr<GC::Ptr<DOM::Document>> Navigable::evaluate_javascript_url(U
     auto header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv);
     response->header_list()->append(move(header));
 
-    response->set_body(TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, result.bytes())));
+    response->set_body(Fetch::Infrastructure::byte_sequence_as_body(realm, result.bytes()));
 
     // 12. Let policyContainer be targetNavigable's active document's policy container.
     auto const& policy_container = active_document()->policy_container();
@@ -1708,7 +1709,7 @@ WebIDL::ExceptionOr<GC::Ptr<DOM::Document>> Navigable::evaluate_javascript_url(U
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-to-a-javascript:-url
-WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHandlingBehavior history_handling, URL::Origin const& initiator_origin, CSPNavigationType csp_navigation_type, String navigation_id)
+void Navigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHandlingBehavior history_handling, URL::Origin const& initiator_origin, CSPNavigationType csp_navigation_type, String navigation_id)
 {
     // 1. Assert: historyHandling is "replace".
     VERIFY(history_handling == HistoryHandlingBehavior::Replace);
@@ -1718,7 +1719,7 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(URL::URL const
 
     // 3. If initiatorOrigin is not same origin-domain with targetNavigable's active document's origin, then return.
     if (!initiator_origin.is_same_origin_domain(active_document()->origin()))
-        return {};
+        return;
 
     // FIXME: 4. Let request be a new request whose URL is url.
 
@@ -1726,12 +1727,12 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(URL::URL const
     (void)csp_navigation_type;
 
     // 6. Let newDocument be the result of evaluating a javascript: URL given targetNavigable, url, and initiatorOrigin.
-    auto new_document = TRY(evaluate_javascript_url(url, initiator_origin, navigation_id));
+    auto new_document = evaluate_javascript_url(url, initiator_origin, navigation_id);
 
     // 7. If newDocument is null, then return.
     if (!new_document) {
         // NOTE: In this case, some JavaScript code was executed, but no new Document was created, so we will not perform a navigation.
-        return {};
+        return;
     }
 
     // 8. Assert: initiatorOrigin is newDocument's origin.
@@ -1776,8 +1777,6 @@ WebIDL::ExceptionOr<void> Navigable::navigate_to_a_javascript_url(URL::URL const
     traversable_navigable()->append_session_history_traversal_steps(GC::create_function(heap(), [this, history_entry, history_handling, navigation_id] {
         finalize_a_cross_document_navigation(*this, history_handling, history_entry);
     }));
-
-    return {};
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#reload

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -156,8 +156,8 @@ public:
 
     WebIDL::ExceptionOr<void> navigate_to_a_fragment(URL::URL const&, HistoryHandlingBehavior, UserNavigationInvolvement, Optional<SerializationRecord> navigation_api_state, String navigation_id);
 
-    WebIDL::ExceptionOr<GC::Ptr<DOM::Document>> evaluate_javascript_url(URL::URL const&, URL::Origin const& new_document_origin, String navigation_id);
-    WebIDL::ExceptionOr<void> navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, URL::Origin const& initiator_origin, CSPNavigationType csp_navigation_type, String navigation_id);
+    GC::Ptr<DOM::Document> evaluate_javascript_url(URL::URL const&, URL::Origin const& new_document_origin, String navigation_id);
+    void navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, URL::Origin const& initiator_origin, CSPNavigationType csp_navigation_type, String navigation_id);
 
     bool allowed_by_sandboxing_to_navigate(Navigable const& target, SourceSnapshotParams const&);
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1055,7 +1055,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
                 //    If an exception is thrown, then catch it, report the exception, insert an element at the adjusted insertion location with template, and return.
                 auto result = declarative_shadow_host_element.attach_a_shadow_root(mode, clonable, serializable, delegates_focus, Bindings::SlotAssignmentMode::Named);
                 if (result.is_error()) {
-                    report_exception(Bindings::dom_exception_to_throw_completion(vm(), result.release_error()), realm());
+                    report_exception(Bindings::exception_to_throw_completion(vm(), result.release_error()), realm());
                     insert_an_element_at_the_adjusted_insertion_location(template_);
                     return;
                 }

--- a/Libraries/LibWeb/HTML/Scripting/ImportMapParseResult.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ImportMapParseResult.cpp
@@ -68,7 +68,7 @@ void ImportMapParseResult::register_import_map(Window& global)
 {
     // 1. If result's error to rethrow is not null, then report the exception given by result's error to rethrow and return.
     if (m_error_to_rethrow.has_value()) {
-        auto completion = Web::Bindings::dom_exception_to_throw_completion(global.vm(), m_error_to_rethrow.value());
+        auto completion = Web::Bindings::exception_to_throw_completion(global.vm(), m_error_to_rethrow.value());
         HTML::report_exception(completion, global.realm());
         return;
     }

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -315,16 +315,18 @@ GC::Ref<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source, Writabl
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     });
 
-    auto success_steps = GC::create_function(realm.heap(), [promise, &realm, writer](ByteBuffer) {
+    auto success_steps = GC::create_function(realm.heap(), [promise, &realm, reader, writer](ByteBuffer) {
         // Make sure we close the acquired writer.
         WebIDL::resolve_promise(realm, writable_stream_default_writer_close(*writer), JS::js_undefined());
+        readable_stream_default_reader_release(*reader);
 
         WebIDL::resolve_promise(realm, promise, JS::js_undefined());
     });
 
-    auto failure_steps = GC::create_function(realm.heap(), [promise, &realm, writer](JS::Value error) {
+    auto failure_steps = GC::create_function(realm.heap(), [promise, &realm, reader, writer](JS::Value error) {
         // Make sure we close the acquired writer.
         WebIDL::resolve_promise(realm, writable_stream_default_writer_close(*writer), JS::js_undefined());
+        readable_stream_default_reader_release(*reader);
 
         WebIDL::reject_promise(realm, promise, error);
     });

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -709,7 +709,7 @@ public:
     {
         // 1. Queue a microtask to perform the following steps:
         HTML::queue_a_microtask(nullptr, GC::create_function(m_realm->heap(), [this, chunk]() mutable {
-            HTML::TemporaryExecutionContext execution_context { m_realm };
+            HTML::TemporaryExecutionContext execution_context { m_realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
             auto controller1 = m_params->branch1->controller()->get<GC::Ref<ReadableByteStreamController>>();
             auto controller2 = m_params->branch2->controller()->get<GC::Ref<ReadableByteStreamController>>();

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -423,7 +423,7 @@ public:
 
                 // 2. If cloneResult is an abrupt completion,
                 if (clone_result.is_exception()) {
-                    auto completion = Bindings::dom_exception_to_throw_completion(m_realm->vm(), clone_result.release_error());
+                    auto completion = Bindings::exception_to_throw_completion(m_realm->vm(), clone_result.release_error());
 
                     // 1. Perform ! ReadableStreamDefaultControllerError(branch1.[[controller]], cloneResult.[[Value]]).
                     readable_stream_default_controller_error(controller1, completion.value().value());
@@ -734,7 +734,7 @@ public:
 
                 // 2. If cloneResult is an abrupt completion,
                 if (clone_result.is_exception()) {
-                    auto completion = Bindings::dom_exception_to_throw_completion(m_realm->vm(), clone_result.release_error());
+                    auto completion = Bindings::exception_to_throw_completion(m_realm->vm(), clone_result.release_error());
 
                     // 1. Perform ! ReadableByteStreamControllerError(branch1.[[controller]], cloneResult.[[Value]]).
                     readable_byte_stream_controller_error(controller1, completion.value().value());
@@ -898,7 +898,7 @@ public:
 
                 // 2. If cloneResult is an abrupt completion,
                 if (clone_result.is_exception()) {
-                    auto completion = Bindings::dom_exception_to_throw_completion(m_realm->vm(), clone_result.release_error());
+                    auto completion = Bindings::exception_to_throw_completion(m_realm->vm(), clone_result.release_error());
 
                     // 1. Perform ! ReadableByteStreamControllerError(byobBranch.[[controller]], cloneResult.[[Value]]).
                     readable_byte_stream_controller_error(byob_controller, completion.value().value());
@@ -1857,7 +1857,7 @@ void readable_byte_stream_controller_pull_into(ReadableByteStreamController& con
     // 8. If bufferResult is an abrupt completion,
     if (buffer_result.is_exception()) {
         // 1. Perform readIntoRequest’s error steps, given bufferResult.[[Value]].
-        auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, buffer_result.exception());
+        auto throw_completion = Bindings::exception_to_throw_completion(vm, buffer_result.exception());
         read_into_request.on_error(*throw_completion.release_value());
 
         // 2. Return.
@@ -4863,7 +4863,7 @@ void set_up_transform_stream_default_controller_from_transformer(TransformStream
 
         // 2. If result is an abrupt completion, return a promise rejected with result.[[Value]].
         if (result.is_error()) {
-            auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, result.exception());
+            auto throw_completion = Bindings::exception_to_throw_completion(vm, result.exception());
             return WebIDL::create_rejected_promise(realm, *throw_completion.release_value());
         }
 
@@ -4951,7 +4951,7 @@ WebIDL::ExceptionOr<void> transform_stream_default_controller_enqueue(TransformS
 
     // 5. If enqueueResult is an abrupt completion,
     if (enqueue_result.is_error()) {
-        auto throw_completion = Bindings::dom_exception_to_throw_completion(vm, enqueue_result.exception());
+        auto throw_completion = Bindings::exception_to_throw_completion(vm, enqueue_result.exception());
 
         // 1. Perform ! TransformStreamErrorWritableAndUnblockWrite(stream, enqueueResult.[[Value]]).
         transform_stream_error_writable_and_unblock_write(*stream, throw_completion.value().value());

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -701,7 +701,7 @@ GC::Ref<WebIDL::Promise> compile_potential_webassembly_response(JS::VM& vm, GC::
         // 8. Consume response’s body as an ArrayBuffer, and let bodyPromise be the result.
         auto body_promise_or_error = response_object.array_buffer();
         if (body_promise_or_error.is_error()) {
-            auto throw_completion = Bindings::dom_exception_to_throw_completion(realm.vm(), body_promise_or_error.release_error());
+            auto throw_completion = Bindings::exception_to_throw_completion(realm.vm(), body_promise_or_error.release_error());
             WebIDL::reject_promise(realm, return_value, *throw_completion.value());
             return JS::js_undefined();
         }

--- a/Libraries/LibWeb/WebIDL/Promise.cpp
+++ b/Libraries/LibWeb/WebIDL/Promise.cpp
@@ -292,7 +292,7 @@ void wait_for_all(JS::Realm& realm, Vector<GC::Ref<Promise>> const& promises, Fu
 
 GC::Ref<Promise> create_rejected_promise_from_exception(JS::Realm& realm, Exception exception)
 {
-    auto throw_completion = Bindings::dom_exception_to_throw_completion(realm.vm(), move(exception));
+    auto throw_completion = Bindings::exception_to_throw_completion(realm.vm(), move(exception));
     return WebIDL::create_rejected_promise(realm, *throw_completion.value());
 }
 

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -574,15 +574,15 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
         // 2. If body is a Document, then set this’s request body to body, serialized, converted, and UTF-8 encoded.
         if (body->has<GC::Root<DOM::Document>>()) {
             auto string_serialized_document = TRY(body->get<GC::Root<DOM::Document>>().cell()->serialize_fragment(DOMParsing::RequireWellFormed::No));
-            m_request_body = TRY(Fetch::Infrastructure::byte_sequence_as_body(realm, string_serialized_document.bytes()));
+            m_request_body = Fetch::Infrastructure::byte_sequence_as_body(realm, string_serialized_document.bytes());
         }
         // 3. Otherwise:
         else {
             // 1. Let bodyWithType be the result of safely extracting body.
-            auto body_with_type = TRY(Fetch::safely_extract_body(realm, body->downcast<Fetch::BodyInitOrReadableBytes>()));
+            auto body_with_type = Fetch::safely_extract_body(realm, body->downcast<Fetch::BodyInitOrReadableBytes>());
 
             // 2. Set this’s request body to bodyWithType’s body.
-            m_request_body = move(body_with_type.body);
+            m_request_body = body_with_type.body;
 
             // 3. Set extractedContentType to bodyWithType’s type.
             extracted_content_type = move(body_with_type.type);


### PR DESCRIPTION
By actually using streams, they get marked as disturbed and the `.bodyUsed` API starts to work. Fixes at least 94 subtests in the WPT `fetch/api/request` test suite.

Pretty far out of my comfort zone for this so a thorough review is appreciated!

WPT results for `fetch/api/request`, before:
```
Ran 1065 checks (971 subtests, 94 tests)
Expected results: 813
Unexpected results: 252
  test: 35 (35 error)
  subtest: 217 (217 fail)
```

And after:
```
Ran 1065 checks (971 subtests, 94 tests)
Expected results: 907
Unexpected results: 158
  test: 35 (35 error)
  subtest: 123 (123 fail)
```
