### PR TITLE
LibJS: Allow unpaired surrogates in String.prototype.replace

### DIFF
--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1401,7 +1401,7 @@ ThrowCompletionOr<String> get_substitution(VM& vm, Utf16View const& matched, Utf
     }
 
     // 6. Return result.
-    return MUST(Utf16View { result }.to_utf8());
+    return MUST(Utf16View { result }.to_utf8(Utf16View::AllowInvalidCodeUnits::Yes));
 }
 
 // 2.1.2 AddDisposableResource ( disposable, V, hint [ , method ] ), https://tc39.es/proposal-explicit-resource-management/#sec-adddisposableresource-disposable-v-hint-disposemethod

--- a/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
+++ b/Libraries/LibJS/Tests/builtins/String/String.prototype.replace.js
@@ -254,3 +254,9 @@ test("substitution with capture group", () => {
     expect("A".replace(/(A)/, "$10")).toBe("A0");
     expect("A".replace(/(A)/, "$2")).toBe("$2");
 });
+
+test("Replace with unpaired surrogate", () => {
+    expect("$".replace("$", "\ud83d")).toBe("\ud83d");
+    expect("$ab".replace("$", "\ud83d")).toBe("\ud83dab");
+    expect("\ud83d$ab".replace("\ud83d$", "ab")).toBe("abab");
+});


### PR DESCRIPTION
This was resulting in a crash for the WPT test case:

https://wpt.live/xhr/send-data-string-invalid-unicode.any.html