### PR TITLE
LibWeb: Make embedded Cloudflare Turnstile widgets appear again

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -66,17 +66,26 @@ void HTMLIFrameElement::inserted()
 {
     HTMLElement::inserted();
 
-    // When an iframe element element is inserted into a document whose browsing context is non-null, the user agent must run these steps:
-    if (in_a_document_tree() && document().browsing_context() && document().is_fully_active()) {
-        // 1. Create a new child navigable for element.
-        MUST(create_new_child_navigable(JS::create_heap_function(realm().heap(), [this] {
-            // 3. Process the iframe attributes for element, with initialInsertion set to true.
-            process_the_iframe_attributes(true);
-            set_content_navigable_initialized();
-        })));
+    // The iframe HTML element insertion steps, given insertedNode, are:
+    // 1. If insertedNode's shadow-including root's browsing context is null, then return.
+    if (!is<DOM::Document>(shadow_including_root()))
+        return;
 
-        // FIXME: 2. If element has a sandbox attribute, then parse the sandboxing directive given the attribute's value and element's iframe sandboxing flag set.
-    }
+    DOM::Document& document = verify_cast<DOM::Document>(shadow_including_root());
+
+    // NOTE: The check for "not fully active" is to prevent a crash on the dom/nodes/node-appendchild-crash.html WPT test.
+    if (!document.browsing_context() || !document.is_fully_active())
+        return;
+
+    // 2. Create a new child navigable for insertedNode.
+    MUST(create_new_child_navigable(JS::create_heap_function(realm().heap(), [this] {
+        // FIXME: 3. If insertedNode has a sandbox attribute, then parse the sandboxing directive given the attribute's
+        //           value and insertedNode's iframe sandboxing flag set.
+
+        // 4. Process the iframe attributes for insertedNode, with initialInsertion set to true.
+        process_the_iframe_attributes(true);
+        set_content_navigable_initialized();
+    })));
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#process-the-iframe-attributes

--- a/Tests/LibWeb/Text/expected/DOM/shadow-root-boundary-of-inserted-node-is-traversed.txt
+++ b/Tests/LibWeb/Text/expected/DOM/shadow-root-boundary-of-inserted-node-is-traversed.txt
@@ -1,0 +1,1 @@
+Hello from script in the shadow root of the just inserted div!

--- a/Tests/LibWeb/Text/expected/HTML/iframe-successfully-loads-in-shadow-root.txt
+++ b/Tests/LibWeb/Text/expected/HTML/iframe-successfully-loads-in-shadow-root.txt
@@ -1,0 +1,2 @@
+Received a message: 'Hello from iframe in the shadow root of the just inserted div!'
+Was it from the shadow root iframe? true

--- a/Tests/LibWeb/Text/input/DOM/shadow-root-boundary-of-inserted-node-is-traversed.html
+++ b/Tests/LibWeb/Text/input/DOM/shadow-root-boundary-of-inserted-node-is-traversed.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const div = document.createElement("div");
+        const shadowRoot = div.attachShadow({ mode: "closed" });
+
+        const script = document.createElement("script");
+        script.innerText = "println('Hello from script in the shadow root of the just inserted div!')";
+        shadowRoot.appendChild(script);
+
+        document.body.appendChild(div);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/iframe-successfully-loads-in-shadow-root.html
+++ b/Tests/LibWeb/Text/input/HTML/iframe-successfully-loads-in-shadow-root.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        const div = document.createElement("div");
+        const shadowRoot = div.attachShadow({ mode: "closed" });
+
+        const iframe = document.createElement("iframe");
+
+        window.addEventListener("message", (messageEvent) => {
+            println(`Received a message: '${messageEvent.data}'`);
+            println(`Was it from the shadow root iframe? ${messageEvent.source === iframe.contentWindow}`);
+            done();
+        });
+
+        iframe.srcdoc = `
+            \u003cscript\u003e
+                window.parent.postMessage("Hello from iframe in the shadow root of the just inserted div!");
+            \u003c/script\u003e
+        `;
+        shadowRoot.appendChild(iframe);
+
+        document.body.appendChild(div);
+    });
+</script>


### PR DESCRIPTION
Embedded Cloudflare Turnstile widgets stopped appearing because they have started inserting the widget iframe into a shadow tree. This PR fixes that!

LibWeb: Actually traverse the shadow root of the inclusive descendant

Previously, the inclusive descendant, which is the node that for_each_shadow_including_inclusive_descendant was called on, would not have it's shadow root traversed if it had one.

This is because the shadow root traversal was in the `for` loop, which begins with the node's first child. The fix here is to move the shadow root traversal outside of the loop, and check if the current node is an element instead.

----

LibWeb: Make iframe insertion steps check the shadow including root

The insertion steps for iframes were following an old version of the spec, where it was checking if the iframe was "in a document tree", which doesn't cross shadow root boundaries. The spec has since been updated to check the shadow including root instead.

This is now needed for Cloudflare Turnstile iframe widgets to appear, as they are now inserted into a shadow root.
