### PR TITLE
LibWeb: Use `[URL]` extended attribute for `HTMLVideoElement.poster`

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLVideoElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.idl
@@ -10,7 +10,7 @@ interface HTMLVideoElement : HTMLMediaElement {
     [CEReactions, Reflect] attribute unsigned long height;
     readonly attribute unsigned long videoWidth;
     readonly attribute unsigned long videoHeight;
-    [CEReactions, Reflect] attribute USVString poster;
+    [CEReactions, Reflect, URL] attribute USVString poster;
     [CEReactions, Reflect=playsinline] attribute boolean playsInline;
 
 };

--- a/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
+++ b/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
@@ -13,6 +13,7 @@ object.data final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 script.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 source.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 track.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+video.poster final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 video.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 q.cite final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 blockquote.cite final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD

--- a/Tests/LibWeb/Text/input/usvstring-url-reflection.html
+++ b/Tests/LibWeb/Text/input/usvstring-url-reflection.html
@@ -18,6 +18,7 @@
             { "script": "src" },
             { "source": "src" },
             { "track": "src" },
+            { "video": "poster" },
             { "video": "src" },
             { "q": "cite" },
             { "blockquote": "cite" },


### PR DESCRIPTION
This fixes 40 subtests in http://wpt.live/html/dom/reflection-embedded.html