### PR TITLE
LibCore: SystemWindows.cpp fix includes

### DIFF
--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -12,7 +12,9 @@
 #include <AK/ByteString.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/System.h>
-#include <WinSock2.h>
+#include <Windows.h>
+#include <cerrno>
+#include <direct.h>
 #include <io.h>
 
 namespace Core::System {


### PR DESCRIPTION
Fixes broken includes, making it compile.