### PR TITLE
CI: Add CMake a preset for "official" builds, and use it for `js` artifacts

### DIFF
--- a/.github/workflows/ladybird-js-artifacts.yml
+++ b/.github/workflows/ladybird-js-artifacts.yml
@@ -49,8 +49,7 @@ jobs:
 
       - name: Create build directory Ubuntu
         run: |
-          cmake --preset CI -B Build \
-            -DCMAKE_BUILD_TYPE=Release \
+          cmake --preset Distribution_CI \
             -DCMAKE_C_COMPILER=gcc-13 \
             -DCMAKE_CXX_COMPILER=g++-13 \
             -DENABLE_GUI_TARGETS=OFF
@@ -62,14 +61,13 @@ jobs:
       #        See: https://github.com/microsoft/vcpkg/discussions/19454
       - name: Create build directory macOS
         run: |
-          cmake --preset CI -B Build \
-            -DCMAKE_BUILD_TYPE=Release \
+          cmake --preset Distribution_CI \
             -DCMAKE_OSX_DEPLOYMENT_TARGET="11.0" \
             -DENABLE_GUI_TARGETS=OFF
         if: ${{ matrix.os_name == 'macOS' }}
 
       - name: Build and package js
-        working-directory: Build
+        working-directory: Build/distribution
         run: |
           ninja js
           cpack
@@ -85,5 +83,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ladybird-js-${{ matrix.package_type }}
-          path: Build/ladybird-js*.tar.gz
+          path: Build/distribution/ladybird-js*.tar.gz
           retention-days: 7

--- a/.github/workflows/ladybird-js-artifacts.yml
+++ b/.github/workflows/ladybird-js-artifacts.yml
@@ -50,8 +50,8 @@ jobs:
       - name: Create build directory Ubuntu
         run: |
           cmake --preset Distribution_CI \
-            -DCMAKE_C_COMPILER=gcc-13 \
-            -DCMAKE_CXX_COMPILER=g++-13 \
+            -DCMAKE_C_COMPILER=clang-18 \
+            -DCMAKE_CXX_COMPILER=clang++-18 \
             -DENABLE_GUI_TARGETS=OFF
         if: ${{ matrix.os_name == 'Linux' }}
 

--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -62,7 +62,7 @@ swizzle_target_properties_for_swift(simdutf::simdutf)
 target_link_libraries(AK PRIVATE simdutf::simdutf)
 
 # FIXME: Make this generic for all imported shared library dependencies and apply globally
-if (NOT CMAKE_SKIP_INSTALL_RULES AND NOT "${VCPKG_INSTALLED_DIR}" STREQUAL "")
+if (BUILD_SHARED_LIBS AND NOT CMAKE_SKIP_INSTALL_RULES AND NOT "${VCPKG_INSTALLED_DIR}" STREQUAL "")
     install(IMPORTED_RUNTIME_ARTIFACTS simdutf::simdutf
             LIBRARY COMPONENT Lagom_Runtime NAMELINK_COMPONENT Lagom_Development
             FRAMEWORK COMPONENT Lagom_Runtime

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -88,6 +88,18 @@
       "toolset": "ClangCL"
     },
     {
+      "name": "Distribution",
+      "inherits": "default",
+      "displayName": "Distribution Config",
+      "description": "Distribution build with static libraries using Ninja generator",
+      "binaryDir": "${fileDir}/Build/distribution",
+      "cacheVariables": {
+        "BUILD_SHARED_LIBS": "OFF",
+        "CMAKE_BUILD_TYPE": "Release",
+        "VCPKG_OVERLAY_TRIPLETS": "${fileDir}/Meta/CMake/vcpkg/distribution-triplets"
+      }
+    },
+    {
       "name": "Debug",
       "inherits": "default",
       "displayName": "Debug Config",
@@ -125,6 +137,15 @@
         "default"
       ],
       "displayName": "Non-Sanitizer CI Config"
+    },
+    {
+      "name": "Distribution_CI",
+      "inherits": [
+        "vcpkg_ci",
+        "Distribution"
+      ],
+      "displayName": "Distribution CI Config",
+      "description": "Distribution build with GitHub Actions cache"
     },
     {
       "name": "Sanitizer_CI",

--- a/Meta/CMake/vcpkg/distribution-triplets/arm64-linux.cmake
+++ b/Meta/CMake/vcpkg/distribution-triplets/arm64-linux.cmake
@@ -1,0 +1,2 @@
+include (${CMAKE_CURRENT_LIST_DIR}/../base-triplets/arm64-linux.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/distribution.cmake)

--- a/Meta/CMake/vcpkg/distribution-triplets/arm64-osx.cmake
+++ b/Meta/CMake/vcpkg/distribution-triplets/arm64-osx.cmake
@@ -1,0 +1,2 @@
+include (${CMAKE_CURRENT_LIST_DIR}/../base-triplets/arm64-osx.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/distribution.cmake)

--- a/Meta/CMake/vcpkg/distribution-triplets/distribution.cmake
+++ b/Meta/CMake/vcpkg/distribution-triplets/distribution.cmake
@@ -1,0 +1,2 @@
+set(VCPKG_BUILD_TYPE release)
+set(VCPKG_LIBRARY_LINKAGE static)

--- a/Meta/CMake/vcpkg/distribution-triplets/x64-linux.cmake
+++ b/Meta/CMake/vcpkg/distribution-triplets/x64-linux.cmake
@@ -1,0 +1,2 @@
+include (${CMAKE_CURRENT_LIST_DIR}/../base-triplets/x64-linux.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/distribution.cmake)

--- a/Meta/CMake/vcpkg/distribution-triplets/x64-osx.cmake
+++ b/Meta/CMake/vcpkg/distribution-triplets/x64-osx.cmake
@@ -1,0 +1,2 @@
+include (${CMAKE_CURRENT_LIST_DIR}/../base-triplets/x64-osx.cmake)
+include (${CMAKE_CURRENT_LIST_DIR}/distribution.cmake)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -581,12 +581,7 @@ if (BUILD_TESTING)
     )
 endif()
 
-# FIXME: When we are using CMake >= 3.21, the library installations can be replaced with RUNTIME_DEPENDENCIES.
-#        https://cmake.org/cmake/help/latest/command/install.html
-include(get_linked_lagom_libraries.cmake)
-get_linked_lagom_libraries(js js_libraries)
-
-install(TARGETS js ${js_libraries} COMPONENT js)
+install(TARGETS js COMPONENT js)
 
 set(CPACK_GENERATOR "TGZ")
 set(CPACK_STRIP_FILES TRUE)


### PR DESCRIPTION
This adds the vcpkg triplets and CMake preset to perform official builds for distribution. These builds are fully static, and currently intended to be used for the `js` ESVU release.

In the future, linking everything statically into the final binary is probably not what we will do for released Ladybird builds. Instead, we may have a "libladybird.so", which is then linked into the binary. But this should be fine for `js` for now.

Example build:
https://github.com/trflynn89/ladybird/actions/runs/11743377506