### PR TITLE
LibWeb: Make SVGs respect their CSS transforms

### DIFF
--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.h
@@ -23,6 +23,7 @@ public:
 
     Layout::SVGSVGBox const& layout_box() const;
 
+    static void paint_svg_box(PaintContext& context, PaintableBox const& svg_box, PaintPhase phase);
     static void paint_descendants(PaintContext& context, PaintableBox const& paintable, PaintPhase phase);
 
 protected:

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -104,7 +104,7 @@ void StackingContext::paint_svg(PaintContext& context, PaintableBox const& paint
     paintable.apply_clip_overflow_rect(context, PaintPhase::Foreground);
     paint_node(paintable, context, PaintPhase::Background);
     paint_node(paintable, context, PaintPhase::Border);
-    SVGSVGPaintable::paint_descendants(context, paintable, phase);
+    SVGSVGPaintable::paint_svg_box(context, paintable, phase);
     paintable.clear_clip_overflow_rect(context, PaintPhase::Foreground);
 }
 

--- a/Tests/LibWeb/Ref/expected/svg-with-css-transform.html
+++ b/Tests/LibWeb/Ref/expected/svg-with-css-transform.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+  svg {
+    position: absolute;
+    top: 50px;
+    left: 50px;
+  }
+</style>
+
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" />
+</svg>

--- a/Tests/LibWeb/Ref/input/svg-with-css-transform.html
+++ b/Tests/LibWeb/Ref/input/svg-with-css-transform.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-with-css-transform.html" />
+<style>
+  body {
+    margin: 0;
+  }
+  svg {
+    transform: translate(50px, 50px);
+  }
+</style>
+
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg" width="100" height="100">
+  <rect width="100" height="100" />
+</svg>


### PR DESCRIPTION
SVG elements used to not care about their CSS transforms.
Now they do.
I've just added a new test, chances are there's one in the WPT suite but I wouldn't quite know where to look.

This fixes a bug on https://battle.crossuniverse.net.