### PR TITLE
CI: Increase timeout a bit, and log each test duration

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Test
         if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
         working-directory: ${{ github.workspace }}
-        run: ctest --preset Sanitizer --output-on-failure --test-dir Build
+        run: ctest --preset Sanitizer --output-on-failure --test-dir Build --timeout 1800
         env:
           TESTS_ONLY: 1
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -173,3 +173,6 @@ Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-i
 Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-fixed.html
 Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-auto.html
 Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-percentage.html
+
+; https://github.com/LadybirdBrowser/ladybird/issues/2659
+Text/input/wpt-import/css/cssom/serialize-values.html

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -45,9 +45,23 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(is_layout_test_mode, "Enable layout test mode", "layout-test-mode");
     args_parser.add_option(rebaseline, "Rebaseline any executed layout or text tests", "rebaseline");
     args_parser.add_option(per_test_timeout_in_seconds, "Per-test timeout (default: 30)", "per-test-timeout", 't', "seconds");
-    args_parser.add_option(verbose, "Log extra information about test results", "verbose", 'v');
     args_parser.add_option(width, "Set viewport width in pixels (default: 800)", "width", 'W', "pixels");
     args_parser.add_option(height, "Set viewport height in pixels (default: 600)", "height", 'H', "pixels");
+
+    args_parser.add_option(Core::ArgsParser::Option {
+        .argument_mode = Core::ArgsParser::OptionArgumentMode::Optional,
+        .help_string = "Log extra information about test results (use multiple times for more information)",
+        .long_name = "verbose",
+        .short_name = 'v',
+        .accept_value = [&](StringView value) -> ErrorOr<bool> {
+            if (value.is_empty() && verbosity < NumericLimits<u8>::max()) {
+                ++verbosity;
+                return true;
+            }
+
+            return false;
+        },
+    });
 }
 
 void Application::create_platform_options(WebView::ChromeOptions& chrome_options, WebView::WebContentOptions& web_content_options)

--- a/UI/Headless/Application.h
+++ b/UI/Headless/Application.h
@@ -44,6 +44,10 @@ public:
             callback(*web_view);
     }
 
+    static constexpr u8 VERBOSITY_LEVEL_LOG_TEST_DURATION = 1;
+    static constexpr u8 VERBOSITY_LEVEL_LOG_SLOWEST_TESTS = 2;
+    static constexpr u8 VERBOSITY_LEVEL_LOG_SKIPPED_TESTS = 3;
+
     int screenshot_timeout { 1 };
     ByteString resources_folder;
     bool dump_failed_ref_tests { false };
@@ -57,7 +61,7 @@ public:
     ByteString test_glob;
     bool test_dry_run { false };
     bool rebaseline { false };
-    bool verbose { false };
+    u8 verbosity { 0 };
     int per_test_timeout_in_seconds { 30 };
     int width { 800 };
     int height { 600 };

--- a/UI/Headless/CMakeLists.txt
+++ b/UI/Headless/CMakeLists.txt
@@ -16,6 +16,6 @@ if (BUILD_TESTING)
     find_package(Python3 REQUIRED)
     add_test(
         NAME LibWeb
-        COMMAND $<TARGET_FILE:headless-browser> --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --python-executable ${Python3_EXECUTABLE} --dump-failed-ref-tests --per-test-timeout 120
+        COMMAND $<TARGET_FILE:headless-browser> --run-tests ${LADYBIRD_SOURCE_DIR}/Tests/LibWeb --python-executable ${Python3_EXECUTABLE} --dump-failed-ref-tests --per-test-timeout 120 --verbose
     )
 endif()

--- a/UI/Headless/Test.h
+++ b/UI/Headless/Test.h
@@ -59,6 +59,7 @@ struct Test {
 
     ByteString input_path {};
     ByteString expectation_path {};
+    ByteString relative_path {};
 
     UnixDateTime start_time {};
     UnixDateTime end_time {};

--- a/UI/Headless/Test.h
+++ b/UI/Headless/Test.h
@@ -63,6 +63,7 @@ struct Test {
 
     UnixDateTime start_time {};
     UnixDateTime end_time {};
+    size_t index { 0 };
 
     String text {};
     bool did_finish_test { false };


### PR DESCRIPTION
We currently have 2 issues with Web tests on CI:
* The GCC pipeline is regularly timing out, and barely finishes in the 1500 second limit when it does pass.
* The macOS pipeline hangs indefinitely until killed by ctest.

To help with these, this bumps the timeout to 1800 seconds, and adds more verbose logging for macOS, so we can see which tests are starting but not finishing (and their duration if they do finish).