### PR TITLE
Formatting: Enforce left-aligned pointer and reference styles

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -19,6 +19,8 @@ RemoveSemicolon: true
 RequiresClausePosition: WithFollowing
 RequiresExpressionIndentation: OuterScope
 SpaceAfterTemplateKeyword: false
+PointerAlignment: Left
+ReferenceAlignment: Left
 
 ---
 Language: ObjC


### PR DESCRIPTION
This change ensures the following formatting styles:
- `type* pointer` for pointers
- `type& reference` for references

Motivated by https://github.com/LadybirdBrowser/ladybird/pull/2266#discussion_r1835709347