### PR TITLE
LibWeb: Avoid unnecessary style recomputation during traversal

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1258,7 +1258,9 @@ void Document::update_layout()
     bool is_display_none = false;
 
     if (is<Element>(node)) {
-        invalidation |= static_cast<Element&>(node).recompute_style();
+        if (needs_full_style_update || node.needs_style_update()) {
+            invalidation |= static_cast<Element&>(node).recompute_style();
+        }
         is_display_none = static_cast<Element&>(node).computed_css_values()->display().is_none();
     }
     node.set_needs_style_update(false);


### PR DESCRIPTION
While traversing the DOM tree, looking for nodes that need a style update, we were recomputing style for every node visited along the way, even nodes that didn't themselves need a style update (but one of their descendants did).

This avoids a bunch of completely unnecessary style recomputation on basically every website.