### PR TITLE
LibWeb: Fix LegacyNullToEmptyString flag handler in IDL

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -372,7 +372,7 @@ static void generate_to_string(SourceGenerator& scoped_generator, ParameterType 
         if (!parameter.type->is_nullable()) {
             scoped_generator.append(R"~~~(
     @string_type@ @cpp_name@;
-    if (!@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null()) {
+    if (@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null()) {
         @cpp_name@ = TRY(WebIDL::@to_string@(vm, @js_name@@js_suffix@));
     }
 )~~~");
@@ -397,7 +397,7 @@ static void generate_to_string(SourceGenerator& scoped_generator, ParameterType 
 
         scoped_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_undefined()) {
-        if (!@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null())
+        if (@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null())
             @cpp_name@ = TRY(WebIDL::@to_string@(vm, @js_name@@js_suffix@));
     })~~~");
         if (!may_be_null) {

--- a/Tests/LibWeb/Text/expected/wpt-import/uievents/constructors/inputevent-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/uievents/constructors/inputevent-constructor.txt
@@ -1,0 +1,14 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 4 tests
+
+4 Pass
+Details
+Result	Test Name	MessagePass	InputEvent constructor without InputEventInit.	
+Pass	InputEvent construtor with InputEventInit where data is null	
+Pass	InputEvent construtor with InputEventInit where data is empty string	
+Pass	InputEvent construtor with InputEventInit where data is non empty string	

--- a/Tests/LibWeb/Text/input/wpt-import/uievents/constructors/inputevent-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/uievents/constructors/inputevent-constructor.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>InputEvent Constructor Tests</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  var e = new InputEvent('type');
+  assert_equals(e.data, null, '.data');
+  assert_false(e.isComposing, '.isComposing');
+}, 'InputEvent constructor without InputEventInit.');
+
+test(function() {
+  var e = new InputEvent('type', { data: null, isComposing: true });
+  assert_equals(e.data, null, '.data');
+  assert_true(e.isComposing, '.isComposing');
+}, 'InputEvent construtor with InputEventInit where data is null');
+
+test(function() {
+  assert_equals(new InputEvent('type', { data: ''}).data, '', '.data');
+}, 'InputEvent construtor with InputEventInit where data is empty string');
+
+test(function() {
+  assert_equals(new InputEvent('type', { data: 'data' }).data, 'data', '.data');
+}, 'InputEvent construtor with InputEventInit where data is non empty string');
+</script>


### PR DESCRIPTION
As suggested by @yyny on Discord

Fix handling of `legacy_null_to_empty_string` in IDL string conversion

- Corrected logic in `generate_to_string` to properly respect the `@legacy_null_to_empty_string@` flag during WebIDL bindings generation.
- The previous condition (`!@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null()`) inverted the intended behavior of `legacy_null_to_empty_string`, causing `null` values to be coerced into empty strings (`""`) when the flag was `false`.
- Updated the condition to (`@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null()`) to:
  - Ensure that `null` is preserved when `legacy_null_to_empty_string = false`.
  - Coerce `null` to an empty string (`""`) when `legacy_null_to_empty_string = true`.
- This change fixes cases where optional string parameters were incorrectly converted to `"null"` or `"undefined"` instead of being treated as `null` or left unset.

Context:
- Resolves issues where nullable or optional WebIDL `DOMString` parameters were misinterpreted due to incorrect handling of `null` and `undefined`.
