### PR TITLE
LibWebView+UI: Move common process launching / WebView init to LibWebView

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -18,7 +18,6 @@
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/URL.h>
 #include <LibWebView/UserAgent.h>
-#include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 
 namespace WebView {
@@ -180,16 +179,13 @@ ErrorOr<void> Application::launch_services()
 ErrorOr<void> Application::launch_request_server()
 {
     // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
-    auto paths = TRY(get_paths_for_helper_process("RequestServer"sv));
-    m_request_server_client = TRY(launch_request_server_process(paths));
-
+    m_request_server_client = TRY(launch_request_server_process());
     return {};
 }
 
 ErrorOr<void> Application::launch_image_decoder_server()
 {
-    auto paths = TRY(get_paths_for_helper_process("ImageDecoder"sv));
-    m_image_decoder_client = TRY(launch_image_decoder_process(paths));
+    m_image_decoder_client = TRY(launch_image_decoder_process());
 
     m_image_decoder_client->on_death = [this]() {
         m_image_decoder_client = nullptr;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -13,7 +13,9 @@
 #include <AK/Swift.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Forward.h>
+#include <LibImageDecoderClient/Client.h>
 #include <LibMain/Main.h>
+#include <LibRequests/RequestClient.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Options.h>
 #include <LibWebView/Process.h>
@@ -34,9 +36,14 @@ public:
     static ChromeOptions const& chrome_options() { return the().m_chrome_options; }
     static WebContentOptions const& web_content_options() { return the().m_web_content_options; }
 
+    static Requests::RequestClient& request_server_client() { return *the().m_request_server_client; }
+    static ImageDecoderClient::Client& image_decoder_client() { return *the().m_image_decoder_client; }
+
     static CookieJar& cookie_jar() { return *the().m_cookie_jar; }
 
     Core::EventLoop& event_loop() { return m_event_loop; }
+
+    ErrorOr<void> launch_services();
 
     void add_child_process(Process&&);
 
@@ -74,10 +81,16 @@ protected:
 private:
     void initialize(Main::Arguments const& arguments, URL::URL new_tab_page_url);
 
+    ErrorOr<void> launch_request_server();
+    ErrorOr<void> launch_image_decoder_server();
+
     static Application* s_the;
 
     ChromeOptions m_chrome_options;
     WebContentOptions m_web_content_options;
+
+    RefPtr<Requests::RequestClient> m_request_server_client;
+    RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
 
     RefPtr<Database> m_database;
     OwnPtr<CookieJar> m_cookie_jar;

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -25,10 +25,10 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     Optional<IPC::File> request_server_socket = {});
 
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths);
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths, NonnullRefPtr<Requests::RequestClient>);
-ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths, StringView serenity_resource_root);
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths);
+ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths);
 
-ErrorOr<IPC::File> connect_new_request_server_client(Requests::RequestClient&);
-ErrorOr<IPC::File> connect_new_image_decoder_client(ImageDecoderClient::Client&);
+ErrorOr<IPC::File> connect_new_request_server_client();
+ErrorOr<IPC::File> connect_new_image_decoder_client();
 
 }

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -8,8 +8,6 @@
 
 #include <AK/Error.h>
 #include <AK/Optional.h>
-#include <AK/Span.h>
-#include <AK/StringView.h>
 #include <LibImageDecoderClient/Client.h>
 #include <LibRequests/RequestClient.h>
 #include <LibWeb/Worker/WebWorkerClient.h>
@@ -20,13 +18,12 @@ namespace WebView {
 
 ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     WebView::ViewImplementation& view,
-    ReadonlySpan<ByteString> candidate_web_content_paths,
     IPC::File image_decoder_socket,
     Optional<IPC::File> request_server_socket = {});
 
-ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process(ReadonlySpan<ByteString> candidate_image_decoder_paths);
-ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process(ReadonlySpan<ByteString> candidate_web_worker_paths);
-ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process(ReadonlySpan<ByteString> candidate_request_server_paths);
+ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
+ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process();
+ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process();
 
 ErrorOr<IPC::File> connect_new_request_server_client();
 ErrorOr<IPC::File> connect_new_image_decoder_client();

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -230,7 +230,6 @@ public:
     Function<void(size_t, Gfx::IntPoint)> on_inspector_requested_cookie_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
     Function<void(String const&)> on_inspector_exported_inspector_html;
-    Function<IPC::File()> on_request_worker_agent;
 
     virtual Web::DevicePixelSize viewport_size() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -230,6 +230,7 @@ public:
     Function<void(size_t, Gfx::IntPoint)> on_inspector_requested_cookie_context_menu;
     Function<void(String const&)> on_inspector_executed_console_script;
     Function<void(String const&)> on_inspector_exported_inspector_html;
+    Function<void()> on_web_content_crashed;
 
     virtual Web::DevicePixelSize viewport_size() const = 0;
     virtual Gfx::IntPoint to_content_position(Gfx::IntPoint widget_position) const = 0;
@@ -253,7 +254,7 @@ protected:
         No,
         Yes,
     };
-    virtual void initialize_client(CreateNewClient = CreateNewClient::Yes) { }
+    virtual void initialize_client(CreateNewClient = CreateNewClient::Yes);
 
     enum class LoadErrorPage {
         No,

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -9,6 +9,7 @@
 #include "ViewImplementation.h"
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWebView/CookieJar.h>
+#include <LibWebView/HelperProcess.h>
 
 namespace WebView {
 
@@ -667,8 +668,8 @@ void WebContentClient::inspector_did_export_inspector_html(u64 page_id, String c
 Messages::WebContentClient::RequestWorkerAgentResponse WebContentClient::request_worker_agent(u64 page_id)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_request_worker_agent)
-            return view->on_request_worker_agent();
+        auto worker_client = MUST(WebView::launch_web_worker_process());
+        return worker_client->clone_transport();
     }
 
     return IPC::File {};

--- a/UI/AppKit/Application/Application.h
+++ b/UI/AppKit/Application/Application.h
@@ -23,9 +23,6 @@ class WebViewBridge;
 - (void)setupWebViewApplication:(Main::Arguments&)arguments
                   newTabPageURL:(URL::URL)new_tab_page_url;
 
-- (ErrorOr<void>)launchRequestServer;
-- (ErrorOr<void>)launchImageDecoder;
-- (ErrorOr<NonnullRefPtr<WebView::WebContentClient>>)launchWebContent:(Ladybird::WebViewBridge&)web_view_bridge;
-- (ErrorOr<IPC::File>)launchWebWorker;
+- (ErrorOr<void>)launchServices;
 
 @end

--- a/UI/AppKit/Application/Application.mm
+++ b/UI/AppKit/Application/Application.mm
@@ -7,12 +7,7 @@
 #include <Interface/LadybirdWebViewBridge.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/ThreadEventQueue.h>
-#include <LibImageDecoderClient/Client.h>
-#include <LibRequests/RequestClient.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/HelperProcess.h>
-#include <LibWebView/Utilities.h>
-#include <LibWebView/WebContentClient.h>
 #include <Utilities/Conversions.h>
 
 #import <Application/Application.h>
@@ -68,73 +63,10 @@ ApplicationBridge::ApplicationBridge(Badge<WebView::Application>, Main::Argument
     m_application_bridge = Ladybird::ApplicationBridge::create(arguments, move(new_tab_page_url));
 }
 
-- (ErrorOr<void>)launchRequestServer
+- (ErrorOr<void>)launchServices
 {
-    auto request_server_paths = TRY(WebView::get_paths_for_helper_process("RequestServer"sv));
-    m_request_server_client = TRY(WebView::launch_request_server_process(request_server_paths, WebView::s_ladybird_resource_root));
-
+    TRY(m_application_bridge->launch_services());
     return {};
-}
-
-static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decoder()
-{
-    auto image_decoder_paths = TRY(WebView::get_paths_for_helper_process("ImageDecoder"sv));
-    return WebView::launch_image_decoder_process(image_decoder_paths);
-}
-
-- (ErrorOr<void>)launchImageDecoder
-{
-    m_image_decoder_client = TRY(launch_new_image_decoder());
-
-    __weak Application* weak_self = self;
-
-    m_image_decoder_client->on_death = [weak_self]() {
-        Application* self = weak_self;
-        if (self == nil) {
-            return;
-        }
-
-        m_image_decoder_client = nullptr;
-
-        if (auto err = [self launchImageDecoder]; err.is_error()) {
-            dbgln("Failed to restart image decoder: {}", err.error());
-            VERIFY_NOT_REACHED();
-        }
-
-        auto num_clients = WebView::WebContentClient::client_count();
-        auto new_sockets = m_image_decoder_client->send_sync_but_allow_failure<Messages::ImageDecoderServer::ConnectNewClients>(num_clients);
-        if (!new_sockets || new_sockets->sockets().size() == 0) {
-            dbgln("Failed to connect {} new clients to ImageDecoder", num_clients);
-            VERIFY_NOT_REACHED();
-        }
-
-        WebView::WebContentClient::for_each_client([sockets = new_sockets->take_sockets()](WebView::WebContentClient& client) mutable {
-            client.async_connect_to_image_decoder(sockets.take_last());
-            return IterationDecision::Continue;
-        });
-    };
-
-    return {};
-}
-
-- (ErrorOr<NonnullRefPtr<WebView::WebContentClient>>)launchWebContent:(Ladybird::WebViewBridge&)web_view_bridge
-{
-    // FIXME: Fail to open the tab, rather than crashing the whole application if this fails
-    auto request_server_socket = TRY(WebView::connect_new_request_server_client(*m_request_server_client));
-    auto image_decoder_socket = TRY(WebView::connect_new_image_decoder_client(*m_image_decoder_client));
-
-    auto web_content_paths = TRY(WebView::get_paths_for_helper_process("WebContent"sv));
-    auto web_content = TRY(WebView::launch_web_content_process(web_view_bridge, web_content_paths, move(image_decoder_socket), move(request_server_socket)));
-
-    return web_content;
-}
-
-- (ErrorOr<IPC::File>)launchWebWorker
-{
-    auto web_worker_paths = TRY(WebView::get_paths_for_helper_process("WebWorker"sv));
-    auto worker_client = TRY(WebView::launch_web_worker_process(web_worker_paths, *m_request_server_client));
-
-    return worker_client->clone_transport();
 }
 
 #pragma mark - NSApplication

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -16,7 +16,6 @@
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <LibWebView/URL.h>
-#include <LibWebView/Utilities.h>
 
 #import <Application/Application.h>
 #import <Application/ApplicationDelegate.h>
@@ -347,7 +346,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
     };
 
     m_web_view_bridge->on_request_worker_agent = []() {
-        auto worker_client = MUST(WebView::launch_web_worker_process(MUST(WebView::get_paths_for_helper_process("WebWorker"sv))));
+        auto worker_client = MUST(WebView::launch_web_worker_process());
         return worker_client->clone_transport();
     };
 

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -12,7 +12,6 @@
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/HelperProcess.h>
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/SourceHighlighter.h>
 #include <LibWebView/URL.h>
@@ -343,11 +342,6 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         }
 
         return [self.observer onCreateNewTab:{} activateTab:activate_tab];
-    };
-
-    m_web_view_bridge->on_request_worker_agent = []() {
-        auto worker_client = MUST(WebView::launch_web_worker_process());
-        return worker_client->clone_transport();
     };
 
     m_web_view_bridge->on_activate_tab = [weak_self]() {

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -12,7 +12,6 @@
 #include <LibWebView/Application.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/UserAgent.h>
-#include <LibWebView/Utilities.h>
 
 #import <Interface/Palette.h>
 
@@ -151,10 +150,7 @@ void WebViewBridge::initialize_client(CreateNewClient create_new_client)
         auto request_server_socket = WebView::connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
         auto image_decoder_socket = WebView::connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
 
-        auto candidate_web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-        auto new_client = launch_web_content_process(*this, candidate_web_content_paths, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
-
-        m_client_state.client = new_client;
+        m_client_state.client = launch_web_content_process(*this, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.cpp
@@ -10,7 +10,9 @@
 #include <LibIPC/File.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWebView/Application.h>
+#include <LibWebView/HelperProcess.h>
 #include <LibWebView/UserAgent.h>
+#include <LibWebView/Utilities.h>
 
 #import <Interface/Palette.h>
 
@@ -143,11 +145,16 @@ Gfx::IntPoint WebViewBridge::to_widget_position(Gfx::IntPoint content_position) 
 
 void WebViewBridge::initialize_client(CreateNewClient create_new_client)
 {
-    VERIFY(on_request_web_content);
-
     if (create_new_client == CreateNewClient::Yes) {
         m_client_state = {};
-        m_client_state.client = on_request_web_content();
+
+        auto request_server_socket = WebView::connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
+        auto image_decoder_socket = WebView::connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
+
+        auto candidate_web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
+        auto new_client = launch_web_content_process(*this, candidate_web_content_paths, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
+
+        m_client_state.client = new_client;
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }

--- a/UI/AppKit/Interface/LadybirdWebViewBridge.h
+++ b/UI/AppKit/Interface/LadybirdWebViewBridge.h
@@ -50,7 +50,6 @@ public:
     };
     Optional<Paintable> paintable();
 
-    Function<NonnullRefPtr<WebView::WebContentClient>()> on_request_web_content;
     Function<void()> on_zoom_level_changed;
 
 private:

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -83,10 +83,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             view->did_allocate_iosurface_backing_stores(message.front_backing_store_id, move(message.front_backing_store_port), message.back_backing_store_id, move(message.back_backing_store_port));
     };
 
-    // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
-    TRY([application launchRequestServer]);
-
-    TRY([application launchImageDecoder]);
+    TRY([application launchServices]);
 
     auto* delegate = [[ApplicationDelegate alloc] init];
     [NSApp setDelegate:delegate];

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -71,17 +71,6 @@ void Application::create_platform_options(WebView::ChromeOptions& chrome_options
     web_content_options.is_layout_test_mode = is_layout_test_mode ? WebView::IsLayoutTestMode::Yes : WebView::IsLayoutTestMode::No;
 }
 
-ErrorOr<void> Application::launch_services()
-{
-    auto request_server_paths = TRY(WebView::get_paths_for_helper_process("RequestServer"sv));
-    m_request_client = TRY(WebView::launch_request_server_process(request_server_paths, resources_folder));
-
-    auto image_decoder_paths = TRY(WebView::get_paths_for_helper_process("ImageDecoder"sv));
-    m_image_decoder_client = TRY(WebView::launch_image_decoder_process(image_decoder_paths));
-
-    return {};
-}
-
 ErrorOr<void> Application::launch_test_fixtures()
 {
     Fixture::initialize_fixtures();

--- a/UI/Headless/Application.h
+++ b/UI/Headless/Application.h
@@ -9,10 +9,7 @@
 #include <AK/ByteString.h>
 #include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
-#include <AK/RefPtr.h>
 #include <AK/Vector.h>
-#include <LibImageDecoderClient/Client.h>
-#include <LibRequests/RequestClient.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWebView/Application.h>
 
@@ -34,11 +31,7 @@ public:
     virtual void create_platform_arguments(Core::ArgsParser&) override;
     virtual void create_platform_options(WebView::ChromeOptions&, WebView::WebContentOptions&) override;
 
-    ErrorOr<void> launch_services();
     ErrorOr<void> launch_test_fixtures();
-
-    static Requests::RequestClient& request_client() { return *the().m_request_client; }
-    static ImageDecoderClient::Client& image_decoder_client() { return *the().m_image_decoder_client; }
 
     HeadlessWebView& create_web_view(Core::AnonymousBuffer theme, Web::DevicePixelSize window_size);
     HeadlessWebView& create_child_web_view(HeadlessWebView const&, u64 page_index);
@@ -68,9 +61,6 @@ public:
     int per_test_timeout_in_seconds { 30 };
 
 private:
-    RefPtr<Requests::RequestClient> m_request_client;
-    RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
-
     Vector<NonnullOwnPtr<HeadlessWebView>> m_web_views;
 };
 

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -30,11 +30,6 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
         return web_view.handle();
     };
 
-    on_request_worker_agent = []() {
-        auto worker_client = MUST(WebView::launch_web_worker_process());
-        return worker_client->clone_transport();
-    };
-
     on_reposition_window = [this](auto position) {
         client().async_set_window_position(m_client_state.page_index, position.template to_type<Web::DevicePixels>());
 

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -8,7 +8,6 @@
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWebView/HelperProcess.h>
-#include <LibWebView/Utilities.h>
 #include <UI/Headless/Application.h>
 #include <UI/Headless/HeadlessWebView.h>
 
@@ -32,9 +31,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
     };
 
     on_request_worker_agent = []() {
-        auto web_worker_paths = MUST(WebView::get_paths_for_helper_process("WebWorker"sv));
-        auto worker_client = MUST(WebView::launch_web_worker_process(web_worker_paths));
-
+        auto worker_client = MUST(WebView::launch_web_worker_process());
         return worker_client->clone_transport();
     };
 
@@ -165,8 +162,7 @@ void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
         auto request_server_socket = WebView::connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
         auto image_decoder_socket = WebView::connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
 
-        auto web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-        m_client_state.client = WebView::launch_web_content_process(*this, web_content_paths, move(image_decoder_socket), move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
+        m_client_state.client = WebView::launch_web_content_process(*this, move(image_decoder_socket), move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }

--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -33,7 +33,7 @@ HeadlessWebView::HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSi
 
     on_request_worker_agent = []() {
         auto web_worker_paths = MUST(WebView::get_paths_for_helper_process("WebWorker"sv));
-        auto worker_client = MUST(WebView::launch_web_worker_process(web_worker_paths, Application::request_client()));
+        auto worker_client = MUST(WebView::launch_web_worker_process(web_worker_paths));
 
         return worker_client->clone_transport();
     };
@@ -162,8 +162,8 @@ NonnullOwnPtr<HeadlessWebView> HeadlessWebView::create_child(HeadlessWebView con
 void HeadlessWebView::initialize_client(CreateNewClient create_new_client)
 {
     if (create_new_client == CreateNewClient::Yes) {
-        auto request_server_socket = WebView::connect_new_request_server_client(Application::request_client()).release_value_but_fixme_should_propagate_errors();
-        auto image_decoder_socket = WebView::connect_new_image_decoder_client(Application::image_decoder_client()).release_value_but_fixme_should_propagate_errors();
+        auto request_server_socket = WebView::connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
+        auto image_decoder_socket = WebView::connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
 
         auto web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
         m_client_state.client = WebView::launch_web_content_process(*this, web_content_paths, move(image_decoder_socket), move(request_server_socket)).release_value_but_fixme_should_propagate_errors();

--- a/UI/Headless/HeadlessWebView.h
+++ b/UI/Headless/HeadlessWebView.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/Function.h>
 #include <AK/RefPtr.h>
 #include <LibCore/Forward.h>
 #include <LibCore/Promise.h>
@@ -30,8 +29,6 @@ public:
 
     TestPromise& test_promise() { return *m_test_promise; }
     void on_test_complete(TestCompletion);
-
-    Function<void()> on_web_content_crashed;
 
 private:
     HeadlessWebView(Core::AnonymousBuffer theme, Web::DevicePixelSize viewport_size);

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -5,9 +5,7 @@
  */
 
 #include <LibCore/ArgsParser.h>
-#include <LibWebView/HelperProcess.h>
 #include <LibWebView/URL.h>
-#include <LibWebView/Utilities.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/Settings.h>
 #include <UI/Qt/StringUtils.h>
@@ -52,38 +50,6 @@ bool Application::event(QEvent* event)
     }
 
     return QApplication::event(event);
-}
-
-static ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_new_image_decoder()
-{
-    auto paths = TRY(WebView::get_paths_for_helper_process("ImageDecoder"sv));
-    return WebView::launch_image_decoder_process(paths);
-}
-
-ErrorOr<void> Application::initialize_image_decoder()
-{
-    m_image_decoder_client = TRY(launch_new_image_decoder());
-
-    m_image_decoder_client->on_death = [this] {
-        m_image_decoder_client = nullptr;
-        if (auto err = this->initialize_image_decoder(); err.is_error()) {
-            dbgln("Failed to restart image decoder: {}", err.error());
-            VERIFY_NOT_REACHED();
-        }
-
-        auto num_clients = WebView::WebContentClient::client_count();
-        auto new_sockets = m_image_decoder_client->send_sync_but_allow_failure<Messages::ImageDecoderServer::ConnectNewClients>(num_clients);
-        if (!new_sockets || new_sockets->sockets().size() == 0) {
-            dbgln("Failed to connect {} new clients to ImageDecoder", num_clients);
-            VERIFY_NOT_REACHED();
-        }
-
-        WebView::WebContentClient::for_each_client([sockets = new_sockets->take_sockets()](WebView::WebContentClient& client) mutable {
-            client.async_connect_to_image_decoder(sockets.take_last());
-            return IterationDecision::Continue;
-        });
-    };
-    return {};
 }
 
 void Application::show_task_manager_window()

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -7,9 +7,6 @@
 #pragma once
 
 #include <AK/Function.h>
-#include <AK/HashTable.h>
-#include <LibImageDecoderClient/Client.h>
-#include <LibRequests/RequestClient.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Application.h>
 #include <UI/Qt/BrowserWindow.h>
@@ -30,10 +27,6 @@ public:
     virtual bool event(QEvent* event) override;
 
     Function<void(URL::URL)> on_open_file;
-    RefPtr<Requests::RequestClient> request_server_client;
-
-    NonnullRefPtr<ImageDecoderClient::Client> image_decoder_client() const { return *m_image_decoder_client; }
-    ErrorOr<void> initialize_image_decoder();
 
     BrowserWindow& new_window(Vector<URL::URL> const& initial_urls, BrowserWindow::IsPopupWindow is_popup_window = BrowserWindow::IsPopupWindow::No, Tab* parent_tab = nullptr, Optional<u64> page_index = {});
 
@@ -50,8 +43,6 @@ private:
 
     TaskManagerWindow* m_task_manager_window { nullptr };
     BrowserWindow* m_active_window { nullptr };
-
-    RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
 };
 
 }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -25,7 +25,6 @@
 #include <LibWeb/UIEvents/MouseButton.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HelperProcess.h>
-#include <LibWebView/Utilities.h>
 #include <LibWebView/WebContentClient.h>
 #include <UI/Qt/Application.h>
 #include <UI/Qt/StringUtils.h>
@@ -128,7 +127,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     };
 
     on_request_worker_agent = [&]() {
-        auto worker_client = MUST(WebView::launch_web_worker_process(MUST(WebView::get_paths_for_helper_process("WebWorker"sv))));
+        auto worker_client = MUST(WebView::launch_web_worker_process());
         return worker_client->clone_transport();
     };
 
@@ -632,10 +631,7 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
         auto request_server_socket = WebView::connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
         auto image_decoder_socket = WebView::connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
 
-        auto candidate_web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
-        auto new_client = launch_web_content_process(*this, candidate_web_content_paths, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
-
-        m_client_state.client = new_client;
+        m_client_state.client = launch_web_content_process(*this, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -128,8 +128,7 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
     };
 
     on_request_worker_agent = [&]() {
-        auto& request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
-        auto worker_client = MUST(WebView::launch_web_worker_process(MUST(WebView::get_paths_for_helper_process("WebWorker"sv)), *request_server_client));
+        auto worker_client = MUST(WebView::launch_web_worker_process(MUST(WebView::get_paths_for_helper_process("WebWorker"sv))));
         return worker_client->clone_transport();
     };
 
@@ -629,13 +628,9 @@ void WebContentView::initialize_client(WebView::ViewImplementation::CreateNewCli
     if (create_new_client == CreateNewClient::Yes) {
         m_client_state = {};
 
-        auto& request_server_client = static_cast<Ladybird::Application*>(QApplication::instance())->request_server_client;
-
-        // FIXME: Fail to open the tab, rather than crashing the whole application if this fails
-        auto request_server_socket = WebView::connect_new_request_server_client(*request_server_client).release_value_but_fixme_should_propagate_errors();
-
-        auto image_decoder = static_cast<Ladybird::Application*>(QApplication::instance())->image_decoder_client();
-        auto image_decoder_socket = WebView::connect_new_image_decoder_client(*image_decoder).release_value_but_fixme_should_propagate_errors();
+        // FIXME: Fail to open the tab, rather than crashing the whole application if these fail.
+        auto request_server_socket = WebView::connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
+        auto image_decoder_socket = WebView::connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
 
         auto candidate_web_content_paths = WebView::get_paths_for_helper_process("WebContent"sv).release_value_but_fixme_should_propagate_errors();
         auto new_client = launch_web_content_process(*this, candidate_web_content_paths, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -126,11 +126,6 @@ WebContentView::WebContentView(QWidget* window, RefPtr<WebView::WebContentClient
         finish_handling_drag_event(event);
     };
 
-    on_request_worker_agent = [&]() {
-        auto worker_client = MUST(WebView::launch_web_worker_process());
-        return worker_client->clone_transport();
-    };
-
     m_select_dropdown = new QMenu("Select Dropdown", this);
     QObject::connect(m_select_dropdown, &QMenu::aboutToHide, this, [this]() {
         if (!m_select_dropdown->activeAction())

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -114,12 +114,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     WebView::copy_default_config_files(Ladybird::Settings::the()->directory());
 
-    // FIXME: Create an abstraction to re-spawn the RequestServer and re-hook up its client hooks to each tab on crash
-    auto request_server_paths = TRY(WebView::get_paths_for_helper_process("RequestServer"sv));
-    auto requests_client = TRY(WebView::launch_request_server_process(request_server_paths, WebView::s_ladybird_resource_root));
-    app->request_server_client = move(requests_client);
-
-    TRY(app->initialize_image_decoder());
+    TRY(app->launch_services());
 
     chrome_process.on_new_window = [&](auto const& urls) {
         app->new_window(urls);


### PR DESCRIPTION
Now that these steps can all be handled within LibWebView, there's no need to have every UI manually implement them.