### PR TITLE
AK: Fix "assignment from temporary" check of `Optional::operator=`

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -446,15 +446,21 @@ public:
         return *this;
     }
 
-    // Note: Disallows assignment from a temporary as this does not do any lifetime extension.
     template<typename U>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE Optional& operator=(U&& value)
-    requires(CanBePlacedInOptional<U> && IsLvalueReference<U>)
+    ALWAYS_INLINE Optional& operator=(U& value)
+    requires(CanBePlacedInOptional<U>)
     {
         m_pointer = &value;
         return *this;
     }
+
+    // Note: Disallows assignment from a temporary as this does not do any lifetime extension.
+    template<typename U>
+    requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
+    ALWAYS_INLINE consteval Optional& operator=(RemoveReference<U> const&& value)
+    requires(CanBePlacedInOptional<U>)
+    = delete;
 
     ALWAYS_INLINE void clear()
     {

--- a/Libraries/LibTest/Macros.h
+++ b/Libraries/LibTest/Macros.h
@@ -132,9 +132,9 @@ bool assume(T const& expression, StringView expression_string, SourceLocation lo
 
 }
 
-#define EXPECT(x)                  \
-    do {                           \
-        ::Test::expect(x, #x##sv); \
+#define EXPECT(...)                                    \
+    do {                                               \
+        ::Test::expect(__VA_ARGS__, #__VA_ARGS__##sv); \
     } while (false)
 
 #define EXPECT_EQ(a, b)                                \

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -272,6 +272,34 @@ TEST_CASE(comparison_reference)
     EXPECT_NE(opt1, opt3);
 }
 
+template<typename To, typename From>
+struct CheckAssignments;
+
+template<typename To, typename From>
+requires(requires { declval<To>() = declval<From>(); })
+struct CheckAssignments<To, From> {
+    static constexpr bool allowed = true;
+};
+
+template<typename To, typename From>
+requires(!requires { declval<To>() = declval<From>(); })
+struct CheckAssignments<To, From> {
+    static constexpr bool allowed = false;
+};
+
+static_assert(CheckAssignments<Optional<int>, int>::allowed);
+static_assert(!CheckAssignments<Optional<int*>, double*>::allowed);
+
+static_assert(CheckAssignments<Optional<int&>, int&>::allowed);
+static_assert(!CheckAssignments<Optional<int&>, int const&>::allowed);
+static_assert(!CheckAssignments<Optional<int&>, int&&>::allowed);
+static_assert(!CheckAssignments<Optional<int&>, int const&&>::allowed);
+
+static_assert(CheckAssignments<Optional<int const&>, int&>::allowed);
+static_assert(CheckAssignments<Optional<int const&>, int const&>::allowed);
+static_assert(CheckAssignments<Optional<int const&>, int&&>::allowed);       // Lifetime extension
+static_assert(CheckAssignments<Optional<int const&>, int const&&>::allowed); // Lifetime extension
+
 TEST_CASE(string_specialization)
 {
     EXPECT_EQ(sizeof(Optional<String>), sizeof(String));


### PR DESCRIPTION
There was an existing check to ensure that `U` was an lvalue reference, but when this check fails, overload resolution will just move right on to the copy asignment operator, which will cause the temporary to be assigned anyway.

Disallowing `Optional<T&>`s to be created from temporaries entirely would be undesired, since existing code has valid reasons for creating `Optional<T&>`s from temporaries, such as for function call arguments.

This fix explicitly deletes the `Optional::operator=(U&&)` operator, so overload resolution stops.