### PR TITLE
LibWeb: Clone CDATASection nodes with the correct node type

### DIFF
--- a/Tests/LibWeb/Text/expected/DOM/CDATASection-cloneNode.txt
+++ b/Tests/LibWeb/Text/expected/DOM/CDATASection-cloneNode.txt
@@ -1,1 +1,1 @@
-Cloned CDATASection node data: PASS
+Cloned #cdata-section node data: PASS

--- a/Tests/LibWeb/Text/input/DOM/CDATASection-cloneNode.html
+++ b/Tests/LibWeb/Text/input/DOM/CDATASection-cloneNode.html
@@ -4,6 +4,6 @@
         const xmlDocument = new DOMParser().parseFromString(`<xml></xml>`, "application/xml");
         const cdata = xmlDocument.createCDATASection("PASS");
         const clone = cdata.cloneNode();
-        println(`Cloned CDATASection node data: ${clone.data}`);
+        println(`Cloned ${clone.nodeName} node data: ${clone.data}`);
     });
 </script>


### PR DESCRIPTION
We were cloning these as plain Text nodes, but the clone must also be a CDATASection node.