### PR TITLE
LibWeb: Remove non-spec condition in scrollable overflow calculation

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -120,11 +120,11 @@ static CSSPixelRect measure_scrollable_overflow(Box const& box)
             //   (including zero-area boxes and accounting for transforms as described above),
             //   provided they themselves have overflow: visible (i.e. do not themselves trap the overflow)
             //   and that scrollable overflow is not already clipped (e.g. by the clip property or the contain property).
-            if (is<Viewport>(box) || child.computed_values().overflow_x() == CSS::Overflow::Visible || child.computed_values().overflow_y() == CSS::Overflow::Visible) {
+            if (child.computed_values().overflow_x() == CSS::Overflow::Visible || child.computed_values().overflow_y() == CSS::Overflow::Visible) {
                 auto child_scrollable_overflow = measure_scrollable_overflow(child);
-                if (is<Viewport>(box) || child.computed_values().overflow_x() == CSS::Overflow::Visible)
+                if (child.computed_values().overflow_x() == CSS::Overflow::Visible)
                     scrollable_overflow_rect.unite_horizontally(child_scrollable_overflow);
-                if (is<Viewport>(box) || child.computed_values().overflow_y() == CSS::Overflow::Visible)
+                if (child.computed_values().overflow_y() == CSS::Overflow::Visible)
                     scrollable_overflow_rect.unite_vertically(child_scrollable_overflow);
             }
 

--- a/Tests/LibWeb/Ref/expected/scrollable-overflow-viewport-bug.html
+++ b/Tests/LibWeb/Ref/expected/scrollable-overflow-viewport-bug.html
@@ -1,0 +1,1 @@
+<!-- This page intentionally left blank -->

--- a/Tests/LibWeb/Ref/input/scrollable-overflow-viewport-bug.html
+++ b/Tests/LibWeb/Ref/input/scrollable-overflow-viewport-bug.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/scrollable-overflow-viewport-bug.html">
+<style>
+  #child {
+    position: absolute;
+    top: 150vh;
+    width: 100px;
+    height: 100px;
+  }
+
+  #holder {
+    position: absolute;
+    overflow: hidden;
+  }
+</style>
+
+<div id="holder"></div>
+<script>
+  const child = document.createElement("div");
+  child.id = "child";
+  holder.appendChild(child);
+</script>


### PR DESCRIPTION
Nothing in the spec says that this part should unconditionally run for the viewport and this is breaking on https://battle.crossuniverse.net/intro, making the page scrollable when it shouldn't be.

I wasn't sure what to call the test for this, so if anyone has better ideas, I'd love to rename it.
Also, yes, it needs to append the child with javascript, if the child is in the page initially, the bug does not occur.