### PR TITLE
LibWeb: Add search element to list of Special tags

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1702,6 +1702,7 @@ bool HTMLParser::is_special_tag(FlyString const& tag_name, Optional<FlyString> c
             HTML::TagNames::plaintext,
             HTML::TagNames::pre,
             HTML::TagNames::script,
+            HTML::TagNames::search,
             HTML::TagNames::section,
             HTML::TagNames::select,
             HTML::TagNames::source,


### PR DESCRIPTION
Adds the `<search>` element to the list of [Special](https://html.spec.whatwg.org/multipage/parsing.html#special) tags, since I didn't realize we had that list when I made the initial PR.