### PR TITLE
LibWeb: Set generated constructors' prototype correctly

### DIFF
--- a/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Libraries/LibJS/Runtime/FunctionObject.h
@@ -21,7 +21,7 @@ class FunctionObject : public Object {
 public:
     virtual ~FunctionObject() = default;
 
-    // Table 7: Additional Essential Internal Methods of Function Objects, https://tc39.es/ecma262/#table-additional-essential-internal-methods-of-function-objects
+    // Table 5: Additional Essential Internal Methods of Function Objects, https://tc39.es/ecma262/#table-additional-essential-internal-methods-of-function-objects
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, ReadonlySpan<Value> arguments_list) = 0;
     virtual ThrowCompletionOr<GC::Ref<Object>> internal_construct([[maybe_unused]] ReadonlySpan<Value> arguments_list, [[maybe_unused]] FunctionObject& new_target) { VERIFY_NOT_REACHED(); }

--- a/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -30,9 +30,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(symbol_has_instance);
 
-    // Totally unnecessary, but sadly still necessary.
-    // TODO: Get rid of the pointless name() method.
-    DeprecatedFlyString m_name { "FunctionPrototype" };
+    // 20.2.3: The Function prototype object has a "name" property whose value is the empty String.
+    DeprecatedFlyString m_name;
 };
 
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -4022,7 +4022,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::for_each)
         generate_variable_statement(iterator_generator, "wrapped_key", interface.pair_iterator_types->get<0>(), "key", interface);
         generate_variable_statement(iterator_generator, "wrapped_value", interface.pair_iterator_types->get<1>(), "value", interface);
         iterator_generator.append(R"~~~(
-        TRY(call(vm, callback.as_function(), vm.argument(1), wrapped_value, wrapped_key, this_value));
+        TRY(JS::call(vm, callback.as_function(), vm.argument(1), wrapped_value, wrapped_key, this_value));
         return {};
     }));
 
@@ -4100,7 +4100,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::for_each)
 
     for (auto& entry : *set) {
         auto value = entry.key;
-        TRY(call(vm, callback.as_function(), vm.argument(1), value, value, impl));
+        TRY(JS::call(vm, callback.as_function(), vm.argument(1), value, value, impl));
     }
 
     return JS::js_undefined();

--- a/Tests/LibWeb/Text/expected/SVG/svg-element-proto.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-element-proto.txt
@@ -1,0 +1,5 @@
+function SVGElement() { [native code] }
+function Element() { [native code] }
+function Node() { [native code] }
+function EventTarget() { [native code] }
+function () { [native code] }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/cssom.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-nesting/cssom.txt
@@ -6,10 +6,10 @@ Rerun
 
 Found 13 tests
 
-11 Pass
-2 Fail
+12 Pass
+1 Fail
 Details
-Result	Test Name	MessageFail	CSSStyleRule is a CSSGroupingRule	
+Result	Test Name	MessagePass	CSSStyleRule is a CSSGroupingRule	
 Pass	Simple CSSOM manipulation of subrules	
 Pass	Simple CSSOM manipulation of subrules 1	
 Pass	Simple CSSOM manipulation of subrules 2	

--- a/Tests/LibWeb/Text/input/SVG/svg-element-proto.html
+++ b/Tests/LibWeb/Text/input/SVG/svg-element-proto.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(SVGElement.toString());
+        println(SVGElement.__proto__.toString());
+        println(SVGElement.__proto__.__proto__.toString());
+        println(SVGElement.__proto__.__proto__.__proto__.toString());
+        println(SVGElement.__proto__.__proto__.__proto__.__proto__.toString());
+    });
+</script>


### PR DESCRIPTION
We were defaulting to `FunctionPrototype` and never actually setting the IDL interface's parent prototype. This fixes the output of `{SomeInterface}.__proto__.toString()`.

Because WPT uses the `.__proto__.toString()` pattern to check interface inheritance, this also fixes a number of subtests. I'm uncertain as to the total amount of tests, but `svg` improved with +32 passes, `WebCryptoAPI` with +23, `dom/idlharness*` with +19 and `webaudio` with +12.