### PR TITLE
CMake: Add warning for missing field initializers globally

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -69,6 +69,7 @@ add_cxx_compile_options(-Wcast-qual)
 add_cxx_compile_options(-Wformat=2)
 add_cxx_compile_options(-Wimplicit-fallthrough)
 add_cxx_compile_options(-Wmissing-declarations)
+add_cxx_compile_options(-Wmissing-field-initializers)
 add_cxx_compile_options(-Wsuggest-override)
 
 add_cxx_compile_options(-Wno-invalid-offsetof)


### PR DESCRIPTION
This warning is already enabled by our existing flags with gcc-13, so make sure that clang checks these as well.