### PR TITLE
LibWeb+LibWebView: Use system font for Mathematical symbols and operators.

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -32,8 +32,8 @@ runs:
 
         sudo apt-get update -y
         sudo apt-get install -y autoconf autoconf-archive automake build-essential ccache clang-18 clang++-18 cmake curl fonts-liberation2 \
-            gcc-13 g++-13 libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev \
-            libstdc++-13-dev lld-18 nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
+            fonts-noto-core gcc-13 g++-13 libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev libstdc++-13-dev lld-18 nasm \
+            ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
@@ -57,7 +57,7 @@ runs:
       run: |
         set -e
         brew update
-        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@18 nasm ninja qt unzip wabt
+        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@18 nasm ninja font-noto-sans-math qt unzip wabt
 
     - name: 'Install vcpkg'
       shell: bash

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2095,6 +2095,10 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
         font_list->add(*emoji_font);
     }
 
+    if (auto math_font = Platform::FontPlugin::the().default_math_font(font_size_in_pt); math_font) {
+        font_list->add(*math_font);
+    }
+
     auto found_font = StyleProperties::font_fallback(monospace, bold);
     font_list->set_last_resort_font(found_font->with_size(font_size_in_pt));
 

--- a/Libraries/LibWeb/Platform/FontPlugin.h
+++ b/Libraries/LibWeb/Platform/FontPlugin.h
@@ -34,6 +34,7 @@ public:
     virtual Gfx::Font& default_font() = 0;
     virtual Gfx::Font& default_fixed_width_font() = 0;
     virtual RefPtr<Gfx::Font> default_emoji_font(float point_size) = 0;
+    virtual RefPtr<Gfx::Font> default_math_font(float point_size) = 0;
 
     virtual FlyString generic_font_name(GenericFont) = 0;
 };

--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -80,6 +80,11 @@ RefPtr<Gfx::Font> FontPlugin::default_emoji_font(float point_size)
     return Gfx::FontDatabase::the().get(default_emoji_font_name, point_size, 400, Gfx::FontWidth::Normal, 0);
 }
 
+RefPtr<Gfx::Font> FontPlugin::default_math_font(float point_size)
+{
+    return Gfx::FontDatabase::the().get("Noto Sans Math"_fly_string, point_size, 400, Gfx::FontWidth::Normal, 0);
+}
+
 #ifdef USE_FONTCONFIG
 static Optional<String> query_fontconfig_for_generic_family(Web::Platform::GenericFont generic_font)
 {

--- a/Libraries/LibWebView/Plugins/FontPlugin.h
+++ b/Libraries/LibWebView/Plugins/FontPlugin.h
@@ -21,6 +21,7 @@ public:
     virtual Gfx::Font& default_font() override;
     virtual Gfx::Font& default_fixed_width_font() override;
     virtual RefPtr<Gfx::Font> default_emoji_font(float point_size) override;
+    virtual RefPtr<Gfx::Font> default_math_font(float point_size) override;
     virtual FlyString generic_font_name(Web::Platform::GenericFont) override;
 
     void update_generic_fonts();

--- a/Tests/LibWeb/Layout/expected/css-text-transform-math-auto.txt
+++ b/Tests/LibWeb/Layout/expected/css-text-transform-math-auto.txt
@@ -2,8 +2,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,16) content-size 784x17 children: not-inline
       BlockContainer <p> at (8,16) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 67, rect: [8,16 118.40625x17] baseline: 13.296875
-            "𝑊𝑒𝑙𝑙, ℎ𝑒𝑙𝑙𝑜 𝑓𝑟𝑖𝑒𝑛𝑑𝑠!"
+        frag 0 from TextNode start: 0, length: 16, rect: [8,16 29.171875x17] baseline: 13.296875
+            "𝑊𝑒𝑙𝑙"
+        frag 1 from TextNode start: 16, length: 2, rect: [37,16 13.046875x17] baseline: 13.296875
+            ", "
+        frag 2 from TextNode start: 18, length: 19, rect: [50,16 33x17] baseline: 13.296875
+            "ℎ𝑒𝑙𝑙𝑜"
+        frag 3 from TextNode start: 37, length: 1, rect: [83,16 8x17] baseline: 13.296875
+            " "
+        frag 4 from TextNode start: 38, length: 28, rect: [91,16 44.171875x17] baseline: 13.296875
+            "𝑓𝑟𝑖𝑒𝑛𝑑𝑠"
+        frag 5 from TextNode start: 66, length: 1, rect: [135,16 3.859375x17] baseline: 13.296875
+            "!"
         TextNode <#text>
       BlockContainer <(anonymous)> at (8,49) content-size 784x0 children: inline
         TextNode <#text>


### PR DESCRIPTION
Adds math symbols rendering support on linux (if it has "Noto Sans Math" font). Closes #2332 

The change broke the test `css-text-transform-math-auto.html`, but fixes the exibition:

_before_
![image](https://github.com/user-attachments/assets/58126644-5f46-472b-957a-7f888ca7476b)

_after_
![image](https://github.com/user-attachments/assets/6e7e322c-c1a7-4d90-b9d0-f6988ee4c9d1)

The test was adjusted accordingly.

