### PR TITLE
LibJS: Encode Cell Values as conventional bottom-tagged pointers

### DIFF
--- a/Libraries/LibGC/BlockAllocator.cpp
+++ b/Libraries/LibGC/BlockAllocator.cpp
@@ -46,6 +46,9 @@ void* BlockAllocator::allocate_block([[maybe_unused]] char const* name)
 
     auto* block = (HeapBlock*)mmap(nullptr, HeapBlock::block_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
     VERIFY(block != MAP_FAILED);
+#ifndef AK_ARCH_32_BIT
+    VERIFY((FlatPtr)block <= 0x00007FFFFFFFFFFF); // Always true on x86-64 Windows/Linux, trivially true on 32-bit systems.
+#endif
     LSAN_REGISTER_ROOT_REGION(block, HeapBlock::block_size);
     return block;
 }

--- a/Libraries/LibGC/Cell.cpp
+++ b/Libraries/LibGC/Cell.cpp
@@ -9,7 +9,7 @@
 
 namespace GC {
 
-void GC::Cell::Visitor::visit(NanBoxedValue const& value)
+void GC::Cell::Visitor::visit(NanBoxedCell const& value)
 {
     if (value.is_cell())
         visit_impl(value.as_cell());

--- a/Libraries/LibGC/Cell.h
+++ b/Libraries/LibGC/Cell.h
@@ -149,7 +149,7 @@ public:
             }
         }
 
-        void visit(NanBoxedValue const& value);
+        void visit(NanBoxedCell const& value);
 
         // Allow explicitly ignoring a GC-allocated member in a visit_edges implementation instead
         // of just not using it.

--- a/Libraries/LibGC/Forward.h
+++ b/Libraries/LibGC/Forward.h
@@ -17,6 +17,8 @@ class ForeignCell;
 class RootImpl;
 class Heap;
 class HeapBlock;
+class NanBoxedCell;
+template<size_t>
 class NanBoxedValue;
 class WeakContainer;
 

--- a/Libraries/LibGC/MarkedVector.h
+++ b/Libraries/LibGC/MarkedVector.h
@@ -68,7 +68,7 @@ public:
     virtual void gather_roots(HashMap<Cell*, GC::HeapRoot>& roots) const override
     {
         for (auto& value : *this) {
-            if constexpr (IsBaseOf<NanBoxedValue, T>) {
+            if constexpr (IsBaseOf<NanBoxedCell, T>) {
                 if (value.is_cell())
                     roots.set(&const_cast<T&>(value).as_cell(), HeapRoot { .type = HeapRoot::Type::MarkedVector });
             } else {

--- a/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Libraries/LibTest/JavaScriptTestRunner.h
@@ -340,7 +340,11 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
     auto test_script = result.release_value();
 
     g_vm->push_execution_context(global_execution_context);
-    MUST(g_vm->bytecode_interpreter().run(*test_script));
+    if (auto maybe_error = g_vm->bytecode_interpreter().run(*test_script); maybe_error.is_error()) {
+        warnln("Unable to push execution context");
+        warnln("{}", maybe_error.release_error().value());
+        cleanup_and_exit();
+    }
     g_vm->pop_execution_context();
 
     auto file_script = parse_script(test_path, *realm);

--- a/Tests/LibJS/test-value-js.cpp
+++ b/Tests/LibJS/test-value-js.cpp
@@ -48,30 +48,17 @@ TEST_CASE(valid_pointer_in_gives_same_pointer_out)
 #define EXPECT_POINTER_TO_SURVIVE(input)                                           \
     {                                                                              \
         JS::Value value(reinterpret_cast<Object*>(static_cast<u64>(input)));       \
-        EXPECT(value.is_object());                                                 \
+        EXPECT(value.is_cell());                                                   \
         EXPECT(!value.is_null());                                                  \
         auto extracted_pointer = JS::Value::extract_pointer_bits(value.encoded()); \
         EXPECT_EQ(static_cast<u64>(input), extracted_pointer);                     \
     }
 
-    EXPECT_POINTER_TO_SURVIVE(0x1);
     EXPECT_POINTER_TO_SURVIVE(0x10);
     EXPECT_POINTER_TO_SURVIVE(0x100);
-    EXPECT_POINTER_TO_SURVIVE(0x00007fffffffffff);
+    EXPECT_POINTER_TO_SURVIVE(0x00007ffffffffff0);
     EXPECT_POINTER_TO_SURVIVE(0x0000700000000000);
     EXPECT_POINTER_TO_SURVIVE(0x0000100000000000);
-
-#if ARCH(X86_64)
-    // On x86-64, the top 16 bits of pointers are equal to bit 47.
-    EXPECT_POINTER_TO_SURVIVE(0xffff800000000000);
-    EXPECT_POINTER_TO_SURVIVE(0xffff800000000001);
-    EXPECT_POINTER_TO_SURVIVE(0xffff800000000010);
-#elif ARCH(AARCH64)
-    // ... but they should contain zeroes on AArch64.
-    EXPECT_POINTER_TO_SURVIVE(0x0000800000000000);
-    EXPECT_POINTER_TO_SURVIVE(0x0000800000000001);
-    EXPECT_POINTER_TO_SURVIVE(0x0000800000000010);
-#endif
 
 #undef EXPECT_POINTER_TO_SURVIVE
 }
@@ -92,25 +79,25 @@ TEST_CASE(non_canon_nans)
 
     EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | 0x1);
     EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | 0x10);
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (NULL_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (UNDEFINED_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (INT32_TAG << GC::TAG_SHIFT) | 0x88);
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (OBJECT_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (OBJECT_TAG << GC::TAG_SHIFT) | 0x1230);
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (STRING_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (STRING_TAG << GC::TAG_SHIFT) | 0x1230);
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (NULL_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (UNDEFINED_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (INT32_TAG << GC::MAX_PAYLOAD_BITS) | 0x88);
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (OBJECT_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (OBJECT_TAG << GC::MAX_PAYLOAD_BITS) | 0x1230);
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (STRING_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | (STRING_TAG << GC::MAX_PAYLOAD_BITS) | 0x1230);
 
     u64 sign_bit = 1ULL << 63;
 
     EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | 0x1);
     EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | 0x10);
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (NULL_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (UNDEFINED_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (INT32_TAG << GC::TAG_SHIFT) | 0x88);
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (OBJECT_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (OBJECT_TAG << GC::TAG_SHIFT) | 0x1230);
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (STRING_TAG << GC::TAG_SHIFT));
-    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (STRING_TAG << GC::TAG_SHIFT) | 0x1230);
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (NULL_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (UNDEFINED_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (INT32_TAG << GC::MAX_PAYLOAD_BITS) | 0x88);
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (OBJECT_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (OBJECT_TAG << GC::MAX_PAYLOAD_BITS) | 0x1230);
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (STRING_TAG << GC::MAX_PAYLOAD_BITS));
+    EXPECT_TO_BE_NAN(GC::CANON_NAN_BITS | sign_bit | (STRING_TAG << GC::MAX_PAYLOAD_BITS) | 0x1230);
 
 #undef EXPECT_TO_BE_NAN
 }


### PR DESCRIPTION
`Cell` values were previously encoded as `NaN`-boxed pointers,
with the `Cell` type encoded in the top bits of the `NaN`-payload.

However, since `Cell` values are so common, this meant that we had to
do a lot of bit masking and bit shifting to retrieve the pointer
everytime we wanted to do a dereference.

Additionally, on all systems we support, (user-space) pointers must
always start with leading `0` bits.

The new encoding therefore takes advantage of this by storing pointers
without any `NaN`-boxing, and `NaN`-boxing the subnormal numbers
instead, which also all start with leading `0` bits.

Since subnormals are rarely seen in practice, it makes sense to do
the masking and shifting on these values instead, and encode the
more common `Cell` pointers in their usual encodings, thereby
increasing performance on average.

We can then further take advantage of the fact that `Cell` pointers are
8-byte aligned, and use the unused bottom bits to store the cell type.

This is called "bottom-tagging", which is better for modern CPUs as it
still allows them to prefetch the right cache line, since cache lines
are also >8-byte (usually 64-byte) aligned, and therefore have no reason
to inspect the bottom bits of a pointer in this case.

Bottom-tagging is also a more conventional approach, and as such
alternative garbage collector implementations are much more likely to
support it as compared to `NaN`-boxing.

Furthermore, since `CellTag::Object == 0`, `Value::as_object()` can
be optimized to a no-op in most cases, which makes the compiler and
the CPU very happy :^)

Note that since encoding non-userspace pointers is no longer supported,
`LibJS` will no longer work correctly in kernel-space and on some
embedded devices.

The capability to encode kernel-space pointers could be added back in
the future by adding a special case for them such that they will still
be `NaN`-boxed as before, at a performance cost of course.