### PR TITLE
LibWeb: Add pseudoElement parameter to GetAnimationsOptions

### DIFF
--- a/Meta/gn/secondary/Userland/Libraries/LibWeb/Animations/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibWeb/Animations/BUILD.gn
@@ -16,5 +16,7 @@ source_set("Animations") {
     "DocumentTimeline.h",
     "KeyframeEffect.cpp",
     "KeyframeEffect.h",
+    "PseudoElementParsing.cpp",
+    "PseudoElementParsing.h",
   ]
 }

--- a/Userland/Libraries/LibWeb/Animations/Animatable.h
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.h
@@ -17,18 +17,19 @@ class CSSTransition;
 
 namespace Web::Animations {
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-keyframeanimationoptions
+// https://drafts.csswg.org/web-animations-1/#dictdef-keyframeanimationoptions
 struct KeyframeAnimationOptions : public KeyframeEffectOptions {
     FlyString id { ""_fly_string };
     Optional<JS::GCPtr<AnimationTimeline>> timeline;
 };
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-getanimationsoptions
+// https://drafts.csswg.org/web-animations-1/#dictdef-getanimationsoptions
 struct GetAnimationsOptions {
     bool subtree { false };
+    Optional<String> pseudo_element {};
 };
 
-// https://www.w3.org/TR/web-animations-1/#animatable
+// https://drafts.csswg.org/web-animations-1/#animatable
 class Animatable {
 public:
     struct TransitionAttributes {
@@ -40,8 +41,8 @@ public:
     virtual ~Animatable() = default;
 
     WebIDL::ExceptionOr<JS::NonnullGCPtr<Animation>> animate(Optional<JS::Handle<JS::Object>> keyframes, Variant<Empty, double, KeyframeAnimationOptions> options = {});
-    Vector<JS::NonnullGCPtr<Animation>> get_animations(GetAnimationsOptions options = {});
-    Vector<JS::NonnullGCPtr<Animation>> get_animations_internal(GetAnimationsOptions options = {});
+    WebIDL::ExceptionOr<Vector<JS::NonnullGCPtr<Animation>>> get_animations(Optional<GetAnimationsOptions> options = {});
+    WebIDL::ExceptionOr<Vector<JS::NonnullGCPtr<Animation>>> get_animations_internal(Optional<GetAnimationsOptions> options = {});
 
     void associate_with_animation(JS::NonnullGCPtr<Animation>);
     void disassociate_with_animation(JS::NonnullGCPtr<Animation>);

--- a/Userland/Libraries/LibWeb/Animations/Animatable.idl
+++ b/Userland/Libraries/LibWeb/Animations/Animatable.idl
@@ -1,19 +1,20 @@
 #import <Animations/Animation.idl>
 #import <Animations/KeyframeEffect.idl>
 
-// https://www.w3.org/TR/web-animations-1/#the-animatable-interface-mixin
+// https://drafts.csswg.org/web-animations-1/#the-animatable-interface-mixin
 interface mixin Animatable {
     Animation animate(object? keyframes, optional (unrestricted double or KeyframeAnimationOptions) options = {});
     sequence<Animation> getAnimations(optional GetAnimationsOptions options = {});
 };
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-keyframeanimationoptions
+// https://drafts.csswg.org/web-animations-1/#dictdef-keyframeanimationoptions
 dictionary KeyframeAnimationOptions : KeyframeEffectOptions {
     DOMString id = "";
     AnimationTimeline? timeline;
 };
 
-// https://www.w3.org/TR/web-animations-1/#dictdef-getanimationsoptions
+// https://drafts.csswg.org/web-animations-1/#dictdef-getanimationsoptions
 dictionary GetAnimationsOptions {
     boolean subtree = false;
+    CSSOMString? pseudoElement = null;
 };

--- a/Userland/Libraries/LibWeb/Animations/PseudoElementParsing.cpp
+++ b/Userland/Libraries/LibWeb/Animations/PseudoElementParsing.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "PseudoElementParsing.h"
+#include <LibWeb/CSS/Parser/Parser.h>
+
+namespace Web::Animations {
+
+// https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudo-element-parsing
+WebIDL::ExceptionOr<Optional<CSS::Selector::PseudoElement>> pseudo_element_parsing(JS::Realm& realm, Optional<String> const& value)
+{
+    // 1. Given the value value, perform the following steps:
+
+    // 2. If value is not null and is an invalid <pseudo-element-selector>,
+    Optional<CSS::Selector::PseudoElement> pseudo_element;
+    if (value.has_value()) {
+        pseudo_element = parse_pseudo_element_selector(CSS::Parser::ParsingContext { realm }, *value);
+        if (!pseudo_element.has_value()) {
+            // 1. Throw a DOMException with error name "SyntaxError".
+            // 2. Abort.
+            return WebIDL::SyntaxError::create(realm, MUST(String::formatted("Invalid pseudo-element selector: \"{}\"", value.value())));
+        }
+    }
+
+    // 3. If value is one of the legacy Selectors Level 2 single-colon selectors (':before', ':after', ':first-letter', or ':first-line'),
+    // then return the equivalent two-colon selector (e.g. '::before').
+    if (value.has_value() && value->is_one_of(":before", ":after", ":first-letter", ":first-line")) {
+        return CSS::Selector::PseudoElement::from_string(MUST(value->substring_from_byte_offset(1)));
+    }
+
+    // 4. Otherwise, return value.
+    return pseudo_element;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Animations/PseudoElementParsing.h
+++ b/Userland/Libraries/LibWeb/Animations/PseudoElementParsing.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
+
+namespace Web::Animations {
+
+// https://drafts.csswg.org/web-animations-1/#dom-keyframeeffect-pseudo-element-parsing
+WebIDL::ExceptionOr<Optional<CSS::Selector::PseudoElement>> pseudo_element_parsing(JS::Realm&, Optional<String> const&);
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     Animations/AnimationTimeline.cpp
     Animations/DocumentTimeline.cpp
     Animations/KeyframeEffect.cpp
+    Animations/PseudoElementParsing.cpp
     ARIA/AriaData.cpp
     ARIA/ARIAMixin.cpp
     ARIA/Roles.cpp

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1579,12 +1579,16 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
         }
     }
 
-    auto animations = element.get_animations_internal({ .subtree = false });
-    for (auto& animation : animations) {
-        if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
-            auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());
-            if (keyframe_effect.pseudo_element_type() == pseudo_element)
-                collect_animation_into(element, pseudo_element, keyframe_effect, style);
+    auto animations = element.get_animations_internal(Animations::GetAnimationsOptions { .subtree = false });
+    if (animations.is_exception()) {
+        dbgln("Error getting animations for element {}", element.debug_description());
+    } else {
+        for (auto& animation : animations.value()) {
+            if (auto effect = animation->effect(); effect && effect->is_keyframe_effect()) {
+                auto& keyframe_effect = *static_cast<Animations::KeyframeEffect*>(effect.ptr());
+                if (keyframe_effect.pseudo_element_type() == pseudo_element)
+                    collect_animation_into(element, pseudo_element, keyframe_effect, style);
+            }
         }
     }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -4695,13 +4695,13 @@ void Document::remove_replaced_animations()
     }
 }
 
-Vector<JS::NonnullGCPtr<Animations::Animation>> Document::get_animations()
+WebIDL::ExceptionOr<Vector<JS::NonnullGCPtr<Animations::Animation>>> Document::get_animations()
 {
     Vector<JS::NonnullGCPtr<Animations::Animation>> relevant_animations;
-    for_each_child_of_type<Element>([&](auto& child) {
-        relevant_animations.extend(child.get_animations({ .subtree = true }));
+    TRY(for_each_child_of_type_fallible<Element>([&](auto& child) -> WebIDL::ExceptionOr<IterationDecision> {
+        relevant_animations.extend(TRY(child.get_animations(Animations::GetAnimationsOptions { .subtree = true })));
         return IterationDecision::Continue;
-    });
+    }));
     return relevant_animations;
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -636,7 +636,7 @@ public:
     void update_animations_and_send_events(Optional<double> const& timestamp);
     void remove_replaced_animations();
 
-    Vector<JS::NonnullGCPtr<Animations::Animation>> get_animations();
+    WebIDL::ExceptionOr<Vector<JS::NonnullGCPtr<Animations::Animation>>> get_animations();
 
     bool ready_to_run_scripts() const { return m_ready_to_run_scripts; }
     void set_ready_to_run_scripts() { m_ready_to_run_scripts = true; }

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -637,6 +637,18 @@ public:
         return const_cast<Node*>(this)->template for_each_child_of_type<U>(move(callback));
     }
 
+    template<typename U, typename Callback>
+    WebIDL::ExceptionOr<void> for_each_child_of_type_fallible(Callback callback)
+    {
+        for (auto* node = first_child(); node; node = node->next_sibling()) {
+            if (is<U>(node)) {
+                if (TRY(callback(verify_cast<U>(*node))) == IterationDecision::Break)
+                    return {};
+            }
+        }
+        return {};
+    }
+
     template<typename U>
     U const* next_sibling_of_type() const
     {

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -174,13 +174,13 @@ void ShadowRoot::for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& 
     }
 }
 
-Vector<JS::NonnullGCPtr<Animations::Animation>> ShadowRoot::get_animations()
+WebIDL::ExceptionOr<Vector<JS::NonnullGCPtr<Animations::Animation>>> ShadowRoot::get_animations()
 {
     Vector<JS::NonnullGCPtr<Animations::Animation>> relevant_animations;
-    for_each_child_of_type<Element>([&](auto& child) {
-        relevant_animations.extend(child.get_animations({ .subtree = true }));
+    TRY(for_each_child_of_type_fallible<Element>([&](auto& child) -> WebIDL::ExceptionOr<IterationDecision> {
+        relevant_animations.extend(TRY(child.get_animations(Animations::GetAnimationsOptions { .subtree = true })));
         return IterationDecision::Continue;
-    });
+    }));
     return relevant_animations;
 }
 

--- a/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Userland/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -60,7 +60,7 @@ public:
 
     void for_each_css_style_sheet(Function<void(CSS::CSSStyleSheet&)>&& callback) const;
 
-    Vector<JS::NonnullGCPtr<Animations::Animation>> get_animations();
+    WebIDL::ExceptionOr<Vector<JS::NonnullGCPtr<Animations::Animation>>> get_animations();
 
     virtual void finalize() override;
 


### PR DESCRIPTION
This corresponds to: https://github.com/w3c/csswg-drafts/pull/11050

For now, we don't do anything useful with this parameter, because we don't yet support animating pseudo-elements.