### PR TITLE
LibGfx: Clean up #include directives

### DIFF
--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -9,10 +9,8 @@
 #include <AK/BitmapView.h>
 #include <AK/Error.h>
 #include <AK/Noncopyable.h>
-#include <AK/Optional.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Try.h>
 #include <AK/Types.h>
 #include <AK/kmalloc.h>
 

--- a/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -10,11 +10,7 @@
 #    pragma GCC optimize("O3")
 #endif
 
-#include <AK/Function.h>
-#include <AK/NumericLimits.h>
 #include <LibGfx/AntiAliasingPainter.h>
-#include <LibGfx/DeprecatedPainter.h>
-#include <LibGfx/Line.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Libraries/LibGfx/AntiAliasingPainter.h
@@ -9,9 +9,7 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/DeprecatedPath.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/LineStyle.h>
 #include <LibGfx/PaintStyle.h>
-#include <LibGfx/Quad.h>
 #include <LibGfx/WindingRule.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/BitmapSequence.cpp
+++ b/Libraries/LibGfx/BitmapSequence.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/Checked.h>
-#include <AK/Forward.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/BitmapSequence.h>

--- a/Libraries/LibGfx/Color.cpp
+++ b/Libraries/LibGfx/Color.cpp
@@ -13,7 +13,6 @@
 #include <AK/Swift.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
-#include <LibGfx/SystemTheme.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>
 #include <ctype.h>

--- a/Libraries/LibGfx/Color.h
+++ b/Libraries/LibGfx/Color.h
@@ -12,7 +12,6 @@
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Math.h>
-#include <AK/SIMD.h>
 #include <AK/StdLibExtras.h>
 #include <LibIPC/Forward.h>
 

--- a/Libraries/LibGfx/DeltaE.cpp
+++ b/Libraries/LibGfx/DeltaE.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
 #include <AK/Math.h>
 #include <LibGfx/DeltaE.h>
 #include <math.h>

--- a/Libraries/LibGfx/DeprecatedPainter.cpp
+++ b/Libraries/LibGfx/DeprecatedPainter.cpp
@@ -12,18 +12,13 @@
 
 #include "DeprecatedPainter.h"
 #include "Bitmap.h"
-#include "Font/Font.h"
 #include <AK/Assertions.h>
 #include <AK/Function.h>
 #include <AK/Math.h>
 #include <AK/Memory.h>
-#include <AK/Stack.h>
 #include <AK/StdLibExtras.h>
-#include <AK/Utf8View.h>
 #include <LibGfx/DeprecatedPath.h>
-#include <LibGfx/Palette.h>
-#include <LibGfx/Quad.h>
-#include <LibGfx/TextLayout.h>
+#include <LibGfx/ScalingMode.h>
 #include <stdio.h>
 
 #if defined(AK_COMPILER_GCC)

--- a/Libraries/LibGfx/DeprecatedPainter.h
+++ b/Libraries/LibGfx/DeprecatedPainter.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Forward.h>
-#include <AK/Memory.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
@@ -16,8 +15,6 @@
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/Point.h>
 #include <LibGfx/Rect.h>
-#include <LibGfx/ScalingMode.h>
-#include <LibGfx/Size.h>
 #include <LibGfx/WindingRule.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/DeprecatedPath.cpp
+++ b/Libraries/LibGfx/DeprecatedPath.cpp
@@ -6,12 +6,9 @@
 
 #include <AK/Math.h>
 #include <AK/StringBuilder.h>
-#include <AK/TypeCasts.h>
 #include <LibGfx/BoundingBox.h>
 #include <LibGfx/DeprecatedPainter.h>
 #include <LibGfx/DeprecatedPath.h>
-#include <LibGfx/Font/ScaledFont.h>
-#include <LibGfx/TextLayout.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/DeprecatedPath.h
+++ b/Libraries/LibGfx/DeprecatedPath.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/Optional.h>
 #include <AK/Vector.h>
 #include <LibGfx/Forward.h>

--- a/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
+++ b/Libraries/LibGfx/EdgeFlagPathRasterizer.cpp
@@ -4,9 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
-#include <AK/Debug.h>
-#include <AK/IntegralMath.h>
+#include <AK/Memory.h>
 #include <AK/Types.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/DeprecatedPainter.h>

--- a/Libraries/LibGfx/Font/Font.h
+++ b/Libraries/LibGfx/Font/Font.h
@@ -7,15 +7,10 @@
 
 #pragma once
 
-#include <AK/Bitmap.h>
-#include <AK/ByteReader.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/Types.h>
-#include <LibCore/MappedFile.h>
-#include <LibGfx/Bitmap.h>
-#include <LibGfx/Size.h>
 
 struct hb_font_t;
 

--- a/Libraries/LibGfx/Font/FontData.h
+++ b/Libraries/LibGfx/Font/FontData.h
@@ -6,9 +6,6 @@
 
 #pragma once
 
-#include <AK/HashMap.h>
-#include <AK/Noncopyable.h>
-#include <AK/RefCounted.h>
 #include <LibCore/Resource.h>
 #include <LibGfx/Forward.h>
 

--- a/Libraries/LibGfx/Font/FontDatabase.h
+++ b/Libraries/LibGfx/Font/FontDatabase.h
@@ -8,7 +8,6 @@
 
 #include <AK/FlyString.h>
 #include <AK/Function.h>
-#include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Forward.h>

--- a/Libraries/LibGfx/Font/PathFontProvider.h
+++ b/Libraries/LibGfx/Font/PathFontProvider.h
@@ -9,7 +9,6 @@
 #include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <AK/HashMap.h>
-#include <AK/OwnPtr.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/Typeface.h>
 

--- a/Libraries/LibGfx/Font/ScaledFont.h
+++ b/Libraries/LibGfx/Font/ScaledFont.h
@@ -8,8 +8,6 @@
 #pragma once
 
 #include <AK/FlyString.h>
-#include <AK/HashMap.h>
-#include <LibGfx/Bitmap.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/Typeface.h>
 

--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <core/SkTypeface.h>
 #include <harfbuzz/hb.h>
 
 #include <LibGfx/Font/ScaledFont.h>

--- a/Libraries/LibGfx/Font/Typeface.h
+++ b/Libraries/LibGfx/Font/Typeface.h
@@ -7,9 +7,7 @@
 #pragma once
 
 #include <AK/HashMap.h>
-#include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
-#include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontData.h>
 #include <LibGfx/Forward.h>
 

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -6,12 +6,10 @@
 
 #include <AK/LsanSuppressions.h>
 #include <LibGfx/Font/FontDatabase.h>
-#include <LibGfx/Font/Typeface.h>
 #include <LibGfx/Font/TypefaceSkia.h>
 
 #include <core/SkData.h>
 #include <core/SkFontMgr.h>
-#include <core/SkRefCnt.h>
 #include <core/SkTypeface.h>
 #ifndef AK_OS_ANDROID
 #    include <ports/SkFontMgr_fontconfig.h>

--- a/Libraries/LibGfx/ICC/BinaryWriter.h
+++ b/Libraries/LibGfx/ICC/BinaryWriter.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
-
 namespace Gfx::ICC {
 
 class Profile;

--- a/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
+++ b/Libraries/LibGfx/ICC/WellKnownProfiles.cpp
@@ -7,7 +7,6 @@
 #include <LibGfx/ICC/Profile.h>
 #include <LibGfx/ICC/Tags.h>
 #include <LibGfx/ICC/WellKnownProfiles.h>
-#include <time.h>
 
 namespace Gfx::ICC {
 

--- a/Libraries/LibGfx/ImageFormats/BooleanDecoder.h
+++ b/Libraries/LibGfx/ImageFormats/BooleanDecoder.h
@@ -7,9 +7,7 @@
 
 #pragma once
 
-#include <AK/BitStream.h>
 #include <AK/Error.h>
-#include <AK/Optional.h>
 #include <AK/Types.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -17,7 +17,6 @@
 #include <LibCompress/Lzw.h>
 #include <LibGfx/ImageFormats/GIFLoader.h>
 #include <LibGfx/Painter.h>
-#include <string.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/ImageFormats/GIFLoader.h
+++ b/Libraries/LibGfx/ImageFormats/GIFLoader.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/MemoryStream.h>
-#include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/ICOLoader.cpp
@@ -4,14 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
 #include <AK/MemoryStream.h>
 #include <AK/Types.h>
 #include <LibGfx/ImageFormats/BMPLoader.h>
 #include <LibGfx/ImageFormats/ICOLoader.h>
 #include <LibGfx/ImageFormats/PNGLoader.h>
-#include <string.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
+++ b/Libraries/LibGfx/ImageFormats/ImageDecoder.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
 #include <LibGfx/ImageFormats/AVIFLoader.h>
 #include <LibGfx/ImageFormats/BMPLoader.h>
 #include <LibGfx/ImageFormats/GIFLoader.h>

--- a/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>

--- a/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/JPEGXLLoader.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Debug.h>
 #include <AK/Error.h>
 #include <LibGfx/ImageFormats/JPEGXLLoader.h>
 #include <jxl/decode.h>

--- a/Libraries/LibGfx/ImageFormats/JPEGXLLoader.h
+++ b/Libraries/LibGfx/ImageFormats/JPEGXLLoader.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/MemoryStream.h>
 #include <LibGfx/ImageFormats/ImageDecoder.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/TinyVGLoader.cpp
@@ -10,7 +10,6 @@
 #include <AK/LEB128.h>
 #include <AK/MemoryStream.h>
 #include <AK/Variant.h>
-#include <LibCore/File.h>
 #include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/DeprecatedPainter.h>
 #include <LibGfx/ImageFormats/TinyVGLoader.h>

--- a/Libraries/LibGfx/ImageFormats/WebPWriter.h
+++ b/Libraries/LibGfx/ImageFormats/WebPWriter.h
@@ -10,7 +10,6 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/ImageFormats/WebPWriterLossless.h>
-#include <LibGfx/Point.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
+++ b/Libraries/LibGfx/ImageFormats/WebPWriterLossless.cpp
@@ -8,11 +8,9 @@
 
 #include <AK/BitStream.h>
 #include <AK/Debug.h>
-#include <AK/Endian.h>
 #include <AK/HashTable.h>
 #include <AK/MemoryStream.h>
 #include <AK/QuickSort.h>
-#include <LibCompress/DeflateTables.h>
 #include <LibCompress/Huffman.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/ImageFormats/WebPSharedLossless.h>

--- a/Libraries/LibGfx/PainterSkia.cpp
+++ b/Libraries/LibGfx/PainterSkia.cpp
@@ -13,20 +13,9 @@
 #include <LibGfx/PathSkia.h>
 
 #include <AK/TypeCasts.h>
-#include <core/SkBitmap.h>
-#include <core/SkBlurTypes.h>
 #include <core/SkCanvas.h>
-#include <core/SkColorFilter.h>
-#include <core/SkMaskFilter.h>
 #include <core/SkPath.h>
-#include <core/SkPathBuilder.h>
-#include <core/SkRRect.h>
-#include <core/SkSurface.h>
 #include <effects/SkGradientShader.h>
-#include <effects/SkImageFilters.h>
-#include <gpu/GrDirectContext.h>
-#include <gpu/ganesh/SkSurfaceGanesh.h>
-#include <pathops/SkPathOps.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SkiaUtils.h>
 
@@ -16,9 +15,7 @@
 #include <gpu/ganesh/SkSurfaceGanesh.h>
 
 #ifdef AK_OS_MACOS
-#    include <gpu/ganesh/mtl/GrMtlBackendContext.h>
 #    include <gpu/ganesh/mtl/GrMtlBackendSurface.h>
-#    include <gpu/ganesh/mtl/GrMtlDirectContext.h>
 #endif
 
 namespace Gfx {

--- a/Libraries/LibGfx/Palette.cpp
+++ b/Libraries/LibGfx/Palette.cpp
@@ -6,9 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Badge.h>
 #include <LibGfx/Palette.h>
-#include <string.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -9,9 +9,10 @@
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Utf8View.h>
+#include <LibGfx/AffineTransform.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/PaintStyle.h>
-#include <LibGfx/ScalingMode.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
 #include <LibGfx/WindingRule.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/PathSkia.cpp
+++ b/Libraries/LibGfx/PathSkia.cpp
@@ -9,7 +9,7 @@
 #include <AK/TypeCasts.h>
 #include <LibGfx/Font/ScaledFont.h>
 #include <LibGfx/PathSkia.h>
-#include <core/SkContourMeasure.h>
+#include <LibGfx/Rect.h>
 #include <core/SkFont.h>
 #include <core/SkPath.h>
 #include <core/SkPathMeasure.h>

--- a/Libraries/LibGfx/Rect.cpp
+++ b/Libraries/LibGfx/Rect.cpp
@@ -5,8 +5,6 @@
  */
 
 #include <AK/ByteString.h>
-#include <AK/Vector.h>
-#include <LibGfx/Line.h>
 #include <LibGfx/Rect.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Encoder.h>

--- a/Libraries/LibGfx/ShareableBitmap.h
+++ b/Libraries/LibGfx/ShareableBitmap.h
@@ -8,7 +8,6 @@
 
 #include <AK/RefPtr.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Size.h>
 #include <LibIPC/Forward.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/SystemTheme.cpp
+++ b/Libraries/LibGfx/SystemTheme.cpp
@@ -11,7 +11,6 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
 #include <LibGfx/SystemTheme.h>
-#include <string.h>
 
 namespace Gfx {
 

--- a/Libraries/LibGfx/SystemTheme.h
+++ b/Libraries/LibGfx/SystemTheme.h
@@ -10,7 +10,6 @@
 
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
-#include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ConfigFile.h>

--- a/Libraries/LibGfx/TextLayout.cpp
+++ b/Libraries/LibGfx/TextLayout.cpp
@@ -7,7 +7,7 @@
 
 #include "TextLayout.h"
 #include <AK/TypeCasts.h>
-#include <LibGfx/Font/ScaledFont.h>
+#include <LibGfx/Point.h>
 #include <harfbuzz/hb.h>
 
 namespace Gfx {

--- a/Libraries/LibGfx/TextLayout.h
+++ b/Libraries/LibGfx/TextLayout.h
@@ -7,16 +7,12 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
-#include <AK/CharacterTypes.h>
 #include <AK/Forward.h>
-#include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <AK/Vector.h>
 #include <LibGfx/Font/Font.h>
-#include <LibGfx/FontCascadeList.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Rect.h>
+#include <LibGfx/Point.h>
 
 namespace Gfx {
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Bitmap.h>
 #include <AK/QuickSort.h>
 #include <LibJS/Runtime/Iterator.h>
 #include <LibWeb/Animations/Animation.h>

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Bitmap.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/GridFormattingContext.h>

--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -16,6 +16,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>
 #include <LibGfx/ImmutableBitmap.h>
+#include <LibGfx/LineStyle.h>
 #include <LibGfx/PaintStyle.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/Palette.h>

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGfx/AntiAliasingPainter.h>
+#include <LibGfx/Quad.h>
 #include <LibWeb/Painting/SVGPathPaintable.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
 

--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -10,6 +10,7 @@
 #include <AK/TypeCasts.h>
 #include <LibCore/Resource.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Font/PathFontProvider.h>
 #include <LibWebView/Plugins/FontPlugin.h>


### PR DESCRIPTION
We actually include what we use where we use it.
This change aims to improve the speed of incremental builds in the future.

I strongly suggest we merge this ASAP to avoid merge conflicts...