### PR TITLE
WebDriver: Transfer session capabilities to new windows, and some window closing fixes

### DIFF
--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -279,7 +279,8 @@ Messages::WebDriverClient::SetTimeoutsResponse WebDriverConnection::set_timeouts
     // 2. Make the session timeouts the new timeouts.
 
     // 3. Return success with data null.
-    return JsonValue {};
+    // NOTE: We return the current timeouts configuration so the client may store them for new sessions.
+    return Web::WebDriver::timeouts_object(m_timeouts_configuration);
 }
 
 // 10.1 Navigate To, https://w3c.github.io/webdriver/#navigate-to

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -193,14 +193,14 @@ Web::WebDriver::Response Session::set_timeouts(JsonValue payload)
 // 11.2 Close Window, https://w3c.github.io/webdriver/#dfn-close-window
 Web::WebDriver::Response Session::close_window()
 {
+    // 3. Close the current top-level browsing context.
+    TRY(perform_async_action([&](auto& connection) {
+        return connection.close_window();
+    }));
+
     {
         // Defer removing the window handle from this session until after we know we are done with its connection.
         ScopeGuard guard { [this] { m_windows.remove(m_current_window_handle); m_current_window_handle = "NoSuchWindowPleaseSelectANewOne"_string; } };
-
-        // 3. Close the current top-level browsing context.
-        TRY(perform_async_action([&](auto& connection) {
-            return connection.close_window();
-        }));
 
         // 4. If there are no more open top-level browsing contexts, then close the session.
         if (m_windows.size() == 1)

--- a/Userland/Services/WebDriver/Session.cpp
+++ b/Userland/Services/WebDriver/Session.cpp
@@ -142,6 +142,13 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<S
             if (m_windows.is_empty())
                 m_client->close_session(session_id());
         };
+
+        web_content_connection->async_set_page_load_strategy(m_page_load_strategy);
+        web_content_connection->async_set_strict_file_interactability(m_strict_file_interactiblity);
+        web_content_connection->async_set_unhandled_prompt_behavior(m_unhandled_prompt_behavior);
+        if (m_timeouts_configuration.has_value())
+            web_content_connection->async_set_timeouts(*m_timeouts_configuration);
+
         m_windows.set(window_handle, Session::Window { window_handle, move(web_content_connection) });
 
         if (m_current_window_handle.is_empty())

--- a/Userland/Services/WebDriver/Session.h
+++ b/Userland/Services/WebDriver/Session.h
@@ -9,12 +9,14 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/JsonValue.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Promise.h>
+#include <LibWeb/WebDriver/Capabilities.h>
 #include <LibWeb/WebDriver/Error.h>
 #include <LibWeb/WebDriver/Response.h>
 #include <WebDriver/WebContentConnection.h>
@@ -28,6 +30,8 @@ class Session : public RefCounted<Session> {
 public:
     Session(unsigned session_id, NonnullRefPtr<Client> client, Web::WebDriver::LadybirdOptions options);
     ~Session();
+
+    void initialize_from_capabilities(JsonObject&);
 
     unsigned session_id() const { return m_id; }
 
@@ -52,6 +56,8 @@ public:
     bool has_window_handle(StringView handle) const { return m_windows.contains(handle); }
 
     ErrorOr<void> start(LaunchBrowserCallbacks const&);
+
+    Web::WebDriver::Response set_timeouts(JsonValue);
     Web::WebDriver::Response close_window();
     Web::WebDriver::Response switch_to_window(StringView);
     Web::WebDriver::Response get_window_handles() const;
@@ -92,6 +98,11 @@ private:
     Optional<pid_t> m_browser_pid;
 
     RefPtr<Core::LocalServer> m_web_content_server;
+
+    Web::WebDriver::PageLoadStrategy m_page_load_strategy { Web::WebDriver::PageLoadStrategy::Normal };
+    Web::WebDriver::UnhandledPromptBehavior m_unhandled_prompt_behavior { Web::WebDriver::UnhandledPromptBehavior::DismissAndNotify };
+    Optional<JsonValue> m_timeouts_configuration;
+    bool m_strict_file_interactiblity { false };
 };
 
 }


### PR DESCRIPTION
Capabilities are configured on a per-session basis, but we were only applying these options to the first WebContent process created. We need to pass these options to new windows created from that process.

This fixes the following WPT tests:
`/webdriver/tests/classic/close_window/user_prompts.py`
`/webdriver/tests/classic/switch_to_window/switch.py`
