### PR TITLE
LibGfx: Sync to_skia_color_type

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -73,6 +73,7 @@ set(SOURCES
 set(SWIFT_EXCLUDE_HEADERS
     MetalContext.h
     VulkanContext.h
+    SkiaUtils.h
 )
 
 if (APPLE)

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibGfx/SkiaUtils.h>
 
 #include <core/SkBitmap.h>
 #include <core/SkImage.h>
@@ -58,23 +59,6 @@ Color ImmutableBitmap::get_pixel(int x, int y) const
 {
     // FIXME: Implement for PaintingSurface
     return m_impl->source.get<NonnullRefPtr<Gfx::Bitmap>>()->get_pixel(x, y);
-}
-
-static SkColorType to_skia_color_type(Gfx::BitmapFormat format)
-{
-    switch (format) {
-    case Gfx::BitmapFormat::Invalid:
-        return kUnknown_SkColorType;
-    case Gfx::BitmapFormat::BGRA8888:
-    case Gfx::BitmapFormat::BGRx8888:
-        return kBGRA_8888_SkColorType;
-    case Gfx::BitmapFormat::RGBA8888:
-        return kRGBA_8888_SkColorType;
-    case Gfx::BitmapFormat::RGBx8888:
-        return kRGB_888x_SkColorType;
-    default:
-        return kUnknown_SkColorType;
-    }
 }
 
 static SkAlphaType to_skia_alpha_type(Gfx::AlphaType alpha_type)

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -7,6 +7,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintingSurface.h>
+#include <LibGfx/SkiaUtils.h>
 
 #include <core/SkColorSpace.h>
 #include <core/SkSurface.h>
@@ -28,21 +29,6 @@ struct PaintingSurface::Impl {
     RefPtr<Bitmap> bitmap;
     RefPtr<SkiaBackendContext> context;
 };
-
-static SkColorType to_skia_color_type(Gfx::BitmapFormat format)
-{
-    switch (format) {
-    case Gfx::BitmapFormat::Invalid:
-        return kUnknown_SkColorType;
-    case Gfx::BitmapFormat::BGRA8888:
-    case Gfx::BitmapFormat::BGRx8888:
-        return kBGRA_8888_SkColorType;
-    case Gfx::BitmapFormat::RGBA8888:
-        return kRGBA_8888_SkColorType;
-    default:
-        return kUnknown_SkColorType;
-    }
-}
 
 NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(RefPtr<SkiaBackendContext> context, Gfx::IntSize size, Gfx::BitmapFormat color_type, Gfx::AlphaType alpha_type)
 {

--- a/Libraries/LibGfx/SkiaUtils.h
+++ b/Libraries/LibGfx/SkiaUtils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Pavel Shliak <shlyakpavel@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <LibGfx/Bitmap.h>
+#include <core/SkColorType.h>
+
+namespace Gfx {
+
+static SkColorType to_skia_color_type(Gfx::BitmapFormat format)
+{
+    switch (format) {
+    case Gfx::BitmapFormat::Invalid:
+        return kUnknown_SkColorType;
+    case Gfx::BitmapFormat::BGRA8888:
+    case Gfx::BitmapFormat::BGRx8888:
+        return kBGRA_8888_SkColorType;
+    case Gfx::BitmapFormat::RGBA8888:
+        return kRGBA_8888_SkColorType;
+    case Gfx::BitmapFormat::RGBx8888:
+        return kRGB_888x_SkColorType;
+    }
+    VERIFY_NOT_REACHED();
+}
+
+}


### PR DESCRIPTION
My 100,000th attempt to unify this. After countless tries, I’ve finally decided to copypaste it to prevent having two conflicting implementations.