### PR TITLE
Build: Fix libpxbackend dependency mismatch

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -57,6 +57,7 @@
         "apng"
       ]
     },
+    "libproxy",
     {
       "name": "libavif",
       "features": [
@@ -140,6 +141,10 @@
     {
       "name": "libpng",
       "version": "1.6.43#3"
+    },
+    {
+      "name": "libproxy",
+      "version": "0.4.18#3"
     },
     {
       "name": "libavif",


### PR DESCRIPTION
libpxbackend was not being installed from vcpkg which lead to use of libpxbackend on the system causing library mismatch in rolling distros(ie arch linux)

**Before:**
![image](https://github.com/user-attachments/assets/c2f0edf9-4fbf-45c7-ad7c-ff03f419d0ef)

**After:**
![image](https://github.com/user-attachments/assets/9a9bc626-8009-4741-9577-13addaefbfed)
