### PR TITLE
UI: Do not place the WebView inside a scroll view

### DIFF
--- a/Ladybird/AppKit/UI/Event.h
+++ b/Ladybird/AppKit/UI/Event.h
@@ -14,7 +14,7 @@
 
 namespace Ladybird {
 
-Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type, NSEvent*, NSView*, NSScrollView*, Web::UIEvents::MouseButton);
+Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type, NSEvent*, NSView*, Web::UIEvents::MouseButton);
 
 Web::DragEvent ns_event_to_drag_event(Web::DragEvent::Type, id<NSDraggingInfo>, NSView*);
 Vector<URL::URL> drag_event_url_list(Web::DragEvent const&);

--- a/Ladybird/AppKit/UI/Event.mm
+++ b/Ladybird/AppKit/UI/Event.mm
@@ -40,7 +40,7 @@ static Web::UIEvents::KeyModifier ns_modifiers_to_key_modifiers(NSEventModifierF
     return static_cast<Web::UIEvents::KeyModifier>(modifiers);
 }
 
-Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* event, NSView* view, NSScrollView* scroll_view, Web::UIEvents::MouseButton button)
+Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* event, NSView* view, Web::UIEvents::MouseButton button)
 {
     auto position = [view convertPoint:event.locationInWindow fromView:nil];
     auto device_position = ns_point_to_gfx_point(position).to_type<Web::DevicePixels>();
@@ -62,8 +62,10 @@ Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* eve
         CGFloat delta_y = -[event scrollingDeltaY];
 
         if (![event hasPreciseScrollingDeltas]) {
-            delta_x *= scroll_view.horizontalLineScroll;
-            delta_y *= scroll_view.verticalLineScroll;
+            static constexpr CGFloat imprecise_scroll_multiplier = 24;
+
+            delta_x *= imprecise_scroll_multiplier;
+            delta_y *= imprecise_scroll_multiplier;
         }
 
         wheel_delta_x = static_cast<int>(delta_x);

--- a/Ladybird/AppKit/UI/Inspector.mm
+++ b/Ladybird/AppKit/UI/Inspector.mm
@@ -129,7 +129,7 @@ static constexpr NSInteger CONTEXT_MENU_DELETE_COOKIE_TAG = 4;
             [NSMenu popUpContextMenu:strong_self.cookie_context_menu withEvent:event forView:strong_self.web_view];
         };
 
-        [self setContentView:self.web_view.enclosingScrollView];
+        [self setContentView:self.web_view];
         [self setTitle:@"Inspector"];
         [self setIsVisible:YES];
     }

--- a/Ladybird/AppKit/UI/LadybirdWebView.h
+++ b/Ladybird/AppKit/UI/LadybirdWebView.h
@@ -48,7 +48,7 @@
 
 @end
 
-@interface LadybirdWebView : NSClipView <NSMenuDelegate>
+@interface LadybirdWebView : NSView <NSMenuDelegate>
 
 - (instancetype)init:(id<LadybirdWebViewObserver>)observer;
 - (instancetype)initAsChild:(id<LadybirdWebViewObserver>)observer
@@ -70,7 +70,6 @@
 
 - (void)handleResize;
 - (void)handleDevicePixelRatioChange;
-- (void)handleScroll;
 - (void)handleVisibility:(BOOL)is_visible;
 
 - (void)setPreferredColorScheme:(Web::CSS::PreferredColorScheme)color_scheme;

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.cpp
@@ -51,16 +51,12 @@ void WebViewBridge::set_system_visibility_state(bool is_visible)
     client().async_set_system_visibility_state(m_client_state.page_index, is_visible);
 }
 
-void WebViewBridge::set_viewport_rect(Gfx::IntRect viewport_rect, ForResize for_resize)
+void WebViewBridge::set_viewport_rect(Gfx::IntRect viewport_rect)
 {
     viewport_rect.set_size(scale_for_device(viewport_rect.size(), m_device_pixel_ratio));
     m_viewport_size = viewport_rect.size();
 
-    client().async_set_viewport_size(m_client_state.page_index, m_viewport_size.to_type<Web::DevicePixels>());
-
-    if (for_resize == ForResize::Yes) {
-        handle_resize();
-    }
+    handle_resize();
 }
 
 void WebViewBridge::update_palette()

--- a/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
+++ b/Ladybird/AppKit/UI/LadybirdWebViewBridge.h
@@ -32,12 +32,7 @@ public:
     float inverse_device_pixel_ratio() const { return 1.0f / m_device_pixel_ratio; }
 
     void set_system_visibility_state(bool is_visible);
-
-    enum class ForResize {
-        Yes,
-        No,
-    };
-    void set_viewport_rect(Gfx::IntRect, ForResize = ForResize::No);
+    void set_viewport_rect(Gfx::IntRect);
 
     void update_palette();
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);

--- a/Ladybird/AppKit/UI/LadybirdWebViewWindow.mm
+++ b/Ladybird/AppKit/UI/LadybirdWebViewWindow.mm
@@ -28,34 +28,14 @@
 
     if (self) {
         self.web_view = web_view;
+
         if (self.web_view == nil)
             self.web_view = [[LadybirdWebView alloc] init:nil];
 
-        [self.web_view setPostsBoundsChangedNotifications:YES];
-
-        auto* scroll_view = [[NSScrollView alloc] init];
-        [scroll_view setHasVerticalScroller:NO];
-        [scroll_view setHasHorizontalScroller:NO];
-        [scroll_view setLineScroll:24];
-
-        [scroll_view setContentView:self.web_view];
-        [scroll_view setDocumentView:[[NSView alloc] init]];
-
-        [[NSNotificationCenter defaultCenter]
-            addObserver:self
-               selector:@selector(onContentScroll:)
-                   name:NSViewBoundsDidChangeNotification
-                 object:[scroll_view contentView]];
+        [self.web_view setClipsToBounds:YES];
     }
 
     return self;
-}
-
-#pragma mark - Private methods
-
-- (void)onContentScroll:(NSNotification*)notification
-{
-    [self.web_view handleScroll];
 }
 
 #pragma mark - NSWindow

--- a/Ladybird/AppKit/UI/Tab.mm
+++ b/Ladybird/AppKit/UI/Tab.mm
@@ -95,7 +95,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 800;
 
         auto* stack_view = [NSStackView stackViewWithViews:@[
             self.search_panel,
-            self.web_view.enclosingScrollView,
+            self.web_view,
         ]];
 
         [stack_view setOrientation:NSUserInterfaceLayoutOrientationVertical];

--- a/Ladybird/AppKit/UI/TaskManager.mm
+++ b/Ladybird/AppKit/UI/TaskManager.mm
@@ -46,7 +46,7 @@ static constexpr CGFloat const WINDOW_HEIGHT = 400;
             [strong_self updateStatistics];
         });
 
-        [self setContentView:self.web_view.enclosingScrollView];
+        [self setContentView:self.web_view];
         [self setTitle:@"Task Manager"];
         [self setIsVisible:YES];
 

--- a/Ladybird/AppKit/UI/TaskManager.swift
+++ b/Ladybird/AppKit/UI/TaskManager.swift
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
  * Copyright (c) 2024, Andrew Kaster <akaster@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -8,30 +8,23 @@
 import Foundation
 import Ladybird.WebView
 import Ladybird.WebViewApplication
+import Ladybird.WebViewWindow
 import SwiftUI
 
-public class TaskManager: NSWindow {
+public class TaskManager: LadybirdWebViewWindow {
 
     private let WINDOW_WIDTH: CGFloat = 600
     private let WINDOW_HEIGHT: CGFloat = 400
 
-    var web_view: LadybirdWebView
     private var timer: Timer?
 
     init() {
         let tab_rect = NSApplication.shared.keyWindow!.frame
         let position_x = tab_rect.origin.x + (tab_rect.size.width - WINDOW_WIDTH) / 2
         let position_y = tab_rect.origin.y + (tab_rect.size.height - WINDOW_HEIGHT) / 2
-
         let window_rect = NSMakeRect(position_x, position_y, WINDOW_WIDTH, WINDOW_HEIGHT)
-        let style_mask = NSWindow.StyleMask.init(arrayLiteral: [
-            NSWindow.StyleMask.titled, NSWindow.StyleMask.closable, NSWindow.StyleMask.miniaturizable,
-            NSWindow.StyleMask.resizable,
-        ])
 
-        self.web_view = LadybirdWebView.init(nil)
-
-        super.init(contentRect: window_rect, styleMask: style_mask, backing: NSWindow.BackingStoreType.buffered, defer: false)
+        super.init(webView: nil, windowRect: window_rect)
 
         self.timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] timer in
             if let strong_self = self {
@@ -39,16 +32,7 @@ public class TaskManager: NSWindow {
             }
         }
 
-        self.web_view.postsBoundsChangedNotifications = true
-        let scroll_view = NSScrollView()
-        scroll_view.hasVerticalScroller = true
-        scroll_view.hasHorizontalScroller = true
-        scroll_view.lineScroll = 24
-
-        scroll_view.contentView = self.web_view
-        scroll_view.documentView = NSView()
-
-        self.contentView = scroll_view
+        self.contentView = self.web_view
         self.title = "Task Manager"
         self.setIsVisible(true)
 

--- a/Ladybird/AppKit/module.modulemap
+++ b/Ladybird/AppKit/module.modulemap
@@ -7,6 +7,11 @@ module Ladybird [system] {
         export *
     }
 
+    explicit module WebViewWindow {
+        header "UI/LadybirdWebViewWindow.h"
+        export *
+    }
+
     explicit module WebViewApplication {
         header "../../Userland/Libraries/LibWebView/Application.h"
         export *

--- a/Ladybird/Qt/FindInPageWidget.cpp
+++ b/Ladybird/Qt/FindInPageWidget.cpp
@@ -18,9 +18,11 @@ FindInPageWidget::FindInPageWidget(Tab* tab, WebContentView* content_view)
     , m_content_view(content_view)
 {
     setFocusPolicy(Qt::FocusPolicy::StrongFocus);
+    setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Fixed);
 
     auto* layout = new QHBoxLayout(this);
     setLayout(layout);
+
     layout->setContentsMargins(5, 5, 5, 5);
     layout->setAlignment(Qt::AlignmentFlag::AlignLeft);
 

--- a/Ladybird/Qt/WebContentView.h
+++ b/Ladybird/Qt/WebContentView.h
@@ -21,10 +21,10 @@
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/ActivateTab.h>
 #include <LibWebView/ViewImplementation.h>
-#include <QAbstractScrollArea>
 #include <QMenu>
 #include <QTimer>
 #include <QUrl>
+#include <QWidget>
 
 class QKeyEvent;
 class QLineEdit;
@@ -42,7 +42,7 @@ namespace Ladybird {
 class Tab;
 
 class WebContentView final
-    : public QAbstractScrollArea
+    : public QWidget
     , public WebView::ViewImplementation {
     Q_OBJECT
 public:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Types.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Types.h
@@ -10,6 +10,7 @@
 #include <AK/Function.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/Parser/Token.h>
 #include <LibWeb/CSS/StyleProperty.h>
 #include <LibWeb/Forward.h>
 

--- a/Userland/Libraries/LibWebView/ViewImplementation.h
+++ b/Userland/Libraries/LibWebView/ViewImplementation.h
@@ -159,7 +159,6 @@ public:
 
     void enable_inspector_prototype();
 
-    Function<void(Gfx::IntSize)> on_did_layout;
     Function<void()> on_ready_to_paint;
     Function<String(Web::HTML::ActivateTab, Web::HTML::WebViewHints, Optional<u64>)> on_new_web_view;
     Function<void()> on_activate_tab;

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -119,14 +119,6 @@ void WebContentClient::did_request_cursor_change(u64 page_id, i32 cursor_type)
     }
 }
 
-void WebContentClient::did_layout(u64 page_id, Gfx::IntSize content_size)
-{
-    if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_did_layout)
-            view->on_did_layout(content_size);
-    }
-}
-
 void WebContentClient::did_change_title(u64 page_id, ByteString const& title)
 {
     if (auto process = WebView::Application::the().find_process(m_process_handle.pid); process.has_value())

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -53,7 +53,6 @@ private:
     virtual void did_finish_loading(u64 page_id, URL::URL const&) override;
     virtual void did_request_refresh(u64 page_id) override;
     virtual void did_request_cursor_change(u64 page_id, i32) override;
-    virtual void did_layout(u64 page_id, Gfx::IntSize) override;
     virtual void did_change_title(u64 page_id, ByteString const&) override;
     virtual void did_change_url(u64 page_id, URL::URL const&) override;
     virtual void did_request_tooltip_override(u64 page_id, Gfx::IntPoint, ByteString const&) override;

--- a/Userland/Services/WebContent/PageClient.cpp
+++ b/Userland/Services/WebContent/PageClient.cpp
@@ -229,11 +229,11 @@ void PageClient::page_did_layout()
 {
     auto* layout_root = this->layout_root();
     VERIFY(layout_root);
+
     if (layout_root->paintable_box()->has_scrollable_overflow())
         m_content_size = page().enclosing_device_rect(layout_root->paintable_box()->scrollable_overflow_rect().value()).size();
     else
         m_content_size = page().enclosing_device_rect(layout_root->paintable_box()->absolute_rect()).size();
-    client().async_did_layout(m_id, m_content_size.to_type<int>());
 }
 
 void PageClient::page_did_change_title(ByteString const& title)

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -25,7 +25,6 @@ endpoint WebContentClient
     did_request_refresh(u64 page_id) =|
     did_paint(u64 page_id, Gfx::IntRect content_rect, i32 bitmap_id) =|
     did_request_cursor_change(u64 page_id, i32 cursor_type) =|
-    did_layout(u64 page_id, Gfx::IntSize content_size) =|
     did_change_title(u64 page_id, ByteString title) =|
     did_change_url(u64 page_id, URL::URL url) =|
     did_request_tooltip_override(u64 page_id, Gfx::IntPoint position, ByteString title) =|


### PR DESCRIPTION
Now that scrolling and rendering scrollbars is handled entirely in the WebContent process, there's no reason to place the WebView inside scroll views.

This doesn't make much of a difference for Qt, but for AppKit we had to do a fair amount of extra work do deal with scroll views, as AppKit separately tracks "content" and "document" views (described here https://github.com/trflynn89/ladybird-appkit/commit/6e5ec9275ed1de3ea39467b342aa80a26cfde2a6).