### PR TITLE
Experiment with dropping angle brackets in the devtools DOM Inspector tree view

### DIFF
--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -610,9 +610,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             comment = escape_html_entities(comment);
 
             builder.appendff("<span class=\"hoverable comment\" {}>", data_attributes.string_view());
-            builder.append("<span>&lt;!--</span>"sv);
-            builder.appendff("<span data-node-type=\"comment\" class=\"editable\">{}</span>", comment);
-            builder.append("<span>--&gt;</span>"sv);
+            builder.appendff("<span data-node-type=\"comment\" class=\"editable\" title=\"comment\">{}</span>", comment);
             builder.append("</span>"sv);
             return;
         }
@@ -636,7 +634,6 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             auto tag = name.to_lowercase();
 
             builder.appendff("<span class=\"hoverable\" {}>", data_attributes.string_view());
-            builder.append("<span>&lt;</span>"sv);
             builder.appendff("<span data-node-type=\"tag\" data-tag=\"{0}\" class=\"editable tag\">{0}</span>", tag);
 
             if (auto attributes = node.get_object("attributes"sv); attributes.has_value()) {
@@ -654,8 +651,6 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
                     dom_node_attributes.empend(MUST(String::from_byte_string(name)), MUST(String::from_byte_string(value_string)));
                 });
             }
-
-            builder.append("<span>&gt;</span>"sv);
         }
 
         // display miscellaneous extra bits of info about the element

--- a/Libraries/LibWebView/SourceHighlighter.h
+++ b/Libraries/LibWebView/SourceHighlighter.h
@@ -87,7 +87,9 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
         }
 
         :root {
-            --comment-color: lightgreen;
+            --comment-color: dimgrey;
+            --comment-hover-color: lightgreen;
+            --details-background-color: #333;
             --keyword-color: orangered;
             --name-color: orange;
             --value-color: deepskyblue;
@@ -100,7 +102,9 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
 
     @media (prefers-color-scheme: light) {
         :root {
-            --comment-color: green;
+            --comment-color: silver;
+            --comment-hover-color: green;
+            --details-background-color: whitesmoke;
             --keyword-color: red;
             --name-color: darkorange;
             --value-color: blue;
@@ -133,12 +137,26 @@ constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
         color: var(--line-number-color);
     }
 
+    details, div {
+        margin-top: 4px;
+        margin-bottom: 4px;
+
+    details {
+        border: 1px solid #777;
+        border-radius: 6px;
+        padding: 2px 3px 2px 3px !important;
+        background-color: var(--details-background-color);
+    }
     .tag {
         font-weight: 600;
         color: var(--keyword-color);
     }
     .comment {
         color: var(--comment-color);
+    }
+    .comment:hover {
+        color: var(--comment-hover-color);
+        background-color: inherit !important;
     }
     .attribute-name {
         color: var(--name-color);


### PR DESCRIPTION
Since elements in the DOM don’t have start tags or end tags or other markup, let’s experiment with making them not look like markup — by dropping the angle brackets added around element names in the tree view in the DOM Inspector.

And let’s also drop the markup-looking delimiters around comments.

Then, to take things further and bring the DOM Inspector tree view more in line with what it’s actually representing, let’s add some styling to more clearly represent elements as containers/boxes that hold/contain other element-node containers, as well as (non-container) text nodes and comments nodes.

In other words, let’s try making a tree of DOM nodes/containers look like a tree of DOM nodes/containers.

And let’s explore making it look less like markup.

Let’s see if we can make something a little more new and fun more adventurous than what older browsers all have.

With just the angle brackets removed, but no new styling, here’s what things look like:

<img width="898" alt="dom-inspector-no-angle-brackets" src="https://github.com/user-attachments/assets/30b9d88f-7001-4cc5-954c-bfbb453c133f">

And with some new styling added, here’s what things look like:

<img width="916" alt="inspector-restyled" src="https://github.com/user-attachments/assets/c7b53bc3-2e01-442c-92e2-7fe9c017c365">

---

Part of the rationale for the changes is: many HTML authors have a somewhat confused view of what’s actually in the DOM. For example, some authors imagine elements in the DOM have start tags and end tags, and other markup features.

So by not representing the DOM as something that looks like markup, we can help authors have a better mental model of what the DOM is — and what a (parsed) HTML document actually is (that is, a tree of DOM nodes).

In other words, let’s try making a tree of DOM nodes look like a tree of DOM nodes. And look less like markup.

Later, if a lot of people end up finding it too unsettling to see this new, somewhat more-adventurous kind of DOM tree view — and want to switch back to the old, more-comfortable-by-way-familiarity-and-inertia markup-like view that older browsers have reflexively all adopted — then we can change it back at that time.

But for now, this changes give us a starting point for something a little fun and new and more exploratory from which we can experiment with and refine further, to see how far we can take it.