### PR TITLE
CI: Ignore changes to Documentation related files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - 'Documentation/**'
+      - '*.md'
+  pull_request:
+    paths-ignore:
+      - 'Documentation/**'
+      - '*.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}


### PR DESCRIPTION
This will prevent CI from running if:
- the only changes included are under the Documentation folder, or
- the only changes included are *.md files in the root

See:
https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-excluding-paths