### PR TITLE
LibWeb: Fix crash from text inside SVG

### DIFF
--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -100,8 +100,8 @@ void SVGSVGPaintable::paint_descendants(PaintContext& context, PaintableBox cons
     };
 
     paintable.before_children_paint(context, PaintPhase::Foreground);
-    paintable.for_each_child([&](auto& child) {
-        paint_svg_box(verify_cast<PaintableBox>(child));
+    paintable.for_each_child_of_type<PaintableBox>([&](PaintableBox& child) {
+        paint_svg_box(child);
         return IterationDecision::Continue;
     });
     paintable.after_children_paint(context, PaintPhase::Foreground);

--- a/Tests/LibWeb/Ref/input/svg-text-crash.html
+++ b/Tests/LibWeb/Ref/input/svg-text-crash.html
@@ -1,0 +1,7 @@
+<!-- matches against itself because the only thing being tested is that this does not crash. -->
+<link rel="match" href="./svg-text-crash.html" />
+<svg>
+    <foreignObject>
+        <span>foo</span>
+    </foreignObject>
+</svg>


### PR DESCRIPTION
This makes it so that ``<foreignObject>``s no longer crash the SVG renderer.
This used to crash but now doesn't:
```html
<!DOCTYPE html>
<svg>
	<foreignObject width="160" height="160">
		<span>foo</span>
	</foreignObject>
</svg>
```

A page that is fixed by this is https://battle.crossuniverse.net/game/index.html

This just skips rendering TextPaintables inside of SVGs.