### PR TITLE
Revert "CI: Increase the default ctest timeout to 1 hour"

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}
-        run: ctest --preset Sanitizer --output-on-failure --test-dir Build --timeout 3600
+        run: ctest --preset Sanitizer --output-on-failure --test-dir Build
         env:
           TESTS_ONLY: 1
 


### PR DESCRIPTION
This reverts commit aeaa284be3881b2ea4b38b967bf4327738119a17.

This didn't actually help. It appears we actually just get stuck, so increasing the timeout to an hour just makes CI take longer.