### PR TITLE
LibWeb: Update handling of "once" event listeners now that spec is fixed

### DIFF
--- a/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -56,9 +56,9 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<GC::Root<DOM::DOMEventLi
         if (phase == Event::Phase::BubblingPhase && listener->capture)
             continue;
 
-        // 5. If listener’s once is true, then remove listener from event’s currentTarget attribute value’s event listener list.
+        // 5. If listener’s once is true, then remove an event listener given event’s currentTarget attribute value and listener.
         if (listener->once)
-            event.current_target()->remove_from_event_listener_list(*listener);
+            event.current_target()->remove_an_event_listener(*listener);
 
         // 6. Let global be listener callback’s associated Realm’s global object.
         auto& callback = listener->callback->callback();

--- a/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -249,17 +249,6 @@ void EventTarget::remove_an_event_listener(DOMEventListener& listener)
     m_data->event_listener_list.remove_first_matching([&](auto& entry) { return entry.ptr() == &listener; });
 }
 
-void EventTarget::remove_from_event_listener_list(DOMEventListener& listener)
-{
-    if (!m_data)
-        return;
-    m_data->event_listener_list.remove_first_matching([&](auto& entry) { return entry.ptr() == &listener; });
-
-    // FIXME: Update this when the spec is updated.
-    // Spec bug: https://github.com/whatwg/dom/issues/1323
-    listener.removed = true;
-}
-
 // https://dom.spec.whatwg.org/#dom-eventtarget-dispatchevent
 WebIDL::ExceptionOr<bool> EventTarget::dispatch_event_binding(Event& event)
 {

--- a/Libraries/LibWeb/DOM/EventTarget.h
+++ b/Libraries/LibWeb/DOM/EventTarget.h
@@ -42,7 +42,6 @@ public:
 
     void add_an_event_listener(DOMEventListener&);
     void remove_an_event_listener(DOMEventListener&);
-    void remove_from_event_listener_list(DOMEventListener&);
 
     Vector<GC::Root<DOMEventListener>> event_listener_list();
 


### PR DESCRIPTION
https://github.com/whatwg/dom/issues/1323 was fixed, and the solution ended up slightly different from what we had, so let's follow the spec.