### PR TITLE
Documentation: fix broken link in README

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -35,5 +35,5 @@ you are welcome to ask on [Discord](../README.md#get-in-touch-and-participate).
 * [LibWeb: From Loading to Painting](LibWebFromLoadingToPainting.md)
 * [LibWeb: Browsing Contexts and Navigables](BrowsingContextsAndNavigables.md)
 * [How to Add an IDL File](AddNewIDLFile.md)
-* [LibWeb Code Style & Patterns](Browser/Patterns.md)
+* [LibWeb Code Style & Patterns](LibWebPatterns.md)
 * [CSS Generated Files](CSSGeneratedFiles.md)


### PR DESCRIPTION
`Browser/Patterns.md` was moved to `LibWebPatterns.md`, this PR updates link of "LibWeb Code Style & Patterns" to point to new url.