### PR TITLE
LibWeb: Make ShadowRealm importValue work

### DIFF
--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -583,29 +583,26 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
             // 5. Set settings's principal realm to O's associated realm
             .principal_realm = object.shape().realm(),
 
-            // 6. Set settings's underlying realm to realm.
-            .underlying_realm = realm,
-
-            // 7. Set settings's module map to a new module map, initially empty.
+            // 6. Set settings's module map to a new module map, initially empty.
             .module_map = realm.create<HTML::ModuleMap>(),
         };
 
-        // 8. Set realm.[[HostDefined]] to settings.
+        // 7. Set realm.[[HostDefined]] to settings.
         realm.set_host_defined(make<Bindings::SyntheticHostDefined>(move(settings), realm.create<Bindings::Intrinsics>(realm)));
 
-        // 9. Set realm.[[GlobalObject]] to globalObject.
+        // 8. Set realm.[[GlobalObject]] to globalObject.
         realm.set_global_object(global_object);
 
-        // 10. Set realm.[[GlobalEnv]] to NewGlobalEnvironment(globalObject, globalObject).
+        // 9. Set realm.[[GlobalEnv]] to NewGlobalEnvironment(globalObject, globalObject).
         realm.set_global_environment(realm.heap().allocate<JS::GlobalEnvironment>(global_object, global_object));
 
-        // 11. Perform ? SetDefaultGlobalBindings(realm).
+        // 10. Perform ? SetDefaultGlobalBindings(realm).
         set_default_global_bindings(realm);
 
         // NOTE: This needs to be done after initialization so that the realm has an intrinsics in its [[HostDefined]]
         global_object->initialize_web_interfaces();
 
-        // 12. Return NormalCompletion(unused).
+        // 11. Return NormalCompletion(unused).
         return {};
     };
 

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -2240,7 +2240,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> nonstandard_resource_loader_file_o
 
     auto request = fetch_params.request();
 
-    auto& page = Bindings::principal_host_defined_page(realm);
+    auto& page = Bindings::principal_host_defined_page(HTML::principal_realm(realm));
 
     // NOTE: Using LoadRequest::create_for_url_on_page here will unconditionally add cookies as long as there's a page available.
     //       However, it is up to http_network_or_cache_fetch to determine if cookies should be added to the request.

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -85,8 +85,8 @@ ByteString module_type_from_module_request(JS::ModuleRequest const& module_reque
 WebIDL::ExceptionOr<URL::URL> resolve_module_specifier(Optional<Script&> referring_script, ByteString const& specifier)
 {
     // 1. Let settingsObject and baseURL be null.
-    Optional<EnvironmentSettingsObject&> settings_object;
-    Optional<URL::URL const&> base_url;
+    GC::Ptr<EnvironmentSettingsObject> settings_object;
+    Optional<URL::URL> base_url;
 
     // 2. If referringScript is not null, then:
     if (referring_script.has_value()) {

--- a/Libraries/LibWeb/HTML/Scripting/SyntheticRealmSettings.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/SyntheticRealmSettings.cpp
@@ -13,7 +13,6 @@ void SyntheticRealmSettings::visit_edges(JS::Cell::Visitor& visitor)
 {
     execution_context->visit_edges(visitor);
     visitor.visit(principal_realm);
-    visitor.visit(underlying_realm);
     visitor.visit(module_map);
 }
 

--- a/Libraries/LibWeb/HTML/Scripting/SyntheticRealmSettings.h
+++ b/Libraries/LibWeb/HTML/Scripting/SyntheticRealmSettings.h
@@ -23,10 +23,6 @@ struct SyntheticRealmSettings {
     // The principal realm which this synthetic realm exists within.
     GC::Ref<JS::Realm> principal_realm;
 
-    // An underlying realm
-    // The synthetic realm which this settings object represents.
-    GC::Ref<JS::Realm> underlying_realm;
-
     // A module map
     // A module map that is used when importing JavaScript modules.
     GC::Ref<ModuleMap> module_map;

--- a/Tests/LibWeb/Text/data/external-module.mjs
+++ b/Tests/LibWeb/Text/data/external-module.mjs
@@ -1,0 +1,1 @@
+export const foo = "Well hello shadows";

--- a/Tests/LibWeb/Text/expected/HTML/ShadowRealm-importValue.txt
+++ b/Tests/LibWeb/Text/expected/HTML/ShadowRealm-importValue.txt
@@ -1,0 +1,1 @@
+Well hello shadows

--- a/Tests/LibWeb/Text/input/HTML/ShadowRealm-importValue.html
+++ b/Tests/LibWeb/Text/input/HTML/ShadowRealm-importValue.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(async done => {
+        const shadowRealm = new ShadowRealm();
+        const promise = shadowRealm.importValue("../../data/external-module.mjs", "foo");
+        const value = await promise;
+        println(value);
+        done();
+    });
+</script>


### PR DESCRIPTION
Fixes two different crashes, and some minor catchup to spec changes in the open HTML spec PR.