### PR TITLE
LibWeb: Allow stacking context to only be created by PaintableBox

### DIFF
--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -128,24 +128,23 @@ TraversalDecision Paintable::hit_test(CSSPixelPoint, HitTestType, Function<Trave
     return TraversalDecision::Continue;
 }
 
+bool Paintable::has_stacking_context() const
+{
+    if (is_paintable_box())
+        return static_cast<PaintableBox const&>(*this).stacking_context();
+    return false;
+}
+
 StackingContext* Paintable::enclosing_stacking_context()
 {
     for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
-        if (auto* stacking_context = ancestor->stacking_context())
+        if (!ancestor->is_paintable_box())
+            continue;
+        if (auto* stacking_context = static_cast<PaintableBox&>(*ancestor).stacking_context())
             return const_cast<StackingContext*>(stacking_context);
     }
     // We should always reach the viewport's stacking context.
     VERIFY_NOT_REACHED();
-}
-
-void Paintable::set_stacking_context(NonnullOwnPtr<StackingContext> stacking_context)
-{
-    m_stacking_context = move(stacking_context);
-}
-
-void Paintable::invalidate_stacking_context()
-{
-    m_stacking_context = nullptr;
 }
 
 void Paintable::set_needs_display(InvalidateDisplayList should_invalidate_display_list)

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -146,12 +146,8 @@ public:
         return TraversalDecision::Continue;
     }
 
-    StackingContext* stacking_context() { return m_stacking_context; }
-    StackingContext const* stacking_context() const { return m_stacking_context; }
-    void set_stacking_context(NonnullOwnPtr<StackingContext>);
+    bool has_stacking_context() const;
     StackingContext* enclosing_stacking_context();
-
-    void invalidate_stacking_context();
 
     virtual void before_paint(PaintContext&, PaintPhase) const { }
     virtual void after_paint(PaintContext&, PaintPhase) const { }
@@ -250,8 +246,6 @@ private:
     GC::Ptr<DOM::Node> m_dom_node;
     GC::Ref<Layout::Node const> m_layout_node;
     Optional<GC::Ptr<PaintableBox>> mutable m_containing_block;
-
-    OwnPtr<StackingContext> m_stacking_context;
 
     SelectionState m_selection_state { SelectionState::None };
 

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -437,6 +437,16 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
     }
 }
 
+void PaintableBox::set_stacking_context(NonnullOwnPtr<StackingContext> stacking_context)
+{
+    m_stacking_context = move(stacking_context);
+}
+
+void PaintableBox::invalidate_stacking_context()
+{
+    m_stacking_context = nullptr;
+}
+
 BordersData PaintableBox::remove_element_kind_from_borders_data(PaintableBox::BordersDataWithElementKind borders_data)
 {
     return {
@@ -933,7 +943,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
     }
 
     for (auto const& fragment : fragments()) {
-        if (fragment.paintable().stacking_context())
+        if (fragment.paintable().has_stacking_context())
             continue;
         auto fragment_absolute_rect = fragment.absolute_rect();
         if (fragment_absolute_rect.contains(position_adjusted_by_scroll_offset)) {

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -35,6 +35,11 @@ public:
 
     virtual void paint(PaintContext&, PaintPhase) const override;
 
+    StackingContext* stacking_context() { return m_stacking_context; }
+    StackingContext const* stacking_context() const { return m_stacking_context; }
+    void set_stacking_context(NonnullOwnPtr<StackingContext>);
+    void invalidate_stacking_context();
+
     virtual Optional<CSSPixelRect> get_masking_area() const;
     virtual Optional<Gfx::Bitmap::MaskKind> get_mask_type() const { return {}; }
     virtual RefPtr<Gfx::ImmutableBitmap> calculate_mask(PaintContext&, CSSPixelRect const&) const { return {}; }
@@ -275,6 +280,8 @@ private:
     virtual DispatchEventOfSameName handle_mousedown(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
     virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
     virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned buttons, unsigned modifiers) override;
+
+    OwnPtr<StackingContext> m_stacking_context;
 
     Optional<OverflowData> m_overflow_data;
 

--- a/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Libraries/LibWeb/Painting/StackingContext.h
@@ -16,13 +16,12 @@ class StackingContext {
     friend class ViewportPaintable;
 
 public:
-    StackingContext(Paintable&, StackingContext* parent, size_t index_in_tree_order);
+    StackingContext(PaintableBox&, StackingContext* parent, size_t index_in_tree_order);
 
     StackingContext* parent() { return m_parent; }
     StackingContext const* parent() const { return m_parent; }
 
-    Paintable const& paintable() const { return *m_paintable; }
-    PaintableBox const& paintable_box() const { return verify_cast<PaintableBox>(*m_paintable); }
+    PaintableBox const& paintable_box() const { return *m_paintable; }
 
     enum class StackingContextPaintPhase {
         BackgroundAndBorders,
@@ -48,14 +47,14 @@ public:
     void set_last_paint_generation_id(u64 generation_id);
 
 private:
-    GC::Ref<Paintable> m_paintable;
+    GC::Ref<PaintableBox> m_paintable;
     StackingContext* const m_parent { nullptr };
     Vector<StackingContext*> m_children;
     size_t m_index_in_tree_order { 0 };
     Optional<u64> m_last_paint_generation_id;
 
-    Vector<GC::Ref<Paintable const>> m_positioned_descendants_and_stacking_contexts_with_stack_level_0;
-    Vector<GC::Ref<Paintable const>> m_non_positioned_floating_descendants;
+    Vector<GC::Ref<PaintableBox const>> m_positioned_descendants_and_stacking_contexts_with_stack_level_0;
+    Vector<GC::Ref<PaintableBox const>> m_non_positioned_floating_descendants;
 
     static void paint_child(PaintContext&, StackingContext const&);
     void paint_internal(PaintContext&) const;

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -40,20 +40,20 @@ void ViewportPaintable::build_stacking_context_tree()
     set_stacking_context(make<StackingContext>(*this, nullptr, 0));
 
     size_t index_in_tree_order = 1;
-    for_each_in_subtree([&](Paintable const& paintable) {
-        const_cast<Paintable&>(paintable).invalidate_stacking_context();
-        auto* parent_context = const_cast<Paintable&>(paintable).enclosing_stacking_context();
-        auto establishes_stacking_context = paintable.layout_node().establishes_stacking_context();
-        if ((paintable.is_positioned() || establishes_stacking_context) && paintable.computed_values().z_index().value_or(0) == 0)
-            parent_context->m_positioned_descendants_and_stacking_contexts_with_stack_level_0.append(paintable);
-        if (!paintable.is_positioned() && paintable.is_floating())
-            parent_context->m_non_positioned_floating_descendants.append(paintable);
+    for_each_in_subtree_of_type<PaintableBox>([&](auto const& paintable_box) {
+        const_cast<PaintableBox&>(paintable_box).invalidate_stacking_context();
+        auto* parent_context = const_cast<PaintableBox&>(paintable_box).enclosing_stacking_context();
+        auto establishes_stacking_context = paintable_box.layout_node().establishes_stacking_context();
+        if ((paintable_box.is_positioned() || establishes_stacking_context) && paintable_box.computed_values().z_index().value_or(0) == 0)
+            parent_context->m_positioned_descendants_and_stacking_contexts_with_stack_level_0.append(paintable_box);
+        if (!paintable_box.is_positioned() && paintable_box.is_floating())
+            parent_context->m_non_positioned_floating_descendants.append(paintable_box);
         if (!establishes_stacking_context) {
-            VERIFY(!paintable.stacking_context());
+            VERIFY(!paintable_box.stacking_context());
             return TraversalDecision::Continue;
         }
         VERIFY(parent_context);
-        const_cast<Paintable&>(paintable).set_stacking_context(make<Painting::StackingContext>(const_cast<Paintable&>(paintable), parent_context, index_in_tree_order++));
+        const_cast<PaintableBox&>(paintable_box).set_stacking_context(make<Painting::StackingContext>(const_cast<PaintableBox&>(paintable_box), parent_context, index_in_tree_order++));
         return TraversalDecision::Continue;
     });
 


### PR DESCRIPTION
For a while we used the wider Paintable type for stacking context, because it was allowed to be created by InlinePaintable and PaintableBox. Now, when InlinePaintable type is gone, we can use more specific PaintableBox type for a stacking context.