### PR TITLE
LibWeb/CSS: Avoid double promotion in CSSColorValue code

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.cpp
@@ -71,7 +71,7 @@ Optional<float> CSSColorValue::resolve_with_reference_value(CSSStyleValue const&
 {
     // <percentage> | <number> | none
     auto normalize_percentage = [one_hundred_percent_value](Percentage const& percentage) {
-        return percentage.as_fraction() * one_hundred_percent_value;
+        return static_cast<float>(percentage.as_fraction()) * one_hundred_percent_value;
     };
 
     if (style_value.is_percentage())

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSHWB.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSHWB.cpp
@@ -13,13 +13,13 @@ namespace Web::CSS {
 Color CSSHWB::to_color(Optional<Layout::NodeWithStyle const&>) const
 {
     auto const h_val = resolve_hue(m_properties.h).value_or(0);
-    auto const w_val = clamp(resolve_with_reference_value(m_properties.w, 100.0).value_or(0), 0, 100) / 100.0;
-    auto const b_val = clamp(resolve_with_reference_value(m_properties.b, 100.0).value_or(0), 0, 100) / 100.0;
+    auto const w_val = clamp(resolve_with_reference_value(m_properties.w, 100.0).value_or(0), 0, 100) / 100.0f;
+    auto const b_val = clamp(resolve_with_reference_value(m_properties.b, 100.0).value_or(0), 0, 100) / 100.0f;
     auto const alpha_val = resolve_alpha(m_properties.alpha).value_or(1);
 
-    if (w_val + b_val >= 1.0) {
-        auto to_byte = [](double value) {
-            return round_to<u8>(clamp(value * 255.0, 0.0, 255.0));
+    if (w_val + b_val >= 1.0f) {
+        auto to_byte = [](float value) {
+            return round_to<u8>(clamp(value * 255.0f, 0.0f, 255.0f));
         };
         u8 gray = to_byte(w_val / (w_val + b_val));
         return Color(gray, gray, gray, to_byte(alpha_val));

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -44,7 +44,7 @@ Color CSSRGB::to_color(Optional<Layout::NodeWithStyle const&>) const
     auto resolve_alpha_to_u8 = [](CSSStyleValue const& style_value) -> Optional<u8> {
         auto alpha_0_1 = resolve_alpha(style_value);
         if (alpha_0_1.has_value())
-            return llround(clamp(alpha_0_1.value() * 255.0, 0.0, 255.0));
+            return llround(clamp(alpha_0_1.value() * 255.0f, 0.0f, 255.0f));
         return {};
     };
 


### PR DESCRIPTION
As seen in https://github.com/LadybirdBrowser/ladybird/pull/1091#issuecomment-2407342711