### PR TITLE
LibWeb: Don't copy url when calling determine_the_origin() in Navigable

### DIFF
--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -60,7 +60,7 @@ bool url_matches_about_srcdoc(URL::URL const& url)
 }
 
 // https://html.spec.whatwg.org/multipage/document-sequences.html#determining-the-origin
-URL::Origin determine_the_origin(Optional<URL::URL> const& url, SandboxingFlagSet sandbox_flags, Optional<URL::Origin> source_origin)
+URL::Origin determine_the_origin(Optional<URL::URL const&> url, SandboxingFlagSet sandbox_flags, Optional<URL::Origin> source_origin)
 {
     // 1. If sandboxFlags has its sandboxed origin browsing context flag set, then return a new opaque origin.
     if (has_flag(sandbox_flags, SandboxingFlagSet::SandboxedOrigin)) {

--- a/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -169,7 +169,7 @@ private:
     GC::Ptr<BrowsingContext> m_previous_sibling;
 };
 
-URL::Origin determine_the_origin(Optional<URL::URL> const&, SandboxingFlagSet, Optional<URL::Origin> source_origin);
+URL::Origin determine_the_origin(Optional<URL::URL const&>, SandboxingFlagSet, Optional<URL::Origin> source_origin);
 
 SandboxingFlagSet determine_the_creation_sandboxing_flags(BrowsingContext const&, GC::Ptr<DOM::Element> embedder);
 


### PR DESCRIPTION
In #1537, determine_the_origin() changed to take
`Optional<URL::URL> const&` as first parameter, but it's passed `Web::Fetch::Infrastructure::Response::url()`, which returns `Optional<URL::URL const&>`. Ladybird does not have SerenityOS/serenity#22870 (yet?), so this mismatch silently creates a copy.

Change determine_the_origin() to take `Optional<URL::URL const&>` instead. No behavior change, saves a copy, and is probably what was originally intended.