### PR TITLE
LibWeb+AK: Prevent segfault when parsing unicode ranges

### DIFF
--- a/AK/GenericLexer.cpp
+++ b/AK/GenericLexer.cpp
@@ -16,9 +16,6 @@ namespace AK {
 // Consume a number of characters
 StringView GenericLexer::consume(size_t count)
 {
-    if (count == 0)
-        return {};
-
     size_t start = m_index;
     size_t length = min(count, m_input.length() - m_index);
     m_index += length;
@@ -29,9 +26,6 @@ StringView GenericLexer::consume(size_t count)
 // Consume the rest of the input
 StringView GenericLexer::consume_all()
 {
-    if (is_eof())
-        return {};
-
     auto rest = m_input.substring_view(m_index, m_input.length() - m_index);
     m_index = m_input.length();
     return rest;
@@ -48,8 +42,6 @@ StringView GenericLexer::consume_line()
     consume_specific('\r');
     consume_specific('\n');
 
-    if (length == 0)
-        return {};
     return m_input.substring_view(start, length);
 }
 
@@ -61,8 +53,6 @@ StringView GenericLexer::consume_until(char stop)
         m_index++;
     size_t length = m_index - start;
 
-    if (length == 0)
-        return {};
     return m_input.substring_view(start, length);
 }
 
@@ -74,8 +64,6 @@ StringView GenericLexer::consume_until(char const* stop)
         m_index++;
     size_t length = m_index - start;
 
-    if (length == 0)
-        return {};
     return m_input.substring_view(start, length);
 }
 
@@ -87,8 +75,6 @@ StringView GenericLexer::consume_until(StringView stop)
         m_index++;
     size_t length = m_index - start;
 
-    if (length == 0)
-        return {};
     return m_input.substring_view(start, length);
 }
 

--- a/AK/GenericLexer.h
+++ b/AK/GenericLexer.h
@@ -184,8 +184,6 @@ public:
             ++m_index;
         size_t length = m_index - start;
 
-        if (length == 0)
-            return {};
         return m_input.substring_view(start, length);
     }
 
@@ -198,8 +196,6 @@ public:
             ++m_index;
         size_t length = m_index - start;
 
-        if (length == 0)
-            return {};
         return m_input.substring_view(start, length);
     }
 

--- a/Tests/LibWeb/Text/expected/css/unicode-range-all-wildcard.txt
+++ b/Tests/LibWeb/Text/expected/css/unicode-range-all-wildcard.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/unicode-range-all-wildcard.html
+++ b/Tests/LibWeb/Text/input/css/unicode-range-all-wildcard.html
@@ -1,0 +1,11 @@
+<style>
+    @font-face {
+        unicode-range: U+??;
+    }
+</style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println("PASS (didn't crash)");
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2217,6 +2217,7 @@ Optional<Gfx::UnicodeRange> Parser::parse_unicode_range(StringView text)
 
     // 3. Consume as many hex digits from text as possible.
     //    then consume as many U+003F QUESTION MARK (?) code points as possible.
+    auto start_position = lexer.tell();
     auto hex_digits = lexer.consume_while(is_ascii_hex_digit);
     auto question_marks = lexer.consume_while([](auto it) { return it == '?'; });
     //    If zero code points were consumed, or more than six code points were consumed,
@@ -2226,7 +2227,7 @@ Optional<Gfx::UnicodeRange> Parser::parse_unicode_range(StringView text)
         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: <urange> start value had {} digits/?s, expected between 1 and 6.", consumed_code_points);
         return {};
     }
-    StringView start_value_code_points { hex_digits.characters_without_null_termination(), consumed_code_points };
+    StringView start_value_code_points = text.substring_view(start_position, consumed_code_points);
 
     //    If any U+003F QUESTION MARK (?) code points were consumed, then:
     if (question_marks.length() > 0) {


### PR DESCRIPTION
Fixes a segfault when parsing a wildcard-only unicode range.