### PR TITLE
LibWeb: Implement `HTMLElement.inputMode` and `HTMLElement.enterKeyHint`

### DIFF
--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -71,6 +71,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(download)                   \
     __ENUMERATE_HTML_ATTRIBUTE(enctype)                    \
     __ENUMERATE_HTML_ATTRIBUTE(ended)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(enterkeyhint)               \
     __ENUMERATE_HTML_ATTRIBUTE(event)                      \
     __ENUMERATE_HTML_ATTRIBUTE(face)                       \
     __ENUMERATE_HTML_ATTRIBUTE(fetchpriority)              \

--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -100,6 +100,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(is)                         \
     __ENUMERATE_HTML_ATTRIBUTE(iscontenteditable)          \
     __ENUMERATE_HTML_ATTRIBUTE(ismap)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(inputmode)                  \
     __ENUMERATE_HTML_ATTRIBUTE(itemscope)                  \
     __ENUMERATE_HTML_ATTRIBUTE(kind)                       \
     __ENUMERATE_HTML_ATTRIBUTE(label)                      \

--- a/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -52,6 +52,17 @@ HTMLElement includes GlobalEventHandlers;
 HTMLElement includes ElementContentEditable;
 HTMLElement includes HTMLOrSVGElement;
 
+// https://html.spec.whatwg.org/multipage/interaction.html#attr-enterkeyhint
+enum EnterKeyHint {
+    "enter",
+    "done",
+    "go",
+    "next",
+    "previous",
+    "search",
+    "send"
+};
+
 // https://html.spec.whatwg.org/#attr-inputmode
 enum InputMode {
     "none",
@@ -67,7 +78,7 @@ enum InputMode {
 // https://html.spec.whatwg.org/#elementcontenteditable
 interface mixin ElementContentEditable {
     [CEReactions] attribute DOMString contentEditable;
-    [FIXME, CEReactions] attribute DOMString enterKeyHint;
+    [Reflect=enterkeyhint, Enumerated=EnterKeyHint, CEReactions] attribute DOMString enterKeyHint;
     readonly attribute boolean isContentEditable;
     [Reflect=inputmode, Enumerated=InputMode, CEReactions] attribute DOMString inputMode;
 };

--- a/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -52,12 +52,24 @@ HTMLElement includes GlobalEventHandlers;
 HTMLElement includes ElementContentEditable;
 HTMLElement includes HTMLOrSVGElement;
 
+// https://html.spec.whatwg.org/#attr-inputmode
+enum InputMode {
+    "none",
+    "text",
+    "tel",
+    "url",
+    "email",
+    "numeric",
+    "decimal",
+    "search"
+};
+
 // https://html.spec.whatwg.org/#elementcontenteditable
 interface mixin ElementContentEditable {
     [CEReactions] attribute DOMString contentEditable;
     [FIXME, CEReactions] attribute DOMString enterKeyHint;
     readonly attribute boolean isContentEditable;
-    [FIXME, CEReactions] attribute DOMString inputMode;
+    [Reflect=inputmode, Enumerated=InputMode, CEReactions] attribute DOMString inputMode;
 };
 
 HTMLElement includes ElementCSSInlineStyle;


### PR DESCRIPTION
These reflect the values of their respective content elements.

This fixes all 234 failing subtests in http://wpt.live/html/dom/reflection-misc.html 

I wasn't sure whether or not to import the fixed WPT test or not since its relatively slow. It has 4877 subtests and takes 1.5 seconds to run on my machine.