### PR TITLE
LibCompress: Clean up #include directives

### DIFF
--- a/Libraries/LibCompress/Deflate.cpp
+++ b/Libraries/LibCompress/Deflate.cpp
@@ -9,8 +9,6 @@
 #include <AK/Assertions.h>
 #include <AK/BinarySearch.h>
 #include <AK/MemoryStream.h>
-#include <string.h>
-
 #include <LibCompress/Deflate.h>
 #include <LibCompress/Huffman.h>
 

--- a/Libraries/LibCompress/Gzip.cpp
+++ b/Libraries/LibCompress/Gzip.cpp
@@ -11,9 +11,6 @@
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
 #include <LibCore/DateTime.h>
-#include <LibCore/File.h>
-#include <LibCore/MappedFile.h>
-#include <LibCore/System.h>
 
 namespace Compress {
 


### PR DESCRIPTION
This change aims to improve the speed of incremental builds in the future.