### PR TITLE
LibWeb: Recompute selection state in Document::update_layout()

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1234,6 +1234,10 @@ void Document::update_layout()
         page().client().page_did_layout();
     }
 
+    if (auto range = get_selection()->range()) {
+        paintable()->recompute_selection_states(*range);
+    }
+
     m_needs_layout = false;
 
     // Scrolling by zero offset will clamp scroll offset back to valid range if it was out of bounds

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1234,8 +1234,6 @@ void Document::update_layout()
         page().client().page_did_layout();
     }
 
-    paintable()->update_selection();
-
     m_needs_layout = false;
 
     // Scrolling by zero offset will clamp scroll offset back to valid range if it was out of bounds

--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -99,7 +99,6 @@ void Range::update_associated_selection()
     auto& document = m_start_container->document();
     if (auto* viewport = document.paintable()) {
         viewport->recompute_selection_states(*this);
-        viewport->update_selection();
         viewport->set_needs_display();
     }
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -672,11 +672,9 @@ void FormAssociatedTextControlElement::selection_was_changed()
     if (!text_paintable)
         return;
     if (m_selection_start == m_selection_end) {
-        text_paintable->set_selected(false);
         text_paintable->set_selection_state(Painting::Paintable::SelectionState::None);
         text_node->document().reset_cursor_blink_cycle();
     } else {
-        text_paintable->set_selected(true);
         text_paintable->set_selection_state(Painting::Paintable::SelectionState::StartAndEnd);
     }
     text_paintable->set_needs_display();

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1182,9 +1182,6 @@ void HTMLInputElement::did_receive_focus()
         return;
     m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
 
-    if (auto* paintable = m_text_node->paintable())
-        paintable->set_selected(true);
-
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
 }
@@ -1193,9 +1190,6 @@ void HTMLInputElement::did_lose_focus()
 {
     if (m_text_node) {
         m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
-
-        if (auto* paintable = m_text_node->paintable())
-            paintable->set_selected(false);
     }
 
     if (m_placeholder_text_node)

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -79,9 +79,6 @@ void HTMLTextAreaElement::did_receive_focus()
         return;
     m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
 
-    if (auto* paintable = m_text_node->paintable())
-        paintable->set_selected(true);
-
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidReceiveFocus);
 }
@@ -90,9 +87,6 @@ void HTMLTextAreaElement::did_lose_focus()
 {
     if (m_text_node)
         m_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);
-
-    if (auto* paintable = m_text_node->paintable())
-        paintable->set_selected(false);
 
     if (m_placeholder_text_node)
         m_placeholder_text_node->invalidate_style(DOM::StyleInvalidationReason::DidLoseFocus);

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -62,7 +62,6 @@ public:
     [[nodiscard]] bool is_absolutely_positioned() const { return m_absolutely_positioned; }
     [[nodiscard]] bool is_floating() const { return m_floating; }
     [[nodiscard]] bool is_inline() const { return m_inline; }
-    [[nodiscard]] bool is_selected() const { return m_selected; }
     [[nodiscard]] CSS::Display display() const;
 
     template<typename U, typename Callback>
@@ -228,7 +227,6 @@ public:
 
     SelectionState selection_state() const { return m_selection_state; }
     void set_selection_state(SelectionState state) { m_selection_state = state; }
-    void set_selected(bool selected) { m_selected = selected; }
 
     Gfx::AffineTransform compute_combined_css_transform() const;
 
@@ -263,7 +261,6 @@ private:
     bool m_absolutely_positioned : 1 { false };
     bool m_floating : 1 { false };
     bool m_inline : 1 { false };
-    bool m_selected : 1 { false };
 };
 
 inline DOM::Node* HitTestResult::dom_node()

--- a/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -187,9 +187,6 @@ Gfx::Orientation PaintableFragment::orientation() const
 
 CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
 {
-    if (!paintable().is_selected())
-        return {};
-
     if (auto const* focused_element = paintable().document().focused_element(); focused_element && is<HTML::FormAssociatedTextControlElement>(*focused_element)) {
         HTML::FormAssociatedTextControlElement const* text_control_element = nullptr;
         if (is<HTML::HTMLInputElement>(*focused_element)) {

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -278,32 +278,6 @@ JS::GCPtr<Selection::Selection> ViewportPaintable::selection() const
     return const_cast<DOM::Document&>(document()).get_selection();
 }
 
-void ViewportPaintable::update_selection()
-{
-    // 1. Start by setting all layout nodes to unselected.
-    for_each_in_inclusive_subtree([&](auto& layout_node) {
-        layout_node.set_selected(false);
-        return TraversalDecision::Continue;
-    });
-
-    // 2. If there is no active Selection or selected Range, return.
-    auto selection = document().get_selection();
-    if (!selection)
-        return;
-    auto range = selection->range();
-    if (!range)
-        return;
-
-    auto* start_container = range->start_container();
-    auto* end_container = range->end_container();
-
-    // 3. Mark the nodes included in range selected.
-    for (auto* node = start_container; node && node != end_container->next_in_pre_order(); node = node->next_in_pre_order()) {
-        if (auto* paintable = node->paintable())
-            paintable->set_selected(true);
-    }
-}
-
 void ViewportPaintable::recompute_selection_states(DOM::Range& range)
 {
     // 1. Start by resetting the selection state of all layout nodes to None.

--- a/Libraries/LibWeb/Painting/ViewportPaintable.h
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.h
@@ -33,7 +33,6 @@ public:
 
     JS::GCPtr<Selection::Selection> selection() const;
     void recompute_selection_states(DOM::Range&);
-    void update_selection();
 
     bool handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y) override;
 


### PR DESCRIPTION
Fixes a bug when text selection disappears after relayout.

With this change Slate.js becomes way more usable:

https://github.com/user-attachments/assets/3a91826b-5475-4e75-8b73-9a6bf0042667

