### PR TITLE
LibWeb: Use available space to resolve sizes in FFC

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -20,12 +20,12 @@ namespace Web::Layout {
 
 CSSPixels FlexFormattingContext::get_pixel_width(Box const& box, CSS::Size const& size) const
 {
-    return calculate_inner_width(box, containing_block_width_as_available_size(box), size);
+    return calculate_inner_width(box, m_available_space->width, size);
 }
 
 CSSPixels FlexFormattingContext::get_pixel_height(Box const& box, CSS::Size const& size) const
 {
-    return calculate_inner_height(box, containing_block_height_as_available_size(box), size);
+    return calculate_inner_height(box, m_available_space->height, size);
 }
 
 FlexFormattingContext::FlexFormattingContext(LayoutState& state, LayoutMode layout_mode, Box const& flex_container, FormattingContext* parent)
@@ -50,6 +50,8 @@ CSSPixels FlexFormattingContext::automatic_content_height() const
 void FlexFormattingContext::run(AvailableSpace const& available_space)
 {
     // This implements https://www.w3.org/TR/css-flexbox-1/#layout-algorithm
+
+    m_available_space = available_space;
 
     // 1. Generate anonymous flex items
     generate_anonymous_flex_items();

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -235,6 +235,7 @@ private:
         AvailableSpace space;
     };
     Optional<AxisAgnosticAvailableSpace> m_available_space_for_items;
+    Optional<AvailableSpace> m_available_space;
 };
 
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1655,34 +1655,6 @@ CSSPixels FormattingContext::containing_block_height_for(NodeWithStyleAndBoxMode
     VERIFY_NOT_REACHED();
 }
 
-AvailableSize FormattingContext::containing_block_width_as_available_size(NodeWithStyleAndBoxModelMetrics const& node) const
-{
-    auto const& used_values = m_state.get(node);
-    switch (used_values.width_constraint) {
-    case SizeConstraint::MinContent:
-        return AvailableSize::make_min_content();
-    case SizeConstraint::MaxContent:
-        return AvailableSize::make_max_content();
-    case SizeConstraint::None:
-        return AvailableSize::make_definite(used_values.containing_block_used_values()->content_width());
-    }
-    VERIFY_NOT_REACHED();
-}
-
-AvailableSize FormattingContext::containing_block_height_as_available_size(NodeWithStyleAndBoxModelMetrics const& node) const
-{
-    auto const& used_values = m_state.get(node);
-    switch (used_values.height_constraint) {
-    case SizeConstraint::MinContent:
-        return AvailableSize::make_min_content();
-    case SizeConstraint::MaxContent:
-        return AvailableSize::make_max_content();
-    case SizeConstraint::None:
-        return AvailableSize::make_definite(used_values.containing_block_used_values()->content_height());
-    }
-    VERIFY_NOT_REACHED();
-}
-
 // https://drafts.csswg.org/css-sizing-3/#stretch-fit-size
 CSSPixels FormattingContext::calculate_stretch_fit_width(Box const& box, AvailableSize const& available_width) const
 {

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -101,9 +101,6 @@ public:
     [[nodiscard]] CSSPixels containing_block_width_for(NodeWithStyleAndBoxModelMetrics const&) const;
     [[nodiscard]] CSSPixels containing_block_height_for(NodeWithStyleAndBoxModelMetrics const&) const;
 
-    [[nodiscard]] AvailableSize containing_block_width_as_available_size(NodeWithStyleAndBoxModelMetrics const&) const;
-    [[nodiscard]] AvailableSize containing_block_height_as_available_size(NodeWithStyleAndBoxModelMetrics const&) const;
-
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/flex-minimum-height-flex-items-012.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/flex-minimum-height-flex-items-012.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	.flexbox 1	
+Result	Test Name	MessagePass	.flexbox 1	

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/percentage-size-quirks.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/percentage-size-quirks.txt
@@ -6,12 +6,11 @@ Rerun
 
 Found 8 tests
 
-7 Pass
-1 Fail
+8 Pass
 Details
 Result	Test Name	MessagePass	.flexbox 1	
 Pass	.flexbox 2	
-Fail	.flexbox 3	
+Pass	.flexbox 3	
 Pass	.flexbox 4	
 Pass	.flexbox 5	
 Pass	.flexbox 6	

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/percentage-size.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-flexbox/percentage-size.txt
@@ -6,12 +6,11 @@ Rerun
 
 Found 8 tests
 
-7 Pass
-1 Fail
+8 Pass
 Details
 Result	Test Name	MessagePass	.flexbox 1	
 Pass	.flexbox 2	
-Fail	.flexbox 3	
+Pass	.flexbox 3	
 Pass	.flexbox 4	
 Pass	.flexbox 5	
 Pass	.flexbox 6	


### PR DESCRIPTION
If available space is definite it should always match the size of the containing block. Therefore, there is no need to do containing block node lookup.