### PR TITLE
LibWeb: Make inline-block node be absolute positioning containing block

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1179,6 +1179,7 @@ CSSPixelRect FormattingContext::content_box_rect_in_static_position_ancestor_coo
         if (current == &ancestor_box)
             return rect;
         auto const& current_state = m_state.get(*current);
+        dbgln("content_box_rect_in_static_position_ancestor_coordinate_space  offset = {}", current_state.offset);
         rect.translate_by(current_state.offset);
     }
     // If we get here, ancestor_box was not an ancestor of `box`!
@@ -1237,6 +1238,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
     CSSPixelPoint used_offset;
 
     auto static_position = m_state.get(box).static_position();
+    dbgln("layout_absolutely_positioned_element  static_position = {}", static_position);
 
     if (box.computed_values().inset().top().is_auto() && box.computed_values().inset().bottom().is_auto()) {
         used_offset.set_y(static_position.y());

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -416,6 +416,7 @@ void InlineFormattingContext::generate_line_boxes()
             if (fragment.layout_node().is_inline_block()) {
                 auto& box = static_cast<NodeWithStyle const&>(fragment.layout_node());
                 auto& box_state = m_state.get_mutable(box);
+                dbgln("fragment offset = {}", fragment.offset());
                 box_state.set_content_offset(fragment.offset());
             }
         }
@@ -505,6 +506,7 @@ StaticPositionRect InlineFormattingContext::calculate_static_position_rect(Box c
         // Easy case: no previous sibling, we're at the top of the containing block.
     }
     auto offset_to_static_parent = content_box_rect_in_static_position_ancestor_coordinate_space(box, *box.containing_block());
+    dbgln("calculate_static_position_rect  offset_to_static_parent = {}", offset_to_static_parent);
     StaticPositionRect static_position_rect;
     static_position_rect.rect = { offset_to_static_parent.location().translated(x, y), { 0, 0 } };
     return static_position_rect;

--- a/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -411,6 +411,16 @@ void InlineFormattingContext::generate_line_boxes()
         }
     }
 
+    for (auto& line_box : line_boxes) {
+        for (auto& fragment : line_box.fragments()) {
+            if (fragment.layout_node().is_inline_block()) {
+                auto& box = static_cast<NodeWithStyle const&>(fragment.layout_node());
+                auto& box_state = m_state.get_mutable(box);
+                box_state.set_content_offset(fragment.offset());
+            }
+        }
+    }
+
     for (auto* box : absolute_boxes) {
         auto& box_state = m_state.get_mutable(*box);
         box_state.set_static_position_rect(calculate_static_position_rect(*box));

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/abspos/static-inside-inline-block-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/abspos/static-inside-inline-block-ref.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Static position inside inline-block</title>
+<link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-width" title="10.3.7 Absolutely positioned, non-replaced elements">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: inline-block; width: 100px; height: 100px;"></div>
+<div style="display: inline-block; width: 100px; height: 100px; background: red;">
+    <div style="width: 100px; height: 100px; background: green;"></div>
+</div>
+<div style="display: inline-block; width: 100px; height: 100px;"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/abspos/static-inside-inline-block.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/abspos/static-inside-inline-block.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<title>Static position inside inline-block</title>
+<link rel="author" title="Martin Robinson" href="mrobinson@igalia.com">
+<link rel="help" href="https://www.w3.org/TR/CSS22/visudet.html#abs-non-replaced-width" title="10.3.7 Absolutely positioned, non-replaced elements">
+<link rel="match" href="../../../../../expected/wpt-import/css/CSS2/abspos/static-inside-inline-block-ref.html">
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div style="display: inline-block; width: 100px; height: 100px;"></div>
+<div style="display: inline-block; width: 100px; height: 100px; background: red;">
+    <div style="position: absolute; width: 100px; height: 100px; background: green;"></div>
+</div>
+<div style="display: inline-block; width: 100px; height: 100px;"></div>


### PR DESCRIPTION
Fixes wpt/css/CSS2/abspos/static-inside-inline-block.html