### PR TITLE
LibWeb: Save Gfx::ImmutableBitmap in ApplyBitmapMask display list item

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -405,7 +405,7 @@ struct ApplyTransform {
 
 struct ApplyMaskBitmap {
     Gfx::IntPoint origin;
-    NonnullRefPtr<Gfx::Bitmap> bitmap;
+    NonnullRefPtr<Gfx::ImmutableBitmap> bitmap;
     Gfx::Bitmap::MaskKind kind;
 
     void translate_by(Gfx::IntPoint const& offset)

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -239,40 +239,6 @@ static SkRRect to_skia_rrect(auto const& rect, CornerRadii const& corner_radii)
     return rrect;
 }
 
-static SkColorType to_skia_color_type(Gfx::BitmapFormat format)
-{
-    switch (format) {
-    case Gfx::BitmapFormat::Invalid:
-        return kUnknown_SkColorType;
-    case Gfx::BitmapFormat::BGRA8888:
-    case Gfx::BitmapFormat::BGRx8888:
-        return kBGRA_8888_SkColorType;
-    case Gfx::BitmapFormat::RGBA8888:
-        return kRGBA_8888_SkColorType;
-    case Gfx::BitmapFormat::RGBx8888:
-        return kRGB_888x_SkColorType;
-    default:
-        return kUnknown_SkColorType;
-    }
-}
-
-static SkBitmap to_skia_bitmap(Gfx::Bitmap const& bitmap)
-{
-    SkColorType color_type = to_skia_color_type(bitmap.format());
-    SkAlphaType alpha_type = bitmap.alpha_type() == Gfx::AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
-    SkImageInfo image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type);
-    SkBitmap sk_bitmap;
-    sk_bitmap.setInfo(image_info);
-
-    if (!sk_bitmap.installPixels(image_info, const_cast<Gfx::ARGB32*>(bitmap.begin()), bitmap.width() * 4)) {
-        VERIFY_NOT_REACHED();
-    }
-
-    sk_bitmap.setImmutable();
-
-    return sk_bitmap;
-}
-
 static SkMatrix to_skia_matrix(Gfx::AffineTransform const& affine_transform)
 {
     SkScalar affine[6];
@@ -1151,8 +1117,7 @@ void DisplayListPlayerSkia::apply_mask_bitmap(ApplyMaskBitmap const& command)
 {
     auto& canvas = surface().canvas();
 
-    auto sk_bitmap = to_skia_bitmap(*command.bitmap);
-    auto mask_image = SkImages::RasterFromBitmap(sk_bitmap);
+    auto const* mask_image = command.bitmap->sk_image();
 
     char const* sksl_shader = nullptr;
     if (command.kind == Gfx::Bitmap::MaskKind::Luminance) {

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -406,7 +406,7 @@ void DisplayListRecorder::apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatr
     });
 }
 
-void DisplayListRecorder::apply_mask_bitmap(Gfx::IntPoint origin, Gfx::Bitmap const& bitmap, Gfx::Bitmap::MaskKind kind)
+void DisplayListRecorder::apply_mask_bitmap(Gfx::IntPoint origin, Gfx::ImmutableBitmap const& bitmap, Gfx::Bitmap::MaskKind kind)
 {
     append(ApplyMaskBitmap {
         .origin = origin,

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -141,7 +141,7 @@ public:
 
     void apply_opacity(float opacity);
     void apply_transform(Gfx::FloatPoint origin, Gfx::FloatMatrix4x4);
-    void apply_mask_bitmap(Gfx::IntPoint origin, Gfx::Bitmap const&, Gfx::Bitmap::MaskKind);
+    void apply_mask_bitmap(Gfx::IntPoint origin, Gfx::ImmutableBitmap const&, Gfx::Bitmap::MaskKind);
 
     DisplayListRecorder(DisplayList&);
     ~DisplayListRecorder();

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -37,7 +37,7 @@ public:
 
     virtual Optional<CSSPixelRect> get_masking_area() const;
     virtual Optional<Gfx::Bitmap::MaskKind> get_mask_type() const { return {}; }
-    virtual RefPtr<Gfx::Bitmap> calculate_mask(PaintContext&, CSSPixelRect const&) const { return {}; }
+    virtual RefPtr<Gfx::ImmutableBitmap> calculate_mask(PaintContext&, CSSPixelRect const&) const { return {}; }
 
     Layout::NodeWithStyleAndBoxModelMetrics& layout_node_with_style_and_box_metrics() { return static_cast<Layout::NodeWithStyleAndBoxModelMetrics&>(Paintable::layout_node()); }
     Layout::NodeWithStyleAndBoxModelMetrics const& layout_node_with_style_and_box_metrics() const { return static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(Paintable::layout_node()); }

--- a/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
@@ -29,7 +29,7 @@ public:
     virtual JS::GCPtr<DOM::Node const> dom_node_of_svg() const override { return dom_node(); }
     virtual Optional<CSSPixelRect> get_masking_area() const override { return get_masking_area_of_svg(); }
     virtual Optional<Gfx::Bitmap::MaskKind> get_mask_type() const override { return get_mask_type_of_svg(); }
-    virtual RefPtr<Gfx::Bitmap> calculate_mask(PaintContext& paint_context, CSSPixelRect const& masking_area) const override { return calculate_mask_of_svg(paint_context, masking_area); }
+    virtual RefPtr<Gfx::ImmutableBitmap> calculate_mask(PaintContext& paint_context, CSSPixelRect const& masking_area) const override { return calculate_mask_of_svg(paint_context, masking_area); }
 
 protected:
     SVGForeignObjectPaintable(Layout::SVGForeignObjectBox const&);

--- a/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
@@ -54,7 +54,7 @@ public:
     virtual JS::GCPtr<DOM::Node const> dom_node_of_svg() const override { return dom_node(); }
     virtual Optional<CSSPixelRect> get_masking_area() const override { return get_masking_area_of_svg(); }
     virtual Optional<Gfx::Bitmap::MaskKind> get_mask_type() const override { return get_mask_type_of_svg(); }
-    virtual RefPtr<Gfx::Bitmap> calculate_mask(PaintContext& paint_context, CSSPixelRect const& masking_area) const override { return calculate_mask_of_svg(paint_context, masking_area); }
+    virtual RefPtr<Gfx::ImmutableBitmap> calculate_mask(PaintContext& paint_context, CSSPixelRect const& masking_area) const override { return calculate_mask_of_svg(paint_context, masking_area); }
 
     void set_computed_transforms(ComputedTransforms computed_transforms)
     {

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -73,7 +73,7 @@ Optional<Gfx::Bitmap::MaskKind> SVGMaskable::get_mask_type_of_svg() const
     return {};
 }
 
-RefPtr<Gfx::Bitmap> SVGMaskable::calculate_mask_of_svg(PaintContext& context, CSSPixelRect const& masking_area) const
+RefPtr<Gfx::ImmutableBitmap> SVGMaskable::calculate_mask_of_svg(PaintContext& context, CSSPixelRect const& masking_area) const
 {
     auto const& graphics_element = verify_cast<SVG::SVGGraphicsElement const>(*dom_node_of_svg());
     auto mask_rect = context.enclosing_device_rect(masking_area);
@@ -108,7 +108,7 @@ RefPtr<Gfx::Bitmap> SVGMaskable::calculate_mask_of_svg(PaintContext& context, CS
         if (!mask_bitmap)
             mask_bitmap = clip_bitmap;
     }
-    return mask_bitmap;
+    return Gfx::ImmutableBitmap::create(*mask_bitmap);
 }
 
 }

--- a/Libraries/LibWeb/Painting/SVGMaskable.h
+++ b/Libraries/LibWeb/Painting/SVGMaskable.h
@@ -19,7 +19,7 @@ public:
 
     Optional<CSSPixelRect> get_masking_area_of_svg() const;
     Optional<Gfx::Bitmap::MaskKind> get_mask_type_of_svg() const;
-    RefPtr<Gfx::Bitmap> calculate_mask_of_svg(PaintContext&, CSSPixelRect const& masking_area) const;
+    RefPtr<Gfx::ImmutableBitmap> calculate_mask_of_svg(PaintContext&, CSSPixelRect const& masking_area) const;
 };
 
 }


### PR DESCRIPTION
This allows to delete duplicated code between DisplayListPlayerSkia.cpp and ImmutableBitmap.cpp responsible for wrapping Gfx::Bitmap in SkImage.