### PR TITLE
LibURL: Convert `basic_parse` input to scalar value string

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -27,17 +27,20 @@ void HTMLHyperlinkElementUtils::reinitialize_url() const
 // https://html.spec.whatwg.org/multipage/links.html#concept-hyperlink-url-set
 void HTMLHyperlinkElementUtils::set_the_url()
 {
-    // 1. If this element's href content attribute is absent, set this element's url to null.
+    // 1. Set this element's url to null.
+    m_url = {};
+
+    // 2. If this element's href content attribute is absent, then return.
     auto href_content_attribute = hyperlink_element_utils_href();
     if (!href_content_attribute.has_value()) {
-        m_url = {};
         hyperlink_element_utils_element().invalidate_style(DOM::StyleInvalidationReason::HTMLHyperlinkElementHrefChange);
         return;
     }
 
-    // 2. Otherwise, parse this element's href content attribute value relative to this element's node document.
-    //    If parsing is successful, set this element's url to the result; otherwise, set this element's url to null.
+    // 3. Let url be the result of encoding-parsing a URL given this element's href content attribute's value, relative to this element's node document.
     m_url = hyperlink_element_utils_document().parse_url(*href_content_attribute);
+
+    // 4. If url is not failure, then set this element's url to url.
     hyperlink_element_utils_element().invalidate_style(DOM::StyleInvalidationReason::HTMLHyperlinkElementHrefChange);
 }
 


### PR DESCRIPTION
Fixes the WPT failure at: https://wpt.fyi/results/url/a-element-xhtml.xhtml%3Fexclude%3D(file%7Cjavascript%7Cmailto)?product=ladybird