### PR TITLE
headless-browser: Do not log skipped tests by default

### DIFF
--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -44,8 +44,8 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(resources_folder, "Path of the base resources folder (defaults to /res)", "resources", 'r', "resources-root-path");
     args_parser.add_option(is_layout_test_mode, "Enable layout test mode", "layout-test-mode");
     args_parser.add_option(rebaseline, "Rebaseline any executed layout or text tests", "rebaseline");
-    args_parser.add_option(log_slowest_tests, "Log the tests with the slowest run times", "log-slowest-tests");
     args_parser.add_option(per_test_timeout_in_seconds, "Per-test timeout (default: 30)", "per-test-timeout", 't', "seconds");
+    args_parser.add_option(verbose, "Log extra information about test results", "verbose", 'v');
 }
 
 void Application::create_platform_options(WebView::ChromeOptions& chrome_options, WebView::WebContentOptions& web_content_options)

--- a/UI/Headless/Application.h
+++ b/UI/Headless/Application.h
@@ -64,7 +64,7 @@ public:
     ByteString test_glob;
     bool test_dry_run { false };
     bool rebaseline { false };
-    bool log_slowest_tests { false };
+    bool verbose { false };
     int per_test_timeout_in_seconds { 30 };
 
 private:

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -501,8 +501,12 @@ ErrorOr<void> run_tests(Core::AnonymousBuffer const& theme, Gfx::IntSize window_
     outln("Pass: {}, Fail: {}, Skipped: {}, Timeout: {}", pass_count, fail_count, skipped_count, timeout_count);
     outln("==================================================");
 
-    for (auto const& non_passing_test : non_passing_tests)
+    for (auto const& non_passing_test : non_passing_tests) {
+        if (non_passing_test.result == TestResult::Skipped && !app.verbose)
+            continue;
+
         outln("{}: {}", test_result_to_string(non_passing_test.result), non_passing_test.test.input_path);
+    }
 
     if (app.verbose) {
         auto tests_to_print = min(10uz, tests.size());

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -504,7 +504,7 @@ ErrorOr<void> run_tests(Core::AnonymousBuffer const& theme, Gfx::IntSize window_
     for (auto const& non_passing_test : non_passing_tests)
         outln("{}: {}", test_result_to_string(non_passing_test.result), non_passing_test.test.input_path);
 
-    if (app.log_slowest_tests) {
+    if (app.verbose) {
         auto tests_to_print = min(10uz, tests.size());
         outln("\nSlowest {} tests:", tests_to_print);
 


### PR DESCRIPTION
We now skip so many tests that the list of skipped tests exceeds the height of my terminal. Let's skip logging these by default, as it is too noisy to find actually relevant information.