### PR TITLE
LibWeb: Do not normalize border radii containing their initial values

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -459,6 +459,7 @@ public:
     BorderData const& border_right() const { return m_noninherited.border_right; }
     BorderData const& border_bottom() const { return m_noninherited.border_bottom; }
 
+    bool has_noninitial_border_radii() const { return m_noninherited.has_noninitial_border_radii; }
     const CSS::BorderRadiusData& border_bottom_left_radius() const { return m_noninherited.border_bottom_left_radius; }
     const CSS::BorderRadiusData& border_bottom_right_radius() const { return m_noninherited.border_bottom_right_radius; }
     const CSS::BorderRadiusData& border_top_left_radius() const { return m_noninherited.border_top_left_radius; }
@@ -630,6 +631,7 @@ protected:
         BorderData border_top;
         BorderData border_right;
         BorderData border_bottom;
+        bool has_noninitial_border_radii;
         BorderRadiusData border_bottom_left_radius;
         BorderRadiusData border_bottom_right_radius;
         BorderRadiusData border_top_left_radius;
@@ -776,10 +778,26 @@ public:
     void set_display(CSS::Display value) { m_noninherited.display = value; }
     void set_backdrop_filter(CSS::ResolvedFilter backdrop_filter) { m_noninherited.backdrop_filter = move(backdrop_filter); }
     void set_filter(CSS::ResolvedFilter filter) { m_noninherited.filter = move(filter); }
-    void set_border_bottom_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_left_radius = move(value); }
-    void set_border_bottom_right_radius(CSS::BorderRadiusData value) { m_noninherited.border_bottom_right_radius = move(value); }
-    void set_border_top_left_radius(CSS::BorderRadiusData value) { m_noninherited.border_top_left_radius = move(value); }
-    void set_border_top_right_radius(CSS::BorderRadiusData value) { m_noninherited.border_top_right_radius = move(value); }
+    void set_border_bottom_left_radius(CSS::BorderRadiusData value)
+    {
+        m_noninherited.has_noninitial_border_radii = true;
+        m_noninherited.border_bottom_left_radius = move(value);
+    }
+    void set_border_bottom_right_radius(CSS::BorderRadiusData value)
+    {
+        m_noninherited.has_noninitial_border_radii = true;
+        m_noninherited.border_bottom_right_radius = move(value);
+    }
+    void set_border_top_left_radius(CSS::BorderRadiusData value)
+    {
+        m_noninherited.has_noninitial_border_radii = true;
+        m_noninherited.border_top_left_radius = move(value);
+    }
+    void set_border_top_right_radius(CSS::BorderRadiusData value)
+    {
+        m_noninherited.has_noninitial_border_radii = true;
+        m_noninherited.border_top_right_radius = move(value);
+    }
     BorderData& border_left() { return m_noninherited.border_left; }
     BorderData& border_top() { return m_noninherited.border_top; }
     BorderData& border_right() { return m_noninherited.border_right; }

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1106,15 +1106,19 @@ void PaintableBox::resolve_paint_properties()
     auto const& layout_node = this->layout_node();
 
     // Border radii
-    CSSPixelRect const border_rect { 0, 0, border_box_width(), border_box_height() };
-    auto const& border_top_left_radius = computed_values.border_top_left_radius();
-    auto const& border_top_right_radius = computed_values.border_top_right_radius();
-    auto const& border_bottom_right_radius = computed_values.border_bottom_right_radius();
-    auto const& border_bottom_left_radius = computed_values.border_bottom_left_radius();
+    BorderRadiiData radii_data {};
+    if (computed_values.has_noninitial_border_radii()) {
+        CSSPixelRect const border_rect { 0, 0, border_box_width(), border_box_height() };
 
-    auto radii_data = normalize_border_radii_data(layout_node, border_rect, border_top_left_radius,
-        border_top_right_radius, border_bottom_right_radius,
-        border_bottom_left_radius);
+        auto const& border_top_left_radius = computed_values.border_top_left_radius();
+        auto const& border_top_right_radius = computed_values.border_top_right_radius();
+        auto const& border_bottom_right_radius = computed_values.border_bottom_right_radius();
+        auto const& border_bottom_left_radius = computed_values.border_bottom_left_radius();
+
+        radii_data = normalize_border_radii_data(layout_node, border_rect, border_top_left_radius,
+            border_top_right_radius, border_bottom_right_radius,
+            border_bottom_left_radius);
+    }
     set_border_radii_data(radii_data);
 
     // Box shadows


### PR DESCRIPTION
Most computed border-radii contain their initial values, and since the normalized initial border radii are always zero, there is no need to do expensive floating point math to normalize them.