### PR TITLE
flake: Fix a broken dev shell

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -102,24 +102,37 @@ sudo xbps-install -S git bash gcc python3 curl cmake zip unzip linux-headers mak
 ### NixOS or with Nix:
 
 > [!NOTE]
-> These steps are out of date, as vcpkg does not work with Nix.
-> Please refer to the nixpkgs package for the most up-to-date build instructions.
->
+> Ladybird's build system uses vcpkg to vendor third-party dependencies, which proves undesirable to use with Nix for [several reasons](https://github.com/LadybirdBrowser/ladybird/issues/371).  
+> As a result, using `ladybird.sh` to compile and run Ladybird will fail. Therefore, it is necessary to use system packages provided by the dev-shell.
+
+To build the project, first enter the shell:
 
 ```console
 nix develop
 
-# With a custom entrypoint, for example your favorite shell
+# With a custom entrypoint, for example, your favorite shell
 nix develop --command bash
+
+# Using nix-shell
+nix-shell UI
+
+# Using nix-shell and a custom shell
+nix-shell UI --command bash
 ```
 
-On NixOS or with Nix using your host `nixpkgs` and the legacy `nix-shell` tool:
-```console
-nix-shell Ladybird
+Then invoke `cmake` directly. For example:
 
-# With a custom entrypoint, for example your favorite shell
-nix-shell --command bash Ladybird
 ```
+cmake -GNinja -BBuild/release
+```
+
+Finally, run `ninja` (or the generator you're using) to start the build:
+
+```
+ninja -CBuild/release
+```
+
+For more information, see [Custom CMake build directory](#custom-cmake-build-directory) and [Running manually](#running-manually).
 
 ### macOS:
 

--- a/UI/default.nix
+++ b/UI/default.nix
@@ -1,25 +1,20 @@
-{ pkgs ? import <nixpkgs> { } }: with pkgs;
+{ pkgs ? import <nixpkgs> { } }:
 
-mkShell.override { stdenv = gcc13Stdenv; } {
-  packages = [
+pkgs.mkShell {
+  packages = with pkgs; [
     ccache
-    cmake
-    libxcrypt
-    ninja
-    pkg-config
-    python3
-    qt6.qtbase
-    qt6.qtbase.dev
-    qt6.qtmultimedia
-    qt6.qttools
-    qt6.qtwayland
-    qt6.qtwayland.dev
-  ];
+  ] ++ (with qt6Packages; [
+    qtbase.dev
+    qttools
+    qtwayland.dev
+  ]);
+
+  inputsFrom = [ pkgs.ladybird ];
 
   shellHook = ''
     # NOTE: This is required to make it find the wayland platform plugin installed
     #       above, but should probably be fixed upstream.
-    export QT_PLUGIN_PATH="$QT_PLUGIN_PATH:${qt6.qtwayland}/lib/qt-6/plugins"
+    export QT_PLUGIN_PATH="$QT_PLUGIN_PATH:${pkgs.qt6.qtwayland}/lib/qt-6/plugins"
     export QT_QPA_PLATFORM="wayland;xcb"
   '';
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "lastModified": 1731676054,
+        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,6 @@
   outputs = { self, nixpkgs, utils, }: utils.lib.eachDefaultSystem (system: let
     pkgs = import nixpkgs { inherit system; };
   in {
-    devShells.default = import ./Ladybird { inherit pkgs; };
+    devShells.default = import ./UI { inherit pkgs; };
   });
 }


### PR DESCRIPTION
The current flake's devShell tries to import `Ladybird` which was renamed to `UI`.

Additionally, many dependencies aren't currently included in the devShell. As ladybird is already packaged downstream, we can pull in those buildInputs along with the extra dev dependencies already defined.
This gets the shell working and ladybird buildable :3