### PR TITLE
AK: Remove clang-specific templates

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -148,15 +148,6 @@ requires(IsConstructible<T, Args...>) inline NonnullOwnPtr<T> make(Args&&... arg
     return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T(forward<Args>(args)...));
 }
 
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<class T, class... Args>
-inline NonnullOwnPtr<T> make(Args&&... args)
-{
-    return NonnullOwnPtr<T>(NonnullOwnPtr<T>::Adopt, *new T { forward<Args>(args)... });
-}
-#endif
-
 // Use like `adopt_nonnull_own_or_enomem(new (nothrow) T(args...))`.
 template<typename T>
 inline ErrorOr<NonnullOwnPtr<T>> adopt_nonnull_own_or_enomem(T* object)
@@ -171,16 +162,6 @@ requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullOwnPtr<T>> try_make(
 {
     return adopt_nonnull_own_or_enomem(new (nothrow) T(forward<Args>(args)...));
 }
-
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullOwnPtr<T>> try_make(Args&&... args)
-
-{
-    return adopt_nonnull_own_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-#endif
 
 template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public DefaultTraits<NonnullOwnPtr<T>> {

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -240,15 +240,6 @@ requires(IsConstructible<T, Args...>) inline ErrorOr<NonnullRefPtr<T>> try_make_
     return adopt_nonnull_ref_or_enomem(new (nothrow) T(forward<Args>(args)...));
 }
 
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline ErrorOr<NonnullRefPtr<T>> try_make_ref_counted(Args&&... args)
-{
-    return adopt_nonnull_ref_or_enomem(new (nothrow) T { forward<Args>(args)... });
-}
-#endif
-
 template<Formattable T>
 struct Formatter<NonnullRefPtr<T>> : Formatter<T> {
     ErrorOr<void> format(FormatBuilder& builder, NonnullRefPtr<T> const& value)
@@ -278,15 +269,6 @@ requires(IsConstructible<T, Args...>) inline NonnullRefPtr<T> make_ref_counted(A
 {
     return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T(forward<Args>(args)...));
 }
-
-#ifdef AK_COMPILER_APPLE_CLANG
-// FIXME: Remove once P0960R3 is available in Apple Clang.
-template<typename T, class... Args>
-inline NonnullRefPtr<T> make_ref_counted(Args&&... args)
-{
-    return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *new T { forward<Args>(args)... });
-}
-#endif
 
 template<typename T>
 struct Traits<NonnullRefPtr<T>> : public DefaultTraits<NonnullRefPtr<T>> {


### PR DESCRIPTION
With Swift interop, we already require latest Xcode versions, that do not need these workarounds
Ref https://github.com/llvm/llvm-project/issues/54040