### PR TITLE
LibWeb: Delete EditableTextNodeOwner

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Text.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Text.cpp
@@ -48,15 +48,6 @@ WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::construct_impl(JS::Realm& real
     return realm.heap().allocate<Text>(realm, window.associated_document(), data);
 }
 
-EditableTextNodeOwner* Text::editable_text_node_owner()
-{
-    if (!m_owner)
-        return nullptr;
-    EditableTextNodeOwner* owner = dynamic_cast<EditableTextNodeOwner*>(m_owner.ptr());
-    VERIFY(owner);
-    return owner;
-}
-
 // https://dom.spec.whatwg.org/#dom-text-splittext
 // https://dom.spec.whatwg.org/#concept-text-split
 WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> Text::split_text(size_t offset)

--- a/Userland/Libraries/LibWeb/DOM/Text.h
+++ b/Userland/Libraries/LibWeb/DOM/Text.h
@@ -13,12 +13,6 @@
 
 namespace Web::DOM {
 
-class EditableTextNodeOwner {
-public:
-    virtual ~EditableTextNodeOwner() = default;
-    virtual void did_edit_text_node() = 0;
-};
-
 class Text
     : public CharacterData
     , public SlottableMixin {
@@ -38,10 +32,6 @@ public:
 
     Optional<size_t> max_length() const { return m_max_length; }
     void set_max_length(Optional<size_t> max_length) { m_max_length = move(max_length); }
-
-    template<DerivedFrom<EditableTextNodeOwner> T>
-    void set_editable_text_node_owner(Badge<T>, Element& owner_element) { m_owner = &owner_element; }
-    EditableTextNodeOwner* editable_text_node_owner();
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Text>> split_text(size_t offset);
     String whole_text();

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -607,7 +607,7 @@ void FormAssociatedTextControlElement::handle_insert(String const& data)
     MUST(set_range_text(data_for_insertion, selection_start.value(), selection_end.value(), Bindings::SelectionMode::End));
 
     text_node->invalidate_style(DOM::StyleInvalidationReason::EditingInsertion);
-    text_node->editable_text_node_owner()->did_edit_text_node();
+    did_edit_text_node();
 }
 
 void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -170,6 +170,8 @@ public:
     bool has_scheduled_selectionchange_event() const { return m_has_scheduled_selectionchange_event; }
     void set_scheduled_selectionchange_event(bool value) { m_has_scheduled_selectionchange_event = value; }
 
+    virtual void did_edit_text_node() = 0;
+
     virtual JS::GCPtr<DOM::Text> form_associated_element_to_text_node() = 0;
     virtual JS::GCPtr<DOM::Text const> form_associated_element_to_text_node() const { return const_cast<FormAssociatedTextControlElement&>(*this).form_associated_element_to_text_node(); }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -850,7 +850,6 @@ void HTMLInputElement::create_text_input_shadow_tree()
 
     m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), String {});
     m_placeholder_text_node->set_data(placeholder());
-    m_placeholder_text_node->set_editable_text_node_owner(Badge<HTMLInputElement> {}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
 
     // https://www.w3.org/TR/css-ui-4/#input-rules
@@ -871,7 +870,6 @@ void HTMLInputElement::create_text_input_shadow_tree()
     } else {
         handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
     }
-    m_text_node->set_editable_text_node_owner(Badge<HTMLInputElement> {}, *this);
     if (type_state() == TypeAttributeState::Password)
         m_text_node->set_is_password_input({}, true);
     handle_maxlength_attribute();

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -50,7 +50,6 @@ namespace Web::HTML {
 class HTMLInputElement final
     : public HTMLElement
     , public FormAssociatedTextControlElement
-    , public DOM::EditableTextNodeOwner
     , public Layout::ImageProvider {
     WEB_PLATFORM_OBJECT(HTMLInputElement, HTMLElement);
     JS_DECLARE_ALLOCATOR(HTMLInputElement);
@@ -150,9 +149,6 @@ public:
 
     WebIDL::ExceptionOr<void> show_picker();
 
-    // ^DOM::EditableTextNodeOwner
-    virtual void did_edit_text_node() override;
-
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-input-element
     // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area
@@ -218,6 +214,8 @@ public:
 
     Optional<String> selection_direction_binding() { return selection_direction(); }
 
+    // ^FormAssociatedTextControlElement
+    virtual void did_edit_text_node() override;
     virtual JS::GCPtr<DOM::Text> form_associated_element_to_text_node() override { return m_text_node; }
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -370,7 +370,6 @@ void HTMLTextAreaElement::create_shadow_tree_if_needed()
 
     m_placeholder_text_node = heap().allocate<DOM::Text>(realm(), document(), String {});
     m_placeholder_text_node->set_data(get_attribute_value(HTML::AttributeNames::placeholder));
-    m_placeholder_text_node->set_editable_text_node_owner(Badge<HTMLTextAreaElement> {}, *this);
     MUST(m_placeholder_element->append_child(*m_placeholder_text_node));
 
     m_inner_text_element = MUST(DOM::create_element(document(), HTML::TagNames::div, Namespace::HTML));
@@ -378,7 +377,6 @@ void HTMLTextAreaElement::create_shadow_tree_if_needed()
 
     m_text_node = heap().allocate<DOM::Text>(realm(), document(), String {});
     handle_readonly_attribute(attribute(HTML::AttributeNames::readonly));
-    m_text_node->set_editable_text_node_owner(Badge<HTMLTextAreaElement> {}, *this);
     // NOTE: If `children_changed()` was called before now, `m_raw_value` will hold the text content.
     //       Otherwise, it will get filled in whenever that does get called.
     m_text_node->set_text_content(m_raw_value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -20,8 +20,7 @@ namespace Web::HTML {
 
 class HTMLTextAreaElement final
     : public HTMLElement
-    , public FormAssociatedTextControlElement
-    , public DOM::EditableTextNodeOwner {
+    , public FormAssociatedTextControlElement {
     WEB_PLATFORM_OBJECT(HTMLTextAreaElement, HTMLElement);
     JS_DECLARE_ALLOCATOR(HTMLTextAreaElement);
     FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLTextAreaElement)
@@ -36,9 +35,6 @@ public:
         static String const textarea = "textarea"_string;
         return textarea;
     }
-
-    // ^DOM::EditableTextNodeOwner
-    virtual void did_edit_text_node() override;
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-textarea-element
@@ -126,6 +122,8 @@ public:
 
     void set_dirty_value_flag(Badge<FormAssociatedElement>, bool flag) { m_dirty_value = flag; }
 
+    // ^FormAssociatedTextControlElement
+    virtual void did_edit_text_node() override;
     virtual JS::GCPtr<DOM::Text> form_associated_element_to_text_node() override { return m_text_node; }
 
 private:


### PR DESCRIPTION
It's no longer needed after FormAssociatedTextControlElement became responsible for managing input events for text controls.