### PR TITLE
LibWeb: Plumb svg stroking state to DisplayListPlayerSkia

### DIFF
--- a/Libraries/LibGfx/Path.h
+++ b/Libraries/LibGfx/Path.h
@@ -72,6 +72,19 @@ public:
     void line_to(Gfx::FloatPoint const& point) { impl().line_to(point); }
     void close_all_subpaths() { impl().close_all_subpaths(); }
     void close() { impl().close(); }
+
+    enum class CapStyle {
+        Butt,
+        Round,
+        Square,
+    };
+
+    enum class JoinStyle {
+        Miter,
+        Round,
+        Bevel,
+    };
+
     void elliptical_arc_to(FloatPoint point, FloatSize radii, float x_axis_rotation, bool large_arc, bool sweep) { impl().elliptical_arc_to(point, radii, x_axis_rotation, large_arc, sweep); }
     void arc_to(FloatPoint point, float radius, bool large_arc, bool sweep) { impl().arc_to(point, radius, large_arc, sweep); }
     void quadratic_bezier_curve_to(FloatPoint through, FloatPoint point) { impl().quadratic_bezier_curve_to(through, point); }

--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -216,6 +216,11 @@ struct FillPathUsingPaintStyle {
 };
 
 struct StrokePathUsingColor {
+    Gfx::Path::CapStyle cap_style;
+    Gfx::Path::JoinStyle join_style;
+    float miter_limit;
+    Vector<float> dash_array;
+    float dash_offset;
     Gfx::IntRect path_bounding_rect;
     Gfx::Path path;
     Color color;
@@ -232,6 +237,11 @@ struct StrokePathUsingColor {
 };
 
 struct StrokePathUsingPaintStyle {
+    Gfx::Path::CapStyle cap_style;
+    Gfx::Path::JoinStyle join_style;
+    float miter_limit;
+    Vector<float> dash_array;
+    float dash_offset;
     Gfx::IntRect path_bounding_rect;
     Gfx::Path path;
     PaintStyle paint_style;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -817,6 +817,7 @@ void DisplayListPlayerSkia::stroke_path_using_color(StrokePathUsingColor const& 
     if (!command.thickness)
         return;
 
+    // FIXME: Use .cap_style, .join_style, .miter_limit, .dash_array, .dash_offset.
     auto& canvas = surface().canvas();
     SkPaint paint;
     paint.setAntiAlias(true);
@@ -834,6 +835,7 @@ void DisplayListPlayerSkia::stroke_path_using_paint_style(StrokePathUsingPaintSt
     if (!command.thickness)
         return;
 
+    // FIXME: Use .cap_style, .join_style, .miter_limit, .dash_array, .dash_offset.
     auto path = to_skia_path(command.path);
     path.offset(command.aa_translation.x(), command.aa_translation.y());
     auto paint = paint_style_to_skia_paint(*command.paint_style, command.bounding_rect().to_type<float>());

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -86,6 +86,11 @@ void DisplayListRecorder::stroke_path(StrokePathUsingColorParams params)
     if (path_bounding_rect.is_empty())
         return;
     append(StrokePathUsingColor {
+        .cap_style = params.cap_style,
+        .join_style = params.join_style,
+        .miter_limit = params.miter_limit,
+        .dash_array = move(params.dash_array),
+        .dash_offset = params.dash_offset,
         .path_bounding_rect = path_bounding_rect,
         .path = move(params.path),
         .color = params.color,
@@ -103,6 +108,11 @@ void DisplayListRecorder::stroke_path(StrokePathUsingPaintStyleParams params)
     if (path_bounding_rect.is_empty())
         return;
     append(StrokePathUsingPaintStyle {
+        .cap_style = params.cap_style,
+        .join_style = params.join_style,
+        .miter_limit = params.miter_limit,
+        .dash_array = move(params.dash_array),
+        .dash_offset = params.dash_offset,
         .path_bounding_rect = path_bounding_rect,
         .path = move(params.path),
         .paint_style = params.paint_style,

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.h
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.h
@@ -61,6 +61,11 @@ public:
     void fill_path(FillPathUsingPaintStyleParams params);
 
     struct StrokePathUsingColorParams {
+        Gfx::Path::CapStyle cap_style;
+        Gfx::Path::JoinStyle join_style;
+        float miter_limit;
+        Vector<float> dash_array;
+        float dash_offset;
         Gfx::Path path;
         Gfx::Color color;
         float thickness;
@@ -69,6 +74,11 @@ public:
     void stroke_path(StrokePathUsingColorParams params);
 
     struct StrokePathUsingPaintStyleParams {
+        Gfx::Path::CapStyle cap_style;
+        Gfx::Path::JoinStyle join_style;
+        float miter_limit;
+        Vector<float> dash_array;
+        float dash_offset;
         Gfx::Path path;
         PaintStyle paint_style;
         float thickness;

--- a/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -234,7 +234,16 @@ void MediaPaintable::paint_control_bar_speaker(PaintContext& context, HTML::HTML
     path.quadratic_bezier_curve_to(device_point(16, 7.5), device_point(13, 12));
     path.move_to(device_point(14, 0));
     path.quadratic_bezier_curve_to(device_point(20, 7.5), device_point(14, 15));
-    context.display_list_recorder().stroke_path({ .path = path, .color = speaker_button_color, .thickness = 1 });
+    context.display_list_recorder().stroke_path({
+        .cap_style = Gfx::Path::CapStyle::Round,
+        .join_style = Gfx::Path::JoinStyle::Round,
+        .miter_limit = 4,
+        .dash_array = {},
+        .dash_offset = 0,
+        .path = path,
+        .color = speaker_button_color,
+        .thickness = 1,
+    });
 
     if (media_element.muted()) {
         context.display_list_recorder().draw_line(device_point(0, 0).to_type<int>(), device_point(20, 15).to_type<int>(), Color::Red, 2);


### PR DESCRIPTION
The state is still ignored there, so no behavior change, but this should make it fairly easy to actually implement complete stroking support for SVGs.