### PR TITLE
LibWeb: Update `Screen` IDL definition to not inherit from `EventTarget`

### DIFF
--- a/Libraries/LibWeb/CSS/Screen.idl
+++ b/Libraries/LibWeb/CSS/Screen.idl
@@ -4,7 +4,7 @@
 
 // https://w3c.github.io/csswg-drafts/cssom-view-1/#screen
 [Exposed=Window]
-interface Screen : EventTarget {
+interface Screen {
     readonly attribute long availWidth;
     readonly attribute long availHeight;
     readonly attribute long width;


### PR DESCRIPTION
Followup to: https://github.com/LadybirdBrowser/ladybird/pull/2586#issuecomment-2500686474