### PR TITLE
headless-browser: Support running tests with the ".xht" extension

### DIFF
--- a/Ladybird/Headless/Test.cpp
+++ b/Ladybird/Headless/Test.cpp
@@ -70,7 +70,7 @@ static ErrorOr<void> collect_dump_tests(Vector<Test>& tests, StringView path, St
             continue;
         }
 
-        if (!name.ends_with(".html"sv) && !name.ends_with(".svg"sv) && !name.ends_with(".xhtml"sv))
+        if (!name.ends_with(".html"sv) && !name.ends_with(".svg"sv) && !name.ends_with(".xhtml"sv) && !name.ends_with(".xht"sv))
             continue;
 
         auto expectation_path = ByteString::formatted("{}/expected/{}/{}.txt", path, trail, LexicalPath::title(name));

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/abspos/abspos-containing-block-initial-004-ref.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/abspos/abspos-containing-block-initial-004-ref.xht
@@ -1,0 +1,9 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" style="background:yellow;"><head><title>CSS Test: Test for containing block for absolutely positioned elements being initial containing block</title>
+<link rel="author" title="Robert O'Callahan" href="mailto:robert@ocallahan.org" />
+<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
+</head><body>
+<div style="position:absolute; top:100px; left:100px; width:100px; height:100px;
+            border:10px solid black;"></div>
+
+
+</body></html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/abspos/abspos-containing-block-initial-004a.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/abspos/abspos-containing-block-initial-004a.xht
@@ -1,0 +1,11 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml" style="position:absolute; left:100px; top:100px; width:100px; height:100px;
+             background:yellow; border:10px solid black;"><head><title>CSS Test: Test for containing block for absolutely positioned elements being initial containing block</title>
+<link rel="author" title="Robert O'Callahan" href="mailto:robert@ocallahan.org" />
+<link rel="author" title="Mozilla Corporation" href="http://mozilla.com/" />
+<link rel="help" href="http://www.w3.org/TR/CSS21/visudet.html#containing-block-details" />
+<link rel="match" href="../../../../../expected/wpt-import/css/CSS2/abspos/abspos-containing-block-initial-004-ref.xht"/>
+<meta name="assert" content="If there is no such ancestor, the containing block is the initial containing block." />
+</head><body>
+
+
+</body></html>


### PR DESCRIPTION
This makes importing WPT reftests with an xht extension easier.