### PR TITLE
AK: Don't implicitly convert `Optional<T&>` to `Optional<T>`

### DIFF
--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -71,14 +71,17 @@ public:
         return static_cast<Self const&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T const*>(&static_cast<Self const&>(*this).value())) : nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T const& fallback) const&
+    template<typename O = T, typename Fallback = O>
+    [[nodiscard]] ALWAYS_INLINE O value_or(Fallback const& fallback) const&
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T&& fallback) &&
+    template<typename O = T, typename Fallback = O>
+    requires(!IsLvalueReference<O> && !IsRvalueReference<O>)
+    [[nodiscard]] ALWAYS_INLINE O value_or(Fallback&& fallback) &&
     {
         if (static_cast<Self&>(*this).has_value())
             return move(static_cast<Self&>(*this).value());

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -336,6 +336,9 @@ private:
 
 template<typename T>
 requires(IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
+    AK_MAKE_DEFAULT_COPYABLE(Optional);
+    AK_MAKE_DEFAULT_MOVABLE(Optional);
+
     template<typename>
     friend class Optional;
 
@@ -369,17 +372,6 @@ public:
     {
     }
 
-    ALWAYS_INLINE Optional(Optional const& other)
-        : m_pointer(other.m_pointer)
-    {
-    }
-
-    ALWAYS_INLINE Optional(Optional&& other)
-        : m_pointer(other.m_pointer)
-    {
-        other.m_pointer = nullptr;
-    }
-
     template<typename U>
     ALWAYS_INLINE Optional(Optional<U>& other)
     requires(CanBePlacedInOptional<U>)
@@ -400,25 +392,6 @@ public:
         : m_pointer(other.ptr())
     {
         other.m_pointer = nullptr;
-    }
-
-    ALWAYS_INLINE Optional& operator=(Optional& other)
-    {
-        m_pointer = other.m_pointer;
-        return *this;
-    }
-
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
-    {
-        m_pointer = other.m_pointer;
-        return *this;
-    }
-
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
-    {
-        m_pointer = other.m_pointer;
-        other.m_pointer = nullptr;
-        return *this;
     }
 
     template<typename U>

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -377,6 +377,8 @@ private:
 
 template<>
 struct Traits<StringView> : public DefaultTraits<StringView> {
+    using PeekType = StringView;
+    using ConstPeekType = StringView;
     static unsigned hash(StringView s) { return s.hash(); }
 };
 

--- a/Libraries/LibCrypto/Certificate/Certificate.h
+++ b/Libraries/LibCrypto/Certificate/Certificate.h
@@ -50,17 +50,17 @@ public:
         return m_members.try_set(move(key), move(value));
     }
 
-    Optional<String> get(StringView key) const
+    Optional<String const&> get(StringView key) const
     {
         return m_members.get(key);
     }
 
-    Optional<String> get(ASN1::AttributeType key) const
+    Optional<String const&> get(ASN1::AttributeType key) const
     {
         return m_members.get(enum_value(key));
     }
 
-    Optional<String> get(ASN1::ObjectClass key) const
+    Optional<String const&> get(ASN1::ObjectClass key) const
     {
         return m_members.get(enum_value(key));
     }

--- a/Libraries/LibHTTP/HeaderMap.h
+++ b/Libraries/LibHTTP/HeaderMap.h
@@ -39,7 +39,7 @@ public:
         return m_map.contains(name);
     }
 
-    [[nodiscard]] Optional<ByteString> get(ByteString const& name) const
+    [[nodiscard]] Optional<ByteString const&> get(ByteString const& name) const
     {
         return m_map.get(name);
     }

--- a/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -101,7 +101,7 @@ Optional<ValueAndAttributes> GenericIndexedPropertyStorage::get(u32 index) const
 {
     if (index >= m_array_size)
         return {};
-    return m_sparse_elements.get(index);
+    return m_sparse_elements.get(index).copy();
 }
 
 void GenericIndexedPropertyStorage::put(u32 index, Value value, PropertyAttributes attributes)

--- a/Libraries/LibURL/Parser.cpp
+++ b/Libraries/LibURL/Parser.cpp
@@ -817,7 +817,7 @@ String Parser::percent_encode_after_encoding(TextCodec::Encoder& encoder, String
 }
 
 // https://url.spec.whatwg.org/#concept-basic-url-parser
-URL Parser::basic_parse(StringView raw_input, Optional<URL> const& base_url, URL* url, Optional<State> state_override, Optional<StringView> encoding)
+URL Parser::basic_parse(StringView raw_input, Optional<URL const&> base_url, URL* url, Optional<State> state_override, Optional<StringView> encoding)
 {
     dbgln_if(URL_PARSER_DEBUG, "URL::Parser::basic_parse: Parsing '{}'", raw_input);
 

--- a/Libraries/LibURL/Parser.h
+++ b/Libraries/LibURL/Parser.h
@@ -58,7 +58,7 @@ public:
     }
 
     // https://url.spec.whatwg.org/#concept-basic-url-parser
-    static URL basic_parse(StringView input, Optional<URL> const& base_url = {}, URL* url = nullptr, Optional<State> state_override = {}, Optional<StringView> encoding = {});
+    static URL basic_parse(StringView input, Optional<URL const&> base_url = {}, URL* url = nullptr, Optional<State> state_override = {}, Optional<StringView> encoding = {});
 
     // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
     static String percent_encode_after_encoding(TextCodec::Encoder&, StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus = false);

--- a/Libraries/LibUnicode/CurrencyCode.cpp
+++ b/Libraries/LibUnicode/CurrencyCode.cpp
@@ -197,7 +197,7 @@ static auto const& ensure_currency_codes()
     return currency_codes;
 }
 
-Optional<CurrencyCode> get_currency_code(StringView currency)
+Optional<CurrencyCode const&> get_currency_code(StringView currency)
 {
     static auto const& currency_codes = ensure_currency_codes();
     return currency_codes.get(currency);

--- a/Libraries/LibUnicode/CurrencyCode.h
+++ b/Libraries/LibUnicode/CurrencyCode.h
@@ -17,6 +17,6 @@ struct CurrencyCode {
     Optional<int> minor_unit {};
 };
 
-Optional<CurrencyCode> get_currency_code(StringView currency);
+Optional<CurrencyCode const&> get_currency_code(StringView currency);
 
 }

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -29,7 +29,7 @@ public:
     virtual String item(size_t index) const = 0;
 
     virtual Optional<StyleProperty> property(PropertyID) const = 0;
-    virtual Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const = 0;
+    virtual Optional<StyleProperty const&> custom_property(FlyString const& custom_property_name) const = 0;
 
     virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority = ""sv);
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID);
@@ -76,7 +76,7 @@ public:
     virtual String item(size_t index) const override;
 
     virtual Optional<StyleProperty> property(PropertyID) const override;
-    virtual Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const override { return m_custom_properties.get(custom_property_name); }
+    virtual Optional<StyleProperty const&> custom_property(FlyString const& custom_property_name) const override { return m_custom_properties.get(custom_property_name); }
 
     virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<String> remove_property(StringView property_name) override;

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -601,7 +601,7 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     };
 }
 
-Optional<StyleProperty> ResolvedCSSStyleDeclaration::custom_property(FlyString const& name) const
+Optional<StyleProperty const&> ResolvedCSSStyleDeclaration::custom_property(FlyString const& name) const
 {
     const_cast<DOM::Document&>(m_element->document()).update_style();
 

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -24,7 +24,7 @@ public:
     virtual String item(size_t index) const override;
 
     virtual Optional<StyleProperty> property(PropertyID) const override;
-    virtual Optional<StyleProperty> custom_property(FlyString const& custom_property_name) const override;
+    virtual Optional<StyleProperty const&> custom_property(FlyString const& custom_property_name) const override;
     virtual WebIDL::ExceptionOr<void> set_property(PropertyID, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<void> set_property(StringView property_name, StringView css_text, StringView priority) override;
     virtual WebIDL::ExceptionOr<String> remove_property(PropertyID) override;

--- a/Libraries/LibWeb/DOMURL/DOMURL.cpp
+++ b/Libraries/LibWeb/DOMURL/DOMURL.cpp
@@ -507,7 +507,7 @@ void strip_trailing_spaces_from_an_opaque_path(DOMURL& url)
 }
 
 // https://url.spec.whatwg.org/#concept-url-parser
-URL::URL parse(StringView input, Optional<URL::URL> const& base_url, Optional<StringView> encoding)
+URL::URL parse(StringView input, Optional<URL::URL const&> base_url, Optional<StringView> encoding)
 {
     // FIXME: We should probably have an extended version of URL::URL for LibWeb instead of standalone functions like this.
 

--- a/Libraries/LibWeb/DOMURL/DOMURL.h
+++ b/Libraries/LibWeb/DOMURL/DOMURL.h
@@ -98,6 +98,6 @@ bool host_is_domain(URL::Host const&);
 void strip_trailing_spaces_from_an_opaque_path(DOMURL& url);
 
 // https://url.spec.whatwg.org/#concept-url-parser
-URL::URL parse(StringView input, Optional<URL::URL> const& base_url = {}, Optional<StringView> encoding = {});
+URL::URL parse(StringView input, Optional<URL::URL const&> base_url = {}, Optional<StringView> encoding = {});
 
 }

--- a/Libraries/LibWeb/Fetch/Request.cpp
+++ b/Libraries/LibWeb/Fetch/Request.cpp
@@ -467,7 +467,7 @@ WebIDL::ExceptionOr<GC::Ref<Request>> Request::construct_impl(JS::Realm& realm, 
     }
 
     // 38. Let inputOrInitBody be initBody if it is non-null; otherwise inputBody.
-    Optional<Infrastructure::Request::BodyType> input_or_init_body = init_body
+    Optional<Infrastructure::Request::BodyType const&> input_or_init_body = init_body
         ? Infrastructure::Request::BodyType { *init_body }
         : input_body;
 

--- a/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
+++ b/Libraries/LibWeb/FileAPI/BlobURLStore.cpp
@@ -108,7 +108,7 @@ void run_unloading_cleanup_steps(GC::Ref<DOM::Document> document)
 }
 
 // https://w3c.github.io/FileAPI/#blob-url-resolve
-Optional<BlobURLEntry> resolve_a_blob_url(URL::URL const& url)
+Optional<BlobURLEntry const&> resolve_a_blob_url(URL::URL const& url)
 {
     // 1. Assert: url’s scheme is "blob".
     VERIFY(url.scheme() == "blob"sv);

--- a/Libraries/LibWeb/FileAPI/BlobURLStore.h
+++ b/Libraries/LibWeb/FileAPI/BlobURLStore.h
@@ -28,7 +28,7 @@ BlobURLStore& blob_url_store();
 ErrorOr<String> generate_new_blob_url();
 ErrorOr<String> add_entry_to_blob_url_store(GC::Ref<Blob> object);
 ErrorOr<void> remove_entry_from_blob_url_store(StringView url);
-Optional<BlobURLEntry> resolve_a_blob_url(URL::URL const&);
+Optional<BlobURLEntry const&> resolve_a_blob_url(URL::URL const&);
 
 void run_unloading_cleanup_steps(GC::Ref<DOM::Document>);
 

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.cpp
@@ -38,7 +38,7 @@ ConnectionQueue& ConnectionQueueHandler::for_key_and_name(StorageAPI::StorageKey
         });
 }
 
-Optional<GC::Root<Database>> Database::for_key_and_name(StorageAPI::StorageKey& key, String& name)
+Optional<GC::Root<Database> const&> Database::for_key_and_name(StorageAPI::StorageKey& key, String& name)
 {
     return m_databases.ensure(key, [] {
                           return HashMap<String, GC::Root<Database>>();

--- a/Libraries/LibWeb/IndexedDB/Internal/Database.h
+++ b/Libraries/LibWeb/IndexedDB/Internal/Database.h
@@ -39,7 +39,7 @@ public:
         return connections;
     }
 
-    [[nodiscard]] static Optional<GC::Root<Database>> for_key_and_name(StorageAPI::StorageKey&, String&);
+    [[nodiscard]] static Optional<GC::Root<Database> const&> for_key_and_name(StorageAPI::StorageKey&, String&);
     [[nodiscard]] static ErrorOr<GC::Root<Database>> create_for_key_and_name(JS::Realm&, StorageAPI::StorageKey&, String&);
     [[nodiscard]] static ErrorOr<void> delete_for_key_and_name(StorageAPI::StorageKey&, String&);
 

--- a/Libraries/LibWebView/CookieJar.cpp
+++ b/Libraries/LibWebView/CookieJar.cpp
@@ -619,7 +619,7 @@ void CookieJar::TransientStorage::set_cookie(CookieStorageKey key, Web::Cookie::
     m_dirty_cookies.set(move(key), move(cookie));
 }
 
-Optional<Web::Cookie::Cookie> CookieJar::TransientStorage::get_cookie(CookieStorageKey const& key)
+Optional<Web::Cookie::Cookie const&> CookieJar::TransientStorage::get_cookie(CookieStorageKey const& key)
 {
     return m_cookies.get(key);
 }

--- a/Libraries/LibWebView/CookieJar.h
+++ b/Libraries/LibWebView/CookieJar.h
@@ -43,7 +43,7 @@ class CookieJar {
 
         void set_cookies(Cookies);
         void set_cookie(CookieStorageKey, Web::Cookie::Cookie);
-        Optional<Web::Cookie::Cookie> get_cookie(CookieStorageKey const&);
+        Optional<Web::Cookie::Cookie const&> get_cookie(CookieStorageKey const&);
 
         size_t size() const { return m_cookies.size(); }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWindowOrWorkerInterfaces.cpp
@@ -265,7 +265,7 @@ void add_@global_object_snake_name@_exposed_interfaces(JS::Object& global)
     static constexpr u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
 )~~~");
 
-    auto add_interface = [](SourceGenerator& gen, StringView name, StringView prototype_class, Optional<LegacyConstructor> const& legacy_constructor, Optional<ByteString> const& legacy_alias_name) {
+    auto add_interface = [](SourceGenerator& gen, StringView name, StringView prototype_class, Optional<LegacyConstructor> const& legacy_constructor, Optional<ByteString const&> legacy_alias_name) {
         gen.set("interface_name", name);
         gen.set("prototype_class", prototype_class);
 

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -247,7 +247,6 @@ TEST_CASE(move_optional_reference)
     y = move(x);
     EXPECT_EQ(y.has_value(), true);
     EXPECT_EQ(y.value(), 3);
-    EXPECT_EQ(x.has_value(), false);
 }
 
 TEST_CASE(short_notation_reference)


### PR DESCRIPTION
C++ will jovially select the implicit conversion operator, even if it's
complete bogus, such as for unknown-size types or non-destructible
types. Therefore, all such conversions (which incur a copy) must
(unfortunately) be explicit so that non-copyable types continue to work.

NOTE: We make an exception for trivially copyable types, since they
are, well, trivially copyable.