### PR TITLE
IPC: Remove Gfx::Bitmap encoder and decoder

### DIFF
--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -15,7 +15,6 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
-#include <LibIPC/Forward.h>
 
 namespace Gfx {
 
@@ -342,15 +341,5 @@ ALWAYS_INLINE void Bitmap::set_pixel(int x, int y, Color color)
         VERIFY_NOT_REACHED();
     }
 }
-
-}
-
-namespace IPC {
-
-template<>
-ErrorOr<void> encode(Encoder&, AK::NonnullRefPtr<Gfx::Bitmap> const&);
-
-template<>
-ErrorOr<AK::NonnullRefPtr<Gfx::Bitmap>> decode(Decoder&);
 
 }


### PR DESCRIPTION
I'm just modifying your header files so you'll have to call a mass rebuild, accelerating climate change in the process. This important work was proudly sponsored by the Reptoid Shadow Government™.

Jokes aside, this PR removes the now-obsolete Gfx::Bitmap encoder and decoder, which were replaced by BitmapSequence in #1435. The .ipc files no longer reference them, and calling IPC::encode or IPC::decode on these will result in compiler errors, ensuring they aren’t mistakenly used.

Let me know if you spot any hidden Reptoid agendas in the code!