### PR TITLE
LibJS: Implement Date-related Temporal modifications

### DIFF
--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -538,6 +538,7 @@ namespace JS {
     P(toSpliced)                             \
     P(toString)                              \
     P(total)                                 \
+    P(toTemporalInstant)                     \
     P(toTimeString)                          \
     P(toUpperCase)                           \
     P(toUTCString)                           \

--- a/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Libraries/LibJS/Runtime/DatePrototype.h
@@ -65,6 +65,8 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(to_time_string);
     JS_DECLARE_NATIVE_FUNCTION(to_utc_string);
 
+    JS_DECLARE_NATIVE_FUNCTION(to_temporal_instant);
+
     JS_DECLARE_NATIVE_FUNCTION(get_year);
     JS_DECLARE_NATIVE_FUNCTION(set_year);
     JS_DECLARE_NATIVE_FUNCTION(to_gmt_string);

--- a/Libraries/LibJS/Runtime/Temporal/Now.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Now.cpp
@@ -119,6 +119,19 @@ JS_DEFINE_NATIVE_FUNCTION(Now::plain_time_iso)
     return MUST(create_temporal_time(vm, iso_date_time.time));
 }
 
+// 2.3.2 SystemUTCEpochMilliseconds ( ), https://tc39.es/proposal-temporal/#sec-temporal-systemutcepochmilliseconds
+double system_utc_epoch_milliseconds(VM& vm)
+{
+    // 1. Let global be GetGlobalObject().
+    auto const& global = vm.get_global_object();
+
+    // 2. Let nowNs be HostSystemUTCEpochNanoseconds(global).
+    auto now_ns = vm.host_system_utc_epoch_nanoseconds(global);
+
+    // 3. Return 𝔽(floor(nowNs / 10**6)).
+    return big_floor(now_ns, NANOSECONDS_PER_MILLISECOND).to_double();
+}
+
 // 2.3.3 SystemUTCEpochNanoseconds ( ), https://tc39.es/proposal-temporal/#sec-temporal-systemutcepochnanoseconds
 Crypto::SignedBigInteger system_utc_epoch_nanoseconds(VM& vm)
 {

--- a/Libraries/LibJS/Runtime/Temporal/Now.h
+++ b/Libraries/LibJS/Runtime/Temporal/Now.h
@@ -32,6 +32,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(plain_time_iso);
 };
 
+double system_utc_epoch_milliseconds(VM&);
 Crypto::SignedBigInteger system_utc_epoch_nanoseconds(VM&);
 ThrowCompletionOr<ISODateTime> system_date_time(VM&, Value temporal_time_zone_like);
 

--- a/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -67,6 +67,12 @@ test("basic functionality", () => {
 test("time clip", () => {
     expect(Date.parse("+999999")).toBeNaN();
     expect(Date.parse("-999999")).toBeNaN();
+
+    const belowMinDate = "-271821-04-19T23:59:59.999Z";
+    expect(belowMinDate).toBeNaN();
+
+    const aboveMaxDate = "+275760-09-13T00:00:00.001Z";
+    expect(aboveMaxDate).toBeNaN();
 });
 
 test("extra micro seconds extension", () => {

--- a/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toTemporalInstant.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toTemporalInstant.js
@@ -1,0 +1,15 @@
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        const date = new Date("2021-07-09T01:36:00Z");
+        const instant = date.toTemporalInstant();
+        expect(instant.epochMilliseconds).toBe(1625794560000);
+    });
+});
+
+describe("errors", () => {
+    test("this value must be a Date object", () => {
+        expect(() => {
+            Date.prototype.toTemporalInstant.call(123);
+        }).toThrowWithMessage(TypeError, "Not an object of type Date");
+    });
+});


### PR DESCRIPTION
\+ a flyby fix to `Date.parse` so that we pass all `Date` test262 tests :)

test262 diff:
```
Diff Tests:
    +9 ✅    -9 ❌

Diff Tests:
    test/built-ins/Date/parse/time-value-maximum-range.js                      ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/length.js                  ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/name.js                    ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/not-a-constructor.js       ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/prop-desc.js               ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/this-value-invalid-date.js ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/this-value-non-date.js     ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/this-value-non-object.js   ❌ -> ✅
    test/built-ins/Date/prototype/toTemporalInstant/this-value-valid-date.js   ❌ -> ✅
```