### PR TITLE
LibWeb: Properly escape URL on error page

### DIFF
--- a/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -33,7 +33,7 @@ ErrorOr<String> load_error_page(URL::URL const& url, StringView error_message)
     auto template_file = TRY(Core::Resource::load_from_uri("resource://ladybird/templates/error.html"sv));
     StringBuilder builder;
     SourceGenerator generator { builder, '%', '%' };
-    generator.set("failed_url", url.to_byte_string());
+    generator.set("failed_url", escape_html_entities(url.to_byte_string()));
     generator.set("error_message", escape_html_entities(error_message));
     generator.append(template_file->data());
     return TRY(String::from_utf8(generator.as_string_view()));


### PR DESCRIPTION
The result of three hours of trying to figure out why going to `data:text/html;<button style="position: absolute">Hello!</button>` loads both the error document and the real document from the malformed data URL into the same page.
(It is malformed because it has a semicolon, not a comma)