### PR TITLE
IDLGenerators: Set reflected unsigned long values according to spec

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMarqueeElement.cpp
@@ -67,7 +67,7 @@ WebIDL::UnsignedLong HTMLMarqueeElement::scroll_amount()
 {
     // The scrollAmount IDL attribute must reflect the scrollamount content attribute. The default value is 6.
     if (auto scroll_amount_string = get_attribute(HTML::AttributeNames::scrollamount); scroll_amount_string.has_value()) {
-        if (auto scroll_amount = parse_non_negative_integer(*scroll_amount_string); scroll_amount.has_value())
+        if (auto scroll_amount = parse_non_negative_integer(*scroll_amount_string); scroll_amount.has_value() && *scroll_amount <= 2147483647)
             return *scroll_amount;
     }
     return 6;
@@ -76,6 +76,8 @@ WebIDL::UnsignedLong HTMLMarqueeElement::scroll_amount()
 // https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-scrollamount
 WebIDL::ExceptionOr<void> HTMLMarqueeElement::set_scroll_amount(WebIDL::UnsignedLong value)
 {
+    if (value > 2147483647)
+        value = 6;
     return set_attribute(HTML::AttributeNames::scrollamount, String::number(value));
 }
 
@@ -84,7 +86,7 @@ WebIDL::UnsignedLong HTMLMarqueeElement::scroll_delay()
 {
     // The scrollDelay IDL attribute must reflect the scrolldelay content attribute. The default value is 85.
     if (auto scroll_delay_string = get_attribute(HTML::AttributeNames::scrolldelay); scroll_delay_string.has_value()) {
-        if (auto scroll_delay = parse_non_negative_integer(*scroll_delay_string); scroll_delay.has_value())
+        if (auto scroll_delay = parse_non_negative_integer(*scroll_delay_string); scroll_delay.has_value() && *scroll_delay <= 2147483647)
             return *scroll_delay;
     }
     return 85;
@@ -93,6 +95,8 @@ WebIDL::UnsignedLong HTMLMarqueeElement::scroll_delay()
 // https://html.spec.whatwg.org/multipage/obsolete.html#dom-marquee-scrolldelay
 WebIDL::ExceptionOr<void> HTMLMarqueeElement::set_scroll_delay(WebIDL::UnsignedLong value)
 {
+    if (value > 2147483647)
+        value = 85;
     return set_attribute(HTML::AttributeNames::scrolldelay, String::number(value));
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -293,7 +293,7 @@ unsigned HTMLTextAreaElement::cols() const
 {
     // The cols and rows attributes are limited to only positive numbers with fallback. The cols IDL attribute's default value is 20.
     if (auto cols_string = get_attribute(HTML::AttributeNames::cols); cols_string.has_value()) {
-        if (auto cols = parse_non_negative_integer(*cols_string); cols.has_value() && *cols > 0)
+        if (auto cols = parse_non_negative_integer(*cols_string); cols.has_value() && *cols > 0 && *cols <= 2147483647)
             return *cols;
     }
     return 20;
@@ -301,6 +301,9 @@ unsigned HTMLTextAreaElement::cols() const
 
 WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_cols(unsigned cols)
 {
+    if (cols > 2147483647)
+        cols = 20;
+
     return set_attribute(HTML::AttributeNames::cols, String::number(cols));
 }
 
@@ -309,7 +312,7 @@ unsigned HTMLTextAreaElement::rows() const
 {
     // The cols and rows attributes are limited to only positive numbers with fallback. The rows IDL attribute's default value is 2.
     if (auto rows_string = get_attribute(HTML::AttributeNames::rows); rows_string.has_value()) {
-        if (auto rows = parse_non_negative_integer(*rows_string); rows.has_value() && *rows > 0)
+        if (auto rows = parse_non_negative_integer(*rows_string); rows.has_value() && *rows > 0 && *rows <= 2147483647)
             return *rows;
     }
     return 2;
@@ -317,6 +320,9 @@ unsigned HTMLTextAreaElement::rows() const
 
 WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_rows(unsigned rows)
 {
+    if (rows > 2147483647)
+        rows = 2;
+
     return set_attribute(HTML::AttributeNames::rows, String::number(rows));
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3834,6 +3834,22 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     else
         MUST(impl->set_attribute(HTML::AttributeNames::@attribute.reflect_name@, String {}));
 )~~~");
+                } else if (attribute.type->name() == "unsigned long") {
+                    // The setter steps are:
+                    // FIXME: 1. If the reflected IDL attribute is limited to only positive numbers and the given value is 0, then throw an "IndexSizeError" DOMException.
+                    // 2. Let minimum be 0.
+                    // FIXME: 3. If the reflected IDL attribute is limited to only positive numbers or limited to only positive numbers with fallback, then set minimum to 1.
+                    // 4. Let newValue be minimum.
+                    // FIXME: 5. If the reflected IDL attribute has a default value, then set newValue to defaultValue.
+                    // 6. If the given value is in the range minimum to 2147483647, inclusive, then set newValue to it.
+                    // 7. Run this's set the content attribute with newValue converted to the shortest possible string representing the number as a valid non-negative integer.
+                    attribute_generator.append(R"~~~(
+    u32 minimum = 0;
+    u32 new_value = minimum;
+    if (cpp_value >= minimum && cpp_value <= 2147483647)
+        new_value = cpp_value;
+    MUST(impl->set_attribute(HTML::AttributeNames::@attribute.reflect_name@, String::number(new_value)));
+)~~~");
                 } else if (attribute.type->is_integer() && !attribute.type->is_nullable()) {
                     attribute_generator.append(R"~~~(
     MUST(impl->set_attribute(HTML::AttributeNames::@attribute.reflect_name@, String::number(cpp_value)));

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -46,3 +46,35 @@ marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "4
 marquee.scrollDelay after marquee.setAttribute("scrolldelay", "4294967295"): 85
 marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 4294967295: 85
 marquee.scrollDelay after marquee.scrollDelay = 4294967295: 85
+textarea.getAttribute("rows") after textarea.setAttribute("rows", "1"): 1
+textarea.rows after textarea.setAttribute("rows", "1"): 1
+textarea.getAttribute("rows") after textarea.rows = 1: 1
+textarea.rows after textarea.rows = 1: 1
+textarea.getAttribute("rows") after textarea.setAttribute("rows", "2147483647"): 2147483647
+textarea.rows after textarea.setAttribute("rows", "2147483647"): 2147483647
+textarea.getAttribute("rows") after textarea.rows = 2147483647: 2147483647
+textarea.rows after textarea.rows = 2147483647: 2147483647
+textarea.getAttribute("rows") after textarea.setAttribute("rows", "2147483648"): 2147483648
+textarea.rows after textarea.setAttribute("rows", "2147483648"): 2
+textarea.getAttribute("rows") after textarea.rows = 2147483648: 2
+textarea.rows after textarea.rows = 2147483648: 2
+textarea.getAttribute("rows") after textarea.setAttribute("rows", "4294967295"): 4294967295
+textarea.rows after textarea.setAttribute("rows", "4294967295"): 2
+textarea.getAttribute("rows") after textarea.rows = 4294967295: 2
+textarea.rows after textarea.rows = 4294967295: 2
+textarea.getAttribute("cols") after textarea.setAttribute("cols", "1"): 1
+textarea.cols after textarea.setAttribute("cols", "1"): 1
+textarea.getAttribute("cols") after textarea.cols = 1: 1
+textarea.cols after textarea.cols = 1: 1
+textarea.getAttribute("cols") after textarea.setAttribute("cols", "2147483647"): 2147483647
+textarea.cols after textarea.setAttribute("cols", "2147483647"): 2147483647
+textarea.getAttribute("cols") after textarea.cols = 2147483647: 2147483647
+textarea.cols after textarea.cols = 2147483647: 2147483647
+textarea.getAttribute("cols") after textarea.setAttribute("cols", "2147483648"): 2147483648
+textarea.cols after textarea.setAttribute("cols", "2147483648"): 20
+textarea.getAttribute("cols") after textarea.cols = 2147483648: 20
+textarea.cols after textarea.cols = 2147483648: 20
+textarea.getAttribute("cols") after textarea.setAttribute("cols", "4294967295"): 4294967295
+textarea.cols after textarea.setAttribute("cols", "4294967295"): 20
+textarea.getAttribute("cols") after textarea.cols = 4294967295: 20
+textarea.cols after textarea.cols = 4294967295: 20

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -14,3 +14,35 @@ img.getAttribute("hspace") after img.setAttribute("hspace", "4294967295"): 42949
 img.hspace after img.setAttribute("hspace", "4294967295"): 0
 img.getAttribute("hspace") after img.hspace = 4294967295: 0
 img.hspace after img.hspace = 4294967295: 0
+marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "1"): 1
+marquee.scrollAmount after marquee.setAttribute("scrollamount", "1"): 1
+marquee.getAttribute("scrollamount") after marquee.scrollAmount = 1: 1
+marquee.scrollAmount after marquee.scrollAmount = 1: 1
+marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "2147483647"): 2147483647
+marquee.scrollAmount after marquee.setAttribute("scrollamount", "2147483647"): 2147483647
+marquee.getAttribute("scrollamount") after marquee.scrollAmount = 2147483647: 2147483647
+marquee.scrollAmount after marquee.scrollAmount = 2147483647: 2147483647
+marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "2147483648"): 2147483648
+marquee.scrollAmount after marquee.setAttribute("scrollamount", "2147483648"): 6
+marquee.getAttribute("scrollamount") after marquee.scrollAmount = 2147483648: 6
+marquee.scrollAmount after marquee.scrollAmount = 2147483648: 6
+marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "4294967295"): 4294967295
+marquee.scrollAmount after marquee.setAttribute("scrollamount", "4294967295"): 6
+marquee.getAttribute("scrollamount") after marquee.scrollAmount = 4294967295: 6
+marquee.scrollAmount after marquee.scrollAmount = 4294967295: 6
+marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "1"): 1
+marquee.scrollDelay after marquee.setAttribute("scrolldelay", "1"): 1
+marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 1: 1
+marquee.scrollDelay after marquee.scrollDelay = 1: 1
+marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "2147483647"): 2147483647
+marquee.scrollDelay after marquee.setAttribute("scrolldelay", "2147483647"): 2147483647
+marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 2147483647: 2147483647
+marquee.scrollDelay after marquee.scrollDelay = 2147483647: 2147483647
+marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "2147483648"): 2147483648
+marquee.scrollDelay after marquee.setAttribute("scrolldelay", "2147483648"): 85
+marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 2147483648: 85
+marquee.scrollDelay after marquee.scrollDelay = 2147483648: 85
+marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "4294967295"): 4294967295
+marquee.scrollDelay after marquee.setAttribute("scrolldelay", "4294967295"): 85
+marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 4294967295: 85
+marquee.scrollDelay after marquee.scrollDelay = 4294967295: 85

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -1,0 +1,16 @@
+img.getAttribute("hspace") after img.setAttribute("hspace", "1"): 1
+img.hspace after img.setAttribute("hspace", "1"): 1
+img.getAttribute("hspace") after img.hspace = 1: 1
+img.hspace after img.hspace = 1: 1
+img.getAttribute("hspace") after img.setAttribute("hspace", "2147483647"): 2147483647
+img.hspace after img.setAttribute("hspace", "2147483647"): 2147483647
+img.getAttribute("hspace") after img.hspace = 2147483647: 2147483647
+img.hspace after img.hspace = 2147483647: 2147483647
+img.getAttribute("hspace") after img.setAttribute("hspace", "2147483648"): 2147483648
+img.hspace after img.setAttribute("hspace", "2147483648"): 0
+img.getAttribute("hspace") after img.hspace = 2147483648: 0
+img.hspace after img.hspace = 2147483648: 0
+img.getAttribute("hspace") after img.setAttribute("hspace", "4294967295"): 4294967295
+img.hspace after img.setAttribute("hspace", "4294967295"): 0
+img.getAttribute("hspace") after img.hspace = 4294967295: 0
+img.hspace after img.hspace = 4294967295: 0

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -23,5 +23,7 @@
         }
 
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
+        testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
+        testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -25,5 +25,7 @@
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
+        testProperty("textarea", "rows", (textarea) => textarea.rows, (textarea, value) => textarea.rows = value);
+        testProperty("textarea", "cols", (textarea) => textarea.cols, (textarea, value) => textarea.cols = value);
     });
 </script>

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        function testProperty(elementName, propertyName, propertyGetter, propertySetter) {
+            const attributeName = propertyName.toLowerCase();
+            function setValue(value) {
+                let element = document.createElement(elementName);
+                element.setAttribute(attributeName, value.toString());
+                println(`${elementName}.getAttribute("${attributeName}") after ${elementName}.setAttribute("${propertyName}", "${value}"): ${element.getAttribute(`${attributeName}`)}`);
+                println(`${elementName}.${propertyName} after ${elementName}.setAttribute("${attributeName}", "${value}"): ${propertyGetter(element)}`);
+
+                element = document.createElement(elementName);
+                propertySetter(element, value);
+                println(`${elementName}.getAttribute("${attributeName}") after ${elementName}.${propertyName} = ${value}: ${element.getAttribute(attributeName)}`);
+                println(`${elementName}.${propertyName} after ${elementName}.${propertyName} = ${value}: ${propertyGetter(element)}`);
+            }
+
+            setValue(1);
+            setValue(2147483647);
+            setValue(2147483648);
+            setValue(4294967295);
+        }
+
+        testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
+    });
+</script>


### PR DESCRIPTION
Setting an unsigned long attribute with IDL to a value outside the range 0 to 2147483647, the value should be set to 0.

Fixes 4 subtests in  http://wpt.live/html/dom/reflection-obsolete.html and 12 subtests in  http://wpt.live/html/dom/reflection-embedded.html