### PR TITLE
LibRegex: Don't immediately ignore TempInverse in optimizer

### DIFF
--- a/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Libraries/LibRegex/RegexOptimizer.cpp
@@ -227,7 +227,7 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
             break;
         case CharacterCompareType::TemporaryInverse:
             temporary_inverse = true;
-            reset_temporary_inverse = true;
+            reset_temporary_inverse = false;
             break;
         case CharacterCompareType::AnyChar:
             // Special case: if not inverted, AnyChar is always in the range.
@@ -349,7 +349,7 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
             break;
         case CharacterCompareType::TemporaryInverse:
             temporary_inverse = true;
-            reset_temporary_inverse = true;
+            reset_temporary_inverse = false;
             break;
         case CharacterCompareType::AnyChar:
             // Special case: if not inverted, AnyChar is always in the range.

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -1042,6 +1042,8 @@ TEST_CASE(optimizer_atomic_groups)
         // (b+)(b+) produces an intermediate block with no matching ops, the optimiser should ignore that block when looking for following matches and correctly detect the overlap between (b+) and (b+).
         // note that the second loop may be rewritten to a ForkReplace, but the first loop should not be rewritten.
         Tuple { "(b+)(b+)"sv, "bbb"sv, true },
+        // Don't treat [\S] as [\s]; see ladybird#2296.
+        Tuple { "([^\\s]+?)\\(([\\s\\S]*)\\)"sv, "a(b)"sv, true },
     };
 
     for (auto& test : tests) {


### PR DESCRIPTION
fe46b2c1411 added the reset-temp-inverse flag, but set it up so all tempinverse ops were negated at the start of the next op; this commit makes it so these flags actually persist for one op and not zero.

Fixes #2296.