### PR TITLE
LibWeb: Fix WPT node attribute tests

### DIFF
--- a/Libraries/LibWeb/DOM/NamedNodeMap.cpp
+++ b/Libraries/LibWeb/DOM/NamedNodeMap.cpp
@@ -61,8 +61,7 @@ Vector<FlyString> NamedNodeMap::supported_property_names() const
     }
 
     // 2. If this NamedNodeMap object’s element is in the HTML namespace and its node document is an HTML document, then for each name in names:
-    // FIXME: Handle the second condition, assume it is an HTML document for now.
-    if (associated_element().namespace_uri() == Namespace::HTML) {
+    if (associated_element().namespace_uri() == Namespace::HTML && associated_element().document().is_html_document()) {
         // 1. Let lowercaseName be name, in ASCII lowercase.
         // 2. If lowercaseName is not equal to name, remove name from names.
         names.remove_all_matching([](auto const& name) { return name != name.to_ascii_lowercase(); });

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/attributes.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/attributes.txt
@@ -6,8 +6,7 @@ Rerun
 
 Found 70 tests
 
-69 Pass
-1 Fail
+70 Pass
 Details
 Result	Test Name	MessagePass	When qualifiedName does not match the Name production, an INVALID_CHARACTER_ERR exception is to be thrown. (toggleAttribute)	
 Pass	When qualifiedName does not match the Name production, an INVALID_CHARACTER_ERR exception is to be thrown, even if the attribute is already present. (toggleAttribute)	
@@ -78,4 +77,4 @@ Pass	Own property correctness with namespaced attribute before same-name non-nam
 Pass	Own property correctness with two namespaced attributes with the same name-with-prefix	
 Pass	Own property names should only include all-lowercase qualified names for an HTML element in an HTML document	
 Pass	Own property names should include all qualified names for a non-HTML element in an HTML document	
-Fail	Own property names should include all qualified names for an HTML element in a non-HTML document	
+Pass	Own property names should include all qualified names for an HTML element in a non-HTML document	


### PR DESCRIPTION
This fixes the [WPT node attribute tests](https://wpt.fyi/results/dom/nodes/attributes.html?label=master&product=ladybird). See the individual commits for more details.