### PR TITLE
LibJS: Some prepatory commits to begin anew with Temporal

### DIFF
--- a/AK/NumberFormat.cpp
+++ b/AK/NumberFormat.cpp
@@ -73,16 +73,20 @@ String human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_se
     return MUST(String::formatted("{} ({} bytes)", human_readable_size_string, size));
 }
 
-String human_readable_time(i64 time_in_seconds)
+String human_readable_time(Duration duration)
 {
-    auto days = time_in_seconds / 86400;
-    time_in_seconds = time_in_seconds % 86400;
+    auto milliseconds = duration.to_milliseconds();
 
-    auto hours = time_in_seconds / 3600;
-    time_in_seconds = time_in_seconds % 3600;
+    auto days = milliseconds / 86400000;
+    milliseconds = milliseconds % 86400000;
 
-    auto minutes = time_in_seconds / 60;
-    time_in_seconds = time_in_seconds % 60;
+    auto hours = milliseconds / 3600000;
+    milliseconds = milliseconds % 3600000;
+
+    auto minutes = milliseconds / 60000;
+    milliseconds = milliseconds % 60000;
+
+    auto seconds = static_cast<double>(milliseconds) / 1000.0;
 
     StringBuilder builder;
 
@@ -95,7 +99,7 @@ String human_readable_time(i64 time_in_seconds)
     if (minutes > 0)
         builder.appendff("{} minute{} ", minutes, minutes == 1 ? "" : "s");
 
-    builder.appendff("{} second{}", time_in_seconds, time_in_seconds == 1 ? "" : "s");
+    builder.appendff("{:.3} second{}", seconds, seconds == 1.0 ? "" : "s");
 
     return MUST(builder.to_string());
 }

--- a/AK/NumberFormat.h
+++ b/AK/NumberFormat.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/Time.h>
 
 namespace AK {
 
@@ -24,7 +25,7 @@ String human_readable_size(u64 size, HumanReadableBasedOn based_on = HumanReadab
 String human_readable_quantity(u64 quantity, HumanReadableBasedOn based_on = HumanReadableBasedOn::Base2, StringView unit = "B"sv, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
 
 String human_readable_size_long(u64 size, UseThousandsSeparator use_thousands_separator = UseThousandsSeparator::No);
-String human_readable_time(i64 time_in_seconds);
+String human_readable_time(Duration);
 String human_readable_digital_time(i64 time_in_seconds);
 
 }

--- a/Libraries/LibJS/Console.h
+++ b/Libraries/LibJS/Console.h
@@ -96,7 +96,6 @@ private:
     virtual void visit_edges(Visitor&) override;
 
     ThrowCompletionOr<String> value_vector_to_string(GC::MarkedVector<Value> const&);
-    ThrowCompletionOr<String> format_time_since(Core::ElapsedTimer timer);
 
     GC::Ref<Realm> m_realm;
     GC::Ptr<ConsoleClient> m_client;

--- a/Libraries/LibJS/Runtime/Date.h
+++ b/Libraries/LibJS/Runtime/Date.h
@@ -58,6 +58,14 @@ constexpr inline double ms_per_day = 86'400'000;
 constexpr inline double ns_per_day = 86'400'000'000'000;
 extern Crypto::SignedBigInteger const ns_per_day_bigint;
 
+struct UTCOffset {
+    Optional<char> sign;
+    Optional<u8> hour;
+    Optional<u8> minute;
+    Optional<u8> second;
+    Optional<StringView> fraction;
+};
+
 double day(double);
 double time_within_day(double);
 u16 days_in_year(i32);
@@ -85,6 +93,7 @@ double make_time(double hour, double min, double sec, double ms);
 double make_day(double year, double month, double date);
 double make_date(double day, double time);
 double time_clip(double time);
+Optional<UTCOffset> parse_utc_offset(StringView);
 bool is_time_zone_offset_string(StringView offset_string);
 double parse_time_zone_offset_string(StringView offset_string);
 

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -11,7 +11,6 @@
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DateTimeFormat.h>
 #include <LibJS/Runtime/Intl/DateTimeFormatConstructor.h>
-#include <LibJS/Runtime/Temporal/TimeZone.h>
 #include <LibUnicode/DateTimeFormat.h>
 #include <LibUnicode/Locale.h>
 
@@ -205,13 +204,13 @@ ThrowCompletionOr<GC::Ref<DateTimeFormat>> create_date_time_format(VM& vm, Funct
 
     if (is_time_zone_offset_string) {
         // a. Let parseResult be ParseText(StringToCodePoints(timeZone), UTCOffset).
-        auto parse_result = Temporal::parse_iso8601(Temporal::Production::TimeZoneNumericUTCOffset, time_zone);
+        auto parse_result = parse_utc_offset(time_zone);
 
         // b. Assert: parseResult is a Parse Node.
         VERIFY(parse_result.has_value());
 
         // c. If parseResult contains more than one MinuteSecond Parse Node, throw a RangeError exception.
-        if (parse_result->time_zone_utc_offset_second.has_value())
+        if (parse_result->second.has_value())
             return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, time_zone, vm.names.timeZone);
 
         // d. Let offsetNanoseconds be ParseTimeZoneOffsetString(timeZone).

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -11,7 +11,6 @@
 #include <AK/String.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Object.h>
-#include <LibJS/Runtime/Temporal/Duration.h>
 #include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
@@ -199,8 +198,22 @@ private:
     Optional<u8> m_fractional_digits;                     // [[FractionalDigits]]
 };
 
+// 1.1.1 Duration Records, https://tc39.es/proposal-intl-duration-format/#sec-duration-records
+struct DurationRecord {
+    double years { 0 };
+    double months { 0 };
+    double weeks { 0 };
+    double days { 0 };
+    double hours { 0 };
+    double minutes { 0 };
+    double seconds { 0 };
+    double milliseconds { 0 };
+    double microseconds { 0 };
+    double nanoseconds { 0 };
+};
+
 struct DurationInstanceComponent {
-    double Temporal::DurationRecord::*value_slot;
+    double DurationRecord::*value_slot;
     DurationFormat::ValueStyle (DurationFormat::*get_style_slot)() const;
     void (DurationFormat::*set_style_slot)(StringView);
     DurationFormat::Display (DurationFormat::*get_display_slot)() const;
@@ -216,16 +229,16 @@ static constexpr AK::Array<StringView, 3> date_values = { "long"sv, "short"sv, "
 static constexpr AK::Array<StringView, 5> time_values = { "long"sv, "short"sv, "narrow"sv, "numeric"sv, "2-digit"sv };
 static constexpr AK::Array<StringView, 4> sub_second_values = { "long"sv, "short"sv, "narrow"sv, "numeric"sv };
 static constexpr AK::Array<DurationInstanceComponent, 10> duration_instances_components {
-    DurationInstanceComponent { &Temporal::DurationRecord::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, "years"sv, "year"sv, date_values, "short"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, "months"sv, "month"sv, date_values, "short"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, "weeks"sv, "week"sv, date_values, "short"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, "days"sv, "day"sv, date_values, "short"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, "hours"sv, "hour"sv, time_values, "numeric"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, "minutes"sv, "minute"sv, time_values, "numeric"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, "seconds"sv, "second"sv, time_values, "numeric"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, "milliseconds"sv, "millisecond"sv, sub_second_values, "numeric"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, "microseconds"sv, "microsecond"sv, sub_second_values, "numeric"sv },
-    DurationInstanceComponent { &Temporal::DurationRecord::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, "nanoseconds"sv, "nanosecond"sv, sub_second_values, "numeric"sv },
+    DurationInstanceComponent { &DurationRecord::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, "years"sv, "year"sv, date_values, "short"sv },
+    DurationInstanceComponent { &DurationRecord::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, "months"sv, "month"sv, date_values, "short"sv },
+    DurationInstanceComponent { &DurationRecord::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, "weeks"sv, "week"sv, date_values, "short"sv },
+    DurationInstanceComponent { &DurationRecord::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, "days"sv, "day"sv, date_values, "short"sv },
+    DurationInstanceComponent { &DurationRecord::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, "hours"sv, "hour"sv, time_values, "numeric"sv },
+    DurationInstanceComponent { &DurationRecord::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, "minutes"sv, "minute"sv, time_values, "numeric"sv },
+    DurationInstanceComponent { &DurationRecord::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, "seconds"sv, "second"sv, time_values, "numeric"sv },
+    DurationInstanceComponent { &DurationRecord::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, "milliseconds"sv, "millisecond"sv, sub_second_values, "numeric"sv },
+    DurationInstanceComponent { &DurationRecord::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, "microseconds"sv, "microsecond"sv, sub_second_values, "numeric"sv },
+    DurationInstanceComponent { &DurationRecord::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, "nanoseconds"sv, "nanosecond"sv, sub_second_values, "numeric"sv },
 };
 
 struct DurationUnitOptions {
@@ -239,15 +252,16 @@ struct DurationFormatPart {
     StringView unit;
 };
 
-ThrowCompletionOr<Temporal::DurationRecord> to_duration_record(VM&, Value input);
+ThrowCompletionOr<DurationRecord> to_duration_record(VM&, Value input);
+i8 duration_sign(DurationRecord const&);
 ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, String const& unit, Object const& options, StringView base_style, ReadonlySpan<StringView> styles_list, StringView digital_base, StringView previous_style, bool two_digit_hours);
-double add_fractional_digits(DurationFormat const&, Temporal::DurationRecord const&);
+double add_fractional_digits(DurationFormat const&, DurationRecord const&);
 bool next_unit_fractional(DurationFormat const&, StringView unit);
 Vector<DurationFormatPart> format_numeric_hours(VM&, DurationFormat const&, double hours_value, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_minutes(VM&, DurationFormat const&, double minutes_value, bool hours_displayed, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_seconds(VM&, DurationFormat const&, double seconds_value, bool minutes_displayed, bool sign_displayed);
-Vector<DurationFormatPart> format_numeric_units(VM&, DurationFormat const&, Temporal::DurationRecord const&, StringView first_numeric_unit, bool sign_displayed);
+Vector<DurationFormatPart> format_numeric_units(VM&, DurationFormat const&, DurationRecord const&, StringView first_numeric_unit, bool sign_displayed);
 Vector<DurationFormatPart> list_format_parts(VM&, DurationFormat const&, Vector<Vector<DurationFormatPart>>& partitioned_parts_list);
-Vector<DurationFormatPart> partition_duration_format_pattern(VM&, DurationFormat const&, Temporal::DurationRecord const&);
+Vector<DurationFormatPart> partition_duration_format_pattern(VM&, DurationFormat const&, DurationRecord const&);
 
 }

--- a/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -22,7 +22,6 @@
 #include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
 #include <LibJS/Runtime/Intl/SegmenterConstructor.h>
 #include <LibJS/Runtime/Intl/SingleUnitIdentifiers.h>
-#include <LibJS/Runtime/Temporal/TimeZone.h>
 #include <LibUnicode/DateTimeFormat.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>

--- a/Libraries/LibJS/Tests/builtins/Function/Function.prototype.toString.js
+++ b/Libraries/LibJS/Tests/builtins/Function/Function.prototype.toString.js
@@ -128,8 +128,8 @@ describe("correct behavior", () => {
         expect(console.debug.toString()).toBe("function debug() { [native code] }");
         expect(Function.toString()).toBe("function Function() { [native code] }");
         expect(
-            Object.getOwnPropertyDescriptor(Temporal.TimeZone.prototype, "id").get.toString()
-        ).toBe("function get id() { [native code] }");
+            Object.getOwnPropertyDescriptor(Intl.NumberFormat.prototype, "format").get.toString()
+        ).toBe("function get format() { [native code] }");
 
         const values = [
             // Callable Proxy

--- a/Libraries/LibJS/Tests/test-common.js
+++ b/Libraries/LibJS/Tests/test-common.js
@@ -599,20 +599,20 @@ class ExpectationError extends Error {
             return;
         }
 
-        const now = () => Temporal.Now.instant().epochNanoseconds;
-        const start = now();
-        const time_us = () => Number(BigInt.asIntN(53, (now() - start) / 1000n));
+        const start = Date.now();
+        const time_ms = () => Date.now() - start;
+
         try {
             callback();
             suite[message] = {
                 result: "pass",
-                duration: time_us(),
+                duration: time_ms(),
             };
         } catch (e) {
             suite[message] = {
                 result: "fail",
                 details: String(e),
-                duration: time_us(),
+                duration: time_ms(),
             };
         }
     };
@@ -652,20 +652,20 @@ class ExpectationError extends Error {
             return;
         }
 
-        const now = () => Temporal.Now.instant().epochNanoseconds;
-        const start = now();
-        const time_us = () => Number(BigInt.asIntN(53, (now() - start) / 1000n));
+        const start = Date.now();
+        const time_ms = () => Date.now() - start;
+
         try {
             callback();
             suite[message] = {
                 result: "fail",
                 details: "Expected test to fail, but it passed",
-                duration: time_us(),
+                duration: time_ms(),
             };
         } catch (e) {
             suite[message] = {
                 result: "xfail",
-                duration: time_us(),
+                duration: time_ms(),
             };
         }
     };
@@ -677,21 +677,21 @@ class ExpectationError extends Error {
     withinSameSecond = callback => {
         let callbackDuration;
         for (let tries = 0; tries < 5; tries++) {
-            const start = Temporal.Now.instant();
+            const start = Date.now();
             const result = callback();
-            const end = Temporal.Now.instant();
-            if (start.epochSeconds !== end.epochSeconds) {
-                callbackDuration = start.until(end);
+            const end = Date.now();
+
+            if (start / 1000 != end / 1000) {
+                callbackDuration = end - start;
                 continue;
             }
+
             return result;
         }
         throw new ExpectationError(
             `Tried to execute callback '${callback}' 5 times within the same second but ` +
                 `failed. Make sure the callback does as little work as possible (the last run ` +
-                `took ${callbackDuration.total(
-                    "milliseconds"
-                )} ms) and the machine is not overloaded. If you see this ` +
+                `took ${callbackDuration}ms) and the machine is not overloaded. If you see this ` +
                 `error appearing in the CI it is most likely a flaky failure!`
         );
     };


### PR DESCRIPTION
These commits are to prepare us to get caught back up with the Temporal spec. My plan is to basically remove our current Temporal implementation and begin anew. I've tried a few times to make updates in place, but everything in Temporal is so intertwined that I've become convinced that is a non-starter.

So the commits here fall into one of two categories:
1. Stop using Temporal facilities that have been removed (e.g. parsing UTC offset strings)
2. Stop using Temporal facilities where we can achieve the same behavior without Temporal (e.g. when we only need millisecond resolution, and not nanoseconds from Temporal).

No test262 diff here.