### PR TITLE
LibWeb: Limit `HTMLInputElement.size` to allowed values

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1861,19 +1861,23 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_min_length(WebIDL::Long value)
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#the-size-attribute
-unsigned HTMLInputElement::size() const
+WebIDL::UnsignedLong HTMLInputElement::size() const
 {
     // The size attribute, if specified, must have a value that is a valid non-negative integer greater than zero.
     // The size IDL attribute is limited to only positive numbers and has a default value of 20.
     if (auto size_string = get_attribute(HTML::AttributeNames::size); size_string.has_value()) {
-        if (auto size = parse_non_negative_integer(*size_string); size.has_value() && size.value() != 0)
+        if (auto size = parse_non_negative_integer(*size_string); size.has_value() && *size != 0 && *size <= 2147483647)
             return *size;
     }
     return 20;
 }
 
-WebIDL::ExceptionOr<void> HTMLInputElement::set_size(unsigned value)
+WebIDL::ExceptionOr<void> HTMLInputElement::set_size(WebIDL::UnsignedLong value)
 {
+    if (value == 0)
+        return WebIDL::IndexSizeError::create(realm(), "Size must be greater than zero"_string);
+    if (value > 2147483647)
+        value = 20;
     return set_attribute(HTML::AttributeNames::size, String::number(value));
 }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -125,8 +125,8 @@ public:
     WebIDL::Long min_length() const;
     WebIDL::ExceptionOr<void> set_min_length(WebIDL::Long);
 
-    unsigned size() const;
-    WebIDL::ExceptionOr<void> set_size(unsigned value);
+    WebIDL::UnsignedLong size() const;
+    WebIDL::ExceptionOr<void> set_size(WebIDL::UnsignedLong value);
 
     struct SelectedCoordinate {
         int x { 0 };

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -299,16 +299,16 @@ unsigned HTMLTextAreaElement::cols() const
     return 20;
 }
 
-WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_cols(unsigned cols)
+WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_cols(WebIDL::UnsignedLong cols)
 {
-    if (cols > 2147483647)
+    if (cols == 0 || cols > 2147483647)
         cols = 20;
 
     return set_attribute(HTML::AttributeNames::cols, String::number(cols));
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-rows
-unsigned HTMLTextAreaElement::rows() const
+WebIDL::UnsignedLong HTMLTextAreaElement::rows() const
 {
     // The cols and rows attributes are limited to only positive numbers with fallback. The rows IDL attribute's default value is 2.
     if (auto rows_string = get_attribute(HTML::AttributeNames::rows); rows_string.has_value()) {
@@ -318,9 +318,9 @@ unsigned HTMLTextAreaElement::rows() const
     return 2;
 }
 
-WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_rows(unsigned rows)
+WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_rows(WebIDL::UnsignedLong rows)
 {
-    if (rows > 2147483647)
+    if (rows == 0 || rows > 2147483647)
         rows = 2;
 
     return set_attribute(HTML::AttributeNames::rows, String::number(rows));

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -102,11 +102,11 @@ public:
     WebIDL::Long min_length() const;
     WebIDL::ExceptionOr<void> set_min_length(WebIDL::Long);
 
-    unsigned cols() const;
+    WebIDL::UnsignedLong cols() const;
     WebIDL::ExceptionOr<void> set_cols(unsigned);
 
-    unsigned rows() const;
-    WebIDL::ExceptionOr<void> set_rows(unsigned);
+    WebIDL::UnsignedLong rows() const;
+    WebIDL::ExceptionOr<void> set_rows(WebIDL::UnsignedLong);
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
     WebIDL::UnsignedLong selection_start_binding() const;

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -14,6 +14,22 @@ img.getAttribute("hspace") after img.setAttribute("hspace", "4294967295"): 42949
 img.hspace after img.setAttribute("hspace", "4294967295"): 0
 img.getAttribute("hspace") after img.hspace = 4294967295: 0
 img.hspace after img.hspace = 4294967295: 0
+input.getAttribute("size") after input.setAttribute("size", "1"): 1
+input.size after input.setAttribute("size", "1"): 1
+input.getAttribute("size") after input.size = 1: 1
+input.size after input.size = 1: 1
+input.getAttribute("size") after input.setAttribute("size", "2147483647"): 2147483647
+input.size after input.setAttribute("size", "2147483647"): 2147483647
+input.getAttribute("size") after input.size = 2147483647: 2147483647
+input.size after input.size = 2147483647: 2147483647
+input.getAttribute("size") after input.setAttribute("size", "2147483648"): 2147483648
+input.size after input.setAttribute("size", "2147483648"): 20
+input.getAttribute("size") after input.size = 2147483648: 20
+input.size after input.size = 2147483648: 20
+input.getAttribute("size") after input.setAttribute("size", "4294967295"): 4294967295
+input.size after input.setAttribute("size", "4294967295"): 20
+input.getAttribute("size") after input.size = 4294967295: 20
+input.size after input.size = 4294967295: 20
 marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "1"): 1
 marquee.scrollAmount after marquee.setAttribute("scrollamount", "1"): 1
 marquee.getAttribute("scrollamount") after marquee.scrollAmount = 1: 1

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -1,3 +1,7 @@
+img.getAttribute("hspace") after img.setAttribute("hspace", "0"): 0
+img.hspace after img.setAttribute("hspace", "0"): 0
+img.getAttribute("hspace") after img.hspace = 0: 0
+img.hspace after img.hspace = 0: 0
 img.getAttribute("hspace") after img.setAttribute("hspace", "1"): 1
 img.hspace after img.setAttribute("hspace", "1"): 1
 img.getAttribute("hspace") after img.hspace = 1: 1
@@ -14,6 +18,9 @@ img.getAttribute("hspace") after img.setAttribute("hspace", "4294967295"): 42949
 img.hspace after img.setAttribute("hspace", "4294967295"): 0
 img.getAttribute("hspace") after img.hspace = 4294967295: 0
 img.hspace after img.hspace = 4294967295: 0
+input.getAttribute("size") after input.setAttribute("size", "0"): 0
+input.size after input.setAttribute("size", "0"): 20
+input.size = 0 threw exception of type IndexSizeError
 input.getAttribute("size") after input.setAttribute("size", "1"): 1
 input.size after input.setAttribute("size", "1"): 1
 input.getAttribute("size") after input.size = 1: 1
@@ -30,6 +37,10 @@ input.getAttribute("size") after input.setAttribute("size", "4294967295"): 42949
 input.size after input.setAttribute("size", "4294967295"): 20
 input.getAttribute("size") after input.size = 4294967295: 20
 input.size after input.size = 4294967295: 20
+marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "0"): 0
+marquee.scrollAmount after marquee.setAttribute("scrollamount", "0"): 0
+marquee.getAttribute("scrollamount") after marquee.scrollAmount = 0: 0
+marquee.scrollAmount after marquee.scrollAmount = 0: 0
 marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "1"): 1
 marquee.scrollAmount after marquee.setAttribute("scrollamount", "1"): 1
 marquee.getAttribute("scrollamount") after marquee.scrollAmount = 1: 1
@@ -46,6 +57,10 @@ marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", 
 marquee.scrollAmount after marquee.setAttribute("scrollamount", "4294967295"): 6
 marquee.getAttribute("scrollamount") after marquee.scrollAmount = 4294967295: 6
 marquee.scrollAmount after marquee.scrollAmount = 4294967295: 6
+marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "0"): 0
+marquee.scrollDelay after marquee.setAttribute("scrolldelay", "0"): 0
+marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 0: 0
+marquee.scrollDelay after marquee.scrollDelay = 0: 0
 marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "1"): 1
 marquee.scrollDelay after marquee.setAttribute("scrolldelay", "1"): 1
 marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 1: 1
@@ -62,6 +77,10 @@ marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "4
 marquee.scrollDelay after marquee.setAttribute("scrolldelay", "4294967295"): 85
 marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 4294967295: 85
 marquee.scrollDelay after marquee.scrollDelay = 4294967295: 85
+textarea.getAttribute("rows") after textarea.setAttribute("rows", "0"): 0
+textarea.rows after textarea.setAttribute("rows", "0"): 2
+textarea.getAttribute("rows") after textarea.rows = 0: 2
+textarea.rows after textarea.rows = 0: 2
 textarea.getAttribute("rows") after textarea.setAttribute("rows", "1"): 1
 textarea.rows after textarea.setAttribute("rows", "1"): 1
 textarea.getAttribute("rows") after textarea.rows = 1: 1
@@ -78,6 +97,10 @@ textarea.getAttribute("rows") after textarea.setAttribute("rows", "4294967295"):
 textarea.rows after textarea.setAttribute("rows", "4294967295"): 2
 textarea.getAttribute("rows") after textarea.rows = 4294967295: 2
 textarea.rows after textarea.rows = 4294967295: 2
+textarea.getAttribute("cols") after textarea.setAttribute("cols", "0"): 0
+textarea.cols after textarea.setAttribute("cols", "0"): 20
+textarea.getAttribute("cols") after textarea.cols = 0: 20
+textarea.cols after textarea.cols = 0: 20
 textarea.getAttribute("cols") after textarea.setAttribute("cols", "1"): 1
 textarea.cols after textarea.setAttribute("cols", "1"): 1
 textarea.getAttribute("cols") after textarea.cols = 1: 1

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -23,6 +23,7 @@
         }
 
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
+        testProperty("input", "size", (input) => input.size, (input, value) => input.size = value);
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
         testProperty("textarea", "rows", (textarea) => textarea.rows, (textarea, value) => textarea.rows = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -11,11 +11,16 @@
                 println(`${elementName}.${propertyName} after ${elementName}.setAttribute("${attributeName}", "${value}"): ${propertyGetter(element)}`);
 
                 element = document.createElement(elementName);
-                propertySetter(element, value);
-                println(`${elementName}.getAttribute("${attributeName}") after ${elementName}.${propertyName} = ${value}: ${element.getAttribute(attributeName)}`);
-                println(`${elementName}.${propertyName} after ${elementName}.${propertyName} = ${value}: ${propertyGetter(element)}`);
+                try {
+                    propertySetter(element, value);
+                    println(`${elementName}.getAttribute("${attributeName}") after ${elementName}.${propertyName} = ${value}: ${element.getAttribute(attributeName)}`);
+                    println(`${elementName}.${propertyName} after ${elementName}.${propertyName} = ${value}: ${propertyGetter(element)}`);
+                } catch (e) {
+                    println(`${elementName}.${propertyName} = ${value} threw exception of type ${e.name}`);    
+                }
             }
 
+            setValue(0);
             setValue(1);
             setValue(2147483647);
             setValue(2147483648);


### PR DESCRIPTION
Attempting to set `HTMLInputElement.size` to 0 via IDL now throws an IndexSizeError DOMException. Attempting to set it to a value larger than 2147483647 results in it being set to the default value.

Fixes 3 subtests in: http://wpt.live/html/dom/reflection-forms-weekmonth.html