### PR TITLE
LibWeb: Fix accname computation for all aria-labelledby cases

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_labelledby.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_labelledby.txt
@@ -1,0 +1,13 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 3 tests
+
+3 Pass
+Details
+Result	Test Name	MessagePass	div group explicitly labelledby heading	
+Pass	div group explicitly labelledby self and heading	
+Pass	nav with verified spaces appended between each of IDREFS	

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_labelledby.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_labelledby.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Labelledby</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests the <a href="https://w3c.github.io/accname/#comp_labelledby">#comp_labelledby</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
+<!--
+
+  Some overlap with other aria-labelledby tests in:
+  - /accname/name/comp_label.html (aria-labelledby / aria-label fallback, etc.)
+  - /accname/name/comp_name_from_content.html
+  - /accname/name/shadowdom/*
+
+-->
+
+<div role="group" aria-labelledby="h" class="ex" data-expectedlabel="first heading" data-testname="div group explicitly labelledby heading">
+  <h2 id="h">first heading</h2>
+  <p>text inside div group</p>
+</div>
+
+<div role="group" aria-label="self label" id="g2" aria-labelledby="g2 h2" class="ex" data-expectedlabel="self label + first heading" data-testname="div group explicitly labelledby self and heading">
+  <h2 id="h2">+ first heading</h2>
+  <p>text inside div group</p>
+</div>
+
+<nav aria-labelledby="s1 s2 s3 s4" class="ex" data-expectedlabel="verify spaces between foreach" data-testname="nav with verified spaces appended between each of IDREFS">
+  <span id="s1">verify</span><span id="s2">spaces</span><span>FAIL IF INCLUDED</span><span id="s3">between</span><span id="s4">foreach</span>
+</nav>
+
+<!--
+
+  BLOCKED on https://github.com/w3c/accname/issues/209
+
+  Once that's resolved, it may be worthwhile to add a new ./comp_labelledby_recursion.html file,
+  so that the implementation diffs rolling in don't penalize this Interop 2024 test.
+
+  All remaining cases of https://w3c.github.io/accname/#comp_labelledby
+  - comp_labelledby_reset
+  - comp_labelledby_foreach
+  - comp_labelledby_set_current
+  - comp_labelledby_recursion
+  - comp_labelledby_append
+  - comp_labelledby_return
+
+-->
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This change ensures that:

- if an element for which an accessible name otherwise wouldn’t be computed is referenced in an `aria-labelledby` value, the accessible name for the element will be computed as expected.

- if an element has both an `aria-label` value and also an `aria-labelledby` value, the text from the `aria-label` value gets included in the computation of the element’s accessible name.

Otherwise, without this change, some elements with `aria-labelledby` values will unexpectedly end up without accessible names, and some elements with `aria-label` values will unexpectedly not have that `aria-label` value included in the element’s accessible name.

This change gets us passing all subtests from the `comp_labelledby.html` test at https://wpt.fyi/results/accname/name?product=ladybird.

> [!NOTE]
> There’s some small overlap between the change in this PR and the change in https://github.com/LadybirdBrowser/ladybird/pull/2294. But I think the two PRs could be reviewed separately without much redunancy in review.  And the change in this PR is smaller less-impactful change that touches much less code — so this PR should be significantly quicker and easier to review.