### PR TITLE
LibWeb: Implement the `HTMLInputElement` width and height attributes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1882,6 +1882,41 @@ WebIDL::ExceptionOr<void> HTMLInputElement::set_size(WebIDL::UnsignedLong value)
     return set_attribute(HTML::AttributeNames::size, String::number(value));
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#dom-input-height
+WebIDL::UnsignedLong HTMLInputElement::height() const
+{
+    const_cast<DOM::Document&>(document()).update_layout();
+
+    // When the input element's type attribute is not in the Image Button state, then no image is available.
+    if (type_state() != TypeAttributeState::ImageButton)
+        return 0;
+
+    // Return the rendered height of the image, in CSS pixels, if the image is being rendered.
+    if (auto* paintable_box = this->paintable_box())
+        return paintable_box->content_height().to_int();
+
+    // On setting [the width or height IDL attribute], they must act as if they reflected the respective content attributes of the same name.
+    if (auto height_string = get_attribute(HTML::AttributeNames::height); height_string.has_value()) {
+        if (auto height = parse_non_negative_integer(*height_string); height.has_value() && *height <= 2147483647)
+            return *height;
+    }
+
+    // ...or else the natural height and height of the image, in CSS pixels, if an image is available but not being rendered
+    if (auto bitmap = current_image_bitmap())
+        return bitmap->height();
+
+    // ...or else 0, if the image is not available or does not have intrinsic dimensions.
+    return 0;
+}
+
+WebIDL::ExceptionOr<void> HTMLInputElement::set_height(WebIDL::UnsignedLong value)
+{
+    if (value > 2147483647)
+        value = 0;
+
+    return set_attribute(HTML::AttributeNames::height, String::number(value));
+}
+
 // https://html.spec.whatwg.org/multipage/input.html#dom-input-width
 WebIDL::UnsignedLong HTMLInputElement::width() const
 {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -128,6 +128,9 @@ public:
     WebIDL::UnsignedLong size() const;
     WebIDL::ExceptionOr<void> set_size(WebIDL::UnsignedLong value);
 
+    WebIDL::UnsignedLong width() const;
+    WebIDL::ExceptionOr<void> set_width(WebIDL::UnsignedLong value);
+
     struct SelectedCoordinate {
         int x { 0 };
         int y { 0 };

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -128,6 +128,9 @@ public:
     WebIDL::UnsignedLong size() const;
     WebIDL::ExceptionOr<void> set_size(WebIDL::UnsignedLong value);
 
+    WebIDL::UnsignedLong height() const;
+    WebIDL::ExceptionOr<void> set_height(WebIDL::UnsignedLong value);
+
     WebIDL::UnsignedLong width() const;
     WebIDL::ExceptionOr<void> set_width(WebIDL::UnsignedLong value);
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -22,7 +22,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, Reflect=formmethod, Enumerated=FormMethodAttribute] attribute DOMString formMethod;
     [CEReactions, Reflect=formnovalidate] attribute boolean formNoValidate;
     [CEReactions, Reflect=formtarget] attribute DOMString formTarget;
-    [FIXME, CEReactions] attribute unsigned long height;
+    [CEReactions] attribute unsigned long height;
     attribute boolean indeterminate;
     [FIXME] readonly attribute HTMLDataListElement? list;
     [CEReactions, Reflect] attribute DOMString max;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -43,7 +43,7 @@ interface HTMLInputElement : HTMLElement {
     [CEReactions, LegacyNullToEmptyString] attribute DOMString value;
     attribute object? valueAsDate;
     attribute unrestricted double valueAsNumber;
-    [FIXME, CEReactions] attribute unsigned long width;
+    [CEReactions] attribute unsigned long width;
 
     undefined stepUp(optional long n = 1);
     undefined stepDown(optional long n = 1);

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -37,6 +37,26 @@ input.getAttribute("size") after input.setAttribute("size", "4294967295"): 42949
 input.size after input.setAttribute("size", "4294967295"): 20
 input.getAttribute("size") after input.size = 4294967295: 20
 input.size after input.size = 4294967295: 20
+input.getAttribute("height") after input.setAttribute("height", "0"): 0
+input.height after input.setAttribute("height", "0"): 0
+input.getAttribute("height") after input.height = 0: 0
+input.height after input.height = 0: 0
+input.getAttribute("height") after input.setAttribute("height", "1"): 1
+input.height after input.setAttribute("height", "1"): 1
+input.getAttribute("height") after input.height = 1: 1
+input.height after input.height = 1: 0
+input.getAttribute("height") after input.setAttribute("height", "2147483647"): 2147483647
+input.height after input.setAttribute("height", "2147483647"): 2147483647
+input.getAttribute("height") after input.height = 2147483647: 2147483647
+input.height after input.height = 2147483647: 0
+input.getAttribute("height") after input.setAttribute("height", "2147483648"): 2147483648
+input.height after input.setAttribute("height", "2147483648"): 0
+input.getAttribute("height") after input.height = 2147483648: 0
+input.height after input.height = 2147483648: 0
+input.getAttribute("height") after input.setAttribute("height", "4294967295"): 4294967295
+input.height after input.setAttribute("height", "4294967295"): 0
+input.getAttribute("height") after input.height = 4294967295: 0
+input.height after input.height = 4294967295: 0
 input.getAttribute("width") after input.setAttribute("width", "0"): 0
 input.width after input.setAttribute("width", "0"): 0
 input.getAttribute("width") after input.width = 0: 0

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -37,6 +37,26 @@ input.getAttribute("size") after input.setAttribute("size", "4294967295"): 42949
 input.size after input.setAttribute("size", "4294967295"): 20
 input.getAttribute("size") after input.size = 4294967295: 20
 input.size after input.size = 4294967295: 20
+input.getAttribute("width") after input.setAttribute("width", "0"): 0
+input.width after input.setAttribute("width", "0"): 0
+input.getAttribute("width") after input.width = 0: 0
+input.width after input.width = 0: 0
+input.getAttribute("width") after input.setAttribute("width", "1"): 1
+input.width after input.setAttribute("width", "1"): 1
+input.getAttribute("width") after input.width = 1: 1
+input.width after input.width = 1: 0
+input.getAttribute("width") after input.setAttribute("width", "2147483647"): 2147483647
+input.width after input.setAttribute("width", "2147483647"): 2147483647
+input.getAttribute("width") after input.width = 2147483647: 2147483647
+input.width after input.width = 2147483647: 0
+input.getAttribute("width") after input.setAttribute("width", "2147483648"): 2147483648
+input.width after input.setAttribute("width", "2147483648"): 0
+input.getAttribute("width") after input.width = 2147483648: 0
+input.width after input.width = 2147483648: 0
+input.getAttribute("width") after input.setAttribute("width", "4294967295"): 4294967295
+input.width after input.setAttribute("width", "4294967295"): 0
+input.getAttribute("width") after input.width = 4294967295: 0
+input.width after input.width = 4294967295: 0
 marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "0"): 0
 marquee.scrollAmount after marquee.setAttribute("scrollamount", "0"): 0
 marquee.getAttribute("scrollamount") after marquee.scrollAmount = 0: 0

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -2,10 +2,19 @@
 <script src="../include.js"></script>
 <script>
     test(() => {
-        function testProperty(elementName, propertyName, propertyGetter, propertySetter) {
+        function testProperty(elementNameOrFactory, propertyName, propertyGetter, propertySetter) {
             const attributeName = propertyName.toLowerCase();
             function setValue(value) {
-                let element = document.createElement(elementName);
+                let element;
+                let elementName;
+                if (typeof elementNameOrFactory === "string") {
+                    element = document.createElement(elementNameOrFactory);
+                    elementName = elementNameOrFactory;
+                } else {
+                    element = elementNameOrFactory();
+                    elementName = element.tagName.toLowerCase();
+                }
+
                 element.setAttribute(attributeName, value.toString());
                 println(`${elementName}.getAttribute("${attributeName}") after ${elementName}.setAttribute("${propertyName}", "${value}"): ${element.getAttribute(`${attributeName}`)}`);
                 println(`${elementName}.${propertyName} after ${elementName}.setAttribute("${attributeName}", "${value}"): ${propertyGetter(element)}`);
@@ -16,7 +25,7 @@
                     println(`${elementName}.getAttribute("${attributeName}") after ${elementName}.${propertyName} = ${value}: ${element.getAttribute(attributeName)}`);
                     println(`${elementName}.${propertyName} after ${elementName}.${propertyName} = ${value}: ${propertyGetter(element)}`);
                 } catch (e) {
-                    println(`${elementName}.${propertyName} = ${value} threw exception of type ${e.name}`);    
+                    println(`${elementName}.${propertyName} = ${value} threw exception of type ${e.name}`);
                 }
             }
 
@@ -27,8 +36,15 @@
             setValue(4294967295);
         }
 
+        const imageButtonInputFactory = () => {
+            const input = document.createElement("input");
+            input.type = "image";
+            return input;
+        }
+
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
         testProperty("input", "size", (input) => input.size, (input, value) => input.size = value);
+        testProperty(imageButtonInputFactory, "width", (input) => input.width, (input, value) => input.width = value);
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
         testProperty("select", "size", (select) => select.size, (select, value) => select.size = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -44,6 +44,7 @@
 
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
         testProperty("input", "size", (input) => input.size, (input, value) => input.size = value);
+        testProperty(imageButtonInputFactory, "height", (input) => input.height, (input, value) => input.height = value);
         testProperty(imageButtonInputFactory, "width", (input) => input.width, (input, value) => input.width = value);
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);


### PR DESCRIPTION
These allow the width and height of image button inputs to be set and queried.

Fixes a total of 32 subtests in http://wpt.live/html/dom/reflection-forms.html and http://wpt.live/html/dom/reflection-forms-weekmonth.html