### PR TITLE
Tests: Allow importing WPT ref-tests

### DIFF
--- a/Documentation/Testing.md
+++ b/Documentation/Testing.md
@@ -118,7 +118,7 @@ You can import certain Web Platform Tests (WPT) tests into your Ladybird clone 
 ./Meta/WPT.sh import html/dom/aria-attribute-reflection.html
 ```
 
-That is, you give `./Meta/WPT.sh import` the path part of any `http://wpt.live/` URL for a WPT test you want to import. It will then download both that test and any of its JavaScript scripts, copy those to the `Tests/LibWeb/Text/input/wpt-import` directory, run the test, and then in the `Tests/LibWeb/Text/expected/wpt-import` directory, it will create a file with the expected results from the test.
+That is, you give `./Meta/WPT.sh import` the path part of any `http://wpt.live/` URL for a WPT test you want to import. It will then download both that test and any of its JavaScript scripts, copy those to the `Tests/LibWeb/<test-type>/input/wpt-import` directory, run the test, and then in the `Tests/LibWeb/<test-type>/expected/wpt-import` directory, it will create a file with the expected results from the test.
 
 
 ## Writing tests

--- a/Meta/import-wpt-test.py
+++ b/Meta/import-wpt-test.py
@@ -8,12 +8,30 @@ from pathlib import Path
 from urllib.parse import urljoin
 from urllib.request import urlopen
 from collections import namedtuple
+from enum import Enum
 
 wpt_base_url = 'https://wpt.live/'
-wpt_import_path = 'Tests/LibWeb/Text/input/wpt-import'
-wpt_expected_path = 'Tests/LibWeb/Text/expected/wpt-import'
+
+
+class TestType(Enum):
+    TEXT = 1, 'Tests/LibWeb/Text/input/wpt-import', 'Tests/LibWeb/Text/expected/wpt-import'
+    REF = 2, 'Tests/LibWeb/Ref/input/wpt-import', 'Tests/LibWeb/Ref/expected/wpt-import'
+
+    def __new__(cls, *args, **kwds):
+        obj = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    def __init__(self, _: str, input_path: str, expected_path: str):
+        self.input_path = input_path
+        self.expected_path = expected_path
+
+
 PathMapping = namedtuple('PathMapping', ['source', 'destination'])
 
+test_type = TestType.TEXT
+raw_reference_path = None  # As specified in the test HTML
+reference_path = None  # With parent directories
 src_values = []
 
 
@@ -26,30 +44,52 @@ class ScriptSrcValueFinder(HTMLParser):
                 src_values.append(attr_dict["src"])
 
 
+class TestTypeIdentifier(HTMLParser):
+    """Identifies what kind of test the page is, and stores it in self.test_type
+    For reference tests, the URL of the reference page is saved as self.reference_path
+    """
+
+    def __init__(self, url):
+        super().__init__()
+        self.url = url
+        self.test_type = TestType.TEXT
+        self.reference_path = None
+
+    def handle_starttag(self, tag, attrs):
+        if tag == "link":
+            attr_dict = dict(attrs)
+            if attr_dict["rel"] == "match":
+                self.test_type = TestType.REF
+                self.reference_path = attr_dict["href"]
+
+
 def map_to_path(sources, is_resource=True, resource_path=None):
     if is_resource:
         # Add it as a sibling path if it's a relative resource
         sibling_location = Path(resource_path).parent.__str__()
-        sibling_import_path = wpt_import_path + '/' + sibling_location
+        sibling_import_path = test_type.input_path + '/' + sibling_location
 
         def remapper(x):
             if x.startswith('/'):
-                return wpt_import_path + x
+                return test_type.input_path + x
             return sibling_import_path + '/' + x
 
         filepaths = list(map(remapper, sources))
         filepaths = list(map(lambda x: Path(x), filepaths))
     else:
-        # Add the wpt_import_path to the sources if root files
+        # Add the test_type.input_path to the sources if root files
         def remapper(x):
-            return wpt_import_path + '/' + x
+            if x.startswith('/'):
+                return test_type.input_path + x
+            return test_type.input_path + '/' + x
 
         filepaths = list(map(lambda x: Path(remapper(x)), sources))
 
     # Map to source and destination
     def path_mapper(x):
-        output_path = wpt_base_url + x.__str__().replace(wpt_import_path, '')
+        output_path = wpt_base_url + x.__str__().replace(test_type.input_path, '')
         return PathMapping(output_path, x.absolute())
+
     filepaths = list(map(path_mapper, filepaths))
 
     return filepaths
@@ -58,8 +98,13 @@ def map_to_path(sources, is_resource=True, resource_path=None):
 def modify_sources(files):
     for file in files:
         # Get the distance to the wpt-imports folder
-        folder_index = str(file).find(wpt_import_path)
-        non_prefixed_path = str(file)[folder_index + len(wpt_import_path):]
+        folder_index = str(file).find(test_type.input_path)
+        if folder_index == -1:
+            folder_index = str(file).find(test_type.expected_path)
+            non_prefixed_path = str(file)[folder_index + len(test_type.expected_path):]
+        else:
+            non_prefixed_path = str(file)[folder_index + len(test_type.input_path):]
+
         parent_folder_count = len(Path(non_prefixed_path).parent.parts) - 1
         parent_folder_path = '../' * parent_folder_count
 
@@ -71,8 +116,14 @@ def modify_sources(files):
             if src_value.startswith('/'):
                 new_src_value = parent_folder_path + src_value[1::]
                 page_source = page_source.replace(src_value, new_src_value)
-                with open(file, 'w') as f:
-                    f.write(str(page_source))
+
+        # Look for mentions of the reference page, and update their href
+        if raw_reference_path is not None:
+            new_reference_path = parent_folder_path + '../../expected/wpt-import/' + reference_path[::]
+            page_source = page_source.replace(raw_reference_path, new_reference_path)
+
+        with open(file, 'w') as f:
+            f.write(str(page_source))
 
 
 def download_files(filepaths):
@@ -104,8 +155,12 @@ def download_files(filepaths):
 
 
 def create_expectation_files(files):
+    # Ref tests don't have an expectation text file
+    if test_type == TestType.REF:
+        return
+
     for file in files:
-        new_path = str(file.destination).replace(wpt_import_path, wpt_expected_path)
+        new_path = str(file.destination).replace(test_type.input_path, test_type.expected_path)
         new_path = new_path.rsplit(".", 1)[0] + '.txt'
 
         expected_file = Path(new_path)
@@ -125,13 +180,31 @@ def main():
     url_to_import = sys.argv[1]
     resource_path = '/'.join(Path(url_to_import).parts[2::])
 
-    main_file = [resource_path]
-    main_paths = map_to_path(main_file, False)
-    files_to_modify = download_files(main_paths)
-    create_expectation_files(main_paths)
-
     with urlopen(url_to_import) as response:
         page = response.read().decode("utf-8")
+
+    global test_type, reference_path, raw_reference_path
+    identifier = TestTypeIdentifier(url_to_import)
+    identifier.feed(page)
+    test_type = identifier.test_type
+    raw_reference_path = identifier.reference_path
+    print(f"Identified {url_to_import} as type {test_type}, ref {raw_reference_path}")
+
+    main_file = [resource_path]
+    main_paths = map_to_path(main_file, False)
+
+    if test_type == TestType.REF and raw_reference_path is None:
+        raise RuntimeError('Failed to file reference path in ref test')
+
+    if raw_reference_path is not None:
+        reference_path = Path(resource_path).parent.joinpath(raw_reference_path).__str__()
+        main_paths.append(PathMapping(
+            wpt_base_url + '/' + reference_path,
+            Path(test_type.expected_path + '/' + reference_path).absolute()
+        ))
+
+    files_to_modify = download_files(main_paths)
+    create_expectation_files(main_paths)
 
     parser = ScriptSrcValueFinder()
     parser.feed(page)

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-nesting/nesting-basic-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-nesting/nesting-basic-ref.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>Basic nesting</title>
+<link rel="author" title="Adam Argyle" href="mailto:argyle@google.com">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/">
+<style>
+  .test {
+    background-color: green;
+    width: 30px;
+    height: 30px;
+    display: grid;
+  }
+
+  body * + * {
+    margin-top: 8px;
+  }
+</style>
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+  <div class="test"></div>
+</body>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-nesting/nesting-basic.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-nesting/nesting-basic.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<title>Basic nesting</title>
+<link rel="author" title="Adam Argyle" href="mailto:argyle@google.com">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/">
+<link rel="match" href="../../../../expected/wpt-import/css/css-nesting/nesting-basic-ref.html">
+<style>
+  .test {
+    background-color: red;
+    width: 30px;
+    height: 30px;
+    display: grid;
+  }
+
+  .test-1 {
+    & > div {
+      background-color: green;
+    }
+  }
+
+  .test-2 {
+    & > div {
+      background-color: green;
+    }
+  }
+
+  .test-3 {
+    & .test-3-child {
+      background-color: green;
+    }
+  }
+
+  span > b {
+    .test-4 section & {
+      display: inline-block;
+      background-color: green;
+      width: 100%;
+      height: 100%;
+    }
+
+    .test-4 section > & {
+      background-color: red;
+    }
+  }
+
+  .test-6 {
+    &.test {
+      background-color: green;
+    }
+  }
+
+  .test-7, .t7- {
+    & + .test-7-child, &.t7-- {
+      background-color: green;
+    }
+  }
+
+  .test-8 {
+    & {
+      background-color: green;
+    }
+  }
+
+  .test-9 {
+    &:is(.t9-, &.t9--) {
+      background-color: green;
+    }
+  }
+
+  .test-10 {
+    & {
+      background-color: red;
+    }
+    background-color: green;
+  }
+
+  .test-11 {
+    & {
+      background-color: red;
+    }
+    background-color: green !important;
+  }
+
+  /* & at top level counts as :scope, i.e. the root element here */
+  & .test-12 {
+    background-color: green;
+  }
+  & > .test-12 {
+    background-color: red !important;
+  }
+
+  body * + * {
+    margin-top: 8px;
+  }
+</style>
+<body>
+  <p>Tests pass if <strong>block is green</strong></p>
+  <div class="test test-1"><div></div></div>
+  <div class="test test-2"><div></div></div>
+  <div class="test test-3"><div class="test-3-child"></div></div>
+  <div class="test test-4">
+    <section>
+      <span><b></b></span>
+    </section>
+  </div>
+  <div class="test test-6"><div></div></div>
+  <div class="test t7- t7--"><div class="test-7-child"></div></div>
+  <div class="test test-8"><div></div></div>
+  <div class="test test-9 t9-- t9-"><div></div></div>
+  <div class="test test-10"><div></div></div>
+  <div class="test test-11"><div></div></div>
+  <div class="test test-12"></div>
+</body>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/cssom.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/cssom.txt
@@ -1,0 +1,23 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 13 tests
+
+13 Fail
+Details
+Result	Test Name	MessageFail	CSSStyleRule is a CSSGroupingRule	
+Fail	Simple CSSOM manipulation of subrules	
+Fail	Simple CSSOM manipulation of subrules 1	
+Fail	Simple CSSOM manipulation of subrules 2	
+Fail	Simple CSSOM manipulation of subrules 3	
+Fail	Simple CSSOM manipulation of subrules 4	
+Fail	Simple CSSOM manipulation of subrules 5	
+Fail	Simple CSSOM manipulation of subrules 6	
+Fail	Simple CSSOM manipulation of subrules 7	
+Fail	Simple CSSOM manipulation of subrules 8	
+Fail	Simple CSSOM manipulation of subrules 9	
+Fail	Simple CSSOM manipulation of subrules 10	
+Fail	Mutating the selectorText of outer rule invalidates inner rules	

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-nesting/cssom.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-nesting/cssom.html
@@ -1,0 +1,188 @@
+<!doctype html>
+<title>Simple CSSOM manipulation of subrules</title>
+<link rel="author" title="Steinar H. Gunderson" href="mailto:sesse@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-nesting-1/">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<style id="ss"></style>
+
+<script>
+  test(() => {
+    assert_equals(CSSStyleRule.__proto__, CSSGroupingRule);
+  }, "CSSStyleRule is a CSSGroupingRule");
+
+  test(() => {
+    let [ss] = document.styleSheets;
+    assert_equals(ss.cssRules.length, 0);
+    ss.insertRule('.a { color: red; }');
+    assert_equals(ss.cssRules.length, 1);
+    assert_equals(ss.cssRules[0].cssText, '.a { color: red; }');
+
+    // Test inserting sub-cssRules, at various positions.
+    ss.cssRules[0].insertRule('& .b { color: green; }');
+    ss.cssRules[0].insertRule('& .c { color: blue; }', 1);
+    ss.cssRules[0].insertRule('& .d { color: hotpink; }', 1);
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  color: red;
+  & .b { color: green; }
+  & .d { color: hotpink; }
+  & .c { color: blue; }
+}`, 'inserting should work');
+
+    // Test deleting a rule.
+    ss.cssRules[0].deleteRule(1);
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  color: red;
+  & .b { color: green; }
+  & .c { color: blue; }
+}`, 'deleting should work');
+  });
+
+  // Test that out-of-bounds throws exceptions and does not affect the stylesheet.
+  const sampleSheetText =
+`.a {
+  color: red;
+  & .b { color: green; }
+  & .c { color: blue; }
+}`;
+
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    assert_throws_dom('IndexSizeError', () => { ss.cssRules[0].insertRule('& .broken {}', 3); });
+    assert_equals(ss.cssRules[0].cssText, sampleSheetText, 'unchanged after no-insert');
+  });
+
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    assert_throws_dom('IndexSizeError', () => { ss.cssRules[0].insertRule('& .broken {}', -1); });
+    assert_equals(ss.cssRules[0].cssText, sampleSheetText, 'unchanged after no-insert');
+  });
+
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    assert_throws_dom('IndexSizeError', () => { ss.cssRules[0].deleteRule(5); });
+    assert_equals(ss.cssRules[0].cssText, sampleSheetText, 'unchanged after no-delete');
+  });
+
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    assert_equals(ss.cssRules[0].cssRules[2], undefined, 'subscript out-of-bounds returns undefined');
+    assert_equals(ss.cssRules[0].cssRules.item(2), null, 'item() out-of-bounds returns null');
+    assert_equals(ss.cssRules[0].cssText, sampleSheetText, 'unchanged after no-access');
+  });
+
+  // Test that inserting an invalid rule throws an exception.
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    let exception;
+    assert_throws_dom('SyntaxError', () => { ss.cssRules[0].insertRule('% {}'); });
+    assert_equals(ss.cssRules[0].cssText, sampleSheetText, 'unchanged after invalid rule');
+  });
+
+  // Test that we can get out single rule through .cssRules.
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    assert_equals(ss.cssRules[0].cssRules[1].cssText, '& .c { color: blue; }');
+  });
+
+  // Test that we can insert a @supports rule, that it serializes in the right place
+  // and has the right parent. Note that the indentation is broken per-spec.
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    ss.cssRules[0].insertRule('@supports selector(&) { & div { font-size: 10px; }}', 1);
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  color: red;
+  & .b { color: green; }
+  @supports selector(&) {
+  & div { font-size: 10px; }
+}
+  & .c { color: blue; }
+}`, '@supports is added');
+
+    assert_equals(ss.cssRules[0].cssRules[1].parentRule, ss.cssRules[0]);
+    ss.cssRules[0].deleteRule(1);
+    assert_equals(ss.cssRules[0].cssText, sampleSheetText);
+  });
+
+  // Nested rules are not part of declaration lists, and thus should not
+  // be possible to insert with .style.
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    ss.cssRules[0].style = 'color: olivedrab; &.d { color: peru; }';
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  color: olivedrab;
+  & .b { color: green; }
+  & .c { color: blue; }
+}`, 'color is changed, new rule is ignored');
+  });
+
+  test(() => {
+    document.getElementById('ss').innerHTML = sampleSheetText;
+    let [ss] = document.styleSheets;
+    ss.cssRules[0].cssRules[0].selectorText = 'div.b .c &';  // Allowed
+    ss.cssRules[0].cssRules[1].selectorText = '.c div.b &, div &';  // Allowed.
+    ss.cssRules[0].insertRule('div & {}'); // Allowed.
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  color: red;
+  div & { }
+  div.b .c & { color: green; }
+  .c div.b &, div & { color: blue; }
+}`, 'selectorText and insertRule');
+  });
+
+  // Rules that are dropped in forgiving parsing but that contain &,
+  // must still be serialized out as they were.
+  test(() => {
+    const text = '.a { :is(!& .foo, .b) { color: green; } }';
+    document.getElementById('ss').innerHTML = text;
+    let [ss] = document.styleSheets;
+    assert_equals(ss.cssRules[0].cssText,
+`.a {
+  :is(!& .foo, .b) { color: green; }
+}`, 'invalid rule containing ampersand is kept in serialization');
+  });
+
+  test((t) => {
+    let main = document.createElement('main');
+    main.innerHTML = `
+      <style>
+        .a {
+          & { z-index:1; }
+          & #inner1 { z-index:1; }
+          .stuff, :is(&) #inner2 { z-index:1; }
+        }
+      </style>
+      <div id="outer" class="b">
+        <div id="inner1"></div>
+        <div id="inner2"></div>
+      </div>
+    `;
+    document.documentElement.append(main);
+    t.add_cleanup(() => main.remove());
+
+    assert_equals(getComputedStyle(outer).zIndex, 'auto');
+    assert_equals(getComputedStyle(inner1).zIndex, 'auto');
+    assert_equals(getComputedStyle(inner2).zIndex, 'auto');
+
+    // .a => .b
+    main.firstElementChild.sheet.cssRules[0].selectorText = '.b';
+
+    assert_equals(getComputedStyle(outer).zIndex, '1');
+    assert_equals(getComputedStyle(inner1).zIndex, '1');
+    assert_equals(getComputedStyle(inner2).zIndex, '1');
+  }, 'Mutating the selectorText of outer rule invalidates inner rules');
+</script>


### PR DESCRIPTION
First off, my Python knowledge is pretty lacking so my code is probably horrible. Apologies in advance, and suggestions welcome. A lot of what I was writing felt a bit hacky.

Usage is still `Meta/WPT.sh some/path/to/a/ref/test.html`: It figures out what kind of test it is, so you don't have to care.

As noted, I've imported a couple of nesting tests (a ref test and a text test) to make sure it all worked right.

One difference with importing ref tests is that you have to wait until they pass before you import them, because unlike text tests, there's no way to save an expectation of "these subtests pass but that one doesn't". Though, the normal skip mechanism will work if you still want to import them.