### PR TITLE
IDL Generator: Fix nullable string set to 'null' instead of actual null

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -395,11 +395,19 @@ static void generate_to_string(SourceGenerator& scoped_generator, ParameterType 
 )~~~");
         }
 
-        scoped_generator.append(R"~~~(
+        if (parameter.type->is_nullable()) {
+            scoped_generator.append(R"~~~(
+    if (!@js_name@@js_suffix@.is_undefined()) {
+        if (!@js_name@@js_suffix@.is_null())
+            @cpp_name@ = TRY(WebIDL::@to_string@(vm, @js_name@@js_suffix@));
+    })~~~");
+        } else {
+            scoped_generator.append(R"~~~(
     if (!@js_name@@js_suffix@.is_undefined()) {
         if (!@legacy_null_to_empty_string@ || !@js_name@@js_suffix@.is_null())
             @cpp_name@ = TRY(WebIDL::@to_string@(vm, @js_name@@js_suffix@));
     })~~~");
+        }
         if (!may_be_null) {
             scoped_generator.append(R"~~~( else {
         @cpp_name@ = MUST(@string_type@::from_utf8(@parameter.optional_default_value@sv));

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Comment-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Comment-constructor.txt
@@ -1,0 +1,26 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 16 tests
+
+16 Pass
+Details
+Result	Test Name	MessagePass	new Comment(): prototype chain	
+Pass	new Comment(): instanceof	
+Pass	new Comment(): no arguments	
+Pass	new Comment(): undefined	
+Pass	new Comment(): null	
+Pass	new Comment(): 42	
+Pass	new Comment(): ""	
+Pass	new Comment(): "-"	
+Pass	new Comment(): "--"	
+Pass	new Comment(): "-->"	
+Pass	new Comment(): "<!--"	
+Pass	new Comment(): "\0"	
+Pass	new Comment(): "\0test"	
+Pass	new Comment(): "&amp;"	
+Pass	new Comment(): two arguments	
+Pass	new Comment() should get the correct ownerDocument across globals	

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/DOMImplementation-createHTMLDocument.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/DOMImplementation-createHTMLDocument.txt
@@ -1,0 +1,23 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 13 tests
+
+13 Pass
+Details
+Result	Test Name	MessagePass	createHTMLDocument test 0: "","",""	
+Pass	createHTMLDocument test 1: null,"null","null"	
+Pass	createHTMLDocument test 2: undefined,undefined,""	
+Pass	createHTMLDocument test 3: "foo bar baz","foo bar baz","foo bar baz"	
+Pass	createHTMLDocument test 4: "foo\t\tbar baz","foo\t\tbar baz","foo bar baz"	
+Pass	createHTMLDocument test 5: "foo\n\nbar baz","foo\n\nbar baz","foo bar baz"	
+Pass	createHTMLDocument test 6: "foo\f\fbar baz","foo\f\fbar baz","foo bar baz"	
+Pass	createHTMLDocument test 7: "foo\r\rbar baz","foo\r\rbar baz","foo bar baz"	
+Pass	Missing title argument	
+Pass	createHTMLDocument(): metadata	
+Pass	createHTMLDocument(): characterSet aliases	
+Pass	createHTMLDocument(): URL parsing	
+Pass	createHTMLDocument(): document location getter is null	

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Text-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Text-constructor.txt
@@ -1,0 +1,26 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 16 tests
+
+16 Pass
+Details
+Result	Test Name	MessagePass	new Text(): prototype chain	
+Pass	new Text(): instanceof	
+Pass	new Text(): no arguments	
+Pass	new Text(): undefined	
+Pass	new Text(): null	
+Pass	new Text(): 42	
+Pass	new Text(): ""	
+Pass	new Text(): "-"	
+Pass	new Text(): "--"	
+Pass	new Text(): "-->"	
+Pass	new Text(): "<!--"	
+Pass	new Text(): "\0"	
+Pass	new Text(): "\0test"	
+Pass	new Text(): "&amp;"	
+Pass	new Text(): two arguments	
+Pass	new Text() should get the correct ownerDocument across globals	

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/documents/dom-tree-accessors/document.title-07.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/documents/dom-tree-accessors/document.title-07.txt
@@ -1,0 +1,19 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 9 tests
+
+9 Pass
+Details
+Result	Test Name	MessagePass	createHTMLDocument test 0: "","",""	
+Pass	createHTMLDocument test 1: null,"null","null"	
+Pass	createHTMLDocument test 2: undefined,undefined,""	
+Pass	createHTMLDocument test 3: "foo bar baz","foo bar baz","foo bar baz"	
+Pass	createHTMLDocument test 4: "foo\t\tbar baz","foo\t\tbar baz","foo bar baz"	
+Pass	createHTMLDocument test 5: "foo\n\nbar baz","foo\n\nbar baz","foo bar baz"	
+Pass	createHTMLDocument test 6: "foo\f\fbar baz","foo\f\fbar baz","foo bar baz"	
+Pass	createHTMLDocument test 7: "foo\r\rbar baz","foo\r\rbar baz","foo bar baz"	
+Pass	Missing title argument	

--- a/Tests/LibWeb/Text/expected/wpt-import/uievents/constructors/inputevent-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/uievents/constructors/inputevent-constructor.txt
@@ -1,0 +1,14 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 4 tests
+
+4 Pass
+Details
+Result	Test Name	MessagePass	InputEvent constructor without InputEventInit.	
+Pass	InputEvent construtor with InputEventInit where data is null	
+Pass	InputEvent construtor with InputEventInit where data is empty string	
+Pass	InputEvent construtor with InputEventInit where data is non empty string	

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Comment-Text-constructor.js
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Comment-Text-constructor.js
@@ -1,0 +1,77 @@
+function test_constructor(ctor) {
+  test(function() {
+    var object = new window[ctor]();
+    assert_equals(Object.getPrototypeOf(object),
+                  window[ctor].prototype, "Prototype chain: " + ctor);
+    assert_equals(Object.getPrototypeOf(Object.getPrototypeOf(object)),
+                  CharacterData.prototype, "Prototype chain: CharacterData");
+    assert_equals(Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(object))),
+                  Node.prototype, "Prototype chain: Node");
+  }, "new " + ctor + "(): prototype chain");
+
+  test(function() {
+    var object = new window[ctor]();
+    assert_true(object instanceof Node, "Should be a Node");
+    assert_true(object instanceof CharacterData, "Should be a CharacterData");
+    assert_true(object instanceof window[ctor], "Should be a " + ctor);
+  }, "new " + ctor + "(): instanceof");
+
+  test(function() {
+    var object = new window[ctor]();
+    assert_equals(object.data, "");
+    assert_equals(object.nodeValue, "");
+    assert_equals(object.ownerDocument, document);
+  }, "new " + ctor + "(): no arguments");
+
+  var testArgs = [
+    [undefined, ""],
+    [null, "null"],
+    [42, "42"],
+    ["", ""],
+    ["-", "-"],
+    ["--", "--"],
+    ["-->", "-->"],
+    ["<!--", "<!--"],
+    ["\u0000", "\u0000"],
+    ["\u0000test", "\u0000test"],
+    ["&amp;", "&amp;"],
+  ];
+
+  testArgs.forEach(function(a) {
+    var argument = a[0], expected = a[1];
+    test(function() {
+      var object = new window[ctor](argument);
+      assert_equals(object.data, expected);
+      assert_equals(object.nodeValue, expected);
+      assert_equals(object.ownerDocument, document);
+    }, "new " + ctor + "(): " + format_value(argument));
+  });
+
+  test(function() {
+    var called = [];
+    var object = new window[ctor]({
+      toString: function() {
+        called.push("first");
+        return "text";
+      }
+    }, {
+      toString: function() {
+        called.push("second");
+        assert_unreached("Should not look at the second argument.");
+      }
+    });
+    assert_equals(object.data, "text");
+    assert_equals(object.nodeValue, "text");
+    assert_equals(object.ownerDocument, document);
+    assert_array_equals(called, ["first"]);
+  }, "new " + ctor + "(): two arguments")
+
+  async_test("new " + ctor + "() should get the correct ownerDocument across globals").step(function() {
+    var iframe = document.createElement("iframe");
+    iframe.onload = this.step_func_done(function() {
+      var object = new iframe.contentWindow[ctor]();
+      assert_equals(object.ownerDocument, iframe.contentDocument);
+    });
+    document.body.appendChild(iframe);
+  });
+}

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Comment-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Comment-constructor.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Comment constructor</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-comment">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="Comment-Text-constructor.js"></script>
+<div id="log"></div>
+<script>
+test_constructor("Comment");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/DOMImplementation-createHTMLDocument.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/DOMImplementation-createHTMLDocument.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<meta charset=windows-1252>
+<!-- Using windows-1252 to ensure that DOMImplementation.createHTMLDocument()
+     doesn't inherit utf-8 from the parent document. -->
+<title>DOMImplementation.createHTMLDocument</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-domimplementation-createhtmldocument">
+<link rel=help href="https://dom.spec.whatwg.org/#dom-documenttype-name">
+<link rel=help href="https://dom.spec.whatwg.org/#dom-documenttype-publicid">
+<link rel=help href="https://dom.spec.whatwg.org/#dom-documenttype-systemid">
+<link rel=help href="https://dom.spec.whatwg.org/#dom-document-documentelement">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="DOMImplementation-createHTMLDocument.js"></script>
+<div id="log"></div>
+<script>
+createHTMLDocuments(function(doc, expectedtitle, normalizedtitle) {
+  assert_true(doc instanceof Document, "Should be a Document")
+  assert_true(doc instanceof Node, "Should be a Node")
+  assert_equals(doc.childNodes.length, 2,
+                "Document should have two child nodes")
+
+  var doctype = doc.doctype
+  assert_true(doctype instanceof DocumentType,
+              "Doctype should be a DocumentType")
+  assert_true(doctype instanceof Node, "Doctype should be a Node")
+  assert_equals(doctype.name, "html")
+  assert_equals(doctype.publicId, "")
+  assert_equals(doctype.systemId, "")
+
+  var documentElement = doc.documentElement
+  assert_true(documentElement instanceof HTMLHtmlElement,
+              "Document element should be a HTMLHtmlElement")
+  assert_equals(documentElement.childNodes.length, 2,
+                "Document element should have two child nodes")
+  assert_equals(documentElement.localName, "html")
+  assert_equals(documentElement.tagName, "HTML")
+
+  var head = documentElement.firstChild
+  assert_true(head instanceof HTMLHeadElement,
+              "Head should be a HTMLHeadElement")
+  assert_equals(head.localName, "head")
+  assert_equals(head.tagName, "HEAD")
+
+  if (expectedtitle !== undefined) {
+    assert_equals(head.childNodes.length, 1)
+
+    var title = head.firstChild
+    assert_true(title instanceof HTMLTitleElement,
+                "Title should be a HTMLTitleElement")
+    assert_equals(title.localName, "title")
+    assert_equals(title.tagName, "TITLE")
+    assert_equals(title.childNodes.length, 1)
+    assert_equals(title.firstChild.data, expectedtitle)
+  } else {
+    assert_equals(head.childNodes.length, 0)
+  }
+
+  var body = documentElement.lastChild
+  assert_true(body instanceof HTMLBodyElement,
+              "Body should be a HTMLBodyElement")
+  assert_equals(body.localName, "body")
+  assert_equals(body.tagName, "BODY")
+  assert_equals(body.childNodes.length, 0)
+})
+
+test(function() {
+  var doc = document.implementation.createHTMLDocument("test");
+  assert_equals(doc.URL, "about:blank");
+  assert_equals(doc.documentURI, "about:blank");
+  assert_equals(doc.compatMode, "CSS1Compat");
+  assert_equals(doc.characterSet, "UTF-8");
+  assert_equals(doc.contentType, "text/html");
+  assert_equals(doc.createElement("DIV").localName, "div");
+}, "createHTMLDocument(): metadata")
+
+test(function() {
+  var doc = document.implementation.createHTMLDocument("test");
+  assert_equals(doc.characterSet, "UTF-8", "characterSet");
+  assert_equals(doc.charset, "UTF-8", "charset");
+  assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
+}, "createHTMLDocument(): characterSet aliases")
+
+test(function() {
+  var doc = document.implementation.createHTMLDocument("test");
+  var a = doc.createElement("a");
+  // In UTF-8: 0xC3 0xA4
+  a.href = "http://example.org/?\u00E4";
+  assert_equals(a.href, "http://example.org/?%C3%A4");
+}, "createHTMLDocument(): URL parsing")
+
+// Test the document location getter is null outside of browser context
+test(function() {
+  var doc = document.implementation.createHTMLDocument();
+  assert_equals(doc.location, null);
+}, "createHTMLDocument(): document location getter is null")
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/DOMImplementation-createHTMLDocument.js
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/DOMImplementation-createHTMLDocument.js
@@ -1,0 +1,25 @@
+function createHTMLDocuments(checkDoc) {
+  var tests = [
+    ["", "", ""],
+    [null, "null", "null"],
+    [undefined, undefined, ""],
+    ["foo  bar baz", "foo  bar baz", "foo bar baz"],
+    ["foo\t\tbar baz", "foo\t\tbar baz", "foo bar baz"],
+    ["foo\n\nbar baz", "foo\n\nbar baz", "foo bar baz"],
+    ["foo\f\fbar baz", "foo\f\fbar baz", "foo bar baz"],
+    ["foo\r\rbar baz", "foo\r\rbar baz", "foo bar baz"],
+  ]
+
+  tests.forEach(function(t, i) {
+    var title = t[0], expectedtitle = t[1], normalizedtitle = t[2]
+    test(function() {
+      var doc = document.implementation.createHTMLDocument(title);
+      checkDoc(doc, expectedtitle, normalizedtitle)
+    }, "createHTMLDocument test " + i + ": " + t.map(function(el) { return format_value(el) }))
+  })
+
+  test(function() {
+    var doc = document.implementation.createHTMLDocument();
+    checkDoc(doc, undefined, "")
+  }, "Missing title argument");
+}

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Text-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Text-constructor.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Text constructor</title>
+<link rel=help href="https://dom.spec.whatwg.org/#dom-text">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="Comment-Text-constructor.js"></script>
+<div id="log"></div>
+<script>
+test_constructor("Text");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/dom/documents/dom-tree-accessors/document.title-07.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/dom/documents/dom-tree-accessors/document.title-07.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<title>Document.title and DOMImplementation.createHTMLDocument</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<script src="../../../../dom/nodes/DOMImplementation-createHTMLDocument.js"></script>
+<div id="log"></div>
+<script>
+createHTMLDocuments(function(doc, expectedtitle, normalizedtitle) {
+  assert_equals(doc.title, normalizedtitle)
+})
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/uievents/constructors/inputevent-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/uievents/constructors/inputevent-constructor.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>InputEvent Constructor Tests</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(function() {
+  var e = new InputEvent('type');
+  assert_equals(e.data, null, '.data');
+  assert_false(e.isComposing, '.isComposing');
+}, 'InputEvent constructor without InputEventInit.');
+
+test(function() {
+  var e = new InputEvent('type', { data: null, isComposing: true });
+  assert_equals(e.data, null, '.data');
+  assert_true(e.isComposing, '.isComposing');
+}, 'InputEvent construtor with InputEventInit where data is null');
+
+test(function() {
+  assert_equals(new InputEvent('type', { data: ''}).data, '', '.data');
+}, 'InputEvent construtor with InputEventInit where data is empty string');
+
+test(function() {
+  assert_equals(new InputEvent('type', { data: 'data' }).data, 'data', '.data');
+}, 'InputEvent construtor with InputEventInit where data is non empty string');
+</script>


### PR DESCRIPTION
As suggested by @yyny on Discord

Resolves issues where nullable or optional WebIDL DOMString parameters were set to 'null' instead of actual null

https://webidl.spec.whatwg.org/#LegacyNullToEmptyString
> Note: This means that even DOMString? must not use [LegacyNullToEmptyString], since null is a valid value of that type.


I cannot reopen https://github.com/LadybirdBrowser/ladybird/pull/2626, so I had to create a new one
Fixes https://github.com/LadybirdBrowser/ladybird/pull/2628 (instead of a hack I introduced there)