### PR TITLE
LibWeb/CSS: Disallow `:has()` and pseudo-elements inside `:has()`

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -187,8 +187,10 @@ SelectorList const& CSSStyleRule::absolutized_selectors() const
             },
         };
         SelectorList absolutized_selectors;
-        for (auto const& selector : selectors())
-            absolutized_selectors.append(selector->absolutized(parent_selector));
+        for (auto const& selector : selectors()) {
+            if (auto absolutized = selector->absolutized(parent_selector))
+                absolutized_selectors.append(absolutized.release_nonnull());
+        }
         m_cached_absolutized_selectors = move(absolutized_selectors);
     } else {
         // NOTE: We can't actually replace & with :scope, because & has to have 0 specificity.

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -413,6 +413,8 @@ private:
     };
     static ContextType context_type_for_at_rule(FlyString const&);
     Vector<ContextType> m_rule_context;
+
+    Vector<PseudoClass> m_pseudo_class_context; // Stack of pseudo-class functions we're currently inside
 };
 
 }

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -608,6 +608,7 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                 .type = Selector::SimpleSelector::Type::PseudoClass,
                 .value = Selector::SimpleSelector::PseudoClassSelector {
                     .type = pseudo_class,
+                    .is_forgiving = true,
                     .argument_selector_list = move(argument_selector_list) }
             };
         }

--- a/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/SelectorParsing.cpp
@@ -641,9 +641,13 @@ Parser::ParseErrorOr<Selector::SimpleSelector> Parser::parse_pseudo_simple_selec
                     .languages = move(languages) }
             };
         }
+        case PseudoClassMetadata::ParameterType::RelativeSelectorList:
         case PseudoClassMetadata::ParameterType::SelectorList: {
             auto function_token_stream = TokenStream(pseudo_function.value);
-            auto not_selector = TRY(parse_a_selector_list(function_token_stream, SelectorType::Standalone));
+            auto selector_type = metadata.parameter_type == PseudoClassMetadata::ParameterType::SelectorList
+                ? SelectorType::Standalone
+                : SelectorType::Relative;
+            auto not_selector = TRY(parse_a_selector_list(function_token_stream, selector_type));
 
             return Selector::SimpleSelector {
                 .type = Selector::SimpleSelector::Type::PseudoClass,

--- a/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -45,7 +45,7 @@
     "argument": ""
   },
   "has": {
-    "argument": "<forgiving-relative-selector-list>"
+    "argument": "<relative-selector-list>"
   },
   "host": {
     "argument": "<compound-selector>?"

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -687,4 +687,11 @@ SelectorList adapt_nested_relative_selector_list(SelectorList const& selectors)
     return new_list;
 }
 
+// https://drafts.csswg.org/selectors/#has-allowed-pseudo-element
+bool is_has_allowed_pseudo_element(Selector::PseudoElement::Type)
+{
+    // No spec currently defines any pseudo-elements that are allowed in :has()
+    return false;
+}
+
 }

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -222,7 +222,7 @@ public:
 
         String serialize() const;
 
-        SimpleSelector absolutized(SimpleSelector const& selector_for_nesting) const;
+        Optional<SimpleSelector> absolutized(SimpleSelector const& selector_for_nesting) const;
     };
 
     enum class Combinator {
@@ -240,7 +240,7 @@ public:
         Combinator combinator { Combinator::None };
         Vector<SimpleSelector> simple_selectors;
 
-        CompoundSelector absolutized(SimpleSelector const& selector_for_nesting) const;
+        Optional<CompoundSelector> absolutized(SimpleSelector const& selector_for_nesting) const;
     };
 
     static NonnullRefPtr<Selector> create(Vector<CompoundSelector>&& compound_selectors)
@@ -254,7 +254,7 @@ public:
     Optional<PseudoElement> const& pseudo_element() const { return m_pseudo_element; }
     NonnullRefPtr<Selector> relative_to(SimpleSelector const&) const;
     bool contains_the_nesting_selector() const { return m_contains_the_nesting_selector; }
-    NonnullRefPtr<Selector> absolutized(SimpleSelector const& selector_for_nesting) const;
+    RefPtr<Selector> absolutized(SimpleSelector const& selector_for_nesting) const;
     u32 specificity() const;
     String serialize() const;
 

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -275,6 +275,8 @@ String serialize_a_group_of_selectors(SelectorList const& selectors);
 
 SelectorList adapt_nested_relative_selector_list(SelectorList const&);
 
+bool is_has_allowed_pseudo_element(Selector::PseudoElement::Type);
+
 }
 
 namespace AK {

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -142,6 +142,8 @@ public:
             // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
             ANPlusBPattern nth_child_pattern {};
 
+            // FIXME: This would make more sense as part of SelectorList but that's currently a `using`
+            bool is_forgiving { false };
             SelectorList argument_selector_list {};
 
             // Used for :lang(en-gb,dk)

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -545,6 +545,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector, int in
                 case CSS::PseudoClassMetadata::ParameterType::CompoundSelector:
                 case CSS::PseudoClassMetadata::ParameterType::ForgivingSelectorList:
                 case CSS::PseudoClassMetadata::ParameterType::ForgivingRelativeSelectorList:
+                case CSS::PseudoClassMetadata::ParameterType::RelativeSelectorList:
                 case CSS::PseudoClassMetadata::ParameterType::SelectorList: {
                     builder.append("([\n"sv);
                     for (auto& child_selector : pseudo_class.argument_selector_list)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -75,6 +75,7 @@ struct PseudoClassMetadata {
         ForgivingRelativeSelectorList,
         Ident,
         LanguageRanges,
+        RelativeSelectorList,
         SelectorList,
     } parameter_type;
     bool is_valid_as_function;
@@ -174,6 +175,8 @@ PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
                 parameter_type = "Ident"_string;
             } else if (argument_string == "<language-ranges>"sv) {
                 parameter_type = "LanguageRanges"_string;
+            } else if (argument_string == "<relative-selector-list>"sv) {
+                parameter_type = "RelativeSelectorList"_string;
             } else if (argument_string == "<selector-list>"sv) {
                 parameter_type = "SelectorList"_string;
             } else {

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -58,7 +58,6 @@ Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/resour
 Text/input/wpt-import/css/css-flexbox/flex-item-compressible-001.html
 
 ; WPT ref-tests that currently fail
-Ref/input/wpt-import/css/css-nesting/has-nesting.html
 Ref/input/wpt-import/css/css-nesting/host-nesting-003.html
 Ref/input/wpt-import/css/css-nesting/host-nesting-004.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-002r.xht

--- a/Tests/LibWeb/Text/expected/css/invalid-selector-in-has.txt
+++ b/Tests/LibWeb/Text/expected/css/invalid-selector-in-has.txt
@@ -1,1 +1,6 @@
 :has(:yakthonk) should be invalid: PASS
+:has(:not(:yakthonk)) should be invalid: PASS
+:has(:has(span)) should be invalid: PASS
+:has(:not(:has(span))) should be invalid: PASS
+:has(::before) should be invalid: PASS
+:has(:not(::before)) should be invalid: PASS

--- a/Tests/LibWeb/Text/expected/css/invalid-selector-in-has.txt
+++ b/Tests/LibWeb/Text/expected/css/invalid-selector-in-has.txt
@@ -1,0 +1,1 @@
+:has(:yakthonk) should be invalid: PASS

--- a/Tests/LibWeb/Text/expected/wpt-import/css/selectors/invalidation/has-with-pseudo-class.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/selectors/invalidation/has-with-pseudo-class.txt
@@ -6,8 +6,8 @@ Rerun
 
 Found 41 tests
 
-31 Pass
-10 Fail
+37 Pass
+4 Fail
 Details
 Result	Test Name	MessagePass	Before set checked on checkbox, testing subject	
 Pass	Set checked on checkbox, testing subject	
@@ -29,24 +29,24 @@ Pass	Unset disabled on option, testing subject3
 Pass	Before set disabled on optgroup, testing subject	
 Pass	Set disabled on optgroup, testing subject	
 Pass	Unset disabled on optgroup, testing subject	
-Fail	Before set disabled on optgroup, testing subject2	
+Pass	Before set disabled on optgroup, testing subject2	
 Pass	Set disabled on optgroup, testing subject2	
-Fail	Unset disabled on optgroup, testing subject2	
+Pass	Unset disabled on optgroup, testing subject2	
 Pass	Before set disabled on optgroup, testing subject3	
 Pass	Set disabled on optgroup, testing subject3	
 Pass	Unset disabled on optgroup, testing subject3	
-Fail	Before set disabled on optgroup, testing subject4	
+Pass	Before set disabled on optgroup, testing subject4	
 Pass	Set disabled on optgroup, testing subject4	
-Fail	Unset disabled on optgroup, testing subject4	
+Pass	Unset disabled on optgroup, testing subject4	
 Pass	Before setting value of text_input, testing subject	
 Fail	Set value of text_input, testing subject	
 Pass	Clear value of text_input, testing subject	
-Fail	Before setting value of text_input, testing subject2	
-Pass	Set value of text_input, testing subject2	
-Fail	Clear value of text_input, testing subject2	
+Pass	Before setting value of text_input, testing subject2	
+Fail	Set value of text_input, testing subject2	
+Pass	Clear value of text_input, testing subject2	
 Pass	Before setting value of text_input, testing subject3	
 Fail	Set value of text_input, testing subject3	
 Pass	Clear value of text_input, testing subject3	
-Fail	Before setting value of text_input, testing subject4	
-Pass	Set value of text_input, testing subject4	
-Fail	Clear value of text_input, testing subject4	
+Pass	Before setting value of text_input, testing subject4	
+Fail	Set value of text_input, testing subject4	
+Pass	Clear value of text_input, testing subject4	

--- a/Tests/LibWeb/Text/input/css/invalid-selector-in-has.html
+++ b/Tests/LibWeb/Text/input/css/invalid-selector-in-has.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style id="style"></style>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let selectors = [
+            ":has(:yakthonk)",
+        ];
+
+        let style = document.getElementById("style");
+
+        for (let selector of selectors) {
+            style.innerText = `${selector} { color: red; }`;
+            println(`${selector} should be invalid: ${style.sheet.cssRules.length === 0 ? "PASS" : "FAIL"}`);
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/css/invalid-selector-in-has.html
+++ b/Tests/LibWeb/Text/input/css/invalid-selector-in-has.html
@@ -5,6 +5,11 @@
     test(() => {
         let selectors = [
             ":has(:yakthonk)",
+            ":has(:not(:yakthonk))",
+            ":has(:has(span))",
+            ":has(:not(:has(span)))",
+            ":has(::before)",
+            ":has(:not(::before))",
         ];
 
         let style = document.getElementById("style");


### PR DESCRIPTION
Fixes #2124.

A few `:has()`-related fixes:
- Make it take a non-forgiving `<relative-selector-list>`
- Prevent `:has( :has() )`
- Prevent `:has( ::pseudo-element )`

Theoretically some pseudo-elements are allowed inside `:has()`, but none are yet defined in any spec that I could find. I've left a `is_has_allowed_pseudo_element()` function that we can add exceptions to in the future.