### PR TITLE
LibWeb: Implement more IntersectionObserver attributes

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -6003,6 +6003,11 @@ Vector<ParsedFontFace::Source> Parser::parse_font_face_src(TokenStream<T>& compo
 template Vector<ParsedFontFace::Source> Parser::parse_font_face_src(TokenStream<Token>& component_values);
 template Vector<ParsedFontFace::Source> Parser::parse_font_face_src(TokenStream<ComponentValue>& component_values);
 
+Vector<ComponentValue> Parser::parse_as_list_of_component_values()
+{
+    return parse_a_list_of_component_values(m_token_stream);
+}
+
 RefPtr<CSSStyleValue> Parser::parse_list_style_value(TokenStream<ComponentValue>& tokens)
 {
     RefPtr<CSSStyleValue> list_position;

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -69,6 +69,8 @@ public:
 
     Vector<ParsedFontFace::Source> parse_as_font_face_src();
 
+    Vector<ComponentValue> parse_as_list_of_component_values();
+
     static NonnullRefPtr<CSSStyleValue> resolve_unresolved_style_value(ParsingContext const&, DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, PropertyID, UnresolvedStyleValue const&);
 
     [[nodiscard]] LengthOrCalculated parse_as_sizes_attribute(DOM::Element const& element, HTML::HTMLImageElement const* img = nullptr);

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.h
@@ -16,7 +16,10 @@ namespace Web::IntersectionObserver {
 struct IntersectionObserverInit {
     Optional<Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>>> root;
     String root_margin { "0px"_string };
+    String scroll_margin { "0px"_string };
     Variant<double, Vector<double>> threshold { 0 };
+    long delay = 0;
+    bool track_visibility = false;
 };
 
 // https://www.w3.org/TR/intersection-observer/#intersectionobserverregistration
@@ -53,7 +56,11 @@ public:
     Vector<GC::Ref<DOM::Element>> const& observation_targets() const { return m_observation_targets; }
 
     Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>, Empty> root() const;
+    String root_margin() const;
+    String scroll_margin() const;
     Vector<double> const& thresholds() const { return m_thresholds; }
+    long delay() const { return m_delay; }
+    bool track_visibility() const { return m_track_visibility; }
 
     Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>> intersection_root() const;
     CSSPixelRect root_intersection_rectangle() const;
@@ -63,11 +70,13 @@ public:
     WebIDL::CallbackType& callback() { return *m_callback; }
 
 private:
-    explicit IntersectionObserver(JS::Realm&, GC::Ptr<WebIDL::CallbackType> callback, Optional<Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>>> const& root, Vector<double>&& thresholds);
+    explicit IntersectionObserver(JS::Realm&, GC::Ptr<WebIDL::CallbackType> callback, Optional<Variant<GC::Root<DOM::Element>, GC::Root<DOM::Document>>> const& root, Vector<CSS::LengthPercentage> root_margin, Vector<CSS::LengthPercentage> scroll_margin, Vector<double>&& thresholds, double debug, bool track_visibility);
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
     virtual void finalize() override;
+
+    static Optional<Vector<CSS::LengthPercentage>> parse_a_margin(JS::Realm&, String);
 
     // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-callback-slot
     GC::Ptr<WebIDL::CallbackType> m_callback;
@@ -75,8 +84,20 @@ private:
     // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-root
     GC::Ptr<DOM::Node> m_root;
 
+    // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-rootmargin
+    Vector<CSS::LengthPercentage> m_root_margin;
+
+    // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-scrollmargin
+    Vector<CSS::LengthPercentage> m_scroll_margin;
+
     // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-thresholds
     Vector<double> m_thresholds;
+
+    // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-delay
+    long m_delay;
+
+    // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-trackvisibility
+    bool m_track_visibility;
 
     // https://www.w3.org/TR/intersection-observer/#dom-intersectionobserver-queuedentries-slot
     Vector<GC::Ref<IntersectionObserverEntry>> m_queued_entries;

--- a/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.idl
+++ b/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.idl
@@ -11,9 +11,12 @@ callback IntersectionObserverCallback = undefined (sequence<IntersectionObserver
 interface IntersectionObserver {
     constructor(IntersectionObserverCallback callback, optional IntersectionObserverInit options = {});
     readonly attribute (Element or Document)? root;
-    [FIXME] readonly attribute DOMString rootMargin;
+    readonly attribute DOMString rootMargin;
+    readonly attribute DOMString scrollMargin;
     // FIXME: `sequence<double>` should be `FrozenArray<double>`
     readonly attribute sequence<double> thresholds;
+    readonly attribute long delay;
+    readonly attribute boolean trackVisibility;
     undefined observe(Element target);
     undefined unobserve(Element target);
     undefined disconnect();
@@ -24,6 +27,8 @@ interface IntersectionObserver {
 dictionary IntersectionObserverInit {
     (Element or Document)? root = null;
     DOMString rootMargin = "0px";
-    // FIXME: DOMString scrollMargin = "0px";
+    DOMString scrollMargin = "0px";
     (double or sequence<double>) threshold = 0;
+    long delay = 0;
+    boolean trackVisibility = false;
 };

--- a/Tests/LibWeb/Text/expected/wpt-import/intersection-observer/observer-attributes.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/intersection-observer/observer-attributes.txt
@@ -1,0 +1,19 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 9 tests
+
+9 Pass
+Details
+Result	Test Name	MessagePass	Observer attribute getters.	
+Pass	observer.root	
+Pass	observer.thresholds	
+Pass	observer.rootMargin	
+Pass	empty observer.thresholds	
+Pass	whitespace observer.rootMargin	
+Pass	set observer.root	
+Pass	set observer.thresholds	
+Pass	set observer.rootMargin	

--- a/Tests/LibWeb/Text/expected/wpt-import/intersection-observer/observer-exceptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/intersection-observer/observer-exceptions.txt
@@ -1,0 +1,19 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 9 tests
+
+9 Pass
+Details
+Result	Test Name	MessagePass	IntersectionObserver constructor with { threshold: [1.1] }	
+Pass	IntersectionObserver constructor with { threshold: ["foo"] }	
+Pass	IntersectionObserver constructor with { rootMargin: "1" }	
+Pass	IntersectionObserver constructor with { rootMargin: "2em" }	
+Pass	IntersectionObserver constructor with { rootMargin: "auto" }	
+Pass	IntersectionObserver constructor with { rootMargin: "calc(1px + 2px)" }	
+Pass	IntersectionObserver constructor with { rootMargin: "1px !important" }	
+Pass	IntersectionObserver constructor with { rootMargin: "1px 1px 1px 1px 1px" }	
+Pass	IntersectionObserver.observe("foo")	

--- a/Tests/LibWeb/Text/input/wpt-import/intersection-observer/observer-attributes.html
+++ b/Tests/LibWeb/Text/input/wpt-import/intersection-observer/observer-attributes.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<div id="root"></div>
+
+<script>
+test(function() {
+  var observer = new IntersectionObserver(function(e) {}, {});
+  test(function() { assert_equals(observer.root, null) },
+       "observer.root");
+  test(function() { assert_array_equals(observer.thresholds, [0]) },
+       "observer.thresholds");
+  test(function() { assert_equals(observer.rootMargin, "0px 0px 0px 0px") },
+       "observer.rootMargin");
+
+  observer = new IntersectionObserver(function(e) {}, {
+    rootMargin: " ",
+    threshold: []
+  });
+  test(function() { assert_array_equals(observer.thresholds, [0]) },
+       "empty observer.thresholds");
+  test(function() { assert_equals(observer.rootMargin, "0px 0px 0px 0px") },
+       "whitespace observer.rootMargin");
+
+  var rootDiv = document.getElementById("root");
+  observer = new IntersectionObserver(function(e) {}, {
+    root: rootDiv,
+    threshold: [0, 0.25, 0.5, 1.0],
+    rootMargin: "10% 20px"
+  });
+  test(function() { assert_equals(observer.root, rootDiv) },
+       "set observer.root");
+  test(function() { assert_array_equals(observer.thresholds, [0, 0.25, 0.5, 1.0]) },
+       "set observer.thresholds");
+  test(function() { assert_equals(observer.rootMargin, "10% 20px 10% 20px") },
+       "set observer.rootMargin");
+}, "Observer attribute getters.");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/intersection-observer/observer-exceptions.html
+++ b/Tests/LibWeb/Text/input/wpt-import/intersection-observer/observer-exceptions.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<script>
+test(function () {
+  assert_throws_js(RangeError, function() {
+    new IntersectionObserver(e => {}, {threshold: [1.1]})
+  })
+}, "IntersectionObserver constructor with { threshold: [1.1] }");
+
+test(function () {
+  assert_throws_js(TypeError, function() {
+    new IntersectionObserver(e => {}, {threshold: ["foo"]})
+  })
+}, 'IntersectionObserver constructor with { threshold: ["foo"] }');
+
+test(function () {
+  assert_throws_dom("SYNTAX_ERR", function() {
+    new IntersectionObserver(e => {}, {rootMargin: "1"})
+  })
+}, 'IntersectionObserver constructor with { rootMargin: "1" }');
+
+test(function () {
+  assert_throws_dom("SYNTAX_ERR", function() {
+    new IntersectionObserver(e => {}, {rootMargin: "2em"})
+  })
+}, 'IntersectionObserver constructor with { rootMargin: "2em" }');
+
+test(function () {
+  assert_throws_dom("SYNTAX_ERR", function() {
+    new IntersectionObserver(e => {}, {rootMargin: "auto"})
+  })
+}, 'IntersectionObserver constructor with { rootMargin: "auto" }');
+
+test(function () {
+  assert_throws_dom("SYNTAX_ERR", function() {
+    new IntersectionObserver(e => {}, {rootMargin: "calc(1px + 2px)"})
+  })
+}, 'IntersectionObserver constructor with { rootMargin: "calc(1px + 2px)" }');
+
+test(function () {
+  assert_throws_dom("SYNTAX_ERR", function() {
+    new IntersectionObserver(e => {}, {rootMargin: "1px !important"})
+  })
+}, 'IntersectionObserver constructor with { rootMargin: "1px !important" }');
+
+test(function () {
+  assert_throws_dom("SYNTAX_ERR", function() {
+    new IntersectionObserver(e => {}, {rootMargin: "1px 1px 1px 1px 1px"})
+  })
+}, 'IntersectionObserver constructor with { rootMargin: "1px 1px 1px 1px 1px" }');
+
+test(function () {
+  assert_throws_js(TypeError, function() {
+    let observer = new IntersectionObserver(c => {}, {});
+    observer.observe("foo");
+  })
+}, 'IntersectionObserver.observe("foo")');
+</script>


### PR DESCRIPTION
This adds the missing IntersectionObserver attributes that we currently do not have.
Only the `rootMargin` is actually functional, since that was easy to do and a FIXME in the same file.
But the other properties now exist so they can be accessed from the right algorithms and from JS.

This also makes us pass some more WPT tests (how many?), two of which I have imported to verify the behavior.
Sadly, the tests for `rootMargin` functionality are very sensitive to floating point errors, so we don't pass those yet.
(but hey, Firefox and Chrome don't pass them either)