### PR TITLE
LibJS: Make SourceTextModule use async_block_start

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -18,6 +18,7 @@ namespace JS {
 
 template<typename T>
 void async_block_start(VM&, T const& async_body, PromiseCapability const&, ExecutionContext&);
+#define async_block_start_statement async_block_start<NonnullRefPtr<Statement const>>
 
 template<typename T>
 void async_function_start(VM&, PromiseCapability const&, T const& async_function_body);


### PR DESCRIPTION
There was a FIXME about this, so I did it.
I hope the `#define` way of doing this is alright, it's the only sensible way I could find to expose that specific version of the template function.
(Calling `async_block_start` directly doesn't work because the linker can't find `async_block_start<NonnullRefPtr<Statement const>>` in that case)