### PR TITLE
IDLGenerators: Throw TypeError if IDL ByteString contains element > 255

### DIFF
--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -225,6 +225,33 @@ JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String
     return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
 }
 
+// https://webidl.spec.whatwg.org/#ref-for-idl-ByteString%E2%91%A7
+JS::ThrowCompletionOr<String> to_byte_string(JS::VM& vm, JS::Value value)
+{
+    // 1. Let x be ? ToString(V).
+    auto x = TRY(value.to_string(vm));
+
+    // 2. If the value of any element of x is greater than 255, then throw a TypeError.
+    for (auto character : x.code_points()) {
+        if (character > 0xFF)
+            return vm.throw_completion<JS::TypeError>(JS::ErrorType::InvalidCodePoint);
+    }
+
+    // 3. Return an IDL ByteString value whose length is the length of x, and where the value of each element is the value of the corresponding element of x.
+    // FIXME: This should return a ByteString.
+    return x;
+}
+
+JS::ThrowCompletionOr<String> to_string(JS::VM& vm, JS::Value value)
+{
+    return value.to_string(vm);
+}
+
+JS::ThrowCompletionOr<String> to_usv_string(JS::VM& vm, JS::Value value)
+{
+    return value.to_well_formed_string(vm);
+}
+
 // https://webidl.spec.whatwg.org/#invoke-a-callback-function
 // https://whatpr.org/webidl/1437.html#invoke-a-callback-function
 JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::MarkedVector<JS::Value> args)

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.h
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.h
@@ -23,6 +23,10 @@ ErrorOr<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source);
 
 JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String const& operation_name, Optional<JS::Value> this_argument, GC::MarkedVector<JS::Value> args);
 
+JS::ThrowCompletionOr<String> to_string(JS::VM&, JS::Value);
+JS::ThrowCompletionOr<String> to_usv_string(JS::VM&, JS::Value);
+JS::ThrowCompletionOr<String> to_byte_string(JS::VM&, JS::Value);
+
 // https://webidl.spec.whatwg.org/#call-a-user-objects-operation
 template<typename... Args>
 JS::Completion call_user_object_operation(WebIDL::CallbackType& callback, String const& operation_name, Optional<JS::Value> this_argument, Args&&... args)

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -33,7 +33,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
     // request
     undefined open(DOMString method, DOMString url);
     undefined open(ByteString method, USVString url, boolean async, optional USVString? username = null, optional USVString? password = null);
-    undefined setRequestHeader(DOMString name, DOMString value);
+    undefined setRequestHeader(ByteString name, ByteString value);
     attribute unsigned long timeout;
     attribute boolean withCredentials;
     [SameObject] readonly attribute XMLHttpRequestUpload upload;

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -58,6 +58,9 @@ Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/resour
 ; Flaky, apparently due to font loading
 Text/input/wpt-import/css/css-flexbox/flex-item-compressible-001.html
 
+; This test currently times out
+Text/input/wpt-import/css/css-flexbox/order-001.htm
+
 ; WPT ref-tests that currently fail
 Ref/input/wpt-import/css/css-nesting/host-nesting-003.html
 Ref/input/wpt-import/css/css-nesting/host-nesting-004.html

--- a/Tests/LibWeb/Text/expected/wpt-import/xhr/setrequestheader-bogus-name.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/xhr/setrequestheader-bogus-name.txt
@@ -1,0 +1,81 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 71 tests
+
+71 Pass
+Details
+Result	Test Name	MessagePass	setRequestHeader should throw with header name "(".	
+Pass	setRequestHeader should throw with header name ")".	
+Pass	setRequestHeader should throw with header name "<".	
+Pass	setRequestHeader should throw with header name ">".	
+Pass	setRequestHeader should throw with header name "@".	
+Pass	setRequestHeader should throw with header name ",".	
+Pass	setRequestHeader should throw with header name ";".	
+Pass	setRequestHeader should throw with header name ":".	
+Pass	setRequestHeader should throw with header name "\\".	
+Pass	setRequestHeader should throw with header name "\"".	
+Pass	setRequestHeader should throw with header name "/".	
+Pass	setRequestHeader should throw with header name "[".	
+Pass	setRequestHeader should throw with header name "]".	
+Pass	setRequestHeader should throw with header name "?".	
+Pass	setRequestHeader should throw with header name "=".	
+Pass	setRequestHeader should throw with header name "{".	
+Pass	setRequestHeader should throw with header name "}".	
+Pass	setRequestHeader should throw with header name " ".	
+Pass	setRequestHeader should throw with header name "".	
+Pass	setRequestHeader should throw with header name "".	
+Pass	setRequestHeader should throw with header name "t\rt".	
+Pass	setRequestHeader should throw with header name "t\nt".	
+Pass	setRequestHeader should throw with header name "t: t".	
+Pass	setRequestHeader should throw with header name "t:t".	
+Pass	setRequestHeader should throw with header name "t<t".	
+Pass	setRequestHeader should throw with header name "t t".	
+Pass	setRequestHeader should throw with header name " tt".	
+Pass	setRequestHeader should throw with header name ":tt".	
+Pass	setRequestHeader should throw with header name "\ttt".	
+Pass	setRequestHeader should throw with header name "\vtt".	
+Pass	setRequestHeader should throw with header name "t\0t".	
+Pass	setRequestHeader should throw with header name "t\"t".	
+Pass	setRequestHeader should throw with header name "t,t".	
+Pass	setRequestHeader should throw with header name "t;t".	
+Pass	setRequestHeader should throw with header name "()[]{}".	
+Pass	setRequestHeader should throw with header name "a?B".	
+Pass	setRequestHeader should throw with header name "a=B".	
+Pass	setRequestHeader should throw with header name "\0".	
+Pass	setRequestHeader should throw with header name "\x01".	
+Pass	setRequestHeader should throw with header name "\x02".	
+Pass	setRequestHeader should throw with header name "\x03".	
+Pass	setRequestHeader should throw with header name "\x04".	
+Pass	setRequestHeader should throw with header name "\x05".	
+Pass	setRequestHeader should throw with header name "\x06".	
+Pass	setRequestHeader should throw with header name "\x07".	
+Pass	setRequestHeader should throw with header name "\b".	
+Pass	setRequestHeader should throw with header name "\t".	
+Pass	setRequestHeader should throw with header name "\n".	
+Pass	setRequestHeader should throw with header name "\v".	
+Pass	setRequestHeader should throw with header name "\f".	
+Pass	setRequestHeader should throw with header name "\r".	
+Pass	setRequestHeader should throw with header name "\x0e".	
+Pass	setRequestHeader should throw with header name "\x0f".	
+Pass	setRequestHeader should throw with header name "\x10".	
+Pass	setRequestHeader should throw with header name "\x11".	
+Pass	setRequestHeader should throw with header name "\x12".	
+Pass	setRequestHeader should throw with header name "\x13".	
+Pass	setRequestHeader should throw with header name "\x14".	
+Pass	setRequestHeader should throw with header name "\x15".	
+Pass	setRequestHeader should throw with header name "\x16".	
+Pass	setRequestHeader should throw with header name "\x17".	
+Pass	setRequestHeader should throw with header name "\x18".	
+Pass	setRequestHeader should throw with header name "\x19".	
+Pass	setRequestHeader should throw with header name "\x1a".	
+Pass	setRequestHeader should throw with header name "\x1b".	
+Pass	setRequestHeader should throw with header name "\x1c".	
+Pass	setRequestHeader should throw with header name "\x1d".	
+Pass	setRequestHeader should throw with header name "\x1e".	
+Pass	setRequestHeader should throw with header name "\x1f".	
+Pass	setRequestHeader should throw with header name "ﾃｽﾄ".	
+Pass	setRequestHeader should throw with header name "X-ﾃｽﾄ".	

--- a/Tests/LibWeb/Text/expected/wpt-import/xhr/setrequestheader-bogus-value.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/xhr/setrequestheader-bogus-value.txt
@@ -1,0 +1,15 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 5 tests
+
+5 Pass
+Details
+Result	Test Name	MessagePass	XMLHttpRequest: setRequestHeader() value argument checks	
+Pass	XMLHttpRequest: setRequestHeader() value argument checks 1	
+Pass	XMLHttpRequest: setRequestHeader() value argument checks 2	
+Pass	XMLHttpRequest: setRequestHeader() value argument checks 3	
+Pass	Omitted value argument	

--- a/Tests/LibWeb/Text/input/wpt-import/xhr/setrequestheader-bogus-name.htm
+++ b/Tests/LibWeb/Text/input/wpt-import/xhr/setrequestheader-bogus-name.htm
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+  <head>
+    <title>XMLHttpRequest: setRequestHeader() name argument checks</title>
+    <meta charset="utf-8">
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[3]" />
+  </head>
+  <body>
+    <div id="log"></div>
+<!--
+       CHAR           = <any US-ASCII character (octets 0 - 127)>
+       CTL            = <any US-ASCII control character
+                        (octets 0 - 31) and DEL (127)>
+       SP             = <US-ASCII SP, space (32)>
+       HT             = <US-ASCII HT, horizontal-tab (9)>
+       token          = 1*<any CHAR except CTLs or separators>
+       separators     = "(" | ")" | "<" | ">" | "@"
+                      | "," | ";" | ":" | "\" | <">
+                      | "/" | "[" | "]" | "?" | "="
+                      | "{" | "}" | SP | HT
+       field-name     = token
+-->
+    <script>
+      function try_name(name) {
+        test(function() {
+          var client = new XMLHttpRequest()
+          client.open("GET", "...")
+          assert_throws_dom("SyntaxError", function() { client.setRequestHeader(name, 'x-value') })
+        }, "setRequestHeader should throw with header name " + format_value(invalid_headers[i]) + ".")
+      }
+      function try_byte_string(name) {
+        test(function() {
+          var client = new XMLHttpRequest()
+          client.open("GET", "...")
+          assert_throws_js(TypeError, function() { client.setRequestHeader(name, 'x-value') })
+        }, "setRequestHeader should throw with header name " + format_value(invalid_byte_strings[i]) + ".")
+      }
+      var invalid_headers = ["(", ")", "<", ">", "@", ",", ";", ":", "\\",
+                             "\"", "/", "[", "]", "?", "=", "{", "}", " ",
+                             /* HT already tested in the loop below */
+                             "\u007f", "", "t\rt", "t\nt", "t: t", "t:t",
+                             "t<t", "t t", " tt", ":tt", "\ttt", "\vtt", "t\0t",
+                             "t\"t", "t,t", "t;t", "()[]{}", "a?B", "a=B"]
+      var invalid_byte_strings = ["ﾃｽﾄ", "X-ﾃｽﾄ"]
+      for (var i = 0; i < 32; ++i) {
+        invalid_headers.push(String.fromCharCode(i))
+      }
+      for (var i = 0; i < invalid_headers.length; ++i) {
+        try_name(invalid_headers[i])
+      }
+      for (var i = 0; i < invalid_byte_strings.length; ++i) {
+        try_byte_string(invalid_byte_strings[i])
+      }
+
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/xhr/setrequestheader-bogus-value.htm
+++ b/Tests/LibWeb/Text/input/wpt-import/xhr/setrequestheader-bogus-value.htm
@@ -1,0 +1,36 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>XMLHttpRequest: setRequestHeader() value argument checks</title>
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+    <link rel="help" href="https://xhr.spec.whatwg.org/#the-setrequestheader()-method" data-tested-assertations="/following::ol/li[4]" />
+  </head>
+  <body>
+    <div id="log"></div>
+    <script>
+      function try_value(value) {
+        test(function() {
+          var client = new XMLHttpRequest();
+          client.open("GET", "...");
+          assert_throws_dom("SyntaxError", function() { client.setRequestHeader("x-test", value) }, ' given value ' + value+', ');
+        });
+      }
+      try_value("t\x00t");
+      try_value("t\rt");
+      try_value("t\nt");
+      test(function() {
+        var client = new XMLHttpRequest();
+        client.open("GET", "...");
+        assert_throws_js(TypeError, function() { client.setRequestHeader("x-test", "ﾃｽﾄ") }, ' given value ﾃｽﾄ,');
+      });
+
+      test(function() {
+        var client = new XMLHttpRequest()
+        client.open("GET", "...")
+        assert_throws_js(TypeError, function() { client.setRequestHeader("x-test") })
+      }, 'Omitted value argument')
+    </script>
+  </body>
+</html>

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -70,7 +70,7 @@ static ErrorOr<void> collect_dump_tests(Vector<Test>& tests, StringView path, St
             continue;
         }
 
-        if (!name.ends_with(".html"sv) && !name.ends_with(".svg"sv) && !name.ends_with(".xhtml"sv) && !name.ends_with(".xht"sv))
+        if (!name.ends_with(".htm"sv) && !name.ends_with(".html"sv) && !name.ends_with(".svg"sv) && !name.ends_with(".xhtml"sv) && !name.ends_with(".xht"sv))
             continue;
 
         auto expectation_path = ByteString::formatted("{}/expected/{}/{}.txt", path, trail, LexicalPath::title(name));


### PR DESCRIPTION
This PR implements the ByteString conversion specified here: https://webidl.spec.whatwg.org/#ref-for-idl-ByteString%E2%91%A7 and also updates `XMLHTTPRequest.setRequestHeader()` to use the correct argument type.

I've also updated `headless-browser` to accept test files ending in '.htm', which allows the relevant WPT test to be imported and run.

Fixes these WPT tests in `xhr/`:
* http://wpt.live/xhr/setrequestheader-bogus-name.htm
* http://wpt.live/xhr/setrequestheader-bogus-value.htm

Also likely fixes a few WPT tests in `fetch/`