### PR TITLE
LibCore: Port Directory to Windows

### DIFF
--- a/AK/LexicalPath.cpp
+++ b/AK/LexicalPath.cpp
@@ -63,6 +63,11 @@ bool LexicalPath::is_absolute_path(StringView path)
     return path.starts_with('/');
 }
 
+bool LexicalPath::is_root() const
+{
+    return m_string == "/";
+}
+
 Vector<ByteString> LexicalPath::parts() const
 {
     Vector<ByteString> vector;

--- a/AK/LexicalPath.h
+++ b/AK/LexicalPath.h
@@ -28,6 +28,8 @@ public:
 
     static bool is_absolute_path(StringView path);
     bool is_absolute() const { return is_absolute_path(m_string); }
+    bool is_root() const;
+
     ByteString const& string() const { return m_string; }
 
     StringView dirname() const { return m_dirname; }

--- a/AK/LexicalPathWindows.cpp
+++ b/AK/LexicalPathWindows.cpp
@@ -45,6 +45,11 @@ bool LexicalPath::is_absolute_path(StringView path)
     return path.length() >= 2 && path[1] == ':';
 }
 
+bool LexicalPath::is_root() const
+{
+    return AK::is_root(m_parts);
+}
+
 Vector<ByteString> LexicalPath::parts() const
 {
     Vector<ByteString> vector;
@@ -81,7 +86,7 @@ ByteString LexicalPath::canonicalized_path(ByteString path)
             continue;
         if (part == ".." && !canonical_parts.is_empty()) {
             // At the root, .. does nothing.
-            if (is_root(canonical_parts))
+            if (AK::is_root(canonical_parts))
                 continue;
             // A .. and a previous non-.. part cancel each other.
             if (canonical_parts.last() != "..") {
@@ -95,7 +100,7 @@ ByteString LexicalPath::canonicalized_path(ByteString path)
     StringBuilder builder;
     builder.join('\\', canonical_parts);
     // "X:" -> "X:\"
-    if (is_root(canonical_parts))
+    if (AK::is_root(canonical_parts))
         builder.append('\\');
     path = builder.to_byte_string();
     return path == "" ? "." : path;

--- a/Libraries/LibCore/AnonymousBufferWindows.cpp
+++ b/Libraries/LibCore/AnonymousBufferWindows.cpp
@@ -28,7 +28,7 @@ AnonymousBufferImpl::~AnonymousBufferImpl()
 
 ErrorOr<NonnullRefPtr<AnonymousBufferImpl>> AnonymousBufferImpl::create(size_t size)
 {
-    HANDLE map_handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, HIWORD(size), LOWORD(size), NULL);
+    HANDLE map_handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, size >> 31 >> 1, size & 0xFFFFFFFF, NULL);
     if (!map_handle)
         return Error::from_windows_error(GetLastError());
 

--- a/Libraries/LibCore/ConfigFile.cpp
+++ b/Libraries/LibCore/ConfigFile.cpp
@@ -12,8 +12,6 @@
 #include <LibCore/Directory.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
-#include <pwd.h>
-#include <sys/types.h>
 
 namespace Core {
 

--- a/Libraries/LibCore/Directory.cpp
+++ b/Libraries/LibCore/Directory.cpp
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Directory.h"
-#include "DirIterator.h"
-#include "System.h"
-#include <dirent.h>
+#include <LibCore/Directory.h>
+#include <LibCore/System.h>
 
 namespace Core {
 
@@ -31,6 +29,7 @@ Directory::~Directory()
         MUST(System::close(m_directory_fd));
 }
 
+#ifndef AK_OS_WINDOWS
 ErrorOr<void> Directory::chown(uid_t uid, gid_t gid)
 {
     if (m_directory_fd == -1)
@@ -38,6 +37,7 @@ ErrorOr<void> Directory::chown(uid_t uid, gid_t gid)
     TRY(Core::System::fchown(m_directory_fd, uid, gid));
     return {};
 }
+#endif
 
 ErrorOr<bool> Directory::is_valid_directory(int fd)
 {
@@ -69,7 +69,7 @@ ErrorOr<Directory> Directory::create(LexicalPath path, CreateDirectories create_
 
 ErrorOr<void> Directory::ensure_directory(LexicalPath const& path, mode_t creation_mode)
 {
-    if (path.basename() == "/" || path.basename() == ".")
+    if (path.is_root() || path.string() == ".")
         return {};
 
     TRY(ensure_directory(path.parent(), creation_mode));

--- a/Libraries/LibCore/Directory.h
+++ b/Libraries/LibCore/Directory.h
@@ -10,14 +10,11 @@
 #include <AK/Error.h>
 #include <AK/Format.h>
 #include <AK/Function.h>
-#include <AK/IterationDecision.h>
 #include <AK/LexicalPath.h>
 #include <AK/Noncopyable.h>
-#include <AK/Optional.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/DirectoryEntry.h>
 #include <LibCore/File.h>
-#include <dirent.h>
 #include <sys/stat.h>
 
 namespace Core {
@@ -51,7 +48,9 @@ public:
     static ErrorOr<void> for_each_entry(StringView path, DirIterator::Flags, ForEachEntryCallback);
     ErrorOr<void> for_each_entry(DirIterator::Flags, ForEachEntryCallback);
 
+#ifndef AK_OS_WINDOWS
     ErrorOr<void> chown(uid_t, gid_t);
+#endif
 
     static ErrorOr<bool> is_valid_directory(int fd);
 

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -12,7 +12,8 @@
 #include <AK/ByteString.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/System.h>
-#include <WinSock2.h>
+#include <Windows.h>
+#include <direct.h>
 #include <io.h>
 
 namespace Core::System {
@@ -20,9 +21,21 @@ namespace Core::System {
 ErrorOr<int> open(StringView path, int options, mode_t mode)
 {
     ByteString string_path = path;
-    int rc = _open(string_path.characters(), options, mode);
-    if (rc < 0)
-        return Error::from_syscall("open"sv, -errno);
+    auto sz_path = string_path.characters();
+    int rc = _open(sz_path, options, mode);
+    if (rc < 0) {
+        int error = errno;
+        struct stat st = {};
+        if (::stat(sz_path, &st) == 0 && (st.st_mode & S_IFDIR)) {
+            HANDLE dir_handle = CreateFile(sz_path, GENERIC_ALL, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
+            if (dir_handle == INVALID_HANDLE_VALUE)
+                return Error::from_windows_error(GetLastError());
+            int dir_fd = _open_osfhandle((intptr_t)dir_handle, 0);
+            if (dir_fd != -1)
+                return dir_fd;
+        }
+        return Error::from_syscall("open"sv, -error);
+    }
     return rc;
 }
 
@@ -131,6 +144,26 @@ ErrorOr<void> unlink(StringView path)
     if (_unlink(path_string.characters()) < 0)
         return Error::from_syscall("unlink"sv, -errno);
     return {};
+}
+
+ErrorOr<void> mkdir(StringView path, mode_t)
+{
+    ByteString str = path;
+    if (_mkdir(str.characters()) < 0)
+        return Error::from_syscall("mkdir"sv, -errno);
+    return {};
+}
+
+ErrorOr<int> openat(int, StringView, int, mode_t)
+{
+    dbgln("Core::System::openat() is not implemented");
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<struct stat> fstatat(int, StringView, int)
+{
+    dbgln("Core::System::fstatat() is not implemented");
+    VERIFY_NOT_REACHED();
 }
 
 }


### PR DESCRIPTION
This PR requires #1918.
<s>This PR is ready for review, but must be rebased before merging. First 3 commits belong to #1918.</s> Update: rebased.

NOTE: The only methods of Directory that are used are create (static), is_valid_directory (static), chown and path, also adopt_fd and is_valid_directory are used internally.
The most used method is create, and it is always called with Directory::CreateDirectories::Yes.
Directory::is_valid_directory is called externally only from Web::ResourceLoader::load.
Directory::chown is called only from SessionManagement::create_session_temporary_directory_if_needed.
Directory::path is called only from ConfigFile::open_for_lib and other ConfigFile methods (indirectly through Formatter\<Directory>::format).
Among these, only chown uses m_directory_fd. As chown is not implemented on Windows, m_directory_fd is essentially not used. I implemented directory support in System::open only to satisfy internal Directory checks. Without it Directory::create creates the actual directory, but returns an error.