### PR TITLE
LibWebView+Services+UI: Move common utilities to LibWebView

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,12 +68,6 @@ endif()
 add_cxx_compile_options(-Wno-expansion-to-defined)
 add_cxx_compile_options(-Wno-user-defined-literals)
 
-if (ANDROID OR APPLE)
-    serenity_option(ENABLE_QT OFF CACHE BOOL "Build ladybird application using Qt GUI")
-else()
-    serenity_option(ENABLE_QT ON CACHE BOOL "Build ladybird application using Qt GUI")
-endif()
-
 if (ANDROID AND ENABLE_QT)
     message(STATUS "Disabling Qt for Android")
     set(ENABLE_QT OFF CACHE BOOL "" FORCE)

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -1,4 +1,5 @@
-include(${SerenityOS_SOURCE_DIR}/Meta/CMake/public_suffix.cmake)
+include(fontconfig)
+include(public_suffix)
 
 set(SOURCES
     Application.cpp
@@ -7,8 +8,10 @@ set(SOURCES
     CookieJar.cpp
     Database.cpp
     InspectorClient.cpp
-    ProcessHandle.cpp
+    Plugins/FontPlugin.cpp
+    Plugins/ImageCodecPlugin.cpp
     Process.cpp
+    ProcessHandle.cpp
     ProcessManager.cpp
     SearchEngine.cpp
     SourceHighlighter.cpp
@@ -71,6 +74,10 @@ if (ENABLE_QT)
     target_link_libraries(LibWebView PRIVATE Qt::Core)
 elseif (APPLE)
     target_link_libraries(LibWebView PRIVATE "-framework Cocoa")
+endif()
+
+if (HAS_FONTCONFIG)
+    target_link_libraries(LibWebView PRIVATE Fontconfig::Fontconfig)
 endif()
 
 if (ENABLE_INSTALL_HEADERS)

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -19,6 +19,20 @@ set(SOURCES
     ${PUBLIC_SUFFIX_SOURCES}
 )
 
+if (ENABLE_QT)
+    list(APPEND SOURCES
+        EventLoop/EventLoopImplementationQt.cpp
+        EventLoop/EventLoopImplementationQtEventTarget.cpp
+    )
+
+    set(CMAKE_AUTOMOC ON)
+    find_package(Qt6 REQUIRED COMPONENTS Core)
+elseif (APPLE)
+    list(APPEND SOURCES
+        EventLoop/EventLoopImplementationMacOS.mm
+    )
+endif()
+
 set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
 
 embed_as_string(
@@ -52,6 +66,12 @@ target_compile_definitions(LibWebView PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENAB
 # Third-party
 find_package(SQLite3 REQUIRED)
 target_link_libraries(LibWebView PRIVATE SQLite::SQLite3)
+
+if (ENABLE_QT)
+    target_link_libraries(LibWebView PRIVATE Qt::Core)
+elseif (APPLE)
+    target_link_libraries(LibWebView PRIVATE "-framework Cocoa")
+endif()
 
 if (ENABLE_INSTALL_HEADERS)
     foreach(header ${GENERATED_SOURCES})

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     ChromeProcess.cpp
     CookieJar.cpp
     Database.cpp
+    HelperProcess.cpp
     InspectorClient.cpp
     Plugins/FontPlugin.cpp
     Plugins/ImageCodecPlugin.cpp
@@ -17,10 +18,15 @@ set(SOURCES
     SourceHighlighter.cpp
     URL.cpp
     UserAgent.cpp
+    Utilities.cpp
     ViewImplementation.cpp
     WebContentClient.cpp
     ${PUBLIC_SUFFIX_SOURCES}
 )
+
+if (APPLE)
+    list(APPEND SOURCES MachPortServer.cpp)
+endif()
 
 if (ENABLE_QT)
     list(APPEND SOURCES
@@ -49,6 +55,10 @@ embed_as_string(
 compile_ipc(UIProcessServer.ipc UIProcessServerEndpoint.h)
 compile_ipc(UIProcessClient.ipc UIProcessClientEndpoint.h)
 
+if (NOT APPLE AND NOT CMAKE_INSTALL_LIBEXECDIR STREQUAL "libexec")
+    set_source_files_properties(Utilities.cpp PROPERTIES COMPILE_DEFINITIONS LADYBIRD_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}")
+endif()
+
 set(GENERATED_SOURCES
     ${GENERATED_SOURCES}
     ../../Services/RequestServer/RequestClientEndpoint.h
@@ -65,6 +75,10 @@ set(GENERATED_SOURCES
 serenity_lib(LibWebView webview)
 target_link_libraries(LibWebView PRIVATE LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibRequests LibJS LibWeb LibUnicode LibURL LibSyntax)
 target_compile_definitions(LibWebView PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENABLE_PUBLIC_SUFFIX_DOWNLOAD}>)
+
+if (APPLE)
+    target_link_libraries(LibWebView PRIVATE LibThreading)
+endif()
 
 # Third-party
 find_package(SQLite3 REQUIRED)

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.h
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,9 +10,9 @@
 #include <AK/NonnullOwnPtr.h>
 #include <LibCore/EventLoopImplementation.h>
 
-namespace Ladybird {
+namespace WebView {
 
-class CFEventLoopManager final : public Core::EventLoopManager {
+class EventLoopManagerMacOS final : public Core::EventLoopManager {
 public:
     virtual NonnullOwnPtr<Core::EventLoopImplementation> make_implementation() override;
 
@@ -28,12 +28,12 @@ public:
     virtual void unregister_signal(int) override;
 };
 
-class CFEventLoopImplementation final : public Core::EventLoopImplementation {
+class EventLoopImplementationMacOS final : public Core::EventLoopImplementation {
 public:
     // FIXME: This currently only manages the main NSApp event loop, as that is all we currently
     //        interact with. When we need multiple event loops, or an event loop that isn't the
     //        NSApp loop, we will need to create our own CFRunLoop.
-    static NonnullOwnPtr<CFEventLoopImplementation> create();
+    static NonnullOwnPtr<EventLoopImplementationMacOS> create();
 
     virtual int exec() override;
     virtual size_t pump(PumpMode) override;
@@ -47,7 +47,7 @@ public:
     virtual void notify_forked_and_in_child() override { }
 
 private:
-    CFEventLoopImplementation() = default;
+    EventLoopImplementationMacOS() = default;
 
     int m_exit_code { 0 };
 };

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.h
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationQt.h
@@ -7,17 +7,14 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
-#include <AK/OwnPtr.h>
 #include <LibCore/EventLoopImplementation.h>
 
-#include <QEvent>
-#include <QEventLoop>
-#include <QSocketNotifier>
-#include <QTimer>
+class QEvent;
+class QEventLoop;
+class QSocketNotifier;
 
-namespace Ladybird {
+namespace WebView {
 
 class EventLoopImplementationQt;
 class EventLoopImplementationQtEventTarget;
@@ -50,20 +47,6 @@ private:
     int m_signal_socket_fds[2] = { -1, -1 };
 };
 
-class QtEventLoopManagerEvent final : public QEvent {
-public:
-    static QEvent::Type process_event_queue_event_type()
-    {
-        static auto const type = static_cast<QEvent::Type>(QEvent::registerEventType());
-        return type;
-    }
-
-    QtEventLoopManagerEvent(QEvent::Type type)
-        : QEvent(type)
-    {
-    }
-};
-
 class EventLoopImplementationQt final : public Core::EventLoopImplementation {
 public:
     static NonnullOwnPtr<EventLoopImplementationQt> create() { return adopt_own(*new EventLoopImplementationQt); }
@@ -89,7 +72,7 @@ private:
     EventLoopImplementationQt();
     bool is_main_loop() const { return m_main_loop; }
 
-    QEventLoop m_event_loop;
+    NonnullOwnPtr<QEventLoop> m_event_loop;
     bool m_main_loop { false };
 };
 

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationQtEventTarget.cpp
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationQtEventTarget.cpp
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <UI/Qt/EventLoopImplementationQtEventTarget.h>
+#include <LibWebView/EventLoop/EventLoopImplementationQt.h>
+#include <LibWebView/EventLoop/EventLoopImplementationQtEventTarget.h>
 
-namespace Ladybird {
+namespace WebView {
 
 bool EventLoopImplementationQtEventTarget::event(QEvent* event)
 {

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationQtEventTarget.h
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationQtEventTarget.h
@@ -6,11 +6,10 @@
 
 #pragma once
 
-#include <UI/Qt/EventLoopImplementationQt.h>
-
 #include <QEvent>
+#include <QObject>
 
-namespace Ladybird {
+namespace WebView {
 
 class EventLoopImplementationQtEventTarget final : public QObject {
     Q_OBJECT

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -7,8 +7,10 @@
 #include <AK/Enumerate.h>
 #include <LibCore/Process.h>
 #include <LibWebView/Application.h>
-#include <UI/HelperProcess.h>
-#include <UI/Utilities.h>
+#include <LibWebView/HelperProcess.h>
+#include <LibWebView/Utilities.h>
+
+namespace WebView {
 
 template<typename ClientType, typename... ClientArguments>
 static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
@@ -190,4 +192,6 @@ ErrorOr<IPC::File> connect_new_image_decoder_client(ImageDecoderClient::Client& 
     TRY(socket.clear_close_on_exec());
 
     return socket;
+}
+
 }

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -16,6 +16,8 @@
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
 
+namespace WebView {
+
 ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     WebView::ViewImplementation& view,
     ReadonlySpan<ByteString> candidate_web_content_paths,
@@ -28,3 +30,5 @@ ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process(Re
 
 ErrorOr<IPC::File> connect_new_request_server_client(Requests::RequestClient&);
 ErrorOr<IPC::File> connect_new_image_decoder_client(ImageDecoderClient::Client&);
+
+}

--- a/Libraries/LibWebView/MachPortServer.cpp
+++ b/Libraries/LibWebView/MachPortServer.cpp
@@ -7,9 +7,9 @@
 #include <AK/Debug.h>
 #include <LibCore/Platform/MachMessageTypes.h>
 #include <LibCore/Platform/ProcessStatisticsMach.h>
-#include <UI/MachPortServer.h>
+#include <LibWebView/MachPortServer.h>
 
-namespace Ladybird {
+namespace WebView {
 
 MachPortServer::MachPortServer()
     : m_thread(Threading::Thread::construct([this]() -> intptr_t { thread_loop(); return 0; }, "MachPortServer"sv))

--- a/Libraries/LibWebView/MachPortServer.h
+++ b/Libraries/LibWebView/MachPortServer.h
@@ -6,18 +6,17 @@
 
 #pragma once
 
+#include <AK/Atomic.h>
 #include <AK/Platform.h>
+#include <AK/String.h>
+#include <LibCore/MachPort.h>
+#include <LibThreading/Thread.h>
 
 #if !defined(AK_OS_MACH)
 #    error "This file is only for Mach kernel-based OS's"
 #endif
 
-#include <AK/Atomic.h>
-#include <AK/String.h>
-#include <LibCore/MachPort.h>
-#include <LibThreading/Thread.h>
-
-namespace Ladybird {
+namespace WebView {
 
 class MachPortServer {
 

--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -12,13 +12,13 @@
 #include <LibCore/StandardPaths.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
-#include <UI/FontPlugin.h>
+#include <LibWebView/Plugins/FontPlugin.h>
 
 #ifdef USE_FONTCONFIG
 #    include <fontconfig/fontconfig.h>
 #endif
 
-namespace Ladybird {
+namespace WebView {
 
 FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_provider)
     : m_is_layout_test_mode(is_layout_test_mode)

--- a/Libraries/LibWebView/Plugins/FontPlugin.h
+++ b/Libraries/LibWebView/Plugins/FontPlugin.h
@@ -11,7 +11,7 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibWeb/Platform/FontPlugin.h>
 
-namespace Ladybird {
+namespace WebView {
 
 class FontPlugin final : public Web::Platform::FontPlugin {
 public:

--- a/Libraries/LibWebView/Plugins/ImageCodecPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/ImageCodecPlugin.cpp
@@ -8,10 +8,10 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 #include <LibImageDecoderClient/Client.h>
-#include <UI/ImageCodecPlugin.h>
+#include <LibWebView/Plugins/ImageCodecPlugin.h>
 #include <UI/Utilities.h>
 
-namespace Ladybird {
+namespace WebView {
 
 ImageCodecPlugin::ImageCodecPlugin(NonnullRefPtr<ImageDecoderClient::Client> client)
     : m_client(move(client))

--- a/Libraries/LibWebView/Plugins/ImageCodecPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/ImageCodecPlugin.cpp
@@ -9,7 +9,7 @@
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibWebView/Plugins/ImageCodecPlugin.h>
-#include <UI/Utilities.h>
+#include <LibWebView/Utilities.h>
 
 namespace WebView {
 

--- a/Libraries/LibWebView/Plugins/ImageCodecPlugin.h
+++ b/Libraries/LibWebView/Plugins/ImageCodecPlugin.h
@@ -10,7 +10,7 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibWeb/Platform/ImageCodecPlugin.h>
 
-namespace Ladybird {
+namespace WebView {
 
 class ImageCodecPlugin final : public Web::Platform::ImageCodecPlugin {
 public:

--- a/Libraries/LibWebView/Utilities.cpp
+++ b/Libraries/LibWebView/Utilities.cpp
@@ -13,16 +13,18 @@
 #include <LibCore/ResourceImplementationFile.h>
 #include <LibCore/System.h>
 #include <LibFileSystem/FileSystem.h>
-#include <UI/Utilities.h>
+#include <LibWebView/Utilities.h>
 
 #define TOKENCAT(x, y) x##y
 #define STRINGIFY(x) TOKENCAT(x, sv)
 
+namespace WebView {
+
 // This is expected to be set from the build scripts, if a packager desires
 #if defined(LADYBIRD_LIBEXECDIR)
-constexpr auto libexec_path = STRINGIFY(LADYBIRD_LIBEXECDIR);
+static constexpr auto libexec_path = STRINGIFY(LADYBIRD_LIBEXECDIR);
 #else
-constexpr auto libexec_path = "libexec"sv;
+static constexpr auto libexec_path = "libexec"sv;
 #endif
 
 ByteString s_ladybird_resource_root;
@@ -111,4 +113,6 @@ ErrorOr<Vector<ByteString>> get_paths_for_helper_process(StringView process_name
     TRY(paths.try_append(ByteString::formatted("./{}", process_name)));
     // NOTE: Add platform-specific paths here
     return paths;
+}
+
 }

--- a/Libraries/LibWebView/Utilities.h
+++ b/Libraries/LibWebView/Utilities.h
@@ -12,6 +12,8 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 
+namespace WebView {
+
 void platform_init();
 void copy_default_config_files(StringView config_path);
 ErrorOr<ByteString> application_directory();
@@ -20,3 +22,5 @@ ErrorOr<Vector<ByteString>> get_paths_for_helper_process(StringView process_name
 extern ByteString s_ladybird_resource_root;
 Optional<ByteString const&> mach_server_name();
 void set_mach_server_name(ByteString name);
+
+}

--- a/Meta/CMake/lagom_options.cmake
+++ b/Meta/CMake/lagom_options.cmake
@@ -14,3 +14,9 @@ serenity_option(LAGOM_TOOLS_ONLY OFF CACHE BOOL "Don't build libraries, utilitie
 serenity_option(ENABLE_LAGOM_CCACHE ON CACHE BOOL "Enable ccache for Lagom builds")
 serenity_option(LAGOM_USE_LINKER "" CACHE STRING "The linker to use (e.g. lld, mold) instead of the system default")
 serenity_option(ENABLE_LAGOM_COVERAGE_COLLECTION OFF CACHE STRING "Enable code coverage instrumentation for lagom binaries in clang")
+
+if (ANDROID OR APPLE)
+    serenity_option(ENABLE_QT OFF CACHE BOOL "Build ladybird application using Qt GUI")
+else()
+    serenity_option(ENABLE_QT ON CACHE BOOL "Build ladybird application using Qt GUI")
+endif()

--- a/Services/ImageDecoder/CMakeLists.txt
+++ b/Services/ImageDecoder/CMakeLists.txt
@@ -10,7 +10,6 @@ if (ANDROID)
     add_library(imagedecoderservice SHARED
         ${LADYBIRD_SOURCE_DIR}/UI/Android/src/main/cpp/ImageDecoderService.cpp
         ${LADYBIRD_SOURCE_DIR}/UI/Android/src/main/cpp/LadybirdServiceBaseJNI.cpp
-        ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
         ${SOURCES}
     )
 else()

--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -10,7 +10,6 @@ if (ANDROID)
     add_library(requestserverservice SHARED
         ${LADYBIRD_SOURCE_DIR}/UI/Android/src/main/cpp/RequestServerService.cpp
         ${LADYBIRD_SOURCE_DIR}/UI/Android/src/main/cpp/LadybirdServiceBaseJNI.cpp
-        ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
         ${SOURCES}
     )
 else()

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -40,12 +40,7 @@ if (HAS_FONTCONFIG)
 endif()
 
 if (ENABLE_QT)
-    qt_add_executable(WebContent
-        ${LADYBIRD_SOURCE_DIR}/UI/Qt/EventLoopImplementationQt.cpp
-        ${LADYBIRD_SOURCE_DIR}/UI/Qt/EventLoopImplementationQtEventTarget.cpp
-        ${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp
-        main.cpp
-    )
+    qt_add_executable(WebContent main.cpp)
     target_link_libraries(WebContent PRIVATE Qt::Core)
     target_compile_definitions(WebContent PRIVATE HAVE_QT=1)
 

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -1,8 +1,6 @@
 include(pulseaudio)
 
 set(SOURCES
-    ${LADYBIRD_SOURCE_DIR}/UI/HelperProcess.cpp
-    ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
     ConnectionFromClient.cpp
     ConsoleGlobalEnvironmentExtensions.cpp
     BackingStoreManager.cpp

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -1,10 +1,7 @@
-include(fontconfig)
 include(pulseaudio)
 
 set(SOURCES
-    ${LADYBIRD_SOURCE_DIR}/UI/FontPlugin.cpp
     ${LADYBIRD_SOURCE_DIR}/UI/HelperProcess.cpp
-    ${LADYBIRD_SOURCE_DIR}/UI/ImageCodecPlugin.cpp
     ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
     ConnectionFromClient.cpp
     ConsoleGlobalEnvironmentExtensions.cpp
@@ -35,10 +32,6 @@ target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD
 
 target_link_libraries(webcontentservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibMedia LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient)
 
-if (HAS_FONTCONFIG)
-    target_link_libraries(webcontentservice PRIVATE Fontconfig::Fontconfig)
-endif()
-
 if (ENABLE_QT)
     qt_add_executable(WebContent main.cpp)
     target_link_libraries(WebContent PRIVATE Qt::Core)
@@ -61,11 +54,6 @@ endif()
 
 target_link_libraries(WebContent PRIVATE webcontentservice LibURL)
 
-target_sources(webcontentservice PUBLIC FILE_SET ladybird TYPE HEADERS
-    BASE_DIRS ${LADYBIRD_SOURCE_DIR}
-    FILES ${LADYBIRD_SOURCE_DIR}/UI/FontPlugin.h
-          ${LADYBIRD_SOURCE_DIR}/UI/ImageCodecPlugin.h
-)
 target_sources(webcontentservice PUBLIC FILE_SET server TYPE HEADERS
     BASE_DIRS ${LADYBIRD_SOURCE_DIR}/Services
     FILES ConnectionFromClient.h

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -28,7 +28,7 @@
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <LibWebView/Plugins/FontPlugin.h>
 #include <LibWebView/Plugins/ImageCodecPlugin.h>
-#include <UI/Utilities.h>
+#include <LibWebView/Utilities.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
 #include <WebContent/WebDriverConnection.h>
@@ -75,7 +75,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #endif
     Core::EventLoop event_loop;
 
-    platform_init();
+    WebView::platform_init();
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
 
@@ -92,7 +92,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     StringView command_line {};
     StringView executable_path {};
-    auto config_path = ByteString::formatted("{}/ladybird/default-config", s_ladybird_resource_root);
+    auto config_path = ByteString::formatted("{}/ladybird/default-config", WebView::s_ladybird_resource_root);
     StringView mach_server_name {};
     Vector<ByteString> certificates;
     int request_server_socket { -1 };

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -34,8 +34,8 @@
 #include <WebContent/WebDriverConnection.h>
 
 #if defined(HAVE_QT)
+#    include <LibWebView/EventLoop/EventLoopImplementationQt.h>
 #    include <QCoreApplication>
-#    include <UI/Qt/EventLoopImplementationQt.h>
 
 #    if defined(HAVE_QT_MULTIMEDIA)
 #        include <UI/Qt/AudioCodecPluginQt.h>
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #if defined(HAVE_QT)
     QCoreApplication app(arguments.argc, arguments.argv);
 
-    Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
+    Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
 #endif
     Core::EventLoop event_loop;
 

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -26,8 +26,8 @@
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/Platform/AudioCodecPluginAgnostic.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
-#include <UI/FontPlugin.h>
-#include <UI/ImageCodecPlugin.h>
+#include <LibWebView/Plugins/FontPlugin.h>
+#include <LibWebView/Plugins/ImageCodecPlugin.h>
 #include <UI/Utilities.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
@@ -169,7 +169,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::HTML::Window::set_internals_object_exposed(expose_internals_object);
 
-    Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(is_layout_test_mode, &font_provider));
+    Web::Platform::FontPlugin::install(*new WebView::FontPlugin(is_layout_test_mode, &font_provider));
 
     TRY(Web::Bindings::initialize_main_thread_vm(Web::HTML::EventLoop::Type::Window));
 
@@ -277,7 +277,7 @@ ErrorOr<void> initialize_image_decoder(int image_decoder_socket)
 
     auto new_client = TRY(try_make_ref_counted<ImageDecoderClient::Client>(IPC::Transport(move(socket))));
 
-    Web::Platform::ImageCodecPlugin::install(*new Ladybird::ImageCodecPlugin(move(new_client)));
+    Web::Platform::ImageCodecPlugin::install(*new WebView::ImageCodecPlugin(move(new_client)));
 
     return {};
 }
@@ -291,7 +291,7 @@ ErrorOr<void> reinitialize_image_decoder(IPC::File const& image_decoder_socket)
 
     auto new_client = TRY(try_make_ref_counted<ImageDecoderClient::Client>(IPC::Transport(move(socket))));
 
-    static_cast<Ladybird::ImageCodecPlugin&>(Web::Platform::ImageCodecPlugin::the()).set_client(move(new_client));
+    static_cast<WebView::ImageCodecPlugin&>(Web::Platform::ImageCodecPlugin::the()).set_client(move(new_client));
 
     return {};
 }

--- a/Services/WebDriver/CMakeLists.txt
+++ b/Services/WebDriver/CMakeLists.txt
@@ -1,5 +1,4 @@
 set(SOURCES
-    ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
     Client.cpp
     Session.cpp
     WebContentConnection.cpp

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -14,14 +14,14 @@
 #include <LibCore/TCPServer.h>
 #include <LibMain/Main.h>
 #include <LibWeb/WebDriver/Capabilities.h>
-#include <UI/Utilities.h>
+#include <LibWebView/Utilities.h>
 #include <WebDriver/Client.h>
 
 static Vector<ByteString> certificates;
 
 static ErrorOr<pid_t> launch_process(StringView application, ReadonlySpan<ByteString> arguments)
 {
-    auto paths = TRY(get_paths_for_helper_process(application));
+    auto paths = TRY(WebView::get_paths_for_helper_process(application));
 
     ErrorOr<pid_t> result = -1;
     for (auto const& path : paths) {
@@ -96,7 +96,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    platform_init();
+    WebView::platform_init();
 
     Web::WebDriver::set_default_interface_mode(headless ? Web::WebDriver::InterfaceMode::Headless : Web::WebDriver::InterfaceMode::Graphical);
 

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -1,6 +1,4 @@
 set(WEBWORKER_SOURCES
-    ${LADYBIRD_SOURCE_DIR}/UI/HelperProcess.cpp
-    ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
     ConnectionFromClient.cpp
     DedicatedWorkerHost.cpp
     PageHost.cpp

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -1,7 +1,4 @@
-include(fontconfig)
-
 set(WEBWORKER_SOURCES
-    ${LADYBIRD_SOURCE_DIR}/UI/FontPlugin.cpp
     ${LADYBIRD_SOURCE_DIR}/UI/HelperProcess.cpp
     ${LADYBIRD_SOURCE_DIR}/UI/Utilities.cpp
     ConnectionFromClient.cpp
@@ -19,10 +16,6 @@ target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR})
 target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/)
 
 target_link_libraries(webworkerservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibRequests LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL)
-
-if (HAS_FONTCONFIG)
-    target_link_libraries(webworkerservice PRIVATE Fontconfig::Fontconfig)
-endif()
 
 if (ENABLE_QT)
     qt_add_executable(WebWorker main.cpp)

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -25,13 +25,7 @@ if (HAS_FONTCONFIG)
 endif()
 
 if (ENABLE_QT)
-    qt_add_executable(WebWorker
-        ${LADYBIRD_SOURCE_DIR}/UI/Qt/EventLoopImplementationQt.cpp
-        ${LADYBIRD_SOURCE_DIR}/UI/Qt/EventLoopImplementationQtEventTarget.cpp
-        ${LADYBIRD_SOURCE_DIR}/UI/Qt/StringUtils.cpp
-        main.cpp
-    )
-    target_link_libraries(WebWorker PRIVATE Qt::Core)
+    qt_add_executable(WebWorker main.cpp)
     target_link_libraries(WebWorker PRIVATE webworkerservice LibWebSocket)
     target_compile_definitions(WebWorker PRIVATE HAVE_QT=1)
 else()

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -19,9 +19,9 @@
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <LibWeb/WebSockets/WebSocket.h>
+#include <LibWebView/HelperProcess.h>
 #include <LibWebView/Plugins/FontPlugin.h>
-#include <UI/HelperProcess.h>
-#include <UI/Utilities.h>
+#include <LibWebView/Utilities.h>
 #include <WebWorker/ConnectionFromClient.h>
 
 #if defined(HAVE_QT)
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #endif
     Core::EventLoop event_loop;
 
-    platform_init();
+    WebView::platform_init();
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
 

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -25,8 +25,8 @@
 #include <WebWorker/ConnectionFromClient.h>
 
 #if defined(HAVE_QT)
+#    include <LibWebView/EventLoop/EventLoopImplementationQt.h>
 #    include <QCoreApplication>
-#    include <UI/Qt/EventLoopImplementationQt.h>
 #endif
 
 static ErrorOr<void> initialize_resource_loader(JS::Heap&, int request_server_socket);
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 #if defined(HAVE_QT)
     QCoreApplication app(arguments.argc, arguments.argv);
-    Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
+    Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
 #endif
     Core::EventLoop event_loop;
 

--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -19,7 +19,7 @@
 #include <LibWeb/Platform/EventLoopPlugin.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <LibWeb/WebSockets/WebSocket.h>
-#include <UI/FontPlugin.h>
+#include <LibWebView/Plugins/FontPlugin.h>
 #include <UI/HelperProcess.h>
 #include <UI/Utilities.h>
 #include <WebWorker/ConnectionFromClient.h>
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Web::Platform::EventLoopPlugin::install(*new Web::Platform::EventLoopPluginSerenity);
 
-    Web::Platform::FontPlugin::install(*new Ladybird::FontPlugin(false));
+    Web::Platform::FontPlugin::install(*new WebView::FontPlugin(false));
 
     TRY(Web::Bindings::initialize_main_thread_vm(Web::HTML::EventLoop::Type::Worker));
 

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -10,9 +10,9 @@
 #include <LibImageDecoderClient/Client.h>
 #include <LibRequests/RequestClient.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/HelperProcess.h>
+#include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
-#include <UI/HelperProcess.h>
-#include <UI/Utilities.h>
 #include <Utilities/Conversions.h>
 
 #import <Application/Application.h>
@@ -70,16 +70,16 @@ ApplicationBridge::ApplicationBridge(Badge<WebView::Application>, Main::Argument
 
 - (ErrorOr<void>)launchRequestServer
 {
-    auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-    m_request_server_client = TRY(launch_request_server_process(request_server_paths, s_ladybird_resource_root));
+    auto request_server_paths = TRY(WebView::get_paths_for_helper_process("RequestServer"sv));
+    m_request_server_client = TRY(WebView::launch_request_server_process(request_server_paths, WebView::s_ladybird_resource_root));
 
     return {};
 }
 
 static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decoder()
 {
-    auto image_decoder_paths = TRY(get_paths_for_helper_process("ImageDecoder"sv));
-    return launch_image_decoder_process(image_decoder_paths);
+    auto image_decoder_paths = TRY(WebView::get_paths_for_helper_process("ImageDecoder"sv));
+    return WebView::launch_image_decoder_process(image_decoder_paths);
 }
 
 - (ErrorOr<void>)launchImageDecoder
@@ -120,19 +120,19 @@ static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decod
 - (ErrorOr<NonnullRefPtr<WebView::WebContentClient>>)launchWebContent:(Ladybird::WebViewBridge&)web_view_bridge
 {
     // FIXME: Fail to open the tab, rather than crashing the whole application if this fails
-    auto request_server_socket = TRY(connect_new_request_server_client(*m_request_server_client));
-    auto image_decoder_socket = TRY(connect_new_image_decoder_client(*m_image_decoder_client));
+    auto request_server_socket = TRY(WebView::connect_new_request_server_client(*m_request_server_client));
+    auto image_decoder_socket = TRY(WebView::connect_new_image_decoder_client(*m_image_decoder_client));
 
-    auto web_content_paths = TRY(get_paths_for_helper_process("WebContent"sv));
-    auto web_content = TRY(launch_web_content_process(web_view_bridge, web_content_paths, move(image_decoder_socket), move(request_server_socket)));
+    auto web_content_paths = TRY(WebView::get_paths_for_helper_process("WebContent"sv));
+    auto web_content = TRY(WebView::launch_web_content_process(web_view_bridge, web_content_paths, move(image_decoder_socket), move(request_server_socket)));
 
     return web_content;
 }
 
 - (ErrorOr<IPC::File>)launchWebWorker
 {
-    auto web_worker_paths = TRY(get_paths_for_helper_process("WebWorker"sv));
-    auto worker_client = TRY(launch_web_worker_process(web_worker_paths, *m_request_server_client));
+    auto web_worker_paths = TRY(WebView::get_paths_for_helper_process("WebWorker"sv));
+    auto worker_client = TRY(WebView::launch_web_worker_process(web_worker_paths, *m_request_server_client));
 
     return worker_client->clone_transport();
 }

--- a/UI/AppKit/CMakeLists.txt
+++ b/UI/AppKit/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(ladybird_impl STATIC
     ${LADYBIRD_SOURCES}
     Application/Application.mm
     Application/ApplicationDelegate.mm
-    Application/EventLoopImplementation.mm
     Interface/Event.mm
     Interface/Inspector.mm
     Interface/InspectorController.mm

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -11,8 +11,6 @@
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/UserAgent.h>
-#include <UI/HelperProcess.h>
-#include <UI/Utilities.h>
 
 #import <Interface/Palette.h>
 

--- a/UI/AppKit/Interface/Palette.mm
+++ b/UI/AppKit/Interface/Palette.mm
@@ -8,7 +8,6 @@
 #include <LibCore/Resource.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
-#include <UI/Utilities.h>
 
 #import <Cocoa/Cocoa.h>
 #import <Interface/Palette.h>

--- a/UI/AppKit/Interface/Tab.mm
+++ b/UI/AppKit/Interface/Tab.mm
@@ -11,7 +11,6 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibURL/URL.h>
 #include <LibWebView/ViewImplementation.h>
-#include <UI/Utilities.h>
 
 #import <Application/ApplicationDelegate.h>
 #import <Interface/Inspector.h>

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +9,7 @@
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/ChromeProcess.h>
+#include <LibWebView/EventLoop/EventLoopImplementationMacOS.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/ViewImplementation.h>
 #include <LibWebView/WebContentClient.h>
@@ -18,7 +19,6 @@
 
 #import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
-#import <Application/EventLoopImplementation.h>
 #import <Interface/Tab.h>
 #import <Interface/TabController.h>
 
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Application* application = [Application sharedApplication];
 
-    Core::EventLoopManager::install(*new Ladybird::CFEventLoopManager);
+    Core::EventLoopManager::install(*new WebView::EventLoopManagerMacOS);
     [application setupWebViewApplication:arguments newTabPageURL:Browser::default_new_tab_url];
 
     platform_init();

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -1,14 +1,5 @@
 include(cmake/ResourceFiles.cmake)
 
-set(LADYBIRD_SOURCES
-    ${CMAKE_CURRENT_SOURCE_DIR}/HelperProcess.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/Utilities.cpp
-)
-set(LADYBIRD_HEADERS
-    HelperProcess.h
-    Utilities.h
-)
-
 function(create_ladybird_bundle target_name)
     set_target_properties(${target_name} PROPERTIES
         OUTPUT_NAME "Ladybird"
@@ -64,24 +55,11 @@ elseif(ANDROID)
    add_subdirectory(Android)
 else()
     # TODO: Check for other GUI frameworks here when we move them in-tree
-    #       For now, we can export a static library of common files for chromes to link to
-    add_library(ladybird STATIC ${LADYBIRD_SOURCES})
+    return()
 endif()
 
 if (NOT TARGET ladybird)
     message(FATAL_ERROR "UI Framework selection must declare a ladybird target")
-endif()
-
-if (APPLE)
-    target_sources(ladybird PRIVATE MachPortServer.cpp)
-    target_link_libraries(ladybird PRIVATE LibThreading)
-endif()
-
-if (ENABLE_INSTALL_HEADERS)
-    target_sources(ladybird PUBLIC FILE_SET ladybird TYPE HEADERS
-        BASE_DIRS ${LADYBIRD_SOURCE_DIR}
-        FILES ${LADYBIRD_HEADERS}
-    )
 endif()
 
 if (TARGET ladybird_impl)
@@ -104,12 +82,6 @@ function(set_helper_process_properties)
         set_target_properties(${targets} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "$<TARGET_FILE_DIR:ladybird>")
     else()
         set_target_properties(${targets} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${IN_BUILD_PREFIX}${CMAKE_INSTALL_LIBEXECDIR}")
-
-        if (NOT CMAKE_INSTALL_LIBEXECDIR STREQUAL "libexec")
-            set_source_files_properties(Utilities.cpp PROPERTIES COMPILE_DEFINITIONS LADYBIRD_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}")
-            set_source_files_properties(Utilities.cpp TARGET_DIRECTORY ladybird PROPERTIES COMPILE_DEFINITIONS LADYBIRD_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}")
-            set_source_files_properties(Utilities.cpp TARGET_DIRECTORY ${targets} PROPERTIES COMPILE_DEFINITIONS LADYBIRD_LIBEXECDIR="${CMAKE_INSTALL_LIBEXECDIR}")
-        endif()
     endif()
 endfunction()
 

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -7,16 +7,16 @@
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
+#include <LibWebView/HelperProcess.h>
+#include <LibWebView/Utilities.h>
 #include <UI/Headless/Application.h>
 #include <UI/Headless/Fixture.h>
 #include <UI/Headless/HeadlessWebView.h>
-#include <UI/HelperProcess.h>
-#include <UI/Utilities.h>
 
 namespace Ladybird {
 
 Application::Application(Badge<WebView::Application>, Main::Arguments&)
-    : resources_folder(s_ladybird_resource_root)
+    : resources_folder(WebView::s_ladybird_resource_root)
     , test_concurrency(Core::System::hardware_concurrency())
     , python_executable_path("python3")
 
@@ -73,11 +73,11 @@ void Application::create_platform_options(WebView::ChromeOptions& chrome_options
 
 ErrorOr<void> Application::launch_services()
 {
-    auto request_server_paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-    m_request_client = TRY(launch_request_server_process(request_server_paths, resources_folder));
+    auto request_server_paths = TRY(WebView::get_paths_for_helper_process("RequestServer"sv));
+    m_request_client = TRY(WebView::launch_request_server_process(request_server_paths, resources_folder));
 
-    auto image_decoder_paths = TRY(get_paths_for_helper_process("ImageDecoder"sv));
-    m_image_decoder_client = TRY(launch_image_decoder_process(image_decoder_paths));
+    auto image_decoder_paths = TRY(WebView::get_paths_for_helper_process("ImageDecoder"sv));
+    m_image_decoder_client = TRY(WebView::launch_image_decoder_process(image_decoder_paths));
 
     return {};
 }

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -7,10 +7,10 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/Crypto/Crypto.h>
+#include <LibWebView/HelperProcess.h>
+#include <LibWebView/Utilities.h>
 #include <UI/Headless/Application.h>
 #include <UI/Headless/HeadlessWebView.h>
-#include <UI/HelperProcess.h>
-#include <UI/Utilities.h>
 
 namespace Ladybird {
 
@@ -32,8 +32,8 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Gfx::IntSize viewp
     };
 
     on_request_worker_agent = []() {
-        auto web_worker_paths = MUST(get_paths_for_helper_process("WebWorker"sv));
-        auto worker_client = MUST(launch_web_worker_process(web_worker_paths, Application::request_client()));
+        auto web_worker_paths = MUST(WebView::get_paths_for_helper_process("WebWorker"sv));
+        auto worker_client = MUST(WebView::launch_web_worker_process(web_worker_paths, Application::request_client()));
 
         return worker_client->clone_transport();
     };
@@ -143,11 +143,11 @@ NonnullOwnPtr<HeadlessWebView> HeadlessWebView::create_child(HeadlessWebView con
 void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
 {
     if (create_new_client == CreateNewClient::Yes) {
-        auto request_server_socket = connect_new_request_server_client(Application::request_client()).release_value_but_fixme_should_propagate_errors();
-        auto image_decoder_socket = connect_new_image_decoder_client(Application::image_decoder_client()).release_value_but_fixme_should_propagate_errors();
+        auto request_server_socket = WebView::connect_new_request_server_client(Application::request_client()).release_value_but_fixme_should_propagate_errors();
+        auto image_decoder_socket = WebView::connect_new_image_decoder_client(Application::image_decoder_client()).release_value_but_fixme_should_propagate_errors();
 
-        auto web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-        m_client_state.client = launch_web_content_process(*this, web_content_paths, move(image_decoder_socket), move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
+        auto web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
+        m_client_state.client = WebView::launch_web_content_process(*this, web_content_paths, move(image_decoder_socket), move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }

--- a/UI/Headless/main.cpp
+++ b/UI/Headless/main.cpp
@@ -21,10 +21,10 @@
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibURL/URL.h>
+#include <LibWebView/Utilities.h>
 #include <UI/Headless/Application.h>
 #include <UI/Headless/HeadlessWebView.h>
 #include <UI/Headless/Test.h>
-#include <UI/Utilities.h>
 
 static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Core::EventLoop& event_loop, Ladybird::HeadlessWebView& view, URL::URL const& url, int screenshot_timeout)
 {
@@ -61,7 +61,7 @@ static ErrorOr<NonnullRefPtr<Core::Timer>> load_page_for_screenshot_and_exit(Cor
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    platform_init();
+    WebView::platform_init();
 
     auto app = Ladybird::Application::create(arguments, "about:newtab"sv);
     TRY(app->launch_services());

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -5,13 +5,13 @@
  */
 
 #include <LibCore/ArgsParser.h>
+#include <LibWebView/HelperProcess.h>
 #include <LibWebView/URL.h>
-#include <UI/HelperProcess.h>
+#include <LibWebView/Utilities.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/TaskManagerWindow.h>
-#include <UI/Utilities.h>
 
 #include <QFileDialog>
 #include <QFileOpenEvent>
@@ -56,8 +56,8 @@ bool Application::event(QEvent* event)
 
 static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decoder()
 {
-    auto paths = TRY(get_paths_for_helper_process("ImageDecoder"sv));
-    return launch_image_decoder_process(paths);
+    auto paths = TRY(WebView::get_paths_for_helper_process("ImageDecoder"sv));
+    return WebView::launch_image_decoder_process(paths);
 }
 
 ErrorOr<void> Application::initialize_image_decoder()

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -25,7 +25,6 @@
 #include <UI/Qt/TabBar.h>
 #include <UI/Qt/TaskManagerWindow.h>
 #include <UI/Qt/WebContentView.h>
-#include <UI/Utilities.h>
 
 #include <QAction>
 #include <QActionGroup>

--- a/UI/Qt/CMakeLists.txt
+++ b/UI/Qt/CMakeLists.txt
@@ -3,8 +3,6 @@ target_sources(ladybird PRIVATE
     Application.cpp
     AutoComplete.cpp
     BrowserWindow.cpp
-    EventLoopImplementationQt.cpp
-    EventLoopImplementationQtEventTarget.cpp
     FindInPageWidget.cpp
     Icon.cpp
     InspectorWidget.cpp

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -24,12 +24,12 @@
 #include <LibWeb/UIEvents/KeyCode.h>
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/HelperProcess.h>
+#include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
-#include <UI/HelperProcess.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/WebContentView.h>
-#include <UI/Utilities.h>
 
 #include <QApplication>
 #include <QCursor>
@@ -129,7 +129,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
 
     on_request_worker_agent = [&]() {
         auto& request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
-        auto worker_client = MUST(launch_web_worker_process(MUST(get_paths_for_helper_process("WebWorker"sv)), *request_server_client));
+        auto worker_client = MUST(WebView::launch_web_worker_process(MUST(WebView::get_paths_for_helper_process("WebWorker"sv)), *request_server_client));
         return worker_client->clone_transport();
     };
 
@@ -632,12 +632,12 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
         auto& request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
 
         // FIXME: Fail to open the tab, rather than crashing the whole application if this fails
-        auto request_server_socket = connect_new_request_server_client(*request_server_client).release_value_but_fixme_should_propagate_errors();
+        auto request_server_socket = WebView::connect_new_request_server_client(*request_server_client).release_value_but_fixme_should_propagate_errors();
 
         auto image_decoder = static_cast<Ladybird::Application*>(QApplication::instance())->image_decoder_client();
-        auto image_decoder_socket = connect_new_image_decoder_client(*image_decoder).release_value_but_fixme_should_propagate_errors();
+        auto image_decoder_socket = WebView::connect_new_image_decoder_client(*image_decoder).release_value_but_fixme_should_propagate_errors();
 
-        auto candidate_web_content_paths = get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
+        auto candidate_web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
         auto new_client = launch_web_content_process(*this, candidate_web_content_paths, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
 
         m_client_state.client = new_client;

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -12,12 +12,12 @@
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/ChromeProcess.h>
+#include <LibWebView/EventLoop/EventLoopImplementationQt.h>
 #include <LibWebView/ProcessManager.h>
 #include <LibWebView/URL.h>
 #include <UI/HelperProcess.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/BrowserWindow.h>
-#include <UI/Qt/EventLoopImplementationQt.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/WebContentView.h>
 #include <UI/Utilities.h>
@@ -64,11 +64,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     AK::set_rich_debug_enabled(true);
 
-    Core::EventLoopManager::install(*new Ladybird::EventLoopManagerQt);
+    Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
 
     auto app = Ladybird::Application::create(arguments, ak_url_from_qstring(Ladybird::Settings::the()->new_tab_page()));
 
-    static_cast<Ladybird::EventLoopImplementationQt&>(Core::EventLoop::current().impl()).set_main_loop();
+    static_cast<WebView::EventLoopImplementationQt&>(Core::EventLoop::current().impl()).set_main_loop();
     TRY(handle_attached_debugger());
 
     platform_init();


### PR DESCRIPTION
We have a bunch of files that we recompile for each of the Ladybird, WebContent, WebWorker, WebDriver, ImageDecoder, and RequestServer targets. Each of these utilities (event loops, process helpers, etc.) can happily live in LibWebView, as all embedders of LibWebView will need these facilities anyways.

Remembered that this was a thing while working on #2251.