### PR TITLE
LibWeb: Use the [Reflect] attribute to implement `HTMLLinkElement.as`

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -91,25 +91,6 @@ void HTMLLinkElement::inserted()
     }
 }
 
-// https://html.spec.whatwg.org/multipage/semantics.html#dom-link-as
-String HTMLLinkElement::as() const
-{
-    String attribute_value = get_attribute_value(HTML::AttributeNames::as);
-
-    if (attribute_value.equals_ignoring_ascii_case("fetch"sv)
-        || attribute_value.equals_ignoring_ascii_case("image"sv)
-        || attribute_value.equals_ignoring_ascii_case("script"sv)
-        || attribute_value.equals_ignoring_ascii_case("style"sv)
-        || attribute_value.equals_ignoring_ascii_case("video"sv)
-        || attribute_value.equals_ignoring_ascii_case("audio"sv)
-        || attribute_value.equals_ignoring_ascii_case("track"sv)
-        || attribute_value.equals_ignoring_ascii_case("font"sv)) {
-        return attribute_value.to_lowercase().release_value();
-    }
-
-    return String {};
-}
-
 WebIDL::ExceptionOr<void> HTMLLinkElement::set_as(String const& value)
 {
     return set_attribute(HTML::AttributeNames::as, move(value));

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -33,7 +33,6 @@ public:
     String rel() const { return get_attribute_value(HTML::AttributeNames::rel); }
     String type() const { return get_attribute_value(HTML::AttributeNames::type); }
     String href() const { return get_attribute_value(HTML::AttributeNames::href); }
-    String as() const;
     WebIDL::ExceptionOr<void> set_as(String const&);
 
     GC::Ref<DOM::DOMTokenList> rel_list();

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -3,6 +3,34 @@
 #import <HTML/HTMLElement.idl>
 #import <HTML/Scripting/Fetching.idl>
 
+// https://fetch.spec.whatwg.org/#concept-potential-destination
+enum PotentialDestination {
+    "",
+    "audio",
+    "audioworklet",
+    "document",
+    "embed",
+    "font",
+    "frame",
+    "iframe",
+    "image",
+    "json",
+    "manifest",
+    "object",
+    "paintworklet",
+    "report",
+    "script",
+    "serviceworker",
+    "sharedworker",
+    "style",
+    "track",
+    "video",
+    "webidentity", 
+    "worker",
+    "xslt",
+    "fetch"
+};
+
 // https://html.spec.whatwg.org/multipage/semantics.html#htmllinkelement
 [Exposed=Window]
 interface HTMLLinkElement : HTMLElement {
@@ -12,7 +40,7 @@ interface HTMLLinkElement : HTMLElement {
     [CEReactions, Reflect, URL] attribute USVString href;
     [CEReactions, Reflect=crossorigin, Enumerated=CORSSettingsAttribute] attribute DOMString? crossOrigin;
     [CEReactions, Reflect] attribute DOMString rel;
-    [CEReactions] attribute DOMString as;
+    [CEReactions, Reflect, Enumerated=PotentialDestination] attribute DOMString as;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
     [CEReactions, Reflect] attribute DOMString media;
     [CEReactions, Reflect] attribute DOMString integrity;


### PR DESCRIPTION
Also ensure that all valid potential destinations are permitted.

This fixes 23 subtests in: http://wpt.live/html/dom/reflection-metadata.html