### PR TITLE
LibWeb: Split the qualified name if there is a prefix

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -99,23 +99,23 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
         m_namespace_stack.last().depth += 1;
     }
 
-    auto qualified_name_or_err = DOM::validate_and_extract(m_document->realm(), m_namespace, MUST(FlyString::from_deprecated_fly_string(name)));
+    auto qualified_name_or_error = DOM::validate_and_extract(m_document->realm(), m_namespace, MUST(FlyString::from_deprecated_fly_string(name)));
 
-    if (qualified_name_or_err.is_error()) {
+    if (qualified_name_or_error.is_error()) {
         m_has_error = true;
         return;
     }
 
-    auto qualified_name = qualified_name_or_err.value();
+    auto qualified_name = qualified_name_or_error.value();
 
-    auto node_or_err = DOM::create_element(m_document, qualified_name.local_name(), qualified_name.namespace_(), qualified_name.prefix());
+    auto node_or_error = DOM::create_element(m_document, qualified_name.local_name(), qualified_name.namespace_(), qualified_name.prefix());
 
-    if (node_or_err.is_error()) {
+    if (node_or_error.is_error()) {
         m_has_error = true;
         return;
     }
 
-    auto node = node_or_err.value();
+    auto node = node_or_error.value();
 
     // When an XML parser with XML scripting support enabled creates a script element,
     // it must have its parser document set and its "force async" flag must be unset.

--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -99,7 +99,23 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
         m_namespace_stack.last().depth += 1;
     }
 
-    auto node = DOM::create_element(m_document, MUST(FlyString::from_deprecated_fly_string(name)), m_namespace).release_value_but_fixme_should_propagate_errors();
+    auto qualified_name_or_err = DOM::validate_and_extract(m_document->realm(), m_namespace, MUST(FlyString::from_deprecated_fly_string(name)));
+
+    if (qualified_name_or_err.is_error()) {
+        m_has_error = true;
+        return;
+    }
+
+    auto qualified_name = qualified_name_or_err.value();
+
+    auto node_or_err = DOM::create_element(m_document, qualified_name.local_name(), qualified_name.namespace_(), qualified_name.prefix());
+
+    if (node_or_err.is_error()) {
+        m_has_error = true;
+        return;
+    }
+
+    auto node = node_or_err.value();
 
     // When an XML parser with XML scripting support enabled creates a script element,
     // it must have its parser document set and its "force async" flag must be unset.

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-namespace-xhtml.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-namespace-xhtml.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	firstElementChild with namespaces

--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/XMLSerializer-serializeToString.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/XMLSerializer-serializeToString.txt
@@ -2,13 +2,13 @@ Harness status: OK
 
 Found 24 tests
 
-8 Pass
-16 Fail
+9 Pass
+15 Fail
 Pass	check XMLSerializer.serializeToString method could parsing xmldoc to string
 Pass	check XMLSerializer.serializeToString method could parsing document to string
 Pass	Check if the default namespace is correctly reset.
 Pass	Check if there is no redundant empty namespace declaration.
-Fail	Check if redundant xmlns="..." is dropped.
+Pass	Check if redundant xmlns="..." is dropped.
 Pass	Check if inconsistent xmlns="..." is dropped.
 Fail	Check if an attribute with namespace and no prefix is serialized with the nearest-declared prefix
 Fail	Check if an attribute with namespace and no prefix is serialized with the nearest-declared prefix even if the prefix is assigned to another namespace.

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-namespace-xhtml.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-namespace-xhtml.xhtml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:pickle="http://ns.example.org/pickle">
+<head>
+<title>firstElementChild with namespaces</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<h1>Test of firstElementChild with namespaces</h1>
+<div id="parentEl">
+  <pickle:dill id="first_element_child"/>
+</div>
+<div id="log"></div>
+<p id="parentEl">The result of this test is
+<span id="first_element_child" style="font-weight:bold;">logged above.</span></p>
+<script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var fec = parentEl.firstElementChild;
+  assert_true(!!fec)
+  assert_equals(fec.nodeType, 1)
+  assert_equals(fec.getAttribute("id"), "first_element_child")
+  assert_equals(fec.localName, "dill")
+})
+]]></script>
+</body>
+</html>


### PR DESCRIPTION
This fixes (at least) one WPT test and I imported it :)

The expected behavior is described here in the spec:
https://dom.spec.whatwg.org/#concept-element-local-name

It was already implemented correctly when constructing a `QualifiedName` in `Element::validate_and_extract`.

I don't know if my sequence of string conversions is the most efficient though, but don't hesitate to comment if there is a better one so that I can learn my way around AK.