### PR TITLE
Tests: Disable a worker test that's flaky on macOS

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -2,6 +2,7 @@
 ; Consistently hang on macOS, see #1306
 Text/input/HTML/cross-origin-window-properties.html
 Text/input/HTML/DedicatedWorkerGlobalScope-instanceof.html
+Text/input/HTML/MessagePort-MessageEvents-should-be-trusted.html
 Text/input/window-scrollTo.html
 
 ; Flaky on CI


### PR DESCRIPTION
Consistently times out locally, but not on CI somehow.