### PR TITLE
LibWeb: Add WebSocket task source

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/Task.h
+++ b/Libraries/LibWeb/HTML/EventLoop/Task.h
@@ -68,6 +68,9 @@ public:
         // https://w3c.github.io/IndexedDB/#database-access-task-source
         DatabaseAccess,
 
+        // https://websockets.spec.whatwg.org/#websocket-task-source
+        WebSocket,
+
         // !!! IMPORTANT: Keep this field last!
         // This serves as the base value of all unique task sources.
         // Some elements, such as the HTMLMediaElement, must have a unique task source per instance.


### PR DESCRIPTION
The WebSocket spec tells us to queue tasks instead of firing events synchronously at WebSockets, so this commit does exactly that.

The way we've implemented web sockets means that the work is spread across multiple libraries and even processes, which is why it doesn't look like the spec verbatim.