### PR TITLE
LibWeb: Implement `::details-content` pseudo element

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -520,6 +520,8 @@ StringView Selector::PseudoElement::name(Selector::PseudoElement::Type pseudo_el
         return "backdrop"sv;
     case Selector::PseudoElement::Type::FileSelectorButton:
         return "file-selector-button"sv;
+    case Selector::PseudoElement::Type::DetailsContent:
+        return "details-content"sv;
     case Selector::PseudoElement::Type::KnownPseudoElementCount:
         break;
     case Selector::PseudoElement::Type::UnknownWebKit:
@@ -560,6 +562,8 @@ Optional<Selector::PseudoElement> Selector::PseudoElement::from_string(FlyString
         return Selector::PseudoElement { Selector::PseudoElement::Type::Backdrop };
     } else if (name.equals_ignoring_ascii_case("file-selector-button"sv)) {
         return Selector::PseudoElement { Selector::PseudoElement::Type::FileSelectorButton };
+    } else if (name.equals_ignoring_ascii_case("details-content"sv)) {
+        return Selector::PseudoElement { Selector::PseudoElement::Type::DetailsContent };
     } else if (name.equals_ignoring_ascii_case("-webkit-slider-runnable-track"sv)) {
         return Selector::PseudoElement { Selector::PseudoElement::Type::SliderRunnableTrack };
     } else if (name.equals_ignoring_ascii_case("-webkit-slider-thumb"sv)) {

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -42,6 +42,7 @@ public:
             SliderThumb,
             Backdrop,
             FileSelectorButton,
+            DetailsContent,
 
             // Keep this last.
             KnownPseudoElementCount,

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/the-details-element/details-pseudo-elements-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/the-details-element/details-pseudo-elements-001-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE HTML>
+<title>Details pseudo-elements</title>
+<style>
+
+div { background: aqua }
+
+</style>
+
+<details open>
+  <summary>The summary</summary>
+  <div>The details!</div>
+</details>

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/the-details-element/details-pseudo-elements-003-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/the-details-element/details-pseudo-elements-003-ref.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<title>::details-content pseudo element is display: block</title>
+<style>
+
+#contents { opacity: 0.5; }
+
+details
+
+</style>
+
+<div>
+  <div>summary</div>
+  <div id="contents">contents</div>
+</div>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/the-details-element/details-pseudo-elements-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/the-details-element/details-pseudo-elements-001.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<title>Details pseudo-elements</title>
+<link rel="match" href="../../../../../expected/wpt-import/html/rendering/the-details-element/details-pseudo-elements-001-ref.html">
+<link rel="help" href="https://github.com/whatwg/html/pull/10265">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#details-content-pseudo">
+<link rel="help" href="https://github.com/dbaron/details-styling">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=1469418">
+<style>
+
+details::details-content {
+  background: aqua;
+  display: block; /* override display: contents for slot */
+}
+
+</style>
+
+<details open>
+  <summary>The summary</summary>
+  <div>The details!</div>
+</details>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/the-details-element/details-pseudo-elements-003.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/the-details-element/details-pseudo-elements-003.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<title>::details-content pseudo element is display: block</title>
+<link rel="match" href="../../../../../expected/wpt-import/html/rendering/the-details-element/details-pseudo-elements-003-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-pseudo-4/#details-content-pseudo">
+<link rel="help" href="https://github.com/whatwg/html/pull/10265">
+<link rel="help" href="https://github.com/dbaron/details-styling">
+<link rel="help" href="https://crbug.com/1469418">
+<style>
+
+summary { display: block }
+details::details-content { opacity: 0.5; }
+
+details
+
+</style>
+
+<details open>
+  <summary>summary</summary>
+  contents
+</details>


### PR DESCRIPTION
Details' contents matches a new details-content pseudo element.

Further work is required to make this pseudo-element behave per spec.

This pseudo should be element-backed per
https://drafts.csswg.org/css-pseudo/#element-backed