### PR TITLE
Documentation: Fix build command for macOS

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -203,7 +203,7 @@ The simplest way to build and run ladybird is via the ladybird.sh script:
 
 On macOS, to build using clang from homebrew:
 ```bash
-CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ ./Meta/ladybird.sh run
+CC=$(brew --prefix llvm@18)/bin/clang CXX=$(brew --prefix llvm@18)/bin/clang++ ./Meta/ladybird.sh run
 ```
 
 You may also choose to start it in `gdb` using:

--- a/Documentation/EditorConfiguration/VSCodeConfiguration.md
+++ b/Documentation/EditorConfiguration/VSCodeConfiguration.md
@@ -303,7 +303,7 @@ If you want to run the debugger, first place the content below in `.vscode/launc
 then run Ladybird with the debug preset and with the `--debug-process WebContent` flag:
 
 ```bash
-CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ BUILD_PRESET=Debug ./Meta/ladybird.sh run ladybird --debug-process WebContent
+CC=$(brew --prefix llvm@18)/bin/clang CXX=$(brew --prefix llvm@18)/bin/clang++ BUILD_PRESET=Debug ./Meta/ladybird.sh run ladybird --debug-process WebContent
 ```
 
 Running Ladybird in this way will pause execution until a debugger is attached. You can then run the debugger by going to the **Run and Debug** menu and selecting the **Attach to WebContent** configuration.


### PR DESCRIPTION
On my system running macOS Ventura 13.7.1 running Homebrew 4.4.6, `brew --prefix llvm` will output the nonexistent path `/usr/local/opt/llvm`, rather than the path I expected, which is `/usr/local/opt/llvm@18`. Without the `@18` at the end of that prefix command, the build system will pick up the system clang instead of the specified one, which may not work.