### PR TITLE
LibWebView: Display layouting information in devtools

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1430,6 +1430,18 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
                 MUST(children.finish());
             }
         }
+
+        if (paintable_box()) {
+            if (paintable_box()->is_scrollable()) {
+                MUST(object.add("scrollable"sv, true));
+            }
+            if (!paintable_box()->is_visible()) {
+                MUST(object.add("invisible"sv, true));
+            }
+            if (paintable_box()->has_stacking_context()) {
+                MUST(object.add("stackingContext"sv, true));
+            }
+        }
     } else if (is_text()) {
         MUST(object.add("type"sv, "text"));
 


### PR DESCRIPTION
This adds some extra info to the side of nodes in the devtools to indicate whether they are scrollable, invisible or create a stacking context.

It indents a large chunk of the code in InspectorClient.cpp so that these can show up on non-element nodes as well, sine those used to early-exit.

Examples:
Note: "stacking context" has been replaced with "isolated" since.
![image](https://github.com/user-attachments/assets/4e56719f-4db6-4c02-af73-b71863da9793)

![image](https://github.com/user-attachments/assets/a7b6293c-2a7e-4444-841f-cf25dce547eb)
