### PR TITLE
AK: Allow `Variant<...>` to be used in constant expressions

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -27,7 +27,7 @@ extern "C" __attribute__((noreturn)) void ak_assertion_failed(char const*);
         (__builtin_expect(!(expr), 0)                                                  \
                 ? ak_assertion_failed(#expr " at " __FILE__ ":" __stringify(__LINE__)) \
                 : (void)0)
-#    define ASSERT_NOT_REACHED ASSERT(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define ASSERT_NOT_REACHED() ASSERT(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #else
 #    define ASSERT(expr)
 #    define ASSERT_NOT_REACHED() __builtin_unreachable()

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -21,7 +21,7 @@ class FlyString {
     AK_MAKE_DEFAULT_COPYABLE(FlyString);
 
 public:
-    FlyString() = default;
+    constexpr FlyString() = default;
 
     static ErrorOr<FlyString> from_utf8(StringView);
     static FlyString from_utf8_without_validation(ReadonlyBytes);
@@ -83,7 +83,7 @@ public:
 private:
     friend class Optional<FlyString>;
 
-    explicit FlyString(nullptr_t)
+    explicit constexpr FlyString(nullptr_t)
         : m_data(Detail::StringBase(nullptr))
     {
     }
@@ -106,38 +106,38 @@ class Optional<FlyString> : public OptionalBase<FlyString> {
 public:
     using ValueType = FlyString;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
-    Optional(Optional<FlyString> const& other)
+    constexpr Optional(Optional<FlyString> const& other)
     {
         if (other.has_value())
             m_value = other.m_value;
     }
 
     Optional(Optional&& other)
-        : m_value(other.m_value)
+        : m_value(move(other.m_value))
     {
     }
 
     template<typename U = FlyString>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    explicit(!IsConvertible<U&&, FlyString>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, FlyString>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<FlyString>> && IsConstructible<FlyString, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             clear();
@@ -146,7 +146,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -156,40 +156,40 @@ public:
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    ALWAYS_INLINE constexpr bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = FlyString(nullptr);
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_invalid();
     }
 
-    [[nodiscard]] FlyString& value() &
+    [[nodiscard]] constexpr FlyString& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] FlyString const& value() const&
+    [[nodiscard]] constexpr FlyString const& value() const&
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] FlyString value() &&
+    [[nodiscard]] constexpr FlyString value() &&
     {
         return release_value();
     }

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -46,7 +46,7 @@ template<typename>
 class Optional;
 
 struct OptionalNone {
-    explicit OptionalNone() = default;
+    explicit constexpr OptionalNone() = default;
 };
 
 template<typename T, typename Self = Optional<T>>
@@ -55,30 +55,30 @@ public:
     using ValueType = T;
 
     template<SameAs<OptionalNone> V>
-    Self& operator=(V)
+    constexpr Self& operator=(V)
     {
         static_cast<Self&>(*this).clear();
         return static_cast<Self&>(*this);
     }
 
-    [[nodiscard]] ALWAYS_INLINE T* ptr() &
+    [[nodiscard]] ALWAYS_INLINE constexpr T* ptr() &
     {
         return static_cast<Self&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T*>(&static_cast<Self&>(*this).value())) : nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const* ptr() const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T const* ptr() const&
     {
         return static_cast<Self const&>(*this).has_value() ? __builtin_launder(reinterpret_cast<T const*>(&static_cast<Self const&>(*this).value())) : nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T const& fallback) const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or(T const& fallback) const&
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T&& fallback) &&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or(T&& fallback) &&
     {
         if (static_cast<Self&>(*this).has_value())
             return move(static_cast<Self&>(*this).value());
@@ -86,7 +86,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE O value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr O value_or_lazy_evaluated(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -94,7 +94,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE Optional<O> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr Optional<O> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -102,7 +102,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<O> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<O> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -110,7 +110,7 @@ public:
     }
 
     template<typename Callback, typename O = T>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<O>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<O>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (static_cast<Self const&>(*this).has_value())
             return static_cast<Self const&>(*this).value();
@@ -118,7 +118,7 @@ public:
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<O> const& other) const
     {
         return static_cast<Self const&>(*this).has_value() == (other).has_value()
             && (!static_cast<Self const&>(*this).has_value() || static_cast<Self const&>(*this).value() == (other).value());
@@ -126,19 +126,19 @@ public:
 
     template<typename O>
     requires(!Detail::IsBaseOf<OptionalBase<T, Self>, O>)
-    ALWAYS_INLINE bool operator==(O const& other) const
+    ALWAYS_INLINE constexpr bool operator==(O const& other) const
     {
         return static_cast<Self const&>(*this).has_value() && static_cast<Self const&>(*this).value() == other;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& operator*() const { return static_cast<Self const&>(*this).value(); }
-    [[nodiscard]] ALWAYS_INLINE T& operator*() { return static_cast<Self&>(*this).value(); }
+    [[nodiscard]] ALWAYS_INLINE constexpr T const& operator*() const { return static_cast<Self const&>(*this).value(); }
+    [[nodiscard]] ALWAYS_INLINE constexpr T& operator*() { return static_cast<Self&>(*this).value(); }
 
-    ALWAYS_INLINE T const* operator->() const { return &static_cast<Self const&>(*this).value(); }
-    ALWAYS_INLINE T* operator->() { return &static_cast<Self&>(*this).value(); }
+    ALWAYS_INLINE constexpr T const* operator->() const { return &static_cast<Self const&>(*this).value(); }
+    ALWAYS_INLINE constexpr T* operator->() { return &static_cast<Self&>(*this).value(); }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (static_cast<Self&>(*this).has_value())
@@ -153,7 +153,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (static_cast<Self const&>(*this).has_value())
@@ -178,13 +178,19 @@ requires(!IsLvalueReference<T>) class [[nodiscard]] Optional<T> : public Optiona
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    ALWAYS_INLINE constexpr Optional()
+    {
+        construct_null_if_necessairy();
+    }
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V)
+    {
+        construct_null_if_necessairy();
+    }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
@@ -194,143 +200,168 @@ public:
     AK_MAKE_CONDITIONALLY_NONMOVABLE(Optional, <T>);
     AK_MAKE_CONDITIONALLY_DESTRUCTIBLE(Optional, <T>);
 
-    ALWAYS_INLINE Optional(Optional const& other)
+    ALWAYS_INLINE constexpr Optional(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T>)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.value());
+            construct_at(&m_value, other.value());
+        else
+            construct_null_if_necessairy();
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    ALWAYS_INLINE constexpr Optional(Optional&& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
-            new (&m_storage) T(other.release_value());
+            construct_at(&m_value, other.release_value());
+        else
+            construct_null_if_necessairy();
     }
 
     template<typename U>
-    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit Optional(Optional<U> const& other)
+    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit constexpr Optional(Optional<U> const& other)
         : m_has_value(other.has_value())
     {
         if (other.has_value())
-            new (&m_storage) T(other.value());
+            construct_at(&m_value, other.value());
+        else
+            construct_null_if_necessairy();
     }
 
     template<typename U>
-    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit Optional(Optional<U>&& other)
+    requires(IsConstructible<T, U &&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit constexpr Optional(Optional<U>&& other)
         : m_has_value(other.has_value())
     {
         if (other.has_value())
-            new (&m_storage) T(other.release_value());
+            construct_at(&m_value, other.value());
+        else
+            construct_null_if_necessairy();
     }
 
     template<typename U = T>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value)
+    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<T>> && IsConstructible<T, U &&>)
         : m_has_value(true)
     {
-        new (&m_storage) T(forward<U>(value));
+        construct_at(&m_value, forward<U>(value));
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional const& other)
     requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
     {
         if (this != &other) {
             clear();
             m_has_value = other.m_has_value;
-            if (other.has_value()) {
-                new (&m_storage) T(other.value());
-            }
+            if (other.has_value())
+                construct_at(&m_value, other.value());
+            else
+                construct_null_if_necessairy();
         }
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
             m_has_value = other.m_has_value;
-            if (other.has_value()) {
-                new (&m_storage) T(other.release_value());
-            }
+            if (other.has_value())
+                construct_at(&m_value, other.release_value());
+            else
+                construct_null_if_necessairy();
         }
         return *this;
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    ALWAYS_INLINE constexpr bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    ALWAYS_INLINE ~Optional()
+    ALWAYS_INLINE constexpr ~Optional()
     requires(!IsTriviallyDestructible<T> && IsDestructible<T>)
     {
         clear();
     }
 
-    ALWAYS_INLINE void clear()
+    ALWAYS_INLINE constexpr void clear()
     {
         if (m_has_value) {
-            value().~T();
+            m_value.~T();
             m_has_value = false;
         }
     }
 
     template<typename... Parameters>
-    ALWAYS_INLINE void emplace(Parameters&&... parameters)
+    ALWAYS_INLINE constexpr void emplace(Parameters&&... parameters)
     {
         clear();
         m_has_value = true;
-        new (&m_storage) T(forward<Parameters>(parameters)...);
+        construct_at(&m_value, forward<Parameters>(parameters)...);
     }
 
     template<typename Callable>
-    ALWAYS_INLINE void lazy_emplace(Callable callable)
+    ALWAYS_INLINE constexpr void lazy_emplace(Callable callable)
     {
         clear();
         m_has_value = true;
-        new (&m_storage) T { callable() };
+        construct_at(&m_value, callable());
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_has_value; }
+    [[nodiscard]] ALWAYS_INLINE constexpr bool has_value() const { return m_has_value; }
 
-    [[nodiscard]] ALWAYS_INLINE T& value() &
+    [[nodiscard]] ALWAYS_INLINE constexpr T& value() &
     {
         VERIFY(m_has_value);
-        return *__builtin_launder(reinterpret_cast<T*>(&m_storage));
+        return m_value;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& value() const&
+    [[nodiscard]] ALWAYS_INLINE constexpr T const& value() const&
     {
         VERIFY(m_has_value);
-        return *__builtin_launder(reinterpret_cast<T const*>(&m_storage));
+        return m_value;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value() &&
+    [[nodiscard]] ALWAYS_INLINE constexpr T value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T release_value()
     {
         VERIFY(m_has_value);
-        T released_value = move(value());
-        value().~T();
+        T released_value = move(m_value);
+        m_value.~T();
         m_has_value = false;
         return released_value;
     }
 
 private:
-    alignas(T) u8 m_storage[sizeof(T)];
+    constexpr void construct_null_if_necessairy()
+    {
+#if defined(AK_COMPILER_GCC) || defined(HAS_ADDRESS_SANITIZER)
+        // NOTE: GCCs -Wuninitialized warning ends up checking this as well.
+        constexpr bool should_construct = true;
+#else
+        constexpr bool should_construct = is_constant_evaluated();
+#endif
+        if (should_construct)
+            m_null = {};
+    }
+
+    union {
+        alignas(T) Array<u8, sizeof(T)> m_null;
+        T m_value;
+    };
     bool m_has_value { false };
 };
 
@@ -345,76 +376,76 @@ requires(IsLvalueReference<T>) class [[nodiscard]] Optional<T> {
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    ALWAYS_INLINE constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
     template<typename U = T>
-    ALWAYS_INLINE Optional(U& value)
+    ALWAYS_INLINE constexpr Optional(U& value)
     requires(CanBePlacedInOptional<U&>)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(RemoveReference<T>& value)
+    ALWAYS_INLINE constexpr Optional(RemoveReference<T>& value)
         : m_pointer(&value)
     {
     }
 
-    ALWAYS_INLINE Optional(Optional const& other)
+    ALWAYS_INLINE constexpr Optional(Optional const& other)
         : m_pointer(other.m_pointer)
     {
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    ALWAYS_INLINE constexpr Optional(Optional&& other)
         : m_pointer(other.m_pointer)
     {
         other.m_pointer = nullptr;
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U>& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U>& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.ptr())
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U> const& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U> const& other)
     requires(CanBePlacedInOptional<U const>)
         : m_pointer(other.ptr())
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional(Optional<U>&& other)
+    ALWAYS_INLINE constexpr Optional(Optional<U>&& other)
     requires(CanBePlacedInOptional<U>)
         : m_pointer(other.ptr())
     {
         other.m_pointer = nullptr;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional& other)
     {
         m_pointer = other.m_pointer;
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional const& other)
     {
         m_pointer = other.m_pointer;
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional&& other)
     {
         m_pointer = other.m_pointer;
         other.m_pointer = nullptr;
@@ -422,7 +453,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U>& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U>& other)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = other.ptr();
@@ -430,7 +461,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U> const& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U> const& other)
     requires(CanBePlacedInOptional<U const>)
     {
         m_pointer = other.ptr();
@@ -438,7 +469,7 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE Optional& operator=(Optional<U>&& other)
+    ALWAYS_INLINE constexpr Optional& operator=(Optional<U>&& other)
     requires(CanBePlacedInOptional<U> && IsLvalueReference<U>)
     {
         m_pointer = other.m_pointer;
@@ -448,7 +479,7 @@ public:
 
     template<typename U>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    ALWAYS_INLINE Optional& operator=(U& value)
+    ALWAYS_INLINE constexpr Optional& operator=(U& value)
     requires(CanBePlacedInOptional<U>)
     {
         m_pointer = &value;
@@ -462,37 +493,37 @@ public:
     requires(CanBePlacedInOptional<U>)
     = delete;
 
-    ALWAYS_INLINE void clear()
+    ALWAYS_INLINE constexpr void clear()
     {
         m_pointer = nullptr;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_pointer != nullptr; }
+    [[nodiscard]] ALWAYS_INLINE constexpr bool has_value() const { return m_pointer != nullptr; }
 
-    [[nodiscard]] ALWAYS_INLINE RemoveReference<T>* ptr()
+    [[nodiscard]] ALWAYS_INLINE constexpr RemoveReference<T>* ptr()
     {
         return m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE RemoveReference<T> const* ptr() const
+    [[nodiscard]] ALWAYS_INLINE constexpr RemoveReference<T> const* ptr() const
     {
         return m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T value()
     {
         VERIFY(m_pointer);
         return *m_pointer;
     }
 
-    [[nodiscard]] ALWAYS_INLINE AddConstToReferencedType<T> value() const
+    [[nodiscard]] ALWAYS_INLINE constexpr AddConstToReferencedType<T> value() const
     {
         VERIFY(m_pointer);
         return *m_pointer;
     }
 
     template<typename U>
-    requires(IsBaseOf<RemoveCVReference<T>, U>) [[nodiscard]] ALWAYS_INLINE AddConstToReferencedType<T> value_or(U& fallback) const
+    requires(IsBaseOf<RemoveCVReference<T>, U>) [[nodiscard]] ALWAYS_INLINE constexpr AddConstToReferencedType<T> value_or(U& fallback) const
     {
         if (m_pointer)
             return value();
@@ -500,38 +531,38 @@ public:
     }
 
     // Note that this ends up copying the value.
-    [[nodiscard]] ALWAYS_INLINE RemoveCVReference<T> value_or(RemoveCVReference<T> fallback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr RemoveCVReference<T> value_or(RemoveCVReference<T> fallback) const
     {
         if (m_pointer)
             return value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] ALWAYS_INLINE constexpr T release_value()
     {
         return *exchange(m_pointer, nullptr);
     }
 
     template<typename U>
-    ALWAYS_INLINE bool operator==(Optional<U> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<U> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename U>
-    ALWAYS_INLINE bool operator==(U const& other) const
+    ALWAYS_INLINE constexpr bool operator==(U const& other) const
     {
         return has_value() && value() == other;
     }
 
-    ALWAYS_INLINE AddConstToReferencedType<T> operator*() const { return value(); }
-    ALWAYS_INLINE T operator*() { return value(); }
+    ALWAYS_INLINE constexpr AddConstToReferencedType<T> operator*() const { return value(); }
+    ALWAYS_INLINE constexpr T operator*() { return value(); }
 
-    ALWAYS_INLINE RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
-    ALWAYS_INLINE RawPtr<RemoveReference<T>> operator->() { return &value(); }
+    ALWAYS_INLINE constexpr RawPtr<AddConst<RemoveReference<T>>> operator->() const { return &value(); }
+    ALWAYS_INLINE constexpr RawPtr<RemoveReference<T>> operator->() { return &value(); }
 
     // Conversion operators from Optional<T&> -> Optional<T>
-    ALWAYS_INLINE operator Optional<RemoveCVReference<T>>() const
+    ALWAYS_INLINE constexpr operator Optional<RemoveCVReference<T>>() const
     {
         if (has_value())
             return Optional<RemoveCVReference<T>>(value());
@@ -539,7 +570,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE T value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr T value_or_lazy_evaluated(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -547,7 +578,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr Optional<T> value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -555,7 +586,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<T> try_value_or_lazy_evaluated(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -563,7 +594,7 @@ public:
     }
 
     template<typename Callback>
-    [[nodiscard]] ALWAYS_INLINE ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
+    [[nodiscard]] ALWAYS_INLINE constexpr ErrorOr<Optional<T>> try_value_or_lazy_evaluated_optional(Callback callback) const
     {
         if (m_pointer != nullptr)
             return value();
@@ -571,7 +602,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper)
     {
         if constexpr (IsErrorOr) {
             if (m_pointer != nullptr)
@@ -586,7 +617,7 @@ public:
     }
 
     template<typename F, typename MappedType = decltype(declval<F>()(declval<T&>())), auto IsErrorOr = IsSpecializationOf<MappedType, ErrorOr>, typename OptionalType = Optional<ConditionallyResultType<IsErrorOr, MappedType>>>
-    ALWAYS_INLINE Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
+    ALWAYS_INLINE constexpr Conditional<IsErrorOr, ErrorOr<OptionalType>, OptionalType> map(F&& mapper) const
     {
         if constexpr (IsErrorOr) {
             if (m_pointer != nullptr)

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -272,8 +272,26 @@ struct __MakeUnsigned<wchar_t> {
 template<typename T>
 using MakeUnsigned = typename __MakeUnsigned<T>::Type;
 
+template<typename T, typename = void>
+struct __AddReference {
+    using LvalueType = T;
+    using TvalueType = T;
+};
+
 template<typename T>
-auto declval() -> T;
+struct __AddReference<T, VoidType<T&>> {
+    using LvalueType = T&;
+    using RvalueType = T&&;
+};
+
+template<typename T>
+using AddLvalueReference = typename __AddReference<T>::LvalueType;
+
+template<typename T>
+using AddRvalueReference = typename __AddReference<T>::RvalueType;
+
+template<typename T>
+auto declval() -> AddRvalueReference<T>;
 
 template<typename...>
 struct __CommonType;
@@ -416,24 +434,6 @@ struct __IdentityType {
 
 template<typename T>
 using IdentityType = typename __IdentityType<T>::Type;
-
-template<typename T, typename = void>
-struct __AddReference {
-    using LvalueType = T;
-    using TvalueType = T;
-};
-
-template<typename T>
-struct __AddReference<T, VoidType<T&>> {
-    using LvalueType = T&;
-    using RvalueType = T&&;
-};
-
-template<typename T>
-using AddLvalueReference = typename __AddReference<T>::LvalueType;
-
-template<typename T>
-using AddRvalueReference = typename __AddReference<T>::RvalueType;
 
 template<class T>
 requires(IsEnum<T>) using UnderlyingType = __underlying_type(T);

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -588,6 +588,7 @@ struct __InvokeResult<MethodType MethodDefBaseType::*, InstanceType, Args...> {
 };
 
 template<typename F, typename... Args>
+requires(requires { (declval<F>())(declval<Args>()...); })
 struct __InvokeResult<F, Args...> {
     using type = decltype((declval<F>())(declval<Args>()...));
 };

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -91,6 +91,15 @@ inline constexpr bool __IsPointerHelper<T*> = true;
 template<class T>
 inline constexpr bool IsPointer = __IsPointerHelper<RemoveCV<T>>;
 
+template<class T>
+inline constexpr bool __IsMemberPointer = false;
+
+template<class T, class C>
+inline constexpr bool __IsMemberPointer<T C::*> = true;
+
+template<class T>
+inline constexpr bool IsMemberPointer = __IsMemberPointer<RemoveCV<T>>;
+
 template<class>
 inline constexpr bool IsFunction = false;
 template<class Ret, class... Args>
@@ -642,6 +651,7 @@ using AK::Detail::IsFundamental;
 using AK::Detail::IsHashCompatible;
 using AK::Detail::IsIntegral;
 using AK::Detail::IsLvalueReference;
+using AK::Detail::IsMemberPointer;
 using AK::Detail::IsMoveAssignable;
 using AK::Detail::IsMoveConstructible;
 using AK::Detail::IsNullPointer;

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -496,6 +496,24 @@ inline constexpr bool IsTriviallyConstructible = __is_trivially_constructible(T,
 template<typename From, typename To>
 inline constexpr bool IsConvertible = requires { declval<void (*)(To)>()(declval<From>()); };
 
+template<typename From, typename To>
+auto __IsNonNarrowingConvertibleHelper(int) -> decltype(declval<void(To)>()({ declval<From>() }), TrueType {});
+template<typename, typename>
+auto __IsNonNarrowingConvertibleHelper(...) -> FalseType;
+
+template<typename From, typename To>
+consteval bool __IsNonNarrowingConvertible()
+{
+    if constexpr ((IsArithmetic<From> || IsEnum<From> || IsPointer<From> || IsMemberPointer<From>) && (IsArithmetic<To> || IsEnum<To>)) {
+        return decltype(__IsNonNarrowingConvertibleHelper<From, To>(0))::value;
+    } else {
+        return IsConvertible<From, To>;
+    }
+}
+
+template<typename From, typename To>
+inline constexpr bool IsNonNarrowingConvertible = __IsNonNarrowingConvertible<From, To>();
+
 template<typename T, typename U>
 inline constexpr bool IsAssignable = requires { declval<T>() = declval<U>(); };
 
@@ -654,6 +672,7 @@ using AK::Detail::IsLvalueReference;
 using AK::Detail::IsMemberPointer;
 using AK::Detail::IsMoveAssignable;
 using AK::Detail::IsMoveConstructible;
+using AK::Detail::IsNonNarrowingConvertible;
 using AK::Detail::IsNullPointer;
 using AK::Detail::IsOneOf;
 using AK::Detail::IsOneOfIgnoringCV;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -10,6 +10,7 @@
 #include <AK/Platform.h>
 #include <AK/StdLibExtraDetails.h>
 
+#include <memory>
 #include <utility>
 
 namespace AK {
@@ -31,6 +32,7 @@ requires(AK::Detail::IsIntegral<T>)
 template<typename... Args>
 void compiletime_fail(Args...);
 
+using std::construct_at;
 using std::forward;
 using std::move;
 }

--- a/AK/String.h
+++ b/AK/String.h
@@ -236,38 +236,38 @@ class Optional<String> : public OptionalBase<String> {
 public:
     using ValueType = String;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
-    Optional(Optional<String> const& other)
+    constexpr Optional(Optional<String> const& other)
     {
         if (other.has_value())
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
+    constexpr Optional(Optional&& other)
         : m_value(move(other.m_value))
     {
     }
 
     template<typename U = String>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    explicit(!IsConvertible<U&&, String>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, String>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<String>> && IsConstructible<String, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             m_value = other.m_value;
@@ -275,7 +275,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             m_value = move(other.m_value);
@@ -284,48 +284,48 @@ public:
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    ALWAYS_INLINE constexpr bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = String(nullptr);
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_invalid();
     }
 
-    [[nodiscard]] String& value() &
+    [[nodiscard]] constexpr String& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] String const& value() const&
+    [[nodiscard]] constexpr String const& value() const&
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] String value() &&
+    [[nodiscard]] constexpr String value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] String release_value()
+    [[nodiscard]] constexpr String release_value()
     {
         VERIFY(has_value());
-        String released_value = m_value;
+        String released_value = move(m_value);
         clear();
         return released_value;
     }

--- a/AK/UntaggedUnion.h
+++ b/AK/UntaggedUnion.h
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024, Jonne Ransijn <jonne@yyny.dev>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Noncopyable.h>
+
+namespace AK {
+
+template<typename...>
+struct UntaggedUnion { };
+
+template<typename T, typename... Rest>
+struct UntaggedUnion<T, Rest...> {
+    friend UntaggedUnion<Rest...>;
+
+    // Allow container classes to keep their trivial default constructor.
+    constexpr UntaggedUnion() = default;
+    constexpr UntaggedUnion()
+    requires(!(Detail::IsTriviallyConstructible<T> && (Detail::IsTriviallyConstructible<Rest> && ...)))
+    {
+    }
+
+    // Allow container classes to keep their trivial destructor.
+    constexpr ~UntaggedUnion() = default;
+    constexpr ~UntaggedUnion()
+    requires(!(Detail::IsTriviallyDestructible<T> && (Detail::IsTriviallyDestructible<Rest> && ...)))
+    {
+    }
+
+    // Allow container classes to keep their trivial copy constructor.
+    constexpr UntaggedUnion(UntaggedUnion const&) = default;
+    constexpr UntaggedUnion(UntaggedUnion const&)
+    requires(!(Detail::IsTriviallyCopyConstructible<T> && (Detail::IsTriviallyCopyConstructible<Rest> && ...)))
+    {
+    }
+    constexpr UntaggedUnion& operator=(UntaggedUnion const&) = default;
+    constexpr UntaggedUnion& operator=(UntaggedUnion const&)
+    requires(!(Detail::IsTriviallyCopyConstructible<T> && (Detail::IsTriviallyCopyConstructible<Rest> && ...)))
+    {
+        return *this;
+    }
+
+    // Allow container classes to keep their trivial move constructor.
+    constexpr UntaggedUnion(UntaggedUnion&&) = default;
+    constexpr UntaggedUnion(UntaggedUnion&&)
+    requires(!(Detail::IsTriviallyMoveConstructible<T> && (Detail::IsTriviallyMoveConstructible<Rest> && ...)))
+    {
+    }
+    constexpr UntaggedUnion& operator=(UntaggedUnion&&) = default;
+    constexpr UntaggedUnion& operator=(UntaggedUnion&&)
+    requires(!(Detail::IsTriviallyMoveConstructible<T> && (Detail::IsTriviallyMoveConstructible<Rest> && ...)))
+    {
+        return *this;
+    }
+
+    // Construct an untagged union of the first element
+    constexpr UntaggedUnion(T&& v)
+        : value(forward<T>(v))
+    {
+    }
+
+    // Construct an untagged union of one of the remaining elements
+    template<typename U>
+    constexpr UntaggedUnion(U&& v)
+    requires(!IsSame<U, T> && (IsSame<U, Rest> || ...))
+        : next(forward<U>(v))
+    {
+    }
+
+    template<typename U, typename... Args>
+    constexpr void set(Args&&... v)
+    {
+        if constexpr (IsSame<RemoveCV<T>, RemoveCV<U>>) {
+            construct_at(&value, forward<Args>(v)...);
+        } else {
+            next.template set<U>(forward<Args>(v)...);
+        }
+    }
+
+    template<typename U>
+    constexpr U& get()
+    {
+        if constexpr (IsSame<RemoveCV<U>, T> || IsSame<RemoveVolatile<U>, T>) {
+            return value;
+        } else {
+            return next.template get<U>();
+        }
+    }
+
+    template<typename U>
+    constexpr U const& get() const
+    {
+        if constexpr (IsSameIgnoringCV<U, T>) {
+            return value;
+        } else {
+            return next.template get<U>();
+        }
+    }
+
+    union {
+        T value;
+        UntaggedUnion<Rest...> next;
+    };
+};
+
+}
+
+#if USING_AK_GLOBALLY
+using AK::UntaggedUnion;
+#endif

--- a/Libraries/LibIPC/Concepts.h
+++ b/Libraries/LibIPC/Concepts.h
@@ -43,9 +43,7 @@ template<typename T, size_t Size>
 constexpr inline bool IsSharedSingleProducerCircularQueue<Core::SharedSingleProducerCircularQueue<T, Size>> = true;
 
 template<typename T>
-constexpr inline bool IsVariant = false;
-template<typename... Ts>
-constexpr inline bool IsVariant<Variant<Ts...>> = true;
+constexpr inline bool IsVariant = AK::Detail::IsSpecializationOf<T, AK::Detail::Variant>;
 
 template<typename T>
 constexpr inline bool IsVector = false;

--- a/Libraries/LibJS/Runtime/Completion.h
+++ b/Libraries/LibJS/Runtime/Completion.h
@@ -164,7 +164,7 @@ class Optional<JS::Completion> : public OptionalBase<JS::Completion> {
 public:
     using ValueType = JS::Completion;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     Optional(Optional<JS::Completion> const& other)
     {
@@ -172,19 +172,19 @@ public:
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
+    constexpr Optional(Optional&& other)
         : m_value(move(other.m_value))
     {
     }
 
     template<typename U = JS::Completion>
-    explicit(!IsConvertible<U&&, JS::Completion>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, JS::Completion>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<JS::Completion>> && IsConstructible<JS::Completion, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             clear();
@@ -193,7 +193,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -207,18 +207,18 @@ public:
         m_value = JS::Completion(JS::Completion::EmptyTag {});
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_empty();
     }
 
-    [[nodiscard]] JS::Completion& value() &
+    [[nodiscard]] constexpr JS::Completion& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] JS::Completion const& value() const&
+    [[nodiscard]] constexpr JS::Completion const& value() const&
     {
         VERIFY(has_value());
         return m_value;

--- a/Libraries/LibJS/Runtime/Value.h
+++ b/Libraries/LibJS/Runtime/Value.h
@@ -154,7 +154,7 @@ public:
         return !is_nan() && !is_infinity();
     }
 
-    Value()
+    constexpr Value()
         : Value(EMPTY_TAG << GC::TAG_SHIFT, (u64)0)
     {
     }
@@ -419,7 +419,7 @@ private:
     ThrowCompletionOr<Value> to_numeric_slow_case(VM&) const;
     ThrowCompletionOr<Value> to_primitive_slow_case(VM&, PreferredType) const;
 
-    Value(u64 tag, u64 val)
+    constexpr Value(u64 tag, u64 val)
     {
         ASSERT(!(tag & val));
         m_value.encoded = tag | val;
@@ -544,10 +544,10 @@ class Optional<JS::Value> : public OptionalBase<JS::Value> {
 public:
     using ValueType = JS::Value;
 
-    Optional() = default;
+    constexpr Optional() = default;
 
     template<SameAs<OptionalNone> V>
-    Optional(V) { }
+    constexpr Optional(V) { }
 
     Optional(Optional<JS::Value> const& other)
     {
@@ -555,27 +555,27 @@ public:
             m_value = other.m_value;
     }
 
-    Optional(Optional&& other)
+    constexpr Optional(Optional&& other)
         : m_value(other.m_value)
     {
     }
 
     template<typename U = JS::Value>
     requires(!IsSame<OptionalNone, RemoveCVReference<U>>)
-    explicit(!IsConvertible<U&&, JS::Value>) Optional(U&& value)
+    explicit(!IsConvertible<U&&, JS::Value>) constexpr Optional(U&& value)
     requires(!IsSame<RemoveCVReference<U>, Optional<JS::Value>> && IsConstructible<JS::Value, U &&>)
         : m_value(forward<U>(value))
     {
     }
 
     template<SameAs<OptionalNone> V>
-    Optional& operator=(V)
+    constexpr Optional& operator=(V)
     {
         clear();
         return *this;
     }
 
-    Optional& operator=(Optional const& other)
+    constexpr Optional& operator=(Optional const& other)
     {
         if (this != &other) {
             clear();
@@ -584,7 +584,7 @@ public:
         return *this;
     }
 
-    Optional& operator=(Optional&& other)
+    constexpr Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -594,34 +594,34 @@ public:
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    ALWAYS_INLINE constexpr bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    ALWAYS_INLINE constexpr bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    void clear()
+    constexpr void clear()
     {
         m_value = {};
     }
 
-    [[nodiscard]] bool has_value() const
+    [[nodiscard]] constexpr bool has_value() const
     {
         return !m_value.is_empty();
     }
 
-    [[nodiscard]] JS::Value& value() &
+    [[nodiscard]] constexpr JS::Value& value() &
     {
         VERIFY(has_value());
         return m_value;
     }
 
-    [[nodiscard]] JS::Value const& value() const&
+    [[nodiscard]] constexpr JS::Value const& value() const&
     {
         VERIFY(has_value());
         return m_value;

--- a/Libraries/LibTest/Macros.h
+++ b/Libraries/LibTest/Macros.h
@@ -130,6 +130,9 @@ bool assume(T const& expression, StringView expression_string, SourceLocation lo
     return true;
 }
 
+template<typename T>
+consteval void expect_consteval(T) { }
+
 }
 
 #define EXPECT(...)                                    \
@@ -178,6 +181,8 @@ bool assume(T const& expression, StringView expression_string, SourceLocation lo
             ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: {}", __FILE__, __LINE__, message); \
         ::Test::set_current_test_result(::Test::TestResult::Failed);                       \
     } while (false)
+
+#define EXPECT_CONSTEVAL(...) ::Test::expect_consteval(__VA_ARGS__)
 
 // To use, specify the lambda to execute in a sub process and verify it exits:
 //  EXPECT_CRASH("This should fail", []{

--- a/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -278,7 +278,7 @@ void BytecodeInterpreter::binary_numeric_operation(Configuration& configuration,
     } else {
         result = call_result;
     }
-    dbgln_if(WASM_TRACE_DEBUG, "{} {} {} = {}", lhs.value(), Operator::name(), rhs.value(), result);
+    dbgln_if(WASM_TRACE_DEBUG, "{} {} {} = {}", lhs, Operator::name(), rhs, result);
     lhs_entry = Value(result);
 }
 
@@ -298,7 +298,7 @@ void BytecodeInterpreter::unary_operation(Configuration& configuration, Args&&..
     } else {
         result = call_result;
     }
-    dbgln_if(WASM_TRACE_DEBUG, "map({}) {} = {}", Operator::name(), *value, result);
+    dbgln_if(WASM_TRACE_DEBUG, "map({}) {} = {}", Operator::name(), value, result);
     entry = Value(result);
 }
 

--- a/Libraries/LibWasm/Types.h
+++ b/Libraries/LibWasm/Types.h
@@ -371,6 +371,12 @@ private:
     };
 };
 
+struct __MemoryArgument {
+    u32 align;
+    u32 offset;
+    MemoryIndex memory_index = 0;
+};
+
 // https://webassembly.github.io/spec/core/bikeshed/#binary-instr
 // https://webassembly.github.io/spec/core/bikeshed/#reference-instructions%E2%91%A6
 // https://webassembly.github.io/spec/core/bikeshed/#parametric-instructions%E2%91%A6
@@ -412,11 +418,9 @@ public:
         TableIndex table;
     };
 
-    struct MemoryArgument {
-        u32 align;
-        u32 offset;
-        MemoryIndex memory_index { 0 };
-    };
+    // NOTE: This is to work around a bug in GCC
+    // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
+    using MemoryArgument = __MemoryArgument;
 
     struct MemoryAndLaneArgument {
         MemoryArgument memory;

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -705,7 +705,6 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
         return;
 
     bool should_clip_overflow = computed_values().overflow_x() != CSS::Overflow::Visible && computed_values().overflow_y() != CSS::Overflow::Visible;
-    Optional<u32> corner_clip_id;
 
     auto clip_box = absolute_padding_box_rect();
     if (get_clip_rect().has_value()) {

--- a/Libraries/LibWeb/WebDriver/Actions.h
+++ b/Libraries/LibWeb/WebDriver/Actions.h
@@ -22,6 +22,19 @@
 
 namespace Web::WebDriver {
 
+struct __PointerFields {
+    PointerInputSource::Subtype pointer_type { PointerInputSource::Subtype::Mouse };
+    Optional<double> width;
+    Optional<double> height;
+    Optional<double> pressure;
+    Optional<double> tangential_pressure;
+    Optional<i32> tilt_x;
+    Optional<i32> tilt_y;
+    Optional<u32> twist;
+    Optional<double> altitude_angle;
+    Optional<double> azimuth_angle;
+};
+
 // https://w3c.github.io/webdriver/#dfn-action-object
 struct ActionObject {
     enum class Subtype {
@@ -49,18 +62,9 @@ struct ActionObject {
         u32 value { 0 };
     };
 
-    struct PointerFields {
-        PointerInputSource::Subtype pointer_type { PointerInputSource::Subtype::Mouse };
-        Optional<double> width;
-        Optional<double> height;
-        Optional<double> pressure;
-        Optional<double> tangential_pressure;
-        Optional<i32> tilt_x;
-        Optional<i32> tilt_y;
-        Optional<u32> twist;
-        Optional<double> altitude_angle;
-        Optional<double> azimuth_angle;
-    };
+    // NOTE: This is to work around a bug in GCC
+    // See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=88165
+    using PointerFields = __PointerFields;
 
     struct PointerUpDownFields : public PointerFields {
         UIEvents::MouseButton button { UIEvents::MouseButton::None };

--- a/Tests/ClangPlugins/CMakeLists.txt
+++ b/Tests/ClangPlugins/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND CLANG_PLUGINS_COMPILE_OPTIONS_FOR_TESTS
     -Wno-literal-range
     -Wno-unknown-warning-option
     -Wno-unqualified-std-cast-call
+    -fgnuc-version=4.2.1 # NOTE: Clang default as of 10.0.0
 )
 
 # Ensure we always check for invalid function field types regardless of the value of ENABLE_CLANG_PLUGINS_INVALID_FUNCTION_MEMBERS


### PR DESCRIPTION
Nearly a complete rewrite, using `UntaggedUnion<...>` to handle constexpr storage. The `MergeAndDeduplicatePacks` mechanism has been replaced with a more generic variant that just removes duplicate types from type packs. This also means that duplicate types now have a shared index, i.e. `Variant<int, int, int, bool> { true }.index() == 1`.