### PR TITLE
CI: Move sanitizer output into a separate CI step

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -185,6 +185,9 @@ jobs:
         run: ctest --preset Sanitizer --output-on-failure --test-dir Build --timeout 1800
         env:
           TESTS_ONLY: 1
+          # NOTE: These are appended to the preset's options.
+          ASAN_OPTIONS: 'log_path=${{ github.workspace }}/asan.log'
+          UBSAN_OPTIONS: 'log_path=${{ github.workspace }}/ubsan.log'
 
       - name: Upload LibWeb Test Artifacts
         if: ${{ always() && inputs.fuzzer == 'NO_FUZZ' }}
@@ -194,6 +197,19 @@ jobs:
           path: ${{ github.workspace }}/Build/UI/Headless/test-dumps
           retention-days: 7
           if-no-files-found: ignore
+
+      - name: Sanitizer Output
+        if: ${{ !cancelled() && inputs.fuzzer == 'NO_FUZZ' }}
+        working-directory: ${{ github.workspace }}
+        run: |
+          log_output=$(find . -maxdepth 1 \( -name 'asan.log.*' -o -name 'ubsan.log.*' \) -exec cat {} \; )
+          if [ -z "$log_output" ]; then
+            echo "No sanitizer issues found."
+          else
+            echo "$log_output"
+            echo "Sanitizer errors happened while running tests; see the Test step above."
+            exit 1
+          fi
 
       - name: Lints
         if: ${{ inputs.os_name == 'Linux' && inputs.fuzzer == 'NO_FUZZ' }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -239,8 +239,8 @@
       "inherits": "default",
       "configurePreset": "Sanitizer",
       "environment": {
-        "ASAN_OPTIONS": "strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1",
-        "UBSAN_OPTIONS": "print_stacktrace=1:print_summary=1:halt_on_error=1"
+        "ASAN_OPTIONS": "strict_string_checks=1:check_initialization_order=1:strict_init_order=1:detect_stack_use_after_return=1:allocator_may_return_null=1:$penv{ASAN_OPTIONS}",
+        "UBSAN_OPTIONS": "print_stacktrace=1:print_summary=1:halt_on_error=1:$penv{UBSAN_OPTIONS}"
       }
     },
     {


### PR DESCRIPTION
Instead of writing ASAN and UBSAN output into the same stream we use for test logging, direct them to log files, named asan.log.$PID and ubsan.log.$PID, and then output them in a separate CI job that runs afterwards. This should hopefully make it easier to see which tests are failing.

The downside is that it's now harder to tell which tests the *SAN errors are related to. Any ideas on that are appreciated. Right now, I think making the test logs actually readable is more important, (after all, we've had thousands-of-lines-long *SAN outputs for months and not solved those issues,) but maybe other people disagree.

For now, a failing workflow showing the results of this can be seen at https://github.com/AtkinsSJ/ladybird/actions/runs/11979541011?pr=1