### PR TITLE
Add SkImage caching for bitmaps

### DIFF
--- a/Userland/Libraries/LibGfx/Forward.h
+++ b/Userland/Libraries/LibGfx/Forward.h
@@ -28,6 +28,7 @@ class Line;
 class AntiAliasingPainter;
 class DeprecatedPainter;
 class Painter;
+class PaintingSurface;
 class Palette;
 class PaletteImpl;
 class DeprecatedPath;

--- a/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/ImageFormats/PNGLoader.h>
 #include <LibGfx/ImageFormats/TIFFLoader.h>
 #include <LibGfx/ImageFormats/TIFFMetadata.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/Painter.h>
 #include <png.h>
 
@@ -239,11 +240,11 @@ ErrorOr<size_t> PNGLoadingContext::read_frames(png_structp png_ptr, png_infop in
             case PNG_BLEND_OP_SOURCE:
                 // All color components of the frame, including alpha, overwrite the current contents of the frame's output buffer region.
                 painter->clear_rect(frame_rect, Gfx::Color::Transparent);
-                painter->draw_bitmap(frame_rect, *decoded_frame_bitmap, decoded_frame_bitmap->rect(), Gfx::ScalingMode::NearestNeighbor, 1.0f);
+                painter->draw_bitmap(frame_rect, Gfx::ImmutableBitmap::create(*decoded_frame_bitmap), decoded_frame_bitmap->rect(), Gfx::ScalingMode::NearestNeighbor, 1.0f);
                 break;
             case PNG_BLEND_OP_OVER:
                 // The frame should be composited onto the output buffer based on its alpha, using a simple OVER operation as described in the "Alpha Channel Processing" section of the PNG specification.
-                painter->draw_bitmap(frame_rect, *decoded_frame_bitmap, decoded_frame_bitmap->rect(), ScalingMode::NearestNeighbor, 1.0f);
+                painter->draw_bitmap(frame_rect, Gfx::ImmutableBitmap::create(*decoded_frame_bitmap), decoded_frame_bitmap->rect(), ScalingMode::NearestNeighbor, 1.0f);
                 break;
             default:
                 VERIFY_NOT_REACHED();
@@ -262,7 +263,7 @@ ErrorOr<size_t> PNGLoadingContext::read_frames(png_structp png_ptr, png_infop in
             case PNG_DISPOSE_OP_PREVIOUS:
                 // The frame's region of the output buffer is to be reverted to the previous contents before rendering the next frame.
                 painter->clear_rect(frame_rect, Gfx::Color::Transparent);
-                painter->draw_bitmap(frame_rect, *prev_output_buffer, IntRect { x, y, width, height }, Gfx::ScalingMode::NearestNeighbor, 1.0f);
+                painter->draw_bitmap(frame_rect, Gfx::ImmutableBitmap::create(*prev_output_buffer), IntRect { x, y, width, height }, Gfx::ScalingMode::NearestNeighbor, 1.0f);
                 break;
             default:
                 VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -6,16 +6,105 @@
 
 #include <LibGfx/ImmutableBitmap.h>
 
+#include <core/SkBitmap.h>
+#include <core/SkImage.h>
+
 namespace Gfx {
+
+struct ImmutableBitmapImpl {
+    sk_sp<SkImage> sk_image;
+    SkBitmap sk_bitmap;
+    RefPtr<Gfx::Bitmap> gfx_bitmap;
+};
+
+int ImmutableBitmap::width() const
+{
+    return m_impl->sk_image->width();
+}
+
+int ImmutableBitmap::height() const
+{
+    return m_impl->sk_image->height();
+}
+
+IntRect ImmutableBitmap::rect() const
+{
+    return { {}, size() };
+}
+
+IntSize ImmutableBitmap::size() const
+{
+    return { width(), height() };
+}
+
+Gfx::AlphaType ImmutableBitmap::alpha_type() const
+{
+    return m_impl->sk_image->alphaType() == kPremul_SkAlphaType ? Gfx::AlphaType::Premultiplied : Gfx::AlphaType::Unpremultiplied;
+}
+
+SkImage const* ImmutableBitmap::sk_image() const
+{
+    return m_impl->sk_image.get();
+}
+
+RefPtr<Gfx::Bitmap const> ImmutableBitmap::bitmap() const
+{
+    return m_impl->gfx_bitmap;
+}
+
+Color ImmutableBitmap::get_pixel(int x, int y) const
+{
+    if (m_impl->gfx_bitmap) {
+        return m_impl->gfx_bitmap->get_pixel(x, y);
+    }
+    VERIFY_NOT_REACHED();
+}
+
+static SkColorType to_skia_color_type(Gfx::BitmapFormat format)
+{
+    switch (format) {
+    case Gfx::BitmapFormat::Invalid:
+        return kUnknown_SkColorType;
+    case Gfx::BitmapFormat::BGRA8888:
+    case Gfx::BitmapFormat::BGRx8888:
+        return kBGRA_8888_SkColorType;
+    case Gfx::BitmapFormat::RGBA8888:
+        return kRGBA_8888_SkColorType;
+    case Gfx::BitmapFormat::RGBx8888:
+        return kRGB_888x_SkColorType;
+    default:
+        return kUnknown_SkColorType;
+    }
+}
+
+static SkAlphaType to_skia_alpha_type(Gfx::AlphaType alpha_type)
+{
+    switch (alpha_type) {
+    case AlphaType::Premultiplied:
+        return kPremul_SkAlphaType;
+    case AlphaType::Unpremultiplied:
+        return kUnpremul_SkAlphaType;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
 
 NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bitmap)
 {
-    return adopt_ref(*new ImmutableBitmap(move(bitmap)));
+    ImmutableBitmapImpl impl;
+    auto info = SkImageInfo::Make(bitmap->width(), bitmap->height(), to_skia_color_type(bitmap->format()), to_skia_alpha_type(bitmap->alpha_type()));
+    impl.sk_bitmap.installPixels(info, const_cast<void*>(static_cast<void const*>(bitmap->scanline(0))), bitmap->pitch());
+    impl.sk_bitmap.setImmutable();
+    impl.sk_image = impl.sk_bitmap.asImage();
+    impl.gfx_bitmap = bitmap;
+    return adopt_ref(*new ImmutableBitmap(make<ImmutableBitmapImpl>(impl)));
 }
 
-ImmutableBitmap::ImmutableBitmap(NonnullRefPtr<Bitmap> bitmap)
-    : m_bitmap(move(bitmap))
+ImmutableBitmap::ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl> impl)
+    : m_impl(move(impl))
 {
 }
+
+ImmutableBitmap::~ImmutableBitmap() = default;
 
 }

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -8,8 +8,6 @@
 
 namespace Gfx {
 
-static size_t s_next_immutable_bitmap_id = 0;
-
 NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bitmap)
 {
     return adopt_ref(*new ImmutableBitmap(move(bitmap)));
@@ -17,7 +15,6 @@ NonnullRefPtr<ImmutableBitmap> ImmutableBitmap::create(NonnullRefPtr<Bitmap> bit
 
 ImmutableBitmap::ImmutableBitmap(NonnullRefPtr<Bitmap> bitmap)
     : m_bitmap(move(bitmap))
-    , m_id(s_next_immutable_bitmap_id++)
 {
 }
 

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2023-2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.h
@@ -28,11 +28,8 @@ public:
     IntRect rect() const { return m_bitmap->rect(); }
     IntSize size() const { return m_bitmap->size(); }
 
-    size_t id() const { return m_id; }
-
 private:
     NonnullRefPtr<Bitmap> m_bitmap;
-    size_t m_id;
 
     explicit ImmutableBitmap(NonnullRefPtr<Bitmap> bitmap);
 };

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.h
@@ -22,6 +22,7 @@ struct ImmutableBitmapImpl;
 class ImmutableBitmap final : public RefCounted<ImmutableBitmap> {
 public:
     static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap);
+    static NonnullRefPtr<ImmutableBitmap> create_snapshot_from_painting_surface(NonnullRefPtr<PaintingSurface>);
 
     ~ImmutableBitmap();
 

--- a/Userland/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Userland/Libraries/LibGfx/ImmutableBitmap.h
@@ -7,31 +7,41 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 
+class SkImage;
+
 namespace Gfx {
+
+struct ImmutableBitmapImpl;
 
 class ImmutableBitmap final : public RefCounted<ImmutableBitmap> {
 public:
     static NonnullRefPtr<ImmutableBitmap> create(NonnullRefPtr<Bitmap> bitmap);
 
-    ~ImmutableBitmap() = default;
+    ~ImmutableBitmap();
 
-    Bitmap const& bitmap() const { return *m_bitmap; }
+    int width() const;
+    int height() const;
+    IntRect rect() const;
+    IntSize size() const;
 
-    size_t width() const { return m_bitmap->width(); }
-    size_t height() const { return m_bitmap->height(); }
+    Gfx::AlphaType alpha_type() const;
 
-    IntRect rect() const { return m_bitmap->rect(); }
-    IntSize size() const { return m_bitmap->size(); }
+    SkImage const* sk_image() const;
+
+    Color get_pixel(int x, int y) const;
+
+    RefPtr<Bitmap const> bitmap() const;
 
 private:
-    NonnullRefPtr<Bitmap> m_bitmap;
+    NonnullOwnPtr<ImmutableBitmapImpl> m_impl;
 
-    explicit ImmutableBitmap(NonnullRefPtr<Bitmap> bitmap);
+    explicit ImmutableBitmap(NonnullOwnPtr<ImmutableBitmapImpl> bitmap);
 };
 
 }

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -23,7 +23,7 @@ public:
     virtual void clear_rect(Gfx::FloatRect const&, Gfx::Color) = 0;
     virtual void fill_rect(Gfx::FloatRect const&, Gfx::Color) = 0;
 
-    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::Bitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, float global_alpha) = 0;
+    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, float global_alpha) = 0;
 
     virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness) = 0;
     virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, float thickness, float global_alpha) = 0;

--- a/Userland/Libraries/LibGfx/PainterSkia.h
+++ b/Userland/Libraries/LibGfx/PainterSkia.h
@@ -20,7 +20,7 @@ public:
 
     virtual void clear_rect(Gfx::FloatRect const&, Color) override;
     virtual void fill_rect(Gfx::FloatRect const&, Color) override;
-    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::Bitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, float global_alpha) override;
+    virtual void draw_bitmap(Gfx::FloatRect const& dst_rect, Gfx::ImmutableBitmap const& src_bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode, float global_alpha) override;
     virtual void stroke_path(Gfx::Path const&, Gfx::Color, float thickness) override;
     virtual void stroke_path(Gfx::Path const&, Gfx::PaintStyle const&, float thickness, float global_alpha) override;
     virtual void fill_path(Gfx::Path const&, Gfx::Color, Gfx::WindingRule) override;

--- a/Userland/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Userland/Libraries/LibGfx/PaintingSurface.cpp
@@ -92,15 +92,6 @@ PaintingSurface::PaintingSurface(NonnullOwnPtr<Impl>&& impl)
 
 PaintingSurface::~PaintingSurface() = default;
 
-NonnullRefPtr<ImmutableBitmap> PaintingSurface::create_snapshot() const
-{
-    auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size()).value();
-    auto image_info = SkImageInfo::Make(bitmap->width(), bitmap->height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType);
-    SkPixmap const pixmap(image_info, bitmap->begin(), bitmap->pitch());
-    sk_surface().readPixels(pixmap, 0, 0);
-    return ImmutableBitmap::create(bitmap);
-}
-
 void PaintingSurface::read_into_bitmap(Gfx::Bitmap& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
@@ -128,6 +119,12 @@ SkCanvas& PaintingSurface::canvas() const
 SkSurface& PaintingSurface::sk_surface() const
 {
     return *m_impl->surface;
+}
+
+template<>
+sk_sp<SkImage> PaintingSurface::sk_image_snapshot() const
+{
+    return m_impl->surface->makeImageSnapshot();
 }
 
 void PaintingSurface::flush() const

--- a/Userland/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Userland/Libraries/LibGfx/PaintingSurface.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintingSurface.h>
 
 #include <core/SkColorSpace.h>
@@ -91,13 +92,13 @@ PaintingSurface::PaintingSurface(NonnullOwnPtr<Impl>&& impl)
 
 PaintingSurface::~PaintingSurface() = default;
 
-RefPtr<Bitmap> PaintingSurface::create_snapshot() const
+NonnullRefPtr<ImmutableBitmap> PaintingSurface::create_snapshot() const
 {
     auto bitmap = Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, size()).value();
     auto image_info = SkImageInfo::Make(bitmap->width(), bitmap->height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType);
     SkPixmap const pixmap(image_info, bitmap->begin(), bitmap->pitch());
     sk_surface().readPixels(pixmap, 0, 0);
-    return bitmap;
+    return ImmutableBitmap::create(bitmap);
 }
 
 void PaintingSurface::read_into_bitmap(Gfx::Bitmap& bitmap)

--- a/Userland/Libraries/LibGfx/PaintingSurface.h
+++ b/Userland/Libraries/LibGfx/PaintingSurface.h
@@ -31,7 +31,6 @@ public:
     static NonnullRefPtr<PaintingSurface> wrap_metal_surface(Gfx::MetalTexture&, RefPtr<SkiaBackendContext>);
 #endif
 
-    NonnullRefPtr<ImmutableBitmap> create_snapshot() const;
     void read_into_bitmap(Bitmap&);
 
     IntSize size() const;
@@ -39,6 +38,9 @@ public:
 
     SkCanvas& canvas() const;
     SkSurface& sk_surface() const;
+
+    template<typename T>
+    T sk_image_snapshot() const;
 
     void flush() const;
 

--- a/Userland/Libraries/LibGfx/PaintingSurface.h
+++ b/Userland/Libraries/LibGfx/PaintingSurface.h
@@ -31,7 +31,7 @@ public:
     static NonnullRefPtr<PaintingSurface> wrap_metal_surface(Gfx::MetalTexture&, RefPtr<SkiaBackendContext>);
 #endif
 
-    RefPtr<Bitmap> create_snapshot() const;
+    NonnullRefPtr<ImmutableBitmap> create_snapshot() const;
     void read_into_bitmap(Bitmap&);
 
     IntSize size() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -169,7 +169,7 @@ Optional<Gfx::Color> ImageStyleValue::color_if_single_pixel_bitmap() const
 {
     if (auto const* b = bitmap(m_current_frame_index)) {
         if (b->width() == 1 && b->height() == 1)
-            return b->bitmap().get_pixel(0, 0);
+            return b->get_pixel(0, 0);
     }
     return {};
 }

--- a/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Canvas/CanvasDrawImage.cpp
@@ -13,10 +13,20 @@ namespace Web::HTML {
 static void default_source_size(CanvasImageSource const& image, float& source_width, float& source_height)
 {
     image.visit(
+        [&source_width, &source_height](JS::Handle<HTMLImageElement> const& source) {
+            if (source->immutable_bitmap()) {
+                source_width = source->immutable_bitmap()->width();
+                source_height = source->immutable_bitmap()->height();
+            } else {
+                // FIXME: This is very janky and not correct.
+                source_width = source->width();
+                source_height = source->height();
+            }
+        },
         [&source_width, &source_height](JS::Handle<SVG::SVGImageElement> const& source) {
-            if (source->bitmap()) {
-                source_width = source->bitmap()->width();
-                source_height = source->bitmap()->height();
+            if (source->current_image_bitmap()) {
+                source_width = source->current_image_bitmap()->width();
+                source_height = source->current_image_bitmap()->height();
             } else {
                 // FIXME: This is very janky and not correct.
                 source_width = source->width()->anim_val()->value();

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -46,8 +46,8 @@ void CanvasPatternPaintStyle::paint(Gfx::IntRect physical_bounding_box, PaintFun
 
     // 6. The resulting bitmap is what is to be rendered, with the same origin and same scale.
 
-    auto const bitmap_width = m_bitmap->width();
-    auto const bitmap_height = m_bitmap->height();
+    auto const bitmap_width = m_immutable_bitmap->width();
+    auto const bitmap_height = m_immutable_bitmap->height();
 
     paint([=, this](auto point) {
         point.translate_by(physical_bounding_box.location());
@@ -78,8 +78,8 @@ void CanvasPatternPaintStyle::paint(Gfx::IntRect physical_bounding_box, PaintFun
                 VERIFY_NOT_REACHED();
             }
         }();
-        if (m_bitmap->rect().contains(point))
-            return m_bitmap->get_pixel(point);
+        if (m_immutable_bitmap->rect().contains(point))
+            return m_immutable_bitmap->get_pixel(point.x(), point.y());
         return Gfx::Color();
     });
 }
@@ -129,14 +129,11 @@ WebIDL::ExceptionOr<JS::GCPtr<CanvasPattern>> CanvasPattern::create(JS::Realm& r
 
     // Note: Bitmap won't be null here, as if it were it would have "bad" usability.
     auto bitmap = image.visit(
-        [](JS::Handle<HTMLImageElement> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); },
-        [](JS::Handle<SVG::SVGImageElement> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); },
-        [](JS::Handle<HTMLCanvasElement> const& source) -> RefPtr<Gfx::Bitmap> {
-            auto snapshot = source->surface()->create_snapshot();
-            return snapshot->bitmap();
-        },
-        [](JS::Handle<HTMLVideoElement> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); },
-        [](JS::Handle<ImageBitmap> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); });
+        [](JS::Handle<HTMLImageElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return source->immutable_bitmap(); },
+        [](JS::Handle<SVG::SVGImageElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return source->current_image_bitmap(); },
+        [](JS::Handle<HTMLCanvasElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return source->surface()->create_snapshot(); },
+        [](JS::Handle<HTMLVideoElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return Gfx::ImmutableBitmap::create(*source->bitmap()); },
+        [](JS::Handle<ImageBitmap> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return Gfx::ImmutableBitmap::create(*source->bitmap()); });
 
     // 6. Let pattern be a new CanvasPattern object with the image image and the repetition behavior given by repetition.
     auto pattern = TRY_OR_THROW_OOM(realm.vm(), CanvasPatternPaintStyle::create(*bitmap, *repetition_value));

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -131,7 +131,7 @@ WebIDL::ExceptionOr<JS::GCPtr<CanvasPattern>> CanvasPattern::create(JS::Realm& r
     auto bitmap = image.visit(
         [](JS::Handle<HTMLImageElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return source->immutable_bitmap(); },
         [](JS::Handle<SVG::SVGImageElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return source->current_image_bitmap(); },
-        [](JS::Handle<HTMLCanvasElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return source->surface()->create_snapshot(); },
+        [](JS::Handle<HTMLCanvasElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return Gfx::ImmutableBitmap::create_snapshot_from_painting_surface(*source->surface()); },
         [](JS::Handle<HTMLVideoElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return Gfx::ImmutableBitmap::create(*source->bitmap()); },
         [](JS::Handle<ImageBitmap> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return Gfx::ImmutableBitmap::create(*source->bitmap()); });
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, MacDue <macdue@dueutil.tech>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -130,7 +131,10 @@ WebIDL::ExceptionOr<JS::GCPtr<CanvasPattern>> CanvasPattern::create(JS::Realm& r
     auto bitmap = image.visit(
         [](JS::Handle<HTMLImageElement> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); },
         [](JS::Handle<SVG::SVGImageElement> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); },
-        [](JS::Handle<HTMLCanvasElement> const& source) -> RefPtr<Gfx::Bitmap> { return source->surface()->create_snapshot(); },
+        [](JS::Handle<HTMLCanvasElement> const& source) -> RefPtr<Gfx::Bitmap> {
+            auto snapshot = source->surface()->create_snapshot();
+            return snapshot->bitmap();
+        },
         [](JS::Handle<HTMLVideoElement> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); },
         [](JS::Handle<ImageBitmap> const& source) -> RefPtr<Gfx::Bitmap> { return *source->bitmap(); });
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasPattern.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasPattern.h
@@ -21,7 +21,7 @@ public:
         NoRepeat
     };
 
-    static ErrorOr<NonnullRefPtr<CanvasPatternPaintStyle>> create(Gfx::Bitmap const& bitmap, Repetition repetition)
+    static ErrorOr<NonnullRefPtr<CanvasPatternPaintStyle>> create(Gfx::ImmutableBitmap const& bitmap, Repetition repetition)
     {
         return adopt_nonnull_ref_or_enomem(new (nothrow) CanvasPatternPaintStyle(bitmap, repetition));
     }
@@ -29,13 +29,13 @@ public:
     virtual void paint(Gfx::IntRect physical_bounding_box, PaintFunction paint) const override;
 
 private:
-    CanvasPatternPaintStyle(Gfx::Bitmap const& bitmap, Repetition repetition)
-        : m_bitmap(bitmap)
+    CanvasPatternPaintStyle(Gfx::ImmutableBitmap const& immutable_bitmap, Repetition repetition)
+        : m_immutable_bitmap(immutable_bitmap)
         , m_repetition(repetition)
     {
     }
 
-    NonnullRefPtr<Gfx::Bitmap const> m_bitmap;
+    NonnullRefPtr<Gfx::ImmutableBitmap> m_immutable_bitmap;
     Repetition m_repetition { Repetition::Repeat };
 };
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -134,7 +134,7 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
             auto surface = source->surface();
             if (!surface)
                 return {};
-            return source->surface()->create_snapshot();
+            return Gfx::ImmutableBitmap::create_snapshot_from_painting_surface(*surface);
         },
         [](JS::Handle<HTMLVideoElement> const& source) -> RefPtr<Gfx::ImmutableBitmap> { return Gfx::ImmutableBitmap::create(*source->bitmap()); },
         [](JS::Handle<ImageBitmap> const& source) -> RefPtr<Gfx::ImmutableBitmap> {
@@ -401,7 +401,7 @@ WebIDL::ExceptionOr<JS::GCPtr<ImageData>> CanvasRenderingContext2D::get_image_da
     // NOTE: We don't attempt to create the underlying bitmap here; if it doesn't exist, it's like copying only transparent black pixels (which is a no-op).
     if (!canvas_element().surface())
         return image_data;
-    auto const snapshot = canvas_element().surface()->create_snapshot();
+    auto const snapshot = Gfx::ImmutableBitmap::create_snapshot_from_painting_surface(*canvas_element().surface());
 
     // 5. Let the source rectangle be the rectangle whose corners are the four points (sx, sy), (sx+sw, sy), (sx+sw, sy+sh), (sx, sy+sh).
     auto source_rect = Gfx::Rect { x, y, abs_width, abs_height };

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -269,7 +269,9 @@ String HTMLCanvasElement::to_data_url(StringView type, Optional<double> quality)
 
     // 3. Let file be a serialization of this canvas element's bitmap as a file, passing type and quality if given.
     auto snapshot = m_surface->create_snapshot();
-    auto file = serialize_bitmap(snapshot->bitmap(), type, move(quality));
+    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_surface->size()));
+    m_surface->read_into_bitmap(*bitmap);
+    auto file = serialize_bitmap(bitmap, type, move(quality));
 
     // 4. If file is null then return "data:,".
     if (file.is_error()) {
@@ -301,8 +303,8 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(JS::NonnullGCPtr<WebIDL::Ca
     // 3. If this canvas element's bitmap has pixels (i.e., neither its horizontal dimension nor its vertical dimension is zero),
     //    then set result to a copy of this canvas element's bitmap.
     if (m_surface) {
-        auto snapshot = m_surface->create_snapshot();
-        bitmap_result = snapshot->bitmap();
+        bitmap_result = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_surface->size()));
+        m_surface->read_into_bitmap(*bitmap_result);
     }
 
     // 4. Run these steps in parallel:

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -268,7 +268,8 @@ String HTMLCanvasElement::to_data_url(StringView type, Optional<double> quality)
         return "data:,"_string;
 
     // 3. Let file be a serialization of this canvas element's bitmap as a file, passing type and quality if given.
-    auto file = serialize_bitmap(*m_surface->create_snapshot(), type, move(quality));
+    auto snapshot = m_surface->create_snapshot();
+    auto file = serialize_bitmap(snapshot->bitmap(), type, move(quality));
 
     // 4. If file is null then return "data:,".
     if (file.is_error()) {
@@ -300,7 +301,8 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(JS::NonnullGCPtr<WebIDL::Ca
     // 3. If this canvas element's bitmap has pixels (i.e., neither its horizontal dimension nor its vertical dimension is zero),
     //    then set result to a copy of this canvas element's bitmap.
     if (m_surface) {
-        bitmap_result = m_surface->create_snapshot();
+        auto snapshot = m_surface->create_snapshot();
+        bitmap_result = snapshot->bitmap();
     }
 
     // 4. Run these steps in parallel:

--- a/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -268,7 +268,7 @@ String HTMLCanvasElement::to_data_url(StringView type, Optional<double> quality)
         return "data:,"_string;
 
     // 3. Let file be a serialization of this canvas element's bitmap as a file, passing type and quality if given.
-    auto snapshot = m_surface->create_snapshot();
+    auto snapshot = Gfx::ImmutableBitmap::create_snapshot_from_painting_surface(*m_surface);
     auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, m_surface->size()));
     m_surface->read_into_bitmap(*bitmap);
     auto file = serialize_bitmap(bitmap, type, move(quality));

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -118,13 +119,6 @@ JS::GCPtr<Layout::Node> HTMLImageElement::create_layout_node(CSS::StylePropertie
 RefPtr<Gfx::ImmutableBitmap> HTMLImageElement::immutable_bitmap() const
 {
     return current_image_bitmap();
-}
-
-RefPtr<Gfx::Bitmap const> HTMLImageElement::bitmap() const
-{
-    if (auto immutable_bitmap = this->immutable_bitmap())
-        return immutable_bitmap->bitmap();
-    return {};
 }
 
 bool HTMLImageElement::is_image_available() const

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -43,7 +44,6 @@ public:
     String src() const { return get_attribute_value(HTML::AttributeNames::src); }
 
     RefPtr<Gfx::ImmutableBitmap> immutable_bitmap() const;
-    RefPtr<Gfx::Bitmap const> bitmap() const;
 
     unsigned width() const;
     WebIDL::ExceptionOr<void> set_width(unsigned);

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
+ * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -337,7 +338,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
                     if (is<HTML::HTMLImageElement>(*node)) {
                         auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
                         auto image_url = image_element.document().parse_url(image_element.src());
-                        m_navigable->page().client().page_did_request_image_context_menu(viewport_position, image_url, "", modifiers, image_element.bitmap());
+                        m_navigable->page().client().page_did_request_image_context_menu(viewport_position, image_url, "", modifiers, image_element.immutable_bitmap()->bitmap());
                     } else if (is<HTML::HTMLMediaElement>(*node)) {
                         auto& media_element = verify_cast<HTML::HTMLMediaElement>(*node);
 

--- a/Userland/Libraries/LibWeb/Painting/Command.h
+++ b/Userland/Libraries/LibWeb/Painting/Command.h
@@ -58,16 +58,6 @@ struct FillRect {
     void translate_by(Gfx::IntPoint const& offset) { rect.translate_by(offset); }
 };
 
-struct DrawScaledBitmap {
-    Gfx::IntRect dst_rect;
-    NonnullRefPtr<Gfx::Bitmap> bitmap;
-    Gfx::IntRect src_rect;
-    Gfx::ScalingMode scaling_mode;
-
-    [[nodiscard]] Gfx::IntRect bounding_rect() const { return dst_rect; }
-    void translate_by(Gfx::IntPoint const& offset) { dst_rect.translate_by(offset); }
-};
-
 struct DrawPaintingSurface {
     Gfx::IntRect dst_rect;
     NonnullRefPtr<Gfx::PaintingSurface> surface;
@@ -427,7 +417,6 @@ struct ApplyMaskBitmap {
 using Command = Variant<
     DrawGlyphRun,
     FillRect,
-    DrawScaledBitmap,
     DrawPaintingSurface,
     DrawScaledImmutableBitmap,
     DrawRepeatedImmutableBitmap,

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -71,7 +71,6 @@ void DisplayListPlayer::execute(DisplayList& display_list)
         // clang-format off
         HANDLE_COMMAND(DrawGlyphRun, draw_glyph_run)
         else HANDLE_COMMAND(FillRect, fill_rect)
-        else HANDLE_COMMAND(DrawScaledBitmap, draw_scaled_bitmap)
         else HANDLE_COMMAND(DrawPaintingSurface, draw_painting_surface)
         else HANDLE_COMMAND(DrawScaledImmutableBitmap, draw_scaled_immutable_bitmap)
         else HANDLE_COMMAND(DrawRepeatedImmutableBitmap, draw_repeated_immutable_bitmap)

--- a/Userland/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayList.h
@@ -45,7 +45,6 @@ public:
 private:
     virtual void draw_glyph_run(DrawGlyphRun const&) = 0;
     virtual void fill_rect(FillRect const&) = 0;
-    virtual void draw_scaled_bitmap(DrawScaledBitmap const&) = 0;
     virtual void draw_painting_surface(DrawPaintingSurface const&) = 0;
     virtual void draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const&) = 0;
     virtual void draw_repeated_immutable_bitmap(DrawRepeatedImmutableBitmap const&) = 0;

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -366,17 +366,6 @@ void DisplayListPlayerSkia::draw_painting_surface(DrawPaintingSurface const& com
     canvas.drawImageRect(image, src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
 }
 
-void DisplayListPlayerSkia::draw_scaled_bitmap(DrawScaledBitmap const& command)
-{
-    auto src_rect = to_skia_rect(command.src_rect);
-    auto dst_rect = to_skia_rect(command.dst_rect);
-    auto bitmap = to_skia_bitmap(command.bitmap);
-    auto image = SkImages::RasterFromBitmap(bitmap);
-    auto& canvas = surface().canvas();
-    SkPaint paint;
-    canvas.drawImageRect(image, src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
-}
-
 void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const& command)
 {
     auto src_rect = to_skia_rect(command.src_rect);

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -381,18 +381,13 @@ void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitm
 {
     auto src_rect = to_skia_rect(command.src_rect);
     auto dst_rect = to_skia_rect(command.dst_rect);
-    auto bitmap = to_skia_bitmap(command.bitmap->bitmap());
-    auto image = SkImages::RasterFromBitmap(bitmap);
     auto& canvas = surface().canvas();
     SkPaint paint;
-    canvas.drawImageRect(image, src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
+    canvas.drawImageRect(command.bitmap->sk_image(), src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
 }
 
 void DisplayListPlayerSkia::draw_repeated_immutable_bitmap(DrawRepeatedImmutableBitmap const& command)
 {
-    auto bitmap = to_skia_bitmap(command.bitmap->bitmap());
-    auto image = SkImages::RasterFromBitmap(bitmap);
-
     SkMatrix matrix;
     auto dst_rect = command.dst_rect.to_type<float>();
     auto src_size = command.bitmap->size().to_type<float>();
@@ -402,7 +397,7 @@ void DisplayListPlayerSkia::draw_repeated_immutable_bitmap(DrawRepeatedImmutable
 
     auto tile_mode_x = command.repeat.x ? SkTileMode::kRepeat : SkTileMode::kDecal;
     auto tile_mode_y = command.repeat.y ? SkTileMode::kRepeat : SkTileMode::kDecal;
-    auto shader = image->makeShader(tile_mode_x, tile_mode_y, sampling_options, matrix);
+    auto shader = command.bitmap->sk_image()->makeShader(tile_mode_x, tile_mode_y, sampling_options, matrix);
 
     SkPaint paint;
     paint.setShader(shader);

--- a/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -33,7 +33,6 @@ private:
     void draw_glyph_run(DrawGlyphRun const&) override;
     void fill_rect(FillRect const&) override;
     void draw_painting_surface(DrawPaintingSurface const&) override;
-    void draw_scaled_bitmap(DrawScaledBitmap const&) override;
     void draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const&) override;
     void draw_repeated_immutable_bitmap(DrawRepeatedImmutableBitmap const&) override;
     void add_clip_rect(AddClipRect const&) override;

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -168,18 +168,6 @@ void DisplayListRecorder::draw_rect(Gfx::IntRect const& rect, Color color, bool 
         .rough = rough });
 }
 
-void DisplayListRecorder::draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode)
-{
-    if (dst_rect.is_empty())
-        return;
-    append(DrawScaledBitmap {
-        .dst_rect = dst_rect,
-        .bitmap = bitmap,
-        .src_rect = src_rect,
-        .scaling_mode = scaling_mode,
-    });
-}
-
 void DisplayListRecorder::draw_painting_surface(Gfx::IntRect const& dst_rect, NonnullRefPtr<Gfx::PaintingSurface> surface, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode)
 {
     if (dst_rect.is_empty())

--- a/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Userland/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -87,7 +87,6 @@ public:
 
     void draw_rect(Gfx::IntRect const& rect, Color color, bool rough = false);
 
-    void draw_scaled_bitmap(Gfx::IntRect const& dst_rect, Gfx::Bitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_painting_surface(Gfx::IntRect const& dst_rect, NonnullRefPtr<Gfx::PaintingSurface>, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
     void draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_rect, Gfx::ImmutableBitmap const& bitmap, Gfx::IntRect const& src_rect, Gfx::ScalingMode scaling_mode = Gfx::ScalingMode::NearestNeighbor);
 

--- a/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -130,7 +130,7 @@ void VideoPaintable::paint(PaintContext& context, PaintPhase phase) const
 
     auto paint_frame = [&](auto const& frame) {
         auto scaling_mode = to_gfx_scaling_mode(computed_values().image_rendering(), frame->rect(), video_rect.to_type<int>());
-        context.display_list_recorder().draw_scaled_bitmap(video_rect.to_type<int>(), *frame, frame->rect(), scaling_mode);
+        context.display_list_recorder().draw_scaled_immutable_bitmap(video_rect.to_type<int>(), Gfx::ImmutableBitmap::create(*frame), frame->rect(), scaling_mode);
     };
 
     auto paint_transparent_black = [&]() {

--- a/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -29,15 +29,6 @@ public:
 
     Gfx::Rect<CSSPixels> bounding_box() const;
 
-    // FIXME: This is a hack for images used as CanvasImageSource. Do something more elegant.
-    RefPtr<Gfx::Bitmap> bitmap() const
-    {
-        auto bitmap = current_image_bitmap();
-        if (!bitmap)
-            return nullptr;
-        return bitmap->bitmap();
-    }
-
     // ^Layout::ImageProvider
     virtual bool is_image_available() const override;
     virtual Optional<CSSPixels> intrinsic_width() const override;

--- a/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -52,7 +52,9 @@ ErrorOr<JS::NonnullGCPtr<HTML::HTMLCanvasElement>, WebDriver::Error> draw_boundi
     //    - Height: paint height
     Gfx::IntRect paint_rect { rect.x(), rect.y(), paint_width, paint_height };
 
-    auto backing_store = Web::Painting::BitmapBackingStore(canvas.surface()->create_snapshot()->bitmap());
+    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, canvas.surface()->size()));
+    canvas.surface()->read_into_bitmap(*bitmap);
+    auto backing_store = Web::Painting::BitmapBackingStore(bitmap);
     browsing_context.page().client().paint(paint_rect.to_type<Web::DevicePixels>(), backing_store);
 
     // 7. Return success with canvas.

--- a/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Userland/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -52,7 +52,7 @@ ErrorOr<JS::NonnullGCPtr<HTML::HTMLCanvasElement>, WebDriver::Error> draw_boundi
     //    - Height: paint height
     Gfx::IntRect paint_rect { rect.x(), rect.y(), paint_width, paint_height };
 
-    auto backing_store = Web::Painting::BitmapBackingStore(canvas.surface()->create_snapshot());
+    auto backing_store = Web::Painting::BitmapBackingStore(canvas.surface()->create_snapshot()->bitmap());
     browsing_context.page().client().paint(paint_rect.to_type<Web::DevicePixels>(), backing_store);
 
     // 7. Return success with canvas.

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -6,11 +6,12 @@
 
 #include <AK/OwnPtr.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Forward.h>
 #include <LibWeb/WebGL/OpenGLContext.h>
 
 namespace Web::WebGL {
 
-OwnPtr<OpenGLContext> OpenGLContext::create(Gfx::Bitmap& bitmap)
+OwnPtr<OpenGLContext> OpenGLContext::create(Gfx::PaintingSurface& bitmap)
 {
     (void)bitmap;
     return {};

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
@@ -13,9 +13,9 @@ namespace Web::WebGL {
 
 class OpenGLContext {
 public:
-    static OwnPtr<OpenGLContext> create(Gfx::Bitmap&);
+    static OwnPtr<OpenGLContext> create(Gfx::PaintingSurface&);
 
-    virtual void present(Gfx::Bitmap&) = 0;
+    virtual void present(Gfx::Bitmap const&) = 0;
     void clear_buffer_to_default_values();
 
     virtual GLenum gl_get_error() = 0;

--- a/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
+++ b/Userland/Libraries/LibWeb/WebGL/OpenGLContext.h
@@ -15,7 +15,7 @@ class OpenGLContext {
 public:
     static OwnPtr<OpenGLContext> create(Gfx::PaintingSurface&);
 
-    virtual void present(Gfx::Bitmap const&) = 0;
+    virtual void present() = 0;
     void clear_buffer_to_default_values();
 
     virtual GLenum gl_get_error() = 0;

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContext.cpp
@@ -46,7 +46,7 @@ JS::ThrowCompletionOr<JS::GCPtr<WebGLRenderingContext>> WebGLRenderingContext::c
     }
 
     VERIFY(canvas_element.surface());
-    auto context = OpenGLContext::create(*canvas_element.surface()->create_snapshot());
+    auto context = OpenGLContext::create(*canvas_element.surface());
 
     if (!context) {
         fire_webgl_context_creation_error(canvas_element);

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -53,7 +53,7 @@ void WebGLRenderingContextBase::present()
     // FIXME: Is this the operation it means?
     m_context->gl_flush();
 
-    m_context->present(canvas_element().surface()->create_snapshot()->bitmap());
+    m_context->present();
 
     // "By default, after compositing the contents of the drawing buffer shall be cleared to their default values, as shown in the table above.
     // This default behavior can be changed by setting the preserveDrawingBuffer attribute of the WebGLContextAttributes object.

--- a/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
+++ b/Userland/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.cpp
@@ -53,7 +53,7 @@ void WebGLRenderingContextBase::present()
     // FIXME: Is this the operation it means?
     m_context->gl_flush();
 
-    m_context->present(*canvas_element().surface()->create_snapshot());
+    m_context->present(canvas_element().surface()->create_snapshot()->bitmap());
 
     // "By default, after compositing the contents of the drawing buffer shall be cleared to their default values, as shown in the table above.
     // This default behavior can be changed by setting the preserveDrawingBuffer attribute of the WebGLContextAttributes object.


### PR DESCRIPTION
This results in performance improvement on every website that has some images, because now we give Skia opportunity to cache images in GPU-memory instead of uploading them on every repaint.

Also solves performance regression introduced by GPU-accelerated canvas on https://playbiolab.com/

See commit messages for details.