### PR TITLE
LibJS: Use correct epoch offset in InterpretISODateTimeOffset

### DIFF
--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -114,7 +114,7 @@ ThrowCompletionOr<Crypto::SignedBigInteger> interpret_iso_date_time_offset(VM& v
             auto rounded_candidate_nanoseconds = round_number_to_increment(candidate_offset, NANOSECONDS_PER_MINUTE, RoundingMode::HalfExpand);
 
             // ii. If roundedCandidateNanoseconds = offsetNanoseconds, then
-            if (candidate_offset.compare_to_double(offset_nanoseconds) == Crypto::UnsignedBigInteger::CompareResult::DoubleEqualsBigInt) {
+            if (rounded_candidate_nanoseconds.compare_to_double(offset_nanoseconds) == Crypto::UnsignedBigInteger::CompareResult::DoubleEqualsBigInt) {
                 // 1. Return candidate.
                 return move(candidate);
             }

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
@@ -39,6 +39,16 @@ describe("correct behavior", () => {
             expect(result).toBe(1);
         });
     });
+
+    test("match minutes", () => {
+        const duration = new Temporal.Duration(1, 0, 0, 0, 24);
+
+        const result = duration.total({
+            unit: "days",
+            relativeTo: "1970-01-01T00:00:00-00:45[Africa/Monrovia]",
+        });
+        expect(result).toBe(366);
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
We were comparing the incorrect offset.

test262 diff:
```
Diff Tests:
    +5 ✅    -5 ❌

Diff Tests:
    test/intl402/Temporal/Duration/compare/relativeto-sub-minute-offset.js         ❌ -> ✅
    test/intl402/Temporal/Duration/prototype/round/relativeto-sub-minute-offset.js ❌ -> ✅
    test/intl402/Temporal/Duration/prototype/total/relativeto-sub-minute-offset.js ❌ -> ✅
    test/intl402/Temporal/ZonedDateTime/from/zoneddatetime-sub-minute-offset.js    ❌ -> ✅
    test/intl402/Temporal/ZonedDateTime/prototype/equals/sub-minute-offset.js      ❌ -> ✅
```