### PR TITLE
LibWeb: Serialize empty InputEventInit data as an empty string

### DIFF
--- a/Libraries/LibWeb/UIEvents/InputEvent.idl
+++ b/Libraries/LibWeb/UIEvents/InputEvent.idl
@@ -14,7 +14,7 @@ interface InputEvent : UIEvent {
 
 // https://w3c.github.io/uievents/#dictdef-inputeventinit
 dictionary InputEventInit : UIEventInit {
-    DOMString? data = null;
+    [LegacyNullToEmptyString] DOMString? data = null;
     boolean isComposing = false;
     DOMString inputType = "";
 };

--- a/Tests/LibWeb/Text/expected/wpt-import/uievents/constructors/inputevent-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/uievents/constructors/inputevent-constructor.txt
@@ -1,0 +1,14 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 4 tests
+
+4 Pass
+Details
+Result	Test Name	MessagePass	InputEvent constructor without InputEventInit.	
+Pass	InputEvent construtor with InputEventInit where data is null	
+Pass	InputEvent construtor with InputEventInit where data is empty string	
+Pass	InputEvent construtor with InputEventInit where data is non empty string	

--- a/Tests/LibWeb/Text/input/wpt-import/uievents/constructors/inputevent-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/uievents/constructors/inputevent-constructor.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>InputEvent Constructor Tests</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  var e = new InputEvent('type');
+  assert_equals(e.data, null, '.data');
+  assert_false(e.isComposing, '.isComposing');
+}, 'InputEvent constructor without InputEventInit.');
+
+test(function() {
+  var e = new InputEvent('type', { data: null, isComposing: true });
+  assert_equals(e.data, null, '.data');
+  assert_true(e.isComposing, '.isComposing');
+}, 'InputEvent construtor with InputEventInit where data is null');
+
+test(function() {
+  assert_equals(new InputEvent('type', { data: ''}).data, '', '.data');
+}, 'InputEvent construtor with InputEventInit where data is empty string');
+
+test(function() {
+  assert_equals(new InputEvent('type', { data: 'data' }).data, 'data', '.data');
+}, 'InputEvent construtor with InputEventInit where data is non empty string');
+</script>


### PR DESCRIPTION
The specification https://w3c.github.io/uievents/#idl-inputeventinit doesn't seem to define this, but the changes in this PR align with the behavior of other browsers and the expectations of WPT.