### PR TITLE
LibIDL: Fix use-after-free in `GenerateWindowOrWorkerInterfaces`

### DIFF
--- a/Libraries/LibIDL/IDLParser.cpp
+++ b/Libraries/LibIDL/IDLParser.cpp
@@ -1250,7 +1250,7 @@ Interface& Parser::parse()
     return interface;
 }
 
-Parser::Parser(ByteString filename, StringView contents, Vector<StringView> import_base_paths)
+Parser::Parser(ByteString filename, StringView contents, Vector<ByteString> import_base_paths)
     : import_base_paths(move(import_base_paths))
     , filename(move(filename))
     , input(contents)
@@ -1258,7 +1258,7 @@ Parser::Parser(ByteString filename, StringView contents, Vector<StringView> impo
 {
 }
 
-Parser::Parser(Parser* parent, ByteString filename, StringView contents, Vector<StringView> import_base_paths)
+Parser::Parser(Parser* parent, ByteString filename, StringView contents, Vector<ByteString> import_base_paths)
     : import_base_paths(move(import_base_paths))
     , filename(move(filename))
     , input(contents)

--- a/Libraries/LibIDL/IDLParser.h
+++ b/Libraries/LibIDL/IDLParser.h
@@ -17,7 +17,7 @@ namespace IDL {
 
 class Parser {
 public:
-    Parser(ByteString filename, StringView contents, Vector<StringView> import_base_paths);
+    Parser(ByteString filename, StringView contents, Vector<ByteString> import_base_paths);
     Interface& parse();
 
     Vector<ByteString> imported_files() const;
@@ -35,7 +35,7 @@ private:
         Yes,
     };
 
-    Parser(Parser* parent, ByteString filename, StringView contents, Vector<StringView> import_base_path);
+    Parser(Parser* parent, ByteString filename, StringView contents, Vector<ByteString> import_base_path);
 
     void assert_specific(char ch);
     void assert_string(StringView expected);
@@ -68,7 +68,7 @@ private:
     ByteString parse_identifier_ending_with_space();
     ByteString parse_identifier_ending_with_space_or(auto... possible_terminating_characters);
 
-    Vector<StringView> import_base_paths;
+    Vector<ByteString> import_base_paths;
     ByteString filename;
     StringView input;
     LineTrackingLexer lexer;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/main.cpp
@@ -21,7 +21,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Core::ArgsParser args_parser;
     StringView path;
-    Vector<StringView> import_base_paths;
+    Vector<ByteString> import_base_paths;
     StringView output_path = "-"sv;
     StringView depfile_path;
     StringView depfile_prefix;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -356,11 +356,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     VERIFY(!paths.is_empty());
     VERIFY(!base_paths.is_empty());
 
-    Vector<StringView> lexical_bases;
+    Vector<ByteString> lexical_bases;
     for (auto const& base_path : base_paths) {
         VERIFY(!base_path.is_empty());
-        LexicalPath lexical_path(base_path);
-        lexical_bases.append(lexical_path.string());
+        lexical_bases.append(base_path);
     }
 
     // Read in all IDL files, we must own the storage for all of these for the lifetime of the program


### PR DESCRIPTION
`lexical_bases` was storing `StringView`s into `ByteString`s returned from `LexicalPath::string()` that might no longer exist.