### PR TITLE
LibWeb+LibTextCodec: Add support for BOM handling and error mode

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -59,6 +59,20 @@ ErrorOr<String> String::from_utf8(StringView view)
     return result;
 }
 
+String String::from_utf16_with_replacement_character(Utf16View const& utf16_view, WithBOMHandling with_bom_handling)
+{
+    StringBuilder builder;
+    if (with_bom_handling == WithBOMHandling::Yes && utf16_view.has_bom()) {
+        for (auto code_point : utf16_view.substring_view(1))
+            builder.append_code_point(code_point);
+    } else {
+        for (auto code_point : utf16_view)
+            builder.append_code_point(code_point);
+    }
+
+    return builder.to_string_without_validation();
+}
+
 ErrorOr<String> String::from_utf16(Utf16View const& utf16)
 {
     if (!utf16.validate())

--- a/AK/String.h
+++ b/AK/String.h
@@ -58,6 +58,7 @@ public:
 
     // Creates a new String using the replacement character for invalid bytes
     [[nodiscard]] static String from_utf8_with_replacement_character(StringView, WithBOMHandling = WithBOMHandling::Yes);
+    [[nodiscard]] static String from_utf16_with_replacement_character(Utf16View const&, WithBOMHandling = WithBOMHandling::Yes);
 
     template<typename T>
     requires(IsOneOf<RemoveCVReference<T>, ByteString, DeprecatedFlyString, FlyString, String>)

--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -363,6 +363,15 @@ bool Utf16View::equals_ignoring_case(Utf16View const& other) const
     return true;
 }
 
+bool Utf16View::has_bom() const
+{
+    if (span().is_empty())
+        return false;
+
+    auto code_unit = host_code_unit(span()[0], m_endianness);
+    return code_unit == 0xFFFE || code_unit == 0xFEFF;
+}
+
 Utf16CodePointIterator& Utf16CodePointIterator::operator++()
 {
     size_t code_units = length_in_code_units();

--- a/AK/Utf16View.h
+++ b/AK/Utf16View.h
@@ -131,6 +131,8 @@ public:
 
     bool equals_ignoring_case(Utf16View const&) const;
 
+    bool has_bom() const;
+
 private:
     u16 const* begin_ptr() const { return m_code_units.data(); }
     u16 const* end_ptr() const { return begin_ptr() + m_code_units.size(); }

--- a/Libraries/LibGfx/ICC/TagTypes.cpp
+++ b/Libraries/LibGfx/ICC/TagTypes.cpp
@@ -730,7 +730,7 @@ ErrorOr<NonnullRefPtr<MultiLocalizedUnicodeTagData>> MultiLocalizedUnicodeTagDat
         while (utf_16be_data.length() >= 2 && utf_16be_data.ends_with(StringView("\0", 2)))
             utf_16be_data = utf_16be_data.substring_view(0, utf_16be_data.length() - 2);
 
-        records[i].text = TRY(utf_16be_decoder.to_utf8(utf_16be_data));
+        records[i].text = TRY(utf_16be_decoder.to_utf8(utf_16be_data, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
     }
 
     return try_make_ref_counted<MultiLocalizedUnicodeTagData>(offset, size, move(records));
@@ -1120,7 +1120,7 @@ ErrorOr<NonnullRefPtr<TextDescriptionTagData>> TextDescriptionTagData::from_byte
             return Error::from_string_literal("ICC::Profile: textDescriptionType Unicode description not \\0-terminated");
 
         StringView utf_16be_data { unicode_description_data, byte_size_without_nul };
-        unicode_description = TRY(TextCodec::decoder_for("utf-16be"sv)->to_utf8(utf_16be_data));
+        unicode_description = TRY(TextCodec::decoder_for("utf-16be"sv)->to_utf8(utf_16be_data, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
     }
 
     // ScriptCode
@@ -1169,7 +1169,7 @@ ErrorOr<NonnullRefPtr<TextDescriptionTagData>> TextDescriptionTagData::from_byte
             if (macintosh_description_data[macintosh_description_length - 1] != '\0')
                 return Error::from_string_literal("ICC::Profile: textDescriptionType ScriptCode not \\0-terminated");
 
-            macintosh_description = TRY(TextCodec::decoder_for("x-mac-roman"sv)->to_utf8({ macintosh_description_data, (size_t)macintosh_description_length - 1 }));
+            macintosh_description = TRY(TextCodec::decoder_for("x-mac-roman"sv)->to_utf8({ macintosh_description_data, (size_t)macintosh_description_length - 1 }, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
         } else {
             dbgln("TODO: ICCProfile textDescriptionType ScriptCode {}, length {}", scriptcode_code, macintosh_description_length);
         }

--- a/Libraries/LibTextCodec/Decoder.h
+++ b/Libraries/LibTextCodec/Decoder.h
@@ -17,9 +17,14 @@ namespace TextCodec {
 
 class Decoder {
 public:
+    enum class ErrorMode {
+        Replacement,
+        Fatal,
+    };
+
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) = 0;
     virtual bool validate(StringView);
-    virtual ErrorOr<String> to_utf8(StringView);
+    virtual ErrorOr<String> to_utf8(StringView, String::WithBOMHandling, ErrorMode);
 
 protected:
     virtual ~Decoder() = default;
@@ -29,21 +34,21 @@ class UTF8Decoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override;
-    virtual ErrorOr<String> to_utf8(StringView) override;
+    virtual ErrorOr<String> to_utf8(StringView, String::WithBOMHandling, ErrorMode) override;
 };
 
 class UTF16BEDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override;
-    virtual ErrorOr<String> to_utf8(StringView) override;
+    virtual ErrorOr<String> to_utf8(StringView, String::WithBOMHandling, ErrorMode) override;
 };
 
 class UTF16LEDecoder final : public Decoder {
 public:
     virtual ErrorOr<void> process(StringView, Function<ErrorOr<void>(u32)> on_code_point) override;
     virtual bool validate(StringView) override;
-    virtual ErrorOr<String> to_utf8(StringView) override;
+    virtual ErrorOr<String> to_utf8(StringView, String::WithBOMHandling, ErrorMode) override;
 };
 
 template<Integral ArrayType = u32>

--- a/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -162,7 +162,7 @@ Vector<Token> Tokenizer::tokenize(StringView input, StringView encoding)
         auto decoder = TextCodec::decoder_for(encoding);
         VERIFY(decoder.has_value());
 
-        auto decoded_input = MUST(decoder->to_utf8(input));
+        auto decoded_input = MUST(decoder->to_utf8(input, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Fatal));
 
         // OPTIMIZATION: If the input doesn't contain any filterable characters, we can skip the filtering
         bool const contains_filterable = [&] {

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -53,7 +53,7 @@ bool build_xml_document(DOM::Document& document, ByteBuffer const& data, Optiona
         convert_to_xml_error_document(document, "XML Document contains improperly-encoded characters"_string);
         return false;
     }
-    auto source = decoder->to_utf8(data).release_value_but_fixme_should_propagate_errors();
+    auto source = decoder->to_utf8(data, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement).release_value_but_fixme_should_propagate_errors();
     XML::Parser parser(source, { .resolve_external_resource = resolve_xml_resource });
     XMLDocumentBuilder builder { document };
     auto result = parser.parse_with_listener(builder);
@@ -168,7 +168,7 @@ static WebIDL::ExceptionOr<GC::Ref<DOM::Document>> load_xml_document(HTML::Navig
             document->completely_finish_loading();
             return;
         }
-        auto source = decoder->to_utf8(data);
+        auto source = decoder->to_utf8(data, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement);
         if (source.is_error()) {
             // FIXME: Insert error message into the document.
             dbgln("Failed to decode XML document: {}", source.error());

--- a/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -75,11 +75,15 @@ WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<GC::Root<WebIDL::Buffer
     auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input.value()->raw_object());
     if (data_buffer_or_error.is_error())
         return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer"_string);
+
     auto& data_buffer = data_buffer_or_error.value();
-    auto result = TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() }));
-    if (this->fatal() && result.contains(0xfffd))
+    auto result = m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() });
+
+    if (result.is_error() && fatal())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Decoding failed"sv };
-    return result;
+
+    VERIFY(!result.is_error());
+    return result.release_value();
 }
 
 }

--- a/Libraries/LibWeb/Encoding/TextDecoder.cpp
+++ b/Libraries/LibWeb/Encoding/TextDecoder.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
  * Copyright (c) 2024, Simon Wanner <simon@skyrising.xyz>
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -68,8 +69,11 @@ void TextDecoder::initialize(JS::Realm& realm)
 // https://encoding.spec.whatwg.org/#dom-textdecoder-decode
 WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<GC::Root<WebIDL::BufferSource>> const& input, Optional<TextDecodeOptions> const&) const
 {
+    auto bom_handling = ignore_bom() ? String::WithBOMHandling::No : String::WithBOMHandling::Yes;
+    auto error_mode = fatal() ? TextCodec::Decoder::ErrorMode::Fatal : TextCodec::Decoder::ErrorMode::Replacement;
+
     if (!input.has_value())
-        return TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({}));
+        return TRY_OR_THROW_OOM(vm(), m_decoder.to_utf8({}, bom_handling, error_mode));
 
     // FIXME: Implement the streaming stuff.
     auto data_buffer_or_error = WebIDL::get_buffer_source_copy(*input.value()->raw_object());
@@ -77,7 +81,7 @@ WebIDL::ExceptionOr<String> TextDecoder::decode(Optional<GC::Root<WebIDL::Buffer
         return WebIDL::OperationError::create(realm(), "Failed to copy bytes from ArrayBuffer"_string);
 
     auto& data_buffer = data_buffer_or_error.value();
-    auto result = m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() });
+    auto result = m_decoder.to_utf8({ data_buffer.data(), data_buffer.size() }, bom_handling, error_mode);
 
     if (result.is_error() && fatal())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, "Decoding failed"sv };

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2856,7 +2856,7 @@ HTMLTokenizer::HTMLTokenizer(StringView input, ByteString const& encoding)
 {
     auto decoder = TextCodec::decoder_for(encoding);
     VERIFY(decoder.has_value());
-    m_decoded_input = decoder->to_utf8(input).release_value_but_fixme_should_propagate_errors().to_byte_string();
+    m_decoded_input = decoder->to_utf8(input, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement).release_value_but_fixme_should_propagate_errors().to_byte_string();
     m_utf8_view = Utf8View(m_decoded_input);
     m_utf8_iterator = m_utf8_view.begin();
     m_prev_utf8_iterator = m_utf8_view.begin();

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizerHelpers.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizerHelpers.cpp
@@ -14,7 +14,7 @@ OptionalString decode_to_utf8(StringView text, StringView encoding)
     auto decoder = TextCodec::decoder_for(encoding);
     if (!decoder.has_value())
         return std::nullopt;
-    auto decoded_or_error = decoder.value().to_utf8(text);
+    auto decoded_or_error = decoder.value().to_utf8(text, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement);
     if (decoded_or_error.is_error())
         return std::nullopt;
     return decoded_or_error.release_value();

--- a/Libraries/LibWeb/Infra/JSON.cpp
+++ b/Libraries/LibWeb/Infra/JSON.cpp
@@ -30,7 +30,7 @@ WebIDL::ExceptionOr<JS::Value> parse_json_bytes_to_javascript_value(JS::Realm& r
 
     // 1. Let string be the result of running UTF-8 decode on bytes.
     TextCodec::UTF8Decoder decoder;
-    auto string = TRY_OR_THROW_OOM(vm, decoder.to_utf8(bytes));
+    auto string = TRY_OR_THROW_OOM(vm, decoder.to_utf8(bytes, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
 
     // 2. Return the result of parsing a JSON string to an Infra value given string.
     return parse_json_string_to_javascript_value(realm, string);

--- a/Meta/Lagom/Fuzzers/FuzzTextDecoder.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTextDecoder.cpp
@@ -24,6 +24,6 @@ extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
     if (!decoder.has_value())
         return 0;
 
-    (void)decoder->to_utf8(encoded_data);
+    (void)decoder->to_utf8(encoded_data, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement);
     return 0;
 }

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -134,7 +134,7 @@ size_t ConnectionFromClient::on_header_received(void* buffer, size_t size, size_
                 auto decoder = TextCodec::decoder_for_exact_name("ISO-8859-1"sv);
                 VERIFY(decoder.has_value());
 
-                request->reason_phrase = MUST(decoder->to_utf8(reason_phrase_string_view));
+                request->reason_phrase = MUST(decoder->to_utf8(reason_phrase_string_view, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
                 return total_size;
             }
         }

--- a/Tests/LibTextCodec/TestTextDecoders.cpp
+++ b/Tests/LibTextCodec/TestTextDecoders.cpp
@@ -24,7 +24,7 @@ TEST_CASE(test_utf8_decode)
     EXPECT(processed_code_points.size() == 1);
     EXPECT(processed_code_points[0] == 0x1F600);
 
-    EXPECT(MUST(decoder.to_utf8(test_string)) == test_string);
+    EXPECT(MUST(decoder.to_utf8(test_string, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement)) == test_string);
 }
 
 TEST_CASE(test_utf16be_decode)
@@ -45,7 +45,7 @@ TEST_CASE(test_utf16be_decode)
     EXPECT(processed_code_points[2] == 0x6B);
     EXPECT(processed_code_points[3] == 0x1F600);
 
-    auto utf8 = MUST(decoder.to_utf8(test_string));
+    auto utf8 = MUST(decoder.to_utf8(test_string, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
     EXPECT_EQ(utf8, "säk😀"sv);
 }
 
@@ -67,6 +67,6 @@ TEST_CASE(test_utf16le_decode)
     EXPECT(processed_code_points[2] == 0x6B);
     EXPECT(processed_code_points[3] == 0x1F600);
 
-    auto utf8 = MUST(decoder.to_utf8(test_string));
+    auto utf8 = MUST(decoder.to_utf8(test_string, String::WithBOMHandling::Yes, TextCodec::Decoder::ErrorMode::Replacement));
     EXPECT_EQ(utf8, "säk😀"sv);
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/encoding/textdecoder-utf16-surrogates.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/encoding/textdecoder-utf16-surrogates.any.txt
@@ -1,0 +1,20 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 10 tests
+
+10 Pass
+Details
+Result	Test Name	MessagePass	utf-16le - lone surrogate lead	
+Pass	utf-16le - lone surrogate lead (fatal flag set)	
+Pass	utf-16le - lone surrogate trail	
+Pass	utf-16le - lone surrogate trail (fatal flag set)	
+Pass	utf-16le - unmatched surrogate lead	
+Pass	utf-16le - unmatched surrogate lead (fatal flag set)	
+Pass	utf-16le - unmatched surrogate trail	
+Pass	utf-16le - unmatched surrogate trail (fatal flag set)	
+Pass	utf-16le - swapped surrogate pair	
+Pass	utf-16le - swapped surrogate pair (fatal flag set)	

--- a/Tests/LibWeb/Text/input/wpt-import/encoding/textdecoder-utf16-surrogates.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/encoding/textdecoder-utf16-surrogates.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Encoding API: UTF-16 surrogate handling</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../encoding/textdecoder-utf16-surrogates.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/encoding/textdecoder-utf16-surrogates.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/encoding/textdecoder-utf16-surrogates.any.js
@@ -1,0 +1,46 @@
+// META: global=window,dedicatedworker,shadowrealm
+// META: title=Encoding API: UTF-16 surrogate handling
+
+var bad = [
+    {
+        encoding: 'utf-16le',
+        input: [0x00, 0xd8],
+        expected: '\uFFFD',
+        name: 'lone surrogate lead'
+    },
+    {
+        encoding: 'utf-16le',
+        input: [0x00, 0xdc],
+        expected: '\uFFFD',
+        name: 'lone surrogate trail'
+    },
+    {
+        encoding: 'utf-16le',
+        input: [0x00, 0xd8, 0x00, 0x00],
+        expected: '\uFFFD\u0000',
+        name: 'unmatched surrogate lead'
+    },
+    {
+        encoding: 'utf-16le',
+        input: [0x00, 0xdc, 0x00, 0x00],
+        expected: '\uFFFD\u0000',
+        name: 'unmatched surrogate trail'
+    },
+    {
+        encoding: 'utf-16le',
+        input: [0x00, 0xdc, 0x00, 0xd8],
+        expected: '\uFFFD\uFFFD',
+        name: 'swapped surrogate pair'
+    }
+];
+
+bad.forEach(function(t) {
+    test(function() {
+        assert_equals(new TextDecoder(t.encoding).decode(new Uint8Array(t.input)), t.expected);
+    }, t.encoding + ' - ' + t.name);
+    test(function() {
+        assert_throws_js(TypeError, function() {
+            new TextDecoder(t.encoding, {fatal: true}).decode(new Uint8Array(t.input))
+        });
+    }, t.encoding + ' - ' + t.name + ' (fatal flag set)');
+});


### PR DESCRIPTION
Fixes a crash running https://wpt.live/encoding/textdecoder-ignorebom.any.html

The factoring definitely feels a bit awkward here. Also considering whether from_utf8 etc should have any BOM handling.