### PR TITLE
LibWeb: Make all  WPT accname/name/comp_name_from_content.html tests pass

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -330,7 +330,7 @@ struct ContentData {
 
     // FIXME: Data is a list of identifiers, strings and image values.
     String data {};
-    String alt_text {};
+    Optional<String> alt_text {};
 };
 
 struct CounterData {

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2472,62 +2472,6 @@ Optional<StringView> Node::first_valid_id(StringView value, Document const& docu
     return {};
 }
 
-// https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te
-ErrorOr<void> Node::append_without_space(StringBuilder x, StringView const& result)
-{
-    // - If X is empty, copy the result to X.
-    // - If X is non-empty, copy the result to the end of X.
-    TRY(x.try_append(result));
-    return {};
-}
-
-// https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te
-ErrorOr<void> Node::append_with_space(StringBuilder x, StringView const& result)
-{
-    // - If X is empty, copy the result to X.
-    if (x.is_empty()) {
-        TRY(x.try_append(result));
-    } else {
-        // - If X is non-empty, add a space to the end of X and then copy the result to X after the space.
-        TRY(x.try_append(" "sv));
-        TRY(x.try_append(result));
-    }
-    return {};
-}
-
-// https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te
-ErrorOr<void> Node::prepend_without_space(StringBuilder x, StringView const& result)
-{
-    // - If X is empty, copy the result to X.
-    if (x.is_empty()) {
-        x.append(result);
-    } else {
-        // - If X is non-empty, copy the result to the start of X.
-        auto temp = TRY(x.to_string());
-        x.clear();
-        TRY(x.try_append(result));
-        TRY(x.try_append(temp));
-    }
-    return {};
-}
-
-// https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te
-ErrorOr<void> Node::prepend_with_space(StringBuilder x, StringView const& result)
-{
-    // - If X is empty, copy the result to X.
-    if (x.is_empty()) {
-        TRY(x.try_append(result));
-    } else {
-        // - If X is non-empty, copy the result to the start of X, and add a space after the copy.
-        auto temp = TRY(x.to_string());
-        x.clear();
-        TRY(x.try_append(result));
-        TRY(x.try_append(" "sv));
-        TRY(x.try_append(temp));
-    }
-    return {};
-}
-
 void Node::add_registered_observer(RegisteredObserver& registered_observer)
 {
     if (!m_registered_observer_list)

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -147,6 +147,11 @@ const HTML::HTMLElement* Node::enclosing_html_element_with_attribute(FlyString c
     return nullptr;
 }
 
+Optional<String> Node::alternative_text() const
+{
+    return {};
+}
+
 // https://dom.spec.whatwg.org/#concept-descendant-text-content
 String Node::descendant_text_content() const
 {
@@ -2320,11 +2325,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         // element (e.g. HTML label or SVG title) that defines a text alternative, return that alternative in the form
         // of a flat string as defined by the host language, unless the element is marked as presentational
         // (role="presentation" or role="none").
-        if (role != ARIA::Role::presentation && role != ARIA::Role::none) {
-            if (is<HTML::HTMLImageElement>(*element)) {
-                if (auto alt = element->get_attribute(HTML::AttributeNames::alt); alt.has_value())
-                    return alt.release_value();
-            }
+        if (role != ARIA::Role::presentation && role != ARIA::Role::none && is<HTML::HTMLImageElement>(*element)) {
+            return element->alternative_text().release_value();
             // TODO: Add handling for SVGTitleElement, and also confirm (through existing WPT test cases) whether
             // HTMLLabelElement is already handled (by the code for step C. “Embedded Control” above) in conformance
             // with the spec requirements — and if not, then add handling for it here.

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2227,7 +2227,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 // b. Compute the text alternative of the current node beginning with step 2. Set the result to that text alternative.
                 auto result = TRY(node->name_or_description(target, document, visited_nodes));
                 // c. Append the result, with a space, to the accumulated text.
-                TRY(Node::append_with_space(total_accumulated_text, result));
+                total_accumulated_text.append(' ');
+                total_accumulated_text.append(result);
             }
             // iii. Return the accumulated text.
             return total_accumulated_text.to_string();
@@ -2388,7 +2389,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                     total_accumulated_text.append(after->computed_values().content().data);
             }
             // v. Return the accumulated text if it is not the empty string ("").
-            return total_accumulated_text.to_string();
+            if (!total_accumulated_text.is_empty())
+                return total_accumulated_text.to_string();
             // Important: Each node in the subtree is consulted only once. If text has been collected from a descendant, but is referenced by another IDREF in some descendant node, then that second, or subsequent, reference is not followed. This is done to avoid infinite loops.
         }
     }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2347,6 +2347,18 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
             // iii. For each child node of the current node:
             element->for_each_child([&total_accumulated_text, current_node, target, &document, &visited_nodes](
                                         DOM::Node const& child_node) mutable {
+                if (!child_node.is_element() && !child_node.is_text())
+                    return IterationDecision::Continue;
+                bool should_add_space = true;
+                const_cast<DOM::Document&>(document).update_layout();
+                auto const* layout_node = child_node.layout_node();
+                if (layout_node) {
+                    auto display = layout_node->display();
+                    if (display.is_inline_outside() && display.is_flow_inside()) {
+                        should_add_space = false;
+                    }
+                }
+
                 if (visited_nodes.contains(child_node.unique_id()))
                     return IterationDecision::Continue;
 
@@ -2356,6 +2368,10 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 // b. Compute the text alternative of the current node beginning with step 2. Set the result to that text alternative.
                 auto result = MUST(current_node->name_or_description(target, document, visited_nodes, IsDescendant::Yes));
 
+                // Append a space character and the result of each step above to the total accumulated text.
+                // AD-HOC: Doing the space-adding here is in a different order from what the spec states.
+                if (should_add_space)
+                    total_accumulated_text.append(' ');
                 // c. Append the result to the accumulated text.
                 total_accumulated_text.append(result);
 
@@ -2368,11 +2384,13 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         }
     }
 
-    // G. Otherwise, if the current node is a Text node, return its textual contents.
+    // G. Text Node: Otherwise, if the current node is a Text Node, return its textual contents.
     if (is_text()) {
-        auto const* text_node = static_cast<DOM::Text const*>(this);
-        return text_node->data();
+        if (layout_node() && layout_node()->is_text_node())
+            return verify_cast<Layout::TextNode>(layout_node())->text_for_rendering();
+        return text_content().value();
     }
+
     // TODO: H. Otherwise, if the current node is a descendant of an element whose Accessible Name or Accessible Description is being computed, and contains descendants, proceed to 2F.i.
 
     // I. Otherwise, if the current node has a Tooltip attribute, return its value.
@@ -2385,8 +2403,6 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         if (tooltip.has_value() && !tooltip->is_empty())
             return tooltip.release_value();
     }
-    // Append the result of each step above, with a space, to the total accumulated text.
-    //
     // After all steps are completed, the total accumulated text is used as the accessible name or accessible description of the element that initiated the computation.
     return total_accumulated_text.to_string();
 }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -795,10 +795,6 @@ private:
     void remove_child_impl(JS::NonnullGCPtr<Node>);
 
     static Optional<StringView> first_valid_id(StringView, Document const&);
-    static ErrorOr<void> append_without_space(StringBuilder, StringView const&);
-    static ErrorOr<void> append_with_space(StringBuilder, StringView const&);
-    static ErrorOr<void> prepend_without_space(StringBuilder, StringView const&);
-    static ErrorOr<void> prepend_with_space(StringBuilder, StringView const&);
 
     JS::GCPtr<Node> m_parent;
     JS::GCPtr<Node> m_first_child;

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -200,6 +200,8 @@ public:
 
     String base_uri() const;
 
+    virtual Optional<String> alternative_text() const;
+
     String descendant_text_content() const;
     Optional<String> text_content() const;
     void set_text_content(Optional<String> const&);

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -40,6 +40,13 @@ public:
 
     virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value) override;
 
+    Optional<String> alternative_text() const override
+    {
+        if (auto alt = get_attribute(HTML::AttributeNames::alt); alt.has_value())
+            return alt.release_value();
+        return {};
+    }
+
     String alt() const { return get_attribute_value(HTML::AttributeNames::alt); }
     String src() const { return get_attribute_value(HTML::AttributeNames::src); }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -254,6 +254,7 @@ void TreeBuilder::create_pseudo_element_if_needed(DOM::Element& element, CSS::Se
 
     element.set_pseudo_element_node({}, pseudo_element, pseudo_element_node);
     insert_node_into_inline_or_block_ancestor(*pseudo_element_node, pseudo_element_display, mode);
+    pseudo_element_node->mutable_computed_values().set_content(pseudo_element_content);
 }
 
 static bool is_ignorable_whitespace(Layout::Node const& node)

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_name_from_content.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_name_from_content.txt
@@ -1,0 +1,70 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 60 tests
+
+60 Pass
+Details
+Result	Test Name	MessagePass	aria button name from content, inline	
+Pass	aria heading name from content, inline	
+Pass	aria link name from content, inline	
+Pass	aria button name from content, block	
+Pass	aria heading name from content, block	
+Pass	aria link name from content, block	
+Pass	button name from content	
+Pass	heading name from content	
+Pass	link name from content	
+Pass	button name from content with ::before	
+Pass	heading name from content with ::before	
+Pass	link name from content with ::before	
+Pass	button name from content with ::after	
+Pass	heading name from content with ::after	
+Pass	link name from content with ::after	
+Pass	button name from content with ::before and ::after	
+Pass	heading name from content with ::before and ::after	
+Pass	link name from content with ::before and ::after	
+Pass	button name from content no space joiners ::before and ::after	
+Pass	heading name from content no space joiners ::before and ::after	
+Pass	link name from content no space joiners ::before and ::after	
+Pass	button name from content with ::before and ::after in rtl	
+Pass	heading name from content with ::before and ::after in rtl	
+Pass	link name from content with ::before and ::after in rtl	
+Pass	button name from fallback content with ::before and ::after	
+Pass	heading name from fallback content with ::before and ::after	
+Pass	link name from fallback content with ::before and ::after	
+Pass	button name from fallback content mixing attr() and strings with ::before and ::after	
+Pass	heading name from fallback content mixing attr() and strings with ::before and ::after	
+Pass	link name from fallback content mixing attr() and strings with ::before and ::after	
+Pass	primitive radio input with ::before containing empty alternative text	
+Pass	primitive radio input with ::before containing empty alternative text for an image	
+Pass	button name from content for each child	
+Pass	heading name from content for each child	
+Pass	link name from content for each child	
+Pass	button name from content for each child including image	
+Pass	heading name from content for each child including image	
+Pass	link name from content for each child including image	
+Pass	button name from content for each child including nested image	
+Pass	heading name from content for each child including nested image	
+Pass	link name from content for each child including nested image	
+Pass	heading name from content for each child including nested button with nested image	
+Pass	heading name from content for each child including nested link with nested image	
+Pass	heading name from content for each child including nested link using aria-label with nested image	
+Pass	heading name from content for each child including nested link using aria-labelledby with nested image	
+Pass	heading name from content for each child including two nested links using aria-labelledby with nested image	
+Pass	link name from content for each child including nested image (referenced elsewhere via labelledby)	
+Pass	button name from content for each child (no space, inline)	
+Pass	heading name from content for each child (no space, inline)	
+Pass	link name from content for each child (no space, inline)	
+Pass	button name from content for each child (no space, display:block)	
+Pass	heading name from content for each child (no space, display:block)	
+Pass	link name from content for each child (no space, display:block)	
+Pass	button name from content for each child (no space, display:inline-block)	
+Pass	heading name from content for each child (no space, display:inline-block)	
+Pass	link name from content for each child (no space, display:inline-block)	
+Pass	heading name from content with text-transform:none	
+Pass	heading name from content with text-transform:uppercase	
+Pass	heading name from content with text-transform:capitalize	
+Pass	heading name from content with text-transform:lowercase	

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_name_from_content.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_name_from_content.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Name From Content</title>
+  <meta charset="utf-8">
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+  <style type="text/css">
+
+     /*
+
+      Since the AccName spec is in flux about whitespace joiners, and the implementations don't match,
+      normalize the whitespace (with extra leading/trailing) space.
+
+      No point in having the same in-flux spec change cause failures the remaining unrelated tests.
+
+      See more here:
+      https://github.com/w3c/accname/issues/205
+      https://github.com/w3c/accname/projects/1#card-42288231
+
+    */
+
+    .simple-before::before {
+      content: " before "; /* [sic] leading and trailing space */
+      margin:0 0.1em;
+    }
+    .simple-after::after {
+      content: " after "; /* [sic] leading and trailing space */
+      margin:0 0.1em;
+    }
+    .no-space::before, .no-space::after {
+      content: "nospace"; /* [sic] Unlike the others, NO extra leading/trailing space here. */
+    }
+    .simple-before:dir(rtl)::before {
+      content: " من قبل "; /* [sic] leading and trailing space */
+    }
+    .simple-after:dir(rtl)::after {
+      content: " بعد "; /* [sic] leading and trailing space */
+    }
+    .fallback-before::before {
+      content: " before "; /* [sic] leading and trailing space */
+      content: " before " / " alt-before "; /* Override the previous line for engines that support the Alternative Text syntax. */
+    }
+    .fallback-after::after {
+      content: " after "; /* [sic] leading and trailing space */
+      content: " after " / " alt-after "; /* Override the previous line for engines that support the Alternative Text syntax. */
+    }
+    .fallback-before-empty::before {
+      content: "before"  / "";
+    }
+    .fallback-before-image-empty::before {
+      content: "before " url(/images/blue.png) / "";
+    }
+    .fallback-before-mixed::before {
+      content: " before "; /* [sic] leading and trailing space */
+      content: " before " / " start " attr(data-alt-text-before) " end "; /* Override the previous line for engines that support the Alternative Text syntax. */
+    }
+    .fallback-after-mixed::after {
+      content: " after "; /* [sic] leading and trailing space */
+      content: " after " / " start " attr(data-alt-text-after) " end "; /* Override the previous line for engines that support the Alternative Text syntax. */
+    }
+    .block > span {
+      display: block;
+      margin: 0 0.1em;
+    }
+    .iblock > span {
+      display: inline-block;
+      margin: 0 0.1em;
+    }
+
+  </style>
+</head>
+<body>
+
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_name_from_content">#comp_name_from_content</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
+<p>This series of tests exercises the button, heading, and link elements, because each have different characteristics worthy of testing in each of the name computation algorithm scenarios:</p>
+<ul>
+  <li>button is a leaf node with sub-level elements presentational.</li>
+  <li>heading is block level, and can contain sub-level interactives like links.</li>
+  <li>link (a[href]) is an interactive inline element that can include non-presentational descendants.</li>
+</ul>
+
+<h1>ARIA roles, inline</h1>
+<span tabindex="0" role="button" data-expectedlabel="label" data-testname="aria button name from content, inline" class="ex">label</span><br>
+<span tabindex="0" role="heading" data-expectedlabel="label" data-testname="aria heading name from content, inline" class="ex">label</span><br>
+<span tabindex="0" role="link" data-expectedlabel="label" data-testname="aria link name from content, inline" class="ex">label</span><br>
+<br>
+
+<h1>ARIA roles, block</h1>
+<div tabindex="0" role="button" data-expectedlabel="label" data-testname="aria button name from content, block" class="ex">label</div>
+<div tabindex="0" role="heading" data-expectedlabel="label" data-testname="aria heading name from content, block" class="ex">label</div>
+<div tabindex="0" role="link" data-expectedlabel="label" data-testname="aria link name from content, block" class="ex">label</div>
+<br>
+
+<h1>simple</h1>
+<button data-expectedlabel="label" data-testname="button name from content" class="ex">label</button><br>
+<h3 data-expectedlabel="label" data-testname="heading name from content" class="ex">label</h3>
+<a href="#" data-expectedlabel="label" data-testname="link name from content" class="ex">label</a><br>
+<br>
+
+<h1>simple with ::before</h1>
+<button data-expectedlabel="before label" data-testname="button name from content with ::before" class="ex simple-before">label</button><br>
+<h3 data-expectedlabel="before label" data-testname="heading name from content with ::before" class="ex simple-before">label</h3>
+<a href="#" data-expectedlabel="before label" data-testname="link name from content with ::before" class="ex simple-before">label</a><br>
+<br>
+
+<h1>simple with ::after</h1>
+<button data-expectedlabel="label after" data-testname="button name from content with ::after" class="ex simple-after">label</button><br>
+<h3 data-expectedlabel="label after" data-testname="heading name from content with ::after" class="ex simple-after">label</h3>
+<a href="#" data-expectedlabel="label after" data-testname="link name from content with ::after" class="ex simple-after">label</a><br>
+<br>
+
+<h1>simple with ::before and ::after</h1>
+<button data-expectedlabel="before label after" data-testname="button name from content with ::before and ::after" class="ex simple-before simple-after">label</button><br>
+<h3 data-expectedlabel="before label after" data-testname="heading name from content with ::before and ::after" class="ex simple-before simple-after">label</h3>
+<a href="#" data-expectedlabel="before label after" data-testname="link name from content with ::before and ::after" class="ex simple-before simple-after">label</a><br>
+<br>
+
+<h1>no space joiners ::before and ::after</h1>
+<button data-expectedlabel="nospacelabelnospace" data-testname="button name from content no space joiners ::before and ::after" class="ex no-space">label</button><br>
+<h3 data-expectedlabel="nospacelabelnospace" data-testname="heading name from content no space joiners ::before and ::after" class="ex no-space">label</h3>
+<a href="#" data-expectedlabel="nospacelabelnospace" data-testname="link name from content no space joiners ::before and ::after" class="ex no-space">label</a><br>
+<br>
+
+<h1>Arabic right-to-left (RTL) with ::before and ::after</h1>
+<div dir="rtl" lang="ar">
+  <button data-expectedlabel="من قبل اسم بعد" data-testname="button name from content with ::before and ::after in rtl" class="ex simple-before simple-after">اسم</button><br>
+  <h3 data-expectedlabel="من قبل اسم بعد" data-testname="heading name from content with ::before and ::after in rtl" class="ex simple-before simple-after">اسم</h3>
+  <a href="#" data-expectedlabel="من قبل اسم بعد" data-testname="link name from content with ::before and ::after in rtl" class="ex simple-before simple-after">اسم</a><br>
+</div>
+<br>
+
+<h1><a href="https://drafts.csswg.org/css-content/#alt">Alternative Text for  CSS content (previously `alt:`)</a> in pseudo-elements</h1>
+<p>rendered text should be "before label after"</p>
+<p>accessibility label should be "alt-before label alt-after"</p>
+<button data-expectedlabel="alt-before label alt-after" data-testname="button name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</button><br>
+<h3 data-expectedlabel="alt-before label alt-after" data-testname="heading name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</h3>
+<a href="#" data-expectedlabel="alt-before label alt-after" data-testname="link name from fallback content with ::before and ::after" class="ex fallback-before fallback-after">label</a><br>
+<br>
+
+<h1><a href="https://drafts.csswg.org/css-content/#alt">Mixed Alternative Text (attr() and strings) for  CSS content (previously `alt:`)</a> in pseudo-elements</h1>
+<p>rendered text should be "before label after"</p>
+<p>accessibility label should be "start alt-before end label start alt-after end"</p>
+<button data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="button name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</button><br>
+<h3 data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="heading name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</h3>
+<a href="#" data-alt-text-before="alt-before" data-alt-text-after="alt-after" data-expectedlabel="start alt-before end label start alt-after end" data-testname="link name from fallback content mixing attr() and strings with ::before and ::after" class="ex fallback-before-mixed fallback-after-mixed">label</a><br>
+<br>
+
+<h1>Empty alternative text for CSS content in pseudo-elements when applied to primitive appearance form controls</h1>
+<p><input data-expectedlabel="" data-testname="primitive radio input with ::before containing empty alternative text" class="ex fallback-before-empty" type=radio style=appearance:none>
+<p><input data-expectedlabel="" data-testname="primitive radio input with ::before containing empty alternative text for an image" class="ex fallback-before-image-empty" type=radio style=appearance:none>
+
+<h1>simple w/ for each child</h1>
+<button data-expectedlabel="one two three" data-testname="button name from content for each child" class="ex"><span>one</span> <span>two</span> <span>three</span></button><br>
+<h3 data-expectedlabel="one two three" data-testname="heading name from content for each child" class="ex"><span>one</span> <span>two</span> <span>three</span></h3>
+<a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child" class="ex"><span>one</span> <span>two</span> <span>three</span></a><br>
+<br>
+
+<h1>simple for each child with image</h1>
+<button data-expectedlabel="one two three" data-testname="button name from content for each child including image" class="ex"><span>one</span> <img alt="two" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> <span>three</span></button><br>
+<h3 data-expectedlabel="one two three" data-testname="heading name from content for each child including image" class="ex"><span>one</span> <img alt="two" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> <span>three</span></h3>
+<a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child including image" class="ex"><span>one</span> <img alt="two" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="> <span>three</span></a><br>
+<br>
+
+
+<h1>simple for each child with extra nesting containing image</h1>
+<button data-expectedlabel="one two three four" data-testname="button name from content for each child including nested image" class="ex"><span>one</span> <span>two <img alt="three" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></span> <span>four</span></button><br>
+<h3 data-expectedlabel="one two three four" data-testname="heading name from content for each child including nested image" class="ex"><span>one</span> <span>two <img alt="three" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></span> <span>four</span></h3>
+<a href="#" data-expectedlabel="one two three four" data-testname="link name from content for each child including nested image" class="ex"><span>one</span> <span>two <img alt="three" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></span> <span>four</span></a><br>
+<br>
+
+<h1>heading with nested button with nested image</h1>
+<h3 data-expectedlabel="heading button image button heading" data-testname="heading name from content for each child including nested button with nested image" class="ex">
+  heading
+  <button>
+    button
+    <img alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    button
+  </button>
+  heading
+</h3>
+
+<h1>heading with nested link with nested image</h1>
+<h3 data-expectedlabel="heading link image link heading" data-testname="heading name from content for each child including nested link with nested image" class="ex">
+  heading
+  <a href="#">
+    link
+    <img alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    link
+  </a>
+  heading
+</h3>
+
+<h1>heading with nested link with nested image using aria-label</h1>
+<h3 data-expectedlabel="heading link aria-label heading" data-testname="heading name from content for each child including nested link using aria-label with nested image" class="ex">
+  heading
+  <a href="#" aria-label="link aria-label"><!-- should skip the other link text -->
+    ignored link text
+    <img id="nested_image_label_1" alt="ignored image alt" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    ignored link text
+  </a>
+  heading
+</h3>
+
+<h1>heading with nested link with nested image using aria-labelledby</h1>
+<h3 data-expectedlabel="heading image heading" data-testname="heading name from content for each child including nested link using aria-labelledby with nested image" class="ex">
+  heading
+  <a href="#" aria-labelledby="nested_image_label1"><!-- should skip the other link text -->
+    ignored link text
+    <img id="nested_image_label1" alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    ignored link text
+  </a>
+  heading
+</h3>
+
+<h1>heading with two nested links referencing image using aria-labelledby</h1>
+<h3 data-expectedlabel="image link2 link3" data-testname="heading name from content for each child including two nested links using aria-labelledby with nested image" class="ex">
+  <a href="#" aria-labelledby="nested_image_label2">
+    link1<!-- this text is skipped because of aria-labelledby -->
+  </a>
+  <a href="#" data-expectedlabel="link2 image link3" data-testname="link name from content for each child including nested image (referenced elsewhere via labelledby)" class="ex">
+    link2
+    <img id="nested_image_label2" alt="image" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+    <!-- image skipped in this link (when computing heading text) because it was already referenced by the first link within this heading label recursion cycle. -->
+    <!-- but image not skipped when computing the text of the link itself since it has not been referenced in that context -->
+    link3
+  </a>
+</h3>
+
+
+<!-- Note: The following test is out of line with the spec, but matching two out of three implementations at the time of writing, and spec changes are expeected. -->
+<!-- See details in https://github.com/w3c/accname/issues/205 -->
+<!-- Final spec resolution will be addressed in AccName Whitespace Project: https://github.com/w3c/accname/projects/1#card-42288231 -->
+<h1>simple w/ for each child (w/o spaces and display:inline)</h1>
+<button data-expectedlabel="onetwothree" data-testname="button name from content for each child (no space, inline)" class="ex"><span>one</span><span>two</span><span>three</span></button><br>
+<h3 data-expectedlabel="onetwothree" data-testname="heading name from content for each child (no space, inline)" class="ex"><span>one</span><span>two</span><span>three</span></h3>
+<a href="#" data-expectedlabel="onetwothree" data-testname="link name from content for each child (no space, inline)" class="ex"><span>one</span><span>two</span><span>three</span></a><br>
+<br>
+
+<h1>simple w/ for each child (w/o spaces and display:block)</h1>
+<button data-expectedlabel="one two three" data-testname="button name from content for each child (no space, display:block)" class="ex block"><span>one</span><span>two</span><span>three</span></button><br>
+<h3 data-expectedlabel="one two three" data-testname="heading name from content for each child (no space, display:block)" class="ex block"><span>one</span><span>two</span><span>three</span></h3>
+<a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child (no space, display:block)" class="ex block"><span>one</span><span>two</span><span>three</span></a><br>
+<br>
+
+<h1>simple w/ for each child (w/o spaces and display:inline block)</h1>
+<button data-expectedlabel="one two three" data-testname="button name from content for each child (no space, display:inline-block)" class="ex iblock"><span>one</span><span>two</span><span>three</span></button><br>
+<h3 data-expectedlabel="one two three" data-testname="heading name from content for each child (no space, display:inline-block)" class="ex iblock"><span>one</span><span>two</span><span>three</span></h3>
+<a href="#" data-expectedlabel="one two three" data-testname="link name from content for each child (no space, display:inline-block)" class="ex iblock"><span>one</span><span>two</span><span>three</span></a><br>
+<br>
+
+<h1 data-expectedlabel="Call us" data-testname="heading name from content with text-transform:none" class="ex" style="text-transform:none;">Call us</h1>
+<h1 data-expectedlabel="CALL US" data-testname="heading name from content with text-transform:uppercase" class="ex" style="text-transform:uppercase;">Call us</h1>
+<h1 data-expectedlabel="Call Us" data-testname="heading name from content with text-transform:capitalize" class="ex" style="text-transform:capitalize;">Call us</h1>
+<h1 data-expectedlabel="call us" data-testname="heading name from content with text-transform:lowercase" class="ex" style="text-transform:lowercase;">Call us</h1>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This PR updates the implementation for [computing accessible names](https://w3c.github.io/accname/#computation-steps) (begun in da5c918) such that it gets Ladybird passing all 60 subtests in the `comp_name_from_content`.html test at https://wpt.fyi/results/accname/name?product=ladybird — an increase in 41 new passes.

To facilitate review and to provide for a more-granular commit history, the changes in this PR are in 7 separate commits:

a6993d243b6 Fix accessible-name computation for pseudo-element content
3f038859253 Fix accessible-name computation for `aria-labelledby` cases
744f325e91b Support computing accessible names from image `alt` attributes
ad53c74fbe2 Use rendered text in accessible-name computation
904899fe791 Ensure spaces get added where expected within accessible names
428915595e7 Import WPT `accname/name/comp_name_from_content.html` test
05a03b8fe7b Remove unused `append_with_space` etc functions from `DOM::Node`