### PR TITLE
LibWeb: Implement BroadcastChannel.postMessage

### DIFF
--- a/Libraries/LibURL/Origin.cpp
+++ b/Libraries/LibURL/Origin.cpp
@@ -10,11 +10,11 @@
 namespace URL {
 
 // https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin
-ByteString Origin::serialize() const
+String Origin::serialize() const
 {
     // 1. If origin is an opaque origin, then return "null"
     if (is_opaque())
-        return "null";
+        return "null"_string;
 
     // 2. Otherwise, let result be origin's scheme.
     StringBuilder result;
@@ -24,15 +24,16 @@ ByteString Origin::serialize() const
     result.append("://"sv);
 
     // 4. Append origin's host, serialized, to result.
-    result.append(Parser::serialize_host(host()).release_value_but_fixme_should_propagate_errors().to_byte_string());
+    result.append(MUST(Parser::serialize_host(host())));
 
     // 5. If origin's port is non-null, append a U+003A COLON character (:), and origin's port, serialized, to result.
     if (port().has_value()) {
         result.append(':');
-        result.append(ByteString::number(*port()));
+        result.append(String::number(*port()));
     }
+
     // 6. Return result
-    return result.to_byte_string();
+    return result.to_string_without_validation();
 }
 
 }

--- a/Libraries/LibURL/Origin.h
+++ b/Libraries/LibURL/Origin.h
@@ -71,7 +71,7 @@ public:
     }
 
     // https://html.spec.whatwg.org/multipage/origin.html#ascii-serialisation-of-an-origin
-    ByteString serialize() const;
+    String serialize() const;
 
     // https://html.spec.whatwg.org/multipage/origin.html#concept-origin-effective-domain
     Optional<Host> effective_domain() const

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4388,7 +4388,7 @@ void Document::restore_the_history_object_state(GC::Ref<HTML::SessionHistoryEntr
 
     // 2. Let state be StructuredDeserialize(entry's classic history API state, targetRealm). If this throws an exception, catch it and let state be null.
     // 3. Set document's history object's state to state.
-    auto state_or_error = HTML::structured_deserialize(target_realm.vm(), entry->classic_history_api_state(), target_realm, {});
+    auto state_or_error = HTML::structured_deserialize(target_realm.vm(), entry->classic_history_api_state(), target_realm);
     if (state_or_error.is_error())
         m_history->set_state(JS::js_null());
     else

--- a/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -213,12 +213,10 @@ WebIDL::ExceptionOr<void> DOMURL::set_href(String const& href)
 }
 
 // https://url.spec.whatwg.org/#dom-url-origin
-WebIDL::ExceptionOr<String> DOMURL::origin() const
+String DOMURL::origin() const
 {
-    auto& vm = realm().vm();
-
     // The origin getter steps are to return the serialization of this’s URL’s origin. [HTML]
-    return TRY_OR_THROW_OOM(vm, String::from_byte_string(m_url.origin().serialize()));
+    return m_url.origin().serialize();
 }
 
 // https://url.spec.whatwg.org/#dom-url-protocol

--- a/Libraries/LibWeb/DOMURL/DOMURL.h
+++ b/Libraries/LibWeb/DOMURL/DOMURL.h
@@ -35,7 +35,7 @@ public:
     WebIDL::ExceptionOr<String> href() const;
     WebIDL::ExceptionOr<void> set_href(String const&);
 
-    WebIDL::ExceptionOr<String> origin() const;
+    String origin() const;
 
     WebIDL::ExceptionOr<String> protocol() const;
     WebIDL::ExceptionOr<void> set_protocol(String const&);

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Requests.cpp
@@ -194,7 +194,7 @@ String Request::serialize_origin() const
         return "null"_string;
 
     // 2. Return request’s origin, serialized.
-    return MUST(String::from_byte_string(m_origin.get<URL::Origin>().serialize()));
+    return m_origin.get<URL::Origin>().serialize();
 }
 
 // https://fetch.spec.whatwg.org/#byte-serializing-a-request-origin

--- a/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
+++ b/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
@@ -43,7 +43,7 @@ ErrorOr<String> generate_new_blob_url()
 
     // 6. If serialized is "null", set it to an implementation-defined value.
     if (serialized == "null"sv)
-        serialized = "ladybird"sv;
+        serialized = "ladybird"_string;
 
     // 7. Append serialized to result.
     TRY(result.try_append(serialized));

--- a/Libraries/LibWeb/HTML/BroadcastChannel.cpp
+++ b/Libraries/LibWeb/HTML/BroadcastChannel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,14 +10,62 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/HTML/BroadcastChannel.h>
 #include <LibWeb/HTML/EventNames.h>
+#include <LibWeb/HTML/MessageEvent.h>
+#include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WorkerGlobalScope.h>
+#include <LibWeb/StorageAPI/StorageKey.h>
 
 namespace Web::HTML {
+
+class BroadcastChannelRepository {
+public:
+    void register_channel(GC::Root<BroadcastChannel>);
+    void unregister_channel(GC::Ref<BroadcastChannel>);
+    Vector<GC::Root<BroadcastChannel>> const& registered_channels_for_key(StorageAPI::StorageKey) const;
+
+private:
+    HashMap<StorageAPI::StorageKey, Vector<GC::Root<BroadcastChannel>>> m_channels;
+};
+
+void BroadcastChannelRepository::register_channel(GC::Root<BroadcastChannel> channel)
+{
+    auto storage_key = Web::StorageAPI::obtain_a_storage_key_for_non_storage_purposes(relevant_settings_object(*channel));
+
+    auto maybe_channels = m_channels.find(storage_key);
+    if (maybe_channels != m_channels.end()) {
+        maybe_channels->value.append(move(channel));
+        return;
+    }
+
+    Vector<GC::Root<BroadcastChannel>> channels;
+    channels.append(move(channel));
+    m_channels.set(storage_key, move(channels));
+}
+
+void BroadcastChannelRepository::unregister_channel(GC::Ref<BroadcastChannel> channel)
+{
+    auto storage_key = Web::StorageAPI::obtain_a_storage_key_for_non_storage_purposes(relevant_settings_object(channel));
+    auto& relevant_channels = m_channels.get(storage_key).value();
+    relevant_channels.remove_first_matching([&](auto c) { return c == channel; });
+}
+
+Vector<GC::Root<BroadcastChannel>> const& BroadcastChannelRepository::registered_channels_for_key(StorageAPI::StorageKey key) const
+{
+    auto maybe_channels = m_channels.get(key);
+    VERIFY(maybe_channels.has_value());
+    return maybe_channels.value();
+}
+
+// FIXME: This should not be static, and live at a storage partitioned level of the user agent.
+static BroadcastChannelRepository s_broadcast_channel_repository;
 
 GC_DEFINE_ALLOCATOR(BroadcastChannel);
 
 GC::Ref<BroadcastChannel> BroadcastChannel::construct_impl(JS::Realm& realm, FlyString const& name)
 {
-    return realm.create<BroadcastChannel>(realm, name);
+    auto channel = realm.create<BroadcastChannel>(realm, name);
+    s_broadcast_channel_repository.register_channel(channel);
+    return channel;
 }
 
 BroadcastChannel::BroadcastChannel(JS::Realm& realm, FlyString const& name)
@@ -31,11 +80,114 @@ void BroadcastChannel::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(BroadcastChannel);
 }
 
+// https://html.spec.whatwg.org/multipage/web-messaging.html#eligible-for-messaging
+bool BroadcastChannel::is_eligible_for_messaging() const
+{
+    // A BroadcastChannel object is said to be eligible for messaging when its relevant global object is either:
+    auto const& global = relevant_global_object(*this);
+
+    // * a Window object whose associated Document is fully active, or
+    if (is<Window>(global))
+        return static_cast<Window const&>(global).associated_document().is_fully_active();
+
+    // * a WorkerGlobalScope object whose closing flag is false and whose worker is not a suspendable worker.
+    // FIXME: Suspendable worker
+    if (is<WorkerGlobalScope>(global))
+        return !static_cast<WorkerGlobalScope const&>(global).is_closing();
+
+    return false;
+}
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-postmessage
+WebIDL::ExceptionOr<void> BroadcastChannel::post_message(JS::Value message)
+{
+    auto& vm = this->vm();
+
+    // 1. If this is not eligible for messaging, then return.
+    if (!is_eligible_for_messaging())
+        return {};
+
+    // 2. If this's closed flag is true, then throw an "InvalidStateError" DOMException.
+    if (m_closed_flag)
+        return WebIDL::InvalidStateError::create(realm(), "BroadcastChannel.postMessage() on a closed channel"_string);
+
+    // 3. Let serialized be StructuredSerialize(message). Rethrow any exceptions.
+    auto serialized = TRY(structured_serialize(vm, message));
+
+    // 4. Let sourceOrigin be this's relevant settings object's origin.
+    auto source_origin = relevant_settings_object(*this).origin();
+
+    // 5. Let sourceStorageKey be the result of running obtain a storage key for non-storage purposes with this's relevant settings object.
+    auto source_storage_key = Web::StorageAPI::obtain_a_storage_key_for_non_storage_purposes(relevant_settings_object(*this));
+
+    // 6. Let destinations be a list of BroadcastChannel objects that match the following criteria:
+    GC::MarkedVector<GC::Ref<BroadcastChannel>> destinations(vm.heap());
+
+    // * The result of running obtain a storage key for non-storage purposes with their relevant settings object equals sourceStorageKey.
+    auto same_origin_broadcast_channels = s_broadcast_channel_repository.registered_channels_for_key(source_storage_key);
+
+    for (auto const& channel : same_origin_broadcast_channels) {
+        // * They are eligible for messaging.
+        if (!channel->is_eligible_for_messaging())
+            continue;
+
+        // * Their channel name is this's channel name.
+        if (channel->name() != name())
+            continue;
+
+        destinations.append(*channel);
+    }
+
+    // 7. Remove source from destinations.
+    destinations.remove_first_matching([&](auto destination) { return destination == this; });
+
+    // FIXME: 8. Sort destinations such that all BroadcastChannel objects whose relevant agents are the same are sorted in creation order, oldest first.
+    //    (This does not define a complete ordering. Within this constraint, user agents may sort the list in any implementation-defined manner.)
+
+    // 9. For each destination in destinations, queue a global task on the DOM manipulation task source given destination's relevant global object to perform the following steps:
+    for (auto destination : destinations) {
+        HTML::queue_global_task(HTML::Task::Source::DOMManipulation, relevant_global_object(destination), GC::create_function(vm.heap(), [&vm, serialized, destination, source_origin] {
+            // 1. If destination's closed flag is true, then abort these steps.
+            if (destination->m_closed_flag)
+                return;
+
+            // 2. Let targetRealm be destination's relevant realm.
+            auto& target_realm = relevant_realm(destination);
+
+            // 3. Let data be StructuredDeserialize(serialized, targetRealm).
+            //    If this throws an exception, catch it, fire an event named messageerror at destination, using MessageEvent, with the
+            //    origin attribute initialized to the serialization of sourceOrigin, and then abort these steps.
+            auto data_or_error = structured_deserialize(vm, serialized, target_realm);
+            if (data_or_error.is_exception()) {
+                MessageEventInit event_init {};
+                event_init.origin = source_origin.serialize();
+                auto event = MessageEvent::create(target_realm, HTML::EventNames::messageerror, event_init);
+                event->set_is_trusted(true);
+                destination->dispatch_event(event);
+                return;
+            }
+
+            // 4. Fire an event named message at destination, using MessageEvent, with the data attribute initialized to data and the
+            //    origin attribute initialized to the serialization of sourceOrigin.
+            MessageEventInit event_init {};
+            event_init.data = data_or_error.release_value();
+            event_init.origin = source_origin.serialize();
+            auto event = MessageEvent::create(target_realm, HTML::EventNames::message, event_init);
+            event->set_is_trusted(true);
+            destination->dispatch_event(event);
+        }));
+    }
+
+    return {};
+}
+
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-close
 void BroadcastChannel::close()
 {
     // The close() method steps are to set this's closed flag to true.
     m_closed_flag = true;
+
+    s_broadcast_channel_repository.unregister_channel(*this);
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage

--- a/Libraries/LibWeb/HTML/BroadcastChannel.cpp
+++ b/Libraries/LibWeb/HTML/BroadcastChannel.cpp
@@ -31,13 +31,6 @@ void BroadcastChannel::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(BroadcastChannel);
 }
 
-// https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-name
-FlyString BroadcastChannel::name()
-{
-    // The name getter steps are to return this's channel name.
-    return m_channel_name;
-}
-
 // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-close
 void BroadcastChannel::close()
 {
@@ -46,25 +39,25 @@ void BroadcastChannel::close()
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage
-void BroadcastChannel::set_onmessage(WebIDL::CallbackType* event_handler)
+void BroadcastChannel::set_onmessage(GC::Ptr<WebIDL::CallbackType> event_handler)
 {
     set_event_handler_attribute(HTML::EventNames::message, event_handler);
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessage
-WebIDL::CallbackType* BroadcastChannel::onmessage()
+GC::Ptr<WebIDL::CallbackType> BroadcastChannel::onmessage()
 {
     return event_handler_attribute(HTML::EventNames::message);
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror
-void BroadcastChannel::set_onmessageerror(WebIDL::CallbackType* event_handler)
+void BroadcastChannel::set_onmessageerror(GC::Ptr<WebIDL::CallbackType> event_handler)
 {
     set_event_handler_attribute(HTML::EventNames::messageerror, event_handler);
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-broadcastchannel-onmessageerror
-WebIDL::CallbackType* BroadcastChannel::onmessageerror()
+GC::Ptr<WebIDL::CallbackType> BroadcastChannel::onmessageerror()
 {
     return event_handler_attribute(HTML::EventNames::messageerror);
 }

--- a/Libraries/LibWeb/HTML/BroadcastChannel.h
+++ b/Libraries/LibWeb/HTML/BroadcastChannel.h
@@ -17,14 +17,19 @@ class BroadcastChannel final : public DOM::EventTarget {
 public:
     [[nodiscard]] static GC::Ref<BroadcastChannel> construct_impl(JS::Realm&, FlyString const& name);
 
-    FlyString name();
+    // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-broadcastchannel-name
+    FlyString const& name() const
+    {
+        // The name getter steps are to return this's channel name.
+        return m_channel_name;
+    }
 
     void close();
 
-    void set_onmessage(WebIDL::CallbackType*);
-    WebIDL::CallbackType* onmessage();
-    void set_onmessageerror(WebIDL::CallbackType*);
-    WebIDL::CallbackType* onmessageerror();
+    void set_onmessage(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onmessage();
+    void set_onmessageerror(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onmessageerror();
 
 private:
     BroadcastChannel(JS::Realm&, FlyString const& name);

--- a/Libraries/LibWeb/HTML/BroadcastChannel.h
+++ b/Libraries/LibWeb/HTML/BroadcastChannel.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Jamie Mansfield <jmansfield@cadixdev.org>
+ * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,6 +25,8 @@ public:
         return m_channel_name;
     }
 
+    WebIDL::ExceptionOr<void> post_message(JS::Value message);
+
     void close();
 
     void set_onmessage(GC::Ptr<WebIDL::CallbackType>);
@@ -35,6 +38,8 @@ private:
     BroadcastChannel(JS::Realm&, FlyString const& name);
 
     virtual void initialize(JS::Realm&) override;
+
+    bool is_eligible_for_messaging() const;
 
     FlyString m_channel_name;
     bool m_closed_flag { false };

--- a/Libraries/LibWeb/HTML/BroadcastChannel.idl
+++ b/Libraries/LibWeb/HTML/BroadcastChannel.idl
@@ -7,7 +7,7 @@ interface BroadcastChannel : EventTarget {
     constructor(DOMString name);
 
     readonly attribute DOMString name;
-    [FIXME] undefined postMessage(any message);
+    undefined postMessage(any message);
     undefined close();
     attribute EventHandler onmessage;
     attribute EventHandler onmessageerror;

--- a/Libraries/LibWeb/HTML/EventSource.cpp
+++ b/Libraries/LibWeb/HTML/EventSource.cpp
@@ -449,7 +449,7 @@ void EventSource::dispatch_the_event()
     //    the value of the event type buffer.
     MessageEventInit init {};
     init.data = JS::PrimitiveString::create(vm(), data_buffer);
-    init.origin = MUST(String::from_byte_string(m_url.origin().serialize()));
+    init.origin = m_url.origin().serialize();
     init.last_event_id = last_event_id;
 
     auto type = m_event_type.is_empty() ? HTML::EventNames::message : m_event_type;

--- a/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -52,7 +52,7 @@ String HTMLHyperlinkElementUtils::origin() const
         return String {};
 
     // 3. Return the serialization of this element's url's origin.
-    return MUST(String::from_byte_string(m_url->origin().serialize()));
+    return m_url->origin().serialize();
 }
 
 // https://html.spec.whatwg.org/multipage/links.html#dom-hyperlink-protocol

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -133,15 +133,13 @@ WebIDL::ExceptionOr<void> Location::set_href(String const& new_href)
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-location-origin
 WebIDL::ExceptionOr<String> Location::origin() const
 {
-    auto& vm = this->vm();
-
     // 1. If this's relevant Document is non-null and its origin is not same origin-domain with the entry settings object's origin, then throw a "SecurityError" DOMException.
     auto const relevant_document = this->relevant_document();
     if (relevant_document && !relevant_document->origin().is_same_origin_domain(entry_settings_object().origin()))
         return WebIDL::SecurityError::create(realm(), "Location's relevant document is not same origin-domain with the entry settings object's origin"_string);
 
     // 2. Return the serialization of this's url's origin.
-    return TRY_OR_THROW_OOM(vm, String::from_byte_string(url().origin().serialize()));
+    return url().origin().serialize();
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-location-protocol

--- a/Libraries/LibWeb/HTML/NavigationDestination.cpp
+++ b/Libraries/LibWeb/HTML/NavigationDestination.cpp
@@ -87,7 +87,7 @@ bool NavigationDestination::same_document() const
 WebIDL::ExceptionOr<JS::Value> NavigationDestination::get_state()
 {
     // The getState() method steps are to return StructuredDeserialize(this's state).
-    return structured_deserialize(vm(), m_state, realm(), {});
+    return structured_deserialize(vm(), m_state, realm());
 }
 
 }

--- a/Libraries/LibWeb/HTML/NavigationHistoryEntry.cpp
+++ b/Libraries/LibWeb/HTML/NavigationHistoryEntry.cpp
@@ -135,7 +135,7 @@ WebIDL::ExceptionOr<JS::Value> NavigationHistoryEntry::get_state()
     // 2. Return StructuredDeserialize(this's session history entry's navigation API state). Rethrow any exceptions.
     //    NOTE: This can in theory throw an exception, if attempting to deserialize a large ArrayBuffer
     //          when not enough memory is available.
-    return structured_deserialize(vm(), m_session_history_entry->navigation_api_state(), realm(), {});
+    return structured_deserialize(vm(), m_session_history_entry->navigation_api_state(), realm());
 }
 
 void NavigationHistoryEntry::set_ondispose(WebIDL::CallbackType* event_handler)

--- a/Libraries/LibWeb/HTML/Scripting/EnvironmentSettingsSnapshot.h
+++ b/Libraries/LibWeb/HTML/Scripting/EnvironmentSettingsSnapshot.h
@@ -23,11 +23,11 @@ public:
     virtual ~EnvironmentSettingsSnapshot() override;
 
     GC::Ptr<DOM::Document> responsible_document() override { return nullptr; }
-    String api_url_character_encoding() override { return m_api_url_character_encoding; }
-    URL::URL api_base_url() override { return m_url; }
-    URL::Origin origin() override { return m_origin; }
-    PolicyContainer policy_container() override { return m_policy_container; }
-    CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() override { return CanUseCrossOriginIsolatedAPIs::No; }
+    String api_url_character_encoding() const override { return m_api_url_character_encoding; }
+    URL::URL api_base_url() const override { return m_url; }
+    URL::Origin origin() const override { return m_origin; }
+    PolicyContainer policy_container() const override { return m_policy_container; }
+    CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() const override { return CanUseCrossOriginIsolatedAPIs::No; }
 
 private:
     String m_api_url_character_encoding;

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -73,19 +73,19 @@ public:
     virtual GC::Ptr<DOM::Document> responsible_document() = 0;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#api-url-character-encoding
-    virtual String api_url_character_encoding() = 0;
+    virtual String api_url_character_encoding() const = 0;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#api-base-url
-    virtual URL::URL api_base_url() = 0;
+    virtual URL::URL api_base_url() const = 0;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-origin
-    virtual URL::Origin origin() = 0;
+    virtual URL::Origin origin() const = 0;
 
     // A policy container https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-policy-container
-    virtual PolicyContainer policy_container() = 0;
+    virtual PolicyContainer policy_container() const = 0;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-cross-origin-isolated-capability
-    virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() = 0;
+    virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() const = 0;
 
     URL::URL parse_url(StringView);
 

--- a/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.cpp
@@ -90,35 +90,35 @@ GC::Ptr<DOM::Document> WindowEnvironmentSettingsObject::responsible_document()
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:api-url-character-encoding
-String WindowEnvironmentSettingsObject::api_url_character_encoding()
+String WindowEnvironmentSettingsObject::api_url_character_encoding() const
 {
     // Return the current character encoding of window's associated Document.
     return m_window->associated_document().encoding_or_default();
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:api-base-url
-URL::URL WindowEnvironmentSettingsObject::api_base_url()
+URL::URL WindowEnvironmentSettingsObject::api_base_url() const
 {
     // Return the current base URL of window's associated Document.
     return m_window->associated_document().base_url();
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:concept-settings-object-origin
-URL::Origin WindowEnvironmentSettingsObject::origin()
+URL::Origin WindowEnvironmentSettingsObject::origin() const
 {
     // Return the origin of window's associated Document.
     return m_window->associated_document().origin();
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:concept-settings-object-policy-container
-PolicyContainer WindowEnvironmentSettingsObject::policy_container()
+PolicyContainer WindowEnvironmentSettingsObject::policy_container() const
 {
     // Return the policy container of window's associated Document.
     return m_window->associated_document().policy_container();
 }
 
 // https://html.spec.whatwg.org/multipage/window-object.html#script-settings-for-window-objects:concept-settings-object-cross-origin-isolated-capability
-CanUseCrossOriginIsolatedAPIs WindowEnvironmentSettingsObject::cross_origin_isolated_capability()
+CanUseCrossOriginIsolatedAPIs WindowEnvironmentSettingsObject::cross_origin_isolated_capability() const
 {
     // FIXME: Return true if both of the following hold, and false otherwise:
     //          1. realm's agent cluster's cross-origin-isolation mode is "concrete", and

--- a/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/WindowEnvironmentSettingsObject.h
@@ -21,11 +21,11 @@ public:
     virtual ~WindowEnvironmentSettingsObject() override;
 
     virtual GC::Ptr<DOM::Document> responsible_document() override;
-    virtual String api_url_character_encoding() override;
-    virtual URL::URL api_base_url() override;
-    virtual URL::Origin origin() override;
-    virtual PolicyContainer policy_container() override;
-    virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() override;
+    virtual String api_url_character_encoding() const override;
+    virtual URL::URL api_base_url() const override;
+    virtual URL::Origin origin() const override;
+    virtual PolicyContainer policy_container() const override;
+    virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() const override;
 
 private:
     WindowEnvironmentSettingsObject(Window&, NonnullOwnPtr<JS::ExecutionContext>);

--- a/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.cpp
@@ -56,25 +56,25 @@ GC::Ref<WorkerEnvironmentSettingsObject> WorkerEnvironmentSettingsObject::setup(
     return settings_object;
 }
 
-URL::URL WorkerEnvironmentSettingsObject::api_base_url()
+URL::URL WorkerEnvironmentSettingsObject::api_base_url() const
 {
     // Return worker global scope's url.
     return m_global_scope->url();
 }
 
-URL::Origin WorkerEnvironmentSettingsObject::origin()
+URL::Origin WorkerEnvironmentSettingsObject::origin() const
 {
     // FIXME: Return a unique opaque origin if worker global scope's url's scheme is "data", and inherited origin otherwise.
     return m_origin;
 }
 
-PolicyContainer WorkerEnvironmentSettingsObject::policy_container()
+PolicyContainer WorkerEnvironmentSettingsObject::policy_container() const
 {
     // Return worker global scope's policy container.
     return m_global_scope->policy_container();
 }
 
-CanUseCrossOriginIsolatedAPIs WorkerEnvironmentSettingsObject::cross_origin_isolated_capability()
+CanUseCrossOriginIsolatedAPIs WorkerEnvironmentSettingsObject::cross_origin_isolated_capability() const
 {
     // FIXME: Return worker global scope's cross-origin isolated capability.
     return CanUseCrossOriginIsolatedAPIs::No;

--- a/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
+++ b/Libraries/LibWeb/HTML/Scripting/WorkerEnvironmentSettingsObject.h
@@ -29,11 +29,11 @@ public:
     virtual ~WorkerEnvironmentSettingsObject() override = default;
 
     GC::Ptr<DOM::Document> responsible_document() override { return nullptr; }
-    String api_url_character_encoding() override { return m_api_url_character_encoding; }
-    URL::URL api_base_url() override;
-    URL::Origin origin() override;
-    PolicyContainer policy_container() override;
-    CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() override;
+    String api_url_character_encoding() const override { return m_api_url_character_encoding; }
+    URL::URL api_base_url() const override;
+    URL::Origin origin() const override;
+    PolicyContainer policy_container() const override;
+    CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() const override;
 
 private:
     virtual void visit_edges(JS::Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -54,7 +54,7 @@ WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Va
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize_for_storage(JS::VM& vm, JS::Value);
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize_internal(JS::VM& vm, JS::Value, bool for_storage, SerializationMemory&);
 
-WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory>);
+WebIDL::ExceptionOr<JS::Value> structured_deserialize(JS::VM& vm, SerializationRecord const& serialized, JS::Realm& target_realm, Optional<DeserializationMemory> = {});
 WebIDL::ExceptionOr<DeserializedRecord> structured_deserialize_internal(JS::VM& vm, ReadonlySpan<u32> const& serialized, JS::Realm& target_realm, DeserializationMemory& memory, Optional<size_t> position = {});
 
 void serialize_boolean_primitive(SerializationRecord& serialized, JS::Value& value);

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -102,7 +102,7 @@ WebIDL::ExceptionOr<JS::Value> UniversalGlobalScopeMixin::structured_clone(JS::V
 
     // 2. Let deserializeRecord be ? StructuredDeserializeWithTransfer(serialized, this's relevant realm).
     // FIXME: Use WithTransfer variant of the AO
-    auto deserialized = TRY(structured_deserialize(vm, serialized, relevant_realm(this_impl()), {}));
+    auto deserialized = TRY(structured_deserialize(vm, serialized, relevant_realm(this_impl())));
 
     // 3. Return deserializeRecord.[[Deserialized]].
     return deserialized;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1077,7 +1077,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         // with the origin attribute initialized to origin and the source attribute initialized to source, and then return.
         if (deserialize_record_or_error.is_exception()) {
             MessageEventInit message_event_init {};
-            message_event_init.origin = MUST(String::from_byte_string(origin));
+            message_event_init.origin = origin;
             message_event_init.source = GC::make_root(source);
 
             auto message_error_event = MessageEvent::create(target_realm, EventNames::messageerror, message_event_init);
@@ -1103,7 +1103,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         //    the source attribute initialized to source, the data attribute initialized to messageClone, and the ports attribute
         //    initialized to newPorts.
         MessageEventInit message_event_init {};
-        message_event_init.origin = MUST(String::from_byte_string(origin));
+        message_event_init.origin = origin;
         message_event_init.source = GC::make_root(source);
         message_event_init.data = message_clone;
         message_event_init.ports = move(new_ports);

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -83,12 +83,10 @@ void WindowOrWorkerGlobalScopeMixin::finalize()
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-origin
-WebIDL::ExceptionOr<String> WindowOrWorkerGlobalScopeMixin::origin() const
+String WindowOrWorkerGlobalScopeMixin::origin() const
 {
-    auto& vm = this_impl().vm();
-
     // The origin getter steps are to return this's relevant settings object's origin, serialized.
-    return TRY_OR_THROW_OOM(vm, String::from_byte_string(relevant_settings_object(this_impl()).origin().serialize()));
+    return relevant_settings_object(this_impl()).origin().serialize();
 }
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#dom-issecurecontext

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -33,7 +33,7 @@ public:
     virtual Bindings::PlatformObject const& this_impl() const = 0;
 
     // JS API functions
-    WebIDL::ExceptionOr<String> origin() const;
+    String origin() const;
     bool is_secure_context() const;
     bool cross_origin_isolated() const;
     GC::Ref<WebIDL::Promise> create_image_bitmap(ImageBitmapSource image, Optional<ImageBitmapOptions> options = {}) const;

--- a/Libraries/LibWeb/HTML/WorkerLocation.cpp
+++ b/Libraries/LibWeb/HTML/WorkerLocation.cpp
@@ -22,11 +22,10 @@ WebIDL::ExceptionOr<String> WorkerLocation::href() const
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-origin
-WebIDL::ExceptionOr<String> WorkerLocation::origin() const
+String WorkerLocation::origin() const
 {
-    auto& vm = realm().vm();
     // The origin getter steps are to return the serialization of this's WorkerGlobalScope object's url's origin.
-    return TRY_OR_THROW_OOM(vm, String::from_byte_string(m_global_scope->url().origin().serialize()));
+    return m_global_scope->url().origin().serialize();
 }
 
 // https://html.spec.whatwg.org/multipage/workers.html#dom-workerlocation-protocol

--- a/Libraries/LibWeb/HTML/WorkerLocation.h
+++ b/Libraries/LibWeb/HTML/WorkerLocation.h
@@ -19,7 +19,7 @@ public:
     virtual ~WorkerLocation() override;
 
     WebIDL::ExceptionOr<String> href() const;
-    WebIDL::ExceptionOr<String> origin() const;
+    String origin() const;
     WebIDL::ExceptionOr<String> protocol() const;
     WebIDL::ExceptionOr<String> host() const;
     WebIDL::ExceptionOr<String> hostname() const;

--- a/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -298,7 +298,7 @@ WebIDL::ExceptionOr<GC::Ref<UserTiming::PerformanceMeasure>> Performance::measur
         auto record = TRY(HTML::structured_serialize(vm, start_or_measure_options_dictionary_object->detail));
 
         // 2. Set entry's detail to the result of calling the StructuredDeserialize algorithm on record and the current realm.
-        detail = TRY(HTML::structured_deserialize(vm, record, realm, Optional<HTML::DeserializationMemory> {}));
+        detail = TRY(HTML::structured_deserialize(vm, record, realm));
     }
 
     // 2. Otherwise, set it to null.

--- a/Libraries/LibWeb/StorageAPI/StorageKey.cpp
+++ b/Libraries/LibWeb/StorageAPI/StorageKey.cpp
@@ -32,9 +32,7 @@ StorageKey obtain_a_storage_key_for_non_storage_purposes(HTML::Environment const
     // 1. Let origin be environment’s origin if environment is an environment settings object; otherwise environment’s creation URL’s origin.
     if (is<HTML::EnvironmentSettingsObject>(environment)) {
         auto const& settings = static_cast<HTML::EnvironmentSettingsObject const&>(environment);
-        // FIXME: EnvironmentSettingsObject::origin() should be const :|
-        auto& mutable_settings = const_cast<HTML::EnvironmentSettingsObject&>(settings);
-        return { mutable_settings.origin() };
+        return { settings.origin() };
     }
     return { environment.creation_url.origin() };
 }

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -5397,7 +5397,7 @@ WebIDL::ExceptionOr<JS::Value> structured_clone(JS::Realm& realm, JS::Value valu
     auto serialized = TRY(HTML::structured_serialize(vm, value));
 
     // 2. Return ? StructuredDeserialize(serialized, the current Realm).
-    return TRY(HTML::structured_deserialize(vm, serialized, realm, {}));
+    return TRY(HTML::structured_deserialize(vm, serialized, realm));
 }
 
 // https://streams.spec.whatwg.org/#close-sentinel

--- a/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
+++ b/Libraries/LibWeb/UserTiming/PerformanceMark.cpp
@@ -86,7 +86,7 @@ WebIDL::ExceptionOr<GC::Ref<PerformanceMark>> PerformanceMark::construct_impl(JS
         auto record = TRY(HTML::structured_serialize(vm, mark_options.detail));
 
         // 2. Set entry's detail to the result of calling the StructuredDeserialize algorithm on record and the current realm.
-        detail = TRY(HTML::structured_deserialize(vm, record, realm, Optional<HTML::DeserializationMemory> {}));
+        detail = TRY(HTML::structured_deserialize(vm, record, realm));
     }
 
     // 2. Create a new PerformanceMark object (entry) with the current global object's realm.

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -124,7 +124,7 @@ ErrorOr<void> WebSocket::establish_web_socket_connection(URL::URL& url_record, V
 
     auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&client.global_object());
     VERIFY(window_or_worker);
-    auto origin_string = MUST(window_or_worker->origin()).to_byte_string();
+    auto origin_string = window_or_worker->origin().to_byte_string();
 
     Vector<ByteString> protcol_byte_strings;
     for (auto const& protocol : protocols)

--- a/Tests/LibWeb/Text/expected/wpt-import/webmessaging/broadcastchannel/basics.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webmessaging/broadcastchannel/basics.any.txt
@@ -1,0 +1,17 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 7 tests
+
+7 Pass
+Details
+Result	Test Name	MessagePass	BroadcastChannel constructor called as normal function	
+Pass	postMessage results in correct event	
+Pass	messages are delivered in port creation order	
+Pass	messages aren't delivered to a closed port	
+Pass	messages aren't delivered to a port closed after calling postMessage.	
+Pass	closing and creating channels during message delivery works correctly	
+Pass	Closing a channel in onmessage prevents already queued tasks from firing onmessage events	

--- a/Tests/LibWeb/Text/expected/wpt-import/webmessaging/broadcastchannel/interface.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webmessaging/broadcastchannel/interface.any.txt
@@ -1,0 +1,23 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 13 tests
+
+13 Pass
+Details
+Result	Test Name	MessagePass	Should throw if no name is provided	
+Pass	Null name should not throw	
+Pass	Undefined name should not throw	
+Pass	Non-empty name should not throw	
+Pass	Non-string name should not throw	
+Pass	postMessage without parameters should throw	
+Pass	postMessage with null should not throw	
+Pass	close should not throw	
+Pass	close should not throw when called multiple times	
+Pass	postMessage after close should throw	
+Pass	BroadcastChannel should have an onmessage event	
+Pass	postMessage should throw with uncloneable data	
+Pass	postMessage should throw InvalidStateError after close, even with uncloneable data	

--- a/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/basics.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/basics.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../webmessaging/broadcastchannel/basics.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/basics.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/basics.any.js
@@ -1,0 +1,128 @@
+test(function() {
+  assert_throws_js(
+      TypeError,
+      () => BroadcastChannel(""),
+      "Calling BroadcastChannel constructor without 'new' must throw"
+    );
+}, "BroadcastChannel constructor called as normal function");
+
+async_test(t => {
+    let c1 = new BroadcastChannel('eventType');
+    let c2 = new BroadcastChannel('eventType');
+
+    c2.onmessage = t.step_func(e => {
+        assert_true(e instanceof MessageEvent);
+        assert_equals(e.target, c2);
+        assert_equals(e.type, 'message');
+        assert_equals(e.origin, location.origin, 'origin');
+        assert_equals(e.data, 'hello world');
+        assert_equals(e.source, null, 'source');
+        t.done();
+      });
+    c1.postMessage('hello world');
+  }, 'postMessage results in correct event');
+
+async_test(t => {
+    let c1 = new BroadcastChannel('order');
+    let c2 = new BroadcastChannel('order');
+    let c3 = new BroadcastChannel('order');
+
+    let events = [];
+    let doneCount = 0;
+    let handler = t.step_func(e => {
+      events.push(e);
+      if (e.data == 'done') {
+        doneCount++;
+        if (doneCount == 2) {
+          assert_equals(events.length, 6);
+          assert_equals(events[0].target, c2, 'target for event 0');
+          assert_equals(events[0].data, 'from c1');
+          assert_equals(events[1].target, c3, 'target for event 1');
+          assert_equals(events[1].data, 'from c1');
+          assert_equals(events[2].target, c1, 'target for event 2');
+          assert_equals(events[2].data, 'from c3');
+          assert_equals(events[3].target, c2, 'target for event 3');
+          assert_equals(events[3].data, 'from c3');
+          assert_equals(events[4].target, c1, 'target for event 4');
+          assert_equals(events[4].data, 'done');
+          assert_equals(events[5].target, c3, 'target for event 5');
+          assert_equals(events[5].data, 'done');
+          t.done();
+        }
+      }
+    });
+    c1.onmessage = handler;
+    c2.onmessage = handler;
+    c3.onmessage = handler;
+
+    c1.postMessage('from c1');
+    c3.postMessage('from c3');
+    c2.postMessage('done');
+  }, 'messages are delivered in port creation order');
+
+async_test(t => {
+    let c1 = new BroadcastChannel('closed');
+    let c2 = new BroadcastChannel('closed');
+    let c3 = new BroadcastChannel('closed');
+
+    c2.onmessage = t.unreached_func();
+    c2.close();
+    c3.onmessage = t.step_func(() => t.done());
+    c1.postMessage('test');
+  }, 'messages aren\'t delivered to a closed port');
+
+ async_test(t => {
+    let c1 = new BroadcastChannel('closed');
+    let c2 = new BroadcastChannel('closed');
+    let c3 = new BroadcastChannel('closed');
+
+    c2.onmessage = t.unreached_func();
+    c3.onmessage = t.step_func(() => t.done());
+    c1.postMessage('test');
+    c2.close();
+}, 'messages aren\'t delivered to a port closed after calling postMessage.');
+
+async_test(t => {
+    let c1 = new BroadcastChannel('create-in-onmessage');
+    let c2 = new BroadcastChannel('create-in-onmessage');
+
+    c2.onmessage = t.step_func(e => {
+        assert_equals(e.data, 'first');
+        c2.close();
+        let c3 = new BroadcastChannel('create-in-onmessage');
+        c3.onmessage = t.step_func(event => {
+            assert_equals(event.data, 'done');
+            t.done();
+          });
+        c1.postMessage('done');
+      });
+    c1.postMessage('first');
+    c2.postMessage('second');
+  }, 'closing and creating channels during message delivery works correctly');
+
+async_test(t => {
+    let c1 = new BroadcastChannel('close-in-onmessage');
+    let c2 = new BroadcastChannel('close-in-onmessage');
+    let c3 = new BroadcastChannel('close-in-onmessage');
+    let events = [];
+    c1.onmessage = e => events.push('c1: ' + e.data);
+    c2.onmessage = e => events.push('c2: ' + e.data);
+    c3.onmessage = e => events.push('c3: ' + e.data);
+
+    // c2 closes itself when it receives the first message
+    c2.addEventListener('message', e => {
+        c2.close();
+      });
+
+    c3.addEventListener('message', t.step_func(e => {
+        if (e.data == 'done') {
+          assert_array_equals(events, [
+              'c2: first',
+              'c3: first',
+              'c3: done']);
+          t.done();
+        }
+      }));
+    c1.postMessage('first');
+    c1.postMessage('done');
+  }, 'Closing a channel in onmessage prevents already queued tasks from firing onmessage events');

--- a/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/interface.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/interface.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../webmessaging/broadcastchannel/interface.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/interface.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/webmessaging/broadcastchannel/interface.any.js
@@ -1,0 +1,65 @@
+test(() => assert_throws_js(TypeError, () => new BroadcastChannel()),
+  'Should throw if no name is provided');
+
+test(() => {
+    let c = new BroadcastChannel(null);
+    assert_equals(c.name, 'null');
+  }, 'Null name should not throw');
+
+test(() => {
+    let c = new BroadcastChannel(undefined);
+    assert_equals(c.name, 'undefined');
+  }, 'Undefined name should not throw');
+
+test(() => {
+    let c = new BroadcastChannel('fooBar');
+    assert_equals(c.name, 'fooBar');
+  }, 'Non-empty name should not throw');
+
+test(() => {
+    let c = new BroadcastChannel(123);
+    assert_equals(c.name, '123');
+  }, 'Non-string name should not throw');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    assert_throws_js(TypeError, () => c.postMessage());
+  }, 'postMessage without parameters should throw');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    c.postMessage(null);
+  }, 'postMessage with null should not throw');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    c.close();
+  }, 'close should not throw');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    c.close();
+    c.close();
+  }, 'close should not throw when called multiple times');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    c.close();
+    assert_throws_dom('InvalidStateError', () => c.postMessage(''));
+  }, 'postMessage after close should throw');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    assert_not_equals(c.onmessage, undefined);
+  }, 'BroadcastChannel should have an onmessage event');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    assert_throws_dom('DataCloneError', () => c.postMessage(Symbol()));
+  }, 'postMessage should throw with uncloneable data');
+
+test(() => {
+    let c = new BroadcastChannel('');
+    c.close();
+    assert_throws_dom('InvalidStateError', () => c.postMessage(Symbol()));
+  }, 'postMessage should throw InvalidStateError after close, even with uncloneable data');


### PR DESCRIPTION
 The repository being in static storage is a bit of a hodgepodge, but in
 line with how our current storage partitioning is done. We should
 eventually move this, along with other across browsing context APIs to a
 proper location at a later stage. But for now, this makes progress on
 the meat of the BroadcastChannel API.

Implemented as I saw this being called on https://www.rnz.co.nz/