### PR TITLE
LibWeb: Apply CSS filters on SVGs

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -27,6 +27,7 @@
 #include <LibGfx/Size.h>
 #include <LibGfx/TextAlignment.h>
 #include <LibGfx/TextLayout.h>
+#include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/CSS/Enums.h>
 #include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
@@ -118,7 +119,6 @@ struct StackingContextTransform {
 
 struct PushStackingContext {
     float opacity;
-    CSS::ResolvedFilter filter;
     // The bounding box of the source paintable (pre-transform).
     Gfx::IntRect source_paintable_rect;
     // A translation to be applied after the stacking context has been transformed.
@@ -398,6 +398,11 @@ struct ApplyOpacity {
     float opacity;
 };
 
+struct ApplyFilters {
+    float opacity;
+    CSS::ResolvedFilter filter;
+};
+
 struct ApplyTransform {
     Gfx::FloatPoint origin;
     Gfx::FloatMatrix4x4 matrix;
@@ -453,6 +458,7 @@ using Command = Variant<
     PaintNestedDisplayList,
     PaintScrollBar,
     ApplyOpacity,
+    ApplyFilters,
     ApplyTransform,
     ApplyMaskBitmap>;
 

--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -399,7 +399,6 @@ struct ApplyOpacity {
 };
 
 struct ApplyFilters {
-    float opacity;
     CSS::ResolvedFilter filter;
 };
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -122,6 +122,7 @@ void DisplayListPlayer::execute(DisplayList& display_list)
         else HANDLE_COMMAND(PaintScrollBar, paint_scrollbar)
         else HANDLE_COMMAND(PaintNestedDisplayList, paint_nested_display_list)
         else HANDLE_COMMAND(ApplyOpacity, apply_opacity)
+        else HANDLE_COMMAND(ApplyFilters, apply_filters)
         else HANDLE_COMMAND(ApplyTransform, apply_transform)
         else HANDLE_COMMAND(ApplyMaskBitmap, apply_mask_bitmap)
         else VERIFY_NOT_REACHED();

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -76,6 +76,7 @@ private:
     virtual void paint_nested_display_list(PaintNestedDisplayList const&) = 0;
     virtual void paint_scrollbar(PaintScrollBar const&) = 0;
     virtual void apply_opacity(ApplyOpacity const&) = 0;
+    virtual void apply_filters(ApplyFilters const&) = 0;
     virtual void apply_transform(ApplyTransform const&) = 0;
     virtual void apply_mask_bitmap(ApplyMaskBitmap const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -396,33 +396,7 @@ void DisplayListPlayerSkia::push_stacking_context(PushStackingContext const& com
                              .translate(-command.transform.origin);
     auto matrix = to_skia_matrix(new_transform);
 
-    if (!command.filter.is_none()) {
-        sk_sp<SkImageFilter> image_filter;
-        auto append_filter = [&image_filter](auto new_filter) {
-            if (image_filter)
-                image_filter = SkImageFilters::Compose(new_filter, image_filter);
-            else
-                image_filter = new_filter;
-        };
-
-        // Apply filters in order
-        for (auto const& filter_function : command.filter.filters)
-            append_filter(to_skia_image_filter(filter_function));
-
-        // We apply opacity as a color filter here so we only need to save and restore a single layer.
-        if (command.opacity < 1) {
-            append_filter(to_skia_image_filter(CSS::ResolvedFilter::FilterFunction {
-                CSS::ResolvedFilter::Color {
-                    CSS::FilterOperation::Color::Type::Opacity,
-                    command.opacity,
-                },
-            }));
-        }
-
-        SkPaint paint;
-        paint.setImageFilter(image_filter);
-        canvas.saveLayer(nullptr, &paint);
-    } else if (command.opacity < 1) {
+    if (command.opacity < 1) {
         auto source_paintable_rect = to_skia_rect(command.source_paintable_rect);
         SkRect dest;
         matrix.mapRect(&dest, source_paintable_rect);
@@ -1101,6 +1075,41 @@ void DisplayListPlayerSkia::apply_opacity(ApplyOpacity const& command)
     SkPaint paint;
     paint.setAlphaf(command.opacity);
     canvas.saveLayer(nullptr, &paint);
+}
+
+void DisplayListPlayerSkia::apply_filters(ApplyFilters const& command)
+{
+    if (command.filter.is_none()) {
+        return;
+    }
+    sk_sp<SkImageFilter> image_filter;
+    auto append_filter = [&image_filter](auto new_filter) {
+        if (image_filter)
+            image_filter = SkImageFilters::Compose(new_filter, image_filter);
+        else
+            image_filter = new_filter;
+    };
+
+    // Apply filters in order
+    for (auto filter : command.filter.filters) {
+        append_filter(to_skia_image_filter(filter));
+    }
+
+    // We apply opacity as a color filter here so we only need to save and restore a single layer.
+    if (command.opacity < 1) {
+        append_filter(to_skia_image_filter(CSS::ResolvedFilter::FilterFunction {
+            CSS::ResolvedFilter::Color {
+                CSS::FilterOperation::Color::Type::Opacity,
+                command.opacity,
+            },
+        }));
+    }
+
+    SkPaint paint;
+    paint.setImageFilter(image_filter);
+    auto& canvas = surface().canvas();
+    canvas.saveLayer(nullptr, &paint);
+    return;
 }
 
 void DisplayListPlayerSkia::apply_transform(ApplyTransform const& command)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -1095,16 +1095,6 @@ void DisplayListPlayerSkia::apply_filters(ApplyFilters const& command)
         append_filter(to_skia_image_filter(filter));
     }
 
-    // We apply opacity as a color filter here so we only need to save and restore a single layer.
-    if (command.opacity < 1) {
-        append_filter(to_skia_image_filter(CSS::ResolvedFilter::FilterFunction {
-            CSS::ResolvedFilter::Color {
-                CSS::FilterOperation::Color::Type::Opacity,
-                command.opacity,
-            },
-        }));
-    }
-
     SkPaint paint;
     paint.setImageFilter(image_filter);
     auto& canvas = surface().canvas();

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -63,6 +63,7 @@ private:
     void paint_scrollbar(PaintScrollBar const&) override;
     void paint_nested_display_list(PaintNestedDisplayList const&) override;
     void apply_opacity(ApplyOpacity const&) override;
+    void apply_filters(ApplyFilters const&) override;
     void apply_transform(ApplyTransform const&) override;
     void apply_mask_bitmap(ApplyMaskBitmap const&) override;
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -397,9 +397,9 @@ void DisplayListRecorder::apply_opacity(float opacity)
     append(ApplyOpacity { .opacity = opacity });
 }
 
-void DisplayListRecorder::apply_filters(float opacity, CSS::ResolvedFilter filter)
+void DisplayListRecorder::apply_filters(CSS::ResolvedFilter filter)
 {
-    append(ApplyFilters { .opacity = opacity, .filter = filter });
+    append(ApplyFilters { .filter = filter });
 }
 
 void DisplayListRecorder::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 matrix)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -285,7 +285,6 @@ void DisplayListRecorder::push_stacking_context(PushStackingContextParams params
 {
     append(PushStackingContext {
         .opacity = params.opacity,
-        .filter = params.filter,
         .source_paintable_rect = params.source_paintable_rect,
         .transform = {
             .origin = params.transform.origin,
@@ -396,6 +395,11 @@ void DisplayListRecorder::paint_scrollbar(int scroll_frame_id, Gfx::IntRect rect
 void DisplayListRecorder::apply_opacity(float opacity)
 {
     append(ApplyOpacity { .opacity = opacity });
+}
+
+void DisplayListRecorder::apply_filters(float opacity, CSS::ResolvedFilter filter)
+{
+    append(ApplyFilters { .opacity = opacity, .filter = filter });
 }
 
 void DisplayListRecorder::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4 matrix)

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -111,7 +111,6 @@ public:
 
     struct PushStackingContextParams {
         float opacity;
-        CSS::ResolvedFilter filter;
         bool is_fixed_position;
         Gfx::IntRect source_paintable_rect;
         StackingContextTransform transform;
@@ -140,6 +139,7 @@ public:
     void paint_scrollbar(int scroll_frame_id, Gfx::IntRect, CSSPixelFraction scroll_size, bool vertical);
 
     void apply_opacity(float opacity);
+    void apply_filters(float opacity, CSS::ResolvedFilter filter);
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4);
     void apply_mask_bitmap(Gfx::IntPoint origin, Gfx::ImmutableBitmap const&, Gfx::Bitmap::MaskKind);
 

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -139,7 +139,7 @@ public:
     void paint_scrollbar(int scroll_frame_id, Gfx::IntRect, CSSPixelFraction scroll_size, bool vertical);
 
     void apply_opacity(float opacity);
-    void apply_filters(float opacity, CSS::ResolvedFilter filter);
+    void apply_filters(CSS::ResolvedFilter filter);
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4);
     void apply_mask_bitmap(Gfx::IntPoint origin, Gfx::ImmutableBitmap const&, Gfx::Bitmap::MaskKind);
 

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -70,7 +70,7 @@ void SVGSVGPaintable::paint_descendants(PaintContext& context, PaintableBox cons
             context.display_list_recorder().apply_opacity(computed_values.opacity());
         }
 
-        context.display_list_recorder().apply_filters(paintable.computed_values().opacity(), paintable.computed_values().filter());
+        context.display_list_recorder().apply_filters(paintable.computed_values().filter());
 
         if (svg_box.has_css_transform()) {
             auto transform_matrix = svg_box.transform();

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -70,6 +70,8 @@ void SVGSVGPaintable::paint_descendants(PaintContext& context, PaintableBox cons
             context.display_list_recorder().apply_opacity(computed_values.opacity());
         }
 
+        context.display_list_recorder().apply_filters(paintable.computed_values().opacity(), paintable.computed_values().filter());
+
         if (svg_box.has_css_transform()) {
             auto transform_matrix = svg_box.transform();
             Gfx::FloatPoint transform_origin = svg_box.transform_origin().template to_type<float>();

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -301,7 +301,6 @@ void StackingContext::paint(PaintContext& context) const
 
     DisplayListRecorder::PushStackingContextParams push_stacking_context_params {
         .opacity = opacity,
-        .filter = paintable_box().computed_values().filter(),
         .is_fixed_position = paintable_box().is_fixed_position(),
         .source_paintable_rect = source_paintable_rect,
         .transform = {
@@ -328,6 +327,7 @@ void StackingContext::paint(PaintContext& context) const
         context.display_list_recorder().push_scroll_frame_id(*paintable_box().scroll_frame_id());
     }
     context.display_list_recorder().push_stacking_context(push_stacking_context_params);
+    context.display_list_recorder().apply_filters(opacity, paintable_box().computed_values().filter());
 
     if (auto mask_image = computed_values.mask_image()) {
         auto mask_display_list = DisplayList::create();

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -327,7 +327,7 @@ void StackingContext::paint(PaintContext& context) const
         context.display_list_recorder().push_scroll_frame_id(*paintable_box().scroll_frame_id());
     }
     context.display_list_recorder().push_stacking_context(push_stacking_context_params);
-    context.display_list_recorder().apply_filters(opacity, paintable_box().computed_values().filter());
+    context.display_list_recorder().apply_filters(paintable_box().computed_values().filter());
 
     if (auto mask_image = computed_values.mask_image()) {
         auto mask_display_list = DisplayList::create();


### PR DESCRIPTION
The code largely mirrors the one in StackingContext::paint() for applying CSS filters to a generic context, with some minor changes.

There's a weird compile issue where `matrix_with_scaled_translation()` is not being found by the compiler, even though StackingContext::paint() uses it with no issues. PaintableBox also has the relevant header file imported as well, so it is not like it is missing somewhere down in an inherited object either.

Compile log (with matrix_with_scaled_translation):

```
/usr/bin/ccache /usr/bin/c++ -DENABLE_COMPILETIME_FORMAT_CHECK -DHAVE_PULSEAUDIO=1 -DLibWeb_EXPORTS -DSK_CODEC_DECODES_BMP -DSK_CODEC_DECODES_GIF -DSK_CODEC_DECODES_ICO -DSK_CODEC_DECODES_JPEG -DSK_CODEC_DECODES_PNG -DSK_CODEC_DECODES_RAW -DSK_CODEC_DECODES_WBMP -DSK_CODEC_DECODES_WEBP -DSK_DISABLE_TRACING -DSK_ENABLE_AVX512_OPTS -DSK_ENABLE_PRECOMPILE -DSK_FONTMGR_ANDROID_AVAILABLE -DSK_FONTMGR_FONTCONFIG_AVAILABLE -DSK_FONTMGR_FREETYPE_DIRECTORY_AVAILABLE -DSK_FONTMGR_FREETYPE_EMBEDDED_AVAILABLE -DSK_FONTMGR_FREETYPE_EMPTY_AVAILABLE -DSK_GAMMA_APPLY_TO_A8 -DSK_GANESH -DSK_GL -DSK_HAS_WUFFS_LIBRARY -DSK_R32_SHIFT=16 -DSK_SUPPORT_PDF -DSK_TYPEFACE_FACTORY_FREETYPE -DSK_USE_PERFETTO -DSK_USE_VMA -DSK_VULKAN -DSK_XML -DUSE_FONTCONFIG=1 -DUSE_VULKAN=1 -D_FILE_OFFSET_BITS=64 -I/app -I/app/Userland/Services -I/app/Userland/Libraries -I/app/Build/release/Lagom -I/app/Build/release/Lagom/Userland/Services -I/app/Build/release/Lagom/Userland/Libraries -I/app/Meta/Lagom/../.. -I/app/Meta/Lagom/../../Userland -I/app/Meta/Lagom/../../Userland/Libraries -I/app/Meta/Lagom/../../Userland/Services -I/app/Build/release -isystem /app/Build/release/vcpkg_installed/x64-linux/include -isystem /app/Build/release/vcpkg_installed/x64-linux/include/skia -O2 -g -DNDEBUG -std=c++23 -fPIC -fdiagnostics-color=always -Wall -Wextra -fno-exceptions -ffp-contract=off -Wcast-qual -Wformat=2 -Wimplicit-fallthrough -Wmissing-declarations -Wmissing-field-initializers -Wsuggest-override -Wno-invalid-offsetof -Wno-unknown-warning-option -Wno-unused-command-line-argument -Werror -Wno-expansion-to-defined -Wno-literal-suffix -Wno-dangling-reference -fno-semantic-interposition -fvisibility-inlines-hidden -fstack-protector-strong -fstrict-flex-arrays=2 -Wno-maybe-uninitialized -Wno-shorten-64-to-32 -fsigned-char -ggnu-pubnames -fPIC -O2 -g1 -MD -MT Lagom/Userland/Libraries/LibWeb/CMakeFiles/LibWeb.dir/Painting/StackingContext.cpp.o -MF Lagom/Userland/Libraries/LibWeb/CMakeFiles/LibWeb.dir/Painting/StackingContext.cpp.o.d -o Lagom/Userland/Libraries/LibWeb/CMakeFiles/LibWeb.dir/Painting/StackingContext.cpp.o -c /app/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
/app/Userland/Libraries/LibWeb/Painting/StackingContext.cpp: In static member function 'static void Web::Painting::StackingContext::paint_svg(Web::PaintContext&, const Web::Painting::PaintableBox&, Web::Painting::PaintPhase)':
/app/Userland/Libraries/LibWeb/Painting/StackingContext.cpp:122:23: error: 'matrix_with_scaled_translation' was not declared in this scope
  122 |             .matrix = matrix_with_scaled_translation(transform_matrix, to_device_pixels_scale),
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option '-Wno-shorten-64-to-32' may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option '-Wno-unused-command-line-argument' may have been intended to silence earlier diagnostics
cc1plus: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
[1692/2668] Building CXX object Lagom/Userla....dir/ReferrerPolicy/AbstractOperations.cpp.o
ninja: build stopped: subcommand failed.
```

Fixes #2015