### PR TITLE
querySelector things

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -129,9 +129,6 @@ Text/input/wpt-import/css/css-nesting/implicit-parent-insertion-crash.html
 Text/input/wpt-import/css/css-nesting/pseudo-part-crash.html
 Text/input/wpt-import/css/css-nesting/pseudo-where-crash.html
 
-; Currently crashes
-Text/input/wpt-import/css/css-nesting/top-level-is-scope.html
-
 ; Imported animation tests are extra slow
 ; https://github.com/LadybirdBrowser/ladybird/issues/2238
 Text/input/wpt-import/css/css-backgrounds/animations/background-color-interpolation.html

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/top-level-is-scope.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/top-level-is-scope.txt
@@ -1,0 +1,12 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 2 tests
+
+2 Pass
+Details
+Result	Test Name	MessagePass	& as direct ancestor	
+Pass	& matches scoped element only, not everything	


### PR DESCRIPTION
This is kind of two unrelated changes, I just didn't realise they were unrelated at the time. 😆 

Saw the test fails, immediately noticed that the two querySelector implementations duplicated a lot of code and decided to combine them. Then... discovered that the test now passes anyway even without that change. Something must have fixed the crash since I added it.