### PR TITLE
Tests: Use `FileSystem::real_path` when comparing paths

### DIFF
--- a/Ladybird/Headless/Test.cpp
+++ b/Ladybird/Headless/Test.cpp
@@ -48,7 +48,7 @@ static ErrorOr<void> load_test_config(StringView test_root_path)
     for (auto const& group : config->groups()) {
         if (group == "Skipped"sv) {
             for (auto& key : config->keys(group))
-                s_skipped_tests.append(LexicalPath::join(test_root_path, key).string());
+                s_skipped_tests.append(TRY(FileSystem::real_path(LexicalPath::join(test_root_path, key).string())));
         } else {
             warnln("Unknown group '{}' in config {}", group, config_path);
         }


### PR DESCRIPTION
Paths in `headless-browser` tests were being compared by string value. With this patch, they will be compared by their real path instead, ensuring relative paths and symlinks are handled correctly.