### PR TITLE
LibWeb: Refactor WebCryptoAPI case-sensitiveness + fix typo

### DIFF
--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -690,13 +690,13 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> RSAOAEP::encrypt(AlgorithmParams c
 
     auto error_message = MUST(String::formatted("Invalid hash function '{}'", hash));
     ErrorOr<ByteBuffer> maybe_padding = Error::from_string_view(error_message.bytes_as_string_view());
-    if (hash.equals_ignoring_ascii_case("SHA-1"sv)) {
+    if (hash == "SHA-1") {
         maybe_padding = ::Crypto::Padding::OAEP::eme_encode<::Crypto::Hash::SHA1, ::Crypto::Hash::MGF>(plaintext, label, public_key.length());
-    } else if (hash.equals_ignoring_ascii_case("SHA-256"sv)) {
+    } else if (hash == "SHA-256") {
         maybe_padding = ::Crypto::Padding::OAEP::eme_encode<::Crypto::Hash::SHA256, ::Crypto::Hash::MGF>(plaintext, label, public_key.length());
-    } else if (hash.equals_ignoring_ascii_case("SHA-384"sv)) {
+    } else if (hash == "SHA-384") {
         maybe_padding = ::Crypto::Padding::OAEP::eme_encode<::Crypto::Hash::SHA384, ::Crypto::Hash::MGF>(plaintext, label, public_key.length());
-    } else if (hash.equals_ignoring_ascii_case("SHA-512"sv)) {
+    } else if (hash == "SHA-512") {
         maybe_padding = ::Crypto::Padding::OAEP::eme_encode<::Crypto::Hash::SHA512, ::Crypto::Hash::MGF>(plaintext, label, public_key.length());
     }
 
@@ -751,13 +751,13 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> RSAOAEP::decrypt(AlgorithmParams c
 
     auto error_message = MUST(String::formatted("Invalid hash function '{}'", hash));
     ErrorOr<ByteBuffer> maybe_plaintext = Error::from_string_view(error_message.bytes_as_string_view());
-    if (hash.equals_ignoring_ascii_case("SHA-1"sv)) {
+    if (hash == "SHA-1") {
         maybe_plaintext = ::Crypto::Padding::OAEP::eme_decode<::Crypto::Hash::SHA1, ::Crypto::Hash::MGF>(padding, label, private_key_length);
-    } else if (hash.equals_ignoring_ascii_case("SHA-256"sv)) {
+    } else if (hash == "SHA-256") {
         maybe_plaintext = ::Crypto::Padding::OAEP::eme_decode<::Crypto::Hash::SHA256, ::Crypto::Hash::MGF>(padding, label, private_key_length);
-    } else if (hash.equals_ignoring_ascii_case("SHA-384"sv)) {
+    } else if (hash == "SHA-384") {
         maybe_plaintext = ::Crypto::Padding::OAEP::eme_decode<::Crypto::Hash::SHA384, ::Crypto::Hash::MGF>(padding, label, private_key_length);
-    } else if (hash.equals_ignoring_ascii_case("SHA-512"sv)) {
+    } else if (hash == "SHA-512") {
         maybe_plaintext = ::Crypto::Padding::OAEP::eme_decode<::Crypto::Hash::SHA512, ::Crypto::Hash::MGF>(padding, label, private_key_length);
     }
 
@@ -2281,13 +2281,13 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> SHA::digest(AlgorithmParams const&
     auto& algorithm_name = algorithm.name;
 
     ::Crypto::Hash::HashKind hash_kind;
-    if (algorithm_name.equals_ignoring_ascii_case("SHA-1"sv)) {
+    if (algorithm_name == "SHA-1") {
         hash_kind = ::Crypto::Hash::HashKind::SHA1;
-    } else if (algorithm_name.equals_ignoring_ascii_case("SHA-256"sv)) {
+    } else if (algorithm_name == "SHA-256") {
         hash_kind = ::Crypto::Hash::HashKind::SHA256;
-    } else if (algorithm_name.equals_ignoring_ascii_case("SHA-384"sv)) {
+    } else if (algorithm_name == "SHA-384") {
         hash_kind = ::Crypto::Hash::HashKind::SHA384;
-    } else if (algorithm_name.equals_ignoring_ascii_case("SHA-512"sv)) {
+    } else if (algorithm_name == "SHA-512") {
         hash_kind = ::Crypto::Hash::HashKind::SHA512;
     } else {
         return WebIDL::NotSupportedError::create(m_realm, MUST(String::formatted("Invalid hash function '{}'", algorithm_name)));
@@ -2321,14 +2321,14 @@ WebIDL::ExceptionOr<Variant<GC::Ref<CryptoKey>, GC::Ref<CryptoKeyPair>>> ECDSA::
     // with domain parameters for the curve identified by the namedCurve member of normalizedAlgorithm.
     Variant<Empty, ::Crypto::Curves::SECP256r1, ::Crypto::Curves::SECP384r1> curve;
     if (normalized_algorithm.named_curve.is_one_of("P-256"sv, "P-384"sv, "P-521"sv)) {
-        if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-256"sv))
+        if (normalized_algorithm.named_curve == "P-256")
             curve = ::Crypto::Curves::SECP256r1 {};
 
-        if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-384"sv))
+        if (normalized_algorithm.named_curve == "P-384")
             curve = ::Crypto::Curves::SECP384r1 {};
 
         // FIXME: Support P-521
-        if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-521"sv))
+        if (normalized_algorithm.named_curve == "P-521")
             return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_string);
     } else {
         // If the namedCurve member of normalizedAlgorithm is a value specified in an applicable specification:
@@ -2458,13 +2458,13 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, GC::
 
     // 3. Let M be the result of performing the digest operation specified by hashAlgorithm using message.
     ::Crypto::Hash::HashKind hash_kind;
-    if (hash_algorithm.equals_ignoring_ascii_case("SHA-1"sv)) {
+    if (hash_algorithm == "SHA-1") {
         hash_kind = ::Crypto::Hash::HashKind::SHA1;
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-256"sv)) {
+    } else if (hash_algorithm == "SHA-256") {
         hash_kind = ::Crypto::Hash::HashKind::SHA256;
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-384"sv)) {
+    } else if (hash_algorithm == "SHA-384") {
         hash_kind = ::Crypto::Hash::HashKind::SHA384;
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-512"sv)) {
+    } else if (hash_algorithm == "SHA-512") {
         hash_kind = ::Crypto::Hash::HashKind::SHA512;
     } else {
         return WebIDL::NotSupportedError::create(m_realm, MUST(String::formatted("Invalid hash function '{}'", hash_algorithm)));
@@ -2492,14 +2492,14 @@ WebIDL::ExceptionOr<JS::Value> ECDSA::verify(AlgorithmParams const& params, GC::
 
     Variant<Empty, ::Crypto::Curves::SECP256r1, ::Crypto::Curves::SECP384r1> curve;
     if (named_curve.is_one_of("P-256"sv, "P-384"sv, "P-521"sv)) {
-        if (named_curve.equals_ignoring_ascii_case("P-256"sv))
+        if (named_curve == "P-256")
             curve = ::Crypto::Curves::SECP256r1 {};
 
-        if (named_curve.equals_ignoring_ascii_case("P-384"sv))
+        if (named_curve == "P-384")
             curve = ::Crypto::Curves::SECP384r1 {};
 
         // FIXME: Support P-521
-        if (named_curve.equals_ignoring_ascii_case("P-521"sv))
+        if (named_curve == "P-521")
             return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_string);
 
         // Perform the ECDSA verifying process, as specified in [RFC6090], Section 5.3,
@@ -2558,14 +2558,14 @@ WebIDL::ExceptionOr<Variant<GC::Ref<CryptoKey>, GC::Ref<CryptoKeyPair>>> ECDH::g
     // with domain parameters for the curve identified by the namedCurve member of normalizedAlgorithm.
     Variant<Empty, ::Crypto::Curves::SECP256r1, ::Crypto::Curves::SECP384r1> curve;
     if (normalized_algorithm.named_curve.is_one_of("P-256"sv, "P-384"sv, "P-521"sv)) {
-        if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-256"sv))
+        if (normalized_algorithm.named_curve == "P-256")
             curve = ::Crypto::Curves::SECP256r1 {};
 
-        if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-384"sv))
+        if (normalized_algorithm.named_curve == "P-384")
             curve = ::Crypto::Curves::SECP384r1 {};
 
         // FIXME: Support P-521
-        if (normalized_algorithm.named_curve.equals_ignoring_ascii_case("P-521"sv))
+        if (normalized_algorithm.named_curve == "P-521")
             return WebIDL::NotSupportedError::create(m_realm, "'P-521' is not supported yet"_string);
     } else {
         // If the namedCurve member of normalizedAlgorithm is a value specified in an applicable specification
@@ -3996,13 +3996,13 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> HKDF::derive_bits(AlgorithmParams 
     // Because we are forced by neither peer pressure nor the spec, we don't support it either.
     auto const& hash_algorithm = TRY(normalized_algorithm.hash.name(realm.vm()));
     ErrorOr<ByteBuffer> result = Error::from_string_literal("noop error");
-    if (hash_algorithm.equals_ignoring_ascii_case("SHA-1"sv)) {
+    if (hash_algorithm == "SHA-1") {
         result = ::Crypto::Hash::HKDF<::Crypto::Hash::SHA1>::derive_key(Optional<ReadonlyBytes>(normalized_algorithm.salt), key_derivation_key, normalized_algorithm.info, length / 8);
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-256"sv)) {
+    } else if (hash_algorithm == "SHA-256") {
         result = ::Crypto::Hash::HKDF<::Crypto::Hash::SHA256>::derive_key(Optional<ReadonlyBytes>(normalized_algorithm.salt), key_derivation_key, normalized_algorithm.info, length / 8);
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-384"sv)) {
+    } else if (hash_algorithm == "SHA-384") {
         result = ::Crypto::Hash::HKDF<::Crypto::Hash::SHA384>::derive_key(Optional<ReadonlyBytes>(normalized_algorithm.salt), key_derivation_key, normalized_algorithm.info, length / 8);
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-512"sv)) {
+    } else if (hash_algorithm == "SHA-512") {
         result = ::Crypto::Hash::HKDF<::Crypto::Hash::SHA512>::derive_key(Optional<ReadonlyBytes>(normalized_algorithm.salt), key_derivation_key, normalized_algorithm.info, length / 8);
     } else {
         return WebIDL::NotSupportedError::create(m_realm, MUST(String::formatted("Invalid hash function '{}'", hash_algorithm)));
@@ -4054,13 +4054,13 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> PBKDF2::derive_bits(AlgorithmParam
     auto iterations = normalized_algorithm.iterations;
     auto derived_key_length_bytes = length / 8;
 
-    if (hash_algorithm.equals_ignoring_ascii_case("SHA-1"sv)) {
+    if (hash_algorithm == "SHA-1") {
         result = ::Crypto::Hash::PBKDF2::derive_key<::Crypto::Authentication::HMAC<::Crypto::Hash::SHA1>>(password, salt, iterations, derived_key_length_bytes);
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-256"sv)) {
+    } else if (hash_algorithm == "SHA-256") {
         result = ::Crypto::Hash::PBKDF2::derive_key<::Crypto::Authentication::HMAC<::Crypto::Hash::SHA256>>(password, salt, iterations, derived_key_length_bytes);
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-384"sv)) {
+    } else if (hash_algorithm == "SHA-384") {
         result = ::Crypto::Hash::PBKDF2::derive_key<::Crypto::Authentication::HMAC<::Crypto::Hash::SHA384>>(password, salt, iterations, derived_key_length_bytes);
-    } else if (hash_algorithm.equals_ignoring_ascii_case("SHA-512"sv)) {
+    } else if (hash_algorithm == "SHA-512") {
         result = ::Crypto::Hash::PBKDF2::derive_key<::Crypto::Authentication::HMAC<::Crypto::Hash::SHA512>>(password, salt, iterations, derived_key_length_bytes);
     } else {
         return WebIDL::NotSupportedError::create(m_realm, MUST(String::formatted("Invalid hash function '{}'", hash_algorithm)));
@@ -5095,13 +5095,13 @@ static WebIDL::ExceptionOr<ByteBuffer> hmac_calculate_message_digest(JS::Realm& 
         return MUST(ByteBuffer::copy(digest.bytes()));
     };
     auto hash_name = hash->name();
-    if (hash_name.equals_ignoring_ascii_case("SHA-1"sv))
+    if (hash_name == "SHA-1")
         return calculate_digest.operator()<::Crypto::Hash::SHA1>();
-    if (hash_name.equals_ignoring_ascii_case("SHA-256"sv))
+    if (hash_name == "SHA-256")
         return calculate_digest.operator()<::Crypto::Hash::SHA256>();
-    if (hash_name.equals_ignoring_ascii_case("SHA-384"sv))
+    if (hash_name == "SHA-384")
         return calculate_digest.operator()<::Crypto::Hash::SHA384>();
-    if (hash_name.equals_ignoring_ascii_case("SHA-512"sv))
+    if (hash_name == "SHA-512")
         return calculate_digest.operator()<::Crypto::Hash::SHA512>();
     return WebIDL::NotSupportedError::create(realm, "Invalid algorithm"_string);
 }
@@ -5109,13 +5109,13 @@ static WebIDL::ExceptionOr<ByteBuffer> hmac_calculate_message_digest(JS::Realm& 
 static WebIDL::ExceptionOr<WebIDL::UnsignedLong> hmac_hash_block_size(JS::Realm& realm, HashAlgorithmIdentifier hash)
 {
     auto hash_name = TRY(hash.name(realm.vm()));
-    if (hash_name.equals_ignoring_ascii_case("SHA-1"sv))
+    if (hash_name == "SHA-1")
         return ::Crypto::Hash::SHA1::digest_size();
-    if (hash_name.equals_ignoring_ascii_case("SHA-256"sv))
+    if (hash_name == "SHA-256")
         return ::Crypto::Hash::SHA256::digest_size();
-    if (hash_name.equals_ignoring_ascii_case("SHA-384"sv))
+    if (hash_name == "SHA-384")
         return ::Crypto::Hash::SHA384::digest_size();
-    if (hash_name.equals_ignoring_ascii_case("SHA-512"sv))
+    if (hash_name == "SHA-512")
         return ::Crypto::Hash::SHA512::digest_size();
     return WebIDL::NotSupportedError::create(realm, MUST(String::formatted("Invalid hash function '{}'", hash_name)));
 }
@@ -5270,28 +5270,28 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> HMAC::import_key(Web::Crypto::AlgorithmP
 
         // 6. If the name attribute of hash is "SHA-1":
         auto hash_name = hash->name();
-        if (hash_name.equals_ignoring_ascii_case("SHA-1"sv)) {
+        if (hash_name == "SHA-1") {
             // If the alg field of jwk is present and is not "HS1", then throw a DataError.
             if (jwk.alg.has_value() && jwk.alg != "HS1"sv)
                 return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
         }
 
         // If the name attribute of hash is "SHA-256":
-        else if (hash_name.equals_ignoring_ascii_case("SHA-256"sv)) {
+        else if (hash_name == "SHA-256") {
             // If the alg field of jwk is present and is not "HS256", then throw a DataError.
             if (jwk.alg.has_value() && jwk.alg != "HS256"sv)
                 return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
         }
 
         // If the name attribute of hash is "SHA-384":
-        else if (hash_name.equals_ignoring_ascii_case("SHA-384"sv)) {
+        else if (hash_name == "SHA-384") {
             // If the alg field of jwk is present and is not "HS384", then throw a DataError.
             if (jwk.alg.has_value() && jwk.alg != "HS384"sv)
                 return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
         }
 
         // If the name attribute of hash is "SHA-512":
-        else if (hash_name.equals_ignoring_ascii_case("SHA-512"sv)) {
+        else if (hash_name == "SHA-512") {
             // If the alg field of jwk is present and is not "HS512", then throw a DataError.
             if (jwk.alg.has_value() && jwk.alg != "HS512"sv)
                 return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
@@ -5420,22 +5420,22 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> HMAC::export_key(Bindings::KeyFormat fo
 
         // If the name attribute of hash is "SHA-1":
         auto hash_name = hash->name();
-        if (hash_name.equals_ignoring_ascii_case("SHA-1"sv)) {
+        if (hash_name == "SHA-1") {
             // Set the alg attribute of jwk to the string "HS1".
             jwk.alg = "HS1"_string;
         }
         // If the name attribute of hash is "SHA-256":
-        else if (hash_name.equals_ignoring_ascii_case("SHA-256"sv)) {
+        else if (hash_name == "SHA-256") {
             // Set the alg attribute of jwk to the string "HS256".
             jwk.alg = "HS256"_string;
         }
         // If the name attribute of hash is "SHA-384":
-        else if (hash_name.equals_ignoring_ascii_case("SHA-384"sv)) {
+        else if (hash_name == "SHA-384") {
             // Set the alg attribute of jwk to the string "HS384".
             jwk.alg = "HS384"_string;
         }
         // If the name attribute of hash is "SHA-512":
-        else if (hash_name.equals_ignoring_ascii_case("SHA-512"sv)) {
+        else if (hash_name == "SHA-512") {
             // Set the alg attribute of jwk to the string "HS512".
             jwk.alg = "HS512"_string;
         }

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -314,14 +314,9 @@ static WebIDL::ExceptionOr<ByteBuffer> generate_random_key(JS::VM& vm, u16 const
 
 AlgorithmParams::~AlgorithmParams() = default;
 
-JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AlgorithmParams::from_value(JS::VM& vm, JS::Value value)
+JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AlgorithmParams::from_value(JS::VM&, JS::Value)
 {
-    auto& object = value.as_object();
-
-    auto name = TRY(object.get("name"));
-    auto name_string = TRY(name.to_string(vm));
-
-    return adopt_own(*new AlgorithmParams { name_string });
+    return adopt_own(*new AlgorithmParams {});
 }
 
 AesCbcParams::~AesCbcParams() = default;
@@ -330,15 +325,12 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesCbcParams::from_value(J
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto iv_value = TRY(object.get("iv"));
     if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto iv = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(iv_value.as_object()));
 
-    return adopt_own<AlgorithmParams>(*new AesCbcParams { name, iv });
+    return adopt_own<AlgorithmParams>(*new AesCbcParams { iv });
 }
 
 AesCtrParams::~AesCtrParams() = default;
@@ -346,9 +338,6 @@ AesCtrParams::~AesCtrParams() = default;
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesCtrParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
-
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
 
     auto iv_value = TRY(object.get("counter"));
     if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
@@ -358,7 +347,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesCtrParams::from_value(J
     auto length_value = TRY(object.get("length"));
     auto length = TRY(length_value.to_u8(vm));
 
-    return adopt_own<AlgorithmParams>(*new AesCtrParams { name, iv, length });
+    return adopt_own<AlgorithmParams>(*new AesCtrParams { iv, length });
 }
 
 AesGcmParams::~AesGcmParams() = default;
@@ -366,9 +355,6 @@ AesGcmParams::~AesGcmParams() = default;
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesGcmParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
-
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
 
     auto iv_value = TRY(object.get("iv"));
     if (!iv_value.is_object() || !(is<JS::TypedArrayBase>(iv_value.as_object()) || is<JS::ArrayBuffer>(iv_value.as_object()) || is<JS::DataView>(iv_value.as_object())))
@@ -389,7 +375,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesGcmParams::from_value(J
         maybe_tag_length = TRY(tag_length_value.to_u8(vm));
     }
 
-    return adopt_own<AlgorithmParams>(*new AesGcmParams { name, iv, maybe_additional_data, maybe_tag_length });
+    return adopt_own<AlgorithmParams>(*new AesGcmParams { iv, maybe_additional_data, maybe_tag_length });
 }
 
 HKDFParams::~HKDFParams() = default;
@@ -397,9 +383,6 @@ HKDFParams::~HKDFParams() = default;
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HKDFParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
-
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
 
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
@@ -414,7 +397,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HKDFParams::from_value(JS:
         return vm.throw_completion<JS::TypeError>(JS::ErrorType::NotAnObjectOfType, "BufferSource");
     auto info = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(info_value.as_object()));
 
-    return adopt_own<AlgorithmParams>(*new HKDFParams { name, hash, salt, info });
+    return adopt_own<AlgorithmParams>(*new HKDFParams { hash, salt, info });
 }
 
 PBKDF2Params::~PBKDF2Params() = default;
@@ -422,9 +405,6 @@ PBKDF2Params::~PBKDF2Params() = default;
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> PBKDF2Params::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
-
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
 
     auto salt_value = TRY(object.get("salt"));
 
@@ -439,7 +419,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> PBKDF2Params::from_value(J
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
-    return adopt_own<AlgorithmParams>(*new PBKDF2Params { name, salt, iterations, hash });
+    return adopt_own<AlgorithmParams>(*new PBKDF2Params { salt, iterations, hash });
 }
 
 RsaKeyGenParams::~RsaKeyGenParams() = default;
@@ -448,9 +428,6 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaKeyGenParams::from_valu
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto modulus_length_value = TRY(object.get("modulusLength"));
     auto modulus_length = TRY(modulus_length_value.to_u32(vm));
 
@@ -462,7 +439,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaKeyGenParams::from_valu
 
     public_exponent = static_cast<JS::Uint8Array&>(public_exponent_value.as_object());
 
-    return adopt_own<AlgorithmParams>(*new RsaKeyGenParams { name, modulus_length, big_integer_from_api_big_integer(public_exponent) });
+    return adopt_own<AlgorithmParams>(*new RsaKeyGenParams { modulus_length, big_integer_from_api_big_integer(public_exponent) });
 }
 
 RsaHashedKeyGenParams::~RsaHashedKeyGenParams() = default;
@@ -471,9 +448,6 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedKeyGenParams::fro
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto modulus_length_value = TRY(object.get("modulusLength"));
     auto modulus_length = TRY(modulus_length_value.to_u32(vm));
 
@@ -488,7 +462,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedKeyGenParams::fro
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
-    return adopt_own<AlgorithmParams>(*new RsaHashedKeyGenParams { name, modulus_length, big_integer_from_api_big_integer(public_exponent), hash });
+    return adopt_own<AlgorithmParams>(*new RsaHashedKeyGenParams { modulus_length, big_integer_from_api_big_integer(public_exponent), hash });
 }
 
 RsaHashedImportParams::~RsaHashedImportParams() = default;
@@ -497,13 +471,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaHashedImportParams::fro
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
-    return adopt_own<AlgorithmParams>(*new RsaHashedImportParams { name, hash });
+    return adopt_own<AlgorithmParams>(*new RsaHashedImportParams { hash });
 }
 
 RsaOaepParams::~RsaOaepParams() = default;
@@ -511,9 +482,6 @@ RsaOaepParams::~RsaOaepParams() = default;
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaOaepParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
-
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
 
     auto label_value = TRY(object.get("label"));
 
@@ -525,7 +493,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> RsaOaepParams::from_value(
         label = TRY_OR_THROW_OOM(vm, WebIDL::get_buffer_source_copy(label_value.as_object()));
     }
 
-    return adopt_own<AlgorithmParams>(*new RsaOaepParams { name, move(label) });
+    return adopt_own<AlgorithmParams>(*new RsaOaepParams { move(label) });
 }
 
 EcdsaParams::~EcdsaParams() = default;
@@ -534,13 +502,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdsaParams::from_value(JS
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
-    return adopt_own<AlgorithmParams>(*new EcdsaParams { name, hash });
+    return adopt_own<AlgorithmParams>(*new EcdsaParams { hash });
 }
 
 EcKeyGenParams::~EcKeyGenParams() = default;
@@ -549,13 +514,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcKeyGenParams::from_value
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto curve_value = TRY(object.get("namedCurve"));
     auto curve = TRY(curve_value.to_string(vm));
 
-    return adopt_own<AlgorithmParams>(*new EcKeyGenParams { name, curve });
+    return adopt_own<AlgorithmParams>(*new EcKeyGenParams { curve });
 }
 
 AesKeyGenParams::~AesKeyGenParams() = default;
@@ -564,13 +526,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesKeyGenParams::from_valu
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto length_value = TRY(object.get("length"));
     auto length = TRY(length_value.to_u16(vm));
 
-    return adopt_own<AlgorithmParams>(*new AesKeyGenParams { name, length });
+    return adopt_own<AlgorithmParams>(*new AesKeyGenParams { length });
 }
 
 AesDerivedKeyParams::~AesDerivedKeyParams() = default;
@@ -579,13 +538,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesDerivedKeyParams::from_
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto length_value = TRY(object.get("length"));
     auto length = TRY(length_value.to_u16(vm));
 
-    return adopt_own<AlgorithmParams>(*new AesDerivedKeyParams { name, length });
+    return adopt_own<AlgorithmParams>(*new AesDerivedKeyParams { length });
 }
 
 EcdhKeyDeriveParams::~EcdhKeyDeriveParams() = default;
@@ -593,9 +549,6 @@ EcdhKeyDeriveParams::~EcdhKeyDeriveParams() = default;
 JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdhKeyDeriveParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
-
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
 
     auto key_value = TRY(object.get("public"));
     auto key_object = TRY(key_value.to_object(vm));
@@ -606,7 +559,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdhKeyDeriveParams::from_
 
     auto& key = verify_cast<CryptoKey>(*key_object);
 
-    return adopt_own<AlgorithmParams>(*new EcdhKeyDeriveParams { name, key });
+    return adopt_own<AlgorithmParams>(*new EcdhKeyDeriveParams { key });
 }
 
 EcKeyImportParams::~EcKeyImportParams() = default;
@@ -615,13 +568,10 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcKeyImportParams::from_va
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto named_curve_value = TRY(object.get("namedCurve"));
     auto named_curve = TRY(named_curve_value.to_string(vm));
 
-    return adopt_own<AlgorithmParams>(*new EcKeyImportParams { name, named_curve });
+    return adopt_own<AlgorithmParams>(*new EcKeyImportParams { named_curve });
 }
 
 HmacImportParams::~HmacImportParams() = default;
@@ -630,9 +580,6 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HmacImportParams::from_val
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
@@ -642,7 +589,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HmacImportParams::from_val
         maybe_length = TRY(length_value.to_u32(vm));
     }
 
-    return adopt_own<AlgorithmParams>(*new HmacImportParams { name, hash, maybe_length });
+    return adopt_own<AlgorithmParams>(*new HmacImportParams { hash, maybe_length });
 }
 
 HmacKeyGenParams::~HmacKeyGenParams() = default;
@@ -651,9 +598,6 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HmacKeyGenParams::from_val
 {
     auto& object = value.as_object();
 
-    auto name_value = TRY(object.get("name"));
-    auto name = TRY(name_value.to_string(vm));
-
     auto hash_value = TRY(object.get("hash"));
     auto hash = TRY(hash_algorithm_identifier_from_value(vm, hash_value));
 
@@ -663,7 +607,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> HmacKeyGenParams::from_val
         maybe_length = TRY(length_value.to_u32(vm));
     }
 
-    return adopt_own<AlgorithmParams>(*new HmacKeyGenParams { name, hash, maybe_length });
+    return adopt_own<AlgorithmParams>(*new HmacKeyGenParams { hash, maybe_length });
 }
 
 // https://w3c.github.io/webcrypto/#rsa-oaep-operations

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -588,9 +588,9 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> AesDerivedKeyParams::from_
     return adopt_own<AlgorithmParams>(*new AesDerivedKeyParams { name, length });
 }
 
-EcdhKeyDerivePrams::~EcdhKeyDerivePrams() = default;
+EcdhKeyDeriveParams::~EcdhKeyDeriveParams() = default;
 
-JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdhKeyDerivePrams::from_value(JS::VM& vm, JS::Value value)
+JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdhKeyDeriveParams::from_value(JS::VM& vm, JS::Value value)
 {
     auto& object = value.as_object();
 
@@ -606,7 +606,7 @@ JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> EcdhKeyDerivePrams::from_v
 
     auto& key = verify_cast<CryptoKey>(*key_object);
 
-    return adopt_own<AlgorithmParams>(*new EcdhKeyDerivePrams { name, key });
+    return adopt_own<AlgorithmParams>(*new EcdhKeyDeriveParams { name, key });
 }
 
 EcKeyImportParams::~EcKeyImportParams() = default;
@@ -2648,7 +2648,7 @@ WebIDL::ExceptionOr<Variant<GC::Ref<CryptoKey>, GC::Ref<CryptoKeyPair>>> ECDH::g
 WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> ECDH::derive_bits(AlgorithmParams const& params, GC::Ref<CryptoKey> key, Optional<u32> length_optional)
 {
     auto& realm = *m_realm;
-    auto const& normalized_algorithm = static_cast<EcdhKeyDerivePrams const&>(params);
+    auto const& normalized_algorithm = static_cast<EcdhKeyDeriveParams const&>(params);
 
     // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Private)
@@ -4121,7 +4121,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> PBKDF2::import_key(AlgorithmParams const
 WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> X25519::derive_bits(AlgorithmParams const& params, GC::Ref<CryptoKey> key, Optional<u32> length_optional)
 {
     auto& realm = *m_realm;
-    auto const& normalized_algorithm = static_cast<EcdhKeyDerivePrams const&>(params);
+    auto const& normalized_algorithm = static_cast<EcdhKeyDeriveParams const&>(params);
 
     // 1. If the [[type]] internal slot of key is not "private", then throw an InvalidAccessError.
     if (key->type() != Bindings::KeyType::Private)
@@ -4620,7 +4620,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> X448::derive_bits(
         return WebIDL::InvalidAccessError::create(m_realm, "Key is not a private key"_string);
 
     // 2. Let publicKey be the public member of normalizedAlgorithm.
-    auto& public_key = static_cast<EcdhKeyDerivePrams const&>(params).public_key;
+    auto& public_key = static_cast<EcdhKeyDeriveParams const&>(params).public_key;
 
     // 3. If the [[type]] internal slot of publicKey is not "public", then throw an InvalidAccessError.
     if (public_key->type() != Bindings::KeyType::Public)

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -577,10 +577,10 @@ private:
     }
 };
 
-struct EcdhKeyDerivePrams : public AlgorithmParams {
-    virtual ~EcdhKeyDerivePrams() override;
+struct EcdhKeyDeriveParams : public AlgorithmParams {
+    virtual ~EcdhKeyDeriveParams() override;
 
-    EcdhKeyDerivePrams(String name, CryptoKey& public_key)
+    EcdhKeyDeriveParams(String name, CryptoKey& public_key)
         : AlgorithmParams(move(name))
         , public_key(public_key)
     {

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.h
@@ -45,11 +45,12 @@ struct HashAlgorithmIdentifier : public AlgorithmIdentifier {
 // https://w3c.github.io/webcrypto/#algorithm-overview
 struct AlgorithmParams {
     virtual ~AlgorithmParams();
-    explicit AlgorithmParams(String name)
-        : name(move(name))
+    explicit AlgorithmParams()
     {
     }
 
+    // NOTE: this is initialized when normalizing the algorithm name as the spec requests.
+    //       It must not be set in `from_value`.
     String name;
 
     static JS::ThrowCompletionOr<NonnullOwnPtr<AlgorithmParams>> from_value(JS::VM&, JS::Value);
@@ -58,9 +59,8 @@ struct AlgorithmParams {
 // https://w3c.github.io/webcrypto/#aes-cbc
 struct AesCbcParams : public AlgorithmParams {
     virtual ~AesCbcParams() override;
-    AesCbcParams(String name, ByteBuffer iv)
-        : AlgorithmParams(move(name))
-        , iv(move(iv))
+    AesCbcParams(ByteBuffer iv)
+        : iv(move(iv))
     {
     }
 
@@ -72,9 +72,8 @@ struct AesCbcParams : public AlgorithmParams {
 // https://w3c.github.io/webcrypto/#dfn-AesCtrParams
 struct AesCtrParams : public AlgorithmParams {
     virtual ~AesCtrParams() override;
-    AesCtrParams(String name, ByteBuffer counter, u8 length)
-        : AlgorithmParams(move(name))
-        , counter(move(counter))
+    AesCtrParams(ByteBuffer counter, u8 length)
+        : counter(move(counter))
         , length(length)
     {
     }
@@ -88,9 +87,8 @@ struct AesCtrParams : public AlgorithmParams {
 // https://w3c.github.io/webcrypto/#dfn-AesGcmParams
 struct AesGcmParams : public AlgorithmParams {
     virtual ~AesGcmParams() override;
-    AesGcmParams(String name, ByteBuffer iv, Optional<ByteBuffer> additional_data, Optional<u8> tag_length)
-        : AlgorithmParams(move(name))
-        , iv(move(iv))
+    AesGcmParams(ByteBuffer iv, Optional<ByteBuffer> additional_data, Optional<u8> tag_length)
+        : iv(move(iv))
         , additional_data(move(additional_data))
         , tag_length(tag_length)
     {
@@ -106,9 +104,8 @@ struct AesGcmParams : public AlgorithmParams {
 // https://w3c.github.io/webcrypto/#hkdf-params
 struct HKDFParams : public AlgorithmParams {
     virtual ~HKDFParams() override;
-    HKDFParams(String name, HashAlgorithmIdentifier hash, ByteBuffer salt, ByteBuffer info)
-        : AlgorithmParams(move(name))
-        , hash(move(hash))
+    HKDFParams(HashAlgorithmIdentifier hash, ByteBuffer salt, ByteBuffer info)
+        : hash(move(hash))
         , salt(move(salt))
         , info(move(info))
     {
@@ -124,9 +121,8 @@ struct HKDFParams : public AlgorithmParams {
 // https://w3c.github.io/webcrypto/#pbkdf2-params
 struct PBKDF2Params : public AlgorithmParams {
     virtual ~PBKDF2Params() override;
-    PBKDF2Params(String name, ByteBuffer salt, u32 iterations, HashAlgorithmIdentifier hash)
-        : AlgorithmParams(move(name))
-        , salt(move(salt))
+    PBKDF2Params(ByteBuffer salt, u32 iterations, HashAlgorithmIdentifier hash)
+        : salt(move(salt))
         , iterations(iterations)
         , hash(move(hash))
     {
@@ -143,9 +139,8 @@ struct PBKDF2Params : public AlgorithmParams {
 struct RsaKeyGenParams : public AlgorithmParams {
     virtual ~RsaKeyGenParams() override;
 
-    RsaKeyGenParams(String name, u32 modulus_length, ::Crypto::UnsignedBigInteger public_exponent)
-        : AlgorithmParams(move(name))
-        , modulus_length(modulus_length)
+    RsaKeyGenParams(u32 modulus_length, ::Crypto::UnsignedBigInteger public_exponent)
+        : modulus_length(modulus_length)
         , public_exponent(move(public_exponent))
     {
     }
@@ -161,8 +156,8 @@ struct RsaKeyGenParams : public AlgorithmParams {
 struct RsaHashedKeyGenParams : public RsaKeyGenParams {
     virtual ~RsaHashedKeyGenParams() override;
 
-    RsaHashedKeyGenParams(String name, u32 modulus_length, ::Crypto::UnsignedBigInteger public_exponent, HashAlgorithmIdentifier hash)
-        : RsaKeyGenParams(move(name), modulus_length, move(public_exponent))
+    RsaHashedKeyGenParams(u32 modulus_length, ::Crypto::UnsignedBigInteger public_exponent, HashAlgorithmIdentifier hash)
+        : RsaKeyGenParams(modulus_length, move(public_exponent))
         , hash(move(hash))
     {
     }
@@ -176,9 +171,8 @@ struct RsaHashedKeyGenParams : public RsaKeyGenParams {
 struct RsaHashedImportParams : public AlgorithmParams {
     virtual ~RsaHashedImportParams() override;
 
-    RsaHashedImportParams(String name, HashAlgorithmIdentifier hash)
-        : AlgorithmParams(move(name))
-        , hash(move(hash))
+    RsaHashedImportParams(HashAlgorithmIdentifier hash)
+        : hash(move(hash))
     {
     }
 
@@ -191,9 +185,8 @@ struct RsaHashedImportParams : public AlgorithmParams {
 struct RsaOaepParams : public AlgorithmParams {
     virtual ~RsaOaepParams() override;
 
-    RsaOaepParams(String name, ByteBuffer label)
-        : AlgorithmParams(move(name))
-        , label(move(label))
+    RsaOaepParams(ByteBuffer label)
+        : label(move(label))
     {
     }
 
@@ -206,9 +199,8 @@ struct RsaOaepParams : public AlgorithmParams {
 struct EcdsaParams : public AlgorithmParams {
     virtual ~EcdsaParams() override;
 
-    EcdsaParams(String name, HashAlgorithmIdentifier hash)
-        : AlgorithmParams(move(name))
-        , hash(move(hash))
+    EcdsaParams(HashAlgorithmIdentifier hash)
+        : hash(move(hash))
     {
     }
 
@@ -221,9 +213,8 @@ struct EcdsaParams : public AlgorithmParams {
 struct EcKeyGenParams : public AlgorithmParams {
     virtual ~EcKeyGenParams() override;
 
-    EcKeyGenParams(String name, NamedCurve named_curve)
-        : AlgorithmParams(move(name))
-        , named_curve(move(named_curve))
+    EcKeyGenParams(NamedCurve named_curve)
+        : named_curve(move(named_curve))
     {
     }
 
@@ -236,9 +227,8 @@ struct EcKeyGenParams : public AlgorithmParams {
 struct AesKeyGenParams : public AlgorithmParams {
     virtual ~AesKeyGenParams() override;
 
-    AesKeyGenParams(String name, u16 length)
-        : AlgorithmParams(move(name))
-        , length(length)
+    AesKeyGenParams(u16 length)
+        : length(length)
     {
     }
 
@@ -251,9 +241,8 @@ struct AesKeyGenParams : public AlgorithmParams {
 struct AesDerivedKeyParams : public AlgorithmParams {
     virtual ~AesDerivedKeyParams() override;
 
-    AesDerivedKeyParams(String name, u16 length)
-        : AlgorithmParams(move(name))
-        , length(length)
+    AesDerivedKeyParams(u16 length)
+        : length(length)
     {
     }
 
@@ -266,9 +255,8 @@ struct AesDerivedKeyParams : public AlgorithmParams {
 struct HmacImportParams : public AlgorithmParams {
     virtual ~HmacImportParams() override;
 
-    HmacImportParams(String name, HashAlgorithmIdentifier hash, Optional<WebIDL::UnsignedLong> length)
-        : AlgorithmParams(move(name))
-        , hash(move(hash))
+    HmacImportParams(HashAlgorithmIdentifier hash, Optional<WebIDL::UnsignedLong> length)
+        : hash(move(hash))
         , length(length)
     {
     }
@@ -283,9 +271,8 @@ struct HmacImportParams : public AlgorithmParams {
 struct HmacKeyGenParams : public AlgorithmParams {
     virtual ~HmacKeyGenParams() override;
 
-    HmacKeyGenParams(String name, HashAlgorithmIdentifier hash, Optional<WebIDL::UnsignedLong> length)
-        : AlgorithmParams(move(name))
-        , hash(move(hash))
+    HmacKeyGenParams(HashAlgorithmIdentifier hash, Optional<WebIDL::UnsignedLong> length)
+        : hash(move(hash))
         , length(length)
     {
     }
@@ -580,9 +567,8 @@ private:
 struct EcdhKeyDeriveParams : public AlgorithmParams {
     virtual ~EcdhKeyDeriveParams() override;
 
-    EcdhKeyDeriveParams(String name, CryptoKey& public_key)
-        : AlgorithmParams(move(name))
-        , public_key(public_key)
+    EcdhKeyDeriveParams(CryptoKey& public_key)
+        : public_key(public_key)
     {
     }
 
@@ -594,9 +580,8 @@ struct EcdhKeyDeriveParams : public AlgorithmParams {
 struct EcKeyImportParams : public AlgorithmParams {
     virtual ~EcKeyImportParams() override;
 
-    EcKeyImportParams(String name, String named_curve)
-        : AlgorithmParams(move(name))
-        , named_curve(move(named_curve))
+    EcKeyImportParams(String named_curve)
+        : named_curve(move(named_curve))
     {
     }
 

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -807,7 +807,7 @@ SupportedAlgorithmsMap const& supported_algorithms()
     // https://w3c.github.io/webcrypto/#ecdh-registration
     define_an_algorithm<ECDH, EcKeyImportParams>("importKey"_string, "ECDH"_string);
     define_an_algorithm<ECDH>("exportKey"_string, "ECDH"_string);
-    define_an_algorithm<ECDH, EcdhKeyDerivePrams>("deriveBits"_string, "ECDH"_string);
+    define_an_algorithm<ECDH, EcdhKeyDeriveParams>("deriveBits"_string, "ECDH"_string);
     define_an_algorithm<ECDH, EcKeyGenParams>("generateKey"_string, "ECDH"_string);
 
     // https://w3c.github.io/webcrypto/#aes-ctr-registration
@@ -867,13 +867,13 @@ SupportedAlgorithmsMap const& supported_algorithms()
     define_an_algorithm<PBKDF2>("get key length"_string, "PBKDF2"_string);
 
     // https://wicg.github.io/webcrypto-secure-curves/#x25519-registration
-    define_an_algorithm<X25519, EcdhKeyDerivePrams>("deriveBits"_string, "X25519"_string);
+    define_an_algorithm<X25519, EcdhKeyDeriveParams>("deriveBits"_string, "X25519"_string);
     define_an_algorithm<X25519>("generateKey"_string, "X25519"_string);
     define_an_algorithm<X25519>("importKey"_string, "X25519"_string);
     define_an_algorithm<X25519>("exportKey"_string, "X25519"_string);
 
     // https://wicg.github.io/webcrypto-secure-curves/#x448-registration
-    define_an_algorithm<X448, EcdhKeyDerivePrams>("deriveBits"_string, "X448"_string);
+    define_an_algorithm<X448, EcdhKeyDeriveParams>("deriveBits"_string, "X448"_string);
     define_an_algorithm<X448>("generateKey"_string, "X448"_string);
     define_an_algorithm<X448>("importKey"_string, "X448"_string);
     define_an_algorithm<X448>("exportKey"_string, "X448"_string);

--- a/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -100,6 +100,8 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
     // 5. If registeredAlgorithms contains a key that is a case-insensitive string match for algName:
     if (auto it = registered_algorithms.find(algorithm_name); it != registered_algorithms.end()) {
         // 1. Set algName to the value of the matching key.
+        algorithm_name = it->key;
+
         // 2. Let desiredType be the IDL dictionary type stored at algName in registeredAlgorithms.
         desired_type = it->value;
     } else {
@@ -110,7 +112,6 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
 
     // 8. Let normalizedAlgorithm be the result of converting the ECMAScript object represented by alg
     // to the IDL dictionary type desiredType, as defined by [WebIDL].
-    // 9. Set the name attribute of normalizedAlgorithm to algName.
     // 10. If an error occurred, return the error and terminate this algorithm.
     // 11. Let dictionaries be a list consisting of the IDL dictionary type desiredType
     // and all of desiredType's inherited dictionaries, in order from least to most derived.
@@ -118,6 +119,11 @@ WebIDL::ExceptionOr<NormalizedAlgorithmAndParameter> normalize_an_algorithm(JS::
     //    Note: All of these steps are handled by the create_methods and parameter_from_value methods.
     auto methods = desired_type.create_methods(realm);
     auto parameter = TRY(desired_type.parameter_from_value(vm, algorithm.get<GC::Root<JS::Object>>()));
+
+    // 9. Set the name attribute of normalizedAlgorithm to algName.
+    VERIFY(parameter->name.is_empty());
+    parameter->name = algorithm_name;
+
     auto normalized_algorithm = NormalizedAlgorithmAndParameter { move(methods), move(parameter) };
 
     // 13. Return normalizedAlgorithm.

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits_curve448.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/cfrg_curves_bits_curve448.https.any.txt
@@ -6,8 +6,8 @@ Rerun
 
 Found 18 tests
 
-16 Pass
-2 Fail
+17 Pass
+1 Fail
 Details
 Result	Test Name	MessagePass	setup - define tests	
 Pass	X448 key derivation checks for all-zero value result with a key of order 0	
@@ -16,7 +16,7 @@ Pass	X448 key derivation checks for all-zero value result with a key of order p-
 Pass	X448 key derivation checks for all-zero value result with a key of order p (=0, order 4)	
 Pass	X448 key derivation checks for all-zero value result with a key of order p+1 (=1, order 1)	
 Pass	X448 good parameters	
-Fail	X448 mixed case parameters	
+Pass	X448 mixed case parameters	
 Pass	X448 short result	
 Fail	X448 non-multiple of 8 bits	
 Pass	X448 missing public property	

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.txt
@@ -6,8 +6,8 @@ Rerun
 
 Found 40 tests
 
-23 Pass
-17 Fail
+25 Pass
+15 Fail
 Details
 Result	Test Name	MessagePass	setup - define tests	
 Fail	P-521 good parameters	
@@ -24,7 +24,7 @@ Fail	P-521 public property value is a private key
 Fail	P-521 public property value is a secret key	
 Fail	P-521 asking for too many bits	
 Pass	P-256 good parameters	
-Fail	P-256 mixed case parameters	
+Pass	P-256 mixed case parameters	
 Pass	P-256 short result	
 Fail	P-256 non-multiple of 8 bits	
 Pass	P-256 missing public curve	
@@ -37,7 +37,7 @@ Pass	P-256 public property value is a private key
 Pass	P-256 public property value is a secret key	
 Fail	P-256 asking for too many bits	
 Pass	P-384 good parameters	
-Fail	P-384 mixed case parameters	
+Pass	P-384 mixed case parameters	
 Pass	P-384 short result	
 Fail	P-384 non-multiple of 8 bits	
 Pass	P-384 missing public curve	

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_keys.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_keys.https.any.txt
@@ -6,8 +6,8 @@ Rerun
 
 Found 31 tests
 
-21 Pass
-10 Fail
+23 Pass
+8 Fail
 Details
 Result	Test Name	MessagePass	setup - define tests	
 Fail	P-521 good parameters	
@@ -21,7 +21,7 @@ Fail	P-521 base key is not a private key
 Fail	P-521 public property value is a private key	
 Fail	P-521 public property value is a secret key	
 Pass	P-256 good parameters	
-Fail	P-256 mixed case parameters	
+Pass	P-256 mixed case parameters	
 Pass	P-256 missing public curve	
 Pass	P-256 public property of algorithm is not a CryptoKey	
 Pass	P-256 mismatched curves	
@@ -31,7 +31,7 @@ Pass	P-256 base key is not a private key
 Pass	P-256 public property value is a private key	
 Pass	P-256 public property value is a secret key	
 Pass	P-384 good parameters	
-Fail	P-384 mixed case parameters	
+Pass	P-384 mixed case parameters	
 Pass	P-384 missing public curve	
 Pass	P-384 public property of algorithm is not a CryptoKey	
 Pass	P-384 mismatched curves	


### PR DESCRIPTION
Following https://github.com/LadybirdBrowser/ladybird/pull/2598#discussion_r1859263798, I have investigated how we handle case-sensitiveness for WebCryptoAPI and made two adjustments:
- All case-insesitive matches have been removed where not stated by the spec
- Algorithm name matching has been made case-insensitive by correcting some existing code and making it closer to spec

Fixes 5 WPT tests and a typo :).