### PR TITLE
CI: Print verbose `ctest` output to help determine slow tests

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}
-        run: ctest --preset Sanitizer --output-on-failure --test-dir Build
+        run: ctest --preset Sanitizer --output-on-failure --test-dir Build --verbose
         env:
           TESTS_ONLY: 1
 


### PR DESCRIPTION
`--verbose` will print the `stdout`/`stderr` output of running tests.