### PR TITLE
LibWeb: Consider every row when calculating table width

### DIFF
--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -1,12 +1,12 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x117 children: not-inline
-      TableWrapper <(anonymous)> at (8,8) content-size 92.359375x117 [BFC] children: not-inline
-        Box <table> at (8,8) content-size 92.359375x117 table-box [TFC] children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 93.359375x117 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 93.359375x117 table-box [TFC] children: not-inline
           BlockContainer <(anonymous)> (not painted) children: inline
             TextNode <#text>
-          Box <tbody> at (8,8) content-size 92.359375x117 table-row-group children: not-inline
-            Box <tr> at (8,8) content-size 92.359375x39 table-row children: not-inline
+          Box <tbody> at (8,8) content-size 93.359375x117 table-row-group children: not-inline
+            Box <tr> at (8,8) content-size 93.359375x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (19,19) content-size 8.453125x17 table-cell [BFC] children: inline
@@ -27,9 +27,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
+              BlockContainer <(anonymous)> at (101.359375,27.5) content-size 0x0 table-cell [BFC] children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,47) content-size 92.359375x39 table-row children: not-inline
+            Box <tr> at (8,47) content-size 93.359375x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (19,58) content-size 8.453125x17 table-cell [BFC] children: inline
@@ -38,7 +39,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,77.5) content-size 39.90625x17 table-cell [BFC] children: inline
+              BlockContainer <td> at (49.453125,77.5) content-size 40.90625x17 table-cell [BFC] children: inline
                 frag 0 from TextNode start: 0, length: 3, rect: [49.453125,77.5 24.046875x17] baseline: 13.296875
                     "6-9"
                 TextNode <#text>
@@ -46,7 +47,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            Box <tr> at (8,86) content-size 92.359375x39 table-row children: not-inline
+            Box <tr> at (8,86) content-size 93.359375x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (19,97) content-size 8.453125x17 table-cell [BFC] children: inline
@@ -61,21 +62,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x117]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 92.359375x117]
-        PaintableBox (Box<TABLE>) [8,8 92.359375x117]
-          PaintableBox (Box<TBODY>) [8,8 92.359375x117]
-            PaintableBox (Box<TR>) [8,8 92.359375x39]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 93.359375x117]
+        PaintableBox (Box<TABLE>) [8,8 93.359375x117]
+          PaintableBox (Box<TBODY>) [8,8 93.359375x117]
+            PaintableBox (Box<TR>) [8,8 93.359375x39]
               PaintableWithLines (BlockContainer<TD>) [8,8 30.453125x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [38.453125,8 30.8125x39]
                 TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [69.265625,8 31.09375x39]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [8,47 92.359375x39]
+              PaintableWithLines (BlockContainer(anonymous)) [100.359375,8 1x39]
+            PaintableBox (Box<TR>) [8,47 93.359375x39]
               PaintableWithLines (BlockContainer<TD>) [8,47 30.453125x39]
                 TextPaintable (TextNode<#text>)
-              PaintableWithLines (BlockContainer<TD>) [38.453125,47 61.90625x78]
+              PaintableWithLines (BlockContainer<TD>) [38.453125,47 62.90625x78]
                 TextPaintable (TextNode<#text>)
-            PaintableBox (Box<TR>) [8,86 92.359375x39]
+            PaintableBox (Box<TR>) [8,86 93.359375x39]
               PaintableWithLines (BlockContainer<TD>) [8,86 30.453125x39]
                 TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
@@ -1,0 +1,61 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x61 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 27.90625x44 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 27.90625x44 table-box [TFC] children: not-inline
+          BlockContainer <(anonymous)> (not painted) children: inline
+            TextNode <#text>
+          Box <tbody> at (10,10) content-size 23.90625x40 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 23.90625x19 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 6.8125x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
+                    "1"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <(anonymous)> at (20.8125,19.5) content-size 0x0 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (22.8125,19.5) content-size 11.09375x0 table-cell [BFC] children: not-inline
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+            Box <tr> at (10,31) content-size 23.90625x19 table-row children: not-inline
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 8.8125x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [11,32 8.8125x17] baseline: 13.296875
+                    "2"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+              BlockContainer <td> at (23.8125,32) content-size 9.09375x17 table-cell [BFC] children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [23.8125,32 9.09375x17] baseline: 13.296875
+                    "3"
+                TextNode <#text>
+              BlockContainer <(anonymous)> (not painted) children: inline
+                TextNode <#text>
+            BlockContainer <(anonymous)> (not painted) children: inline
+              TextNode <#text>
+      BlockContainer <(anonymous)> at (8,52) content-size 784x17 children: inline
+        frag 0 from TextNode start: 1, length: 19, rect: [8,52 162.109375x17] baseline: 13.296875
+            "PASS (didn't crash)"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x61]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 27.90625x44]
+        PaintableBox (Box<TABLE>) [8,8 27.90625x44]
+          PaintableBox (Box<TBODY>) [10,10 23.90625x40]
+            PaintableBox (Box<TR>) [10,10 23.90625x19]
+              PaintableWithLines (BlockContainer<TD>) [10,10 8.8125x19]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [20.8125,10 0x19]
+              PaintableWithLines (BlockContainer(anonymous)) [22.8125,10 11.09375x19]
+            PaintableBox (Box<TR>) [10,31 23.90625x19]
+              PaintableWithLines (BlockContainer<TD>) [10,31 10.8125x19]
+                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [22.8125,31 11.09375x19]
+                TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,52 784x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/table/colspan-overflow-crash.html
+++ b/Tests/LibWeb/Layout/input/table/colspan-overflow-crash.html
@@ -1,0 +1,10 @@
+<table>
+    <tr>
+        <td>1</td>
+    </tr>
+    <tr>
+        <td colspan="2">2</td>
+        <td>3</td>
+    </tr>
+</table>
+PASS (didn't crash)

--- a/Userland/Libraries/LibWeb/Layout/TableGrid.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableGrid.cpp
@@ -43,7 +43,7 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
                     rowspan = node.row_span();
                 }
 
-                if (x_width < x_current + colspan && y_current == 0)
+                if (x_width < x_current + colspan)
                     x_width = x_current + colspan;
                 if (y_height < y_current + rowspan)
                     y_height = y_current + rowspan;


### PR DESCRIPTION
Prevents a crash on https://en.wikipedia.org/wiki/Roguelike.

The crash occurs when a colspan causes cell's position to be further than the width of the first row (see crashtest).