### PR TITLE
LibWeb: Fix Canvas.toDataURL and Canvas.toBlob signatures

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.h
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.h
@@ -35,8 +35,8 @@ public:
     WebIDL::ExceptionOr<void> set_width(unsigned);
     WebIDL::ExceptionOr<void> set_height(unsigned);
 
-    String to_data_url(StringView type, Optional<double> quality);
-    WebIDL::ExceptionOr<void> to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, StringView type, Optional<double> quality);
+    String to_data_url(StringView type, JS::Value quality);
+    WebIDL::ExceptionOr<void> to_blob(JS::NonnullGCPtr<WebIDL::CallbackType> callback, StringView type, JS::Value quality);
 
     void present();
 

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.idl
@@ -16,8 +16,8 @@ interface HTMLCanvasElement : HTMLElement {
 
     RenderingContext? getContext(DOMString contextId, optional any options = null);
 
-    USVString toDataURL(optional DOMString type = "image/png", optional double quality);
-    undefined toBlob(BlobCallback _callback, optional DOMString type = "image/png", optional double quality);
+    USVString toDataURL(optional DOMString type = "image/png", optional any quality);
+    undefined toBlob(BlobCallback _callback, optional DOMString type = "image/png", optional any quality);
 
 };
 

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -72,7 +72,7 @@ Response encode_canvas_element(HTML::HTMLCanvasElement& canvas)
 
     // 3. Let file be a serialization of the canvas element’s bitmap as a file, using "image/png" as an argument.
     // 4. Let data url be a data: URL representing file. [RFC2397]
-    auto data_url = canvas.to_data_url("image/png"sv, {});
+    auto data_url = canvas.to_data_url("image/png"sv, JS::js_undefined());
 
     // 5. Let index be the index of "," in data url.
     auto index = data_url.find_byte_offset(',');


### PR DESCRIPTION
Fix the function signatures of Canvas.toDataURL() and Canvas.toBlob() and make both functions accept non-numbers as the quality parameter, in which case it will just use the default quality instead of raising an exception.
This makes toDataURL.arguments.1.html, toDataURL.arguments.2.html and toDataURL.jpeg.quality.notnumber.html in
wpt/html/semantics/embedded-content/the-canvas-element pass :^)