### PR TITLE
LibCrypto+LibWeb: Refactor PEM decoding + RSA / EC key parsing

### DIFF
--- a/Libraries/LibCrypto/ASN1/Constants.h
+++ b/Libraries/LibCrypto/ASN1/Constants.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2020-2023, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCrypto/ASN1/DER.h>
+
+namespace Crypto::ASN1 {
+
+constexpr static Array<int, 7>
+    rsa_encryption_oid { 1, 2, 840, 113549, 1, 1, 1 },
+    rsa_md5_encryption_oid { 1, 2, 840, 113549, 1, 1, 4 },
+    rsa_sha1_encryption_oid { 1, 2, 840, 113549, 1, 1, 5 },
+    rsa_sha256_encryption_oid { 1, 2, 840, 113549, 1, 1, 11 },
+    rsa_sha384_encryption_oid { 1, 2, 840, 113549, 1, 1, 12 },
+    rsa_sha512_encryption_oid { 1, 2, 840, 113549, 1, 1, 13 },
+    rsa_sha224_encryption_oid { 1, 2, 840, 113549, 1, 1, 14 },
+    ecdsa_with_sha224_encryption_oid { 1, 2, 840, 10045, 4, 3, 1 },
+    ecdsa_with_sha256_encryption_oid { 1, 2, 840, 10045, 4, 3, 2 },
+    ecdsa_with_sha384_encryption_oid { 1, 2, 840, 10045, 4, 3, 3 },
+    ecdsa_with_sha512_encryption_oid { 1, 2, 840, 10045, 4, 3, 4 },
+    secp256r1_oid { 1, 2, 840, 10045, 3, 1, 7 };
+
+constexpr static Array<int, 6>
+    ec_public_key_encryption_oid { 1, 2, 840, 10045, 2, 1 };
+
+constexpr static Array<int, 5>
+    secp384r1_oid { 1, 3, 132, 0, 34 },
+    secp521r1_oid { 1, 3, 132, 0, 35 };
+
+constexpr static Array<int, 4>
+    x25519_oid { 1, 3, 101, 110 },
+    x448_oid { 1, 3, 101, 111 },
+    ed25519_oid { 1, 3, 101, 112 },
+    ed448_oid { 1, 3, 101, 113 },
+    key_usage_oid { 2, 5, 29, 15 },
+    subject_alternative_name_oid { 2, 5, 29, 17 },
+    issuer_alternative_name_oid { 2, 5, 29, 18 },
+    basic_constraints_oid { 2, 5, 29, 19 };
+
+#define _ENUM(key, value) key,
+
+#define __ENUM_OBJECT_CLASS                   \
+    _ENUM(ApplicationProcess, "2.5.6.11"sv)   \
+    _ENUM(Country, "2.5.6.2"sv)               \
+    _ENUM(DcObject, "1.3.6.1.4.1.1466.344"sv) \
+    _ENUM(Device, "2.5.6.14"sv)               \
+    _ENUM(GroupOfNames, "2.5.6.9"sv)          \
+    _ENUM(GroupOfUniqueNames, "2.5.6.17"sv)   \
+    _ENUM(Locality, "2.5.6.3"sv)              \
+    _ENUM(Organization, "2.5.6.4"sv)          \
+    _ENUM(OrganizationalPerson, "2.5.6.7"sv)  \
+    _ENUM(OrganizationalRole, "2.5.6.8"sv)    \
+    _ENUM(OrganizationalUnit, "2.5.6.5"sv)    \
+    _ENUM(Person, "2.5.6.6"sv)                \
+    _ENUM(ResidentialPerson, "2.5.6.10"sv)    \
+    _ENUM(UidObject, "1.3.6.1.1.3.1"sv)
+
+// NOTE: Type = O
+// NOTE: This list is not exhaustive. If more members are needed, find them at the link below.
+// https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-3
+enum class ObjectClass {
+    __ENUM_OBJECT_CLASS
+};
+
+#define __ENUM_ATTRIBUTE_TYPE                       \
+    _ENUM(BusinessCategory, "2.5.4.15"sv)           \
+    _ENUM(C, "2.5.4.6"sv)                           \
+    _ENUM(Cn, "2.5.4.3"sv)                          \
+    _ENUM(Dc, "0.9.2342.19200300.100.1.25"sv)       \
+    _ENUM(Description, "2.5.4.13"sv)                \
+    _ENUM(DestinationIndicator, "2.5.4.27"sv)       \
+    _ENUM(DistinguishedName, "2.5.4.49"sv)          \
+    _ENUM(DnQualifier, "2.5.4.46"sv)                \
+    _ENUM(EnhancedSearchGuide, "2.5.4.47"sv)        \
+    _ENUM(Email, "1.2.840.113549.1.9.1"sv)          \
+    _ENUM(FacsimileTelephoneNumber, "2.5.4.23"sv)   \
+    _ENUM(GenerationQualifier, "2.5.4.44"sv)        \
+    _ENUM(GivenName, "2.5.4.42"sv)                  \
+    _ENUM(HouseIdentifier, "2.5.4.51"sv)            \
+    _ENUM(Initials, "2.5.4.43"sv)                   \
+    _ENUM(InternationalISDNNumber, "2.5.4.25"sv)    \
+    _ENUM(L, "2.5.4.7"sv)                           \
+    _ENUM(Member, "2.5.4.31"sv)                     \
+    _ENUM(Name, "2.5.4.41"sv)                       \
+    _ENUM(O, "2.5.4.10"sv)                          \
+    _ENUM(Ou, "2.5.4.11"sv)                         \
+    _ENUM(Owner, "2.5.4.32"sv)                      \
+    _ENUM(PhysicalDeliveryOfficeName, "2.5.4.19"sv) \
+    _ENUM(PostalAddress, "2.5.4.16"sv)              \
+    _ENUM(PostalCode, "2.5.4.17"sv)                 \
+    _ENUM(PostOfficeBox, "2.5.4.18"sv)              \
+    _ENUM(PreferredDeliveryMethod, "2.5.4.28"sv)    \
+    _ENUM(RegisteredAddress, "2.5.4.26"sv)          \
+    _ENUM(RoleOccupant, "2.5.4.33"sv)               \
+    _ENUM(SearchGuide, "2.5.4.14"sv)                \
+    _ENUM(SeeAlso, "2.5.4.34"sv)                    \
+    _ENUM(SerialNumber, "2.5.4.5"sv)                \
+    _ENUM(Sn, "2.5.4.4"sv)                          \
+    _ENUM(St, "2.5.4.8"sv)                          \
+    _ENUM(Street, "2.5.4.9"sv)                      \
+    _ENUM(Surname, "2.5.4.4"sv)                     \
+    _ENUM(TelephoneNumber, "2.5.4.20"sv)            \
+    _ENUM(TeletexTerminalIdentifier, "2.5.4.22"sv)  \
+    _ENUM(TelexNumber, "2.5.4.21"sv)                \
+    _ENUM(Title, "2.5.4.12"sv)                      \
+    _ENUM(Uid, "0.9.2342.19200300.100.1.1"sv)       \
+    _ENUM(UniqueMember, "2.5.4.50"sv)               \
+    _ENUM(UserPassword, "2.5.4.35"sv)               \
+    _ENUM(X121Address, "2.5.4.24"sv)                \
+    _ENUM(X500UniqueIdentifier, "2.5.4.45"sv)
+
+// NOTE: Type = A
+// NOTE: This list is not exhaustive. If more members are needed, find them at the link below.
+// https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-3
+enum class AttributeType {
+    __ENUM_ATTRIBUTE_TYPE
+};
+
+#undef _ENUM
+
+constexpr static StringView enum_value(ObjectClass object_class)
+{
+#define _ENUM(key, value)  \
+    case ObjectClass::key: \
+        return value;
+
+    switch (object_class) {
+        __ENUM_OBJECT_CLASS
+    }
+
+    return "Unknown"sv;
+#undef _ENUM
+#undef __ENUM_OBJECT_CLASS
+}
+
+constexpr static StringView enum_value(AttributeType object_class)
+{
+#define _ENUM(key, value)    \
+    case AttributeType::key: \
+        return value;
+
+    switch (object_class) {
+        __ENUM_ATTRIBUTE_TYPE
+    }
+
+    return "Unknown"sv;
+#undef _ENUM
+#undef __ENUM_ATTRIBUTE_TYPE
+}
+
+}

--- a/Libraries/LibCrypto/ASN1/PEM.h
+++ b/Libraries/LibCrypto/ASN1/PEM.h
@@ -7,17 +7,25 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
-#include <AK/Span.h>
 
 namespace Crypto {
 
 enum class PEMType {
+    Unknown,
     Certificate,
     PrivateKey,
+    PublicKey,
+    RSAPrivateKey,
+    RSAPublicKey
 };
 
-ByteBuffer decode_pem(ReadonlyBytes);
-ErrorOr<Vector<ByteBuffer>> decode_pems(ReadonlyBytes);
+struct DecodedPEM {
+    PEMType type { PEMType::Unknown };
+    ByteBuffer data;
+};
+
+DecodedPEM decode_pem(ReadonlyBytes);
+ErrorOr<Vector<DecodedPEM>> decode_pems(ReadonlyBytes);
 ErrorOr<ByteBuffer> encode_pem(ReadonlyBytes, PEMType = PEMType::Certificate);
 
 }

--- a/Libraries/LibCrypto/Certificate/Certificate.cpp
+++ b/Libraries/LibCrypto/Certificate/Certificate.cpp
@@ -335,6 +335,17 @@ ErrorOr<SubjectPublicKey> parse_subject_public_key_info(Crypto::ASN1::Decoder& d
         EXIT_SCOPE();
         return public_key;
     }
+    if (public_key.algorithm.identifier.span() == ASN1::ec_public_key_encryption_oid.span()) {
+        auto maybe_key = Crypto::PK::EC::parse_ec_key(public_key.raw_key, false, current_scope);
+        if (maybe_key.is_error()) {
+            ERROR_WITH_SCOPE(maybe_key.release_error());
+        }
+
+        public_key.ec = move(maybe_key.release_value().public_key);
+
+        EXIT_SCOPE();
+        return public_key;
+    }
 
     // https://datatracker.ietf.org/doc/html/rfc8410#section-9
     // For all of the OIDs, the parameters MUST be absent.

--- a/Libraries/LibCrypto/Certificate/Certificate.cpp
+++ b/Libraries/LibCrypto/Certificate/Certificate.cpp
@@ -395,9 +395,9 @@ ErrorOr<PrivateKey> parse_private_key_info(Crypto::ASN1::Decoder& decoder, Vecto
         return private_key;
     }
     if (private_key.algorithm.identifier.span() == ASN1::ec_public_key_encryption_oid.span()) {
-        auto maybe_key = Crypto::PK::EC::parse_ec_key(value.bytes());
+        auto maybe_key = Crypto::PK::EC::parse_ec_key(value.bytes(), true, current_scope);
         if (maybe_key.is_error()) {
-            ERROR_WITH_SCOPE(TRY(String::formatted("Invalid EC key at {}: {}", current_scope, maybe_key.release_error())));
+            ERROR_WITH_SCOPE(maybe_key.release_error());
         }
 
         private_key.ec = move(maybe_key.release_value().private_key);

--- a/Libraries/LibCrypto/Certificate/Certificate.cpp
+++ b/Libraries/LibCrypto/Certificate/Certificate.cpp
@@ -15,67 +15,11 @@
 #include <LibCrypto/PK/EC.h>
 
 namespace {
+// Used by ASN1 macros
 static String s_error_string;
 }
 
 namespace Crypto::Certificate {
-
-#define ERROR_WITH_SCOPE(error)                                                  \
-    do {                                                                         \
-        s_error_string = TRY(String::formatted("{}: {}", current_scope, error)); \
-        return Error::from_string_view(s_error_string.bytes_as_string_view());   \
-    } while (0)
-
-#define ENTER_TYPED_SCOPE(tag_kind_name, scope)                                                                                                               \
-    do {                                                                                                                                                      \
-        if (auto tag = decoder.peek(); tag.is_error() || tag.value().kind != Crypto::ASN1::Kind::tag_kind_name) {                                             \
-            if (tag.is_error())                                                                                                                               \
-                ERROR_WITH_SCOPE(TRY(String::formatted(scope " data was invalid: {}", tag.error())));                                                         \
-            else                                                                                                                                              \
-                ERROR_WITH_SCOPE(TRY(String::formatted(scope " data was not of kind " #tag_kind_name " was {}", Crypto::ASN1::kind_name(tag.value().kind)))); \
-        }                                                                                                                                                     \
-        ENTER_SCOPE(scope);                                                                                                                                   \
-    } while (0)
-
-#define ENTER_SCOPE(scope)                                                                \
-    do {                                                                                  \
-        if (auto result = decoder.enter(); result.is_error()) {                           \
-            ERROR_WITH_SCOPE(TRY(String::formatted("Failed to enter scope: {}", scope))); \
-        }                                                                                 \
-        PUSH_SCOPE(scope)                                                                 \
-    } while (0)
-
-#define PUSH_SCOPE(scope) current_scope.append(#scope##sv);
-
-#define EXIT_SCOPE()                                                                             \
-    do {                                                                                         \
-        if (auto error = decoder.leave(); error.is_error()) {                                    \
-            ERROR_WITH_SCOPE(TRY(String::formatted("Failed to exit scope: {}", error.error()))); \
-        }                                                                                        \
-        POP_SCOPE();                                                                             \
-    } while (0)
-
-#define POP_SCOPE() current_scope.remove(current_scope.size() - 1);
-
-#define READ_OBJECT(kind_name, type_name, value_name)                                                                    \
-    auto value_name##_result = decoder.read<type_name>(Crypto::ASN1::Class::Universal, Crypto::ASN1::Kind::kind_name);   \
-    if (value_name##_result.is_error()) {                                                                                \
-        ERROR_WITH_SCOPE(TRY(String::formatted("Read of kind " #kind_name " failed: {}", value_name##_result.error()))); \
-    }                                                                                                                    \
-    auto value_name = value_name##_result.release_value();
-
-#define REWRITE_TAG(kind_name)                                                                                              \
-    auto value_name##_result = decoder.rewrite_tag(Crypto::ASN1::Kind::kind_name);                                          \
-    if (value_name##_result.is_error()) {                                                                                   \
-        ERROR_WITH_SCOPE(TRY(String::formatted("Rewrite of kind " #kind_name " failed: {}", value_name##_result.error()))); \
-    }
-
-#define DROP_OBJECT()                                                                   \
-    do {                                                                                \
-        if (auto error = decoder.drop(); error.is_error()) {                            \
-            ERROR_WITH_SCOPE(TRY(String::formatted("Drop failed: {}", error.error()))); \
-        }                                                                               \
-    } while (0)
 
 static ErrorOr<Crypto::UnsignedBigInteger> parse_certificate_version(Crypto::ASN1::Decoder& decoder, Vector<StringView> current_scope)
 {

--- a/Libraries/LibCrypto/Certificate/Certificate.cpp
+++ b/Libraries/LibCrypto/Certificate/Certificate.cpp
@@ -112,9 +112,9 @@ ErrorOr<Vector<int>> parse_ec_parameters(Crypto::ASN1::Decoder& decoder, Vector<
     POP_SCOPE();
 
     constexpr static Array<Span<int const>, 3> known_curve_identifiers {
-        secp256r1_oid,
-        secp384r1_oid,
-        secp521r1_oid
+        ASN1::secp256r1_oid,
+        ASN1::secp384r1_oid,
+        ASN1::secp521r1_oid
     };
 
     bool is_known_curve = false;
@@ -144,18 +144,18 @@ static ErrorOr<AlgorithmIdentifier> parse_algorithm_identifier(Crypto::ASN1::Dec
     POP_SCOPE();
 
     constexpr static Array<Span<int const>, 12> known_algorithm_identifiers {
-        rsa_encryption_oid,
-        rsa_md5_encryption_oid,
-        rsa_sha1_encryption_oid,
-        rsa_sha256_encryption_oid,
-        rsa_sha384_encryption_oid,
-        rsa_sha512_encryption_oid,
-        ecdsa_with_sha256_encryption_oid,
-        ecdsa_with_sha384_encryption_oid,
-        ec_public_key_encryption_oid,
-        x25519_oid,
-        ed25519_oid,
-        x448_oid,
+        ASN1::rsa_encryption_oid,
+        ASN1::rsa_md5_encryption_oid,
+        ASN1::rsa_sha1_encryption_oid,
+        ASN1::rsa_sha256_encryption_oid,
+        ASN1::rsa_sha384_encryption_oid,
+        ASN1::rsa_sha512_encryption_oid,
+        ASN1::ecdsa_with_sha256_encryption_oid,
+        ASN1::ecdsa_with_sha384_encryption_oid,
+        ASN1::ec_public_key_encryption_oid,
+        ASN1::x25519_oid,
+        ASN1::ed25519_oid,
+        ASN1::x448_oid,
     };
 
     bool is_known_algorithm = false;
@@ -180,13 +180,13 @@ static ErrorOr<AlgorithmIdentifier> parse_algorithm_identifier(Crypto::ASN1::Dec
     //      sha512WithRSAEncryption  OBJECT IDENTIFIER  ::=  { pkcs-1 13 }
     //      sha224WithRSAEncryption  OBJECT IDENTIFIER  ::=  { pkcs-1 14 }
     constexpr static Array<Span<int const>, 8> rsa_null_algorithms = {
-        rsa_encryption_oid,
-        rsa_md5_encryption_oid,
-        rsa_sha1_encryption_oid,
-        rsa_sha256_encryption_oid,
-        rsa_sha384_encryption_oid,
-        rsa_sha512_encryption_oid,
-        rsa_sha224_encryption_oid,
+        ASN1::rsa_encryption_oid,
+        ASN1::rsa_md5_encryption_oid,
+        ASN1::rsa_sha1_encryption_oid,
+        ASN1::rsa_sha256_encryption_oid,
+        ASN1::rsa_sha384_encryption_oid,
+        ASN1::rsa_sha512_encryption_oid,
+        ASN1::rsa_sha224_encryption_oid,
     };
 
     bool is_rsa_null_algorithm = false;
@@ -216,14 +216,14 @@ static ErrorOr<AlgorithmIdentifier> parse_algorithm_identifier(Crypto::ASN1::Dec
     // https://datatracker.ietf.org/doc/html/rfc8410#section-9
     // For all of the OIDs, the parameters MUST be absent.
     constexpr static Array<Span<int const>, 8> no_parameter_algorithms = {
-        ecdsa_with_sha224_encryption_oid,
-        ecdsa_with_sha256_encryption_oid,
-        ecdsa_with_sha384_encryption_oid,
-        ecdsa_with_sha512_encryption_oid,
-        x25519_oid,
-        x448_oid,
-        ed25519_oid,
-        ed448_oid
+        ASN1::ecdsa_with_sha224_encryption_oid,
+        ASN1::ecdsa_with_sha256_encryption_oid,
+        ASN1::ecdsa_with_sha384_encryption_oid,
+        ASN1::ecdsa_with_sha512_encryption_oid,
+        ASN1::x25519_oid,
+        ASN1::x448_oid,
+        ASN1::ed25519_oid,
+        ASN1::ed448_oid
     };
 
     bool is_no_parameter_algorithm = false;
@@ -239,7 +239,7 @@ static ErrorOr<AlgorithmIdentifier> parse_algorithm_identifier(Crypto::ASN1::Dec
         return AlgorithmIdentifier(algorithm);
     }
 
-    if (algorithm.span() == ec_public_key_encryption_oid.span()) {
+    if (algorithm.span() == ASN1::ec_public_key_encryption_oid.span()) {
         // The parameters associated with id-ecPublicKey SHOULD be absent or ECParameters,
         // and NULL is allowed to support legacy implementations.
         if (decoder.eof()) {
@@ -380,7 +380,7 @@ ErrorOr<SubjectPublicKey> parse_subject_public_key_info(Crypto::ASN1::Decoder& d
 
     public_key.raw_key = TRY(ByteBuffer::copy(TRY(value.raw_bytes())));
 
-    if (public_key.algorithm.identifier.span() == rsa_encryption_oid.span()) {
+    if (public_key.algorithm.identifier.span() == ASN1::rsa_encryption_oid.span()) {
         auto key = Crypto::PK::RSA::parse_rsa_key(TRY(value.raw_bytes()));
         if (!key.public_key.length()) {
             return Error::from_string_literal("Invalid RSA key");
@@ -395,11 +395,11 @@ ErrorOr<SubjectPublicKey> parse_subject_public_key_info(Crypto::ASN1::Decoder& d
     // https://datatracker.ietf.org/doc/html/rfc8410#section-9
     // For all of the OIDs, the parameters MUST be absent.
     constexpr static Array<Span<int const>, 5> no_parameter_algorithms = {
-        ec_public_key_encryption_oid,
-        x25519_oid,
-        x448_oid,
-        ed25519_oid,
-        ed448_oid
+        ASN1::ec_public_key_encryption_oid,
+        ASN1::x25519_oid,
+        ASN1::x448_oid,
+        ASN1::ed25519_oid,
+        ASN1::ed448_oid
     };
 
     for (auto const& inner : no_parameter_algorithms) {
@@ -439,7 +439,7 @@ ErrorOr<PrivateKey> parse_private_key_info(Crypto::ASN1::Decoder& decoder, Vecto
 
     private_key.raw_key = TRY(ByteBuffer::copy(value.bytes()));
 
-    if (private_key.algorithm.identifier.span() == rsa_encryption_oid.span()) {
+    if (private_key.algorithm.identifier.span() == ASN1::rsa_encryption_oid.span()) {
         auto key = Crypto::PK::RSA::parse_rsa_key(value.bytes());
         if (key.private_key.length() == 0) {
             ERROR_WITH_SCOPE(TRY(String::formatted("Invalid RSA key at {}", current_scope)));
@@ -450,7 +450,7 @@ ErrorOr<PrivateKey> parse_private_key_info(Crypto::ASN1::Decoder& decoder, Vecto
         EXIT_SCOPE();
         return private_key;
     }
-    if (private_key.algorithm.identifier.span() == ec_public_key_encryption_oid.span()) {
+    if (private_key.algorithm.identifier.span() == ASN1::ec_public_key_encryption_oid.span()) {
         auto maybe_key = Crypto::PK::EC::parse_ec_key(value.bytes());
         if (maybe_key.is_error()) {
             ERROR_WITH_SCOPE(TRY(String::formatted("Invalid EC key at {}: {}", current_scope, maybe_key.release_error())));
@@ -465,11 +465,11 @@ ErrorOr<PrivateKey> parse_private_key_info(Crypto::ASN1::Decoder& decoder, Vecto
     // https://datatracker.ietf.org/doc/html/rfc8410#section-9
     // For all of the OIDs, the parameters MUST be absent.
     constexpr static Array<Span<int const>, 5> no_parameter_algorithms = {
-        ec_public_key_encryption_oid,
-        x25519_oid,
-        x448_oid,
-        ed25519_oid,
-        ed448_oid
+        ASN1::ec_public_key_encryption_oid,
+        ASN1::x25519_oid,
+        ASN1::x448_oid,
+        ASN1::ed25519_oid,
+        ASN1::ed448_oid
     };
 
     for (auto const& inner : no_parameter_algorithms) {
@@ -701,26 +701,26 @@ static ErrorOr<void> parse_extension(Crypto::ASN1::Decoder& decoder, Vector<Stri
 
     Crypto::ASN1::Decoder extension_decoder { extension_value.bytes() };
     Vector<StringView, 8> extension_scope {};
-    if (extension_id == subject_alternative_name_oid) {
+    if (extension_id == ASN1::subject_alternative_name_oid) {
         is_known_extension = true;
         auto alternate_names = TRY(parse_subject_alternative_names(extension_decoder, extension_scope));
         certificate.SAN = alternate_names;
     }
 
-    if (extension_id == key_usage_oid) {
+    if (extension_id == ASN1::key_usage_oid) {
         is_known_extension = true;
         auto usage = TRY(parse_key_usage(extension_decoder, extension_scope));
         certificate.is_allowed_to_sign_certificate = usage.get(5);
     }
 
-    if (extension_id == basic_constraints_oid) {
+    if (extension_id == ASN1::basic_constraints_oid) {
         is_known_extension = true;
         auto constraints = TRY(parse_basic_constraints(extension_decoder, extension_scope));
         certificate.is_certificate_authority = constraints.is_certificate_authority;
         certificate.path_length_constraint = constraints.path_length_constraint.to_u64();
     }
 
-    if (extension_id == issuer_alternative_name_oid) {
+    if (extension_id == ASN1::issuer_alternative_name_oid) {
         is_known_extension = true;
         auto alternate_names = TRY(parse_issuer_alternative_names(extension_decoder, extension_scope));
         certificate.IAN = alternate_names;
@@ -899,23 +899,23 @@ ErrorOr<String> RelativeDistinguishedName::to_string() const
     StringBuilder cert_name;
 
     for (auto const& [member_identifier, value] : m_members) {
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::SerialNumber), "SERIALNUMBER");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Email), "MAIL");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Title), "T");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::PostalCode), "PC");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::DnQualifier), "DNQ");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::GivenName), "GIVENNAME");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Surname), "SN");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::SerialNumber), "SERIALNUMBER");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Email), "MAIL");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Title), "T");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::PostalCode), "PC");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::DnQualifier), "DNQ");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::GivenName), "GIVENNAME");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Surname), "SN");
 
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Cn), "CN");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::L), "L");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::St), "ST");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::O), "O");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Ou), "OU");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::C), "C");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Street), "STREET");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Dc), "DC");
-        ADD_IF_RECOGNIZED(enum_value(AttributeType::Uid), "UID");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Cn), "CN");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::L), "L");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::St), "ST");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::O), "O");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Ou), "OU");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::C), "C");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Street), "STREET");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Dc), "DC");
+        ADD_IF_RECOGNIZED(enum_value(ASN1::AttributeType::Uid), "UID");
 
         cert_name.appendff("\\{}={}", member_identifier, value);
     }

--- a/Libraries/LibCrypto/Certificate/Certificate.h
+++ b/Libraries/LibCrypto/Certificate/Certificate.h
@@ -31,40 +31,20 @@ constexpr static Array<int, 7>
     ecdsa_with_sha256_encryption_oid { 1, 2, 840, 10045, 4, 3, 2 },
     ecdsa_with_sha384_encryption_oid { 1, 2, 840, 10045, 4, 3, 3 },
     ecdsa_with_sha512_encryption_oid { 1, 2, 840, 10045, 4, 3, 4 },
-    ec_public_key_encryption_oid { 1, 2, 840, 10045, 2, 1 },
+    secp256r1_oid { 1, 2, 840, 10045, 3, 1, 7 };
+
+constexpr static Array<int, 6>
+    ec_public_key_encryption_oid { 1, 2, 840, 10045, 2, 1 };
+
+constexpr static Array<int, 5>
+    secp384r1_oid { 1, 3, 132, 0, 34 },
+    secp521r1_oid { 1, 3, 132, 0, 35 };
+
+constexpr static Array<int, 4>
     x25519_oid { 1, 3, 101, 110 },
     x448_oid { 1, 3, 101, 111 },
     ed25519_oid { 1, 3, 101, 112 },
     ed448_oid { 1, 3, 101, 113 },
-    secp256r1_oid { 1, 2, 840, 10045, 3, 1, 7 },
-    secp384r1_oid { 1, 3, 132, 0, 34 },
-    secp521r1_oid { 1, 3, 132, 0, 35 };
-
-constexpr static Array<Array<int, 7>, 12> known_algorithm_identifiers {
-    rsa_encryption_oid,
-    rsa_md5_encryption_oid,
-    rsa_sha1_encryption_oid,
-    rsa_sha256_encryption_oid,
-    rsa_sha384_encryption_oid,
-    rsa_sha512_encryption_oid,
-    ecdsa_with_sha256_encryption_oid,
-    ecdsa_with_sha384_encryption_oid,
-    ec_public_key_encryption_oid,
-    x25519_oid,
-    ed25519_oid,
-    x448_oid,
-};
-
-constexpr static Array<int, 7>
-    curve_ansip384r1 { 1, 3, 132, 0, 34 },
-    curve_prime256 { 1, 2, 840, 10045, 3, 1, 7 };
-
-constexpr static Array<Array<int, 7>, 9> known_curve_identifiers {
-    curve_ansip384r1,
-    curve_prime256
-};
-
-constexpr static Array<int, 4>
     key_usage_oid { 2, 5, 29, 15 },
     subject_alternative_name_oid { 2, 5, 29, 17 },
     issuer_alternative_name_oid { 2, 5, 29, 18 },

--- a/Libraries/LibCrypto/Certificate/Certificate.h
+++ b/Libraries/LibCrypto/Certificate/Certificate.h
@@ -12,154 +12,13 @@
 #include <AK/Time.h>
 #include <AK/Types.h>
 #include <LibCore/ConfigFile.h>
+#include <LibCrypto/ASN1/Constants.h>
 #include <LibCrypto/ASN1/DER.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/PK/EC.h>
 #include <LibCrypto/PK/RSA.h>
 
 namespace Crypto::Certificate {
-
-constexpr static Array<int, 7>
-    rsa_encryption_oid { 1, 2, 840, 113549, 1, 1, 1 },
-    rsa_md5_encryption_oid { 1, 2, 840, 113549, 1, 1, 4 },
-    rsa_sha1_encryption_oid { 1, 2, 840, 113549, 1, 1, 5 },
-    rsa_sha256_encryption_oid { 1, 2, 840, 113549, 1, 1, 11 },
-    rsa_sha384_encryption_oid { 1, 2, 840, 113549, 1, 1, 12 },
-    rsa_sha512_encryption_oid { 1, 2, 840, 113549, 1, 1, 13 },
-    rsa_sha224_encryption_oid { 1, 2, 840, 113549, 1, 1, 14 },
-    ecdsa_with_sha224_encryption_oid { 1, 2, 840, 10045, 4, 3, 1 },
-    ecdsa_with_sha256_encryption_oid { 1, 2, 840, 10045, 4, 3, 2 },
-    ecdsa_with_sha384_encryption_oid { 1, 2, 840, 10045, 4, 3, 3 },
-    ecdsa_with_sha512_encryption_oid { 1, 2, 840, 10045, 4, 3, 4 },
-    secp256r1_oid { 1, 2, 840, 10045, 3, 1, 7 };
-
-constexpr static Array<int, 6>
-    ec_public_key_encryption_oid { 1, 2, 840, 10045, 2, 1 };
-
-constexpr static Array<int, 5>
-    secp384r1_oid { 1, 3, 132, 0, 34 },
-    secp521r1_oid { 1, 3, 132, 0, 35 };
-
-constexpr static Array<int, 4>
-    x25519_oid { 1, 3, 101, 110 },
-    x448_oid { 1, 3, 101, 111 },
-    ed25519_oid { 1, 3, 101, 112 },
-    ed448_oid { 1, 3, 101, 113 },
-    key_usage_oid { 2, 5, 29, 15 },
-    subject_alternative_name_oid { 2, 5, 29, 17 },
-    issuer_alternative_name_oid { 2, 5, 29, 18 },
-    basic_constraints_oid { 2, 5, 29, 19 };
-
-#define _ENUM(key, value) key,
-
-#define __ENUM_OBJECT_CLASS                   \
-    _ENUM(ApplicationProcess, "2.5.6.11"sv)   \
-    _ENUM(Country, "2.5.6.2"sv)               \
-    _ENUM(DcObject, "1.3.6.1.4.1.1466.344"sv) \
-    _ENUM(Device, "2.5.6.14"sv)               \
-    _ENUM(GroupOfNames, "2.5.6.9"sv)          \
-    _ENUM(GroupOfUniqueNames, "2.5.6.17"sv)   \
-    _ENUM(Locality, "2.5.6.3"sv)              \
-    _ENUM(Organization, "2.5.6.4"sv)          \
-    _ENUM(OrganizationalPerson, "2.5.6.7"sv)  \
-    _ENUM(OrganizationalRole, "2.5.6.8"sv)    \
-    _ENUM(OrganizationalUnit, "2.5.6.5"sv)    \
-    _ENUM(Person, "2.5.6.6"sv)                \
-    _ENUM(ResidentialPerson, "2.5.6.10"sv)    \
-    _ENUM(UidObject, "1.3.6.1.1.3.1"sv)
-
-// NOTE: Type = O
-// NOTE: This list is not exhaustive. If more members are needed, find them at the link below.
-// https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-3
-enum class ObjectClass {
-    __ENUM_OBJECT_CLASS
-};
-
-#define __ENUM_ATTRIBUTE_TYPE                       \
-    _ENUM(BusinessCategory, "2.5.4.15"sv)           \
-    _ENUM(C, "2.5.4.6"sv)                           \
-    _ENUM(Cn, "2.5.4.3"sv)                          \
-    _ENUM(Dc, "0.9.2342.19200300.100.1.25"sv)       \
-    _ENUM(Description, "2.5.4.13"sv)                \
-    _ENUM(DestinationIndicator, "2.5.4.27"sv)       \
-    _ENUM(DistinguishedName, "2.5.4.49"sv)          \
-    _ENUM(DnQualifier, "2.5.4.46"sv)                \
-    _ENUM(EnhancedSearchGuide, "2.5.4.47"sv)        \
-    _ENUM(Email, "1.2.840.113549.1.9.1"sv)          \
-    _ENUM(FacsimileTelephoneNumber, "2.5.4.23"sv)   \
-    _ENUM(GenerationQualifier, "2.5.4.44"sv)        \
-    _ENUM(GivenName, "2.5.4.42"sv)                  \
-    _ENUM(HouseIdentifier, "2.5.4.51"sv)            \
-    _ENUM(Initials, "2.5.4.43"sv)                   \
-    _ENUM(InternationalISDNNumber, "2.5.4.25"sv)    \
-    _ENUM(L, "2.5.4.7"sv)                           \
-    _ENUM(Member, "2.5.4.31"sv)                     \
-    _ENUM(Name, "2.5.4.41"sv)                       \
-    _ENUM(O, "2.5.4.10"sv)                          \
-    _ENUM(Ou, "2.5.4.11"sv)                         \
-    _ENUM(Owner, "2.5.4.32"sv)                      \
-    _ENUM(PhysicalDeliveryOfficeName, "2.5.4.19"sv) \
-    _ENUM(PostalAddress, "2.5.4.16"sv)              \
-    _ENUM(PostalCode, "2.5.4.17"sv)                 \
-    _ENUM(PostOfficeBox, "2.5.4.18"sv)              \
-    _ENUM(PreferredDeliveryMethod, "2.5.4.28"sv)    \
-    _ENUM(RegisteredAddress, "2.5.4.26"sv)          \
-    _ENUM(RoleOccupant, "2.5.4.33"sv)               \
-    _ENUM(SearchGuide, "2.5.4.14"sv)                \
-    _ENUM(SeeAlso, "2.5.4.34"sv)                    \
-    _ENUM(SerialNumber, "2.5.4.5"sv)                \
-    _ENUM(Sn, "2.5.4.4"sv)                          \
-    _ENUM(St, "2.5.4.8"sv)                          \
-    _ENUM(Street, "2.5.4.9"sv)                      \
-    _ENUM(Surname, "2.5.4.4"sv)                     \
-    _ENUM(TelephoneNumber, "2.5.4.20"sv)            \
-    _ENUM(TeletexTerminalIdentifier, "2.5.4.22"sv)  \
-    _ENUM(TelexNumber, "2.5.4.21"sv)                \
-    _ENUM(Title, "2.5.4.12"sv)                      \
-    _ENUM(Uid, "0.9.2342.19200300.100.1.1"sv)       \
-    _ENUM(UniqueMember, "2.5.4.50"sv)               \
-    _ENUM(UserPassword, "2.5.4.35"sv)               \
-    _ENUM(X121Address, "2.5.4.24"sv)                \
-    _ENUM(X500UniqueIdentifier, "2.5.4.45"sv)
-
-// NOTE: Type = A
-// NOTE: This list is not exhaustive. If more members are needed, find them at the link below.
-// https://www.iana.org/assignments/ldap-parameters/ldap-parameters.xhtml#ldap-parameters-3
-enum class AttributeType {
-    __ENUM_ATTRIBUTE_TYPE
-};
-
-#undef _ENUM
-
-constexpr static StringView enum_value(ObjectClass object_class)
-{
-#define _ENUM(key, value)  \
-    case ObjectClass::key: \
-        return value;
-
-    switch (object_class) {
-        __ENUM_OBJECT_CLASS
-    }
-
-    return "Unknown"sv;
-#undef _ENUM
-#undef __ENUM_OBJECT_CLASS
-}
-
-constexpr static StringView enum_value(AttributeType object_class)
-{
-#define _ENUM(key, value)    \
-    case AttributeType::key: \
-        return value;
-
-    switch (object_class) {
-        __ENUM_ATTRIBUTE_TYPE
-    }
-
-    return "Unknown"sv;
-#undef _ENUM
-#undef __ENUM_ATTRIBUTE_TYPE
-}
 
 struct AlgorithmIdentifier {
     AlgorithmIdentifier()
@@ -196,19 +55,19 @@ public:
         return m_members.get(key);
     }
 
-    Optional<String> get(AttributeType key) const
+    Optional<String> get(ASN1::AttributeType key) const
     {
         return m_members.get(enum_value(key));
     }
 
-    Optional<String> get(ObjectClass key) const
+    Optional<String> get(ASN1::ObjectClass key) const
     {
         return m_members.get(enum_value(key));
     }
 
     String common_name() const
     {
-        auto entry = get(AttributeType::Cn);
+        auto entry = get(ASN1::AttributeType::Cn);
         if (entry.has_value()) {
             return entry.value();
         }
@@ -218,7 +77,7 @@ public:
 
     String organizational_unit() const
     {
-        return get(AttributeType::Ou).value_or({});
+        return get(ASN1::AttributeType::Ou).value_or({});
     }
 
 private:

--- a/Libraries/LibCrypto/Certificate/Certificate.h
+++ b/Libraries/LibCrypto/Certificate/Certificate.h
@@ -92,6 +92,7 @@ struct Validity {
 class SubjectPublicKey {
 public:
     Crypto::PK::RSAPublicKey<Crypto::UnsignedBigInteger> rsa;
+    Crypto::PK::ECPublicKey<Crypto::UnsignedBigInteger> ec;
 
     AlgorithmIdentifier algorithm;
     ByteBuffer raw_key;

--- a/Libraries/LibCrypto/PK/EC.h
+++ b/Libraries/LibCrypto/PK/EC.h
@@ -81,7 +81,7 @@ class EC : public PKSystem<ECPrivateKey<IntegerType>, ECPublicKey<IntegerType>> 
 public:
     using KeyPairType = ECKeyPair<PublicKeyType, PrivateKeyType>;
 
-    static ErrorOr<KeyPairType> parse_ec_key(ReadonlyBytes der);
+    static ErrorOr<KeyPairType> parse_ec_key(ReadonlyBytes der, bool is_private, Vector<StringView> current_scope);
 };
 
 }

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -266,7 +266,7 @@ void RSA::import_private_key(ReadonlyBytes bytes, bool pem)
 {
     ByteBuffer buffer;
     if (pem) {
-        buffer = decode_pem(bytes);
+        buffer = decode_pem(bytes).data;
         bytes = buffer;
     }
 
@@ -282,7 +282,7 @@ void RSA::import_public_key(ReadonlyBytes bytes, bool pem)
 {
     ByteBuffer buffer;
     if (pem) {
-        buffer = decode_pem(bytes);
+        buffer = decode_pem(bytes).data;
         bytes = buffer;
     }
 

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -95,7 +95,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
 
         auto oid = oid_result.release_value();
         // Now let's check that the OID matches "RSA key"
-        if (oid != Crypto::Certificate::rsa_encryption_oid) {
+        if (oid != Crypto::ASN1::rsa_encryption_oid) {
             // Oh well. not an RSA key at all.
             dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: Not an RSA key");
             return false;

--- a/Libraries/LibCrypto/PK/RSA.h
+++ b/Libraries/LibCrypto/PK/RSA.h
@@ -152,7 +152,7 @@ class RSA : public PKSystem<RSAPrivateKey<IntegerType>, RSAPublicKey<IntegerType
 public:
     using KeyPairType = RSAKeyPair<PublicKeyType, PrivateKeyType>;
 
-    static KeyPairType parse_rsa_key(ReadonlyBytes der);
+    static ErrorOr<KeyPairType> parse_rsa_key(ReadonlyBytes der, bool is_private, Vector<StringView> current_scope);
     static KeyPairType generate_key_pair(size_t bits = 256, IntegerType e = 65537)
     {
         IntegerType p;

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -13,6 +13,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/Timer.h>
 #include <LibCrypto/ASN1/ASN1.h>
+#include <LibCrypto/ASN1/Constants.h>
 #include <LibCrypto/ASN1/PEM.h>
 #include <LibCrypto/Certificate/Certificate.h>
 #include <LibCrypto/Curves/Ed25519.h>
@@ -316,25 +317,25 @@ bool Context::verify_certificate_pair(Certificate const& subject, Certificate co
 
     bool is_rsa = true;
 
-    if (identifier == Crypto::Certificate::rsa_encryption_oid) {
+    if (identifier == Crypto::ASN1::rsa_encryption_oid) {
         kind = Crypto::Hash::HashKind::None;
-    } else if (identifier == Crypto::Certificate::rsa_md5_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::rsa_md5_encryption_oid) {
         kind = Crypto::Hash::HashKind::MD5;
-    } else if (identifier == Crypto::Certificate::rsa_sha1_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::rsa_sha1_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA1;
-    } else if (identifier == Crypto::Certificate::rsa_sha256_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::rsa_sha256_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA256;
-    } else if (identifier == Crypto::Certificate::rsa_sha384_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::rsa_sha384_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA384;
-    } else if (identifier == Crypto::Certificate::rsa_sha512_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::rsa_sha512_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA512;
-    } else if (identifier == Crypto::Certificate::ecdsa_with_sha256_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::ecdsa_with_sha256_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA256;
         is_rsa = false;
-    } else if (identifier == Crypto::Certificate::ecdsa_with_sha384_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::ecdsa_with_sha384_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA384;
         is_rsa = false;
-    } else if (identifier == Crypto::Certificate::ecdsa_with_sha512_encryption_oid) {
+    } else if (identifier == Crypto::ASN1::ecdsa_with_sha512_encryption_oid) {
         kind = Crypto::Hash::HashKind::SHA512;
         is_rsa = false;
     }
@@ -597,9 +598,9 @@ ErrorOr<Vector<Certificate>> DefaultRootCACertificates::parse_pem_root_certifica
 
 ErrorOr<SupportedGroup> oid_to_curve(Vector<int> curve)
 {
-    if (curve == Crypto::Certificate::secp384r1_oid)
+    if (curve == Crypto::ASN1::secp384r1_oid)
         return SupportedGroup::SECP384R1;
-    if (curve == Crypto::Certificate::secp256r1_oid)
+    if (curve == Crypto::ASN1::secp256r1_oid)
         return SupportedGroup::SECP256R1;
 
     return AK::Error::from_string_literal("Unknown curve oid");

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -597,9 +597,9 @@ ErrorOr<Vector<Certificate>> DefaultRootCACertificates::parse_pem_root_certifica
 
 ErrorOr<SupportedGroup> oid_to_curve(Vector<int> curve)
 {
-    if (curve == Crypto::Certificate::curve_ansip384r1)
+    if (curve == Crypto::Certificate::secp384r1_oid)
         return SupportedGroup::SECP384R1;
-    if (curve == Crypto::Certificate::curve_prime256)
+    if (curve == Crypto::Certificate::secp256r1_oid)
         return SupportedGroup::SECP256R1;
 
     return AK::Error::from_string_literal("Unknown curve oid");

--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -501,12 +501,12 @@ Vector<Certificate> TLSv12::parse_pem_certificate(ReadonlyBytes certificate_pem_
     }
 
     auto decoded_certificate = Crypto::decode_pem(certificate_pem_buffer);
-    if (decoded_certificate.is_empty()) {
+    if (decoded_certificate.type != Crypto::PEMType::Certificate) {
         dbgln("Certificate not PEM");
         return {};
     }
 
-    auto maybe_certificate = Certificate::parse_certificate(decoded_certificate);
+    auto maybe_certificate = Certificate::parse_certificate(decoded_certificate.data);
     if (!maybe_certificate.is_error()) {
         dbgln("Invalid certificate");
         return {};
@@ -576,7 +576,7 @@ ErrorOr<Vector<Certificate>> DefaultRootCACertificates::parse_pem_root_certifica
     auto certs = TRY(Crypto::decode_pems(data));
 
     for (auto& cert : certs) {
-        auto certificate_result = Certificate::parse_certificate(cert.bytes());
+        auto certificate_result = Certificate::parse_certificate(cert.data);
         if (certificate_result.is_error()) {
             // FIXME: It would be nice to have more informations about the certificate we failed to parse.
             //        Like: Issuer, Algorithm, CN, etc

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -11,6 +11,7 @@
 #include <AK/HashTable.h>
 #include <AK/QuickSort.h>
 #include <LibCrypto/ASN1/ASN1.h>
+#include <LibCrypto/ASN1/Constants.h>
 #include <LibCrypto/ASN1/DER.h>
 #include <LibCrypto/Authentication/HMAC.h>
 #include <LibCrypto/Certificate/Certificate.h>
@@ -813,7 +814,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> RSAOAEP::import_key(Web::Crypto::Algorit
 
         // 4. If the algorithm object identifier field of the algorithm AlgorithmIdentifier field of spki
         //    is not equal to the rsaEncryption object identifier defined in [RFC3447], then throw a DataError.
-        if (spki.algorithm.identifier != ::Crypto::Certificate::rsa_encryption_oid)
+        if (spki.algorithm.identifier != ::Crypto::ASN1::rsa_encryption_oid)
             return WebIDL::DataError::create(m_realm, "Algorithm object identifier is not the rsaEncryption object identifier"_string);
 
         // 5. Let publicKey be the result of performing the parse an ASN.1 structure algorithm,
@@ -850,7 +851,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> RSAOAEP::import_key(Web::Crypto::Algorit
 
         // 4. If the algorithm object identifier field of the privateKeyAlgorithm PrivateKeyAlgorithm field of privateKeyInfo
         //    is not equal to the rsaEncryption object identifier defined in [RFC3447], then throw a DataError.
-        if (private_key_info.algorithm.identifier != ::Crypto::Certificate::rsa_encryption_oid)
+        if (private_key_info.algorithm.identifier != ::Crypto::ASN1::rsa_encryption_oid)
             return WebIDL::DataError::create(m_realm, "Algorithm object identifier is not the rsaEncryption object identifier"_string);
 
         // 5. Let rsaPrivateKey be the result of performing the parse an ASN.1 structure algorithm,
@@ -1071,7 +1072,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> RSAOAEP::export_key(Bindings::KeyFormat
         //   that represents the RSA public key represented by the [[handle]] internal slot of key
         auto maybe_data = handle.visit(
             [&](::Crypto::PK::RSAPublicKey<> const& public_key) -> ErrorOr<ByteBuffer> {
-                return TRY(::Crypto::PK::wrap_in_subject_public_key_info(public_key, Array { ::Crypto::Certificate::rsa_encryption_oid }, nullptr));
+                return TRY(::Crypto::PK::wrap_in_subject_public_key_info(public_key, ::Crypto::ASN1::rsa_encryption_oid, nullptr));
             },
             [](auto) -> ErrorOr<ByteBuffer> {
                 VERIFY_NOT_REACHED();
@@ -1098,7 +1099,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> RSAOAEP::export_key(Bindings::KeyFormat
         // that represents the RSA private key represented by the [[handle]] internal slot of key
         auto maybe_data = handle.visit(
             [&](::Crypto::PK::RSAPrivateKey<> const& private_key) -> ErrorOr<ByteBuffer> {
-                return TRY(::Crypto::PK::wrap_in_private_key_info(private_key, Array { ::Crypto::Certificate::rsa_encryption_oid }, nullptr));
+                return TRY(::Crypto::PK::wrap_in_private_key_info(private_key, ::Crypto::ASN1::rsa_encryption_oid, nullptr));
             },
             [](auto) -> ErrorOr<ByteBuffer> {
                 VERIFY_NOT_REACHED();
@@ -2707,7 +2708,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ECDH::import_key(AlgorithmParams const& 
 
         // 4. If the algorithm object identifier field of the algorithm AlgorithmIdentifier field of spki
         //    is not equal to the id-ecPublicKey object identifier defined in [RFC5480], then throw a DataError.
-        if (spki.algorithm.identifier != ::Crypto::Certificate::ec_public_key_encryption_oid)
+        if (spki.algorithm.identifier != ::Crypto::ASN1::ec_public_key_encryption_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
 
         // 5. If the parameters field of the algorithm AlgorithmIdentifier field of spki is absent, then throw a DataError.
@@ -2722,17 +2723,17 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ECDH::import_key(AlgorithmParams const& 
         String named_curve;
 
         // 9. If params is equivalent to the secp256r1 object identifier defined in [RFC5480]:
-        if (ec_params == ::Crypto::Certificate::secp256r1_oid) {
+        if (ec_params == ::Crypto::ASN1::secp256r1_oid) {
             // Set namedCurve to "P-256".
             named_curve = "P-256"_string;
         }
         // If params is equivalent to the secp384r1 object identifier defined in [RFC5480]:
-        else if (ec_params == ::Crypto::Certificate::secp384r1_oid) {
+        else if (ec_params == ::Crypto::ASN1::secp384r1_oid) {
             // Set namedCurve to "P-384".
             named_curve = "P-384"_string;
         }
         // If params is equivalent to the secp521r1 object identifier defined in [RFC5480]:
-        else if (ec_params == ::Crypto::Certificate::secp521r1_oid) {
+        else if (ec_params == ::Crypto::ASN1::secp521r1_oid) {
             // Set namedCurve to "P-521".
             named_curve = "P-521"_string;
         }
@@ -2810,7 +2811,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ECDH::import_key(AlgorithmParams const& 
 
         // 4. If the algorithm object identifier field of the privateKeyAlgorithm PrivateKeyAlgorithm field of privateKeyInfo
         //    is not equal to the id-ecPublicKey object identifier defined in [RFC5480], then throw a DataError.
-        if (private_key_info.algorithm.identifier != ::Crypto::Certificate::ec_public_key_encryption_oid)
+        if (private_key_info.algorithm.identifier != ::Crypto::ASN1::ec_public_key_encryption_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
 
         // 5. If the parameters field of the privateKeyAlgorithm PrivateKeyAlgorithmIdentifier field
@@ -2826,17 +2827,17 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ECDH::import_key(AlgorithmParams const& 
         String named_curve;
 
         // 9. If params is equivalent to the secp256r1 object identifier defined in [RFC5480]:
-        if (ec_params == ::Crypto::Certificate::secp256r1_oid) {
+        if (ec_params == ::Crypto::ASN1::secp256r1_oid) {
             // Set namedCurve to "P-256".
             named_curve = "P-256"_string;
         }
         // If params is equivalent to the secp384r1 object identifier defined in [RFC5480]:
-        else if (ec_params == ::Crypto::Certificate::secp384r1_oid) {
+        else if (ec_params == ::Crypto::ASN1::secp384r1_oid) {
             // Set namedCurve to "P-384".
             named_curve = "P-384"_string;
         }
         // If params is equivalent to the secp521r1 object identifier defined in [RFC5480]:
-        else if (ec_params == ::Crypto::Certificate::secp521r1_oid) {
+        else if (ec_params == ::Crypto::ASN1::secp521r1_oid) {
             // Set namedCurve to "P-521".
             named_curve = "P-521"_string;
         }
@@ -3146,15 +3147,15 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ECDH::export_key(Bindings::KeyFormat fo
 
                     Span<int const> ec_params;
                     if (algorithm.named_curve() == "P-256"sv)
-                        ec_params = ::Crypto::Certificate::secp256r1_oid;
+                        ec_params = ::Crypto::ASN1::secp256r1_oid;
                     else if (algorithm.named_curve() == "P-384"sv)
-                        ec_params = ::Crypto::Certificate::secp384r1_oid;
+                        ec_params = ::Crypto::ASN1::secp384r1_oid;
                     else if (algorithm.named_curve() == "P-521"sv)
-                        ec_params = ::Crypto::Certificate::secp521r1_oid;
+                        ec_params = ::Crypto::ASN1::secp521r1_oid;
                     else
                         VERIFY_NOT_REACHED();
 
-                    return TRY(::Crypto::PK::wrap_in_subject_public_key_info(public_key_bytes, ::Crypto::Certificate::ec_public_key_encryption_oid, ec_params));
+                    return TRY(::Crypto::PK::wrap_in_subject_public_key_info(public_key_bytes, ::Crypto::ASN1::ec_public_key_encryption_oid, ec_params));
                 },
                 [](auto) -> ErrorOr<ByteBuffer> {
                     VERIFY_NOT_REACHED();
@@ -3213,15 +3214,15 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ECDH::export_key(Bindings::KeyFormat fo
                 [&](::Crypto::PK::ECPrivateKey<> const& private_key) -> ErrorOr<ByteBuffer> {
                     Span<int const> ec_params;
                     if (algorithm.named_curve() == "P-256"sv)
-                        ec_params = ::Crypto::Certificate::secp256r1_oid;
+                        ec_params = ::Crypto::ASN1::secp256r1_oid;
                     else if (algorithm.named_curve() == "P-384"sv)
-                        ec_params = ::Crypto::Certificate::secp384r1_oid;
+                        ec_params = ::Crypto::ASN1::secp384r1_oid;
                     else if (algorithm.named_curve() == "P-521"sv)
-                        ec_params = ::Crypto::Certificate::secp521r1_oid;
+                        ec_params = ::Crypto::ASN1::secp521r1_oid;
                     else
                         VERIFY_NOT_REACHED();
 
-                    return TRY(::Crypto::PK::wrap_in_private_key_info(private_key, ::Crypto::Certificate::ec_public_key_encryption_oid, ec_params));
+                    return TRY(::Crypto::PK::wrap_in_private_key_info(private_key, ::Crypto::ASN1::ec_public_key_encryption_oid, ec_params));
                 },
                 [](auto) -> ErrorOr<ByteBuffer> {
                     VERIFY_NOT_REACHED();
@@ -3502,7 +3503,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ED25519::import_key(
 
         // 4. If the algorithm object identifier field of the algorithm AlgorithmIdentifier field of spki
         //    is not equal to the id-Ed25519 object identifier defined in [RFC8410], then throw a DataError.
-        if (spki.algorithm.identifier != ::Crypto::Certificate::ed25519_oid)
+        if (spki.algorithm.identifier != ::Crypto::ASN1::ed25519_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm identifier"_string);
 
         // 5. If the parameters field of the algorithm AlgorithmIdentifier field of spki is present, then throw a DataError.
@@ -3544,7 +3545,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> ED25519::import_key(
 
         // 4. If the algorithm object identifier field of the privateKeyAlgorithm PrivateKeyAlgorithm field
         //    of privateKeyInfo is not equal to the id-Ed25519 object identifier defined in [RFC8410], then throw a DataError.
-        if (private_key_info.algorithm.identifier != ::Crypto::Certificate::ed25519_oid)
+        if (private_key_info.algorithm.identifier != ::Crypto::ASN1::ed25519_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm identifier"_string);
 
         // 5. If the parameters field of the privateKeyAlgorithm PrivateKeyAlgorithmIdentifier field of privateKeyInfo is present,
@@ -3752,7 +3753,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ED25519::export_key(Bindings::KeyFormat
         //    * Set the algorithm field to an AlgorithmIdentifier ASN.1 type with the following properties:
         //      * Set the algorithm object identifier to the id-Ed25519 OID defined in [RFC8410].
         //    * Set the subjectPublicKey field to keyData.
-        auto ed25519_oid = ::Crypto::Certificate::ed25519_oid;
+        auto ed25519_oid = ::Crypto::ASN1::ed25519_oid;
         auto data = TRY_OR_THROW_OOM(vm, ::Crypto::PK::wrap_in_subject_public_key_info(key_data, ed25519_oid, nullptr));
 
         // 3. Let result be a new ArrayBuffer associated with the relevant global object of this [HTML], and containing data.
@@ -3771,7 +3772,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> ED25519::export_key(Bindings::KeyFormat
         //      * Set the algorithm object identifier to the id-Ed25519 OID defined in [RFC8410].
         //    * Set the privateKey field to the result of DER-encoding a CurvePrivateKey ASN.1 type, as defined in Section 7 of [RFC8410], that represents the Ed25519 private key represented by the [[handle]] internal slot of key
 
-        auto ed25519_oid = ::Crypto::Certificate::ed25519_oid;
+        auto ed25519_oid = ::Crypto::ASN1::ed25519_oid;
         auto data = TRY_OR_THROW_OOM(vm, ::Crypto::PK::wrap_in_private_key_info(key_data, ed25519_oid, nullptr));
 
         // 3. Let result be a new ArrayBuffer associated with the relevant global object of this [HTML], and containing data.
@@ -4195,7 +4196,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> X25519::import_key([[maybe_unused]] Web:
 
         // 4. If the algorithm object identifier field of the algorithm AlgorithmIdentifier field of spki
         //    is not equal to the id-X25519 object identifier defined in [RFC8410], then throw a DataError.
-        if (spki.algorithm.identifier != ::Crypto::Certificate::x25519_oid)
+        if (spki.algorithm.identifier != ::Crypto::ASN1::x25519_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
 
         // 5. If the parameters field of the algorithm AlgorithmIdentifier field of spki is present, then throw a DataError.
@@ -4236,7 +4237,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> X25519::import_key([[maybe_unused]] Web:
 
         // 4. If the algorithm object identifier field of the privateKeyAlgorithm PrivateKeyAlgorithm field of privateKeyInfo
         //    is not equal to the id-X25519 object identifier defined in [RFC8410], then throw a DataError.
-        if (private_key_info.algorithm.identifier != ::Crypto::Certificate::x25519_oid)
+        if (private_key_info.algorithm.identifier != ::Crypto::ASN1::x25519_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
 
         // 5. If the parameters field of the privateKeyAlgorithm PrivateKeyAlgorithmIdentifier field of privateKeyInfo is present, then throw a DataError.
@@ -4441,7 +4442,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> X25519::export_key(Bindings::KeyFormat 
         //    Set the algorithm object identifier to the id-X25519 OID defined in [RFC8410].
         //    Set the subjectPublicKey field to keyData.
         auto public_key = handle.get<ByteBuffer>();
-        auto data = TRY_OR_THROW_OOM(vm, ::Crypto::PK::wrap_in_subject_public_key_info(public_key, Array { ::Crypto::Certificate::x25519_oid }, nullptr));
+        auto data = TRY_OR_THROW_OOM(vm, ::Crypto::PK::wrap_in_subject_public_key_info(public_key, ::Crypto::ASN1::x25519_oid, nullptr));
 
         // 3. Let result be a new ArrayBuffer associated with the relevant global object of this [HTML], and containing data.
         result = JS::ArrayBuffer::create(m_realm, data);
@@ -4460,7 +4461,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> X25519::export_key(Bindings::KeyFormat 
         //    Set the privateKey field to the result of DER-encoding a CurvePrivateKey ASN.1 type, as defined in Section 7 of [RFC8410],
         //    that represents the X25519 private key represented by the [[handle]] internal slot of key
         auto private_key = handle.get<ByteBuffer>();
-        auto data = TRY_OR_THROW_OOM(vm, ::Crypto::PK::wrap_in_private_key_info(private_key, Array { ::Crypto::Certificate::x25519_oid }, nullptr));
+        auto data = TRY_OR_THROW_OOM(vm, ::Crypto::PK::wrap_in_private_key_info(private_key, ::Crypto::ASN1::x25519_oid, nullptr));
 
         // 3. Let result be a new ArrayBuffer associated with the relevant global object of this [HTML], and containing data.
         result = JS::ArrayBuffer::create(m_realm, data);
@@ -4684,7 +4685,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> X448::export_key(Bindings::KeyFormat fo
         //    * Set the algorithm field to an AlgorithmIdentifier ASN.1 type with the following properties:
         //      * Set the algorithm object identifier to the id-X448 OID defined in [RFC8410].
         //    * Set the subjectPublicKey field to keyData.
-        auto x448_oid = ::Crypto::Certificate::x448_oid;
+        auto x448_oid = ::Crypto::ASN1::x448_oid;
         auto data = TRY_OR_THROW_OOM(m_realm->vm(), ::Crypto::PK::wrap_in_subject_public_key_info(key_data, x448_oid, nullptr));
 
         // 3. Let result be a new ArrayBuffer associated with the relevant global object of this [HTML], and containing data.
@@ -4702,7 +4703,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::Object>> X448::export_key(Bindings::KeyFormat fo
         //    * Set the privateKeyAlgorithm field to a PrivateKeyAlgorithmIdentifier ASN.1 type with the following properties:
         //      * Set the algorithm object identifier to the id-X448 OID defined in [RFC8410].
         //    * Set the privateKey field to the result of DER-encoding a CurvePrivateKey ASN.1 type, as defined in Section 7 of [RFC8410], that represents the X448 private key represented by the [[handle]] internal slot of key
-        auto x448_oid = ::Crypto::Certificate::x448_oid;
+        auto x448_oid = ::Crypto::ASN1::x448_oid;
         auto data = TRY_OR_THROW_OOM(m_realm->vm(), ::Crypto::PK::wrap_in_private_key_info(key_data, x448_oid, nullptr));
 
         // 3. Let result be a new ArrayBuffer associated with the relevant global object of this [HTML], and containing data.
@@ -4780,7 +4781,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> X448::import_key(
         auto spki = TRY(parse_a_subject_public_key_info(m_realm, key_data.get<ByteBuffer>()));
 
         // 4. If the algorithm object identifier field of the algorithm AlgorithmIdentifier field of spki is not equal to the id-X448 object identifier defined in [RFC8410], then throw a DataError.
-        if (spki.algorithm.identifier != ::Crypto::Certificate::x448_oid)
+        if (spki.algorithm.identifier != ::Crypto::ASN1::x448_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
 
         // 5. If the parameters field of the algorithm AlgorithmIdentifier field of spki is present, then throw a DataError.
@@ -4823,7 +4824,7 @@ WebIDL::ExceptionOr<GC::Ref<CryptoKey>> X448::import_key(
         auto private_key = private_key_info.raw_key;
 
         // 4. If the algorithm object identifier field of the privateKeyAlgorithm PrivateKeyAlgorithm field of privateKeyInfo is not equal to the id-X448 object identifier defined in [RFC8410], then throw a DataError.
-        if (private_key_info.algorithm.identifier != ::Crypto::Certificate::x448_oid)
+        if (private_key_info.algorithm.identifier != ::Crypto::ASN1::x448_oid)
             return WebIDL::DataError::create(m_realm, "Invalid algorithm"_string);
 
         // 5. If the parameters field of the privateKeyAlgorithm PrivateKeyAlgorithmIdentifier field of privateKeyInfo is present, then throw a DataError.

--- a/Meta/Lagom/Fuzzers/FuzzRSAKeyParsing.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRSAKeyParsing.cpp
@@ -11,6 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    Crypto::PK::RSA::parse_rsa_key({ data, size });
+    (void)Crypto::PK::RSA::parse_rsa_key({ data, size }, true, {});
+    (void)Crypto::PK::RSA::parse_rsa_key({ data, size }, false, {});
     return 0;
 }

--- a/Tests/LibCrypto/TestRSA.cpp
+++ b/Tests/LibCrypto/TestRSA.cpp
@@ -127,7 +127,7 @@ c8yGzl89pYST
     EXPECT_EQ(decoded.type, Crypto::PEMType::PrivateKey);
     auto decoder = Crypto::ASN1::Decoder { decoded.data };
     auto priv_key_info = MUST(Crypto::Certificate::parse_private_key_info(decoder, {}));
-    auto keypair = Crypto::PK::RSA::parse_rsa_key(priv_key_info.raw_key);
+    auto keypair = MUST(Crypto::PK::RSA::parse_rsa_key(priv_key_info.raw_key, true, {}));
     auto priv_der = MUST(priv_key_info.rsa.export_as_der());
     auto rsa_encryption_oid = Array<int, 7> { 1, 2, 840, 113549, 1, 1, 1 };
     auto wrapped_priv_der = MUST(Crypto::PK::wrap_in_private_key_info(priv_key_info.raw_key, rsa_encryption_oid, nullptr));

--- a/Tests/LibTLS/TestTLSCertificateParser.cpp
+++ b/Tests/LibTLS/TestTLSCertificateParser.cpp
@@ -33,7 +33,7 @@ TEST_CASE(test_private_key_info_decode)
     Crypto::ASN1::Decoder decoder(decoded_keyder);
     auto private_key_info = TRY_OR_FAIL(Crypto::Certificate::parse_private_key_info(decoder));
 
-    EXPECT_EQ(private_key_info.algorithm.identifier, Crypto::Certificate::rsa_encryption_oid);
+    EXPECT_EQ(private_key_info.algorithm.identifier, Crypto::ASN1::rsa_encryption_oid);
     auto& key = private_key_info.rsa;
 
     EXPECT_EQ(key.length() * 8, 512u);

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_bits.https.any.txt
@@ -6,8 +6,8 @@ Rerun
 
 Found 40 tests
 
-25 Pass
-15 Fail
+30 Pass
+10 Fail
 Details
 Result	Test Name	MessagePass	setup - define tests	
 Fail	P-521 good parameters	
@@ -16,12 +16,12 @@ Fail	P-521 short result
 Fail	P-521 non-multiple of 8 bits	
 Pass	P-521 missing public curve	
 Pass	P-521 public property of algorithm is not a CryptoKey	
-Fail	P-521 mismatched curves	
+Pass	P-521 mismatched curves	
 Fail	P-521 public property of algorithm is not an ECDSA public key	Cannot access property "publicKey" on null object "ecdsaKeyPairs[namedCurve]"
-Fail	P-521 no deriveBits usage for base key	
-Fail	P-521 base key is not a private key	
-Fail	P-521 public property value is a private key	
-Fail	P-521 public property value is a secret key	
+Pass	P-521 no deriveBits usage for base key	
+Pass	P-521 base key is not a private key	
+Pass	P-521 public property value is a private key	
+Pass	P-521 public property value is a secret key	
 Fail	P-521 asking for too many bits	
 Pass	P-256 good parameters	
 Pass	P-256 mixed case parameters	

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_keys.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/derive_bits_keys/ecdh_keys.https.any.txt
@@ -6,20 +6,20 @@ Rerun
 
 Found 31 tests
 
-23 Pass
-8 Fail
+28 Pass
+3 Fail
 Details
 Result	Test Name	MessagePass	setup - define tests	
 Fail	P-521 good parameters	
 Fail	P-521 mixed case parameters	
 Pass	P-521 missing public curve	
 Pass	P-521 public property of algorithm is not a CryptoKey	
-Fail	P-521 mismatched curves	
+Pass	P-521 mismatched curves	
 Fail	P-521 public property of algorithm is not an ECDSA public key	Cannot access property "publicKey" on null object "ecdsaKeyPairs[namedCurve]"
-Fail	P-521 no deriveKey usage for base key	
-Fail	P-521 base key is not a private key	
-Fail	P-521 public property value is a private key	
-Fail	P-521 public property value is a secret key	
+Pass	P-521 no deriveKey usage for base key	
+Pass	P-521 base key is not a private key	
+Pass	P-521 public property value is a private key	
+Pass	P-521 public property value is a secret key	
 Pass	P-256 good parameters	
 Pass	P-256 mixed case parameters	
 Pass	P-256 missing public curve	

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/import_export/ec_importKey.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/import_export/ec_importKey.https.any.txt
@@ -137,11 +137,11 @@ Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, 
 Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-521}, false, [sign, sign])	
 Fail	Empty Usages: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDSA, namedCurve: P-521}, false, [])	
 Pass	Good parameters: P-256 bits (spki, buffer(91), {name: ECDH, namedCurve: P-256}, true, [])	
-Optional Feature Unsupported	Good parameters: P-256 bits (spki, buffer(59, compressed), {name: ECDH, namedCurve: P-256}, true, [])	Compressed point format not supported: DataError: Unsupported key format
+Optional Feature Unsupported	Good parameters: P-256 bits (spki, buffer(59, compressed), {name: ECDH, namedCurve: P-256}, true, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: Unsupported public key format
 Pass	Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-256}, true, [])	
 Pass	ECDH any JWK alg: P-256 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-256}, true, [])	
 Pass	Good parameters: P-256 bits (raw, buffer(65), {name: ECDH, namedCurve: P-256}, true, [])	
-Optional Feature Unsupported	Good parameters: P-256 bits (raw, buffer(33, compressed), {name: ECDH, namedCurve: P-256}, true, [])	Compressed point format not supported: DataError: Invalid key size
+Optional Feature Unsupported	Good parameters: P-256 bits (raw, buffer(33, compressed), {name: ECDH, namedCurve: P-256}, true, [])	Compressed point format not supported: DataError: Failed to parse key
 Pass	Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveKey])	
 Pass	Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveBits, deriveKey])	
 Pass	Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, true, [deriveBits])	
@@ -157,11 +157,11 @@ Pass	Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, n
 Pass	ECDH any JWK alg: P-256 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-256}, true, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, true, [])	
 Pass	Good parameters: P-256 bits (spki, buffer(91), {name: ECDH, namedCurve: P-256}, false, [])	
-Optional Feature Unsupported	Good parameters: P-256 bits (spki, buffer(59, compressed), {name: ECDH, namedCurve: P-256}, false, [])	Compressed point format not supported: DataError: Unsupported key format
+Optional Feature Unsupported	Good parameters: P-256 bits (spki, buffer(59, compressed), {name: ECDH, namedCurve: P-256}, false, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: Unsupported public key format
 Pass	Good parameters: P-256 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-256}, false, [])	
 Pass	ECDH any JWK alg: P-256 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-256}, false, [])	
 Pass	Good parameters: P-256 bits (raw, buffer(65), {name: ECDH, namedCurve: P-256}, false, [])	
-Optional Feature Unsupported	Good parameters: P-256 bits (raw, buffer(33, compressed), {name: ECDH, namedCurve: P-256}, false, [])	Compressed point format not supported: DataError: Invalid key size
+Optional Feature Unsupported	Good parameters: P-256 bits (raw, buffer(33, compressed), {name: ECDH, namedCurve: P-256}, false, [])	Compressed point format not supported: DataError: Failed to parse key
 Pass	Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveKey])	
 Pass	Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveBits, deriveKey])	
 Pass	Good parameters: P-256 bits (pkcs8, buffer(138), {name: ECDH, namedCurve: P-256}, false, [deriveBits])	
@@ -177,11 +177,11 @@ Pass	Good parameters: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, n
 Pass	ECDH any JWK alg: P-256 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-256}, false, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-256 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-256}, false, [])	
 Pass	Good parameters: P-384 bits (spki, buffer(120), {name: ECDH, namedCurve: P-384}, true, [])	
-Optional Feature Unsupported	Good parameters: P-384 bits (spki, buffer(72, compressed), {name: ECDH, namedCurve: P-384}, true, [])	Compressed point format not supported: DataError: Unsupported key format
+Optional Feature Unsupported	Good parameters: P-384 bits (spki, buffer(72, compressed), {name: ECDH, namedCurve: P-384}, true, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: Unsupported public key format
 Pass	Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-384}, true, [])	
 Pass	ECDH any JWK alg: P-384 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-384}, true, [])	
 Pass	Good parameters: P-384 bits (raw, buffer(97), {name: ECDH, namedCurve: P-384}, true, [])	
-Optional Feature Unsupported	Good parameters: P-384 bits (raw, buffer(49, compressed), {name: ECDH, namedCurve: P-384}, true, [])	Compressed point format not supported: DataError: Invalid key size
+Optional Feature Unsupported	Good parameters: P-384 bits (raw, buffer(49, compressed), {name: ECDH, namedCurve: P-384}, true, [])	Compressed point format not supported: DataError: Failed to parse key
 Pass	Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveKey])	
 Pass	Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveBits, deriveKey])	
 Pass	Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, true, [deriveBits])	
@@ -197,11 +197,11 @@ Pass	Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, n
 Pass	ECDH any JWK alg: P-384 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-384}, true, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, true, [])	
 Pass	Good parameters: P-384 bits (spki, buffer(120), {name: ECDH, namedCurve: P-384}, false, [])	
-Optional Feature Unsupported	Good parameters: P-384 bits (spki, buffer(72, compressed), {name: ECDH, namedCurve: P-384}, false, [])	Compressed point format not supported: DataError: Unsupported key format
+Optional Feature Unsupported	Good parameters: P-384 bits (spki, buffer(72, compressed), {name: ECDH, namedCurve: P-384}, false, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: Unsupported public key format
 Pass	Good parameters: P-384 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-384}, false, [])	
 Pass	ECDH any JWK alg: P-384 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-384}, false, [])	
 Pass	Good parameters: P-384 bits (raw, buffer(97), {name: ECDH, namedCurve: P-384}, false, [])	
-Optional Feature Unsupported	Good parameters: P-384 bits (raw, buffer(49, compressed), {name: ECDH, namedCurve: P-384}, false, [])	Compressed point format not supported: DataError: Invalid key size
+Optional Feature Unsupported	Good parameters: P-384 bits (raw, buffer(49, compressed), {name: ECDH, namedCurve: P-384}, false, [])	Compressed point format not supported: DataError: Failed to parse key
 Pass	Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveKey])	
 Pass	Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveBits, deriveKey])	
 Pass	Good parameters: P-384 bits (pkcs8, buffer(185), {name: ECDH, namedCurve: P-384}, false, [deriveBits])	
@@ -217,11 +217,11 @@ Pass	Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, n
 Pass	ECDH any JWK alg: P-384 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-384}, false, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [])	
 Fail	Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, true, [])	
-Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, true, [])	Compressed point format not supported: DataError: Unsupported key format
+Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, true, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: Unsupported public key format
 Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, true, [])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-521}, true, [])	
 Fail	Good parameters: P-521 bits (raw, buffer(133), {name: ECDH, namedCurve: P-521}, true, [])	
-Optional Feature Unsupported	Good parameters: P-521 bits (raw, buffer(67, compressed), {name: ECDH, namedCurve: P-521}, true, [])	Compressed point format not supported: DataError: Invalid key size
+Optional Feature Unsupported	Good parameters: P-521 bits (raw, buffer(67, compressed), {name: ECDH, namedCurve: P-521}, true, [])	Compressed point format not supported: DataError: Failed to parse key
 Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveKey])	
 Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey])	
 Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits])	
@@ -237,11 +237,11 @@ Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, n
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [])	
 Pass	Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, false, [])	
-Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Unsupported key format
+Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: [ "SubjectPublicKeyInfo"sv ]: Unsupported public key format
 Pass	Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	Good parameters: P-521 bits (raw, buffer(133), {name: ECDH, namedCurve: P-521}, false, [])	
-Optional Feature Unsupported	Good parameters: P-521 bits (raw, buffer(67, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Invalid key size
+Optional Feature Unsupported	Good parameters: P-521 bits (raw, buffer(67, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Failed to parse key
 Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey])	
 Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey])	
 Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits])	

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/import_export/ec_importKey.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/import_export/ec_importKey.https.any.txt
@@ -6,8 +6,8 @@ Rerun
 
 Found 246 tests
 
-90 Pass
-144 Fail
+97 Pass
+137 Fail
 12 Optional Feature Unsupported
 Details
 Result	Test Name	MessageFail	Good parameters: P-256 bits (spki, buffer(91), {name: ECDSA, namedCurve: P-256}, true, [verify])	
@@ -217,7 +217,7 @@ Pass	Good parameters: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, n
 Pass	ECDH any JWK alg: P-384 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-384}, false, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-384 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-384}, false, [])	
 Fail	Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, true, [])	
-Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, true, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv, "AlgorithmIdentifier"sv ]: Unknown named curve [ 1, 3, 132, 0, 35, 0, 0 ]
+Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, true, [])	Compressed point format not supported: DataError: Unsupported key format
 Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, true, [])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-521}, true, [])	
 Fail	Good parameters: P-521 bits (raw, buffer(133), {name: ECDH, namedCurve: P-521}, true, [])	
@@ -226,7 +226,7 @@ Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P
 Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey])	
 Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveBits])	
 Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits, deriveKey, deriveBits])	
-Fail	Empty Usages: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [])	
+Pass	Empty Usages: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, true, [])	
 Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveKey])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-521}, true, [deriveKey])	
 Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveBits, deriveKey])	
@@ -236,17 +236,17 @@ Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, d, alg), {name: E
 Fail	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-521}, true, [deriveKey, deriveBits, deriveKey, deriveBits])	
 Pass	Empty Usages: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, true, [])	
-Fail	Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, false, [])	
-Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Error parsing subjectPublicKeyInfo: [ "SubjectPublicKeyInfo"sv, "AlgorithmIdentifier"sv ]: Unknown named curve [ 1, 3, 132, 0, 35, 0, 0 ]
+Pass	Good parameters: P-521 bits (spki, buffer(158), {name: ECDH, namedCurve: P-521}, false, [])	
+Optional Feature Unsupported	Good parameters: P-521 bits (spki, buffer(90, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Unsupported key format
 Pass	Good parameters: P-521 bits (jwk, object(kty, crv, x, y), {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, alg), {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	Good parameters: P-521 bits (raw, buffer(133), {name: ECDH, namedCurve: P-521}, false, [])	
 Optional Feature Unsupported	Good parameters: P-521 bits (raw, buffer(67, compressed), {name: ECDH, namedCurve: P-521}, false, [])	Compressed point format not supported: DataError: Invalid key size
-Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey])	
-Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey])	
-Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits])	
-Fail	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey, deriveBits, deriveKey, deriveBits])	
-Fail	Empty Usages: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [])	
+Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey])	
+Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey])	
+Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveBits])	
+Pass	Good parameters: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [deriveKey, deriveBits, deriveKey, deriveBits])	
+Pass	Empty Usages: P-521 bits (pkcs8, buffer(241), {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveKey])	
 Pass	ECDH any JWK alg: P-521 bits (jwk, object(kty, crv, x, y, d, alg), {name: ECDH, namedCurve: P-521}, false, [deriveKey])	
 Pass	Good parameters: P-521 bits (jwk, object(kty, crv, x, y, d), {name: ECDH, namedCurve: P-521}, false, [deriveBits, deriveKey])	

--- a/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/WebCryptoAPI/import_export/ec_importKey_failures_ECDH.https.any.txt
@@ -6,8 +6,7 @@ Rerun
 
 Found 608 tests
 
-606 Pass
-2 Fail
+608 Pass
 Details
 Result	Test Name	MessagePass	Bad usages: importKey(spki, {name: ECDH, namedCurve: P-256}, true, [encrypt])	
 Pass	Bad usages: importKey(spki, {name: ECDH, namedCurve: P-256}, false, [encrypt])	
@@ -473,8 +472,8 @@ Pass	Empty usages: importKey(pkcs8, {name: ECDH, namedCurve: P-384}, true, [])
 Pass	Empty usages: importKey(pkcs8, {name: ECDH, namedCurve: P-384}, false, [])	
 Pass	Empty usages: importKey(jwk(private), {name: ECDH, namedCurve: P-384}, true, [])	
 Pass	Empty usages: importKey(jwk(private), {name: ECDH, namedCurve: P-384}, false, [])	
-Fail	Empty usages: importKey(pkcs8, {name: ECDH, namedCurve: P-521}, true, [])	
-Fail	Empty usages: importKey(pkcs8, {name: ECDH, namedCurve: P-521}, false, [])	
+Pass	Empty usages: importKey(pkcs8, {name: ECDH, namedCurve: P-521}, true, [])	
+Pass	Empty usages: importKey(pkcs8, {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	Empty usages: importKey(jwk(private), {name: ECDH, namedCurve: P-521}, true, [])	
 Pass	Empty usages: importKey(jwk(private), {name: ECDH, namedCurve: P-521}, false, [])	
 Pass	Bad key length: importKey(spki, {name: ECDH, namedCurve: P-256}, true, [])	


### PR DESCRIPTION
This is mainly refactoring of the ASN1 and PEM code around RSA and EC:
- Some stuff has been moved from `Crypto::Certificate` to `Crypto::ASN1` to be easily accessible.
- Treating ASN1 OIDs has been made simpler by categorizing them by length
- PEM decoding has been improved by returning the type and verifying the header and footer are consistent
- `RSA::parse_rsa_key` has been heavily simplified by utilizing existing code for PKCS#8 parsing

Got a couple of WPT tests as a bonus.