### PR TITLE
LibWeb: Make MouseEvent.offsetX/Y ignore transforms

### DIFF
--- a/Tests/LibWeb/Text/expected/CSSOMView/mouse-event-offset-values.txt
+++ b/Tests/LibWeb/Text/expected/CSSOMView/mouse-event-offset-values.txt
@@ -1,0 +1,2 @@
+offsetX: 45.75
+offsetY: 57.078125

--- a/Tests/LibWeb/Text/input/CSSOMView/mouse-event-offset-values.html
+++ b/Tests/LibWeb/Text/input/CSSOMView/mouse-event-offset-values.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    div {
+        width: 100px;
+        height: 100px;
+        background-color: gray;
+        transform: rotate(45deg);
+    }
+</style>
+<div onClick="
+    println(`offsetX: ${event.offsetX}`);
+    println(`offsetY: ${event.offsetY}`);
+"></div>
+
+<script src="../include.js"></script>
+
+<script>
+    test(() => {
+        internals.click(50, 60);
+    });
+</script>


### PR DESCRIPTION
That is what the spec calls it, at least.
In code, this manifests as making the offset very aware of the element's transform cause the click position comes relative to the viewport, not the transformed element.

IMPORTANT:
For this to give the correct numbers, #2364 needs to be merged first to fix all the other issues that MouseEvent positions have.