### PR TITLE
LibWeb: Improve cursor position behavior for non-latin text

### DIFF
--- a/Tests/LibWeb/Text/expected/Editing/move-cursor-using-keyboard-in-contenteditable-with-ru-text.txt
+++ b/Tests/LibWeb/Text/expected/Editing/move-cursor-using-keyboard-in-contenteditable-with-ru-text.txt
@@ -1,0 +1,7 @@
+selection anchorOffset: 6 focusOffset: 6
+> Pressing Left key
+selection anchorOffset: 5 focusOffset: 5
+> Pressing Left key
+selection anchorOffset: 4 focusOffset: 4
+> Pressing Right key
+selection anchorOffset: 5 focusOffset: 5

--- a/Tests/LibWeb/Text/input/Editing/move-cursor-using-keyboard-in-contenteditable-with-ru-text.html
+++ b/Tests/LibWeb/Text/input/Editing/move-cursor-using-keyboard-in-contenteditable-with-ru-text.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #editable {
+        border: 2px solid #333;
+        padding: 20px;
+        max-width: 600px;
+        min-height: 200px;
+        background-color: #f9f9f9;
+    }
+</style>
+<div id="editable" contenteditable="true">привет</div>
+<script>
+    test(() => {
+        const editable = document.getElementById("editable");
+        // Focusing of contenteditable should move the cursor to the end of the text in it
+        editable.focus();
+
+        const selection = window.getSelection();
+        println(`selection anchorOffset: ${selection.anchorOffset} focusOffset: ${selection.focusOffset}`);
+
+        println("> Pressing Left key");
+        internals.sendKey(editable, "Left", 0);
+        println(`selection anchorOffset: ${selection.anchorOffset} focusOffset: ${selection.focusOffset}`);
+
+        println("> Pressing Left key");
+        internals.sendKey(editable, "Left", 0);
+        println(`selection anchorOffset: ${selection.anchorOffset} focusOffset: ${selection.focusOffset}`);
+
+        println("> Pressing Right key");
+        internals.sendKey(editable, "Right", 0);
+        println(`selection anchorOffset: ${selection.anchorOffset} focusOffset: ${selection.focusOffset}`);
+    });
+</script>

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -561,8 +561,9 @@ void paint_cursor_if_needed(PaintContext& context, TextPaintable const& paintabl
     auto fragment_rect = fragment.absolute_rect();
 
     auto text = fragment.string_view();
+    auto utf8_view = Utf8View(text).unicode_substring_view(0, document.cursor_position()->offset() - fragment.start());
     CSSPixelRect cursor_rect {
-        fragment_rect.x() + CSSPixels::nearest_value_for(paintable.layout_node().first_available_font().width(text.substring_view(0, document.cursor_position()->offset() - fragment.start()))),
+        fragment_rect.x() + CSSPixels::nearest_value_for(paintable.layout_node().first_available_font().width(utf8_view)),
         fragment_rect.top(),
         1,
         fragment_rect.height()

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -493,12 +493,14 @@ void Selection::move_offset_to_next_character(bool collapse_selection)
         return;
 
     auto& text_node = static_cast<DOM::Text&>(*anchor_node);
-    if (auto offset = text_node.grapheme_segmenter().next_boundary(focus_offset()); offset.has_value()) {
+    auto focus_offset_in_bytes = Utf8View { text_node.data() }.byte_offset_of(focus_offset());
+    if (auto byte_offset = text_node.grapheme_segmenter().next_boundary(focus_offset_in_bytes); byte_offset.has_value()) {
+        auto offset = Utf8View { text_node.data() }.substring_view(0, *byte_offset).length();
         if (collapse_selection) {
-            MUST(collapse(*anchor_node, *offset));
+            MUST(collapse(*anchor_node, offset));
             m_document->reset_cursor_blink_cycle();
         } else {
-            MUST(set_base_and_extent(*anchor_node, anchor_offset(), *anchor_node, *offset));
+            MUST(set_base_and_extent(*anchor_node, anchor_offset(), *anchor_node, offset));
         }
     }
 }
@@ -510,12 +512,14 @@ void Selection::move_offset_to_previous_character(bool collapse_selection)
         return;
 
     auto& text_node = static_cast<DOM::Text&>(*anchor_node);
-    if (auto offset = text_node.grapheme_segmenter().previous_boundary(focus_offset()); offset.has_value()) {
+    auto focus_offset_in_bytes = Utf8View { text_node.data() }.byte_offset_of(focus_offset());
+    if (auto byte_offset = text_node.grapheme_segmenter().previous_boundary(focus_offset_in_bytes); byte_offset.has_value()) {
+        auto offset = Utf8View { text_node.data() }.substring_view(0, *byte_offset).length();
         if (collapse_selection) {
-            MUST(collapse(*anchor_node, *offset));
+            MUST(collapse(*anchor_node, offset));
             m_document->reset_cursor_blink_cycle();
         } else {
-            MUST(set_base_and_extent(*anchor_node, anchor_offset(), *anchor_node, *offset));
+            MUST(set_base_and_extent(*anchor_node, anchor_offset(), *anchor_node, offset));
         }
     }
 }
@@ -529,18 +533,19 @@ void Selection::move_offset_to_next_word(bool collapse_selection)
 
     auto& text_node = static_cast<DOM::Text&>(*anchor_node);
     while (true) {
-        auto focus_offset = this->focus_offset();
-        if (focus_offset == text_node.data().bytes_as_string_view().length()) {
+        auto focus_offset_in_bytes = Utf8View { text_node.data() }.byte_offset_of(focus_offset());
+        if (focus_offset_in_bytes == text_node.data().byte_count()) {
             return;
         }
 
-        if (auto offset = text_node.word_segmenter().next_boundary(focus_offset); offset.has_value()) {
-            auto word = text_node.data().code_points().substring_view(focus_offset, *offset - focus_offset);
+        if (auto byte_offset = text_node.word_segmenter().next_boundary(focus_offset_in_bytes); byte_offset.has_value()) {
+            auto word = text_node.data().code_points().substring_view(focus_offset_in_bytes, *byte_offset - focus_offset_in_bytes);
+            auto offset = Utf8View { text_node.data() }.substring_view(0, *byte_offset).length();
             if (collapse_selection) {
-                MUST(collapse(anchor_node, *offset));
+                MUST(collapse(anchor_node, offset));
                 m_document->reset_cursor_blink_cycle();
             } else {
-                MUST(set_base_and_extent(*anchor_node, this->anchor_offset(), *anchor_node, *offset));
+                MUST(set_base_and_extent(*anchor_node, this->anchor_offset(), *anchor_node, offset));
             }
             if (Unicode::Segmenter::should_continue_beyond_word(word))
                 continue;
@@ -558,14 +563,15 @@ void Selection::move_offset_to_previous_word(bool collapse_selection)
 
     auto& text_node = static_cast<DOM::Text&>(*anchor_node);
     while (true) {
-        auto focus_offset = this->focus_offset();
-        if (auto offset = text_node.word_segmenter().previous_boundary(focus_offset); offset.has_value()) {
-            auto word = text_node.data().code_points().substring_view(focus_offset, focus_offset - *offset);
+        auto focus_offset_in_bytes = Utf8View { text_node.data() }.byte_offset_of(focus_offset());
+        if (auto byte_offset = text_node.word_segmenter().previous_boundary(focus_offset_in_bytes); byte_offset.has_value()) {
+            auto word = text_node.data().code_points().substring_view(focus_offset_in_bytes, focus_offset_in_bytes - *byte_offset);
+            auto offset = Utf8View { text_node.data() }.substring_view(0, *byte_offset).length();
             if (collapse_selection) {
-                MUST(collapse(anchor_node, *offset));
+                MUST(collapse(anchor_node, offset));
                 m_document->reset_cursor_blink_cycle();
             } else {
-                MUST(set_base_and_extent(*anchor_node, anchor_offset(), *anchor_node, *offset));
+                MUST(set_base_and_extent(*anchor_node, anchor_offset(), *anchor_node, offset));
             }
             if (Unicode::Segmenter::should_continue_beyond_word(word))
                 continue;


### PR DESCRIPTION
Both grapheme and word segmenters accept and return byte offsets, while
anchor and focus offsets in the Selection object are UTF-16 code unit
offsets. Prior to this change, we mistakenly mixed these up by passing
code unit offsets into the segmenter and then saving the returned byte
offset as a code unit offset in the Selection object. This led to
incorrect behavior for non-latin scripts, where a character may occupy
more than one byte.

This change is a step toward achieving more correct behavior, as we now
convert between byte offsets and code units when interacting with the
segmenter. However, the use of UTF-8 instead of UTF-16 for conversion
remains incorrect.