### PR TITLE
LibWeb: Ensure inputs are repainted when their checkedness is toggled

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -166,6 +166,8 @@ void HTMLInputElement::set_checked(bool checked, ChangeSource change_source)
     m_checked = checked;
 
     invalidate_style(DOM::StyleInvalidationReason::HTMLInputElementSetChecked);
+    if (auto* paintable = this->paintable())
+        paintable->set_needs_display();
 }
 
 void HTMLInputElement::set_checked_binding(bool checked)


### PR DESCRIPTION
Previously, input elements weren't always redrawn when their checkedness was set programmatically.

The issue can be seen on the following test page:

```html
<!DOCTYPE html>
<input id="checkbox" type="checkbox">
<input id="radio1" type="radio" name="radio">
<input id="radio2" type="radio" name="radio">

<script>
    const checkbox = document.getElementById("checkbox");
    const radio1 = document.getElementById("radio1");
    const radio2 = document.getElementById("radio2");
    let currentRadio = radio1
    setInterval(() => {
        checkbox.click();
        currentRadio.click();
        currentRadio = currentRadio === radio1 ? radio2 : radio1;
    }, 100);
</script>
```
Before this change, all of the above inputs would appear to remain unchecked - unless something happened which forced a repaint - such as a window resize.

I've tried to create a reftest that replicates this issue, but it seems that you need to wait some amount of time before the issue will manifest. For example, the inputs will be correctly repainted if the above test is changed to use `setTimeout` with a delay of 1 millisecond, but they won't be repainted if the delay is changed to 100 milliseconds (on my local machine).