### PR TITLE
LibWeb: Use [Reflect] to implement `HTMLImageElement.decoding`

### DIFF
--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -60,6 +60,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(data)                       \
     __ENUMERATE_HTML_ATTRIBUTE(datetime)                   \
     __ENUMERATE_HTML_ATTRIBUTE(declare)                    \
+    __ENUMERATE_HTML_ATTRIBUTE(decoding)                   \
     __ENUMERATE_HTML_ATTRIBUTE(default_)                   \
     __ENUMERATE_HTML_ATTRIBUTE(defaultchecked)             \
     __ENUMERATE_HTML_ATTRIBUTE(defaultselected)            \

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -127,6 +127,11 @@ void HTMLImageElement::form_associated_element_attribute_changed(FlyString const
         if (layout_node())
             did_update_alt_text(verify_cast<Layout::ImageBox>(*layout_node()));
     }
+
+    if (name == HTML::AttributeNames::decoding) {
+        if (value.has_value() && (value->equals_ignoring_ascii_case("sync"sv) || value->equals_ignoring_ascii_case("async"sv)))
+            dbgln("FIXME: HTMLImageElement.decoding = '{}' is not implemented yet", value->to_ascii_lowercase());
+    }
 }
 
 GC::Ptr<Layout::Node> HTMLImageElement::create_layout_node(CSS::StyleProperties style)
@@ -1169,32 +1174,6 @@ void HTMLImageElement::animate()
 
     if (paintable())
         paintable()->set_needs_display();
-}
-
-StringView HTMLImageElement::decoding() const
-{
-    switch (m_decoding_hint) {
-    case ImageDecodingHint::Sync:
-        return "sync"sv;
-    case ImageDecodingHint::Async:
-        return "async"sv;
-    case ImageDecodingHint::Auto:
-        return "auto"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-void HTMLImageElement::set_decoding(String decoding)
-{
-    if (decoding == "sync"sv) {
-        dbgln("FIXME: HTMLImageElement.decoding = 'sync' is not implemented yet");
-        m_decoding_hint = ImageDecodingHint::Sync;
-    } else if (decoding == "async"sv) {
-        dbgln("FIXME: HTMLImageElement.decoding = 'async' is not implemented yet");
-        m_decoding_hint = ImageDecodingHint::Async;
-    } else
-        m_decoding_hint = ImageDecodingHint::Auto;
 }
 
 bool HTMLImageElement::allows_auto_sizes() const

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -87,10 +87,6 @@ public:
     // https://html.spec.whatwg.org/multipage/images.html#select-an-image-source
     [[nodiscard]] Optional<ImageSourceAndPixelDensity> select_an_image_source();
 
-    StringView decoding() const;
-
-    void set_decoding(String);
-
     void set_source_set(SourceSet);
 
     ImageRequest& current_request() { return *m_current_request; }
@@ -162,15 +158,6 @@ private:
     SourceSet m_source_set;
 
     CSSPixelSize m_last_seen_viewport_size;
-
-    // https://html.spec.whatwg.org/multipage/images.html#image-decoding-hint
-    enum class ImageDecodingHint {
-        Auto,
-        Sync,
-        Async
-    };
-
-    ImageDecodingHint m_decoding_hint = ImageDecodingHint::Auto;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -2,6 +2,14 @@
 #import <HTML/HTMLElement.idl>
 #import <HTML/Scripting/Fetching.idl>
 
+// https://html.spec.whatwg.org/multipage/images.html#image-decoding-hint
+[MissingValueDefault=auto, InvalidValueDefault=auto]
+enum Decoding {
+    "sync",
+    "async",
+    "auto"
+};
+
 // https://html.spec.whatwg.org/multipage/embedded-content.html#htmlimageelement
 [Exposed=Window, LegacyFactoryFunction=Image(optional unsigned long width, optional unsigned long height)]
 interface HTMLImageElement : HTMLElement {
@@ -22,7 +30,7 @@ interface HTMLImageElement : HTMLElement {
     readonly attribute boolean complete;
     readonly attribute USVString currentSrc;
     [CEReactions, Reflect=referrerpolicy, Enumerated=ReferrerPolicy] attribute DOMString referrerPolicy;
-    [CEReactions] attribute DOMString decoding;
+    [CEReactions, Enumerated=Decoding, Reflect] attribute DOMString decoding;
     [CEReactions, Enumerated=LazyLoadingAttribute, Reflect] attribute DOMString loading;
     [CEReactions, Enumerated=FetchPriorityAttribute, Reflect=fetchpriority] attribute DOMString fetchPriority;
 


### PR DESCRIPTION
This ensures the correct behavior when the value of the `decoding` attribute is changed with `setAttribute()`.

Fixes 36 subtests in: http://wpt.live/html/dom/reflection-embedded.html