### PR TITLE
LibWeb/CSS: Allow calc() values in media queries

### DIFF
--- a/Libraries/LibWeb/CSS/CalculatedOr.cpp
+++ b/Libraries/LibWeb/CSS/CalculatedOr.cpp
@@ -47,15 +47,15 @@ NonnullRefPtr<CSSStyleValue> FrequencyOrCalculated::create_style_value() const
     return FrequencyStyleValue::create(value());
 }
 
-i64 IntegerOrCalculated::resolve_calculated(NonnullRefPtr<CSSMathValue> const& calculated, Layout::Node const&) const
+i64 IntegerOrCalculated::resolve_calculated(NonnullRefPtr<CSSMathValue> const& calculated, Layout::Node const& layout_node) const
 {
-    return calculated->resolve_integer().value();
+    return calculated->resolve_integer(layout_node).value();
 }
 
-i64 IntegerOrCalculated::resolved() const
+i64 IntegerOrCalculated::resolved(Length::ResolutionContext const& context) const
 {
     if (is_calculated())
-        return calculated()->resolve_integer().value();
+        return calculated()->resolve_integer(context).value();
     return value();
 }
 
@@ -81,9 +81,9 @@ NonnullRefPtr<CSSStyleValue> LengthOrCalculated::create_style_value() const
     return LengthStyleValue::create(value());
 }
 
-double NumberOrCalculated::resolve_calculated(NonnullRefPtr<CSSMathValue> const& calculated, Layout::Node const&) const
+double NumberOrCalculated::resolve_calculated(NonnullRefPtr<CSSMathValue> const& calculated, Layout::Node const& layout_node) const
 {
-    return calculated->resolve_number().value();
+    return calculated->resolve_number(layout_node).value();
 }
 
 NonnullRefPtr<CSSStyleValue> NumberOrCalculated::create_style_value() const

--- a/Libraries/LibWeb/CSS/CalculatedOr.cpp
+++ b/Libraries/LibWeb/CSS/CalculatedOr.cpp
@@ -52,6 +52,13 @@ i64 IntegerOrCalculated::resolve_calculated(NonnullRefPtr<CSSMathValue> const& c
     return calculated->resolve_integer().value();
 }
 
+i64 IntegerOrCalculated::resolved() const
+{
+    if (is_calculated())
+        return calculated()->resolve_integer().value();
+    return value();
+}
+
 NonnullRefPtr<CSSStyleValue> IntegerOrCalculated::create_style_value() const
 {
     return IntegerStyleValue::create(value());
@@ -97,6 +104,13 @@ NonnullRefPtr<CSSStyleValue> PercentageOrCalculated::create_style_value() const
 Resolution ResolutionOrCalculated::resolve_calculated(NonnullRefPtr<CSSMathValue> const& calculated, Layout::Node const&) const
 {
     return calculated->resolve_resolution().value();
+}
+
+Resolution ResolutionOrCalculated::resolved() const
+{
+    if (is_calculated())
+        return calculated()->resolve_resolution().value();
+    return value();
 }
 
 NonnullRefPtr<CSSStyleValue> ResolutionOrCalculated::create_style_value() const

--- a/Libraries/LibWeb/CSS/CalculatedOr.h
+++ b/Libraries/LibWeb/CSS/CalculatedOr.h
@@ -119,7 +119,7 @@ class IntegerOrCalculated : public CalculatedOr<i64> {
 public:
     using CalculatedOr<i64>::CalculatedOr;
 
-    [[nodiscard]] i64 resolved() const;
+    [[nodiscard]] i64 resolved(Length::ResolutionContext const&) const;
 
 private:
     virtual i64 resolve_calculated(NonnullRefPtr<CSSMathValue> const&, Layout::Node const&) const override;

--- a/Libraries/LibWeb/CSS/CalculatedOr.h
+++ b/Libraries/LibWeb/CSS/CalculatedOr.h
@@ -119,6 +119,8 @@ class IntegerOrCalculated : public CalculatedOr<i64> {
 public:
     using CalculatedOr<i64>::CalculatedOr;
 
+    [[nodiscard]] i64 resolved() const;
+
 private:
     virtual i64 resolve_calculated(NonnullRefPtr<CSSMathValue> const&, Layout::Node const&) const override;
     virtual NonnullRefPtr<CSSStyleValue> create_style_value() const override;
@@ -156,6 +158,8 @@ private:
 class ResolutionOrCalculated : public CalculatedOr<Resolution> {
 public:
     using CalculatedOr<Resolution>::CalculatedOr;
+
+    [[nodiscard]] Resolution resolved() const;
 
 private:
     virtual Resolution resolve_calculated(NonnullRefPtr<CSSMathValue> const&, Layout::Node const&) const override;

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -15,6 +15,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/HTML/Window.h>
 #include <LibWeb/Layout/Node.h>
 
 namespace Web::CSS {
@@ -129,6 +130,18 @@ CSSPixels Length::viewport_relative_length_to_px(CSSPixelRect const& viewport_re
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+Length::ResolutionContext Length::ResolutionContext::for_window(HTML::Window const& window)
+{
+    auto const& initial_font = window.associated_document().style_computer().initial_font();
+    Gfx::FontPixelMetrics const& initial_font_metrics = initial_font.pixel_metrics();
+    Length::FontMetrics font_metrics { CSSPixels { initial_font.pixel_size() }, initial_font_metrics };
+    return Length::ResolutionContext {
+        .viewport_rect = window.page().web_exposed_screen_area(),
+        .font_metrics = font_metrics,
+        .root_font_metrics = font_metrics,
+    };
 }
 
 Length::ResolutionContext Length::ResolutionContext::for_layout_node(Layout::Node const& node)

--- a/Libraries/LibWeb/CSS/Length.h
+++ b/Libraries/LibWeb/CSS/Length.h
@@ -158,6 +158,7 @@ public:
     StringView unit_name() const;
 
     struct ResolutionContext {
+        [[nodiscard]] static Length::ResolutionContext for_window(HTML::Window const&);
         [[nodiscard]] static Length::ResolutionContext for_layout_node(Layout::Node const&);
 
         CSSPixelRect viewport_rect;

--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -90,12 +90,12 @@ bool MediaFeature::evaluate(HTML::Window const& window) const
         return false;
     auto queried_value = maybe_queried_value.release_value();
 
+    auto resolution_context = Length::ResolutionContext::for_window(window);
     switch (m_type) {
     case Type::IsTrue:
         if (queried_value.is_integer())
-            return queried_value.integer().resolved() != 0;
+            return queried_value.integer().resolved(resolution_context) != 0;
         if (queried_value.is_length()) {
-            auto resolution_context = Length::ResolutionContext::for_window(window);
             auto length = queried_value.length().resolved(resolution_context);
             return length.raw_value() != 0;
         }
@@ -149,17 +149,18 @@ bool MediaFeature::compare(HTML::Window const& window, MediaFeatureValue left, C
     }
 
     if (left.is_integer()) {
+        auto resolution_context = Length::ResolutionContext::for_window(window);
         switch (comparison) {
         case Comparison::Equal:
-            return left.integer().resolved() == right.integer().resolved();
+            return left.integer().resolved(resolution_context) == right.integer().resolved(resolution_context);
         case Comparison::LessThan:
-            return left.integer().resolved() < right.integer().resolved();
+            return left.integer().resolved(resolution_context) < right.integer().resolved(resolution_context);
         case Comparison::LessThanOrEqual:
-            return left.integer().resolved() <= right.integer().resolved();
+            return left.integer().resolved(resolution_context) <= right.integer().resolved(resolution_context);
         case Comparison::GreaterThan:
-            return left.integer().resolved() > right.integer().resolved();
+            return left.integer().resolved(resolution_context) > right.integer().resolved(resolution_context);
         case Comparison::GreaterThanOrEqual:
-            return left.integer().resolved() >= right.integer().resolved();
+            return left.integer().resolved(resolution_context) >= right.integer().resolved(resolution_context);
         }
         VERIFY_NOT_REACHED();
     }

--- a/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Libraries/LibWeb/CSS/MediaQuery.h
@@ -10,11 +10,10 @@
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
+#include <LibWeb/CSS/CalculatedOr.h>
 #include <LibWeb/CSS/GeneralEnclosed.h>
-#include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/MediaFeatureID.h>
 #include <LibWeb/CSS/Ratio.h>
-#include <LibWeb/CSS/Resolution.h>
 
 namespace Web::CSS {
 
@@ -26,7 +25,7 @@ public:
     {
     }
 
-    explicit MediaFeatureValue(Length length)
+    explicit MediaFeatureValue(LengthOrCalculated length)
         : m_value(move(length))
     {
     }
@@ -36,23 +35,28 @@ public:
     {
     }
 
-    explicit MediaFeatureValue(Resolution resolution)
+    explicit MediaFeatureValue(ResolutionOrCalculated resolution)
         : m_value(move(resolution))
     {
     }
 
-    explicit MediaFeatureValue(float number)
-        : m_value(number)
+    explicit MediaFeatureValue(IntegerOrCalculated integer)
+        : m_value(move(integer))
+    {
+    }
+
+    explicit MediaFeatureValue(i64 integer)
+        : m_value(IntegerOrCalculated(integer))
     {
     }
 
     String to_string() const;
 
     bool is_ident() const { return m_value.has<Keyword>(); }
-    bool is_length() const { return m_value.has<Length>(); }
-    bool is_number() const { return m_value.has<float>(); }
+    bool is_length() const { return m_value.has<LengthOrCalculated>(); }
+    bool is_integer() const { return m_value.has<IntegerOrCalculated>(); }
     bool is_ratio() const { return m_value.has<Ratio>(); }
-    bool is_resolution() const { return m_value.has<Resolution>(); }
+    bool is_resolution() const { return m_value.has<ResolutionOrCalculated>(); }
     bool is_same_type(MediaFeatureValue const& other) const;
 
     Keyword const& ident() const
@@ -61,10 +65,10 @@ public:
         return m_value.get<Keyword>();
     }
 
-    Length const& length() const
+    LengthOrCalculated const& length() const
     {
         VERIFY(is_length());
-        return m_value.get<Length>();
+        return m_value.get<LengthOrCalculated>();
     }
 
     Ratio const& ratio() const
@@ -73,20 +77,20 @@ public:
         return m_value.get<Ratio>();
     }
 
-    Resolution const& resolution() const
+    ResolutionOrCalculated const& resolution() const
     {
         VERIFY(is_resolution());
-        return m_value.get<Resolution>();
+        return m_value.get<ResolutionOrCalculated>();
     }
 
-    float number() const
+    IntegerOrCalculated integer() const
     {
-        VERIFY(is_number());
-        return m_value.get<float>();
+        VERIFY(is_integer());
+        return m_value.get<IntegerOrCalculated>();
     }
 
 private:
-    Variant<Keyword, Length, Ratio, Resolution, float> m_value;
+    Variant<Keyword, LengthOrCalculated, Ratio, ResolutionOrCalculated, IntegerOrCalculated> m_value;
 };
 
 // https://www.w3.org/TR/mediaqueries-4/#mq-features

--- a/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -551,8 +551,6 @@ OwnPtr<MediaCondition> Parser::parse_media_in_parens(TokenStream<ComponentValue>
 // `<mf-value>`, https://www.w3.org/TR/mediaqueries-4/#typedef-mf-value
 Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID media_feature, TokenStream<ComponentValue>& tokens)
 {
-    // NOTE: Calculations are not allowed for media feature values, at least in the current spec, so we reject them.
-
     // Identifiers
     if (tokens.next_token().is(Token::Type::Ident)) {
         auto transaction = tokens.begin_transaction();
@@ -570,11 +568,11 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Boolean)) {
         auto transaction = tokens.begin_transaction();
         tokens.discard_whitespace();
-        if (auto integer = parse_integer(tokens); integer.has_value() && !integer->is_calculated()) {
-            auto integer_value = integer->value();
+        if (auto integer = parse_integer(tokens); integer.has_value()) {
+            auto integer_value = integer.value().resolved();
             if (integer_value == 0 || integer_value == 1) {
                 transaction.commit();
-                return MediaFeatureValue(integer_value);
+                return MediaFeatureValue(integer.release_value());
             }
         }
     }
@@ -582,9 +580,9 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     // Integer
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Integer)) {
         auto transaction = tokens.begin_transaction();
-        if (auto integer = parse_integer(tokens); integer.has_value() && !integer->is_calculated()) {
+        if (auto integer = parse_integer(tokens); integer.has_value()) {
             transaction.commit();
-            return MediaFeatureValue(integer->value());
+            return MediaFeatureValue(integer.release_value());
         }
     }
 
@@ -592,9 +590,9 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Length)) {
         auto transaction = tokens.begin_transaction();
         tokens.discard_whitespace();
-        if (auto length = parse_length(tokens); length.has_value() && !length->is_calculated()) {
+        if (auto length = parse_length(tokens); length.has_value()) {
             transaction.commit();
-            return MediaFeatureValue(length->value());
+            return MediaFeatureValue(length.release_value());
         }
     }
 
@@ -612,9 +610,9 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Resolution)) {
         auto transaction = tokens.begin_transaction();
         tokens.discard_whitespace();
-        if (auto resolution = parse_resolution(tokens); resolution.has_value() && !resolution->is_calculated()) {
+        if (auto resolution = parse_resolution(tokens); resolution.has_value()) {
             transaction.commit();
-            return MediaFeatureValue(resolution->value());
+            return MediaFeatureValue(resolution.release_value());
         }
     }
 

--- a/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -569,8 +569,7 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
         auto transaction = tokens.begin_transaction();
         tokens.discard_whitespace();
         if (auto integer = parse_integer(tokens); integer.has_value()) {
-            auto integer_value = integer.value().resolved();
-            if (integer_value == 0 || integer_value == 1) {
+            if (integer.value().is_calculated() || integer->value() == 0 || integer->value() == 1) {
                 transaction.commit();
                 return MediaFeatureValue(integer.release_value());
             }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
@@ -2797,17 +2797,47 @@ Optional<Time> CSSMathValue::resolve_time_percentage(Time const& percentage_basi
 Optional<double> CSSMathValue::resolve_number() const
 {
     auto result = m_calculation->resolve({}, {});
+
     if (result.value().has<Number>())
         return result.value().get<Number>().value();
     return {};
 }
 
+Optional<double> CSSMathValue::resolve_number(Length::ResolutionContext const& context) const
+{
+    auto result = m_calculation->resolve(context, {});
+
+    if (result.value().has<Number>())
+        return result.value().get<Number>().value();
+    return {};
+}
+
+Optional<double> CSSMathValue::resolve_number(Layout::Node const& layout_node) const
+{
+    return resolve_number(Length::ResolutionContext::for_layout_node(layout_node));
+}
+
 Optional<i64> CSSMathValue::resolve_integer() const
 {
     auto result = m_calculation->resolve({}, {});
+
     if (result.value().has<Number>())
         return result.value().get<Number>().integer_value();
     return {};
+}
+
+Optional<i64> CSSMathValue::resolve_integer(Length::ResolutionContext const& context) const
+{
+    auto result = m_calculation->resolve(context, {});
+
+    if (result.value().has<Number>())
+        return result.value().get<Number>().integer_value();
+    return {};
+}
+
+Optional<i64> CSSMathValue::resolve_integer(Layout::Node const& layout_node) const
+{
+    return resolve_integer(Length::ResolutionContext::for_layout_node(layout_node));
 }
 
 bool CSSMathValue::contains_percentage() const

--- a/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.h
@@ -99,7 +99,7 @@ public:
 
     bool resolves_to_length() const { return m_resolved_type.matches_length(); }
     bool resolves_to_length_percentage() const { return m_resolved_type.matches_length_percentage(); }
-    [[nodiscard]] Optional<Length> resolve_length(Length::ResolutionContext const&) const;
+    Optional<Length> resolve_length(Length::ResolutionContext const&) const;
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
     Optional<Length> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
     Optional<Length> resolve_length_percentage(Layout::Node const&, CSSPixels percentage_basis) const;
@@ -119,7 +119,11 @@ public:
     bool resolves_to_number() const { return m_resolved_type.matches_number(); }
     bool resolves_to_number_percentage() const { return m_resolved_type.matches_number_percentage(); }
     Optional<double> resolve_number() const;
+    Optional<double> resolve_number(Length::ResolutionContext const&) const;
+    Optional<double> resolve_number(Layout::Node const& layout_node) const;
     Optional<i64> resolve_integer() const;
+    Optional<i64> resolve_integer(Length::ResolutionContext const&) const;
+    Optional<i64> resolve_integer(Layout::Node const& layout_node) const;
 
     bool resolves_to_dimension() const { return m_resolved_type.matches_dimension(); }
 

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-001.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: support for calc in Media Queries</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+		<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="calc can be used in Media Queries">
+		<style>
+			div {
+				width: 100px;
+				height: 100px;
+				background-color: red;
+			}
+			@media (min-width: calc(1px - 1px)){
+				div { background-color: green; }
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-002.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: evaluation of em in calc in Media Queries</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+		<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+		<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="The size in pixels of the 'em' unit used in calc inside a media query does not depend on declarations and use the initial value.">
+		<style>
+			:root { font-size: 30000px; }
+			p { font-size: 16px; }
+			div {
+				width: 100px;
+				height: 100px;
+				background-color: red;
+			}
+			@media (min-width: calc(1em)){
+				div { background-color: green; }
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1em)){
+				div { background-color: green; }
+			}
+		</style>
+	</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-003.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: evaluation of ex in calc in Media Queries</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+		<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+		<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="The size in pixels of the 'ex' unit used in calc inside a media query does not depend on declarations and use the initial value.">
+		<style>
+			:root { font-size: 30000px; }
+			p { font-size: 16px; }
+			div {
+				width: 100px;
+				height: 100px;
+				background-color: red;
+			}
+			@media (min-width: calc(1ex)){
+				div { background-color: green; }
+			}
+		</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1ex)){
+				div { background-color: green; }
+			}
+		</style>
+	</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-004.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: evaluation of ch in calc in Media Queries</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+		<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+		<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="The size in pixels of the 'ch' unit used in calc inside a media query does not depend on declarations and use the initial value.">
+		<style>
+			:root { font-size: 30000px; }
+			p { font-size: 16px; }
+			div {
+				width: 100px;
+				height: 100px;
+				background-color: red;
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1ch)){
+				div { background-color: green; }
+			}
+		</style>
+	</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-005.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: evaluation of rem in calc in Media Queries</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+		<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+		<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="The size in pixels of the 'rem' unit used in calc inside a media query does not depend on declarations and use the initial value.">
+		<style>
+			:root { font-size: 30000px; }
+			p { font-size: 16px; }
+			div {
+				width: 100px;
+				height: 100px;
+				background-color: red;
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+		<script>
+		  document.body.offsetTop;
+		</script>
+		<style>
+			@media (min-width: calc(1rem)){
+				div { background-color: green; }
+			}
+		</style>
+	</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-006.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="author" title="Xiaocheng Hu" href="xiaochengh@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="help" href="https://www.w3.org/TR/css3-mediaqueries/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="The 'in' unit used in calc is not mistaken as 'px'.">
+<style>
+p { font-size: 16px; }
+#target {
+  width: 100px;
+  height: 100px;
+  background-color: green;
+}
+@media (min-width: calc(100in)) {
+  /* Should not be selected */
+  #target { background-color: red }
+}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id=target></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-007.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-007.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Test: evaluation of mixed-unit calc in Media Queries</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-4/#calc-func">
+<link rel="help" href="https://drafts.csswg.org/mediaqueries-4/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<style>
+	:root { font-size: 30000px; }
+	p { font-size: 16px; }
+	div {
+		width: 100px;
+		height: 100px;
+		background-color: red;
+	}
+	@media (min-width: calc(1px + 1rem)) {
+		div { background-color: green; }
+	}
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-008.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-008.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: support for calc in Media Queries</title>
+		<link rel="author" title="Romain Menke" href="https://github.com/romainmenke">
+		<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+		<link rel="help" href="https://drafts.csswg.org/css-values-4/#ratios">
+		<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/3757">
+		<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="calc can be used in Media Queries">
+		<style>
+			div {
+				background-color: red;
+				height: 100px;
+				width: 100px;
+			}
+			@media screen and (min-aspect-ratio: calc(59/79)) {
+				div {
+					background-color: green;
+				}
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-resolution.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-resolution.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<title>Test: support for calc resolution in Media Queries</title>
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<meta name="assert" content="calc resolution can be used in Media Queries">
+<style>
+  #test {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+
+  @media (resolution >= calc(2x - 96dpi)){
+    #test {
+      background-color: green;
+    }
+  }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div id="test"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-001.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<title>Test: support for calc with sign() in Media Queries</title>
+<link rel="author" title="Daniil Sakhapov" href="mailto:sakhapov@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<style>
+  :root {
+    font-size: 16px;
+  }
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+
+  @media (width > calc(1px * (1 + sign(16px - 1rem)))) {
+    div {
+      background-color: green;
+    }
+  }
+</style>
+
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-002.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-002.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Test: support for calc with sign() in Media Queries</title>
+<link rel="author" title="Daniil Sakhapov" href="mailto:sakhapov@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<style>
+  :root {
+    font-size: 16px;
+  }
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+
+  @media (width > calc(-1px * sign(15px - 1rem))) {
+    div {
+      background-color: green;
+    }
+  }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-004.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Test: support for calc with sign() in Media Queries</title>
+<link rel="author" title="Daniil Sakhapov" href="mailto:sakhapov@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<style>
+  :root {
+    font-size: 16px;
+  }
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+
+  @media (resolution > calc(-1dppx * sign(17px - 1rem))) {
+    div {
+      background-color: green;
+    }
+  }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-005.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-005.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Test: support for calc with sign() in Media Queries</title>
+<link rel="author" title="Daniil Sakhapov" href="mailto:sakhapov@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<style>
+  :root {
+    font-size: 16px;
+  }
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: red;
+  }
+
+  @media (grid: calc(2 * sign(16px - 1rem))) {
+    div {
+      background-color: green;
+    }
+  }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-006.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-calc-sign-function-006.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<title>Test: support for calc with sign() in Media Queries</title>
+<link rel="author" title="Daniil Sakhapov" href="mailto:sakhapov@chromium.org">
+<link rel="help" href="http://www.w3.org/TR/css3-values/#calc-notation">
+<link rel="help" href="http://www.w3.org/TR/css3-mediaqueries/#units">
+<link rel="match" href="../../../../expected/wpt-import/css/mediaqueries/../reference/ref-filled-green-100px-square.xht">
+<style>
+  :root {
+    font-size: 16px;
+  }
+  div {
+    width: 100px;
+    height: 100px;
+    background-color: green;
+  }
+
+  @media (grid: calc(2 * sign(17px - 1rem))) {
+    div {
+      background-color: red;
+    }
+  }
+</style>
+<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+<div></div>


### PR DESCRIPTION
It was initially thought that the spec disallows them, but this turned out to be incorrect. This fixes several WPT subtests. It also fixes an issue on Wikipedia articles where the table of contents is sometimes rendered above the title, if the viewport width is small enough.