### PR TITLE
LibJS: Preserve the original `this` value

### DIFF
--- a/Userland/Libraries/LibJS/Tests/functions/function-assignment-in-arguments.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-assignment-in-arguments.js
@@ -1,0 +1,5 @@
+test("overwriting this during function call still binds the original", () => {
+    let tmp = new Map();
+    // prettier-ignore
+    tmp.set("", tmp = []);
+});


### PR DESCRIPTION
As shown in the test added by this patch, it was possible to re-assign the `this` value of a member function call while it was executing. Let's copy the original this value like we already do with the callee.

Fixes #2226.