### PR TITLE
Meta: Add ffmpeg to vcpkg dependencies

### DIFF
--- a/.devcontainer/features/ladybird/devcontainer-feature.json
+++ b/.devcontainer/features/ladybird/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "Ladybird Development",
     "id": "ladybird",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Enable development of Ladybird libraries and applications",
     "options": {
         "llvm_version": {

--- a/.devcontainer/features/ladybird/install.sh
+++ b/.devcontainer/features/ladybird/install.sh
@@ -28,7 +28,7 @@ install_llvm_key() {
 ### Install packages
 
 apt update -y
-apt install -y lsb-release git python3 autoconf autoconf-archive automake build-essential cmake libavcodec-dev libavformat-dev libavutil-dev libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev qt6-wayland ccache fonts-liberation2 zip unzip curl tar
+apt install -y lsb-release git python3 autoconf autoconf-archive automake build-essential cmake libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-multimedia-dev qt6-wayland ccache fonts-liberation2 zip unzip curl tar
 ### Ensure new enough host compiler is available
 
 VERSION="0.0.0"

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,7 +32,7 @@ runs:
 
         sudo apt-get update -y
         sudo apt-get install -y autoconf autoconf-archive automake build-essential ccache clang-18 clang++-18 cmake curl fonts-liberation2 \
-            gcc-13 g++-13 libavcodec-dev libavformat-dev libavutil-dev libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev \
+            gcc-13 g++-13 libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev \
             libstdc++-13-dev lld-18 nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
@@ -57,7 +57,7 @@ runs:
       run: |
         set -e
         brew update
-        brew install autoconf autoconf-archive automake bash ccache coreutils ffmpeg llvm@18 nasm ninja qt unzip wabt
+        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@18 nasm ninja qt unzip wabt
 
     - name: 'Install vcpkg'
       shell: bash

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -2,7 +2,7 @@
 
 ## Build Prerequisites
 
-Qt6 development packages, FFmpeg, nasm, additional build tools, and a C++23 capable compiler like g++-13 or clang-17 are required.
+Qt6 development packages, nasm, additional build tools, and a C++23 capable compiler like g++-13 or clang-17 are required.
 
 CMake 3.25 or newer must be available in $PATH.
 
@@ -15,7 +15,7 @@ CMake 3.25 or newer must be available in $PATH.
 
 <!-- Note: If you change something here, please also change it in the `devcontainer/devcontainer.json` file. -->
 ```bash
-sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libavcodec-dev libavformat-dev libavutil-dev libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
+sudo apt install autoconf autoconf-archive automake build-essential ccache cmake curl fonts-liberation2 git libgl1-mesa-dev nasm ninja-build pkg-config qt6-base-dev qt6-tools-dev-tools qt6-wayland tar unzip zip
 ```
 
 #### CMake 3.25 or newer:
@@ -79,24 +79,24 @@ sudo apt install qt6-multimedia-dev
 ### Arch Linux/Manjaro:
 
 ```
-sudo pacman -S --needed autoconf-archive automake base-devel ccache cmake curl ffmpeg libgl nasm ninja qt6-base qt6-multimedia qt6-tools qt6-wayland ttf-liberation tar unzip zip
+sudo pacman -S --needed autoconf-archive automake base-devel ccache cmake curl libgl nasm ninja qt6-base qt6-multimedia qt6-tools qt6-wayland ttf-liberation tar unzip zip
 ```
 
 ### Fedora or derivatives:
 ```
-sudo dnf install autoconf-archive automake ccache cmake curl libavcodec-free-devel libavformat-free-devel liberation-sans-fonts libglvnd-devel nasm ninja-build perl-FindBin perl-IPC-Cmd qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
+sudo dnf install autoconf-archive automake ccache cmake curl liberation-sans-fonts libglvnd-devel nasm ninja-build perl-FindBin perl-IPC-Cmd qt6-qtbase-devel qt6-qtmultimedia-devel qt6-qttools-devel qt6-qtwayland-devel tar unzip zip zlib-ng-compat-static
 ```
 
 ### openSUSE:
 ```
-sudo zypper install autoconf-archive automake ccache cmake curl ffmpeg-7-libavcodec-devel ffmpeg-7-libavformat-devel gcc13 gcc13-c++ liberation-fonts libglvnd-devel nasm ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel tar unzip zip
+sudo zypper install autoconf-archive automake ccache cmake curl gcc13 gcc13-c++ liberation-fonts libglvnd-devel nasm ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel tar unzip zip
 ```
 The build process requires at least python3.7; openSUSE Leap only features Python 3.6 as default, so it is recommendable to install package python311 and create a virtual environment (venv) in this case.
 
 ### Void Linux:
 ```
 sudo xbps-install -Su # (optional) ensure packages are up to date to avoid "Transaction aborted due to unresolved dependencies."
-sudo xbps-install -S git bash gcc python3 curl cmake zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm MesaLib-devel ninja ffmpeg-devel qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel
+sudo xbps-install -S git bash gcc python3 curl cmake zip unzip linux-headers make pkg-config autoconf automake autoconf-archive nasm MesaLib-devel ninja qt6-base-devel qt6-multimedia-devel qt6-tools-devel qt6-wayland-devel
 ```
 
 ### NixOS or with Nix:
@@ -127,7 +127,7 @@ Xcode 14 versions before 14.3 might crash while building ladybird. Xcode 14.3 or
 
 ```
 xcode-select --install
-brew install autoconf autoconf-archive automake ccache cmake ffmpeg nasm ninja pkg-config
+brew install autoconf autoconf-archive automake ccache cmake nasm ninja pkg-config
 ```
 
 If you wish to use clang from homebrew instead:

--- a/Meta/CMake/fontconfig.cmake
+++ b/Meta/CMake/fontconfig.cmake
@@ -1,3 +1,5 @@
+include_guard()
+
 if (NOT APPLE AND NOT ANDROID)
     find_package(Fontconfig REQUIRED)
     set(HAS_FONTCONFIG ON CACHE BOOL "" FORCE)

--- a/Meta/CMake/skia.cmake
+++ b/Meta/CMake/skia.cmake
@@ -1,8 +1,15 @@
 include_guard()
 
+include(fontconfig)
+
 find_package(unofficial-skia CONFIG)
 if(unofficial-skia_FOUND)
     set(SKIA_TARGET unofficial::skia::skia)
+    if (HAS_FONTCONFIG)
+        set(CMAKE_CXX_LINK_GROUP_USING_no_as_needed_SUPPORTED TRUE)
+        set(CMAKE_CXX_LINK_GROUP_USING_no_as_needed "LINKER:--push-state,--no-as-needed" "LINKER:--pop-state")
+        set_property(TARGET unofficial::skia::skia APPEND PROPERTY INTERFACE_LINK_LIBRARIES "$<LINK_GROUP:no_as_needed,Fontconfig::Fontconfig>")
+    endif()
 else()
     find_package(PkgConfig)
 

--- a/Meta/CMake/vulkan.cmake
+++ b/Meta/CMake/vulkan.cmake
@@ -1,3 +1,5 @@
+include_guard()
+
 if (NOT APPLE)
     find_package(VulkanHeaders CONFIG QUIET)
     find_package(Vulkan QUIET)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,6 +13,22 @@
       "platform": "windows"
     },
     {
+      "name": "ffmpeg",
+      "platform": "!android",
+      "features": [
+        "avcodec",
+        "avformat",
+        "dav1d",
+        "openh264",
+        "opus",
+        "webp",
+        "theora",
+        "vorbis",
+        "vpx",
+        "zlib"
+      ]
+    },
+    {
       "name": "fontconfig",
       "platform": "linux | freebsd | openbsd | osx | windows"
     },
@@ -96,6 +112,10 @@
     {
       "name": "curl",
       "version": "8.10.1#0"
+    },
+    {
+      "name": "ffmpeg",
+      "version": "6.1.1#11"
     },
     {
       "name": "fontconfig",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -16,7 +16,22 @@
       "name": "fontconfig",
       "platform": "linux | freebsd | openbsd | osx | windows"
     },
-    "harfbuzz",
+    {
+      "name": "harfbuzz",
+      "platform": "linux | freebsd | openbsd | windows",
+      "features": [
+        "freetype",
+        "icu"
+      ]
+    },
+    {
+      "name": "harfbuzz",
+      "platform": "osx",
+      "features": [
+        "coretext",
+        "icu"
+      ]
+    },
     "icu",
     "libjpeg-turbo",
     "libjxl",
@@ -46,13 +61,19 @@
       "platform": "osx",
       "features": [
         "metal",
-        "fontconfig"
+        "fontconfig",
+        "harfbuzz",
+        "icu"
       ]
     },
     {
       "name": "skia",
       "platform": "linux | freebsd | openbsd | windows",
       "features": [
+        "freetype",
+        "fontconfig",
+        "harfbuzz",
+        "icu",
         "vulkan"
       ]
     },


### PR DESCRIPTION
Now that we are using shared libraries, it is possible to add
into our vcpkg dependencies without worrying about LGPL.

And some assorted vcpkg + CMake cleanup.

Replacement for #291 