### PR TITLE
LibJS: Parse dates like "November 19 2024 00:00:00 +0900"

### DIFF
--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -191,6 +191,7 @@ static double parse_date_string(VM& vm, ByteString const& date_string)
         "%d%t%b%t%Y"sv,                        // "01 Jan 2000"
         "%d%t%b%t%Y%t%R"sv,                    // "01 Jan 2000 08:00"
         "%A,%t%B%t%e,%t%Y,%t%R%t%Z"sv,         // "Tuesday, October 29, 2024, 18:00 UTC"
+        "%B%t%d%t%Y%t%T%t%z"sv,                // "November 19 2024 00:00:00 +0900"
     };
 
     for (auto const& format : extra_formats) {

--- a/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -40,6 +40,7 @@ test("basic functionality", () => {
     expect(Date.parse("1/27/2024, 9:28:30 AM")).toBe(1706369310000);
     expect(Date.parse("01 February 2013")).toBe(1359698400000);
     expect(Date.parse("Tuesday, October 29, 2024, 18:00 UTC")).toBe(1730224800000);
+    expect(Date.parse("November 19 2024 00:00:00 +0900")).toBe(1731942000000);
 
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
     setTimeZone(originalTimeZone);


### PR DESCRIPTION
This format is used on https://jojowiki.com/ to show countdowns to new releases.