### PR TITLE
LibWeb: Stop radio buttons firing change events when losing focus

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -638,6 +638,7 @@ void HTMLInputElement::commit_pending_changes()
     case TypeAttributeState::Text:
     case TypeAttributeState::URL:
     case TypeAttributeState::Checkbox:
+    case TypeAttributeState::RadioButton:
         if (!m_has_uncommitted_changes)
             return;
         break;

--- a/Tests/LibWeb/Text/expected/checkbox-focus-lost-no-change-event.txt
+++ b/Tests/LibWeb/Text/expected/checkbox-focus-lost-no-change-event.txt
@@ -1,0 +1,1 @@
+PASS: Change event was not fired

--- a/Tests/LibWeb/Text/expected/radio-button-focus-lost-no-change-event.txt
+++ b/Tests/LibWeb/Text/expected/radio-button-focus-lost-no-change-event.txt
@@ -1,0 +1,1 @@
+PASS: Change event was not fired

--- a/Tests/LibWeb/Text/input/checkbox-focus-lost-no-change-event.html
+++ b/Tests/LibWeb/Text/input/checkbox-focus-lost-no-change-event.html
@@ -2,14 +2,21 @@
 <input type="checkbox" id="checkbox">
 <script src="include.js"></script>
 <script>
+    let changeEventFired = false;
     checkbox.addEventListener("change", () => {
-      println("Change event was fired when it shouldn't have been.");
+      changeEventFired = true;
     });
     asyncTest(async done => {
         checkbox.focus();
         await new Promise(resolve => setTimeout(resolve, 0));
         checkbox.blur();
         await new Promise(resolve => setTimeout(resolve, 0));
+
+        if (changeEventFired) {
+            println("FAIL: Change event was fired when it shouldn't have been.");
+        } else {
+            println("PASS: Change event was not fired");
+        }
 
         done();
     });

--- a/Tests/LibWeb/Text/input/radio-button-focus-lost-no-change-event.html
+++ b/Tests/LibWeb/Text/input/radio-button-focus-lost-no-change-event.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<input type="radio" id="radioButton">
+<script src="include.js"></script>
+<script>
+    let changeEventFired = false;
+    radioButton.addEventListener("change", () => {
+      changeEventFired = true;
+    });
+    asyncTest(async done => {
+        radioButton.focus();
+        await new Promise(resolve => setTimeout(resolve, 0));
+        radioButton.blur();
+        await new Promise(resolve => setTimeout(resolve, 0));
+
+        if (changeEventFired) {
+            println("FAIL: Change event was fired when it shouldn't have been.");
+        } else {
+            println("PASS: Change event was not fired");
+        }
+
+        done();
+    });
+</script>


### PR DESCRIPTION
I have checked since #2379 and radio buttons should indeed work this way also.