### PR TITLE
LibWeb: Add MediaSourceExtensions events

### DIFF
--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -45,6 +45,7 @@
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/MathML/TagNames.h>
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/NavigationTiming/EntryNames.h>
 #include <LibWeb/PerformanceTimeline/EntryTypes.h>
@@ -105,6 +106,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
     HTML::EventNames::initialize_strings();
     HTML::TagNames::initialize_strings();
     MathML::TagNames::initialize_strings();
+    MediaSourceExtensions::EventNames::initialize_strings();
     Namespace::initialize_strings();
     NavigationTiming::EntryNames::initialize_strings();
     PerformanceTimeline::EntryTypes::initialize_strings();

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -576,6 +576,7 @@ set(SOURCES
     MathML/TagNames.cpp
     MediaCapabilitiesAPI/MediaCapabilities.cpp
     MediaSourceExtensions/BufferedChangeEvent.cpp
+    MediaSourceExtensions/EventNames.cpp
     MediaSourceExtensions/ManagedMediaSource.cpp
     MediaSourceExtensions/ManagedSourceBuffer.cpp
     MediaSourceExtensions/MediaSource.cpp

--- a/Libraries/LibWeb/MediaSourceExtensions/EventNames.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/EventNames.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
+
+namespace Web::MediaSourceExtensions::EventNames {
+
+#define __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(name) FlyString name;
+ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(__ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE)
+#undef __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE
+
+void initialize_strings()
+{
+    static bool s_initialized = false;
+    VERIFY(!s_initialized);
+
+#define __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(name) \
+    name = #name##_fly_string;
+    ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(__ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE)
+#undef __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE
+
+    s_initialized = true;
+}
+
+}

--- a/Libraries/LibWeb/MediaSourceExtensions/EventNames.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/EventNames.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+
+namespace Web::MediaSourceExtensions::EventNames {
+
+#define ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(E) \
+    E(abort)                                            \
+    E(addsourcebuffer)                                  \
+    E(bufferedchange)                                   \
+    E(endstreaming)                                     \
+    E(error)                                            \
+    E(removesourcebuffer)                               \
+    E(sourceclose)                                      \
+    E(sourceended)                                      \
+    E(sourceopen)                                       \
+    E(startstreaming)                                   \
+    E(update)                                           \
+    E(updateend)                                        \
+    E(updatestart)
+
+#define __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(name) extern FlyString name;
+ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(__ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE)
+#undef __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE
+
+void initialize_strings();
+
+}

--- a/Libraries/LibWeb/MediaSourceExtensions/ManagedMediaSource.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/ManagedMediaSource.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ManagedMediaSourcePrototype.h>
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
 #include <LibWeb/MediaSourceExtensions/ManagedMediaSource.h>
 
 namespace Web::MediaSourceExtensions {
@@ -28,6 +29,30 @@ void ManagedMediaSource::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(ManagedMediaSource);
+}
+
+// https://w3c.github.io/media-source/#dom-managedmediasource-onstartstreaming
+void ManagedMediaSource::set_onstartstreaming(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::startstreaming, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-managedmediasource-onstartstreaming
+GC::Ptr<WebIDL::CallbackType> ManagedMediaSource::onstartstreaming()
+{
+    return event_handler_attribute(EventNames::startstreaming);
+}
+
+// https://w3c.github.io/media-source/#dom-managedmediasource-onendstreaming
+void ManagedMediaSource::set_onendstreaming(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::endstreaming, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-managedmediasource-onendstreaming
+GC::Ptr<WebIDL::CallbackType> ManagedMediaSource::onendstreaming()
+{
+    return event_handler_attribute(EventNames::endstreaming);
 }
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/ManagedMediaSource.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/ManagedMediaSource.h
@@ -18,6 +18,12 @@ class ManagedMediaSource : public MediaSource {
 public:
     [[nodiscard]] static WebIDL::ExceptionOr<GC::Ref<ManagedMediaSource>> construct_impl(JS::Realm&);
 
+    void set_onstartstreaming(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onstartstreaming();
+
+    void set_onendstreaming(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onendstreaming();
+
 private:
     ManagedMediaSource(JS::Realm&);
 

--- a/Libraries/LibWeb/MediaSourceExtensions/ManagedMediaSource.idl
+++ b/Libraries/LibWeb/MediaSourceExtensions/ManagedMediaSource.idl
@@ -6,6 +6,6 @@
 interface ManagedMediaSource : MediaSource {
     constructor();
     [FIXME] readonly attribute boolean streaming;
-    [FIXME] attribute EventHandler onstartstreaming;
-    [FIXME] attribute EventHandler onendstreaming;
+    attribute EventHandler onstartstreaming;
+    attribute EventHandler onendstreaming;
 };

--- a/Libraries/LibWeb/MediaSourceExtensions/ManagedSourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/ManagedSourceBuffer.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ManagedSourceBufferPrototype.h>
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
 #include <LibWeb/MediaSourceExtensions/ManagedSourceBuffer.h>
 
 namespace Web::MediaSourceExtensions {
@@ -23,6 +24,18 @@ void ManagedSourceBuffer::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(ManagedSourceBuffer);
+}
+
+// https://w3c.github.io/media-source/#dom-managedsourcebuffer-onbufferedchange
+void ManagedSourceBuffer::set_onbufferedchange(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::bufferedchange, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-managedsourcebuffer-onbufferedchange
+GC::Ptr<WebIDL::CallbackType> ManagedSourceBuffer::onbufferedchange()
+{
+    return event_handler_attribute(EventNames::bufferedchange);
 }
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/ManagedSourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/ManagedSourceBuffer.h
@@ -16,6 +16,9 @@ class ManagedSourceBuffer : public SourceBuffer {
     GC_DECLARE_ALLOCATOR(ManagedSourceBuffer);
 
 public:
+    void set_onbufferedchange(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onbufferedchange();
+
 private:
     ManagedSourceBuffer(JS::Realm&);
 

--- a/Libraries/LibWeb/MediaSourceExtensions/ManagedSourceBuffer.idl
+++ b/Libraries/LibWeb/MediaSourceExtensions/ManagedSourceBuffer.idl
@@ -4,5 +4,5 @@
 // https://w3c.github.io/media-source/#managedsourcebuffer-interface
 [Exposed=(Window,DedicatedWorker)]
 interface ManagedSourceBuffer : SourceBuffer {
-    [FIXME] attribute EventHandler onbufferedchange;
+    attribute EventHandler onbufferedchange;
 };

--- a/Libraries/LibWeb/MediaSourceExtensions/MediaSource.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/MediaSource.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/MediaSourcePrototype.h>
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
 #include <LibWeb/MediaSourceExtensions/MediaSource.h>
 
 namespace Web::MediaSourceExtensions {
@@ -28,6 +29,42 @@ void MediaSource::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(MediaSource);
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-onsourceopen
+void MediaSource::set_onsourceopen(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::sourceopen, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-onsourceopen
+GC::Ptr<WebIDL::CallbackType> MediaSource::onsourceopen()
+{
+    return event_handler_attribute(EventNames::sourceopen);
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-onsourceended
+void MediaSource::set_onsourceended(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::sourceended, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-onsourceended
+GC::Ptr<WebIDL::CallbackType> MediaSource::onsourceended()
+{
+    return event_handler_attribute(EventNames::sourceended);
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-onsourceclose
+void MediaSource::set_onsourceclose(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::sourceclose, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-mediasource-onsourceclose
+GC::Ptr<WebIDL::CallbackType> MediaSource::onsourceclose()
+{
+    return event_handler_attribute(EventNames::sourceclose);
 }
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/MediaSource.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/MediaSource.h
@@ -21,6 +21,15 @@ public:
     // https://w3c.github.io/media-source/#dom-mediasource-canconstructindedicatedworker
     static bool can_construct_in_dedicated_worker(JS::VM&) { return true; }
 
+    void set_onsourceopen(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onsourceopen();
+
+    void set_onsourceended(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onsourceended();
+
+    void set_onsourceclose(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onsourceclose();
+
 protected:
     MediaSource(JS::Realm&);
 

--- a/Libraries/LibWeb/MediaSourceExtensions/MediaSource.idl
+++ b/Libraries/LibWeb/MediaSourceExtensions/MediaSource.idl
@@ -27,9 +27,9 @@ interface MediaSource : EventTarget {
     [FIXME] readonly  attribute ReadyState readyState;
 
     [FIXME] attribute unrestricted double duration;
-    [FIXME] attribute EventHandler onsourceopen;
-    [FIXME] attribute EventHandler onsourceended;
-    [FIXME] attribute EventHandler onsourceclose;
+    attribute EventHandler onsourceopen;
+    attribute EventHandler onsourceended;
+    attribute EventHandler onsourceclose;
 
     static readonly attribute boolean canConstructInDedicatedWorker;
 

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SourceBufferPrototype.h>
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
 #include <LibWeb/MediaSourceExtensions/SourceBuffer.h>
 
 namespace Web::MediaSourceExtensions {
@@ -23,6 +24,66 @@ void SourceBuffer::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SourceBuffer);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onupdatestart
+void SourceBuffer::set_onupdatestart(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::updatestart, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onupdatestart
+GC::Ptr<WebIDL::CallbackType> SourceBuffer::onupdatestart()
+{
+    return event_handler_attribute(EventNames::updatestart);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onupdate
+void SourceBuffer::set_onupdate(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::update, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onupdate
+GC::Ptr<WebIDL::CallbackType> SourceBuffer::onupdate()
+{
+    return event_handler_attribute(EventNames::update);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onupdateend
+void SourceBuffer::set_onupdateend(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::updateend, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onupdateend
+GC::Ptr<WebIDL::CallbackType> SourceBuffer::onupdateend()
+{
+    return event_handler_attribute(EventNames::updateend);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onerror
+void SourceBuffer::set_onerror(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::error, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onerror
+GC::Ptr<WebIDL::CallbackType> SourceBuffer::onerror()
+{
+    return event_handler_attribute(EventNames::error);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onabort
+void SourceBuffer::set_onabort(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::abort, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebuffer-onabort
+GC::Ptr<WebIDL::CallbackType> SourceBuffer::onabort()
+{
+    return event_handler_attribute(EventNames::abort);
 }
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.h
@@ -15,6 +15,22 @@ class SourceBuffer : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(SourceBuffer, DOM::EventTarget);
     GC_DECLARE_ALLOCATOR(SourceBuffer);
 
+public:
+    void set_onupdatestart(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onupdatestart();
+
+    void set_onupdate(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onupdate();
+
+    void set_onupdateend(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onupdateend();
+
+    void set_onerror(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onerror();
+
+    void set_onabort(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onabort();
+
 protected:
     SourceBuffer(JS::Realm&);
 

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.idl
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBuffer.idl
@@ -23,11 +23,11 @@ interface SourceBuffer : EventTarget {
     [FIXME] attribute double appendWindowStart;
     [FIXME] attribute unrestricted double appendWindowEnd;
 
-    [FIXME] attribute EventHandler onupdatestart;
-    [FIXME] attribute EventHandler onupdate;
-    [FIXME] attribute EventHandler onupdateend;
-    [FIXME] attribute EventHandler onerror;
-    [FIXME] attribute EventHandler onabort;
+    attribute EventHandler onupdatestart;
+    attribute EventHandler onupdate;
+    attribute EventHandler onupdateend;
+    attribute EventHandler onerror;
+    attribute EventHandler onabort;
 
     [FIXME] undefined appendBuffer(BufferSource data);
     [FIXME] undefined abort();

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/SourceBufferListPrototype.h>
+#include <LibWeb/MediaSourceExtensions/EventNames.h>
 #include <LibWeb/MediaSourceExtensions/SourceBufferList.h>
 
 namespace Web::MediaSourceExtensions {
@@ -23,6 +24,30 @@ void SourceBufferList::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(SourceBufferList);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebufferlist-onaddsourcebuffer
+void SourceBufferList::set_onaddsourcebuffer(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::addsourcebuffer, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebufferlist-onaddsourcebuffer
+GC::Ptr<WebIDL::CallbackType> SourceBufferList::onaddsourcebuffer()
+{
+    return event_handler_attribute(EventNames::addsourcebuffer);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebufferlist-onremovesourcebuffer
+void SourceBufferList::set_onremovesourcebuffer(GC::Ptr<WebIDL::CallbackType> event_handler)
+{
+    set_event_handler_attribute(EventNames::removesourcebuffer, event_handler);
+}
+
+// https://w3c.github.io/media-source/#dom-sourcebufferlist-onremovesourcebuffer
+GC::Ptr<WebIDL::CallbackType> SourceBufferList::onremovesourcebuffer()
+{
+    return event_handler_attribute(EventNames::removesourcebuffer);
 }
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.h
@@ -15,6 +15,13 @@ class SourceBufferList : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(SourceBufferList, DOM::EventTarget);
     GC_DECLARE_ALLOCATOR(SourceBufferList);
 
+public:
+    void set_onaddsourcebuffer(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onaddsourcebuffer();
+
+    void set_onremovesourcebuffer(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onremovesourcebuffer();
+
 private:
     SourceBufferList(JS::Realm&);
 

--- a/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.idl
+++ b/Libraries/LibWeb/MediaSourceExtensions/SourceBufferList.idl
@@ -6,8 +6,8 @@
 interface SourceBufferList : EventTarget {
     [FIXME] readonly attribute unsigned long length;
 
-    [FIXME] attribute EventHandler onaddsourcebuffer;
-    [FIXME] attribute EventHandler onremovesourcebuffer;
+    attribute EventHandler onaddsourcebuffer;
+    attribute EventHandler onremovesourcebuffer;
 
     [FIXME] getter SourceBuffer (unsigned long index);
 };


### PR DESCRIPTION
Continuing the boilerplate for these interfaces.