### PR TITLE
LibWeb: Don't crash from clipping grid spans

### DIFF
--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -1849,9 +1849,6 @@ CSSPixelRect GridFormattingContext::get_grid_area_rect(GridItem const& grid_item
 
         auto resolved_span = grid_item.span(dimension) * 2;
         auto gap_adjusted_position = grid_item.gap_adjusted_position(dimension);
-        if (gap_adjusted_position + resolved_span > tracks_and_gaps.size()) {
-            resolved_span = tracks_and_gaps.size() - gap_adjusted_position;
-        }
 
         int start = gap_adjusted_position;
         int end = start + resolved_span;

--- a/Tests/LibWeb/Layout/expected/grid/grid-row-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/grid-row-overflow-crash.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x0 children: not-inline
+      Box <div> at (8,8) content-size 784x0 positioned [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div> at (8,8) content-size 0x0 positioned [BFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x0]
+      PaintableBox (Box<DIV>) [8,8 784x0]
+        PaintableWithLines (BlockContainer<DIV>) [8,8 0x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]

--- a/Tests/LibWeb/Layout/expected/grid/row-gaps-with-overflowing-spans-crash.txt
+++ b/Tests/LibWeb/Layout/expected/grid/row-gaps-with-overflowing-spans-crash.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x48 children: not-inline
+      Box <div> at (8,8) content-size 784x48 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        BlockContainer <div> at (8,24) content-size 784x32 [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 1, rect: [8,24 6.34375x17] baseline: 13.296875
+              "1"
+          TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,56) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x48]
+      PaintableBox (Box<DIV>) [8,8 784x48]
+        PaintableWithLines (BlockContainer<DIV>) [8,24 784x32]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,56 784x0]

--- a/Tests/LibWeb/Layout/input/grid/grid-row-overflow-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/grid-row-overflow-crash.html
@@ -1,0 +1,3 @@
+<div style="display: grid; position: relative">
+    <div style="position: absolute; grid-row: 3"></div>
+</div>

--- a/Tests/LibWeb/Layout/input/grid/row-gaps-with-overflowing-spans-crash.html
+++ b/Tests/LibWeb/Layout/input/grid/row-gaps-with-overflowing-spans-crash.html
@@ -1,0 +1,3 @@
+<div style="display: grid; grid-row-gap: 16px; grid-template-rows: 1fr 1fr">
+    <div style="grid-row: 2 / span 3">1</div>
+</div>


### PR DESCRIPTION
Fixes 9 crashes in WPT `/css/css-grid/`.

This removes a check added in https://github.com/SerenityOS/serenity/pull/16669 which was added to fix a separate bug.
The test added in that PR was removed in https://github.com/LadybirdBrowser/ladybird/pull/1584 so I have re-added it as a layout test.

The check appears to no longer be necessary as the old test still passes without it.
I have also verified that this change doesn't cause any regressions by comparing WPT results before and after (with the VERIFY removed so that the crashes don't hide any regressions).

Finally, I have added a minimised reproduction of a WPT crash.