### PR TITLE
LibWeb: Make select element use option's label, not text content

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -114,6 +114,13 @@ String HTMLOptionElement::label() const
 void HTMLOptionElement::set_label(String const& label)
 {
     MUST(set_attribute(HTML::AttributeNames::label, label));
+
+    // NOTE: This option's select element may need to show different contents now.
+    if (selected()) {
+        if (auto select_element = first_ancestor_of_type<HTMLSelectElement>()) {
+            select_element->update_inner_text_element();
+        }
+    }
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -399,7 +399,7 @@ void HTMLSelectElement::show_the_picker_if_applicable()
             for (auto const& child : opt_group_element.children_as_vector()) {
                 if (is<HTMLOptionElement>(*child)) {
                     auto& option_element = verify_cast<HTMLOptionElement>(*child);
-                    option_group_items.append(SelectItemOption { id_counter++, option_element.selected(), option_element.disabled(), option_element, strip_newlines(option_element.text_content()), option_element.value() });
+                    option_group_items.append(SelectItemOption { id_counter++, option_element.selected(), option_element.disabled(), option_element, strip_newlines(option_element.label()), option_element.value() });
                 }
             }
             m_select_items.append(SelectItemOptionGroup { opt_group_element.get_attribute(AttributeNames::label).value_or(String {}), option_group_items });
@@ -407,7 +407,7 @@ void HTMLSelectElement::show_the_picker_if_applicable()
 
         if (is<HTMLOptionElement>(*child)) {
             auto& option_element = verify_cast<HTMLOptionElement>(*child);
-            m_select_items.append(SelectItemOption { id_counter++, option_element.selected(), option_element.disabled(), option_element, strip_newlines(option_element.text_content()), option_element.value() });
+            m_select_items.append(SelectItemOption { id_counter++, option_element.selected(), option_element.disabled(), option_element, strip_newlines(option_element.label()), option_element.value() });
         }
 
         if (is<HTMLHRElement>(*child))
@@ -553,15 +553,16 @@ void HTMLSelectElement::create_shadow_tree_if_needed()
     update_inner_text_element();
 }
 
+// FIXME: This needs to be called any time the selected option's children are modified.
 void HTMLSelectElement::update_inner_text_element()
 {
     if (!m_inner_text_element)
         return;
 
-    // Update inner text element to text content of selected option
+    // Update inner text element to the label of the selected option
     for (auto const& option_element : list_of_options()) {
         if (option_element->selected()) {
-            m_inner_text_element->set_text_content(strip_newlines(option_element->text_content()));
+            m_inner_text_element->set_text_content(strip_newlines(option_element->label()));
             return;
         }
     }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -97,6 +97,8 @@ public:
     void update_selectedness();
 
 private:
+    friend class HTMLOptionElement;
+
     HTMLSelectElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;

--- a/Tests/LibWeb/Ref/expected/select-option-use-label.html
+++ b/Tests/LibWeb/Ref/expected/select-option-use-label.html
@@ -1,0 +1,4 @@
+<!doctype html>
+<select>
+  <option>label</option>
+</select>

--- a/Tests/LibWeb/Ref/input/select-option-use-label.html
+++ b/Tests/LibWeb/Ref/input/select-option-use-label.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<link rel="match" href="../expected/select-option-use-label.html" />
+<select>
+  <option label="label"></option>
+</select>


### PR DESCRIPTION
Relevant spec:
https://html.spec.whatwg.org/#the-select-element-2
"An [option](https://html.spec.whatwg.org/#the-option-element) element is expected to be rendered by displaying the element's [label](https://html.spec.whatwg.org/#concept-option-label), indented under its [optgroup](https://html.spec.whatwg.org/#the-optgroup-element) element if it has one."

I'm also opening a bug report for the ``FIXME:`` I've added along the way.