### PR TITLE
LibWeb: Consolidate the attribute change handlers

### DIFF
--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -173,11 +173,7 @@ public:
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const { }
 
-    // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
-    virtual void attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
-
     void run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value);
 
     CSS::RequiredInvalidationAfterStyleChange recompute_style();
 
@@ -429,6 +425,9 @@ protected:
     virtual void removed_from(Node*) override;
     virtual void children_changed() override;
     virtual i32 default_tab_index_value() const;
+
+    // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext
+    virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
 
     virtual void computed_css_values_changed() { }
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -23,33 +23,33 @@ namespace Web::HTML {
 //    HTMLElement::inserted() -> Use form_associated_element_was_inserted()
 //    HTMLElement::removed_from() -> Use form_associated_element_was_removed()
 //
-#define FORM_ASSOCIATED_ELEMENT(ElementBaseClass, ElementClass)                                                                      \
-private:                                                                                                                             \
-    virtual HTMLElement& form_associated_element_to_html_element() override                                                          \
-    {                                                                                                                                \
-        static_assert(IsBaseOf<HTMLElement, ElementClass>);                                                                          \
-        return *this;                                                                                                                \
-    }                                                                                                                                \
-                                                                                                                                     \
-    virtual void inserted() override                                                                                                 \
-    {                                                                                                                                \
-        ElementBaseClass::inserted();                                                                                                \
-        form_node_was_inserted();                                                                                                    \
-        form_associated_element_was_inserted();                                                                                      \
-    }                                                                                                                                \
-                                                                                                                                     \
-    virtual void removed_from(DOM::Node* node) override                                                                              \
-    {                                                                                                                                \
-        ElementBaseClass::removed_from(node);                                                                                        \
-        form_node_was_removed();                                                                                                     \
-        form_associated_element_was_removed(node);                                                                                   \
-    }                                                                                                                                \
-                                                                                                                                     \
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override \
-    {                                                                                                                                \
-        ElementBaseClass::attribute_changed(name, old_value, value);                                                                 \
-        form_node_attribute_changed(name, value);                                                                                    \
-        form_associated_element_attribute_changed(name, value);                                                                      \
+#define FORM_ASSOCIATED_ELEMENT(ElementBaseClass, ElementClass)                                                                                                             \
+private:                                                                                                                                                                    \
+    virtual HTMLElement& form_associated_element_to_html_element() override                                                                                                 \
+    {                                                                                                                                                                       \
+        static_assert(IsBaseOf<HTMLElement, ElementClass>);                                                                                                                 \
+        return *this;                                                                                                                                                       \
+    }                                                                                                                                                                       \
+                                                                                                                                                                            \
+    virtual void inserted() override                                                                                                                                        \
+    {                                                                                                                                                                       \
+        ElementBaseClass::inserted();                                                                                                                                       \
+        form_node_was_inserted();                                                                                                                                           \
+        form_associated_element_was_inserted();                                                                                                                             \
+    }                                                                                                                                                                       \
+                                                                                                                                                                            \
+    virtual void removed_from(DOM::Node* node) override                                                                                                                     \
+    {                                                                                                                                                                       \
+        ElementBaseClass::removed_from(node);                                                                                                                               \
+        form_node_was_removed();                                                                                                                                            \
+        form_associated_element_was_removed(node);                                                                                                                          \
+    }                                                                                                                                                                       \
+                                                                                                                                                                            \
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override \
+    {                                                                                                                                                                       \
+        ElementBaseClass::attribute_changed(name, old_value, value, namespace_);                                                                                            \
+        form_node_attribute_changed(name, value);                                                                                                                           \
+        form_associated_element_attribute_changed(name, value);                                                                                                             \
     }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#selection-direction

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -40,9 +40,10 @@ void HTMLAnchorElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_rel_list);
 }
 
-void HTMLAnchorElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLAnchorElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == HTML::AttributeNames::href) {
         set_the_url();
     } else if (name == HTML::AttributeNames::rel) {

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -46,7 +46,7 @@ private:
     virtual bool has_download_preference() const;
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.cpp
@@ -33,9 +33,10 @@ void HTMLAreaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_rel_list);
 }
 
-void HTMLAreaElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLAreaElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == HTML::AttributeNames::href) {
         set_the_url();
     } else if (name == HTML::AttributeNames::rel) {

--- a/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -29,7 +29,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
 
     // ^HTML::HTMLHyperlinkElementUtils

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -46,9 +46,9 @@ void HTMLBaseElement::removed_from(Node* parent)
     document().update_base_element({});
 }
 
-void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLBaseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // The frozen base URL must be immediately set for an element whenever any of the following situations occur:
     // - The base element is the first base element in tree order with an href content attribute in its Document, and its href content attribute is changed.

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -24,7 +24,7 @@ public:
 
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
 private:
     HTMLBaseElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -59,9 +59,10 @@ void HTMLBodyElement::apply_presentational_hints(CSS::StyleProperties& style) co
     });
 }
 
-void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name.equals_ignoring_ascii_case("link"sv)) {
         // https://html.spec.whatwg.org/multipage/rendering.html#the-page:rules-for-parsing-a-legacy-colour-value-3
         auto color = parse_legacy_color_value(value.value_or(String {}));

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.h
@@ -21,7 +21,7 @@ class HTMLBodyElement final
 public:
     virtual ~HTMLBodyElement() override;
 
-    virtual void attribute_changed(FlyString const&, Optional<String> const& old_value, Optional<String> const&) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     // https://www.w3.org/TR/html-aria/#el-body

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -53,9 +53,9 @@ void HTMLDetailsElement::removed_from(DOM::Node*)
     set_shadow_root(nullptr);
 }
 
-void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // https://html.spec.whatwg.org/multipage/interactive-elements.html#details-notification-task-steps
     if (name == HTML::AttributeNames::open) {

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -34,7 +34,7 @@ private:
     virtual void inserted() override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);
 

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -595,9 +595,10 @@ bool HTMLElement::cannot_navigate() const
     return !is<HTML::HTMLAnchorElement>(this) && !is_connected();
 }
 
-void HTMLElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Element::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+    HTMLOrSVGElement::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::contenteditable) {
         if (!value.has_value()) {
@@ -625,12 +626,6 @@ void HTMLElement::attribute_changed(FlyString const& name, Optional<String> cons
     }
     ENUMERATE_GLOBAL_EVENT_HANDLERS(__ENUMERATE)
 #undef __ENUMERATE
-}
-
-void HTMLElement::attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
-{
-    Base::attribute_change_steps(local_name, old_value, value, namespace_);
-    HTMLOrSVGElement::attribute_change_steps(local_name, old_value, value, namespace_);
 }
 
 WebIDL::ExceptionOr<void> HTMLElement::cloned(Web::DOM::Node& copy, bool clone_children)

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -81,8 +81,7 @@ protected:
 
     virtual void initialize(JS::Realm&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
-    virtual void attribute_change_steps(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) override;
     virtual void inserted() override;
 

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -602,9 +602,10 @@ WebIDL::ExceptionOr<void> HTMLFormElement::set_action(String const& value)
     return set_attribute(AttributeNames::action, value);
 }
 
-void HTMLFormElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLFormElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == HTML::AttributeNames::rel) {
         if (m_rel_list)
             m_rel_list->associated_attribute_changed(value.value_or(String {}));

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -108,7 +108,7 @@ private:
     virtual JS::Value named_item_value(FlyString const& name) const override;
     virtual Vector<FlyString> supported_property_names() const override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     ErrorOr<String> pick_an_encoding() const;
 

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -65,9 +65,9 @@ void HTMLFrameElement::removed_from(DOM::Node* node)
 }
 
 // https://html.spec.whatwg.org/multipage/obsolete.html#frames:frame-3
-void HTMLFrameElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLFrameElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // Whenever a frame element with a non-null content navigable has its src attribute set, changed, or removed, the
     // user agent must process the frame attributes.

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.h
@@ -26,7 +26,7 @@ private:
     // ^DOM::Element
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
     virtual void adjust_computed_style(CSS::StyleProperties&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -34,9 +34,9 @@ void HTMLFrameSetElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLFrameSetElement);
 }
 
-void HTMLFrameSetElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLFrameSetElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)                     \

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.h
@@ -27,7 +27,7 @@ private:
     virtual void adjust_computed_style(CSS::StyleProperties&) override;
 
     virtual void initialize(JS::Realm&) override;
-    virtual void attribute_changed(FlyString const&, Optional<String> const& old_value, Optional<String> const&) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     // ^HTML::GlobalEventHandlers
     virtual JS::GCPtr<EventTarget> global_event_handlers_to_event_target(FlyString const& event_name) override;

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -45,9 +45,9 @@ void HTMLIFrameElement::adjust_computed_style(CSS::StyleProperties& style)
         style.set_property(CSS::PropertyID::Display, CSS::DisplayStyleValue::create(CSS::Display::from_short(CSS::Display::Short::None)));
 }
 
-void HTMLIFrameElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLIFrameElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:process-the-iframe-attributes-2
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:process-the-iframe-attributes-3

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -41,7 +41,7 @@ private:
     // ^DOM::Element
     virtual void inserted() override;
     virtual void removed_from(Node*) override;
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
 
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:dimension-attributes

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -129,9 +129,9 @@ bool HTMLLinkElement::has_loaded_icon() const
     return m_relationship & Relationship::Icon && resource() && resource()->is_loaded() && resource()->has_encoded_data();
 }
 
-void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // 4.6.7 Link types - https://html.spec.whatwg.org/multipage/links.html#linkTypes
     if (name == HTML::AttributeNames::rel) {

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -47,7 +47,7 @@ private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void attribute_changed(FlyString const&, Optional<String> const& old_value, Optional<String> const&) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -98,9 +98,9 @@ void HTMLMediaElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_pending_play_promises);
 }
 
-void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::src) {
         load_element().release_value_but_fixme_should_propagate_errors();

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -140,7 +140,7 @@ protected:
     virtual void finalize() override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
 

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -34,9 +34,9 @@ void HTMLOptionElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLOptionElement);
 }
 
-void HTMLOptionElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLOptionElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::selected) {
         if (!value.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -44,7 +44,7 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
-    void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void ask_for_a_reset();
 

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
@@ -58,7 +58,7 @@ void HTMLOrSVGElement<ElementBase>::blur()
 
 // https://html.spec.whatwg.org/#dom-noncedelement-nonce
 template<typename ElementBase>
-void HTMLOrSVGElement<ElementBase>::attribute_change_steps(FlyString const& local_name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const& namespace_)
+void HTMLOrSVGElement<ElementBase>::attribute_changed(FlyString const& local_name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
     // 1. If element does not include HTMLOrSVGElement, then return.
     // 2. If localName is not nonce or namespace is not null, then return.

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.h
@@ -25,7 +25,7 @@ public:
     void blur();
 
 protected:
-    void attribute_change_steps(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&);
+    void attribute_changed(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&);
     WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool);
     void inserted();
     void visit_edges(JS::Cell::Visitor&);

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -50,9 +50,9 @@ void HTMLScriptElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_preparation_time_document);
 }
 
-void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::crossorigin) {
         m_crossorigin = cors_setting_attribute_from_keyword(value);

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -70,7 +70,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
     void prepare_script();

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -117,9 +117,9 @@ void HTMLSlotElement::assign(Vector<SlottableHandle> nodes)
 }
 
 // https://dom.spec.whatwg.org/#ref-for-concept-element-attributes-change-ext
-void HTMLSlotElement::attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+void HTMLSlotElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_change_steps(local_name, old_value, value, namespace_);
+    Base::attribute_changed(local_name, old_value, value, namespace_);
 
     // 1. If element is a slot, localName is name, and namespace is null, then:
     if (local_name == AttributeNames::name && !namespace_.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.h
@@ -45,7 +45,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
-    virtual void attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes
     Vector<DOM::Slottable> m_manually_assigned_nodes;

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -108,9 +108,10 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
     });
 }
 
-void HTMLTableElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLTableElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == HTML::AttributeNames::cellpadding) {
         if (value.has_value())
             m_padding = max(0, parse_integer(value.value()).value_or(0));

--- a/Libraries/LibWeb/HTML/HTMLTableElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.h
@@ -59,7 +59,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     JS::GCPtr<DOM::HTMLCollection> mutable m_rows;
     JS::GCPtr<DOM::HTMLCollection> mutable m_t_bodies;

--- a/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -35,9 +35,9 @@ void HTMLTrackElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_track);
 }
 
-void HTMLTrackElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLTrackElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    HTMLElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // https://html.spec.whatwg.org/multipage/media.html#sourcing-out-of-band-text-tracks
     // As the kind, label, and srclang attributes are set, changed, or removed, the text track must update accordingly, as per the definitions above.

--- a/Libraries/LibWeb/HTML/HTMLTrackElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTrackElement.h
@@ -30,7 +30,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     JS::GCPtr<TextTrack> m_track;
 };

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -54,9 +54,9 @@ void HTMLVideoElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_fetch_controller);
 }
 
-void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void HTMLVideoElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == HTML::AttributeNames::poster) {
         determine_element_poster_frame(value).release_value_but_fixme_should_propagate_errors();

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -55,7 +55,7 @@ private:
     virtual void finalize() override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     // https://html.spec.whatwg.org/multipage/media.html#the-video-element:dimension-attributes
     virtual bool supports_dimension_attributes() const override { return true; }

--- a/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -20,10 +20,10 @@ MathMLElement::MathMLElement(DOM::Document& document, DOM::QualifiedName qualifi
 {
 }
 
-void MathMLElement::attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+void MathMLElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_change_steps(local_name, old_value, value, namespace_);
-    HTMLOrSVGElement::attribute_change_steps(local_name, old_value, value, namespace_);
+    Base::attribute_changed(local_name, old_value, value, namespace_);
+    HTMLOrSVGElement::attribute_changed(local_name, old_value, value, namespace_);
 }
 
 WebIDL::ExceptionOr<void> MathMLElement::cloned(DOM::Node& node, bool clone_children)

--- a/Libraries/LibWeb/MathML/MathMLElement.h
+++ b/Libraries/LibWeb/MathML/MathMLElement.h
@@ -24,7 +24,7 @@ public:
     virtual Optional<ARIA::Role> default_role() const override;
 
 protected:
-    virtual void attribute_change_steps(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) override;
     virtual void inserted() override;
     virtual JS::GCPtr<DOM::EventTarget> global_event_handlers_to_event_target(FlyString const&) override { return *this; }

--- a/Libraries/LibWeb/SVG/SVGAElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGAElement.cpp
@@ -34,9 +34,10 @@ void SVGAElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_rel_list);
 }
 
-void SVGAElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGAElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == SVG::AttributeNames::href) {
         invalidate_style(DOM::StyleInvalidationReason::HTMLHyperlinkElementHrefChange);
     }

--- a/Libraries/LibWeb/SVG/SVGAElement.h
+++ b/Libraries/LibWeb/SVG/SVGAElement.h
@@ -32,7 +32,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     // ^DOM::Element
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
 
     JS::GCPtr<DOM::DOMTokenList> m_rel_list;

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.cpp
@@ -28,9 +28,10 @@ void SVGClipPathElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGClipPathElement);
 }
 
-void SVGClipPathElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGClipPathElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == AttributeNames::clipPathUnits)
         m_clip_path_units = AttributeParser::parse_units(value.value_or(String {}));
 }

--- a/Libraries/LibWeb/SVG/SVGClipPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGClipPathElement.h
@@ -33,7 +33,7 @@ public:
         return PreserveAspectRatio { PreserveAspectRatio::Align::None, {} };
     }
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     ClipPathUnits clip_path_units() const
     {

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -35,17 +35,12 @@ void SVGElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_class_name_animated_string);
 }
 
-void SVGElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(local_name, old_value, value, namespace_);
+    HTMLOrSVGElement::attribute_changed(local_name, old_value, value, namespace_);
 
     update_use_elements_that_reference_this();
-}
-
-void SVGElement::attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
-{
-    Base::attribute_change_steps(local_name, old_value, value, namespace_);
-    HTMLOrSVGElement::attribute_change_steps(local_name, old_value, value, namespace_);
 }
 
 WebIDL::ExceptionOr<void> SVGElement::cloned(DOM::Node& copy, bool clone_children)

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -31,8 +31,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
-    virtual void attribute_change_steps(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) override;
     virtual void children_changed() override;
     virtual void inserted() override;

--- a/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -26,9 +26,9 @@ void SVGEllipseElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGEllipseElement);
 }
 
-void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGEllipseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGeometryElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::cx) {
         m_center_x = AttributeParser::parse_coordinate(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -18,7 +18,7 @@ class SVGEllipseElement final : public SVGGeometryElement {
 public:
     virtual ~SVGEllipseElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 

--- a/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -19,9 +19,10 @@ SVGGradientElement::SVGGradientElement(DOM::Document& document, DOM::QualifiedNa
 {
 }
 
-void SVGGradientElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGGradientElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == AttributeNames::gradientUnits) {
         m_gradient_units = AttributeParser::parse_units(value.value_or(String {}));
     } else if (name == AttributeNames::spreadMethod) {

--- a/Libraries/LibWeb/SVG/SVGGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.h
@@ -43,7 +43,7 @@ class SVGGradientElement
 public:
     virtual ~SVGGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&) const = 0;
 

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -37,9 +37,10 @@ void SVGGraphicsElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGGraphicsElement);
 }
 
-void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGGraphicsElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == "transform"sv) {
         auto transform_list = AttributeParser::parse_transform(value.value_or(String {}));
         if (transform_list.has_value())

--- a/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -32,7 +32,7 @@ class SVGGraphicsElement : public SVGElement {
 public:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     Optional<Gfx::Color> fill_color() const;
     Optional<Gfx::Color> stroke_color() const;

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -42,9 +42,10 @@ void SVGImageElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_resource_request);
 }
 
-void SVGImageElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGImageElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGraphicsElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == SVG::AttributeNames::x) {
         auto parsed_value = AttributeParser::parse_coordinate(value.value_or(String {}));
         MUST(x()->base_val()->set_value(parsed_value.value_or(0)));

--- a/Libraries/LibWeb/SVG/SVGImageElement.h
+++ b/Libraries/LibWeb/SVG/SVGImageElement.h
@@ -20,7 +20,7 @@ class SVGImageElement
     WEB_PLATFORM_OBJECT(SVGImageElement, SVGGraphicsElement);
 
 public:
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     JS::NonnullGCPtr<SVG::SVGAnimatedLength> x();
     JS::NonnullGCPtr<SVG::SVGAnimatedLength> y();

--- a/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -26,9 +26,9 @@ void SVGLineElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGLineElement);
 }
 
-void SVGLineElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGLineElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGeometryElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::x1) {
         m_x1 = AttributeParser::parse_number_percentage(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -18,7 +18,7 @@ class SVGLineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGLineElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 

--- a/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGLinearGradientElement.cpp
@@ -28,9 +28,9 @@ void SVGLinearGradientElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGLinearGradientElement);
 }
 
-void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGLinearGradientElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGradientElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // FIXME: Should allow for `<number-percentage> | <length>` for x1, x2, y1, y2
     if (name == SVG::AttributeNames::x1) {

--- a/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGLinearGradientElement.h
@@ -19,7 +19,7 @@ class SVGLinearGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGLinearGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Libraries/LibWeb/SVG/SVGMaskElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.cpp
@@ -33,9 +33,10 @@ JS::GCPtr<Layout::Node> SVGMaskElement::create_layout_node(CSS::StyleProperties)
     return nullptr;
 }
 
-void SVGMaskElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGMaskElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGraphicsElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == AttributeNames::maskUnits) {
         m_mask_units = AttributeParser::parse_units(value.value_or(String {}));
     } else if (name == AttributeNames::maskContentUnits) {

--- a/Libraries/LibWeb/SVG/SVGMaskElement.h
+++ b/Libraries/LibWeb/SVG/SVGMaskElement.h
@@ -36,7 +36,7 @@ public:
         return PreserveAspectRatio { PreserveAspectRatio::Align::None, {} };
     }
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual JS::GCPtr<Layout::Node> create_layout_node(CSS::StyleProperties) override;
 

--- a/Libraries/LibWeb/SVG/SVGPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPathElement.cpp
@@ -97,9 +97,9 @@ void SVGPathElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGPathElement);
 }
 
-void SVGPathElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGPathElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGeometryElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == "d")
         m_instructions = AttributeParser::parse_path_data(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGPathElement.h
+++ b/Libraries/LibWeb/SVG/SVGPathElement.h
@@ -20,7 +20,7 @@ class SVGPathElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPathElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 

--- a/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPolygonElement.cpp
@@ -26,9 +26,9 @@ void SVGPolygonElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGPolygonElement);
 }
 
-void SVGPolygonElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGPolygonElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGeometryElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::points)
         m_points = AttributeParser::parse_points(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGPolygonElement.h
+++ b/Libraries/LibWeb/SVG/SVGPolygonElement.h
@@ -17,7 +17,7 @@ class SVGPolygonElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolygonElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 

--- a/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGPolylineElement.cpp
@@ -26,9 +26,9 @@ void SVGPolylineElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGPolylineElement);
 }
 
-void SVGPolylineElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGPolylineElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGeometryElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::points)
         m_points = AttributeParser::parse_points(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGPolylineElement.h
+++ b/Libraries/LibWeb/SVG/SVGPolylineElement.h
@@ -17,7 +17,7 @@ class SVGPolylineElement final : public SVGGeometryElement {
 public:
     virtual ~SVGPolylineElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 

--- a/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGRadialGradientElement.cpp
@@ -25,9 +25,9 @@ void SVGRadialGradientElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGRadialGradientElement);
 }
 
-void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGRadialGradientElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGradientElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // FIXME: These are <length> or <coordinate> in the spec, but all examples seem to allow percentages
     // and unitless values.

--- a/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
+++ b/Libraries/LibWeb/SVG/SVGRadialGradientElement.h
@@ -19,7 +19,7 @@ class SVGRadialGradientElement : public SVGGradientElement {
 public:
     virtual ~SVGRadialGradientElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Optional<Painting::PaintStyle> to_gfx_paint_style(SVGPaintContext const&) const override;
 

--- a/Libraries/LibWeb/SVG/SVGRectElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGRectElement.cpp
@@ -28,9 +28,9 @@ void SVGRectElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGRectElement);
 }
 
-void SVGRectElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGRectElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGeometryElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::x) {
         m_x = AttributeParser::parse_coordinate(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGRectElement.h
+++ b/Libraries/LibWeb/SVG/SVGRectElement.h
@@ -18,7 +18,7 @@ class SVGRectElement final : public SVGGeometryElement {
 public:
     virtual ~SVGRectElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual Gfx::Path get_path(CSSPixelSize viewport_size) override;
 

--- a/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -101,9 +101,9 @@ void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) cons
         style.set_property(CSS::PropertyID::Height, height.release_nonnull());
 }
 
-void SVGSVGElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGSVGElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGraphicsElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox)) {
         if (!value.has_value()) {

--- a/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -91,7 +91,7 @@ private:
 
     virtual bool is_svg_svg_element() const override { return true; }
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void update_fallback_view_box_for_svg_as_image();
 

--- a/Libraries/LibWeb/SVG/SVGStopElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStopElement.cpp
@@ -21,9 +21,10 @@ SVGStopElement::SVGStopElement(DOM::Document& document, DOM::QualifiedName quali
 {
 }
 
-void SVGStopElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGStopElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name == SVG::AttributeNames::offset) {
         m_offset = AttributeParser::parse_number_percentage(value.value_or(String {}));
     }

--- a/Libraries/LibWeb/SVG/SVGStopElement.h
+++ b/Libraries/LibWeb/SVG/SVGStopElement.h
@@ -21,7 +21,7 @@ class SVGStopElement final : public SVGElement {
 public:
     virtual ~SVGStopElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     JS::NonnullGCPtr<SVGAnimatedNumber> offset() const;
 

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.cpp
@@ -50,9 +50,10 @@ void SVGSymbolElement::apply_presentational_hints(CSS::StyleProperties& style) c
     }
 }
 
-void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGSymbolElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
+
     if (name.equals_ignoring_ascii_case(SVG::AttributeNames::viewBox)) {
         m_view_box = try_parse_view_box(value.value_or(String {}));
         m_view_box_for_bindings->set_nulled(!m_view_box.has_value());

--- a/Libraries/LibWeb/SVG/SVGSymbolElement.h
+++ b/Libraries/LibWeb/SVG/SVGSymbolElement.h
@@ -40,7 +40,7 @@ private:
 
     bool is_direct_child_of_use_shadow_tree() const;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     Optional<ViewBox> m_view_box;
 

--- a/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextPositioningElement.cpp
@@ -29,9 +29,9 @@ void SVGTextPositioningElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SVGTextPositioningElement);
 }
 
-void SVGTextPositioningElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGTextPositioningElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    SVGGraphicsElement::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     if (name == SVG::AttributeNames::x) {
         m_x = AttributeParser::parse_number_percentage(value.value_or(String {}));

--- a/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
+++ b/Libraries/LibWeb/SVG/SVGTextPositioningElement.h
@@ -16,7 +16,7 @@ class SVGTextPositioningElement : public SVGTextContentElement {
     WEB_PLATFORM_OBJECT(SVGTextPositioningElement, SVGTextContentElement);
 
 public:
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     Gfx::FloatPoint get_offset(CSSPixelSize const& viewport_size) const;
 

--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -55,9 +55,9 @@ void SVGUseElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_resource_request);
 }
 
-void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value)
+void SVGUseElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value);
+    Base::attribute_changed(name, old_value, value, namespace_);
 
     // https://svgwg.org/svg2-draft/struct.html#UseLayout
     if (name == SVG::AttributeNames::x) {

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -24,7 +24,7 @@ class SVGUseElement final
 public:
     virtual ~SVGUseElement() override = default;
 
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual void inserted() override;
 


### PR DESCRIPTION
We currently have 2 virtual methods to inform DOM::Element subclasses when an attribute has changed, one of which is spec-compliant. This patch removes the non-compliant variant.