### PR TITLE
Tests: Disable an animation test that's flaky on CI

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -9,9 +9,11 @@ Ref/input/css-keyframe-fill-forwards.html
 Ref/input/unicode-range.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
+
+; Animation tests are flaky
 Text/input/css/cubic-bezier-infinite-slope-crash.html
 Text/input/css/transition-basics.html
-
+Text/input/wpt-import/css/css-backgrounds/animations/box-shadow-interpolation.html
 ; Flaky on CI, see #19
 Text/input/WebAnimations/misc/DocumentTimeline.html
 


### PR DESCRIPTION
Timed out here: https://github.com/LadybirdBrowser/ladybird/actions/runs/11739680501/job/32704663141?pr=2216#step:17:3378

Seems like animations tests are generally flaky so I've grouped them.

cc @awesomekling as you added this one yesterday.