### PR TITLE
Reduce usage of containing_block() in layout code

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -793,7 +793,8 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     m_margin_state.add_margin(box_state.margin_bottom);
     m_margin_state.update_block_waiting_for_final_y_position();
 
-    compute_inset(box);
+    auto const& block_container_state = m_state.get(block_container);
+    compute_inset(box, content_box_rect(block_container_state).size());
 
     // Now that our children are formatted we place the ListItemBox with the left space we remembered.
     if (is<ListItemBox>(box)) {
@@ -1012,7 +1013,8 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    resolve_vertical_box_model_metrics(box, m_state.get(block_container).content_width());
+    auto const& block_container_state = m_state.get(block_container);
+    resolve_vertical_box_model_metrics(box, block_container_state.content_width());
 
     compute_width(box, available_space);
 
@@ -1166,7 +1168,7 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
     if (line_builder)
         line_builder->recalculate_available_space();
 
-    compute_inset(box);
+    compute_inset(box, content_box_rect(block_container_state).size());
 
     if (independent_formatting_context)
         independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -651,7 +651,7 @@ void BlockFormattingContext::layout_block_level_box(Box const& box, BlockContain
     if (is<ListItemMarkerBox>(box))
         return;
 
-    resolve_vertical_box_model_metrics(box);
+    resolve_vertical_box_model_metrics(box, m_state.get(block_container).content_width());
 
     if (box.is_floating()) {
         auto const y = m_y_offset_of_current_block_container.value();
@@ -848,11 +848,10 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer const& b
     }
 }
 
-void BlockFormattingContext::resolve_vertical_box_model_metrics(Box const& box)
+void BlockFormattingContext::resolve_vertical_box_model_metrics(Box const& box, CSSPixels width_of_containing_block)
 {
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
-    auto width_of_containing_block = containing_block_width_for(box);
 
     box_state.margin_top = computed_values.margin().top().to_px(box, width_of_containing_block);
     box_state.margin_bottom = computed_values.margin().bottom().to_px(box, width_of_containing_block);
@@ -1006,14 +1005,14 @@ void BlockFormattingContext::layout_viewport(AvailableSpace const& available_spa
     }
 }
 
-void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const&, AvailableSpace const& available_space, CSSPixels y, LineBuilder* line_builder)
+void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer const& block_container, AvailableSpace const& available_space, CSSPixels y, LineBuilder* line_builder)
 {
     VERIFY(box.is_floating());
 
     auto& box_state = m_state.get_mutable(box);
     auto const& computed_values = box.computed_values();
 
-    resolve_vertical_box_model_metrics(box);
+    resolve_vertical_box_model_metrics(box, m_state.get(block_container).content_width());
 
     compute_width(box, available_space);
 

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -50,7 +50,7 @@ public:
 
     void layout_block_level_box(Box const&, BlockContainer const&, CSSPixels& bottom_of_lowest_margin_box, AvailableSpace const&);
 
-    void resolve_vertical_box_model_metrics(Box const&);
+    void resolve_vertical_box_model_metrics(Box const&, CSSPixels width_of_containing_block);
 
     enum class DidIntroduceClearance {
         Yes,

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -176,7 +176,7 @@ void FlexFormattingContext::run(AvailableSpace const& available_space)
             if (auto independent_formatting_context = layout_inside(item.box, LayoutMode::Normal, item.used_values.available_inner_space_or_constraints_from(m_available_space_for_items->space)))
                 independent_formatting_context->parent_context_did_dimension_child_root_box();
 
-            compute_inset(item.box);
+            compute_inset(item.box, content_box_rect(m_flex_container_state).size());
         }
     }
 }

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1328,7 +1328,7 @@ void FormattingContext::compute_height_for_absolutely_positioned_replaced_elemen
 }
 
 // https://www.w3.org/TR/css-position-3/#relpos-insets
-void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box)
+void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box, CSSPixelSize containing_block_size)
 {
     if (box.computed_values().position() != CSS::Positioning::Relative)
         return;
@@ -1363,8 +1363,8 @@ void FormattingContext::compute_inset(NodeWithStyleAndBoxModelMetrics const& box
     auto const& computed_values = box.computed_values();
 
     // FIXME: Respect the containing block's writing-mode.
-    resolve_two_opposing_insets(computed_values.inset().left(), computed_values.inset().right(), box_state.inset_left, box_state.inset_right, containing_block_width_for(box));
-    resolve_two_opposing_insets(computed_values.inset().top(), computed_values.inset().bottom(), box_state.inset_top, box_state.inset_bottom, containing_block_height_for(box));
+    resolve_two_opposing_insets(computed_values.inset().left(), computed_values.inset().right(), box_state.inset_left, box_state.inset_right, containing_block_size.width());
+    resolve_two_opposing_insets(computed_values.inset().top(), computed_values.inset().bottom(), box_state.inset_top, box_state.inset_bottom, containing_block_size.height());
 }
 
 // https://drafts.csswg.org/css-sizing-3/#fit-content-size

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1640,21 +1640,6 @@ CSSPixels FormattingContext::containing_block_width_for(NodeWithStyleAndBoxModel
     VERIFY_NOT_REACHED();
 }
 
-CSSPixels FormattingContext::containing_block_height_for(NodeWithStyleAndBoxModelMetrics const& node) const
-{
-    auto const& used_values = m_state.get(node);
-
-    switch (used_values.height_constraint) {
-    case SizeConstraint::MinContent:
-        return 0;
-    case SizeConstraint::MaxContent:
-        return CSSPixels::max();
-    case SizeConstraint::None:
-        return used_values.containing_block_used_values()->content_height();
-    }
-    VERIFY_NOT_REACHED();
-}
-
 // https://drafts.csswg.org/css-sizing-3/#stretch-fit-size
 CSSPixels FormattingContext::calculate_stretch_fit_width(Box const& box, AvailableSize const& available_width) const
 {
@@ -1829,46 +1814,6 @@ CSSPixelRect FormattingContext::margin_box_rect(LayoutState::UsedValues const& u
     };
 }
 
-CSSPixelRect FormattingContext::margin_box_rect(Box const& box) const
-{
-    return margin_box_rect(m_state.get(box));
-}
-
-CSSPixelRect FormattingContext::border_box_rect(LayoutState::UsedValues const& used_values) const
-{
-    return {
-        used_values.offset.translated(-used_values.border_box_left(), -used_values.border_box_top()),
-        {
-            used_values.border_box_left() + used_values.content_width() + used_values.border_box_right(),
-            used_values.border_box_top() + used_values.content_height() + used_values.border_box_bottom(),
-        },
-    };
-}
-
-CSSPixelRect FormattingContext::border_box_rect(Box const& box) const
-{
-    return border_box_rect(m_state.get(box));
-}
-
-CSSPixelRect FormattingContext::border_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const& used_values, Box const& ancestor_box) const
-{
-    auto rect = border_box_rect(used_values);
-    if (&used_values.node() == &ancestor_box)
-        return rect;
-    for (auto const* current = used_values.containing_block_used_values(); current; current = current->containing_block_used_values()) {
-        if (&current->node() == &ancestor_box)
-            return rect;
-        rect.translate_by(current->offset);
-    }
-    // If we get here, ancestor_box was not a containing block ancestor of `box`!
-    VERIFY_NOT_REACHED();
-}
-
-CSSPixelRect FormattingContext::border_box_rect_in_ancestor_coordinate_space(Box const& box, Box const& ancestor_box) const
-{
-    return border_box_rect_in_ancestor_coordinate_space(m_state.get(box), ancestor_box);
-}
-
 CSSPixelRect FormattingContext::content_box_rect(Box const& box) const
 {
     return content_box_rect(m_state.get(box));
@@ -1891,11 +1836,6 @@ CSSPixelRect FormattingContext::content_box_rect_in_ancestor_coordinate_space(La
     }
     // If we get here, ancestor_box was not a containing block ancestor of `box`!
     VERIFY_NOT_REACHED();
-}
-
-CSSPixelRect FormattingContext::content_box_rect_in_ancestor_coordinate_space(Box const& box, Box const& ancestor_box) const
-{
-    return content_box_rect_in_ancestor_coordinate_space(m_state.get(box), ancestor_box);
 }
 
 CSSPixelRect FormattingContext::margin_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const& used_values, Box const& ancestor_box) const

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -106,7 +106,7 @@ public:
 
     bool can_skip_is_anonymous_text_run(Box&);
 
-    void compute_inset(NodeWithStyleAndBoxModelMetrics const&);
+    void compute_inset(NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize containing_block_size);
 
 protected:
     FormattingContext(Type, LayoutMode, LayoutState&, Box const&, FormattingContext* parent = nullptr);

--- a/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Libraries/LibWeb/Layout/FormattingContext.h
@@ -50,7 +50,6 @@ public:
     FormattingContext const* parent() const { return m_parent; }
 
     Type type() const { return m_type; }
-    bool is_block_formatting_context() const { return type() == Type::Block; }
 
     virtual bool inhibits_floating() const { return false; }
 
@@ -82,24 +81,16 @@ public:
     virtual CSSPixels greatest_child_width(Box const&) const;
 
     [[nodiscard]] CSSPixelRect absolute_content_rect(Box const&) const;
-    [[nodiscard]] CSSPixelRect absolute_content_rect(LayoutState::UsedValues const&) const;
-    [[nodiscard]] CSSPixelRect margin_box_rect(Box const&) const;
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect margin_box_rect(LayoutState::UsedValues const&) const;
     [[nodiscard]] CSSPixelRect margin_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
-    [[nodiscard]] CSSPixelRect border_box_rect(Box const&) const;
-    [[nodiscard]] CSSPixelRect border_box_rect(LayoutState::UsedValues const&) const;
-    [[nodiscard]] CSSPixelRect border_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
-    [[nodiscard]] CSSPixelRect border_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect content_box_rect(Box const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect(LayoutState::UsedValues const&) const;
-    [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_ancestor_coordinate_space(LayoutState::UsedValues const&, Box const& ancestor_box) const;
     [[nodiscard]] CSSPixels box_baseline(Box const&) const;
     [[nodiscard]] CSSPixelRect content_box_rect_in_static_position_ancestor_coordinate_space(Box const&, Box const& ancestor_box) const;
 
     [[nodiscard]] CSSPixels containing_block_width_for(NodeWithStyleAndBoxModelMetrics const&) const;
-    [[nodiscard]] CSSPixels containing_block_height_for(NodeWithStyleAndBoxModelMetrics const&) const;
 
     [[nodiscard]] CSSPixels calculate_stretch_fit_width(Box const&, AvailableSize const&) const;
     [[nodiscard]] CSSPixels calculate_stretch_fit_height(Box const&, AvailableSize const&) const;

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2029,12 +2029,9 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
 
     resolve_track_spacing(GridDimension::Row);
 
-    auto const& containing_block_state = m_state.get(*grid_container().containing_block());
-    auto height_of_containing_block = containing_block_state.content_height();
-    auto height_of_container_block_as_available_size = AvailableSize::make_definite(height_of_containing_block);
     CSSPixels min_height = 0;
     if (!grid_computed_values.min_height().is_auto())
-        min_height = calculate_inner_height(grid_container(), height_of_container_block_as_available_size, grid_computed_values.min_height());
+        min_height = calculate_inner_height(grid_container(), available_space.height, grid_computed_values.min_height());
 
     // If automatic grid container height is less than min-height, we need to re-run the track sizing algorithm
     if (m_automatic_content_height < min_height) {

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2060,8 +2060,9 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
     for (auto& grid_item : m_grid_items) {
         auto& grid_item_box_state = m_state.get_mutable(grid_item.box);
         CSSPixelPoint margin_offset = { grid_item_box_state.margin_box_left(), grid_item_box_state.margin_box_top() };
-        grid_item_box_state.offset = get_grid_area_rect(grid_item).top_left() + margin_offset;
-        compute_inset(grid_item.box);
+        auto const grid_area_rect = get_grid_area_rect(grid_item);
+        grid_item_box_state.offset = grid_area_rect.top_left() + margin_offset;
+        compute_inset(grid_item.box, grid_area_rect.size());
 
         auto available_space_for_children = AvailableSpace(AvailableSize::make_definite(grid_item_box_state.content_width()), AvailableSize::make_definite(grid_item_box_state.content_height()));
         if (auto independent_formatting_context = layout_inside(grid_item.box, LayoutMode::Normal, available_space_for_children))

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -294,7 +294,7 @@ void InlineFormattingContext::generate_line_boxes()
         }
         case InlineLevelIterator::Item::Type::Element: {
             auto& box = verify_cast<Layout::Box>(*item.node);
-            compute_inset(box);
+            compute_inset(box, content_box_rect(m_containing_block_used_values).size());
             if (containing_block().computed_values().white_space() != CSS::WhiteSpace::Nowrap) {
                 auto minimum_space_needed_on_line = item.border_box_width();
                 if (item.margin_start < 0)

--- a/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
+++ b/Libraries/LibWeb/Layout/InlineLevelIterator.cpp
@@ -48,7 +48,7 @@ void InlineLevelIterator::enter_node_with_box_model_metrics(Layout::NodeWithStyl
     m_extra_leading_metrics->padding += used_values.padding_left;
 
     // Now's our chance to resolve the inset properties for this node.
-    m_inline_formatting_context.compute_inset(node);
+    m_inline_formatting_context.compute_inset(node, m_inline_formatting_context.content_box_rect(m_containing_block_used_values).size());
 
     m_box_model_node_stack.append(node);
 }

--- a/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -46,7 +46,7 @@ CSSPixels TableFormattingContext::run_caption_layout(CSS::CaptionSide phase)
         auto const& child_box = static_cast<Box const&>(*child);
         // FIXME: Since caption only has inline children, BlockFormattingContext doesn't resolve the vertical metrics.
         //        We need to do it manually here.
-        caption_context->resolve_vertical_box_model_metrics(child_box);
+        caption_context->resolve_vertical_box_model_metrics(child_box, m_available_space->width.to_px_or_zero());
         auto const& caption_state = m_state.get(child_box);
         if (phase == CSS::CaptionSide::Top) {
             m_state.get_mutable(table_box()).set_content_y(caption_state.content_height() + caption_state.margin_box_bottom());

--- a/Tests/LibWeb/Layout/expected/grid/relative-position-grid-item-with-percentage-insets.txt
+++ b/Tests/LibWeb/Layout/expected/grid/relative-position-grid-item-with-percentage-insets.txt
@@ -1,0 +1,54 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x318 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x302 children: not-inline
+      Box <div.grid-container> at (9,9) content-size 300x300 [GFC] children: not-inline
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        Box <div.grid-item> at (20,20) content-size 123x123 flex-container(row) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (58.140625,73) content-size 46.71875x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 6, rect: [58.140625,73 46.71875x17] baseline: 13.296875
+                "Item 1"
+            TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        Box <div.grid-item.relative-item> at (247.5,97.5) content-size 123x123 positioned flex-container(row) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (284.40625,150.5) content-size 49.1875x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 6, rect: [284.40625,150.5 49.1875x17] baseline: 13.296875
+                "Item 2"
+            TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        Box <div.grid-item> at (20,175) content-size 123x123 flex-container(row) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (56.765625,228) content-size 49.46875x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 6, rect: [56.765625,228 49.46875x17] baseline: 13.296875
+                "Item 3"
+            TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+        Box <div.grid-item> at (175,175) content-size 123x123 flex-container(row) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (212.4375,228) content-size 48.125x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 6, rect: [212.4375,228 48.125x17] baseline: 13.296875
+                "Item 4"
+            TextNode <#text>
+        BlockContainer <(anonymous)> (not painted) [BFC] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,310) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x318]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x302]
+      PaintableBox (Box<DIV>.grid-container) [8,8 302x302] overflow: [9,9 372.5x300]
+        PaintableBox (Box<DIV>.grid-item) [9,9 145x145]
+          PaintableWithLines (BlockContainer(anonymous)) [58.140625,73 46.71875x17]
+            TextPaintable (TextNode<#text>)
+        PaintableBox (Box<DIV>.grid-item.relative-item) [236.5,86.5 145x145]
+          PaintableWithLines (BlockContainer(anonymous)) [284.40625,150.5 49.1875x17]
+            TextPaintable (TextNode<#text>)
+        PaintableBox (Box<DIV>.grid-item) [9,164 145x145]
+          PaintableWithLines (BlockContainer(anonymous)) [56.765625,228 49.46875x17]
+            TextPaintable (TextNode<#text>)
+        PaintableBox (Box<DIV>.grid-item) [164,164 145x145]
+          PaintableWithLines (BlockContainer(anonymous)) [212.4375,228 48.125x17]
+            TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,310 784x0]

--- a/Tests/LibWeb/Layout/input/grid/relative-position-grid-item-with-percentage-insets.html
+++ b/Tests/LibWeb/Layout/input/grid/relative-position-grid-item-with-percentage-insets.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<style>
+.grid-container {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+    width: 300px;
+    height: 300px;
+    border: 1px solid #ccc;
+}
+
+.grid-item {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: #eee;
+    border: 1px solid #aaa;
+    padding: 10px;
+}
+
+.relative-item {
+    position: relative;
+    left: 50%;
+    top: 50%;
+    background-color: #cce;
+}
+</style>
+<div class="grid-container">
+    <div class="grid-item">Item 1</div>
+    <div class="grid-item relative-item">Item 2</div>
+    <div class="grid-item">Item 3</div>
+    <div class="grid-item">Item 4</div>
+</div>


### PR DESCRIPTION
There are two main reasons to gradually remove usage of containing_block():
- It does not account for grid areas that form containing block for grid items but not present in layout tree
- It does make introducing partial layout optimization a lot harder since formatting context depends on values located up in the tree