### PR TITLE
LibWeb/HTML: Implement cite attribute according to spec

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLModElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLModElement.idl
@@ -6,7 +6,7 @@ interface HTMLModElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute USVString cite;
+    [CEReactions, Reflect, URL] attribute USVString cite;
     [CEReactions, Reflect=datetime] attribute DOMString dateTime;
 
 };

--- a/Libraries/LibWeb/HTML/HTMLQuoteElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLQuoteElement.idl
@@ -6,6 +6,6 @@ interface HTMLQuoteElement : HTMLElement {
 
     [HTMLConstructor] constructor();
 
-    [CEReactions, Reflect] attribute USVString cite;
+    [CEReactions, Reflect, URL] attribute USVString cite;
 
 };

--- a/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
+++ b/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
@@ -14,3 +14,7 @@ script.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 source.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 track.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 video.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+q.cite final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+blockquote.cite final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+ins.cite final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+del.cite final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD

--- a/Tests/LibWeb/Text/input/usvstring-url-reflection.html
+++ b/Tests/LibWeb/Text/input/usvstring-url-reflection.html
@@ -19,6 +19,10 @@
             { "source": "src" },
             { "track": "src" },
             { "video": "src" },
+            { "q": "cite" },
+            { "blockquote": "cite" },
+            { "ins": "cite" },
+            { "del": "cite" },
         ];
         for (const elementDescriptor of elementList) {
             [elementName, propertyName] = Object.entries(elementDescriptor)[0];


### PR DESCRIPTION
Implements the cite attribute of `q` and `blockqoute` elements according to spec by returning a valid URL.

This makes the remaining cases in http://wpt.live/html/dom/reflection-text.html pass.