### PR TITLE
LibJS: Make compile flag compatible with clang-cl

### DIFF
--- a/Libraries/LibJS/CMakeLists.txt
+++ b/Libraries/LibJS/CMakeLists.txt
@@ -260,5 +260,9 @@ if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "i.86.*")
     target_link_libraries(LibJS PRIVATE atomic)
 endif()
 
-target_compile_options(LibJS PRIVATE -fno-omit-frame-pointer)
+# This flag has no effect on Windows
+if (NOT WIN32)
+    target_compile_options(LibJS PRIVATE -fno-omit-frame-pointer)
+endif()
+
 target_link_libraries(LibJS PUBLIC JSClangPlugin)


### PR DESCRIPTION
Clang-cl doesn't recognize -fno-omit-frame-pointe, and it is a noop on Windows.