### PR TITLE
LibGfx: Do not return or store BPP

### DIFF
--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -114,25 +114,7 @@ public:
 
     [[nodiscard]] size_t pitch() const { return m_pitch; }
 
-    [[nodiscard]] static unsigned bpp_for_format(BitmapFormat format)
-    {
-        switch (format) {
-        case BitmapFormat::BGRx8888:
-        case BitmapFormat::BGRA8888:
-            return 32;
-        default:
-            VERIFY_NOT_REACHED();
-        case BitmapFormat::Invalid:
-            return 0;
-        }
-    }
-
     [[nodiscard]] static size_t minimum_pitch(size_t width, BitmapFormat);
-
-    [[nodiscard]] unsigned bpp() const
-    {
-        return bpp_for_format(m_format);
-    }
 
     [[nodiscard]] bool has_alpha_channel() const { return m_format == BitmapFormat::BGRA8888 || m_format == BitmapFormat::RGBA8888; }
     [[nodiscard]] BitmapFormat format() const { return m_format; }


### PR DESCRIPTION
This commit moves some of the actual code from the header file to the CPP file to reduce header size and improve encapsulation. Additionally, it ensures that the bpp is correctly returned for all supported image formats, which may help prevent potential runtime crashes in the future.