### PR TITLE
Tests: Remove duplicate skipped test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -13,7 +13,6 @@ Text/input/Crypto/SubtleCrypto-generateKey.html
 ; Animation tests are flaky
 Text/input/css/cubic-bezier-infinite-slope-crash.html
 Text/input/css/transition-basics.html
-Text/input/wpt-import/css/css-backgrounds/animations/box-shadow-interpolation.html
 ; Flaky on CI, see #19
 Text/input/WebAnimations/misc/DocumentTimeline.html
 


### PR DESCRIPTION
Maybe it's worth doing some CI checks on the test config, to avoid this, and make sure the tests actually exist in tree. :thinkies: