### PR TITLE
LibWeb: Use correct specifier to pad font language override value

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5777,7 +5777,7 @@ RefPtr<CSSStyleValue> Parser::parse_font_language_override_value(TokenStream<Com
         }
         transaction.commit();
         if (length < 4)
-            return StringStyleValue::create(MUST(String::formatted("{<4}", string_value)));
+            return StringStyleValue::create(MUST(String::formatted("{:<4}", string_value)));
         return string;
     }
 

--- a/Tests/LibWeb/Text/expected/css/font-language-override-short.txt
+++ b/Tests/LibWeb/Text/expected/css/font-language-override-short.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/css/font-language-override-short.html
+++ b/Tests/LibWeb/Text/input/css/font-language-override-short.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const element = document.createElement('div');
+        element.style.fontLanguageOverride = '"eng"';
+        document.body.appendChild(element);
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
Previously the browser would crash when parsing short font-language-override values.

Fixes #2423