### PR TITLE
LibWeb: Don't end parsing after reaching the insertion point

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -706,14 +706,14 @@ WebIDL::ExceptionOr<void> Document::close()
     if (!m_parser)
         return {};
 
-    // FIXME: 4. Insert an explicit "EOF" character at the end of the parser's input stream.
+    // 4. Insert an explicit "EOF" character at the end of the parser's input stream.
     m_parser->tokenizer().insert_eof();
 
     // 5. If there is a pending parsing-blocking script, then return.
     if (pending_parsing_blocking_script())
         return {};
 
-    // FIXME: 6. Run the tokenizer, processing resulting tokens as they are emitted, and stopping when the tokenizer reaches the explicit "EOF" character or spins the event loop.
+    // 6. Run the tokenizer, processing resulting tokens as they are emitted, and stopping when the tokenizer reaches the explicit "EOF" character or spins the event loop.
     m_parser->run();
 
     // AD-HOC: This ensures that a load event is fired if the node navigable's container is an iframe.

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -191,10 +191,6 @@ void HTMLParser::run(HTMLTokenizer::StopAtInsertionPoint stop_at_insertion_point
     m_stop_parsing = false;
 
     for (;;) {
-        // FIXME: Find a better way to say that we come from Document::close() and want to process EOF.
-        if (!m_tokenizer.is_eof_inserted() && m_tokenizer.is_insertion_point_reached())
-            break;
-
         auto optional_token = m_tokenizer.next_token(stop_at_insertion_point);
         if (!optional_token.has_value())
             break;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/execution-timing/149.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/execution-timing/149.txt
@@ -1,0 +1,22 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 12 tests
+
+12 Pass
+Details
+Result	Test Name	MessagePass	for='window' event='onload()' parser inserted executes immediately	
+Pass	for='window' event='onload' parser inserted executes immediately	
+Pass	for=' WINdow ' event='ONload ' parser inserted executes immediately	
+Pass	for='window' event='load' parser inserted does not execute	
+Pass	for='window' event='onpageshow' parser inserted does not execute	
+Pass	for='document' event='onload' parser inserted does not execute	
+Pass	for='window' event='onload()' dom inserted executes immediately	
+Pass	for='window' event='onload' dom inserted executes immediately	
+Pass	for=' WINdow ' event='ONload ' dom inserted executes immediately	
+Pass	for='window' event='load' dom inserted does not execute	
+Pass	for='window' event='onpageshow' dom inserted does not execute	
+Pass	for='document' event='onload' dom inserted does not execute	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/html5lib_scripted_webkit01.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/html5lib_scripted_webkit01.txt
@@ -6,8 +6,7 @@ Rerun
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Details
 Result	Test Name	MessagePass	html5lib_scripted_webkit01.html 3ff6ec1125852c7933bf6d89ecb375354e6e1b40	
-Fail	html5lib_scripted_webkit01.html 46ae362de712eb9c55916de93110299dbbcb5726	
+Pass	html5lib_scripted_webkit01.html 46ae362de712eb9c55916de93110299dbbcb5726	

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/execution-timing/149.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/execution-timing/149.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html><head>
+  <title>scheduler: event/for attribute on script</title>
+  <script src="../../../../../resources/testharness.js"></script>
+  <script src="../../../../../resources/testharnessreport.js"></script>
+  <script src="testlib/testlib.js"></script>
+</head>
+<body>
+<div id="log"></div>
+<script>
+
+attributes = [
+  {for:"window", event:"onload()", expect:true},
+  {for:"window", event:"onload", expect:true},
+  {for:"  WINdow\t\n", event:"ONload\t\n", expect:true},
+  {for:"window", event:"load", expect:false},
+  {for:"window", event:"onpageshow", expect:false},
+  {for:"document", event:"onload", expect:false},
+]
+
+function test_maker(array_name) {
+  return function(x, i) {
+    var title = "for='" + x.for + "' event='" + x.event + "' " + array_name.replace("_", " ") + " " + (x.expect ? "executes immediately" : "does not execute");
+    script_content = "var d =" + array_name + "[" + i  + "];"
+    script_content += x.expect?"d[1].step(function() {d[3] = true});":"d[1].step(function() {assert_unreached()});"
+    return [x, async_test(title), script_content, false];
+  }
+}
+
+parser_inserted = attributes.map(test_maker("parser_inserted"));
+dom_inserted = attributes.map(test_maker("dom_inserted"));
+
+parser_inserted.forEach(function(x) {
+  var d = x[0];
+  document.write("<script for='" + d.for + "' event='" + d.event + "'>" + x[2] + "<\/script>");
+});
+
+dom_inserted.forEach(function(x) {
+  var d = x[0];
+  var s = document.createElement("script");
+  s.setAttribute("event", d.event);
+  s.setAttribute("for", d.for);
+  s.textContent = x[2];
+  document.body.appendChild(s);
+});
+</script>
+
+<script>
+var all_tests = parser_inserted.concat(dom_inserted);
+
+all_tests.filter(function(x) {return x[0]["expect"]}).forEach(function(x) {var t = x[1]; t.step(function() {assert_true(x[3])});})
+
+onload = function() {
+  all_tests.forEach(function(x) {var t = x[1]; t.step(function() {t.done()})});
+}
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/execution-timing/testlib/testlib.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/execution-timing/testlib/testlib.js
@@ -1,0 +1,43 @@
+/*
+* Utility functions for script scheduler test
+*/
+(function(){ /* namespace hiding local variables like arOrderOfAllEvents from global scope */
+    window.testlib = {};
+    window.eventOrder = [];
+    var arNumberOfScriptsParsedPerEvent=[];
+    window.log = function (str){
+        eventOrder.push(str);
+        arNumberOfScriptsParsedPerEvent.push(document.getElementsByTagName('script').length);
+    }
+
+    window.testlib.addScript = function(source, attributes, parent, firstInParent,funcPrepare) {
+        try{
+            parent = parent||document.body;
+            var script = document.createElement('script');
+            if(funcPrepare) {
+                funcPrepare(script);
+            }
+            if(source)script.appendChild( document.createTextNode(source) );
+            for( var name in attributes){
+                if(/^on/i.test(name)) {
+                    script[name] = attributes[name];
+                } else {
+                    script.setAttribute(name, attributes[name]);
+                }
+            }
+            if (firstInParent && parent.firstChild) {
+                parent.insertBefore(script, parent.firstChild);
+            } else {
+                parent.appendChild(script);
+            }
+        } catch(e) {
+            log('ERROR when adding script to DOM!');
+            alert(e);
+        }
+        return script;
+    }
+
+    window.testlib.urlParam = function(relativeURL) {
+        return location.href.replace( /\d*\.html$/, relativeURL);
+    }
+})();


### PR DESCRIPTION
Fixes #2564, also fixes 13 WPT timeouts (the largest has been imported).

I've run `domparsing`, `dom`, `html/dom`, `html/syntax/parsing`, `html/semantics/scripting-1/the-script-element`, `html/browsers/browsing-the-web`, and `html/webappapis` to confirm that there aren't any regressions.