### PR TITLE
LibCore: Add includes for S_ISDIR on Windows

### DIFF
--- a/Libraries/LibCore/ResourceImplementation.cpp
+++ b/Libraries/LibCore/ResourceImplementation.cpp
@@ -9,6 +9,10 @@
 #include <LibCore/ResourceImplementationFile.h>
 #include <LibCore/System.h>
 
+#if defined(AK_OS_WINDOWS)
+#    include <dirent.h>
+#endif
+
 namespace Core {
 
 static OwnPtr<ResourceImplementation> s_the;

--- a/Libraries/LibCore/ResourceImplementationFile.cpp
+++ b/Libraries/LibCore/ResourceImplementationFile.cpp
@@ -11,6 +11,10 @@
 #include <LibCore/ResourceImplementationFile.h>
 #include <LibCore/System.h>
 
+#if defined(AK_OS_WINDOWS)
+#    include <dirent.h>
+#endif
+
 namespace Core {
 
 ResourceImplementationFile::ResourceImplementationFile(String base_directory)


### PR DESCRIPTION
Adds include for dirent.h which we use in LibCore to provide the S_ISDIR macro on Windows. Fixes compilation of ResourceImplementation.cpp and ResourceImplementationFile.cpp
