### PR TITLE
LibGfx: Adjust matrices for XYZ -> sRGB conversions

### DIFF
--- a/Libraries/LibGfx/Color.cpp
+++ b/Libraries/LibGfx/Color.cpp
@@ -505,22 +505,22 @@ Color Color::from_rec2020(float r, float g, float b, float alpha)
 
 Color Color::from_xyz50(float x, float y, float z, float alpha)
 {
-    // See commit description for these values
-    float red = 3.13397926 * x - 1.61689519 * y - 0.49070587 * z;
-    float green = -0.97840009 * x + 1.91589112 * y + 0.03339256 * z;
-    float blue = 0.07200357 * x - 0.22897505 * y + 1.40517398 * z;
+    // See commit description for these values.
+    float r = +3.134136 * x - 1.617386 * y - 0.490662 * z;
+    float g = -0.978795 * x + 1.916254 * y + 0.033443 * z;
+    float b = +0.071955 * x - 0.228977 * y + 1.405386 * z;
 
-    return from_linear_srgb(red, green, blue, alpha);
+    return from_linear_srgb(r, g, b, alpha);
 }
 
 Color Color::from_xyz65(float x, float y, float z, float alpha)
 {
-    // https://en.wikipedia.org/wiki/SRGB#From_CIE_XYZ_to_sRGB
-    float red = 3.2406 * x - 1.5372 * y - 0.4986 * z;
-    float green = -0.9689 * x + 1.8758 * y + 0.0415 * z;
-    float blue = 0.0557 * x - 0.2040 * y + 1.0570 * z;
+    // See commit description for these values.
+    float r = +3.240970 * x - 1.537383 * y - 0.498611 * z;
+    float g = -0.969244 * x + 1.875968 * y + 0.041555 * z;
+    float b = +0.055630 * x - 0.203977 * y + 1.056972 * z;
 
-    return from_linear_srgb(red, green, blue, alpha);
+    return from_linear_srgb(r, g, b, alpha);
 }
 
 Color Color::from_lab(float L, float a, float b, float alpha)

--- a/Tests/LibGfx/TestColor.cpp
+++ b/Tests/LibGfx/TestColor.cpp
@@ -14,3 +14,10 @@ TEST_CASE(color)
         EXPECT_EQ(gray, gray.to_grayscale());
     }
 }
+
+TEST_CASE(all_green)
+{
+    EXPECT_EQ(Color(Color::NamedColor::Green), Color::from_lab(87.8185, -79.2711, 80.9946));
+    EXPECT_EQ(Color(Color::NamedColor::Green), Color::from_xyz50(0.385152, 0.716887, 0.097081));
+    EXPECT_EQ(Color(Color::NamedColor::Green), Color::from_xyz65(0.357584, 0.715169, 0.119195));
+}

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -59,7 +59,6 @@ Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/resour
 Text/input/wpt-import/css/css-flexbox/flex-item-compressible-001.html
 
 ; WPT ref-tests that currently fail
-Ref/input/wpt-import/css/css-color/srgb-linear-004.html
 Ref/input/wpt-import/css/css-nesting/host-nesting-003.html
 Ref/input/wpt-import/css/css-nesting/host-nesting-004.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-002r.xht


### PR DESCRIPTION
TL;DR: There are two available sets of coefficients for the conversion matrices from XYZ to sRGB. We switched from one set to the other, which is what the WPT tests are expecting.

All RGB color spaces, like display-p3 or rec2020, are defined by their three color chromacities and a white point. This is also the case for the video color space Rec. 709, from which the sRGB color space is derived. The sRGB specification is however a bit different.

In 1996, when formalizing the sRGB spec the authors published a draft that is still available here [1]. In this document, they also provide the matrix to convert from the XYZ color space to sRGB. This matrix can be verified quite easily by using the usual math equations. But hold on, here come the plot twist: at the time of publication, the spec contained a different matrix than the one in the draft (the spec is obviously behind a pay wall, but the numbers are also reported in this official document [2]). This official matrix, is at a first glance simply a wrongly rounded version of the one in the draft publication. It however has some interesting properties: it can be inverted twice (so a roundtrip) in 8 bits and not suffer from any errors from the calculations.

So, we are here with two versions of the XYZ -> sRGB matrix, the one from the spec, which is:
 - better for computations in 8 bits,
 - and official. This is the one that, by authority, we should use. And a second version, that can be found in the draft, which:
 - makes sense, as directly derived from the chromacities,
 - is publicly available,
 - and (thus?) used in most places.

The old coefficients were the one from the spec, this commit change them for the one derived from the mathematical formulae. The Python script to compute these values is available at the end of the commit description.

More details about this subject can be found here [3].

[1] https://www.w3.org/Graphics/Color/sRGB.html
[2] https://color.org/chardata/rgb/sRGB.pdf
[3] https://photosauce.net/blog/post/making-a-minimal-srgb-icc-profile-part-3-choose-your-colors-carefully

The Python script:

```python
# http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html

from numpy.typing import NDArray
import numpy as np

### sRGB
# https://www.w3.org/TR/css-color-4/#predefined-sRGB
srgb_r_chromacity = np.array([0.640, 0.330])
srgb_g_chromacity = np.array([0.300, 0.600])
srgb_b_chromacity = np.array([0.150, 0.060])
##

## White points
white_point_d50 = np.array([0.345700, 0.358500])
white_point_d65 = np.array([0.312700, 0.329000])
#

r_chromacity = srgb_r_chromacity
g_chromacity = srgb_g_chromacity
b_chromacity = srgb_b_chromacity
white_point = white_point_d65

def tristmimulus_vector(chromacity: NDArray) -> NDArray:
    return np.array([
        chromacity[0] /chromacity[1],
        1,
        (1 - chromacity[0] - chromacity[1]) / chromacity[1]
    ])

tristmimulus_matrix = np.hstack((
    tristmimulus_vector(r_chromacity).reshape(3, 1),
    tristmimulus_vector(g_chromacity).reshape(3, 1),
    tristmimulus_vector(b_chromacity).reshape(3, 1),
))

scaling_factors = (np.linalg.inv(tristmimulus_matrix) @
                   tristmimulus_vector(white_point))

M = tristmimulus_matrix * scaling_factors

np.set_printoptions(formatter={'float_kind':'{:.6f}'.format})
xyz_65_to_srgb = np.linalg.inv(M)

# http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
# Let's convert from D50 to D65 using the Bradford method.
m_a = np.array([
    [0.8951000, 0.2664000, -0.1614000],
    [-0.7502000, 1.7135000, 0.0367000],
    [0.0389000, -0.0685000, 1.0296000]
])

cone_response_source = m_a @ tristmimulus_vector(white_point_d50)
cone_response_destination = m_a @ tristmimulus_vector(white_point_d65)

cone_response_ratio = cone_response_destination / cone_response_source
m = np.linalg.inv(m_a) @ np.diagflat(cone_response_ratio) @ m_a

D50_to_D65 = m
xyz_50_to_srgb = xyz_65_to_srgb @ D50_to_D65

print(xyz_50_to_srgb)
print(xyz_65_to_srgb)
```