### PR TITLE
LibWeb: Fix incorrect spec link for the @supports rule

### DIFF
--- a/Libraries/LibWeb/CSS/Supports.h
+++ b/Libraries/LibWeb/CSS/Supports.h
@@ -15,7 +15,7 @@
 
 namespace Web::CSS {
 
-// https://www.w3.org/TR/css-conditional-4/#at-supports
+// https://www.w3.org/TR/css-conditional-3/#at-supports
 class Supports final : public RefCounted<Supports> {
     friend class Parser::Parser;
 


### PR DESCRIPTION
It didn't go to the right level of the spec. (anymore, probably)