### PR TITLE
LibCrypto: Use size_t integer literal in ASN1/Der.cpp

### DIFF
--- a/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Libraries/LibCrypto/ASN1/DER.cpp
@@ -265,7 +265,7 @@ ErrorOr<void> Encoder::write_length(size_t value)
 
     double minimum_bits = AK::log2(value);
     size_t size_in_bits = AK::floor(minimum_bits) + 1;
-    size_t size = ceil_div(size_in_bits, 8ul);
+    size_t size = ceil_div(size_in_bits, 8z);
     TRY(write_byte(0x80 | size));
 
     for (size_t i = 0; i < size; i++) {
@@ -433,7 +433,7 @@ ErrorOr<void> Encoder::write_bit_string(BitStringView view, Optional<Class> clas
     auto total_size_in_bits = view.byte_length() * 8 - unused_bits;
 
     TRY(write_tag(class_, type, kind));
-    TRY(write_length(ceil_div(total_size_in_bits, 8ul) + 1));
+    TRY(write_length(ceil_div(total_size_in_bits, 8z) + 1));
     TRY(write_byte(unused_bits));
     return write_bytes(view.underlying_bytes());
 }

--- a/Libraries/LibCrypto/ASN1/DER.cpp
+++ b/Libraries/LibCrypto/ASN1/DER.cpp
@@ -265,7 +265,7 @@ ErrorOr<void> Encoder::write_length(size_t value)
 
     double minimum_bits = AK::log2(value);
     size_t size_in_bits = AK::floor(minimum_bits) + 1;
-    size_t size = ceil_div(size_in_bits, 8z);
+    size_t size = ceil_div(size_in_bits, 8uz);
     TRY(write_byte(0x80 | size));
 
     for (size_t i = 0; i < size; i++) {
@@ -433,7 +433,7 @@ ErrorOr<void> Encoder::write_bit_string(BitStringView view, Optional<Class> clas
     auto total_size_in_bits = view.byte_length() * 8 - unused_bits;
 
     TRY(write_tag(class_, type, kind));
-    TRY(write_length(ceil_div(total_size_in_bits, 8z) + 1));
+    TRY(write_length(ceil_div(total_size_in_bits, 8uz) + 1));
     TRY(write_byte(unused_bits));
     return write_bytes(view.underlying_bytes());
 }


### PR DESCRIPTION
On x86_64 Windows an unsigned long is 4 bytes, while a size_t is 8. As such this code causes a static assert checking that the size of both arguments to ceil_div is equal to fail at compilation time. This commit fixes this by replacing the unsigned long int literal with a size_t int literal.