### PR TITLE
Meta: Remove outdated FIXME about using declaration in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,11 +2,5 @@ Userland/Libraries/LibJS/Tests/invalid-lhs-in-assignment.js
 Userland/Libraries/LibJS/Tests/unicode-identifier-escape.js
 Userland/Libraries/LibJS/Tests/modules/failing.mjs
 
-# FIXME: Remove once prettier is updated to support using declarations.
-Userland/Libraries/LibJS/Tests/builtins/DisposableStack/DisposableStack.prototype.@@dispose.js
-Userland/Libraries/LibJS/Tests/modules/top-level-dispose.mjs
-Userland/Libraries/LibJS/Tests/using-declaration.js
-Userland/Libraries/LibJS/Tests/using-for-loops.js
-
 Tests/LibWeb/Ref/input/wpt-import
 Tests/LibWeb/Text/input/wpt-import


### PR DESCRIPTION
This was implemented upstream since prettier 3.0.3

Link: https://github.com/prettier/prettier/blob/main/CHANGELOG.md#303