### PR TITLE
UI: Send the current system visibility state to new WebContent clients

### DIFF
--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -92,6 +92,12 @@ void ViewImplementation::did_update_window_rect()
     client().async_did_update_window_rect(m_client_state.page_index);
 }
 
+void ViewImplementation::set_system_visibility_state(Web::HTML::VisibilityState visibility_state)
+{
+    m_system_visibility_state = visibility_state;
+    client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
+}
+
 void ViewImplementation::load(URL::URL const& url)
 {
     m_url = url;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -54,6 +54,8 @@ public:
     void set_window_size(Gfx::IntSize);
     void did_update_window_rect();
 
+    void set_system_visibility_state(Web::HTML::VisibilityState);
+
     void load(URL::URL const&);
     void load_html(StringView);
     void load_empty_document();
@@ -292,6 +294,8 @@ protected:
 
     RefPtr<Core::Promise<LexicalPath>> m_pending_screenshot;
     RefPtr<Core::Promise<String>> m_pending_info_request;
+
+    Web::HTML::VisibilityState m_system_visibility_state { Web::HTML::VisibilityState::Hidden };
 
     Web::HTML::AudioPlayState m_audio_play_state { Web::HTML::AudioPlayState::Paused };
     size_t m_number_of_elements_playing_audio { 0 };

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -71,7 +71,7 @@ static bool is_primitive_type(ByteString const& type)
 static bool is_simple_type(ByteString const& type)
 {
     // Small types that it makes sense just to pass by value.
-    return type.is_one_of("AK::CaseSensitivity", "AK::Duration", "Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Web::DevicePixelRect", "Core::File::OpenMode", "Web::Cookie::Source", "Web::EventResult", "Web::HTML::AllowMultipleFiles", "Web::HTML::AudioPlayState", "Web::HTML::HistoryHandlingBehavior", "WebView::PageInfoType");
+    return type.is_one_of("AK::CaseSensitivity", "AK::Duration", "Gfx::Color", "Web::DevicePixels", "Gfx::IntPoint", "Gfx::FloatPoint", "Web::DevicePixelPoint", "Gfx::IntSize", "Gfx::FloatSize", "Web::DevicePixelSize", "Web::DevicePixelRect", "Core::File::OpenMode", "Web::Cookie::Source", "Web::EventResult", "Web::HTML::AllowMultipleFiles", "Web::HTML::AudioPlayState", "Web::HTML::HistoryHandlingBehavior", "Web::HTML::VisibilityState", "WebView::PageInfoType");
 }
 
 static bool is_primitive_or_simple_type(ByteString const& type)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -1135,14 +1135,10 @@ void ConnectionFromClient::request_file(u64 page_id, Web::FileRequest file_reque
     async_did_request_file(page_id, path, id);
 }
 
-void ConnectionFromClient::set_system_visibility_state(u64 page_id, bool visible)
+void ConnectionFromClient::set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state)
 {
-    if (auto page = this->page(page_id); page.has_value()) {
-        page->page().top_level_traversable()->set_system_visibility_state(
-            visible
-                ? Web::HTML::VisibilityState::Visible
-                : Web::HTML::VisibilityState::Hidden);
-    }
+    if (auto page = this->page(page_id); page.has_value())
+        page->page().top_level_traversable()->set_system_visibility_state(visibility_state);
 }
 
 void ConnectionFromClient::js_console_input(u64 page_id, ByteString const& js_source)

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -105,7 +105,7 @@ private:
     virtual void set_window_size(u64 page_id, Web::DevicePixelSize) override;
     virtual void did_update_window_rect(u64 page_id) override;
     virtual void handle_file_return(u64 page_id, i32 error, Optional<IPC::File> const& file, i32 request_id) override;
-    virtual void set_system_visibility_state(u64 page_id, bool visible) override;
+    virtual void set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState) override;
 
     virtual void js_console_input(u64 page_id, ByteString const&) override;
     virtual void run_javascript(u64 page_id, ByteString const&) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -1,6 +1,6 @@
-#include <LibURL/URL.h>
-#include <LibIPC/File.h>
 #include <LibGfx/Rect.h>
+#include <LibIPC/File.h>
+#include <LibURL/URL.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/CSS/PreferredContrast.h>
 #include <LibWeb/CSS/PreferredMotion.h>
@@ -8,6 +8,7 @@
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/HTML/ColorPickerUpdateState.h>
 #include <LibWeb/HTML/SelectedFile.h>
+#include <LibWeb/HTML/VisibilityState.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWebView/Attribute.h>
@@ -97,7 +98,7 @@ endpoint WebContentServer
 
     handle_file_return(u64 page_id, i32 error, Optional<IPC::File> file, i32 request_id) =|
 
-    set_system_visibility_state(u64 page_id, bool visible) =|
+    set_system_visibility_state(u64 page_id, Web::HTML::VisibilityState visibility_state) =|
 
     alert_closed(u64 page_id) =|
     confirm_closed(u64 page_id, bool accepted) =|

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -212,7 +212,9 @@ struct HideCursor {
 
 - (void)handleVisibility:(BOOL)is_visible
 {
-    m_web_view_bridge->set_system_visibility_state(is_visible);
+    m_web_view_bridge->set_system_visibility_state(is_visible
+            ? Web::HTML::VisibilityState::Visible
+            : Web::HTML::VisibilityState::Hidden);
 }
 
 - (void)findInPage:(NSString*)query

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -44,11 +44,6 @@ void WebViewBridge::set_device_pixel_ratio(float device_pixel_ratio)
     client().async_set_device_pixels_per_css_pixel(m_client_state.page_index, m_device_pixel_ratio * m_zoom_level);
 }
 
-void WebViewBridge::set_system_visibility_state(bool is_visible)
-{
-    client().async_set_system_visibility_state(m_client_state.page_index, is_visible);
-}
-
 void WebViewBridge::set_viewport_rect(Gfx::IntRect viewport_rect)
 {
     viewport_rect.set_size(scale_for_device(viewport_rect.size(), m_device_pixel_ratio));

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -163,6 +163,8 @@ void WebViewBridge::initialize_client(CreateNewClient create_new_client)
 
     client().async_set_device_pixels_per_css_pixel(m_client_state.page_index, m_device_pixel_ratio);
     client().async_set_preferred_color_scheme(m_client_state.page_index, m_preferred_color_scheme);
+
+    set_system_visibility_state(m_system_visibility_state);
     update_palette();
 
     if (!m_screen_rects.is_empty()) {

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.h
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.h
@@ -31,7 +31,6 @@ public:
     void set_device_pixel_ratio(float device_pixel_ratio);
     float inverse_device_pixel_ratio() const { return 1.0f / m_device_pixel_ratio; }
 
-    void set_system_visibility_state(bool is_visible);
     void set_viewport_rect(Gfx::IntRect);
 
     void update_palette();

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -136,6 +136,8 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         m_pending_dialog = Web::Page::PendingDialog::None;
         m_pending_prompt_text.clear();
     };
+
+    m_system_visibility_state = Web::HTML::VisibilityState::Visible;
 }
 
 NonnullOwnPtr<HeadlessWebView> HeadlessWebView::create(Core::AnonymousBuffer theme, Web::DevicePixelSize window_size)
@@ -177,7 +179,7 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
     client().async_set_window_size(m_client_state.page_index, viewport_size());
     client().async_update_screen_rects(m_client_state.page_index, { screen_rect }, 0);
 
-    set_system_visibility_state(Web::HTML::VisibilityState::Visible);
+    set_system_visibility_state(m_system_visibility_state);
 
     if (Application::chrome_options().allow_popups == WebView::AllowPopups::Yes)
         client().async_debug_request(m_client_state.page_index, "block-pop-ups"sv, "off"sv);

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -54,11 +54,11 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
     };
 
     on_restore_window = [this]() {
-        client().async_set_system_visibility_state(m_client_state.page_index, true);
+        set_system_visibility_state(Web::HTML::VisibilityState::Visible);
     };
 
     on_minimize_window = [this]() {
-        client().async_set_system_visibility_state(m_client_state.page_index, false);
+        set_system_visibility_state(Web::HTML::VisibilityState::Hidden);
     };
 
     on_maximize_window = [this]() {
@@ -173,10 +173,11 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
     client().async_set_window_handle(m_client_state.page_index, m_client_state.client_handle);
 
     client().async_update_system_theme(m_client_state.page_index, m_theme);
-    client().async_set_system_visibility_state(m_client_state.page_index, true);
     client().async_set_viewport_size(m_client_state.page_index, viewport_size());
     client().async_set_window_size(m_client_state.page_index, viewport_size());
     client().async_update_screen_rects(m_client_state.page_index, { screen_rect }, 0);
+
+    set_system_visibility_state(Web::HTML::VisibilityState::Visible);
 
     if (Application::chrome_options().allow_popups == WebView::AllowPopups::Yes)
         client().async_debug_request(m_client_state.page_index, "block-pop-ups"sv, "off"sv);

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -655,8 +655,10 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
     client().async_set_window_handle(m_client_state.page_index, m_client_state.client_handle);
 
     client().async_set_device_pixels_per_css_pixel(m_client_state.page_index, m_device_pixel_ratio);
-    update_palette();
 
+    set_system_visibility_state(m_system_visibility_state);
+
+    update_palette();
     update_screen_rects();
 
     if (auto webdriver_content_ipc_path = WebView::Application::chrome_options().webdriver_content_ipc_path; webdriver_content_ipc_path.has_value())

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -557,13 +557,13 @@ void WebContentView::update_zoom()
 void WebContentView::showEvent(QShowEvent* event)
 {
     QWidget::showEvent(event);
-    client().async_set_system_visibility_state(m_client_state.page_index, true);
+    set_system_visibility_state(Web::HTML::VisibilityState::Visible);
 }
 
 void WebContentView::hideEvent(QHideEvent* event)
 {
     QWidget::hideEvent(event);
-    client().async_set_system_visibility_state(m_client_state.page_index, false);
+    set_system_visibility_state(Web::HTML::VisibilityState::Hidden);
 }
 
 static Core::AnonymousBuffer make_system_theme_from_qt_palette(QWidget& widget, WebContentView::PaletteMode mode)


### PR DESCRIPTION
After a crash, we need to inform the new WebContent process of the current system visibility state.

I think at this point, we can move most of the work that all `initialize_client` implementations do to LibWebView, but that should be a separate refactor.