### PR TITLE
LibWeb/HTML: Use default input size (20) when value is 0

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1863,9 +1863,10 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_min_length(WebIDL::Long value)
 // https://html.spec.whatwg.org/multipage/input.html#the-size-attribute
 unsigned HTMLInputElement::size() const
 {
+    // The size attribute, if specified, must have a value that is a valid non-negative integer greater than zero.
     // The size IDL attribute is limited to only positive numbers and has a default value of 20.
     if (auto size_string = get_attribute(HTML::AttributeNames::size); size_string.has_value()) {
-        if (auto size = parse_non_negative_integer(*size_string); size.has_value())
+        if (auto size = parse_non_negative_integer(*size_string); size.has_value() && size.value() != 0)
             return *size;
     }
     return 20;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/rendering/widgets/input-text-size.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/rendering/widgets/input-text-size.txt
@@ -1,0 +1,16 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 5 tests
+
+4 Pass
+1 Fail
+Details
+Result	Test Name	MessagePass	A misssing attribute is equivalent to size=20	
+Pass	An invalid attribute value is equivalent to size=20	
+Pass	The width depends on a size attribute	
+Pass	Size attribute value affects layout-dependent computed style	
+Fail	Size attribute value is not a presentational hint	

--- a/Tests/LibWeb/Text/input/wpt-import/html/rendering/widgets/input-text-size.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/rendering/widgets/input-text-size.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/C/#the-input-element-as-a-text-entry-widget">
+<title>Test `size` attribute behavior</title>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<body>
+
+<input id="missing">
+<input id="invalid" size="-1">
+<input id="size0" size="0">
+<input id="size1" size="1">
+<input id="size10" size="10">
+<input id="size20" size="20">
+<input id="size21" size="21">
+<input id="computed" style="border:none; padding:0;" size="19">
+<input id="computedNone" style="display:none" size="17">
+
+<script>
+test(() => {
+  assert_equals(missing.offsetWidth, size20.offsetWidth);
+}, 'A misssing attribute is equivalent to size=20');
+
+test(() => {
+  assert_equals(invalid.offsetWidth, size20.offsetWidth, 'size="-1"');
+  assert_equals(size0.offsetWidth, size20.offsetWidth, 'size="0"');
+}, 'An invalid attribute value is equivalent to size=20');
+
+test(() => {
+  assert_less_than(size1.offsetWidth, size10.offsetWidth, '1 < 10');
+  assert_less_than(size10.offsetWidth, size20.offsetWidth, '10 < 20');
+  assert_less_than(size20.offsetWidth, size21.offsetWidth, '20 < 21');
+}, 'The width depends on a size attribute');
+
+test(() => {
+  const computedString = getComputedStyle(computed).width;
+  assert_equals(computed.offsetWidth,
+      Math.round(computedString.substring(0, computedString.length - 2)));
+}, 'Size attribute value affects layout-dependent computed style');
+
+test(() => {
+  const computedString = getComputedStyle(computedNone).width;
+  assert_equals(computedString, 'auto');
+}, 'Size attribute value is not a presentational hint');
+</script>
+


### PR DESCRIPTION
According to the HTML specification, the `size` attribute of an input element must be a valid non-negative integer greater than zero. If the value is invalid or set to `0`, the default size of `20` should be used.

This change fixes one issue identified in https://wpt.live/html/rendering/widgets/input-text-size.html