### PR TITLE
LibWeb: Implement transfer for Resizable/ArrayBuffer

### DIFF
--- a/Libraries/LibWeb/HTML/StructuredSerialize.h
+++ b/Libraries/LibWeb/HTML/StructuredSerialize.h
@@ -25,7 +25,7 @@
 namespace Web::HTML {
 
 struct TransferDataHolder {
-    Vector<u8> data;
+    Vector<u32> data;
     Vector<IPC::File> fds;
 };
 
@@ -46,6 +46,8 @@ struct DeserializedRecord {
 
 enum class TransferType : u8 {
     MessagePort,
+    ArrayBuffer,
+    ResizableArrayBuffer,
 };
 
 WebIDL::ExceptionOr<SerializationRecord> structured_serialize(JS::VM& vm, JS::Value);

--- a/Tests/LibWeb/Text/expected/Worker/Worker-postMessage-transfer.txt
+++ b/Tests/LibWeb/Text/expected/Worker/Worker-postMessage-transfer.txt
@@ -1,1 +1,3 @@
+Buffer length before transfer: 12
+Buffer length after transfer: 0
 Message received from worker: Hello, world

--- a/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 150 tests
 
-124 Pass
-25 Fail
+133 Pass
+16 Fail
 1 Optional Feature Unsupported
 Pass	primitive undefined
 Pass	primitive null
@@ -118,10 +118,10 @@ Fail	Object ImageData object, ImageData 1x1 non-transparent non-black
 Pass	Array sparse
 Pass	Array with non-index property
 Pass	Object with index property and length
-Fail	Array with circular reference
-Fail	Object with circular reference
-Fail	Array with identical property values
-Fail	Object with identical property values
+Pass	Array with circular reference
+Pass	Object with circular reference
+Pass	Array with identical property values
+Pass	Object with identical property values
 Pass	Object with property on prototype
 Pass	Object with non-enumerable property
 Pass	Object with non-writable property
@@ -143,14 +143,14 @@ Pass	Length-tracking TypedArray
 Pass	Length-tracking DataView
 Pass	Serializing OOB TypedArray throws
 Pass	Serializing OOB DataView throws
-Fail	ArrayBuffer
-Fail	MessagePort
-Fail	A detached ArrayBuffer cannot be transferred
+Pass	ArrayBuffer
+Pass	MessagePort
+Pass	A detached ArrayBuffer cannot be transferred
 Pass	A detached platform object cannot be transferred
 Pass	Transferring a non-transferable platform object fails
-Fail	An object whose interface is deleted from the global object must still be received
+Pass	An object whose interface is deleted from the global object must still be received
 Optional Feature Unsupported	A subclass instance will be received as its closest transferable superclass
-Fail	Resizable ArrayBuffer is transferable
+Pass	Resizable ArrayBuffer is transferable
 Fail	Length-tracking TypedArray is transferable
 Fail	Length-tracking DataView is transferable
 Pass	Transferring OOB TypedArray throws

--- a/Tests/LibWeb/Text/input/Worker/Worker-postMessage-transfer.html
+++ b/Tests/LibWeb/Text/input/Worker/Worker-postMessage-transfer.html
@@ -24,6 +24,8 @@
         const message = encoder.encode("Hello, world");
         const myBuf = message.buffer;
 
+        println('Buffer length before transfer: ' + myBuf.byteLength);
         worker.postMessage(myBuf, [myBuf]);
+        println('Buffer length after transfer: ' + myBuf.byteLength);
     });
 </script>


### PR DESCRIPTION
Implement transfer logic for ArrayBuffer and ResizableArrayBuffer.

Change TransferDataHolder data type to Vector<u32> to reuse existing
serialization infrastructure.

Fix 5 WPT tests in `safe-passing-of-structured-data/window-postmessage.window.html`
that are related to transport, as well as `LibWeb/Text/input/Worker/Worker-postMessage-transfer.html`.
The latter is currently ignored due to flakiness in CI, so no rebaseline is
needed.

During serialization with transfer, initialize memory with known index
and initialize Serializer at position that dependent on the memory.
This is mandatory to make ArrayBuffer transport to work. It also happens
to fix 4 WPT tests, that are related to curcular references during
serialization.