### PR TITLE
AK+LibMain: Perform LSAN checks ahead of process shutdown

### DIFF
--- a/AK/LsanSuppressions.h
+++ b/AK/LsanSuppressions.h
@@ -8,9 +8,10 @@
 
 #include <AK/Platform.h>
 
-#ifdef HAS_ADDRESS_SANITIZER
+#if defined(HAS_ADDRESS_SANITIZER)
+#    include <sanitizer/lsan_interface.h>
+
 extern "C" {
-char const* __lsan_default_suppressions();
 char const* __lsan_default_suppressions()
 {
     // Both Skia and Chromium suppress false positive FontConfig leaks
@@ -20,3 +21,14 @@ char const* __lsan_default_suppressions()
 }
 }
 #endif
+
+namespace AK {
+
+inline void perform_leak_sanitizer_checks()
+{
+#if defined(HAS_ADDRESS_SANITIZER)
+    __lsan_do_leak_check();
+#endif
+}
+
+}

--- a/Libraries/LibMain/Main.cpp
+++ b/Libraries/LibMain/Main.cpp
@@ -5,6 +5,8 @@
  */
 
 #include <AK/Format.h>
+#include <AK/LsanSuppressions.h>
+#include <AK/ScopeGuard.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibMain/Main.h>
@@ -41,10 +43,14 @@ int main(int argc, char** argv)
         .argv = argv,
         .strings = arguments.span(),
     });
+
+    ScopeGuard guard { []() { AK::perform_leak_sanitizer_checks(); } };
+
     if (result.is_error()) {
         auto error = result.release_error();
         warnln("\033[31;1mRuntime error\033[0m: {}", error);
         return Main::return_code_for_errors();
     }
+
     return result.value();
 }


### PR DESCRIPTION
From the documentation of __lsan_do_leak_check:

    By calling this function early during process shutdown, you can
    instruct LSan to ignore shutdown-only leaks which happen later on.

We currently have tens of thousands of lines of LSAN output at the end
of each LibWeb test run on CI. May of these are expected leaks; e.g. we
load a bunch of fonts at WebContent process start and just hold on to
them statically, until process exit.

By calling this LSAN method just before we exit from LibMain's main(),
we get a much shorter report of what appear to be more legit leaks.