### PR TITLE
LibWeb: Use `[URL]` extended attribute for `HTMLInputElement.src`

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -36,7 +36,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect=readonly] attribute boolean readOnly;
     [CEReactions, Reflect] attribute boolean required;
     [CEReactions] attribute unsigned long size;
-    [CEReactions, Reflect] attribute USVString src;
+    [CEReactions, Reflect, URL] attribute USVString src;
     [CEReactions, Reflect] attribute DOMString step;
     [CEReactions] attribute DOMString type;
     [CEReactions, Reflect=value] attribute DOMString defaultValue;

--- a/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
+++ b/Tests/LibWeb/Text/expected/usvstring-url-reflection.txt
@@ -7,6 +7,7 @@ iframe.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 img.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 img.longDesc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 img.lowsrc final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
+input.src final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 link.href final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 object.codeBase final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD
 object.data final URL path segment: %EF%BF%BDa%EF%BF%BDb%EF%BF%BD

--- a/Tests/LibWeb/Text/input/usvstring-url-reflection.html
+++ b/Tests/LibWeb/Text/input/usvstring-url-reflection.html
@@ -12,6 +12,7 @@
             { "img": "src" },
             { "img": "longDesc" },
             { "img": "lowsrc" },
+            { "input": "src" },
             { "link": "href" },
             { "object": "codeBase" },
             { "object": "data" },


### PR DESCRIPTION
This fixes 40 subtests in:  http://wpt.live/html/dom/reflection-forms-weekmonth.html