### PR TITLE
CI: Increase the default ctest timeout to 1 hour

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}
-        run: ctest --preset Sanitizer --output-on-failure --test-dir Build
+        run: ctest --preset Sanitizer --output-on-failure --test-dir Build --timeout 3600
         env:
           TESTS_ONLY: 1
 


### PR DESCRIPTION
We seem to be brushing up against the 1500s limit (25 minutes) on both macOS and Linux+GCC workflows. As we keep importing more WPT tests, we will exasperate the issue.