### PR TITLE
headless-browser: Handle WebContent crashes similar to the graphical UIs

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -496,7 +496,7 @@ void ViewImplementation::handle_resize()
 
 void ViewImplementation::handle_web_content_process_crash(LoadErrorPage load_error_page)
 {
-    dbgln("WebContent process crashed!");
+    dbgln("\033[31;1mWebContent process crashed!\033[0m Last page loaded: {}", m_url);
     dbgln("Consider raising an issue at https://github.com/LadybirdBrowser/ladybird/issues/new/choose");
 
     ++m_crash_count;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -254,7 +254,11 @@ protected:
     };
     virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) { }
 
-    void handle_web_content_process_crash();
+    enum class LoadErrorPage {
+        No,
+        Yes,
+    };
+    void handle_web_content_process_crash(LoadErrorPage = LoadErrorPage::Yes);
 
     struct SharedBitmap {
         i32 id { -1 };

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -168,9 +168,12 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
         client().async_connect_to_webdriver(m_client_state.page_index, *web_driver_ipc_path);
 
     m_client_state.client->on_web_content_process_crash = [this] {
-        warnln("\033[31;1mWebContent Crashed!!\033[0m");
-        warnln("    Last page loaded: {}", url());
-        VERIFY_NOT_REACHED();
+        Core::deferred_invoke([this] {
+            handle_web_content_process_crash(LoadErrorPage::No);
+
+            if (on_web_content_crashed)
+                on_web_content_crashed();
+        });
     };
 }
 

--- a/UI/Headless/HeadlessWebView.h
+++ b/UI/Headless/HeadlessWebView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Badge.h>
+#include <AK/Function.h>
 #include <AK/RefPtr.h>
 #include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
@@ -30,6 +31,8 @@ public:
 
     TestPromise& test_promise() { return *m_test_promise; }
     void on_test_complete(TestCompletion);
+
+    Function<void()> on_web_content_crashed;
 
 private:
     HeadlessWebView(Core::AnonymousBuffer theme, Gfx::IntSize viewport_size);

--- a/UI/Headless/Test.h
+++ b/UI/Headless/Test.h
@@ -34,6 +34,7 @@ enum class TestResult {
     Fail,
     Skipped,
     Timeout,
+    Crashed,
 };
 
 static constexpr StringView test_result_to_string(TestResult result)
@@ -47,6 +48,8 @@ static constexpr StringView test_result_to_string(TestResult result)
         return "Skipped"sv;
     case TestResult::Timeout:
         return "Timeout"sv;
+    case TestResult::Crashed:
+        return "Crashed"sv;
     }
     VERIFY_NOT_REACHED();
 }


### PR DESCRIPTION
Instead of bringing the whole browser down, let's re-initialize the WebContent client so we can move on. This is particularly needed for WPT.