### PR TITLE
LibWeb: Fix MouseEvent position values

### DIFF
--- a/Tests/LibWeb/Text/expected/CSSOMView/mouse-event-x-y-values.txt
+++ b/Tests/LibWeb/Text/expected/CSSOMView/mouse-event-x-y-values.txt
@@ -1,0 +1,10 @@
+x: 50
+y: 50
+screenX: 50
+screenY: 50
+clientX: 50
+clientY: 50
+pageX: 50
+pageY: 60
+offsetX: 42
+offsetY: 52

--- a/Tests/LibWeb/Text/input/CSSOMView/mouse-event-x-y-values.html
+++ b/Tests/LibWeb/Text/input/CSSOMView/mouse-event-x-y-values.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: gray;
+    }
+    body {
+        height: 200vh;
+    }
+</style>
+<div onClick="
+    println(`x: ${event.x}`);
+    println(`y: ${event.y}`);
+    println(`screenX: ${event.screenX}`);
+    println(`screenY: ${event.screenY}`);
+    println(`clientX: ${event.clientX}`);
+    println(`clientY: ${event.clientY}`);
+    println(`pageX: ${event.pageX}`);
+    println(`pageY: ${event.pageY}`);
+    println(`offsetX: ${event.offsetX}`);
+    println(`offsetY: ${event.offsetY}`);
+"></div>
+
+<script src="../include.js"></script>
+
+<script>
+    test(() => {
+        window.scrollBy(0, 10)
+        internals.click(50, 50);
+    });
+</script>


### PR DESCRIPTION
The clientX and clientY values are, as per the spec, the offset from the viewport.
This makes them actually be that and also fixes up the calculations for offsetX, offsetY, pageX and pageY.
I assume all of these got messed up in some sort of refactor in the past.

The spec comment from the now-removed ``compute_mouse_event_client_offset()`` function sadly has no convenient place to be anymore so, for now, it is just gone as well.
Personally, I think it'd make sense to refactor a lot of this file so that not every mouse event repeats a large chunk of (almost) identical code. That way there'd be a nice place to put the comment without repeating it all over the file.
But that is out of the scope of this PR.

Also: I know, offsetX and Y are not fully fixed yet, they still don't ignore the element's CSS transforms but I am working on that in a new PR.