### PR TITLE
CI: Upgrade to macOS 15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             clang_plugins: true
 
           - os_name: 'macOS'
-            os: macos-14
+            os: macos-15
             fuzzer: 'NO_FUZZ'
             toolchain: 'Clang'
             clang_plugins: false

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -102,7 +102,7 @@ jobs:
 
       # https://github.com/actions/runner-images/issues/9330
       - name: Enable Microphone Access (macOS 14)
-        if: ${{ inputs.os == 'macos-14' }}
+        if: ${{ inputs.os_name == 'macOS' }}
         run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
 
       - name: Create Build Environment


### PR DESCRIPTION
For some reason, Microsoft have decided to remove Xcode 16 from macOS 14
images. We require Xcode 16 for Swift 6.

See: https://github.com/actions/runner-images/issues/10703

Because macOS 15 images are still in preview, their availability is much
lower than macOS 14 images. To hopefully alleviate the amount of time we
are waiting in the runner queue, for now this only upgrades the workflow
which uses Swift.