### PR TITLE
Meta+LibJS: Upgrade to prettier version 3.3.3

### DIFF
--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install JS Dependencies
         shell: bash
-        run: npm install -g prettier@2.7.1
+        run: npm install -g prettier@3.3.3
 
       - name: Lint
         run: ${{ github.workspace }}/Meta/lint-ci.sh

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -30,8 +30,8 @@ if (( ${#files[@]} )); then
         exit 1
     fi
 
-    if ! prettier --version | grep -q '\b2\.' ; then
-        echo "You are using '$(prettier --version)', which appears to not be prettier 2."
+    if ! prettier --version | grep -q '\b3\.' ; then
+        echo "You are using '$(prettier --version)', which appears to not be prettier 3."
         exit 1
     fi
 

--- a/Meta/lint-prettier.sh
+++ b/Meta/lint-prettier.sh
@@ -30,7 +30,7 @@ if (( ${#files[@]} )); then
         exit 1
     fi
 
-    if ! prettier --version | grep -qF '2.' ; then
+    if ! prettier --version | grep -q '\b2\.' ; then
         echo "You are using '$(prettier --version)', which appears to not be prettier 2."
         exit 1
     fi

--- a/Userland/Libraries/LibJS/Tests/modules/import-with-assertions.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/import-with-assertions.mjs
@@ -1,4 +1,4 @@
-import * as self from "./import-with-assertions.mjs" assert { "key": "value", key2: "value2", default: "shouldwork" };
-import "./import-with-assertions.mjs" assert { "key": "value", key2: "value2", default: "shouldwork" };
+import * as self from "./import-with-assertions.mjs" assert { key: "value", key2: "value2", default: "shouldwork" };
+import "./import-with-assertions.mjs" assert { key: "value", key2: "value2", default: "shouldwork" };
 
-export { passed } from "./module-with-default.mjs" assert { "key": "value", key2: "value2", default: "shouldwork" };
+export { passed } from "./module-with-default.mjs" assert { key: "value", key2: "value2", default: "shouldwork" };

--- a/Userland/Libraries/LibJS/Tests/test-common-tests.js
+++ b/Userland/Libraries/LibJS/Tests/test-common-tests.js
@@ -63,8 +63,10 @@ test("toHaveLength", () => {
     expect([1]).toHaveLength(1);
     expect({ length: 1 }).toHaveLength(1);
 
-    expect("a\
-b").toHaveLength(2);
+    expect(
+        "a\
+b"
+    ).toHaveLength(2);
 
     expect(() => {
         expect(1).toHaveLength();

--- a/Userland/Libraries/LibJS/Tests/this-value-strict.js
+++ b/Userland/Libraries/LibJS/Tests/this-value-strict.js
@@ -179,7 +179,7 @@ describe("functions on created objects", () => {
 
             expect(obj2.func()).toBe(obj2);
             expect(obj2.arrow()).toBe(customThisValue);
-        }.bind(customThisValue)());
+        }).bind(customThisValue)();
     });
 });
 

--- a/Userland/Libraries/LibJS/Tests/this-value.js
+++ b/Userland/Libraries/LibJS/Tests/this-value.js
@@ -177,7 +177,7 @@ describe("functions on created objects", () => {
 
             expect(obj2.func()).toBe(obj2);
             expect(obj2.arrow()).toBe(customThisValue);
-        }.bind(customThisValue)());
+        }).bind(customThisValue)();
     });
 });
 


### PR DESCRIPTION
Prettier v3 was released over a year ago, and most users will have it by default by now.