### PR TITLE
LibWeb: Increase tolerance on DocumentTimeline test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -14,8 +14,6 @@ Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/css/cubic-bezier-infinite-slope-crash.html
 Text/input/css/transition-basics.html
 Text/input/wpt-import/css/css-backgrounds/animations/box-shadow-interpolation.html
-; Flaky on CI, see #19
-Text/input/WebAnimations/misc/DocumentTimeline.html
 
 ; Worker tests are flaky on CI
 Text/input/Worker/Worker-blob.html

--- a/Tests/LibWeb/Text/input/WebAnimations/misc/DocumentTimeline.html
+++ b/Tests/LibWeb/Text/input/WebAnimations/misc/DocumentTimeline.html
@@ -2,8 +2,8 @@
 <script src="../../include.js"></script>
 <script>
     test(() => {
-        function timesAreClose(a, b) {
-            return Math.abs(a - b) <= 1;
+        function timesAreClose(a, b, tolerance = 5) {
+            return Math.abs(a - b) <= tolerance;
         }
         let timeline = new DocumentTimeline();
         println(`new timeline time equals document timeline time: ${timesAreClose(timeline.currentTime, document.timeline.currentTime)}`);


### PR DESCRIPTION
Fixes #19 

This PR increases the tolerance to 5 which should make it not fail.