### PR TITLE
LibWeb: Make default document readiness be "complete"

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -823,7 +823,13 @@ private:
     GC::Ptr<Document> m_associated_inert_template_document;
     GC::Ptr<Document> m_appropriate_template_contents_owner_document;
 
-    HTML::DocumentReadyState m_readiness { HTML::DocumentReadyState::Loading };
+    // https://html.spec.whatwg.org/multipage/dom.html#current-document-readiness
+    // Each Document has a current document readiness, a string, initially "complete".
+    // Spec Note: For Document objects created via the create and initialize a Document object algorithm, this will be
+    //            immediately reset to "loading" before any script can observe the value of document.readyState.
+    //            This default applies to other cases such as initial about:blank Documents or Documents without a
+    //            browsing context.
+    HTML::DocumentReadyState m_readiness { HTML::DocumentReadyState::Complete };
     String m_content_type { "application/xml"_string };
     Optional<String> m_pragma_set_default_language;
     Optional<String> m_encoding;

--- a/Tests/LibWeb/Text/expected/HTML/document-readyState-is-initially-complete.txt
+++ b/Tests/LibWeb/Text/expected/HTML/document-readyState-is-initially-complete.txt
@@ -1,0 +1,5 @@
+readyState of 'new Document()' should be 'complete': 'complete'
+readyState of 'document.implementation.createHTMLDocument()' should be 'complete': 'complete'
+readyState of 'document.implementation.createDocument()' should be 'complete': 'complete'
+FIXME: readyState of 'new DOMParser().parseFromString('', 'text/html')' should be 'complete': 'interactive'
+readyState of 'iframe.contentDocument' of initial about:blank iframe should be 'complete': 'complete'

--- a/Tests/LibWeb/Text/input/HTML/Window-postMessage.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-postMessage.html
@@ -127,21 +127,11 @@
         globalThis.doneCallback = done;
 
         const blobIframeLoadPromise = new Promise(resolve => {
-            if (blobIframe.contentDocument.readyState === "complete") {
-                resolve();
-            }
-            else {
-                blobIframe.onload = () => resolve();
-            }
+            blobIframe.onload = () => resolve();
         });
 
         const srcdocIframeLoadPromise = new Promise(resolve => {
-            if (iframe.contentDocument.readyState === "complete") {
-                resolve()
-            }
-            else {
-                iframe.onload = () => resolve();
-            }
+            iframe.onload = () => resolve();
         });
 
         Promise.all([blobIframeLoadPromise, srcdocIframeLoadPromise]).then(() => {

--- a/Tests/LibWeb/Text/input/HTML/document-readyState-is-initially-complete.html
+++ b/Tests/LibWeb/Text/input/HTML/document-readyState-is-initially-complete.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`readyState of 'new Document()' should be 'complete': '${new Document().readyState}'`);
+        println(`readyState of 'document.implementation.createHTMLDocument()' should be 'complete': '${document.implementation.createHTMLDocument().readyState}'`);
+        println(`readyState of 'document.implementation.createDocument()' should be 'complete': '${document.implementation.createDocument('http://www.w3.org/1999/xhtml', '').readyState}'`);
+        println(`FIXME: readyState of 'new DOMParser().parseFromString('', 'text/html')' should be 'complete': '${new DOMParser().parseFromString('', 'text/html').readyState}'`);
+
+        const iframe = document.createElement("iframe");
+        document.body.appendChild(iframe);
+        println(`readyState of 'iframe.contentDocument' of initial about:blank iframe should be 'complete': '${iframe.contentDocument.readyState}'`);
+    });
+</script>


### PR DESCRIPTION
This is required by mini Cloudflare invisible challenges, as it will only run if the readyState is not "loading". If it is "loading", then it waits for readystatechange to check that it's not "loading" anymore.

Initial about:blank iframes do not go through the full navigation and thus don't go through HTMLParser::the_end, which sets the ready state to something other than "loading". Therefore, the challenge would never run, as readyState would never change.

Seen on https://discord.com/login