### PR TITLE
LibWeb: Ignore negative values when setting `HTMLProgressElement.max`

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -61,7 +61,7 @@ WebIDL::ExceptionOr<void> HTMLProgressElement::set_value(double value)
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-progress-max
-double HTMLProgressElement::max() const
+WebIDL::Double HTMLProgressElement::max() const
 {
     if (auto max_string = get_attribute(HTML::AttributeNames::max); max_string.has_value()) {
         if (auto max = parse_floating_point_number(*max_string); max.has_value())
@@ -74,7 +74,7 @@ double HTMLProgressElement::max() const
 WebIDL::ExceptionOr<void> HTMLProgressElement::set_max(double value)
 {
     if (value <= 0)
-        value = 1;
+        return {};
 
     TRY(set_attribute(HTML::AttributeNames::max, String::number(value)));
     update_progress_value_element();

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -22,8 +22,8 @@ public:
     double value() const;
     WebIDL::ExceptionOr<void> set_value(double);
 
-    double max() const;
-    WebIDL::ExceptionOr<void> set_max(double value);
+    WebIDL::Double max() const;
+    WebIDL::ExceptionOr<void> set_max(WebIDL::Double value);
 
     double position() const;
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLProgressElement-set-attributes.txt
@@ -9,4 +9,4 @@ max attribute after setting max attribute to 100: 100
 value attribute after setting max attribute to 101: 100
 value attribute after setting value attribute to -1: 0
 value attribute after setting max attribute to 0: 0
-max attribute after setting max attribute to 0: 1
+max attribute after setting max attribute to 0: 100


### PR DESCRIPTION
When attempting to set `HTMLProgressElement.max` to a value not greater than 0, we were previously setting the value to 1. We now retain the previous value.

This fixes 4 subtests in: http://wpt.live/html/dom/reflection-forms.html