### PR TITLE
LibWeb: Copy `m_resize_observers` before iterating

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -15,6 +15,7 @@
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
 #include <LibCore/Timer.h>
+#include <LibGC/MarkedVector.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -5160,7 +5161,14 @@ size_t Document::broadcast_active_resize_observations()
     auto shallowest_target_depth = NumericLimits<size_t>::max();
 
     // 2. For each observer in document.[[resizeObservers]] run these steps:
-    for (auto const& observer : m_resize_observers) {
+
+    // NOTE: We make a copy of the resize observers list to avoid modifying it while iterating.
+    GC::MarkedVector<GC::Ref<ResizeObserver::ResizeObserver>> resize_observers(heap());
+    resize_observers.ensure_capacity(m_resize_observers.size());
+    for (auto const& observer : m_resize_observers)
+        resize_observers.append(observer);
+
+    for (auto const& observer : resize_observers) {
         // 1. If observer.[[activeTargets]] slot is empty, continue.
         if (observer->active_targets().is_empty()) {
             continue;


### PR DESCRIPTION
An inopportune garbage collection may cause collected `ResizeObserver`s to unregister themselves from `m_resize_observers` while we are iterating over it, resulting in a use-after-free.

Copy the vector to avoid this scenario.

Fixes #2011.

A better solution might be to queue `ResizeObserver` de-registrations, or to `swap_remove` unregistered `ResizeObserver`s in such a way that indexed iteration remains well-defined (assuming the order of `ResizeObserver` in `m_resize_observers` is irrelevant).

> **EDIT**: The order of resize observers _is_ relevant. It is possible to still keep well-defined indexed iteration _without_ `swap_remove` or memory allocations, though, with:
> ```c++
> GC::Ptr<ResizeObserver> observer;
> for (size_t i=0; i < m_resize_observers.size(); i += size_t(observer.ptr() == m_resize_observers[i].ptr()) {
>     observer = m_resize_observers[i];
>     // ...
> }
> ```
> but perhaps that is just a _bit_ too fragile.