### PR TITLE
LibWeb: Don't treat auto insets as definite for child of abspos element

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1226,10 +1226,15 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
 
     // If the box width and/or height is fixed and/or or resolved from inset properties,
     // mark the size as being definite (since layout was not required to resolve it, per CSS-SIZING-3).
-    if (box.computed_values().inset().left().is_length() && box.computed_values().inset().right().is_length()) {
+    auto is_length_but_not_auto = [](auto& length_percentage) {
+        return length_percentage.is_length() && !length_percentage.is_auto();
+    };
+    if (is_length_but_not_auto(box.computed_values().inset().left())
+        && is_length_but_not_auto(box.computed_values().inset().right())) {
         box_state.set_has_definite_width(true);
     }
-    if (box.computed_values().inset().top().is_length() && box.computed_values().inset().bottom().is_length()) {
+    if (is_length_but_not_auto(box.computed_values().inset().top())
+        && is_length_but_not_auto(box.computed_values().inset().bottom())) {
         box_state.set_has_definite_height(true);
     }
 

--- a/Tests/LibWeb/Layout/expected/child-of-abspos-percentage-height.txt
+++ b/Tests/LibWeb/Layout/expected/child-of-abspos-percentage-height.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x0 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 36.84375x17 positioned [BFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 36.84375x17 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 36.84375x17]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 36.84375x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/child-of-abspos-percentage-height.html
+++ b/Tests/LibWeb/Layout/input/child-of-abspos-percentage-height.html
@@ -1,0 +1,5 @@
+<!doctype html><style>
+* { outline: 1px solid black; }
+body { position: absolute; }
+div { height: 100%; }
+</style><body><div>hello


### PR DESCRIPTION
This fixes an issue where the welcome screen wasn't showing up the first time you visit https://puter.com/ :^)

Before:
<img width="1123" alt="Screenshot 2024-11-27 at 18 59 22" src="https://github.com/user-attachments/assets/ab9db7dd-2459-41cf-a8ea-d75e87ae4722">

After:
<img width="1123" alt="Screenshot 2024-11-27 at 18 45 49" src="https://github.com/user-attachments/assets/8a00dd36-470c-49e1-9053-90aca6fa0364">
