### PR TITLE
WebDriver: Bring the Back and Forward endpoints up to spec

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -3043,6 +3043,19 @@ bool Document::anything_is_delaying_the_load_event() const
     return false;
 }
 
+void Document::set_page_showing(bool page_showing)
+{
+    if (m_page_showing == page_showing)
+        return;
+
+    m_page_showing = page_showing;
+
+    for (auto document_observer : m_document_observers) {
+        if (document_observer->document_page_showing_observer())
+            document_observer->document_page_showing_observer()->function()(m_page_showing);
+    }
+}
+
 void Document::invalidate_stacking_context_tree()
 {
     if (auto* paintable_box = this->paintable_box())

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -426,7 +426,7 @@ public:
     void decrement_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
 
     bool page_showing() const { return m_page_showing; }
-    void set_page_showing(bool value) { m_page_showing = value; }
+    void set_page_showing(bool);
 
     bool hidden() const;
     StringView visibility_state() const;

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.cpp
@@ -27,6 +27,7 @@ void DocumentObserver::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_completely_loaded);
     visitor.visit(m_document_readiness_observer);
     visitor.visit(m_document_visibility_state_observer);
+    visitor.visit(m_document_page_showing_observer);
 }
 
 void DocumentObserver::finalize()
@@ -65,6 +66,14 @@ void DocumentObserver::set_document_visibility_state_observer(Function<void(HTML
         m_document_visibility_state_observer = JS::create_heap_function(vm().heap(), move(callback));
     else
         m_document_visibility_state_observer = nullptr;
+}
+
+void DocumentObserver::set_document_page_showing_observer(Function<void(bool)> callback)
+{
+    if (callback)
+        m_document_page_showing_observer = JS::create_heap_function(vm().heap(), move(callback));
+    else
+        m_document_page_showing_observer = nullptr;
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
+++ b/Userland/Libraries/LibWeb/DOM/DocumentObserver.h
@@ -32,6 +32,9 @@ public:
     [[nodiscard]] JS::GCPtr<JS::HeapFunction<void(HTML::VisibilityState)>> document_visibility_state_observer() const { return m_document_visibility_state_observer; }
     void set_document_visibility_state_observer(Function<void(HTML::VisibilityState)>);
 
+    [[nodiscard]] JS::GCPtr<JS::HeapFunction<void(bool)>> document_page_showing_observer() const { return m_document_page_showing_observer; }
+    void set_document_page_showing_observer(Function<void(bool)>);
+
 private:
     explicit DocumentObserver(JS::Realm&, DOM::Document&);
 
@@ -43,6 +46,7 @@ private:
     JS::GCPtr<JS::HeapFunction<void()>> m_document_completely_loaded;
     JS::GCPtr<JS::HeapFunction<void(HTML::DocumentReadyState)>> m_document_readiness_observer;
     JS::GCPtr<JS::HeapFunction<void(HTML::VisibilityState)>> m_document_visibility_state_observer;
+    JS::GCPtr<JS::HeapFunction<void(bool)>> m_document_page_showing_observer;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -311,8 +311,6 @@ public:
     virtual void paint(DevicePixelRect const&, Painting::BackingStore&, PaintOptions = {}) = 0;
     virtual void page_did_change_title(ByteString const&) { }
     virtual void page_did_change_url(URL::URL const&) { }
-    virtual void page_did_request_navigate_back() { }
-    virtual void page_did_request_navigate_forward() { }
     virtual void page_did_request_refresh() { }
     virtual void page_did_request_resize_window(Gfx::IntSize) { }
     virtual void page_did_request_reposition_window(Gfx::IntPoint) { }

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -100,18 +100,6 @@ void WebContentClient::did_find_in_page(u64 page_id, size_t current_match_index,
     }
 }
 
-void WebContentClient::did_request_navigate_back(u64 page_id)
-{
-    if (auto view = view_for_page_id(page_id); view.has_value())
-        view->traverse_the_history_by_delta(-1);
-}
-
-void WebContentClient::did_request_navigate_forward(u64 page_id)
-{
-    if (auto view = view_for_page_id(page_id); view.has_value())
-        view->traverse_the_history_by_delta(1);
-}
-
 void WebContentClient::did_request_refresh(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value())

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -51,8 +51,6 @@ private:
 
     virtual void did_paint(u64 page_id, Gfx::IntRect const&, i32) override;
     virtual void did_finish_loading(u64 page_id, URL::URL const&) override;
-    virtual void did_request_navigate_back(u64 page_id) override;
-    virtual void did_request_navigate_forward(u64 page_id) override;
     virtual void did_request_refresh(u64 page_id) override;
     virtual void did_request_cursor_change(u64 page_id, i32) override;
     virtual void did_layout(u64 page_id, Gfx::IntSize) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -246,16 +246,6 @@ void PageClient::page_did_change_url(URL::URL const& url)
     client().async_did_change_url(m_id, url);
 }
 
-void PageClient::page_did_request_navigate_back()
-{
-    client().async_did_request_navigate_back(m_id);
-}
-
-void PageClient::page_did_request_navigate_forward()
-{
-    client().async_did_request_navigate_forward(m_id);
-}
-
 void PageClient::page_did_request_refresh()
 {
     client().async_did_request_refresh(m_id);

--- a/Userland/Services/WebContent/PageClient.h
+++ b/Userland/Services/WebContent/PageClient.h
@@ -109,8 +109,6 @@ private:
     virtual void page_did_layout() override;
     virtual void page_did_change_title(ByteString const&) override;
     virtual void page_did_change_url(URL::URL const&) override;
-    virtual void page_did_request_navigate_back() override;
-    virtual void page_did_request_navigate_forward() override;
     virtual void page_did_request_refresh() override;
     virtual void page_did_request_resize_window(Gfx::IntSize) override;
     virtual void page_did_request_reposition_window(Gfx::IntPoint) override;

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -22,8 +22,6 @@ endpoint WebContentClient
 {
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
-    did_request_navigate_back(u64 page_id) =|
-    did_request_navigate_forward(u64 page_id) =|
     did_request_refresh(u64 page_id) =|
     did_paint(u64 page_id, Gfx::IntRect content_rect, i32 bitmap_id) =|
     did_request_cursor_change(u64 page_id, i32 cursor_type) =|

--- a/Userland/Services/WebContent/WebDriverConnection.cpp
+++ b/Userland/Services/WebContent/WebDriverConnection.cpp
@@ -359,19 +359,68 @@ Messages::WebDriverClient::GetCurrentUrlResponse WebDriverConnection::get_curren
 // 10.3 Back, https://w3c.github.io/webdriver/#dfn-back
 Messages::WebDriverClient::BackResponse WebDriverConnection::back()
 {
-    // 1. If the current top-level browsing context is no longer open, return error with error code no such window.
+    // 1. If session's current top-level browsing context is no longer open, return error with error code no such window.
     TRY(ensure_current_top_level_browsing_context_is_open());
 
-    // 2. Handle any user prompts and return its value if it is an error.
+    // 2. Try to handle any user prompts with session.
     handle_any_user_prompts([this]() {
-        // 3. Traverse the history by a delta –1 for the current browsing context.
-        current_browsing_context().page().client().page_did_request_navigate_back();
+        auto& realm = current_top_level_browsing_context()->active_document()->realm();
 
-        // FIXME: 4. If the previous step completed results in a pageHide event firing, wait until pageShow event fires or for the session page load timeout milliseconds to pass, whichever occurs sooner.
-        // FIXME: 5. If the previous step completed by the session page load timeout being reached, and user prompts have been handled, return error with error code timeout.
+        // 3. Let timeout be session' session timeouts page load timeout.
+        auto timeout = m_timeouts_configuration.page_load_timeout;
 
-        // 6. Return success with data null.
-        async_driver_execution_complete(JsonValue {});
+        // 4. Let timer be a new timer.
+        auto timer = realm.heap().allocate<Web::WebDriver::HeapTimer>(realm);
+
+        auto on_complete = JS::create_heap_function(realm.heap(), [this, timer]() {
+            timer->stop();
+
+            if (m_document_observer) {
+                m_document_observer->set_document_page_showing_observer({});
+                m_document_observer = nullptr;
+            }
+
+            // 8. If timer' timeout fired flag is set:
+            if (timer->is_timed_out()) {
+                // 1. Handle any user prompts.
+                handle_any_user_prompts([this]() {
+                    // 2. Return error with error code timeout.
+                    async_driver_execution_complete(Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::Timeout, "Navigation timed out"sv));
+                });
+
+                return;
+            }
+
+            // 9. Return success with data null.
+            async_driver_execution_complete(JsonValue {});
+        });
+
+        // 5. If timeout is not null:
+        if (timeout.has_value()) {
+            // 1. Start the timer with timer and timeout.
+            timer->start(*timeout, on_complete);
+        }
+
+        // 6. Traverse the history by a delta –1 for session's current browsing context.
+        current_top_level_browsing_context()->top_level_traversable()->traverse_the_history_by_delta(-1);
+
+        // 7. If the previous step completed results in a pageHide event firing, wait until pageShow event fires or
+        //    timer' timeout fired flag to be set, whichever occurs first.
+        current_top_level_browsing_context()->top_level_traversable()->append_session_history_traversal_steps(JS::create_heap_function(realm.heap(), [this, timer, on_complete]() {
+            if (timer->is_timed_out())
+                return;
+
+            if (auto* document = current_top_level_browsing_context()->active_document(); document->page_showing()) {
+                on_complete->function()();
+            } else {
+                auto& realm = document->realm();
+
+                m_document_observer = realm.heap().allocate<Web::DOM::DocumentObserver>(realm, realm, *document);
+                m_document_observer->set_document_page_showing_observer([on_complete](auto) {
+                    on_complete->function()();
+                });
+            }
+        }));
     });
 
     return JsonValue {};


### PR DESCRIPTION
Fixes the following tests, which were previously timing out:
```
/webdriver/tests/classic/back/back.py
/webdriver/tests/classic/back/user_prompts.py
/webdriver/tests/classic/forward/forward.py
/webdriver/tests/classic/forward/user_prompts.py
```