### PR TITLE
LibWeb: Set element as target element if url fragment matches its id

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -232,7 +232,12 @@ void HTMLParser::run(HTMLTokenizer::StopAtInsertionPoint stop_at_insertion_point
             break;
         }
     }
-
+    // Set element as target element if url fragment matches its id.
+    auto url_fragment = m_document->url().fragment();
+    GC::Ptr<DOM::Element> target_element;
+    if (url_fragment.has_value() && (target_element = m_document->get_element_by_id(url_fragment.value()))) {
+        m_document->set_target_element(target_element);
+    }
     flush_character_insertions();
 }
 

--- a/Tests/LibWeb/Ref/expected/iframe-target-element.html
+++ b/Tests/LibWeb/Ref/expected/iframe-target-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<iframe id="iframe"></iframe>
+
+<script>
+const IFRAME_DATA_SRC = `data:text/html,
+    
+    <p id="foo">This should be green.</p>
+    <style>%23foo { color: green; }<\/style>#foo`.replace('\n', '');
+
+const iframe = document.getElementById("iframe");
+iframe.src = IFRAME_DATA_SRC;
+</script>

--- a/Tests/LibWeb/Ref/input/iframe-target-element.html
+++ b/Tests/LibWeb/Ref/input/iframe-target-element.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/iframe-target-element.html" />
+<iframe id="iframe"></iframe>
+
+<script>
+const IFRAME_DATA_SRC = `data:text/html,
+    <style>:target { color: green; }<\/style>
+    <p id="foo">This should be green.</p>#foo`.replace('\n', '');
+
+const iframe = document.getElementById("iframe");
+iframe.src = IFRAME_DATA_SRC;
+</script>


### PR DESCRIPTION
Fixes the problem with https://wpt.live/url/data-uri-fragment.html