### PR TITLE
LibWeb: Compute accessible names for hidden/hidden-but-referenced nodes

### DIFF
--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -348,6 +348,12 @@ public:
 
     virtual bool include_in_accessibility_tree() const override;
 
+    bool is_hidden() const;
+    bool has_hidden_ancestor() const;
+
+    bool is_referenced() const;
+    bool has_referenced_and_hidden_ancestor() const;
+
     void enqueue_a_custom_element_upgrade_reaction(HTML::CustomElementDefinition& custom_element_definition);
     void enqueue_a_custom_element_callback_reaction(FlyString const& callback_name, GC::MarkedVector<JS::Value> arguments);
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2288,11 +2288,24 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 return element->aria_label().release_value();
             return total_accumulated_text.to_string();
         }
-        // C. Embedded Control: Otherwise, if the current node is a control embedded
-        // within the label (e.g. any element directly referenced by aria-labelledby) for
-        // another widget, where the user can adjust the embedded control's value, then
-        // return the embedded control as part of the text alternative in the following
-        // manner:
+
+        // D. AriaLabel: Otherwise, if the current node has an aria-label attribute whose value is not undefined, not
+        // the empty string, nor, when trimmed of whitespace, is not the empty string:
+        // AD-HOC: We’ve reordered substeps C and D from https://w3c.github.io/accname/#step2 — because
+        // the more-specific per-HTML-element requirements at https://w3c.github.io/html-aam/#accname-computation
+        // necessitate doing so, and the “input with label for association is superceded by aria-label” subtest at
+        // https://wpt.fyi/results/accname/name/comp_label.html won’t pass unless we do this reordering.
+        // Spec PR: https://github.com/w3c/aria/pull/2377
+        if (target == NameOrDescription::Name && element->aria_label().has_value() && !element->aria_label()->is_empty() && !element->aria_label()->bytes_as_string_view().is_whitespace()) {
+            // TODO: - If traversal of the current node is due to recursion and the current node is an embedded control as defined in step 2E, ignore aria-label and skip to rule 2E.
+            // https://github.com/w3c/aria/pull/2385 and https://github.com/w3c/accname/issues/173
+            if (!element->is_html_slot_element())
+                return element->aria_label().value();
+        }
+
+        // C. Embedded Control: Otherwise, if the current node is a control embedded within the label (e.g. any element
+        // directly referenced by aria-labelledby) for another widget, where the user can adjust the embedded control's
+        // value, then return the embedded control as part of the text alternative in the following manner:
         GC::Ptr<DOM::NodeList> labels;
         if (is<HTML::HTMLElement>(this))
             labels = (const_cast<HTML::HTMLElement&>(static_cast<HTML::HTMLElement const&>(*current_node))).labels();
@@ -2370,16 +2383,6 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 }
             }
             return builder.to_string();
-        }
-
-        // D. AriaLabel: Otherwise, if the current node has an aria-label attribute whose
-        // value is not undefined, not the empty string, nor, when trimmed of whitespace,
-        // is not the empty string:
-        if (target == NameOrDescription::Name && element->aria_label().has_value() && !element->aria_label()->is_empty() && !element->aria_label()->bytes_as_string_view().is_whitespace()) {
-            // TODO: - If traversal of the current node is due to recursion and the current node is an embedded control as defined in step 2E, ignore aria-label and skip to rule 2E.
-            // https://github.com/w3c/aria/pull/2385 and https://github.com/w3c/accname/issues/173
-            if (!element->is_html_slot_element())
-                return element->aria_label().value();
         }
 
         // E. Host Language Label: Otherwise, if the current node's native markup provides an attribute (e.g. alt) or

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_hidden_not_referenced.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_hidden_not_referenced.txt
@@ -1,0 +1,15 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 5 tests
+
+5 Pass
+Details
+Result	Test Name	MessagePass	button containing a rendered, unreferenced element that is aria-hidden=true, an unreferenced element with the hidden host language attribute, and an unreferenced element that is unconditionally rendered	
+Pass	button labelled by element that is aria-hidden=true	
+Pass	button labelled by element with the hidden host language attribute	
+Pass	link labelled by elements with assorted visibility and a11y tree exposure	
+Pass	heading with name from content, containing element that is visibility:hidden with nested content that is visibility:visible	

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_label.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_label.txt
@@ -1,0 +1,141 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 131 tests
+
+131 Pass
+Details
+Result	Test Name	MessagePass	label valid on div with alert role	
+Pass	label valid on div with alertdialog role	
+Pass	label valid on div with application role	
+Pass	label valid on div with article role	
+Pass	label valid on div with banner role	
+Pass	label valid on div with blockquote role	
+Pass	label valid on div with button role	
+Pass	label valid on div with cell role	
+Pass	label valid on div with checkbox role	
+Pass	label valid on div with columnheader role	
+Pass	label valid on div with combobox role	
+Pass	label valid on div with complementary role	
+Pass	label valid on div with contentinfo role	
+Pass	label valid on div with dialog role	
+Pass	label valid on div with directory role	
+Pass	label valid on div with document role	
+Pass	label valid on div with feed role	
+Pass	label valid on div with figure role	
+Pass	label valid on div with form role	
+Pass	label valid on div with grid role	
+Pass	label valid on div with gridcell role	
+Pass	label valid on div with group role	
+Pass	label valid on div with heading role	
+Pass	label valid on div with img role	
+Pass	label valid on div with link role	
+Pass	label valid on div with list role	
+Pass	label valid on div with listbox role	
+Pass	label valid on div with listitem role	
+Pass	label valid on div with log role	
+Pass	label valid on div with main role	
+Pass	label valid on div with marquee role	
+Pass	label valid on div with math role	
+Pass	label valid on div with menu role	
+Pass	label valid on div with menubar role	
+Pass	label valid on div with menuitem role	
+Pass	label valid on div with menuitemcheckbox role	
+Pass	label valid on div with menuitemradio role	
+Pass	label valid on div with meter role	
+Pass	label valid on div with navigation role	
+Pass	label valid on div with note role	
+Pass	label valid on div with option role	
+Pass	label valid on div with progressbar role	
+Pass	label valid on div with radio role	
+Pass	label valid on div with radiogroup role	
+Pass	label valid on div with region role	
+Pass	label valid on div with row role	
+Pass	label valid on div with rowgroup role	
+Pass	label valid on div with rowheader role	
+Pass	label valid on div with scrollbar role	
+Pass	label valid on div with search role	
+Pass	label valid on div with searchbox role	
+Pass	label valid on div with separator role	
+Pass	label valid on div with slider role	
+Pass	label valid on div with spinbutton role	
+Pass	label valid on div with status role	
+Pass	label valid on div with switch role	
+Pass	label valid on div with tab role	
+Pass	label valid on div with table role	
+Pass	label valid on div with tablist role	
+Pass	label valid on div with tabpanel role	
+Pass	label valid on div with textbox role	
+Pass	label valid on div with timer role	
+Pass	label valid on div with toolbar role	
+Pass	label valid on div with tooltip role	
+Pass	label valid on div with tree role	
+Pass	label valid on div with treegrid role	
+Pass	label valid on div with treeitem role	
+Pass	label valid on link element	
+Pass	label valid on article element	
+Pass	label valid on aside element	
+Pass	label valid on blockquote element	
+Pass	label valid on button element	
+Pass	label valid on dl element	
+Pass	label valid on footer element	
+Pass	label valid on fieldset element	
+Pass	label valid on figure element	
+Pass	label valid on form element	
+Pass	label valid on header element	
+Pass	label valid on h1 element	
+Pass	label valid on h2 element	
+Pass	label valid on h3 element	
+Pass	label valid on h4 element	
+Pass	label valid on h5 element	
+Pass	label valid on h6 element	
+Pass	label valid on hr element	
+Pass	label valid on img element	
+Pass	label valid on input type checkbox element	
+Pass	label valid on input type radio element	
+Pass	label valid on input type search element	
+Pass	label valid on input type text element	
+Pass	label valid on listitem element	
+Pass	label valid on main element	
+Pass	label valid on math element	
+Pass	label valid on meter element	
+Pass	label valid on nav element	
+Pass	label valid on list (ordered) element	
+Pass	label valid on section element	
+Pass	label valid on select element	
+Pass	label valid on option element	
+Pass	label valid on table element	
+Pass	label valid on thead element	
+Pass	label valid on th element with the scope of col	
+Pass	label valid on th (scope row) element	
+Pass	label valid on tbody element	
+Pass	label valid on tr element	
+Pass	label valid on td element	
+Pass	label valid on tfoot element	
+Pass	label valid on textarea element	
+Pass	label valid on list (unordered) element	
+Pass	button's hidden referenced name (display:none) supercedes aria-label	
+Pass	button's hidden referenced name (visibility:hidden) supercedes aria-label	
+Pass	button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label	
+Pass	link's aria-labelledby name supercedes aria-label	
+Pass	img's aria-label supercedes alt attribute	
+Pass	svg's aria-label supercedes title tag	
+Pass	input with label for association is superceded by aria-label	
+Pass	button name from contents is superceded by aria-label	
+Pass	h1 text is superceded by aria-label	
+Pass	button with title is superceded by aria-label	
+Pass	textarea's name with trailing whitespace in aria-label is valid	
+Pass	link's name with leading whitespace in aria-label is valid	
+Pass	button with blank braille pattern has name as such (not treated as whitespace per Unicode standard)	
+Pass	div with role alert and carriage return in aria-label is valid	
+Pass	link's name with tab in aria-label is valid	
+Pass	button with leading form feed control character in aria-label is valid	
+Pass	nav with trailing nbsp char aria-label is valid (nbsp is preserved in name)	
+Pass	button with leading nbsp char in aria-label is valid (and uses aria-label)	
+Pass	button with empty aria-label does not use aria-label as name	
+Pass	textarea with tab character as aria-label does not use aria-label as name	
+Pass	button with carriage return as aria-label does not use aria-label as name	
+Pass	button with space characters as aria-label does not use aria-label as name	

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_labelledby_hidden_nodes.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_labelledby_hidden_nodes.txt
@@ -1,0 +1,37 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 27 tests
+
+27 Pass
+Details
+Result	Test Name	MessagePass	button with aria-labelledby using display:none hidden span (with nested span)	
+Pass	button with aria-labelledby using display:none hidden span (with nested spans, depth 2)	
+Pass	button with aria-labelledby using span without display:none (with nested display:none spans, depth 2)	
+Pass	button with aria-labelledby using display:none hidden span (with nested sibling spans)	
+Pass	button with aria-labelledby using span without display:none (with nested display:none sibling spans)	
+Pass	button with aria-labelledby using span with display:none (with nested display:inline sibling spans)	
+Pass	button with aria-labelledby using visibility:hidden span (with nested span)	
+Pass	button with aria-labelledby using visibility:hidden span (with nested spans, depth 2)	
+Pass	button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden spans, depth 2)	
+Pass	button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)	
+Pass	button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden sibling spans)	
+Pass	button with aria-labelledby using span with visibility:hidden (with nested visibility:visible sibling spans)	
+Pass	button with aria-labelledby using visibility:collapse span (with nested span)	
+Pass	button with aria-labelledby using visibility:collapse span (with nested spans, depth 2)	
+Pass	button with aria-labelledby using span without visibility:collapse (with nested visibility:visible spans, depth 2)	
+Pass	button with aria-labelledby using visibility:collapse span (with nested sibling spans)	
+Pass	button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse sibling spans)	
+Pass	button with aria-labelledby using span with visibility:collapse (with nested visible sibling spans)	
+Pass	button with aria-labelledby using aria-hidden span (with nested span)	
+Pass	button with aria-labelledby using aria-hidden span (with nested spans, depth 2)	
+Pass	button with aria-labelledby using span without aria-hidden (with nested aria-hidden spans, depth 2)	
+Pass	button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)	
+Pass	button with aria-labelledby using HTML5 hidden span (with nested span)	
+Pass	button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)	
+Pass	button with aria-labelledby using span without HTML5 hidden (with nested HTML5 hidden spans, depth 2)	
+Pass	button with aria-labelledby using HTML5 hidden span (with nested hidden sibling spans)	
+Pass	button with aria-labelledby using span without HTML5 hidden (with nested hidden sibling spans)	

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_hidden_not_referenced.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_hidden_not_referenced.html
@@ -1,0 +1,92 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Name Comp: Hidden Not Referenced</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_hidden_not_referenced">#comp_hidden_not_referenced</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
+<button
+  class="ex"
+  data-expectedlabel="visible to all users"
+  data-testname="button containing a rendered, unreferenced element that is aria-hidden=true, an unreferenced element with the hidden host language attribute, and an unreferenced element that is unconditionally rendered"
+>
+  <span aria-hidden="true">hidden,</span>
+  <span hidden>hidden from all users,</span>
+  <span>visible to all users</span>
+</button>
+
+<button
+  class="ex"
+  data-expectedlabel="hidden but referenced,"
+  data-testname="button labelled by element that is aria-hidden=true"
+  aria-labelledby="button-label-2"
+>
+  <span aria-hidden="true" id="button-label-2">hidden but referenced,</span>
+  <span hidden>hidden from all users,</span>
+  <span>visible to all users</span>
+</button>
+
+<button
+  class="ex"
+  data-expectedlabel="hidden from all users but referenced,"
+  data-testname="button labelled by element with the hidden host language attribute"
+  aria-labelledby="button-label-3"
+>
+  <span aria-hidden="true">hidden,</span>
+  <span hidden id="button-label-3">hidden from all users but referenced,</span>
+  <span>visible to all users</span>
+</button>
+
+<a
+  class="ex"
+  data-testname="link labelled by elements with assorted visibility and a11y tree exposure"
+  data-expectedlabel="visible to all users, hidden but referenced, hidden from all users but referenced"
+  href="#"
+  aria-labelledby="link-label-1a link-label-1b link-label-1c"
+>
+  <span id="link-label-1a">
+    <span>visible to all users,</span>
+    <span aria-hidden="true">hidden,</span>
+  </span>
+  <span aria-hidden="true" id="link-label-1b">hidden but referenced,</span>
+  <span hidden id="link-label-1c">hidden from all users but referenced</span>
+</a>
+
+<h2
+  class="ex"
+  data-testname="heading with name from content, containing element that is visibility:hidden with nested content that is visibility:visible"
+  data-expectedlabel="visible to all users, un-hidden for all users"
+>
+  visible to all users,
+  <span style="visibility: hidden;">
+    hidden from all users,
+    <span style="visibility: visible;">un-hidden for all users</span>
+  </span>
+</h2>
+
+<!-- TODO: Test cases once https://github.com/w3c/aria/issues/1256 resolved: -->
+<!--       - button labelled by an element that is aria-hidden=true which contains a nested child that is aria-hidden=false -->
+<!--       - button labelled by an element that is aria-hidden=false which belongs to a parent that is aria-hidden=true -->
+<!--       - heading with name from content, containing rendered content that is aria-hidden=true with nested, rendered content that is aria-hidden=false -->
+<!--       - heading with name from content, containing element with the hidden host language attribute with nested content that is aria-hidden=false -->
+
+<!-- TODO: New test case?
+<!--       What is the expectation for a details element when it’s given an -->
+<!--       explicit role that allows name from contents (e.g., `comment`) -->
+<!--       but is also not in the open state, and therefore has contents -->
+<!--       that are both not rendered and excluded from the a11y tree. -->
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_label.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_label.html
@@ -1,0 +1,244 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Label</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<h1>AccName: Label Tests</h1>
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_label">#comp_label</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
+<!-- https://www.w3.org/TR/wai-aria/#namefromauthor -->
+
+<!-- Embedded controls tested in ./comp_embedded_control.html -->
+
+<h2>Elements with roles that support aria-label use</h2>
+<!-- https://www.w3.org/TR/wai-aria/#namefromauthor -->
+
+<div role="alert" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with alert role" class="ex">x</div>
+<div role="alertdialog" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with alertdialog role" class="ex">x</div>
+<div role="application" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with application role" class="ex">x</div>
+<div role="article" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with article role" class="ex">x</div>
+<!-- associationlist and related removed pending: https://github.com/w3c/aria/issues/1662 -->
+<div role="banner" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with banner role" class="ex">x</div>
+<div role="blockquote" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with blockquote role" class="ex">x</div>
+<div role="button" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with button role" class="ex">x</div>
+<div role="cell" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with cell role" class="ex">x</div>
+<div role="checkbox" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with checkbox role" class="ex">x</div>
+<div role="columnheader" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with columnheader role" class="ex">x</div>
+<div role="combobox" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with combobox role" class="ex">x</div>
+<div role="complementary" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with complementary role" class="ex">x</div>
+<div role="contentinfo" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with contentinfo role" class="ex">x</div>
+<div role="dialog" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with dialog role" class="ex">x</div>
+<div role="directory" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with directory role" class="ex">x</div>
+<div role="document" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with document role" class="ex">x</div>
+<div role="feed" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with feed role" class="ex">x</div>
+<div role="figure" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with figure role" class="ex">x</div>
+<div role="form" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with form role" class="ex">x</div>
+<div role="grid" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with grid role" class="ex">x</div>
+<div role="gridcell" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with gridcell role" class="ex">x</div>
+<div role="group" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with group role" class="ex">x</div>
+<div role="heading" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with heading role" class="ex">x</div>
+<div role="img" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with img role" class="ex">x</div>
+<div role="link" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with link role" class="ex">x</div>
+<div role="list" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with list role" class="ex">x</div>
+<div role="listbox" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with listbox role" class="ex">x</div>
+<div role="listitem" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with listitem role" class="ex">x</div>
+<!-- listitemkey and listitemvalue pending: https://github.com/w3c/aria/issues/1662 -->
+<div role="log" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with log role" class="ex">x</div>
+<div role="main" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with main role" class="ex">x</div>
+<div role="marquee" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with marquee role" class="ex">x</div>
+<div role="math" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with math role" class="ex">x</div>
+<div role="menu" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with menu role" class="ex">x</div>
+<div role="menubar" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with menubar role" class="ex">x</div>
+<div role="menuitem" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with menuitem role" class="ex">x</div>
+<div role="menuitemcheckbox" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with menuitemcheckbox role" class="ex">x</div>
+<div role="menuitemradio" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with menuitemradio role" class="ex">x</div>
+<div role="meter" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with meter role" class="ex">x</div>
+<div role="navigation" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with navigation role" class="ex">x</div>
+<div role="note" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with note role" class="ex">x</div>
+<div role="option" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with option role" class="ex">x</div>
+<div role="progressbar" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with progressbar role" class="ex">x</div>
+<div role="radio" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with radio role" class="ex">x</div>
+<div role="radiogroup" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with radiogroup role" class="ex">x</div>
+<div role="region" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with region role" class="ex">x</div>
+<div role="row" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with row role" class="ex">x</div>
+<div role="rowgroup" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with rowgroup role" class="ex">x</div>
+<div role="rowheader" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with rowheader role" class="ex">x</div>
+<div role="scrollbar" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with scrollbar role" class="ex">x</div>
+<div role="search" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with search role" class="ex">x</div>
+<div role="searchbox" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with searchbox role" class="ex">x</div>
+<div role="separator" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with separator role" class="ex">x</div>
+<div role="slider" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with slider role" class="ex">x</div>
+<div role="spinbutton" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with spinbutton role" class="ex">x</div>
+<div role="status" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with status role" class="ex">x</div>
+<div role="switch" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with switch role" class="ex">x</div>
+<div role="tab" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with tab role" class="ex">x</div>
+<div role="table" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with table role" class="ex">x</div>
+<div role="tablist" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with tablist role" class="ex">x</div>
+<div role="tabpanel" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with tabpanel role" class="ex">x</div>
+<div role="textbox" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with textbox role" class="ex">x</div>
+<div role="timer" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with timer role" class="ex">x</div>
+<div role="toolbar" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with toolbar role" class="ex">x</div>
+<div role="tooltip" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with tooltip role" class="ex">x</div>
+<div role="tree" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with tree role" class="ex">x</div>
+<div role="treegrid" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with treegrid role" class="ex">x</div>
+<div role="treeitem" aria-label="label" data-expectedlabel="label" data-testname="label valid on div with treeitem role" class="ex">x</div>
+
+<h2>HTML elements that support aria-label</h2>
+<!-- aria-label permitted on "all elements of the base markup" with exceptions: https://w3c.github.io/aria/#aria-label -->
+
+<a href="" aria-label="label" data-expectedlabel="label" data-testname="label valid on link element" class="ex">x</a>
+<article aria-label="label" data-expectedlabel="label" data-testname="label valid on article element" class="ex">x</article>
+<aside aria-label="label" data-expectedlabel="label" data-testname="label valid on aside element" class="ex">x</aside>
+<blockquote aria-label="label" data-expectedlabel="label" data-testname="label valid on blockquote element" class="ex">x</blockquote>
+<button aria-label="label" data-expectedlabel="label" data-testname="label valid on button element" class="ex">x</button>
+<dl aria-label="label" data-expectedlabel="label" data-testname="label valid on dl element" class="ex">
+  <!-- dt/dd pending listitemkey and listitemvalue roles: https://github.com/w3c/aria/issues/1662 -->
+  <!-- Currently these map to `term` and `definition` for which name is prohibited. -->
+  <!-- Using aria-label here would be an authoring error, however whether there is a user agent requirement to ignore the author provided role is still pending https://github.com/w3c/accname/issues/240 -->
+  <!-- See "Priorities of Constituencies" https://www.w3.org/TR/design-principles/#priority-of-constituencies -->
+  <dt>x</dt>
+  <dd>x</dd>
+</dl>
+<footer aria-label="label" data-expectedlabel="label" data-testname="label valid on footer element" class="ex">x</footer>
+<fieldset aria-label="label" data-expectedlabel="label" data-testname="label valid on fieldset element" class="ex">x</fieldset>
+<figure aria-label="label" data-expectedlabel="label" data-testname="label valid on figure element" class="ex">x</figure>
+<form action="" aria-label="label" data-expectedlabel="label" data-testname="label valid on form element" class="ex">x</form>
+<header aria-label="label" data-expectedlabel="label" data-testname="label valid on header element" class="ex">x</header>
+<h1 aria-label="label" data-expectedlabel="label" data-testname="label valid on h1 element" class="ex">x</h1>
+<h2 aria-label="label" data-expectedlabel="label" data-testname="label valid on h2 element" class="ex">x</h2>
+<h3 aria-label="label" data-expectedlabel="label" data-testname="label valid on h3 element" class="ex">x</h3>
+<h4 aria-label="label" data-expectedlabel="label" data-testname="label valid on h4 element" class="ex">x</h4>
+<h5 aria-label="label" data-expectedlabel="label" data-testname="label valid on h5 element" class="ex">x</h5>
+<h6 aria-label="label" data-expectedlabel="label" data-testname="label valid on h6 element" class="ex">x</h6>
+<hr aria-label="label" data-expectedlabel="label" data-testname="label valid on hr element" class="ex" />
+<img alt="" aria-label="label" data-expectedlabel="label" data-testname="label valid on img element" class="ex" />
+<input type="checkbox" aria-label="label" data-expectedlabel="label" data-testname="label valid on input type checkbox element" class="ex"/>
+<input type="radio" aria-label="label" data-expectedlabel="label" data-testname="label valid on input type radio element" class="ex" />
+<input type="search" aria-label="label" data-expectedlabel="label" data-testname="label valid on input type search element" class="ex" />
+<input type="text" aria-label="label" data-expectedlabel="label" data-testname="label valid on input type text element" class="ex" />
+<li aria-label="label" data-expectedlabel="label" data-testname="label valid on listitem element" class="ex">x</li>
+<main aria-label="label" data-expectedlabel="label" data-testname="label valid on main element" class="ex">x</main>
+<math aria-label="label" data-expectedlabel="label" data-testname="label valid on math element" class="ex">x</math>
+<meter aria-label="label" data-expectedlabel="label" data-testname="label valid on meter element" class="ex">x</meter>
+<nav aria-label="label" data-expectedlabel="label" data-testname="label valid on nav element" class="ex">x</nav>
+<ol aria-label="label" data-expectedlabel="label" data-testname="label valid on list (ordered) element" class="ex">x</ol>
+<section aria-label="label" data-expectedlabel="label" data-testname="label valid on section element" class="ex">x</section>
+<select aria-label="label" data-expectedlabel="label" data-testname="label valid on select element" class="ex">x</select>
+<select>
+  <option aria-label="label" value="foo" data-expectedlabel="label" data-testname="label valid on option element" class="ex">x</option>
+</select>
+<table aria-label="label" data-expectedlabel="label" data-testname="label valid on table element" class="ex">
+  <thead aria-label="label" data-expectedlabel="label" data-testname="label valid on thead element" class="ex">
+    <tr>
+      <th scope="col" aria-label="label" data-expectedlabel="label" data-testname="label valid on th element with the scope of col" class="ex">x</th>
+      <th scope="row" aria-label="label" data-expectedlabel="label" data-testname="label valid on th (scope row) element" class="ex">x</th>
+    </tr>
+  </thead>
+  <tbody aria-label="label" data-expectedlabel="label" data-testname="label valid on tbody element" class="ex">
+    <tr aria-label="label" data-expectedlabel="label" data-testname="label valid on tr element" class="ex">
+      <td aria-label="label" data-expectedlabel="label" data-testname="label valid on td element" class="ex">x</td>
+      <td>x</td>
+    </tr>
+  </tbody>
+    <tfoot aria-label="label" data-expectedlabel="label" data-testname="label valid on tfoot element" class="ex">
+      <tr>
+        <td>x</td>
+        <td>x</td>
+      </tr>
+    </tfoot>
+</table>
+<textarea aria-label="label" data-expectedlabel="label" data-testname="label valid on textarea element" class="ex">x</textarea>
+<ul aria-label="label" data-expectedlabel="label" data-testname="label valid on list (unordered) element" class="ex">x</ul>
+
+<h2>Name computation precedence tests</h2>
+<!-- Name computation: https://w3c.github.io/accname/#computation-steps -->
+
+<!-- Step 2A: Hidden Not Referenced supercedes 2D: AriaLabel, also see wpt/accname/name/comp_hidden_not_referenced.html -->
+<button aria-labelledby="span1" aria-label="foo" data-expectedlabel="label" data-testname="button's hidden referenced name (display:none) supercedes aria-label" class="ex">
+  <span id="span1" style="display:none;">
+    <span id="span2" style="display:none;">label</span>
+  </span>
+x
+</button>
+
+<button aria-labelledby="span3" aria-label="foo" data-expectedlabel="label" data-testname="button's hidden referenced name (visibility:hidden) supercedes aria-label" class="ex">
+  <span id="span3" style="visibility:hidden;">
+    <span id="span4" style="visibility:hidden;">label</span>
+  </span>
+  x
+</button>
+
+<button aria-labelledby="span5" aria-label="foo" data-expectedlabel="foo" data-testname="button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal falls back to aria-label" class="ex">
+  <span id="span5">
+    <span id="span6" style="visibility:hidden;">label</span>
+  </span>
+  x
+</button>
+
+<!-- Step 2B: LabelledBy supercedes 2D: AriaLabel, also see wpt/accname/name/comp_labelledby.html -->
+<a href="#" aria-labelledby="span7" aria-label="foo" data-expectedlabel="label" data-testname="link's aria-labelledby name supercedes aria-label" class="ex">x</a>
+<span id="span7">label</span>
+
+<!-- Step 2C: Embedded Control labelling supercedes 2D: AriaLabel, see wpt/accname/name/comp_embedded_control.html -->
+
+<!-- Step 2E: Host Language Label is superceded by 2D: AriaLabel, also see wpt/accname/name/comp_host_language_label.html -->
+<img alt="alt" aria-label="foo" data-expectedlabel="foo" data-testname="img's aria-label supercedes alt attribute" class="ex" />
+
+<svg aria-label="foo" data-expectedlabel="foo" data-testname="svg's aria-label supercedes title tag" class="ex">
+  <circle cx="5" cy="5" r="4">
+    <title>circle</title>
+  </circle>
+</svg>
+
+<label for="input1">label</label>
+<input type="text" id="input1" aria-label="foo" data-expectedlabel="foo" data-testname="input with label for association is superceded by aria-label" class="ex" />
+
+<!-- Step 2F: Name From Content is superceded by 2D: AriaLabel, also see wpt/accname/name/comp_name_from_content.html -->
+<button aria-label="label" data-expectedlabel="label" data-testname="button name from contents is superceded by aria-label" class="ex">x</button>
+
+<!-- Step 2G: Text Node is superceded by 2D: AriaLabel, also see wpt/accname/name/comp_text_node.html -->
+<h1 aria-label="label" data-expectedlabel="label" data-testname="h1 text is superceded by aria-label" class="ex">x</h1>
+
+<!-- Step 2H: Recursive Name from Content, see wpt/accname/name/comp_name_from_content.html  -->
+
+<!-- Step 2I: Tooltip is superceded by 2D: AriaLabel, also see wpt/accname/name/comp_tooltip.html -->
+<button aria-label="label" title="foo" data-expectedlabel="label" data-testname="button with title is superceded by aria-label" class="ex">x</button>
+
+<h2>Empty/whitespace aria-label tests</h2>
+<!--
+- AccName computation links to the following definition of "Whitespace": https://infra.spec.whatwg.org/#ascii-whitespace
+- Generally, if the current node has an aria-label attribute whose value is not the empty string (including when trimmed of whitespace), return the value of aria-label.
+
+Note: PR for computedLabel whitespace trimming in aria-utils.js: https://github.com/web-platform-tests/wpt/pull/42407/files#diff-6870d82f11ff11cf7c7b544756cecfdac2046acbfe2fbb0640e6d415fbf99916
+
+-->
+
+<textarea aria-label="label  " data-expectedlabel="label" data-testname="textarea's name with trailing whitespace in aria-label is valid" class="ex">x</textarea>
+<a href="#" aria-label="     label" data-expectedlabel="label" data-testname="link's name with leading whitespace in aria-label is valid" class="ex">x</a>
+<button aria-label="⠀" data-expectedlabel="⠀" data-testname="button with blank braille pattern has name as such (not treated as whitespace per Unicode standard)" class="ex">my button</button>
+<div role="alert" aria-label="
+alert message" data-expectedlabel="alert message" data-testname="div with role alert and carriage return in aria-label is valid" class="ex">x</div>
+<a href="#" aria-label="  label" data-expectedlabel="label" data-testname="link's name with tab in aria-label is valid" class="ex">x</a>
+<button aria-label="label" data-expectedlabel="label" data-testname="button with leading form feed control character in aria-label is valid" class="ex">my button</button>
+<nav aria-label="label&nbsp;" data-expectedlabel="label&nbsp;" data-testname="nav with trailing nbsp char aria-label is valid (nbsp is preserved in name)" class="ex">x</nav>
+<button aria-label="&nbsp;label" data-expectedlabel="&nbsp;label" data-testname="button with leading nbsp char in aria-label is valid (and uses aria-label)" class="ex">my button</button>
+
+<button aria-label="" data-testname="button with empty aria-label does not use aria-label as name" data-expectedlabel="my button" class="ex">my button</button>
+<textarea aria-label="  " title="title" data-testname="textarea with tab character as aria-label does not use aria-label as name" data-expectedlabel="title" class="ex">textarea contents</textarea>
+<button aria-label="
+" data-testname="button with carriage return as aria-label does not use aria-label as name" data-expectedlabel="my button" class="ex">my button</button>
+<button aria-label="      " data-testname="button with space characters as aria-label does not use aria-label as name" data-expectedlabel="my button" class="ex">my button</button>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_labelledby_hidden_nodes.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_labelledby_hidden_nodes.html
@@ -1,0 +1,245 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Labelledby & Hidden Nodes</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests hidden node name computation as part of the <a href="https://w3c.github.io/accname/#comp_labelledby">#comp_labelledby</a> portion of the AccName <em>Name Computation</em> algorithm.</p>
+
+<!--
+
+  These tests verify browser conformance with the following note as part of accName computation Step 2B:
+
+  "The result of LabelledBy Recursion in combination with Hidden Not Referenced means
+  that user agents MUST include all nodes in the subtree as part of
+  the accessible name or accessible description, when the node referenced
+  by aria-labelledby or aria-describedby is hidden."
+
+-->
+
+<h2>Testing with <code>display:none</code></h2>
+
+    <button aria-labelledby="a11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using display:none hidden span (with nested span)" class="ex">x</button>
+    <span id="a11" style="display: none;">
+        foo
+        <span id="a12">bar</span>
+    </span>
+
+    <button aria-labelledby="a21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested spans, depth 2)" class="ex">x</button>
+    <span id="a21" style="display: none;">
+        foo
+        <span id="a22">
+            bar
+            <span id="a23">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="a31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none spans, depth 2)" class="ex">x</button>
+    <span id="a31">
+        foo
+        <span id="a32" style="display: none;">
+            bar
+            <span id="a33">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="a41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using display:none hidden span (with nested sibling spans)" class="ex">x</button>
+    <span id="a41" style="display: none;">
+        foo
+        <span id="a42">bar</span>
+        <span id="a43">baz</span>
+    </span>
+
+    <button aria-labelledby="a51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without display:none (with nested display:none sibling spans)" class="ex">x</button>
+    <span id="a51">
+        foo
+        <span id="a52" style="display: none;">bar</span>
+        <span id="a53" style="display: none;">baz</span>
+    </span>
+
+    <button aria-labelledby="a61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with display:none (with nested display:inline sibling spans)" class="ex">x</button>
+    <span id="a61" style="display: none;">
+        foo
+        <span id="a62" style="display: inline;">bar</span>
+        <span id="a63" style="display: inline;">baz</span>
+    </span>
+
+<h2>Testing with <code>visibility:hidden</code></h2>
+
+    <button aria-labelledby="b11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:hidden span (with nested span)" class="ex">x</button>
+    <span id="b11" style="visibility: hidden;">
+        foo
+        <span id="b12">bar</span>
+    </span>
+
+    <button aria-labelledby="b21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden span (with nested spans, depth 2)" class="ex">x</button>
+    <span id="b21" style="visibility: hidden;">
+        foo
+        <span id="b22">
+            bar
+            <span id="b23">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="b31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden spans, depth 2)" class="ex">x</button>
+    <span id="b31">
+        foo
+        <span id="b32" style="visibility: hidden;">
+            bar
+            <span id="b33">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="b41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:hidden hidden span (with nested sibling spans)" class="ex">x</button>
+    <span id="b41" style="visibility: hidden;">
+        foo
+        <span id="b42">bar</span>
+        <span id="b43">baz</span>
+    </span>
+
+    <button aria-labelledby="b51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:hidden (with nested visibility:hidden sibling spans)" class="ex">x</button>
+    <span id="b51">
+        foo
+        <span id="b52" style="visibility: hidden;">bar</span>
+        <span id="b53" style="visibility: hidden;">baz</span>
+    </span>
+
+    <button aria-labelledby="b61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:hidden (with nested visibility:visible sibling spans)" class="ex">x</button>
+    <span id="b61" style="visibility: hidden;">
+        foo
+        <span id="b62" style="visibility: visible;">bar</span>
+        <span id="b63" style="visibility: visible;">baz</span>
+    </span>
+
+<h2>Testing with <code>visibility:collapse</code></h2>
+
+    <button aria-labelledby="c11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using visibility:collapse span (with nested span)" class="ex">x</button>
+    <span id="c11" style="visibility: collapse;">
+        foo
+        <span id="c12">bar</span>
+    </span>
+
+    <button aria-labelledby="c21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested spans, depth 2)" class="ex">x</button>
+    <span id="c21" style="visibility: collapse;">
+        foo
+        <span id="c22">
+            bar
+            <span id="c23">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="c31" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:visible spans, depth 2)" class="ex">x</button>
+    <span id="c31">
+        foo
+        <span id="c32" style="visibility: visible;">
+            bar
+            <span id="c33" style="visibility: visible;">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="c41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using visibility:collapse span (with nested sibling spans)" class="ex">x</button>
+    <span id="c41" style="visibility: collapse;">
+        foo
+        <span id="c42">bar</span>
+        <span id="c43">baz</span>
+    </span>
+
+    <button aria-labelledby="c51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without visibility:collapse (with nested visibility:collapse sibling spans)" class="ex">x</button>
+    <span id="c51">
+        foo
+        <span id="c52" style="visibility: collapse;">bar</span>
+        <span id="c53" style="visibility: collapse;">baz</span>
+    </span>
+
+    <button aria-labelledby="c61" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using span with visibility:collapse (with nested visible sibling spans)" class="ex">x</button>
+    <span id="c61" style="visibility: collapse;">
+        foo
+        <span id="c62" style="visibility: visible;">bar</span>
+        <span id="c63" style="visibility: visible;">baz</span>
+    </span>
+
+<h2>Testing with <code>aria-hidden</code></h2>
+
+    <button aria-labelledby="d11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using aria-hidden span (with nested span)" class="ex">x</button>
+    <span id="d11" aria-hidden="true">
+        foo
+        <span id="d12">bar</span>
+    </span>
+
+    <button aria-labelledby="d21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden span (with nested spans, depth 2)" class="ex">x</button>
+    <span id="d21" aria-hidden="true">
+        foo
+        <span id="d22">
+            bar
+            <span id="d23">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="d31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without aria-hidden (with nested aria-hidden spans, depth 2)" class="ex">x</button>
+    <span id="d31">
+        foo
+        <span id="d32" aria-hidden="true">
+            bar
+            <span id="d33">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="d41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using aria-hidden hidden span (with nested sibling spans)" class="ex">x</button>
+    <span id="d41" aria-hidden="true">
+        foo
+        <span id="d42">bar</span>
+        <span id="d43">baz</span>
+    </span>
+
+<h2>Testing with <code>hidden</code> attribute</h2>
+
+    <button aria-labelledby="e11" data-expectedlabel="foo bar" data-testname="button with aria-labelledby using HTML5 hidden span (with nested span)" class="ex">x</button>
+    <span id="e11" hidden>
+        foo
+        <span id="e12">bar</span>
+    </span>
+
+    <button aria-labelledby="e21" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested spans, depth 2)" class="ex">x</button>
+    <span id="e21" hidden>
+        foo
+        <span id="e22">
+            bar
+            <span id="e23">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="e31" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested HTML5 hidden spans, depth 2)" class="ex">x</button>
+    <span id="e31">
+        foo
+        <span id="e32" hidden>
+            bar
+            <span id="e33">baz</span>
+        </span>
+    </span>
+
+    <button aria-labelledby="e41" data-expectedlabel="foo bar baz" data-testname="button with aria-labelledby using HTML5 hidden span (with nested hidden sibling spans)" class="ex">x</button>
+    <span id="e41" hidden>
+        foo
+        <span id="e42">bar</span>
+        <span id="e43">baz</span>
+    </span>
+
+    <button aria-labelledby="e51" data-expectedlabel="foo" data-testname="button with aria-labelledby using span without HTML5 hidden (with nested hidden sibling spans)" class="ex">x</button>
+    <span id="e51">
+        foo
+        <span id="e52" hidden>bar</span>
+        <span id="e53" hidden>baz</span>
+    </span>
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This change implements full support for the _“A. Hidden Not Referenced”_ step at https://w3c.github.io/accname/#step2A in the “Accessible Name and Description Computation” spec — including handling all hidden nodes that must be ignored, as well as handling hidden nodes that, for the purposes of accessible-name computation, must not be ignored (due to having `aria-labelledby`/`aria-describedby` references from other nodes).

Otherwise, without this change, not all cases of hidden nodes get ignored as expected, while cases of nodes that are hidden but that have `aria-labelledby`/`aria-describedby` references from other nodes get unexpectedly ignored.

For the tests at https://wpt.fyi/results/accname/name?product=ladybird, this change gets us passing:

- all 27 subtests in the `comp_labelledby_hidden_nodes.html` test
- all 5 subtests in the `comp_hidden_not_referenced.html` test

Otherwise, without this change, we fail all those tests.

Additionally, a separate commit here makes us give the value of the aria-label attribute the correct precedence for accessible-name computation required by the “Accessible Name and Description Computation” and HTML-AAM specs and by the corresponding WPT tests.

That gets us passing all 131 subtests in the `comp_label.html` test at https://wpt.fyi/results/accname/name?product=ladybird