### PR TITLE
UI: Set headless-browser width and height

### DIFF
--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -46,6 +46,8 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(rebaseline, "Rebaseline any executed layout or text tests", "rebaseline");
     args_parser.add_option(per_test_timeout_in_seconds, "Per-test timeout (default: 30)", "per-test-timeout", 't', "seconds");
     args_parser.add_option(verbose, "Log extra information about test results", "verbose", 'v');
+    args_parser.add_option(width, "Set viewport width in pixels (default: 800)", "width", 'W', "pixels");
+    args_parser.add_option(height, "Set viewport height in pixels (default: 600)", "height", 'H', "pixels");
 }
 
 void Application::create_platform_options(WebView::ChromeOptions& chrome_options, WebView::WebContentOptions& web_content_options)

--- a/UI/Headless/Application.h
+++ b/UI/Headless/Application.h
@@ -66,6 +66,8 @@ public:
     bool rebaseline { false };
     bool verbose { false };
     int per_test_timeout_in_seconds { 30 };
+    int width { 800 };
+    int height { 600 };
 
 private:
     RefPtr<Requests::RequestClient> m_request_client;

--- a/UI/Headless/main.cpp
+++ b/UI/Headless/main.cpp
@@ -71,8 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto theme_path = LexicalPath::join(app->resources_folder, "themes"sv, "Default.ini"sv);
     auto theme = TRY(Gfx::load_system_theme(theme_path.string()));
 
-    // FIXME: Allow passing the window size as an argument.
-    static constexpr Web::DevicePixelSize window_size { 800, 600 };
+    static Web::DevicePixelSize window_size { app->width, app->height };
 
     if (!app->test_root_path.is_empty()) {
         app->test_root_path = LexicalPath::absolute_path(TRY(FileSystem::current_working_directory()), app->test_root_path);


### PR DESCRIPTION
This change is required for https://github.com/LadybirdBrowser/ladybird/issues/2306
Otherwise, tests cannot be matched correctly 
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/672460dd-4847-4da1-b739-6149d20a6172">
