### PR TITLE
Make document.write() work better + import some WPT coverage

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -188,6 +188,8 @@ void HTMLParser::visit_edges(Cell::Visitor& visitor)
 
 void HTMLParser::run(HTMLTokenizer::StopAtInsertionPoint stop_at_insertion_point)
 {
+    m_stop_parsing = false;
+
     for (;;) {
         // FIXME: Find a better way to say that we come from Document::close() and want to process EOF.
         if (!m_tokenizer.is_eof_inserted() && m_tokenizer.is_insertion_point_reached())

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -30,12 +30,14 @@ namespace Web::HTML {
         SWITCH_TO_WITH_UNCLEAN_BUILDER(new_state); \
     } while (0)
 
-#define SWITCH_TO_WITH_UNCLEAN_BUILDER(new_state) \
-    do {                                          \
-        will_switch_to(State::new_state);         \
-        m_state = State::new_state;               \
-        CONSUME_NEXT_INPUT_CHARACTER;             \
-        goto new_state;                           \
+#define SWITCH_TO_WITH_UNCLEAN_BUILDER(new_state)                                                 \
+    do {                                                                                          \
+        will_switch_to(State::new_state);                                                         \
+        m_state = State::new_state;                                                               \
+        if (stop_at_insertion_point == StopAtInsertionPoint::Yes && is_insertion_point_reached()) \
+            return {};                                                                            \
+        CONSUME_NEXT_INPUT_CHARACTER;                                                             \
+        goto new_state;                                                                           \
     } while (0)
 
 #define RECONSUME_IN(new_state)              \

--- a/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/ambiguous-ampersand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/ambiguous-ampersand.txt
@@ -6,9 +6,9 @@ Rerun
 
 Found 3 tests
 
-1 Pass
-2 Fail
+2 Pass
+1 Fail
 Details
-Result	Test Name	MessageFail	Check number of divs	
+Result	Test Name	MessagePass	Check number of divs	
 Pass	Check div structure: network	
-Fail	Check div structure: document.write	Cannot access property "childNodes" on undefined object "div"
+Fail	Check div structure: document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/001.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/002.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/003.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/003.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/004.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/004.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/005.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/005.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/006.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/006.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/008.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/008.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/009.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/009.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/010.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/010.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/010.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/010.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/011.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/011.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/011.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/011.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/012.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/012.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/013.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/013.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/014.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/014.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	Cannot access property "firstChild" on null object "document.body"

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/014.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/014.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	Cannot access property "firstChild" on null object "document.body"
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/015.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/015.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/015.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/015.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/016.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/016.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/017.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/017.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/017.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/017.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/018.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/018.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/019.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/019.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/020.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/020.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/021.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/021.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/022.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/022.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/023.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/023.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/024.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/024.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/025.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/025.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/026.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/026.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/027.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/027.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/028.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/028.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/029.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/029.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/030.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/030.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/031.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/031.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/032.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/032.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/033.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/033.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/033.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/033.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/034.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/034.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/035.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/035.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/035.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/035.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/036.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/036.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/037.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/037.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/038.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/038.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	Cannot access property "childNodes" on null object "document.body"
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/038.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/038.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	Cannot access property "childNodes" on null object "document.body"

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/039.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/039.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/039.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/039.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/040.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/040.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write entity	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/041.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/041.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write entity	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/042.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/042.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write entity	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/043.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/043.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write entity	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/044.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/044.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/045.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/045.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/046.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/046.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write	
+Result	Test Name	MessagePass	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/046.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/046.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/049.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/049.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write plaintext	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/049.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/049.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write plaintext	
+Result	Test Name	MessagePass	document.write plaintext	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/050.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/050.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write plaintext	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/051.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/051.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write \r\n	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-01.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-01.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write in XHTML	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-02.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-02.txt
@@ -1,0 +1,13 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 3 tests
+
+3 Pass
+Details
+Result	Test Name	MessagePass	Calling document.write with null and undefined	
+Pass	document.write(null)	
+Pass	document.write(undefined)	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_001.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_002.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write into iframe	
+Result	Test Name	MessagePass	document.write into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_002.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_002.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_003.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write script into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_004.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_004.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write script into iframe write back into parent	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_005.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_005.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script into iframe write back into parent	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_006.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_006.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write external script into iframe write back into parent	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_007.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_007.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write comment into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_008.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_008.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write plaintext into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_008.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_008.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write plaintext into iframe	
+Result	Test Name	MessagePass	document.write plaintext into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_009.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_009.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write plaintext into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_009.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_009.txt
@@ -6,6 +6,6 @@ Rerun
 
 Found 1 tests
 
-1 Fail
+1 Pass
 Details
-Result	Test Name	MessageFail	document.write plaintext into iframe	
+Result	Test Name	MessagePass	document.write plaintext into iframe	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_010.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_010.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write plaintext	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_001.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_001.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_003.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_003.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write script writing a further script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_005.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_005.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_006.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_006.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script followed by internal script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_007.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_007.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	document.write external script that document.writes inline script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_008.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_008.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script that document.writes external script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_010.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_010.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script tokenizer order	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_011.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_011.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script that document.writes external script	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_012.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_012.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Fail
+Details
+Result	Test Name	MessageFail	document.write external script tokenizer order	

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/001.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("PASS");
+  assert_equals(document.body.textContent, "PASS");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/002.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/002.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/003.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/003.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<");
+  document.write("i>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/004.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/004.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i");
+  document.write(">Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/005.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/005.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i>");
+  document.write("Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/006.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/006.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id='test'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i ");
+  document.write("id='test'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/007.js
@@ -1,0 +1,4 @@
+t.step(function() {
+         order.push(2);
+         document.write("<script>t.step(function() {order.push(3)})</script>");
+       });

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/008.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/008.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i i");
+  document.write("d='test'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/008.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/008.js
@@ -1,0 +1,4 @@
+t.step(function() {
+         order.push(2);
+         document.write("<script src=\"008-1.js\"></script>");
+       });

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/009.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/009.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id");
+  document.write("='test'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/010.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/010.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id=");
+  document.write("'test'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/011.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/011.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id='");
+  document.write("test'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/012.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/012.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id='te");
+  document.write("st'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/013.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/013.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id='test");
+  document.write("'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/014.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/014.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id='test'");
+  document.write(">Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/015.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/015.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i id='test'");
+  document.write("class='a'>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute("id"), "test");
+  assert_equals(document.body.firstChild.getAttribute("class"), "a");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/016.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/016.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<i>Filler Text");
+  document.write("</i><b>Filler Text");
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+  assert_equals(document.body.childNodes[1].localName, "b");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/017.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/017.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  var s = "<i id=test>Filler Text</i><b>Filler Text"
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+  assert_equals(document.body.firstChild.localName, "i");
+  assert_equals(document.body.firstChild.getAttribute('id'), "test");
+  assert_equals(document.body.firstChild.textContent, "Filler Text");
+  assert_equals(document.body.childNodes[1].localName, "b");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/018.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/018.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+function() {
+  document.write("<body>");
+  var s = "<!--comment--><i>Filler Text</i>"
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+  assert_equals(document.body.firstChild.nodeType, document.COMMENT_NODE);
+  assert_equals(document.body.firstChild.data, "comment");
+  assert_equals(document.body.childNodes[1].localName, "i");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/019.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/019.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<i");
+});
+</script>
+>Filler Text</i>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "i");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/020.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/020.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><");
+});
+</script>!--comment-->
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].nodeType, document.COMMENT_NODE);
+  assert_equals(document.body.childNodes[0].data, "comment");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/021.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/021.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><sp");
+});
+</script>an>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/022.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/022.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span>");
+});
+</script>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/023.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/023.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span ");
+});
+</script>id=a>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/024.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/024.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span i");
+});
+</script>d=a>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/025.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/025.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id");
+});
+</script>=a>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/026.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/026.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id=");
+});
+</script>a>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/027.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/027.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id=a");
+});
+</script>>Filler Text</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/028.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/028.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id=a>Filler Text<");
+});
+</script>/span><b>Filler Text</b></span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+  assert_equals(document.body.childNodes[1].localName, "b");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/029.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/029.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id=a>Filler Text</");
+});
+</script>span><b>Filler Text</b></span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+  assert_equals(document.body.childNodes[1].localName, "b");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/030.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/030.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id=a>Filler Text</sp");
+});
+</script>an><b>Filler Text</b></span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+  assert_equals(document.body.childNodes[1].localName, "b");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/031.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/031.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span id=a>Filler Text</span");
+});
+</script>><b>Filler Text</b></span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "span");
+  assert_equals(document.body.childNodes[0].getAttribute("id"), "a");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+  assert_equals(document.body.childNodes[1].localName, "b");
+  assert_equals(document.body.childNodes[1].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/032.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/032.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var tag_name_length = 100000;
+  var tag_name = "";
+  for (var i=0; i<tag_name_length; i++) {
+    tag_name += "a";
+  }
+  document.write("<body><" + tag_name + ">Filler Text</" + tag_name + ">");
+});
+</script>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/033.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/033.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+test(
+  function() {
+    document.writeln("<i");
+    var s = " b='a'>Filler"
+    for (var i=0; i<s.length; i++) {
+      document.write(s[i]+"\n");
+    }
+    document.writeln("</i");
+    document.writeln(">");
+    assert_equals(document.body.childNodes[0].localName, "i");
+    assert_equals(document.body.childNodes[0].getAttribute("b"), "\na\n");
+    assert_equals(document.body.childNodes[0].textContent, "\nF\ni\nl\nl\ne\nr\n");
+  }
+);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/034.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/034.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<svg><![CDATA[Filler Text]]></svg>";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "svg");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/035.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/035.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<svg><!";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script>[CDATA[Filler Text]]></svg>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "svg");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/036.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/036.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<svg><![CDATA[Filler Text]";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script>]></svg>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "svg");
+  assert_equals(document.body.childNodes[0].textContent, "Filler Text");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/037.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/037.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<body><!DOCTYPE html>";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script><script>
+t.step(function() {
+  //Nothing should be inserted into the DOM for the doctype node so
+  //just checking nothing odd happens
+  assert_equals(document.body.childNodes[0].localName, "script");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/038.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/038.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<body><";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script>!DOCTYPE html><script>
+t.step(function() {
+  //Nothing should be inserted into the DOM for the doctype node so
+  //just checking nothing odd happens
+  assert_equals(document.body.childNodes[0].localName, "script");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/039.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/039.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<body><!";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script>DOCTYPE html><script>
+t.step(function() {
+  //Nothing should be inserted into the DOM for the doctype node so
+  //just checking nothing odd happens
+  assert_equals(document.body.childNodes[0].localName, "script");
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/040.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/040.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>document.write entity</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = test(function() {
+  document.write("<body><span>&notin;abc");
+  assert_equals(document.body.childNodes[0].textContent, "\u2209abc");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/041.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/041.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<title>document.write entity</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = test(function() {
+  var s = "<body><span>&notin;abc";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+  assert_equals(document.body.childNodes[0].textContent, "\u2209abc");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/042.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/042.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>document.write entity</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span>&not");
+});
+</script>in;abc</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].textContent, "\u2209abc");
+})
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/043.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/043.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<title>document.write entity</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><span>&");
+});
+</script>notabc</span>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].textContent, "\u00ACabc");
+})
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/044.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/044.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<body><textarea><span>Filler</span></textarea>");
+});
+</script>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "textarea");
+  assert_equals(document.body.childNodes[0].textContent, "<span>Filler</span>");
+})
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/045.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/045.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<body><textarea><span>Filler</span></textarea>";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "textarea");
+  assert_equals(document.body.childNodes[0].textContent, "<span>Filler</span>");
+})
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/046.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/046.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>document.write</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  var s = "<body><textarea>";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+});
+</script><span>Filler</span></textarea>
+<script>
+t.step(function() {
+  assert_equals(document.body.childNodes[0].localName, "textarea");
+  assert_equals(document.body.childNodes[0].textContent, "<span>Filler</span>");
+})
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/049.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/049.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>document.write plaintext</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div><script>
+test(function() {
+  var s = "<table><tr><td>Text</tr><plaintext><tr><td>Filler ";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+  }
+  document.close();
+  assert_equals(document.body.childNodes[2].nodeType, document.ELEMENT_NODE);
+  assert_equals(document.body.childNodes[2].localName, "plaintext");
+  assert_equals(document.body.childNodes[2].textContent, "<tr><td>Filler ");
+  assert_equals(document.body.childNodes[3].nodeType, document.ELEMENT_NODE);
+  assert_equals(document.body.childNodes[3].localName, "table");
+  assert_equals(document.body.childNodes[3].textContent, "Text");
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/050.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/050.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>document.write plaintext</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div><script>
+var t = async_test();
+
+t.step(function() {
+  document.write("<plaintext>");
+  assert_equals(document.body.childNodes[2].nodeType, document.ELEMENT_NODE);
+  assert_equals(document.body.childNodes[2].localName, "plaintext");
+  var s = "Filler ";
+  for (var i=0; i<s.length; i++) {
+    document.write(s[i]);
+    assert_equals(document.body.childNodes[2].textContent, s.slice(0,i+1));
+  }
+  document.close();
+});
+
+onload = function() {
+  t.step(function() {
+    assert_equals(document.body.childNodes[2].textContent, "Filler Text\n");
+  });
+  t.done();
+}
+</script>Text

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/051.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/051.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write \r\n</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<div id="log"></div>
+
+<script>
+var t = async_test();
+
+t.step(function() {
+  document.write("\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\nA");
+})
+
+onload = function() {
+  t.step(function() {
+    const lastNode = document.getElementById('after');
+    assert_equals(lastNode.previousSibling.data, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nAB");
+  });
+  t.done();
+};
+</script>B<div id=after></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-01.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-01.xhtml
@@ -1,0 +1,19 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>document.write in XHTML</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com"/>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#document.write%28%29"/>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+test(function() {
+  assert_throws_dom("INVALID_STATE_ERR", function() {
+    document.write("Failure: document.write actually worked");
+  }, "document.write in XHTML should throw an INVALID_STATE_ERR ");
+}, "document.write in XHTML");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-02.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/document.write-02.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<title>document.write and null/undefined</title>
+<link rel="author" title="Ms2ger" href="mailto:ms2ger@gmail.com">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-document-write%28%29">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#documents-in-the-dom">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+test(function() {
+  var iframe = document.createElement("iframe");
+  document.body.appendChild(iframe);
+  doc = iframe.contentDocument;
+  test(function() {
+    doc.open();
+    doc.write(null);
+    doc.close();
+    assert_equals(doc.documentElement.textContent, "null");
+  }, "document.write(null)");
+  test(function() {
+    doc.open();
+    doc.write(undefined);
+    doc.close();
+    assert_equals(doc.documentElement.textContent, "undefined");
+  }, "document.write(undefined)");
+}, "Calling document.write with null and undefined");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_001.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<title>document.write into iframe</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+test(
+function() {
+  var iframe = document.getElementById("test");
+  iframe.contentDocument.write("Filler Text");
+  iframe.contentDocument.close();
+  assert_equals(iframe.contentDocument.body.textContent, "Filler Text");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_002.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_002.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write into iframe</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+test(
+function() {
+  var iframe = document.getElementById("test");
+  var s = "<i id='a'>Filler Text</i><b id=b>Filler Text</b>"
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s[i]);
+  }
+  iframe.contentDocument.close();
+  assert_equals(iframe.contentDocument.body.childNodes[0].textContent, "Filler Text");
+  assert_equals(iframe.contentDocument.body.childNodes[0].localName, "i");
+  assert_equals(iframe.contentDocument.body.childNodes[0].getAttribute('id'), "a");
+  assert_equals(iframe.contentDocument.body.childNodes[1].textContent, "Filler Text");
+  assert_equals(iframe.contentDocument.body.childNodes[1].localName, "b");
+  assert_equals(iframe.contentDocument.body.childNodes[1].getAttribute('id'), "b");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_003.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_003.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>document.write script into iframe</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+test(
+function() {
+  var iframe = document.getElementById("test");
+  var s = "<script>document.write(\"<i id='a'>Filler Text</i>\")</script" + "><b id=b>Filler Text</b>"
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s[i]);
+  }
+  iframe.contentDocument.close();
+  //Note: <script> ends up in <head>
+  assert_equals(iframe.contentDocument.body.childNodes[0].textContent, "Filler Text");
+  assert_equals(iframe.contentDocument.body.childNodes[0].localName, "i");
+  assert_equals(iframe.contentDocument.body.childNodes[0].getAttribute('id'), "a");
+  assert_equals(iframe.contentDocument.body.childNodes[1].textContent, "Filler Text");
+  assert_equals(iframe.contentDocument.body.childNodes[1].localName, "b");
+  assert_equals(iframe.contentDocument.body.childNodes[1].getAttribute('id'), "b");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_004.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_004.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write script into iframe write back into parent</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+var t = async_test();
+var iframe = document.getElementById("test");
+var order = [];
+t.step(function() {
+  order.push(1);
+  var s = "<script>parent.order.push(2); parent.document.write('<script>order.push(3);</script'+'>'); parent.order.push(4)</script" + ">";
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s[i]);
+  }
+  iframe.contentDocument.close();
+  order.push(5);
+  assert_array_equals(order, [1,2,3,4,5])
+}
+);
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_005.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_005.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>document.write external script into iframe write back into parent</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+var t = async_test();
+var iframe = document.getElementById("test");
+var order = [];
+t.step(function() {
+  order.push(1);
+  var s = "<script src='iframe_005.js'></script" + ">";
+  iframe.contentDocument.write(s);
+  iframe.contentDocument.close();
+  order.push(2);
+  assert_array_equals(order, [1,2])
+}
+);
+addEventListener("load", function() {
+    t.step(function() {
+      assert_array_equals(order, [1,2,3,4,5])
+    });
+    t.done();
+}, false);
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_006.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_006.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write external script into iframe write back into parent</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+var t = async_test();
+var iframe = document.getElementById("test");
+var order = [];
+t.step(function() {
+  order.push(1);
+  var s = "<script>parent.order.push(2); parent.document.write('<script>order.push(3); iframe.contentDocument.write(\"<script>parent.order.push(4)</script\"+\">\");order.push(5);</script' + '>'); parent.order.push(6)</script"+">";
+  iframe.contentDocument.write(s);
+  iframe.contentDocument.close();
+  order.push(7);
+  assert_array_equals(order, [1,2,3,4,5,6,7]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_007.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_007.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<title>document.write comment into iframe</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+test(function() {
+  var iframe = document.getElementById("test");
+  var s = "<!--Filler-->";
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s);
+  }
+  iframe.contentDocument.close();
+  assert_equals(iframe.contentDocument.childNodes[0].nodeType, document.COMMENT_NODE);
+  assert_equals(iframe.contentDocument.childNodes[0].data, "Filler");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_008.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_008.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<title>document.write plaintext into iframe</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+test(function() {
+  var iframe = document.getElementById("test");
+  var s = "<plaintext><span>Filler Text";
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s[i]);
+  }
+  iframe.contentDocument.close();
+  assert_equals(iframe.contentDocument.body.childNodes[0].nodeType, document.ELEMENT_NODE);
+  assert_equals(iframe.contentDocument.body.childNodes[0].localName, "plaintext");
+  assert_equals(iframe.contentDocument.body.childNodes[0].textContent, "<span>Filler Text");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_009.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_009.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>document.write plaintext into iframe</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+test(function() {
+  var iframe = document.getElementById("test");
+  var s = "<table><tr><td>Text</tr><plaintext><tr><td>Filler ";
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s[i]);
+  }
+  iframe.contentDocument.close();
+  assert_equals(iframe.contentDocument.body.childNodes[0].nodeType, document.ELEMENT_NODE);
+  assert_equals(iframe.contentDocument.body.childNodes[0].localName, "plaintext");
+  assert_equals(iframe.contentDocument.body.childNodes[0].textContent, "<tr><td>Filler ");
+  assert_equals(iframe.contentDocument.body.childNodes[1].nodeType, document.ELEMENT_NODE);
+  assert_equals(iframe.contentDocument.body.childNodes[1].localName, "table");
+  assert_equals(iframe.contentDocument.body.childNodes[1].textContent, "Text");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_010.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/iframe_010.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<title>document.write plaintext</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<iframe id="test"></iframe>
+<script>
+var t = async_test();
+var iframe = document.getElementById("test");
+
+function check_dom() {
+  assert_equals(iframe.contentDocument.body.childNodes[0].localName, "plaintext")
+  assert_equals(iframe.contentDocument.body.childNodes[0].textContent, "Filler ")
+  assert_equals(iframe.contentDocument.body.childNodes[1].localName, "table")
+}
+
+t.step(function() {
+  var s = "<script>document.write('<table><plaintext>Filler '); document.close(); top.t.step(function() {top.check_dom()})</script" + ">";
+  for (var i=0; i<s.length; i++) {
+    iframe.contentDocument.write(s[i]);
+  }
+  t.done();
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_001.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_001.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>document.write script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<script>t.done();<"+"/script>");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_003.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_003.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<title>document.write script writing a further script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+t.step(function() {
+  document.write("<script>document.write('<script>t.done()</script'+'>')<"+"/script>");
+});
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_005.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_005.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>document.write external script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+  document.write("<script src='005.js'><"+"/script>");
+  order.push(2);
+});
+</script>
+<script>
+order.push(4);
+t.step(function() {
+  assert_array_equals(order, [1,2,3,4]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_006.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_006.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<title>document.write external script followed by internal script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+  document.write("<script src='006.js'><"+"/script><script>t.step(function(){order.push(4)})</script"+">");
+  order.push(2);
+});
+</script>
+<script>
+t.step(function() {
+  order.push(5);
+  assert_array_equals(order, [1,2,3,4,5]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_007.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_007.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write external script that document.writes inline script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+});
+</script>
+<script src="007.js"></script>
+<script>
+t.step(function() {
+  order.push(4);
+  assert_array_equals(order, [1,2,3,4]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_008.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_008.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<title>document.write external script that document.writes external script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+});
+</script>
+<script src="008.js"></script>
+<script>
+t.step(function() {
+  order.push(4);
+  assert_array_equals(order, [1,2,3,4]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_010.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_010.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write external script tokenizer order</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+  document.write("<script src='010.js'></script" + "><meta><script src='010-1.js'></script" + ">");
+  order.push(2);
+  assert_equals(document.getElementsByTagName("meta").length, 0);
+});
+</script>
+<script>
+t.step(function() {
+  order.push(5);
+  assert_equals(document.getElementsByTagName("meta").length, 1);
+  assert_array_equals(order, [1,2,3,4,5]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_011.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_011.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write external script that document.writes external script</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+  document.write("<script src='011.js'></script" + "><meta>");
+  order.push(2);
+  assert_equals(document.getElementsByTagName("meta").length, 0);
+});
+</script>
+<script>
+t.step(function() {
+  order.push(5);
+  assert_equals(document.getElementsByTagName("meta").length, 3, "Number of meta elements at end");
+  assert_array_equals(order, [1,2,3,4,5]);
+});
+t.done();
+</script>
+<div id="log"></div>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_012.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/document-write/script_012.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<title>document.write external script tokenizer order</title>
+<script src="../../../../resources/testharness.js"></script><script src="../../../../resources/testharnessreport.js"></script>
+<script>
+var t = async_test();
+var order = [];
+t.step(function() {
+  order.push(1);
+  document.write("<script>order.push(2); document.write('<script src=\"012.js\"></script' + '><meta>'); order.push(3); t.step(function() {assert_equals(document.getElementsByTagName('meta').length, 0)});</script" + "><meta>");
+  order.push(4);
+  assert_equals(document.getElementsByTagName("meta").length, 0);
+});
+</script>
+<script>
+t.step(function() {
+  order.push(6);
+  assert_equals(document.getElementsByTagName("meta").length, 2);
+  assert_array_equals(order, [1,2,3,4,5,6]);
+});
+t.done();
+</script>
+<div id="log"></div>


### PR DESCRIPTION
See individual commits. The main thing here is that we now handle feeding the tokenizer with one character at a time way better than before.

Closes #2321 