### PR TITLE
LibJS: Correctly return cached value for global var bindings

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1118,6 +1118,7 @@ inline ThrowCompletionOr<Value> get_global(Interpreter& interpreter, IdentifierT
             auto value = binding_object.get_direct(cache.property_offset.value());
             if (value.is_accessor())
                 return TRY(call(vm, value.as_accessor().getter(), js_undefined()));
+            return value;
         }
 
         // OPTIMIZATION: For global lexical bindings, if the global declarative environment hasn't changed,


### PR DESCRIPTION
When the cached value was not an accessor, it was simply ignored. This is the value we really want, so we can just return it. 
Not sure why this was not done before, but I could not find any problems with it.

Shows up to 5x improvements on some benchmarks, and 1.4x in general js-benchmarks.
I was specifically profiling imaging-gaussian-blur.js, which saw the greatest improvement.

```
Suite       Test                                   Speedup  Old (Mean ± Range)        New (Mean ± Range)
----------  -----------------------------------  ---------  ------------------------  ------------------------
...
Kraken      imaging-gaussian-blur.js                 5.181  69.403 ± 61.580 … 73.960  13.397 ± 12.160 … 15.240
...
SunSpider   Total                                    1.244  3.413                     2.743
Kraken      Total                                    2.42   93.050                    38.453
Octane      Total                                    1.286  295.707                   229.997
All Suites  Total                                    1.446  392.170                   271.193
```

This mostly knocks get_global out of the profiler, leaving Op::initialize_or_set_binding at the top, which is mostly Object::get_own_property and Object::define_own_property.