### PR TITLE
LibGfx: Reimplement from_hsla

### DIFF
--- a/Tests/LibGfx/TestColor.cpp
+++ b/Tests/LibGfx/TestColor.cpp
@@ -28,3 +28,18 @@ TEST_CASE(hsv)
     EXPECT_EQ(Color(51, 179, 51, 128), Color::from_hsv(120, 0.714285714, .7).with_opacity(0.5));
     EXPECT_EQ(Color(87, 128, 77), Color::from_hsv(108, 0.4, .5));
 }
+
+TEST_CASE(hsl)
+{
+    EXPECT_EQ(Color(191, 191, 0), Color::from_hsl(-300, 1.0, 0.375));
+    EXPECT_EQ(Color(159, 138, 96), Color::from_hsl(400, 0.25, 0.5));
+    EXPECT_EQ(Color(159, 96, 128), Color::from_hsl(330, 0.25, 0.5));
+    EXPECT_EQ(Color(128, 0, 128), Color::from_hsl(300, 1.0, 0.25));
+    EXPECT_EQ(Color(0, 128, 128), Color::from_hsl(180, 1.0, 0.25));
+    EXPECT_EQ(Color(128, 239, 16), Color::from_hsl(90, 0.875, 0.5));
+    EXPECT_EQ(Color(128, 223, 32), Color::from_hsl(90, 0.75, 0.5));
+    EXPECT_EQ(Color(128, 207, 48), Color::from_hsl(90, 0.625, 0.5));
+    EXPECT_EQ(Color(128, 191, 64), Color::from_hsl(90, 0.5, 0.5));
+    EXPECT_EQ(Color(128, 175, 80), Color::from_hsl(90, 0.375, 0.5));
+    EXPECT_EQ(Color(128, 159, 96), Color::from_hsl(90, 0.25, 0.5));
+}


### PR DESCRIPTION
- Hue now wraps properly when negative or larger than 360
- The hsl to rgb conversion now closely mirrors the code example from the spec.

This fixes a number of WPT tests in
/css/css-color/parsing/color-computed-hsl.html