### PR TITLE
LibWeb: Unapply CSS filters after applying them to SVG

### DIFF
--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -59,8 +59,9 @@ void SVGSVGPaintable::paint_descendants(PaintContext& context, PaintableBox cons
     auto paint_svg_box = [&](auto& svg_box) {
         auto const& computed_values = svg_box.computed_values();
 
+        auto filters = paintable.computed_values().filter();
         auto masking_area = svg_box.get_masking_area();
-        auto needs_to_save_state = computed_values.opacity() < 1 || svg_box.has_css_transform() || svg_box.get_masking_area().has_value();
+        auto needs_to_save_state = computed_values.opacity() < 1 || svg_box.has_css_transform() || svg_box.get_masking_area().has_value() || !filters.is_none();
 
         if (needs_to_save_state) {
             context.display_list_recorder().save();
@@ -70,7 +71,7 @@ void SVGSVGPaintable::paint_descendants(PaintContext& context, PaintableBox cons
             context.display_list_recorder().apply_opacity(computed_values.opacity());
         }
 
-        context.display_list_recorder().apply_filters(paintable.computed_values().filter());
+        context.display_list_recorder().apply_filters(filters);
 
         if (svg_box.has_css_transform()) {
             auto transform_matrix = svg_box.transform();

--- a/Tests/LibWeb/Ref/expected/svg-restore-after-filter.html
+++ b/Tests/LibWeb/Ref/expected/svg-restore-after-filter.html
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<svg width="10" height="10">
+  <rect width="10" height="10" fill="white"/>
+</svg>
+<span>This should be visible.</span>

--- a/Tests/LibWeb/Ref/input/svg-restore-after-filter.html
+++ b/Tests/LibWeb/Ref/input/svg-restore-after-filter.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-restore-after-filter.html">
+<svg style="filter: opacity(0)" width="10" height="10">
+  <rect width="10" height="10"/>
+</svg>
+<span>This should be visible.</span>


### PR DESCRIPTION
This fixes a regression introduced by #2248.