### PR TITLE
LibWeb: Allow FormData entry list to be mutated within a FormDataEvent

### DIFF
--- a/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
+++ b/Libraries/LibWeb/HTML/FormControlInfrastructure.cpp
@@ -201,7 +201,7 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
         }
     }
     // 6. Let form data be a new FormData object associated with entry list.
-    auto form_data = TRY(XHR::FormData::construct_impl(realm, entry_list));
+    auto form_data = TRY(XHR::FormData::construct_impl(realm, move(entry_list)));
 
     // 7. Fire an event named formdata at form using FormDataEvent, with the formData attribute initialized to form data and the bubbles attribute initialized to true.
     FormDataEventInit init {};
@@ -214,7 +214,7 @@ WebIDL::ExceptionOr<Optional<Vector<XHR::FormDataEntry>>> construct_entry_list(J
     form.set_constructing_entry_list(false);
 
     // 9. Return a clone of entry list.
-    return entry_list;
+    return form_data->entry_list();
 }
 
 ErrorOr<String> normalize_line_breaks(StringView value)

--- a/Tests/LibWeb/Text/expected/HTML/form-add-dynamic-formdata.txt
+++ b/Tests/LibWeb/Text/expected/HTML/form-add-dynamic-formdata.txt
@@ -1,0 +1,2 @@
+formData.get('field1') === 'value1': true
+formData.get('field2') === 'value2': true

--- a/Tests/LibWeb/Text/input/HTML/form-add-dynamic-formdata.html
+++ b/Tests/LibWeb/Text/input/HTML/form-add-dynamic-formdata.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<form id="test-form">
+    <input type="text" name="field1" value="value1">
+</form>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const form = document.getElementById('test-form');
+
+        form.addEventListener('formdata', (event) => {
+            event.formData.append('field2', 'value2');
+        });
+
+        const formData = new FormData(form);
+
+        println(`formData.get('field1') === 'value1': ${formData.get('field1') === 'value1'}`);
+        println(`formData.get('field2') === 'value2': ${formData.get('field2') === 'value2'}`);
+    });
+</script>


### PR DESCRIPTION
Previously, the list was copied when constructing the FormData object, then the original list was passed to the event, meaning any changes to the list that happened within the event would not be reflected outside of it.

Fixes: http://wpt.live/xhr/formdata.html - this test can't be imported because it relies on a python endpoint.

Fixes: #2464