### PR TITLE
LibWeb: Always return a rejected Promise for functions which throw

### DIFF
--- a/Libraries/LibWeb/Streams/WritableStream.cpp
+++ b/Libraries/LibWeb/Streams/WritableStream.cpp
@@ -58,7 +58,7 @@ bool WritableStream::locked() const
 }
 
 // https://streams.spec.whatwg.org/#ws-close
-GC::Ptr<WebIDL::Promise> WritableStream::close()
+GC::Ref<WebIDL::Promise> WritableStream::close()
 {
     auto& realm = this->realm();
 
@@ -79,7 +79,7 @@ GC::Ptr<WebIDL::Promise> WritableStream::close()
 }
 
 // https://streams.spec.whatwg.org/#ws-abort
-GC::Ptr<WebIDL::Promise> WritableStream::abort(JS::Value reason)
+GC::Ref<WebIDL::Promise> WritableStream::abort(JS::Value reason)
 {
     auto& realm = this->realm();
 

--- a/Libraries/LibWeb/Streams/WritableStream.h
+++ b/Libraries/LibWeb/Streams/WritableStream.h
@@ -49,8 +49,8 @@ public:
     virtual ~WritableStream() = default;
 
     bool locked() const;
-    GC::Ptr<WebIDL::Promise> abort(JS::Value reason);
-    GC::Ptr<WebIDL::Promise> close();
+    GC::Ref<WebIDL::Promise> abort(JS::Value reason);
+    GC::Ref<WebIDL::Promise> close();
     WebIDL::ExceptionOr<GC::Ref<WritableStreamDefaultWriter>> get_writer();
 
     bool backpressure() const { return m_backpressure; }

--- a/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
+++ b/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.cpp
@@ -52,7 +52,7 @@ GC::Ptr<WebIDL::Promise> WritableStreamDefaultWriter::ready()
 }
 
 // https://streams.spec.whatwg.org/#default-writer-abort
-GC::Ptr<WebIDL::Promise> WritableStreamDefaultWriter::abort(JS::Value reason)
+GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::abort(JS::Value reason)
 {
     auto& realm = this->realm();
 
@@ -67,7 +67,7 @@ GC::Ptr<WebIDL::Promise> WritableStreamDefaultWriter::abort(JS::Value reason)
 }
 
 // https://streams.spec.whatwg.org/#default-writer-close
-GC::Ptr<WebIDL::Promise> WritableStreamDefaultWriter::close()
+GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::close()
 {
     auto& realm = this->realm();
 
@@ -106,7 +106,7 @@ void WritableStreamDefaultWriter::release_lock()
 }
 
 // https://streams.spec.whatwg.org/#default-writer-write
-GC::Ptr<WebIDL::Promise> WritableStreamDefaultWriter::write(JS::Value chunk)
+GC::Ref<WebIDL::Promise> WritableStreamDefaultWriter::write(JS::Value chunk)
 {
     auto& realm = this->realm();
 

--- a/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.h
+++ b/Libraries/LibWeb/Streams/WritableStreamDefaultWriter.h
@@ -28,10 +28,10 @@ public:
     GC::Ptr<WebIDL::Promise> closed();
     WebIDL::ExceptionOr<Optional<double>> desired_size() const;
     GC::Ptr<WebIDL::Promise> ready();
-    GC::Ptr<WebIDL::Promise> abort(JS::Value reason);
-    GC::Ptr<WebIDL::Promise> close();
+    GC::Ref<WebIDL::Promise> abort(JS::Value reason);
+    GC::Ref<WebIDL::Promise> close();
     void release_lock();
-    GC::Ptr<WebIDL::Promise> write(JS::Value chunk);
+    GC::Ref<WebIDL::Promise> write(JS::Value chunk);
 
     GC::Ptr<WebIDL::Promise> closed_promise() { return m_closed_promise; }
     void set_closed_promise(GC::Ptr<WebIDL::Promise> value) { m_closed_promise = value; }

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/read-min.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/read-min.any.txt
@@ -6,11 +6,10 @@ Rerun
 
 Found 24 tests
 
-23 Pass
-1 Fail
+24 Pass
 Details
 Result	Test Name	MessagePass	ReadableStream with byte source: read({ min }) rejects if min is 0	
-Fail	ReadableStream with byte source: read({ min }) rejects if min is negative	
+Pass	ReadableStream with byte source: read({ min }) rejects if min is negative	
 Pass	ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (Uint8Array)	
 Pass	ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (Uint16Array)	
 Pass	ReadableStream with byte source: read({ min }) rejects if min is larger than view's length (DataView)	


### PR DESCRIPTION
We were previously throwing an exception if the generated code was
throwing an exception before it hit the implementation of the interface.
Instead, we are meant to catch any exception, and wrap that in a
rejected promise.

For example, this was impacting the fixed test in this commit as an
exception was being thrown when invoking WebIDL::convert_to_int<T>
as the given number was out of range, and the [EnforceRange]
extended attribute decorates that attribute.

This same type of case is seen for a few tests in WPT.