### PR TITLE
LibWeb: Make Selection APIs throw on DocumentType node inputs

### DIFF
--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -196,6 +196,12 @@ WebIDL::ExceptionOr<void> Selection::collapse(GC::Ptr<DOM::Node> node, unsigned 
         return {};
     }
 
+    // FIXME: Update this to match the spec once the spec is updated.
+    // Spec PR: https://github.com/w3c/selection-api/pull/342
+    if (node->is_document_type()) {
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Selection.collapse() with DocumentType node"_string);
+    }
+
     // 2. The method must throw an IndexSizeError exception if offset is longer than node's length and abort these steps.
     if (offset > node->length()) {
         return WebIDL::IndexSizeError::create(realm(), "Selection.collapse() with offset longer than node's length"_string);
@@ -361,6 +367,12 @@ WebIDL::ExceptionOr<void> Selection::set_base_and_extent(GC::Ref<DOM::Node> anch
 // https://w3c.github.io/selection-api/#dom-selection-selectallchildren
 WebIDL::ExceptionOr<void> Selection::select_all_children(GC::Ref<DOM::Node> node)
 {
+    // FIXME: Update this to match the spec once the spec is updated.
+    // Spec PR: https://github.com/w3c/selection-api/pull/342
+    if (node->is_document_type()) {
+        return WebIDL::InvalidNodeTypeError::create(realm(), "Selection.selectAllChildren() with DocumentType node"_string);
+    }
+
     // 1. If node's root is not the document associated with this, abort these steps.
     if (&node->root() != m_document.ptr())
         return {};


### PR DESCRIPTION
This matches the behavior of all major engines, and is covered by hundreds of subtests in WPT.

Spec PR: https://github.com/w3c/selection-api/pull/342