### PR TITLE
LibWeb: Prevent checkboxes from firing change events when losing focus

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -637,6 +637,7 @@ void HTMLInputElement::commit_pending_changes()
     case TypeAttributeState::Telephone:
     case TypeAttributeState::Text:
     case TypeAttributeState::URL:
+    case TypeAttributeState::Checkbox:
         if (!m_has_uncommitted_changes)
             return;
         break;

--- a/Tests/LibWeb/Text/input/checkbox-focus-lost-no-change-event.html
+++ b/Tests/LibWeb/Text/input/checkbox-focus-lost-no-change-event.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<input type="checkbox" id="checkbox">
+<script src="include.js"></script>
+<script>
+    checkbox.addEventListener("change", () => {
+      println("Change event was fired when it shouldn't have been.");
+    });
+    asyncTest(async done => {
+        checkbox.focus();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        checkbox.blur();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        done();
+    });
+</script>


### PR DESCRIPTION
Toggling the checkbox is committing a specific value so the change event should not be re-fired when the checkbox looses focus.

I *think* this should also apply to radio buttons but I haven't checked and also never used one, so I'm not including that in this PR for now.

A specific page that is fixed by this is the very bottom 'Developer Options' checkbox at https://battle.crossuniverse.net/settings/index.html which currently incorrectly hides the options it revealed when losing focus.