### PR TITLE
LibWeb: Update existing style object when setting style attribute

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -513,6 +513,19 @@ void PropertyOwningCSSStyleDeclaration::set_the_declarations(Vector<StylePropert
     m_custom_properties = move(custom_properties);
 }
 
+void ElementInlineCSSStyleDeclaration::set_declarations_from_text(StringView css_text)
+{
+    // FIXME: What do we do if the element is null?
+    if (!m_element) {
+        dbgln("FIXME: Returning from ElementInlineCSSStyleDeclaration::declarations_from_text as m_element is null.");
+        return;
+    }
+
+    empty_the_declarations();
+    auto style = parse_css_style_attribute(CSS::Parser::ParsingContext(m_element->document()), css_text, *m_element.ptr());
+    set_the_declarations(style->properties(), style->custom_properties());
+}
+
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext
 WebIDL::ExceptionOr<void> ElementInlineCSSStyleDeclaration::set_css_text(StringView css_text)
 {
@@ -526,11 +539,8 @@ WebIDL::ExceptionOr<void> ElementInlineCSSStyleDeclaration::set_css_text(StringV
     // NOTE: See ResolvedCSSStyleDeclaration.
 
     // 2. Empty the declarations.
-    empty_the_declarations();
-
     // 3. Parse the given value and, if the return value is not the empty list, insert the items in the list into the declarations, in specified order.
-    auto style = parse_css_style_attribute(CSS::Parser::ParsingContext(m_element->document()), css_text, *m_element.ptr());
-    set_the_declarations(style->properties(), style->custom_properties());
+    set_declarations_from_text(css_text);
 
     // 4. Update style attribute for the CSS declaration block.
     update_style_attribute();

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -123,6 +123,8 @@ public:
 
     bool is_updating() const { return m_updating; }
 
+    void set_declarations_from_text(StringView);
+
     virtual WebIDL::ExceptionOr<void> set_css_text(StringView) override;
 
 private:

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2740,7 +2740,12 @@ void Element::attribute_changed(FlyString const& local_name, Optional<String> co
             // https://drafts.csswg.org/cssom/#ref-for-cssstyledeclaration-updating-flag
             if (m_inline_style && m_inline_style->is_updating())
                 return;
-            m_inline_style = parse_css_style_attribute(CSS::Parser::ParsingContext(document()), *value, *this);
+            if (!m_inline_style) {
+                m_inline_style = parse_css_style_attribute(CSS::Parser::ParsingContext(document()), *value, *this);
+            } else {
+                // NOTE: ElementInlineCSSStyleDeclaration::set_css_text should never throw an exception.
+                m_inline_style->set_declarations_from_text(*value);
+            }
             set_needs_style_update(true);
         }
     } else if (local_name == HTML::AttributeNames::dir) {

--- a/Tests/LibWeb/Text/expected/wpt-import/domparsing/style_attribute_html.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/domparsing/style_attribute_html.txt
@@ -6,10 +6,9 @@ Rerun
 
 Found 4 tests
 
-2 Pass
-2 Fail
+4 Pass
 Details
 Result	Test Name	MessagePass	Parsing of initial style attribute	
-Fail	Parsing of invalid style attribute	
-Fail	Parsing of style attribute	
+Pass	Parsing of invalid style attribute	
+Pass	Parsing of style attribute	
 Pass	Update style.backgroundColor	


### PR DESCRIPTION
Previously any existing ElementInlineCSSStyleDeclaration would get overwritten by e.setAttribute("style", ...), while it should be updated instead.

This fixes 2 WPT subtests.