### PR TITLE
LibGfx+LibWeb: Copy bitmap onto the returned canvas when taking a screenshot

### DIFF
--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -101,6 +101,15 @@ void PaintingSurface::read_into_bitmap(Gfx::Bitmap& bitmap)
     m_impl->surface->readPixels(pixmap, 0, 0);
 }
 
+void PaintingSurface::write_from_bitmap(Gfx::Bitmap& bitmap)
+{
+    auto color_type = to_skia_color_type(bitmap.format());
+    auto alpha_type = bitmap.alpha_type() == Gfx::AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type);
+    SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
+    m_impl->surface->writePixels(pixmap, 0, 0);
+}
+
 IntSize PaintingSurface::size() const
 {
     return m_impl->size;

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -32,6 +32,7 @@ public:
 #endif
 
     void read_into_bitmap(Bitmap&);
+    void write_from_bitmap(Bitmap&);
 
     IntSize size() const;
     IntRect rect() const;

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -53,9 +53,9 @@ ErrorOr<JS::NonnullGCPtr<HTML::HTMLCanvasElement>, WebDriver::Error> draw_boundi
     Gfx::IntRect paint_rect { rect.x(), rect.y(), paint_width, paint_height };
 
     auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, canvas.surface()->size()));
-    canvas.surface()->read_into_bitmap(*bitmap);
     auto backing_store = Web::Painting::BitmapBackingStore(bitmap);
     browsing_context.page().client().paint(paint_rect.to_type<Web::DevicePixels>(), backing_store);
+    canvas.surface()->write_from_bitmap(*bitmap);
 
     // 7. Return success with canvas.
     return canvas;


### PR DESCRIPTION
Previously, we always returned a blank canvas from `draw_bounding_box_from_the_framebuffer()`, which caused many WPT reftests to pass erroneously.