### PR TITLE
CMake: Check for Swift-aware C++ compiler more robustly

### DIFF
--- a/Meta/CMake/Swift/swift-settings.cmake
+++ b/Meta/CMake/Swift/swift-settings.cmake
@@ -1,16 +1,17 @@
 enable_language(Swift)
 
 if (CMAKE_Swift_COMPILER_VERSION VERSION_LESS 6.0)
-    message(FATAL_ERROR
-        "Swift 6.0 or newer is required to parse C++ headers in C++23 mode"
-    )
+    message(FATAL_ERROR "Swift 6.0 or newer is required to parse C++ headers in C++23 mode")
 endif()
 
-# FIXME: How to verify this on non-Apple?
-if (APPLE AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-    message(FATAL_ERROR
-        "Swift files must use Clang that was bundled with swiftc"
-    )
+# Check for a Swift-aware clang
+include(CheckCXXSourceCompiles)
+check_cxx_source_compiles([=[
+    struct __attribute__((swift_name("CxxS"))) __attribute__((swift_attr("~Copyable"))) S { int& x; };
+    int main() {}
+]=] CXX_COMPILER_SUPPORTS_SWIFT_ATTRS)
+if (NOT CXX_COMPILER_SUPPORTS_SWIFT_ATTRS)
+    message(FATAL_ERROR "A Swift-aware C++ compiler is required to build with Swift interop enabled")
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/InitializeSwift.cmake)


### PR DESCRIPTION
Instead of looking for "AppleClang", we can just check whether the CMAKE_CXX_COMPILER understands swift_attr and swift_name.