### PR TITLE
LibWeb: Transform PaintableBox::hit_test positions

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -865,7 +865,7 @@ TraversalDecision PaintableBox::hit_test(CSSPixelPoint position, HitTestType typ
     if (hit_test_scrollbars(position_adjusted_by_scroll_offset, callback) == TraversalDecision::Break)
         return TraversalDecision::Break;
 
-    if (layout_node_with_style_and_box_metrics().is_viewport()) {
+    if (is_viewport()) {
         auto& viewport_paintable = const_cast<ViewportPaintable&>(static_cast<ViewportPaintable const&>(*this));
         viewport_paintable.build_stacking_context_tree_if_needed();
         viewport_paintable.document().update_paint_and_hit_testing_properties_if_needed();

--- a/Tests/LibWeb/Text/expected/hit_testing/css-transforms.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/css-transforms.txt
@@ -1,0 +1,1 @@
+clicked the <input>

--- a/Tests/LibWeb/Text/input/hit_testing/css-transforms.html
+++ b/Tests/LibWeb/Text/input/hit_testing/css-transforms.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<div>
+    <input id="input" type="text">
+    <div id="div" style="position: absolute; transform: translate(0px, 42px);">
+        This text should not be hit when clicking the input.
+    </div>
+</div>
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        document.getElementById("input").addEventListener("click", () => {
+            println("clicked the <input>");
+        });
+        document.getElementById("div").addEventListener("click", () => {
+            println("clicked the <div>");
+        });
+        window.addEventListener("load", () => {
+            internals.click(12, 12);
+            done();
+        })
+    });
+</script>


### PR DESCRIPTION
Elements with transforms were tested on their pre-transformed
positions, causing incorrect hits.

Copy the position transformation done in `StackingContext::hit_test`
to ensure that hit tests are done on the _actual_ position.

Fixes #2530.