### PR TITLE
Attempt to implement WebAssembly errors

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -778,6 +778,7 @@ set(SOURCES
     WebAssembly/Module.cpp
     WebAssembly/Table.cpp
     WebAssembly/WebAssembly.cpp
+    WebAssembly/Error.cpp
     WebAudio/AudioBuffer.cpp
     WebAudio/AudioBufferSourceNode.cpp
     WebAudio/AudioContext.cpp

--- a/Libraries/LibWeb/WebAssembly/Error.cpp
+++ b/Libraries/LibWeb/WebAssembly/Error.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Pavel Shliak <shlyakpavel@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Error.h"
+#include <LibJS/Runtime/GlobalObject.h>
+
+namespace Web::WebAssembly {
+
+GC_DEFINE_ALLOCATOR(CompileError);
+
+GC::Ref<CompileError> CompileError::create(JS::Realm& realm)
+{
+    return realm.heap().allocate<CompileError>(realm.intrinsics().error_prototype());
+}
+
+GC::Ref<CompileError> CompileError::create(JS::Realm& realm, StringView message)
+{
+    auto& vm = realm.vm();
+    auto error = CompileError::create(realm);
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
+    error->define_direct_property(vm.names.message, JS::PrimitiveString::create(vm, message), attr);
+    return error;
+}
+
+CompileError::CompileError(JS::Object& prototype)
+    : JS::Error(prototype)
+{
+}
+
+GC_DEFINE_ALLOCATOR(LinkError);
+
+GC::Ref<LinkError> LinkError::create(JS::Realm& realm)
+{
+    return realm.heap().allocate<LinkError>(realm.intrinsics().error_prototype());
+}
+
+GC::Ref<LinkError> LinkError::create(JS::Realm& realm, StringView message)
+{
+    auto& vm = realm.vm();
+    auto error = LinkError::create(realm);
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
+    error->define_direct_property(vm.names.message, JS::PrimitiveString::create(vm, message), attr);
+    return error;
+}
+
+LinkError::LinkError(JS::Object& prototype)
+    : JS::Error(prototype)
+{
+}
+
+GC_DEFINE_ALLOCATOR(RuntimeError);
+
+GC::Ref<RuntimeError> RuntimeError::create(JS::Realm& realm)
+{
+    return realm.heap().allocate<RuntimeError>(realm.intrinsics().error_prototype());
+}
+
+GC::Ref<RuntimeError> RuntimeError::create(JS::Realm& realm, StringView message)
+{
+    auto& vm = realm.vm();
+    auto error = RuntimeError::create(realm);
+    u8 attr = JS::Attribute::Writable | JS::Attribute::Configurable;
+    error->define_direct_property(vm.names.message, JS::PrimitiveString::create(vm, message), attr);
+    return error;
+}
+
+RuntimeError::RuntimeError(JS::Object& prototype)
+    : JS::Error(prototype)
+{
+}
+
+} // namespace Web::WebAssembly

--- a/Libraries/LibWeb/WebAssembly/Error.h
+++ b/Libraries/LibWeb/WebAssembly/Error.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Pavel Shliak <shlyakpavel@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Error.h>
+
+namespace Web::WebAssembly {
+
+class CompileError final : public JS::Error {
+    JS_OBJECT(CompileError, Error);
+    GC_DECLARE_ALLOCATOR(CompileError);
+
+public:
+    static GC::Ref<CompileError> create(JS::Realm&);
+    static GC::Ref<CompileError> create(JS::Realm&, StringView message);
+    virtual ~CompileError() override = default;
+
+private:
+    explicit CompileError(JS::Object& prototype);
+};
+
+class LinkError final : public JS::Error {
+    JS_OBJECT(LinkError, Error);
+    GC_DECLARE_ALLOCATOR(LinkError);
+
+public:
+    static GC::Ref<LinkError> create(JS::Realm&);
+    static GC::Ref<LinkError> create(JS::Realm&, StringView message);
+    virtual ~LinkError() override = default;
+
+private:
+    explicit LinkError(JS::Object& prototype);
+};
+
+class RuntimeError final : public JS::Error {
+    JS_OBJECT(RuntimeError, Error);
+    GC_DECLARE_ALLOCATOR(RuntimeError);
+
+public:
+    static GC::Ref<RuntimeError> create(JS::Realm&);
+    static GC::Ref<RuntimeError> create(JS::Realm&, StringView message);
+    virtual ~RuntimeError() override = default;
+
+private:
+    explicit RuntimeError(JS::Object& prototype);
+};
+
+} // namespace Web::WebAssembly

--- a/Libraries/LibWeb/WebAssembly/Error.h
+++ b/Libraries/LibWeb/WebAssembly/Error.h
@@ -11,7 +11,7 @@
 namespace Web::WebAssembly {
 
 class CompileError final : public JS::Error {
-    JS_OBJECT(CompileError, Error);
+    JS_OBJECT(CompileError, JS::Error);
     GC_DECLARE_ALLOCATOR(CompileError);
 
 public:
@@ -24,7 +24,7 @@ private:
 };
 
 class LinkError final : public JS::Error {
-    JS_OBJECT(LinkError, Error);
+    JS_OBJECT(LinkError, JS::Error);
     GC_DECLARE_ALLOCATOR(LinkError);
 
 public:
@@ -37,7 +37,7 @@ private:
 };
 
 class RuntimeError final : public JS::Error {
-    JS_OBJECT(RuntimeError, Error);
+    JS_OBJECT(RuntimeError, JS::Error);
     GC_DECLARE_ALLOCATOR(RuntimeError);
 
 public:

--- a/Libraries/LibWeb/WebAssembly/Module.cpp
+++ b/Libraries/LibWeb/WebAssembly/Module.cpp
@@ -9,6 +9,7 @@
 #include <LibJS/Runtime/VM.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ModulePrototype.h>
+#include <LibWeb/WebAssembly/Error.h>
 #include <LibWeb/WebAssembly/Module.h>
 #include <LibWeb/WebAssembly/WebAssembly.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
@@ -25,7 +26,7 @@ WebIDL::ExceptionOr<GC::Ref<Module>> Module::construct_impl(JS::Realm& realm, GC
     auto stable_bytes_or_error = WebIDL::get_buffer_source_copy(bytes->raw_object());
     if (stable_bytes_or_error.is_error()) {
         VERIFY(stable_bytes_or_error.error().code() == ENOMEM);
-        return vm.throw_completion<JS::InternalError>(vm.error_message(JS::VM::ErrorMessage::OutOfMemory));
+        return vm.throw_completion<CompileError>(vm.error_message(JS::VM::ErrorMessage::OutOfMemory));
     }
     auto stable_bytes = stable_bytes_or_error.release_value();
 

--- a/Libraries/LibWeb/WebAssembly/Table.cpp
+++ b/Libraries/LibWeb/WebAssembly/Table.cpp
@@ -29,11 +29,15 @@ static Wasm::ValueType table_kind_to_value_type(Bindings::TableKind kind)
     VERIFY_NOT_REACHED();
 }
 
+// https://webassembly.github.io/spec/js-api/#tables
 WebIDL::ExceptionOr<GC::Ref<Table>> Table::construct_impl(JS::Realm& realm, TableDescriptor& descriptor, JS::Value value)
 {
     auto& vm = realm.vm();
 
     auto reference_type = table_kind_to_value_type(descriptor.element);
+    // If elementType is not a reftype, throw a TypeError exception.
+    if (!reference_type.is_reference())
+        return vm.throw_completion<JS::TypeError>("elementType is not a reftype"_string);
     auto reference_value = vm.argument_count() == 1
         ? Detail::default_webassembly_value(vm, reference_type)
         : TRY(Detail::to_webassembly_value(vm, value, reference_type));


### PR DESCRIPTION
Check this: https://github.com/WebAssembly/spec/issues/1549
Check this: https://github.com/SerenityOS/serenity/pull/15248

Also, instantiate_module should be probably rewritten according to spec, with comments etc
Also, checking that function is function doesn't work for some unknown reason and we accept anything as function in the constructor and up to instantiate_module chain

There were a lot of WPT tests that we passed by coincidence, expect regressions 

I'm publishing this here as this stuff is far above my spec understanding and coding skills, so any advice or help would be greatly appreciated. You can always find me as kukushechka on Discord #wasm

Key difference to the original implementation at Serenity:
1. Written from scratch, I didn't know that one existed
2. Does not use preprocessor shenanigans, so can be parsed by clangd in IDE
3. Never mixes global JS Errors with WebAssembly scope errors. These should stay inside WebAssembly module.
4. Actually works and passes most of the previously working WPT tests. Previous implementation at Serenity caused a lot of regressions due to non-spec constructors. I aim to have no regressions once this PR is ready, but who knows..
5. Uses Strings instead of StringViews. I consider this a problem and I am going to fix that before PR is ready

This code still tends to reject promises without exceptions in the situations where exceptions are required.