### PR TITLE
LibWeb: Calculate hidden password text using code-point count

### DIFF
--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -321,6 +321,11 @@ String const& TextNode::text_for_rendering() const
 // NOTE: This collapses whitespace into a single ASCII space if the CSS white-space property tells us to.
 void TextNode::compute_text_for_rendering()
 {
+    if (dom_node().is_password_input()) {
+        m_text_for_rendering = MUST(String::repeated('*', dom_node().data().code_points().length()));
+        return;
+    }
+
     bool collapse = [](CSS::WhiteSpace white_space) {
         switch (white_space) {
         case CSS::WhiteSpace::Normal:
@@ -344,11 +349,6 @@ void TextNode::compute_text_for_rendering()
     auto data = apply_text_transform(dom_node().data(), computed_values().text_transform(), lang).release_value_but_fixme_should_propagate_errors();
 
     auto data_view = data.bytes_as_string_view();
-
-    if (dom_node().is_password_input()) {
-        m_text_for_rendering = MUST(String::repeated('*', data_view.length()));
-        return;
-    }
 
     if (!collapse || data.is_empty()) {
         m_text_for_rendering = data;

--- a/Tests/LibWeb/Layout/expected/unicode-password-input.txt
+++ b/Tests/LibWeb/Layout/expected/unicode-password-input.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 200x19] baseline: 14.296875
+      BlockContainer <input> at (9,9) content-size 200x19 inline-block [BFC] children: not-inline
+        Box <div> at (11,10) content-size 196x17 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (11,10) content-size 196x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 14, rect: [11,10 111.125x17] baseline: 13.296875
+                "**************"
+            TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x37]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<INPUT>) [8,8 202x21]
+        PaintableBox (Box<DIV>) [9,9 200x19]
+          PaintableWithLines (BlockContainer<DIV>) [11,10 196x17]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/unicode-password-input.html
+++ b/Tests/LibWeb/Layout/input/unicode-password-input.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<input type="password" value="こんにちは、友達のみなさん！">


### PR DESCRIPTION
This means that an `<input type=password>` will show the correct number of *s in it when non-ASCII characters are entered.

We also don't need to perform text-transform on these as that doesn't affect the output length, so I've moved it earlier.

(The text is supposedly "Well, hello friends!" in Japanese, but I'm having to trust Kagi Translate on that.)