### PR TITLE
Revert "LibCore/MappedFile: Remove unnecessary fcntl call"

### DIFF
--- a/Libraries/LibCore/MappedFile.cpp
+++ b/Libraries/LibCore/MappedFile.cpp
@@ -27,6 +27,8 @@ ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_file(NonnullOwnPtr<Core:
 
 ErrorOr<NonnullOwnPtr<MappedFile>> MappedFile::map_from_fd_and_close(int fd, [[maybe_unused]] StringView path, Mode mode)
 {
+    TRY(Core::System::fcntl(fd, F_SETFD, FD_CLOEXEC));
+
     ScopeGuard fd_close_guard = [fd] {
         (void)System::close(fd);
     };


### PR DESCRIPTION
This reverts commit 153dc6686ce804b46cfbbd09122c02e306aedc96.

Seeing if this fixes the constant LSAN errors on CI.