### PR TITLE
Tests: Allow wpt.live URLs for both “WPT.sh run” and “WPT.sh import”

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -131,6 +131,8 @@ for i in "${!TEST_LIST[@]}"; do
     item="${TEST_LIST[i]}"
     item="${item#"$WPT_SOURCE_DIR"/}"
     item="${item#*Tests/LibWeb/WPT/wpt/}"
+    item="${item#http://wpt.live/}"
+    item="${item#https://wpt.live/}"
     TEST_LIST[i]="$item"
 done
 
@@ -193,6 +195,12 @@ serve_wpt()
 
 import_wpt()
 {
+    for i in "${!INPUT_PATHS[@]}"; do
+        item="${INPUT_PATHS[i]}"
+        item="${item#http://wpt.live/}"
+        item="${item#https://wpt.live/}"
+        INPUT_PATHS[i]="$item"
+    done
     pushd "${LADYBIRD_SOURCE_DIR}" > /dev/null
         ./Meta/ladybird.sh build headless-browser
         for path in "${INPUT_PATHS[@]}"; do


### PR DESCRIPTION
This change allows you to give `http[s]://wpt.live/` URLs to the `WPT.sh` script for both the `WPT.sh run` and `WPT.sh import` commands.

That facilitates the use case where you’ve navigated to a wpt.live URL in a browser, and you want to just directly copy-paste the URL in order to either run the test in Ladybird, or import the test into the repo.

Otherwise, without this change, when using `WPT.sh`, you’re limited to needing to specify either a WPT path fragment or filesystem pathname — which doesn’t allow for easy copy-paste directly from wpt.fyi.