### PR TITLE
LibWeb: Implement some viewport proximity features

### DIFF
--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -85,6 +85,17 @@ enum class CustomElementState {
     Custom,
 };
 
+// https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
+// An element that has content-visibility: auto is in one of three states when it comes to its proximity to the viewport:
+enum class ProximityToTheViewport {
+    // - The element is close to the viewport:
+    CloseToTheViewport,
+    // - The element is far away from the viewport:
+    FarAwayFromTheViewport,
+    // - The element’s proximity to the viewport is not determined:
+    NotDetermined,
+};
+
 class Element
     : public ParentNode
     , public ChildNode<Element>
@@ -377,6 +388,10 @@ public:
     void resolve_counters(CSS::ComputedProperties&);
     void inherit_counters();
 
+    ProximityToTheViewport proximity_to_the_viewport() const { return m_proximity_to_the_viewport; }
+    void determine_proximity_to_the_viewport();
+    bool is_relevant_to_the_user();
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -469,6 +484,9 @@ private:
     OwnPtr<CSS::CountersSet> m_counters_set;
 
     GC::Ptr<DOM::Element> m_aria_active_descendant_element;
+
+    // https://drafts.csswg.org/css-contain/#proximity-to-the-viewport
+    ProximityToTheViewport m_proximity_to_the_viewport { ProximityToTheViewport::NotDetermined };
 };
 
 template<>


### PR DESCRIPTION
This gets rid of some FIXMEs related to viewport proximity and relevancy to the user in the [update the rendering](https://html.spec.whatwg.org/#update-the-rendering) algorithm.

I know there is no tests, but I tried some of the relevant WPT tests for the new sections and none of them are passing yet so I assume there is other code missing elsewhere that would need to actually make use of the element's proximity to the viewport. (beyond just setting it in this one place.)

So I don't think there is any sensible tests that can be written for these two functions on their own.