### PR TITLE
WebContent: Ensure we mark a driver endpoint as complete in early return

### DIFF
--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -338,7 +338,7 @@ void Page::prompt_closed(Optional<String> response)
     }
 }
 
-void Page::dismiss_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed)
+void Page::dismiss_dialog(JS::NonnullGCPtr<JS::HeapFunction<void()>> on_dialog_closed)
 {
     m_on_pending_dialog_closed = on_dialog_closed;
 
@@ -355,7 +355,7 @@ void Page::dismiss_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed)
     }
 }
 
-void Page::accept_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed)
+void Page::accept_dialog(JS::NonnullGCPtr<JS::HeapFunction<void()>> on_dialog_closed)
 {
     m_on_pending_dialog_closed = on_dialog_closed;
 

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -148,8 +148,8 @@ public:
     bool has_pending_dialog() const { return m_pending_dialog != PendingDialog::None; }
     PendingDialog pending_dialog() const { return m_pending_dialog; }
     Optional<String> const& pending_dialog_text() const { return m_pending_dialog_text; }
-    void dismiss_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed = nullptr);
-    void accept_dialog(JS::GCPtr<JS::HeapFunction<void()>> on_dialog_closed = nullptr);
+    void dismiss_dialog(JS::NonnullGCPtr<JS::HeapFunction<void()>> on_dialog_closed);
+    void accept_dialog(JS::NonnullGCPtr<JS::HeapFunction<void()>> on_dialog_closed);
 
     void did_request_color_picker(WeakPtr<HTML::HTMLInputElement> target, Color current_color);
     void color_picker_update(Optional<Color> picked_color, HTML::ColorPickerUpdateState state);

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -659,6 +659,7 @@ Messages::WebDriverClient::SwitchToParentFrameResponse WebDriverConnection::swit
         TRY(ensure_current_browsing_context_is_open());
 
         // 2. Return success with data null.
+        async_driver_execution_complete(JsonValue {});
         return JsonValue {};
     }
 


### PR DESCRIPTION
Fixes a mistake from 3da20aca65d5cf71799ea0c51b40536676398194.