### PR TITLE
LibWeb: Guard MediaQueryList event listener removal against null 

### DIFF
--- a/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -80,7 +80,7 @@ bool MediaQueryList::evaluate()
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-mediaquerylist-addlistener
-void MediaQueryList::add_listener(DOM::IDLEventListener* listener)
+void MediaQueryList::add_listener(JS::GCPtr<DOM::IDLEventListener> listener)
 {
     // 1. If listener is null, terminate these steps.
     if (!listener)
@@ -94,7 +94,7 @@ void MediaQueryList::add_listener(DOM::IDLEventListener* listener)
 }
 
 // https://www.w3.org/TR/cssom-view/#dom-mediaquerylist-removelistener
-void MediaQueryList::remove_listener(DOM::IDLEventListener* listener)
+void MediaQueryList::remove_listener(JS::GCPtr<DOM::IDLEventListener> listener)
 {
     // 1. Remove an event listener from the associated list of event listeners, whose type is change, callback is listener, and capture is false.
     // NOTE: While the spec doesn't technically use remove_event_listener and instead manipulates the list directly, every major engine uses remove_event_listener.

--- a/Libraries/LibWeb/CSS/MediaQueryList.cpp
+++ b/Libraries/LibWeb/CSS/MediaQueryList.cpp
@@ -99,7 +99,8 @@ void MediaQueryList::remove_listener(JS::GCPtr<DOM::IDLEventListener> listener)
     // 1. Remove an event listener from the associated list of event listeners, whose type is change, callback is listener, and capture is false.
     // NOTE: While the spec doesn't technically use remove_event_listener and instead manipulates the list directly, every major engine uses remove_event_listener.
     //       This means if an event listener removes another event listener that comes after it, the removed event listener will not be invoked.
-    remove_event_listener_without_options(HTML::EventNames::change, *listener);
+    if (listener)
+        remove_event_listener_without_options(HTML::EventNames::change, *listener);
 }
 
 void MediaQueryList::set_onchange(WebIDL::CallbackType* event_handler)

--- a/Libraries/LibWeb/CSS/MediaQueryList.h
+++ b/Libraries/LibWeb/CSS/MediaQueryList.h
@@ -26,8 +26,8 @@ public:
     bool matches() const;
     bool evaluate();
 
-    void add_listener(DOM::IDLEventListener*);
-    void remove_listener(DOM::IDLEventListener*);
+    void add_listener(JS::GCPtr<DOM::IDLEventListener>);
+    void remove_listener(JS::GCPtr<DOM::IDLEventListener>);
 
     void set_onchange(WebIDL::CallbackType*);
     WebIDL::CallbackType* onchange();


### PR DESCRIPTION
A recently imported WPT test has a subtest that effectively does the following:
```js
const mql = window.matchMedia("");
mql.removeListener(null);
```

This should fix the all-red CI currently on master.