### PR TITLE
LibWeb: Avoid expensive Vector filtering in event loop

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -95,6 +95,8 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
+    [[nodiscard]] Vector<GC::Root<DOM::Document>> documents_in_this_event_loop_matching(auto callback) const;
+
     void update_the_rendering();
 
     Type m_type { Type::Window };


### PR DESCRIPTION
Instead of collecting all documents in a big vector and then filtering the vector (twice!) with remove_all_matching(), we now pass a filter callback to documents_in_this_event_loop_matching() and avoid all the extra shuffling work.

Saw this stuff hogging ~20% of CPU time when profiling a WebContent process in the middle of a WPT run.