### PR TITLE
LibJS: Stop lazily coercing numeric PropertyKeys

### DIFF
--- a/Libraries/LibGC/Root.h
+++ b/Libraries/LibGC/Root.h
@@ -122,6 +122,18 @@ private:
 };
 
 template<class T>
+inline bool operator==(Root<T> const& lhs, Root<T> const& rhs)
+{
+    return lhs.ptr() == rhs.ptr();
+}
+
+template<class T>
+inline bool operator!=(Root<T> const& lhs, Root<T> const& rhs)
+{
+    return lhs.ptr() != rhs.ptr();
+}
+
+template<class T>
 inline Root<T> make_root(T* cell, SourceLocation location = SourceLocation::current())
 {
     if (!cell)

--- a/Libraries/LibJS/Console.cpp
+++ b/Libraries/LibJS/Console.cpp
@@ -172,7 +172,7 @@ static ThrowCompletionOr<GC::Ref<Object>> create_table_row(Realm& realm, Value r
 
     // 2. Set `row["(index)"]` to `rowIndex`
     {
-        auto key = PropertyKey("(index)");
+        auto key = PropertyKey { "(index)", PropertyKey::StringMayBeNumber::No };
         TRY(row->set(key, row_index, Object::ShouldThrowExceptions::No));
 
         add_column(key);
@@ -228,12 +228,11 @@ static ThrowCompletionOr<GC::Ref<Object>> create_table_row(Realm& realm, Value r
     }
     // 5. Otherwise,
     else {
-        PropertyKey key("Value");
         // 5.1. Set `row["Value"]` to `tabularDataItem`
-        TRY(row->set(key, tabular_data_item, Object::ShouldThrowExceptions::No));
+        TRY(row->set(vm.names.Value, tabular_data_item, Object::ShouldThrowExceptions::No));
 
         // 5.2. If `finalColumns` does not contain "Value", append "Value" to `finalColumns`
-        add_column(key);
+        add_column(vm.names.Value);
     }
 
     // 6. Return row
@@ -322,10 +321,10 @@ ThrowCompletionOr<Value> Console::table()
             auto final_data = Object::create(realm(), nullptr);
 
             // 5.2. Set `finalData["rows"]` to `finalRows`
-            TRY(final_data->set(PropertyKey("rows"), table_rows, Object::ShouldThrowExceptions::No));
+            TRY(final_data->set(vm.names.rows, table_rows, Object::ShouldThrowExceptions::No));
 
             // 5.3. Set finalData["columns"] to finalColumns
-            TRY(final_data->set(PropertyKey("columns"), table_cols, Object::ShouldThrowExceptions::No));
+            TRY(final_data->set(vm.names.columns, table_cols, Object::ShouldThrowExceptions::No));
 
             // 5.4. Perform `Printer("table", finalData)`
             GC::MarkedVector<Value> args(vm.heap());

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -13,6 +13,7 @@
 namespace JS {
 
 #define ENUMERATE_STANDARD_PROPERTY_NAMES(P) \
+    P(_)                                     \
     P(__defineGetter__)                      \
     P(__defineSetter__)                      \
     P(__lookupGetter__)                      \
@@ -94,6 +95,7 @@ namespace JS {
     P(copyWithin)                            \
     P(cos)                                   \
     P(cosh)                                  \
+    P(columns)                               \
     P(count)                                 \
     P(countReset)                            \
     P(create)                                \
@@ -123,6 +125,7 @@ namespace JS {
     P(difference)                            \
     P(dir)                                   \
     P(direction)                             \
+    P(disabledFeatures)                      \
     P(disambiguation)                        \
     P(disposed)                              \
     P(done)                                  \
@@ -170,6 +173,7 @@ namespace JS {
     P(fontcolor)                             \
     P(fontsize)                              \
     P(forEach)                               \
+    P(formAssociated)                        \
     P(format)                                \
     P(formatMatcher)                         \
     P(formatRange)                           \
@@ -366,10 +370,12 @@ namespace JS {
     P(Number)                                \
     P(numberingSystem)                       \
     P(numeric)                               \
+    P(observedAttributes)                    \
     P(of)                                    \
     P(offset)                                \
     P(offsetNanoseconds)                     \
     P(omitPadding)                           \
+    P(opener)                                \
     P(overflow)                              \
     P(ownKeys)                               \
     P(padEnd)                                \
@@ -419,6 +425,7 @@ namespace JS {
     P(roundingIncrement)                     \
     P(roundingMode)                          \
     P(roundingPriority)                      \
+    P(rows)                                  \
     P(script)                                \
     P(seal)                                  \
     P(second)                                \
@@ -569,6 +576,7 @@ namespace JS {
     P(use)                                   \
     P(useGrouping)                           \
     P(UTC)                                   \
+    P(Value)                                 \
     P(value)                                 \
     P(valueOf)                               \
     P(values)                                \

--- a/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Libraries/LibJS/Runtime/PropertyKey.h
@@ -15,14 +15,10 @@
 namespace JS {
 
 class PropertyKey {
-public:
-    enum class Type : u8 {
-        Invalid,
-        Number,
-        String,
-        Symbol,
-    };
+    AK_MAKE_DEFAULT_COPYABLE(PropertyKey);
+    AK_MAKE_DEFAULT_MOVABLE(PropertyKey);
 
+public:
     enum class StringMayBeNumber {
         Yes,
         No,
@@ -42,130 +38,56 @@ public:
 
     template<Integral T>
     PropertyKey(T index)
+        : m_data(index)
     {
         // FIXME: Replace this with requires(IsUnsigned<T>)?
         //        Needs changes in various places using `int` (but not actually being in the negative range)
         VERIFY(index >= 0);
         if constexpr (NumericLimits<T>::max() >= NumericLimits<u32>::max()) {
             if (index >= NumericLimits<u32>::max()) {
-                m_string = ByteString::number(index);
-                m_type = Type::String;
-                m_string_may_be_number = false;
+                m_data = DeprecatedFlyString { ByteString::number(index) };
                 return;
             }
         }
-
-        m_type = Type::Number;
-        m_number = index;
     }
 
-    PropertyKey(char const* chars)
-        : m_type(Type::String)
-        , m_string(DeprecatedFlyString(chars))
+    PropertyKey(DeprecatedFlyString string, StringMayBeNumber string_may_be_number = StringMayBeNumber::Yes)
+        : m_data { try_coerce_into_number(move(string), string_may_be_number) }
     {
     }
 
     PropertyKey(ByteString const& string)
-        : m_type(Type::String)
-        , m_string(DeprecatedFlyString(string))
+        : PropertyKey(DeprecatedFlyString(string))
     {
     }
 
-    PropertyKey(FlyString const& string)
-        : m_type(Type::String)
-        , m_string(string.to_deprecated_fly_string())
-    {
-    }
-
-    PropertyKey(DeprecatedFlyString string, StringMayBeNumber string_may_be_number = StringMayBeNumber::Yes)
-        : m_string_may_be_number(string_may_be_number == StringMayBeNumber::Yes)
-        , m_type(Type::String)
-        , m_string(move(string))
+    template<size_t N>
+    PropertyKey(char const (&chars)[N])
+        : PropertyKey(DeprecatedFlyString(chars))
     {
     }
 
     PropertyKey(GC::Ref<Symbol> symbol)
-        : m_type(Type::Symbol)
-        , m_symbol(symbol)
+        : m_data { symbol }
     {
     }
 
     PropertyKey(StringOrSymbol const& string_or_symbol)
-    {
-        if (string_or_symbol.is_string()) {
-            m_string = string_or_symbol.as_string();
-            m_type = Type::String;
-        } else if (string_or_symbol.is_symbol()) {
-            m_symbol = const_cast<Symbol*>(string_or_symbol.as_symbol());
-            m_type = Type::Symbol;
+        : m_data {
+            string_or_symbol.is_string()
+                ? Variant<DeprecatedFlyString, GC::Root<Symbol>, u32> { string_or_symbol.as_string() }
+                : Variant<DeprecatedFlyString, GC::Root<Symbol>, u32> { const_cast<Symbol*>(string_or_symbol.as_symbol()) }
         }
-    }
-
-    ALWAYS_INLINE Type type() const { return m_type; }
-
-    bool is_number() const
     {
-        if (m_type == Type::Number)
-            return true;
-        if (m_type != Type::String || !m_string_may_be_number)
-            return false;
-
-        return const_cast<PropertyKey*>(this)->try_coerce_into_number();
-    }
-    bool is_string() const
-    {
-        if (m_type != Type::String)
-            return false;
-        if (!m_string_may_be_number)
-            return true;
-
-        return !const_cast<PropertyKey*>(this)->try_coerce_into_number();
-    }
-    bool is_symbol() const { return m_type == Type::Symbol; }
-
-    bool try_coerce_into_number()
-    {
-        VERIFY(m_string_may_be_number);
-        if (m_string.is_empty()) {
-            m_string_may_be_number = false;
-            return false;
-        }
-
-        if (char first = m_string.characters()[0]; first < '0' || first > '9') {
-            m_string_may_be_number = false;
-            return false;
-        } else if (m_string.length() > 1 && first == '0') {
-            m_string_may_be_number = false;
-            return false;
-        }
-
-        auto property_index = m_string.to_number<unsigned>(TrimWhitespace::No);
-        if (!property_index.has_value() || property_index.value() == NumericLimits<u32>::max()) {
-            m_string_may_be_number = false;
-            return false;
-        }
-        m_type = Type::Number;
-        m_number = *property_index;
-        return true;
     }
 
-    u32 as_number() const
-    {
-        VERIFY(is_number());
-        return m_number;
-    }
+    bool is_number() const { return m_data.has<u32>(); }
+    bool is_string() const { return m_data.has<DeprecatedFlyString>(); }
+    bool is_symbol() const { return m_data.has<GC::Root<Symbol>>(); }
 
-    DeprecatedFlyString const& as_string() const
-    {
-        VERIFY(is_string());
-        return m_string;
-    }
-
-    Symbol const* as_symbol() const
-    {
-        VERIFY(is_symbol());
-        return m_symbol;
-    }
+    u32 as_number() const { return m_data.get<u32>(); }
+    DeprecatedFlyString const& as_string() const { return m_data.get<DeprecatedFlyString>(); }
+    Symbol const* as_symbol() const { return m_data.get<GC::Root<Symbol>>(); }
 
     ByteString to_string() const
     {
@@ -184,11 +106,23 @@ public:
     }
 
 private:
-    bool m_string_may_be_number { true };
-    Type m_type { Type::Invalid };
-    u32 m_number { 0 };
-    DeprecatedFlyString m_string;
-    GC::Root<Symbol> m_symbol;
+    friend Traits<JS::PropertyKey>;
+
+    static Variant<DeprecatedFlyString, u32> try_coerce_into_number(DeprecatedFlyString string, StringMayBeNumber string_may_be_number)
+    {
+        if (string_may_be_number != StringMayBeNumber::Yes)
+            return string;
+        if (string.is_empty())
+            return string;
+        if (string.starts_with("0"sv) && string.length() != 1)
+            return string;
+        auto property_index = string.to_number<u32>(TrimWhitespace::No);
+        if (!property_index.has_value() || property_index.value() >= NumericLimits<u32>::max())
+            return string;
+        return property_index.release_value();
+    }
+
+    Variant<DeprecatedFlyString, u32, GC::Root<Symbol>> m_data;
 };
 
 }
@@ -199,28 +133,15 @@ template<>
 struct Traits<JS::PropertyKey> : public DefaultTraits<JS::PropertyKey> {
     static unsigned hash(JS::PropertyKey const& name)
     {
-        if (name.is_string())
-            return name.as_string().hash();
-        if (name.is_number())
-            return int_hash(name.as_number());
-        return ptr_hash(name.as_symbol());
+        return name.m_data.visit(
+            [](DeprecatedFlyString const& string) { return string.hash(); },
+            [](GC::Root<JS::Symbol> const& symbol) { return ptr_hash(symbol.ptr()); },
+            [](u32 const& number) { return int_hash(number); });
     }
 
     static bool equals(JS::PropertyKey const& a, JS::PropertyKey const& b)
     {
-        if (a.type() != b.type())
-            return false;
-
-        switch (a.type()) {
-        case JS::PropertyKey::Type::Number:
-            return a.as_number() == b.as_number();
-        case JS::PropertyKey::Type::String:
-            return a.as_string() == b.as_string();
-        case JS::PropertyKey::Type::Symbol:
-            return a.as_symbol() == b.as_symbol();
-        default:
-            VERIFY_NOT_REACHED();
-        }
+        return a.m_data == b.m_data;
     }
 };
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -156,7 +156,7 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
 
         auto name = input_property.as_string().utf8_string();
         if (name == "all"sv) {
-            all_value = TRY(keyframe_object.get(JS::PropertyKey { "all"sv }));
+            all_value = TRY(keyframe_object.get(vm.names.all));
             for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
                 auto property = static_cast<CSS::PropertyID>(i);
                 if (CSS::is_animatable_property(property))
@@ -183,7 +183,7 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
         // 1. Let raw value be the result of calling the [[Get]] internal method on keyframe input, with property name
         //    as the property key and keyframe input as the receiver.
         // 2. Check the completion record of raw value.
-        JS::PropertyKey key { property_name.to_byte_string() };
+        JS::PropertyKey key { property_name.to_byte_string(), JS::PropertyKey::StringMayBeNumber::No };
         auto raw_value = TRY(keyframe_object.has_property(key)) ? TRY(keyframe_object.get(key)) : *all_value;
 
         using PropertyValuesType = Conditional<AL == AllowLists::Yes, Vector<String>, String>;
@@ -827,7 +827,7 @@ WebIDL::ExceptionOr<GC::MarkedVector<JS::Object*>> KeyframeEffect::get_keyframes
 
             for (auto const& [id, value] : keyframe.parsed_properties()) {
                 auto value_string = JS::PrimitiveString::create(vm, value->to_string());
-                TRY(object->set(JS::PropertyKey(DeprecatedFlyString(CSS::camel_case_string_from_property_id(id))), value_string, ShouldThrowExceptions::Yes));
+                TRY(object->set(JS::PropertyKey { DeprecatedFlyString(CSS::camel_case_string_from_property_id(id)), JS::PropertyKey::StringMayBeNumber::No }, value_string, ShouldThrowExceptions::Yes));
             }
 
             m_keyframe_objects.append(object);

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -156,7 +156,7 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
 
         auto name = input_property.as_string().utf8_string();
         if (name == "all"sv) {
-            all_value = TRY(keyframe_object.get(JS::PropertyKey { name }));
+            all_value = TRY(keyframe_object.get(JS::PropertyKey { "all"sv }));
             for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
                 auto property = static_cast<CSS::PropertyID>(i);
                 if (CSS::is_animatable_property(property))
@@ -183,7 +183,7 @@ static WebIDL::ExceptionOr<KeyframeType<AL>> process_a_keyframe_like_object(JS::
         // 1. Let raw value be the result of calling the [[Get]] internal method on keyframe input, with property name
         //    as the property key and keyframe input as the receiver.
         // 2. Check the completion record of raw value.
-        JS::PropertyKey key { property_name };
+        JS::PropertyKey key { property_name.to_byte_string() };
         auto raw_value = TRY(keyframe_object.has_property(key)) ? TRY(keyframe_object.get(key)) : *all_value;
 
         using PropertyValuesType = Conditional<AL == AllowLists::Yes, Vector<String>, String>;

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -218,7 +218,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
         VERIFY(attribute_changed_callback_iterator != lifecycle_callbacks.end());
         if (attribute_changed_callback_iterator->value) {
             // 1. Let observedAttributesIterable be ? Get(constructor, "observedAttributes").
-            auto observed_attributes_iterable = TRY(constructor->callback->get(JS::PropertyKey { "observedAttributes" }));
+            auto observed_attributes_iterable = TRY(constructor->callback->get(vm.names.observedAttributes));
 
             // 2. If observedAttributesIterable is not undefined, then set observedAttributes to the result of converting observedAttributesIterable to a sequence<DOMString>. Rethrow any exceptions from the conversion.
             if (!observed_attributes_iterable.is_undefined())
@@ -229,7 +229,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
         Vector<String> disabled_features;
 
         // 7. Let disabledFeaturesIterable be ? Get(constructor, "disabledFeatures").
-        auto disabled_features_iterable = TRY(constructor->callback->get(JS::PropertyKey { "disabledFeatures" }));
+        auto disabled_features_iterable = TRY(constructor->callback->get(vm.names.disabledFeatures));
 
         // 8. If disabledFeaturesIterable is not undefined, then set disabledFeatures to the result of converting disabledFeaturesIterable to a sequence<DOMString>. Rethrow any exceptions from the conversion.
         if (!disabled_features_iterable.is_undefined())
@@ -242,7 +242,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
         disable_shadow = disabled_features.contains_slow("shadow"sv);
 
         // 11. Let formAssociatedValue be ? Get( constructor, "formAssociated").
-        auto form_associated_value = TRY(constructor->callback->get(JS::PropertyKey { "formAssociated" }));
+        auto form_associated_value = TRY(constructor->callback->get(vm.names.formAssociated));
 
         // 12. Set formAssociated to the result of converting formAssociatedValue to a boolean. Rethrow any exceptions from the conversion.
         // NOTE: Converting to a boolean cannot throw with ECMAScript.

--- a/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAllCollection.cpp
@@ -118,7 +118,7 @@ Variant<GC::Ref<DOM::HTMLCollection>, GC::Ref<DOM::Element>, Empty> HTMLAllColle
         return Empty {};
 
     // 2. Return the result of getting the "all"-indexed or named element(s) from this, given nameOrIndex.
-    return get_the_all_indexed_or_named_elements(name_or_index.value());
+    return get_the_all_indexed_or_named_elements(name_or_index.value().to_deprecated_fly_string());
 }
 
 // https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#dom-htmlallcollection-nameditem

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -935,8 +935,7 @@ WebIDL::ExceptionOr<void> Window::set_opener(JS::Value value)
 
     // 2. If the given value is non-null, then perform ? DefinePropertyOrThrow(this, "opener", { [[Value]]: the given value, [[Writable]]: true, [[Enumerable]]: true, [[Configurable]]: true }).
     if (!value.is_null()) {
-        static JS::PropertyKey opener_property_key { "opener", JS::PropertyKey::StringMayBeNumber::No };
-        TRY(define_property_or_throw(opener_property_key, { .value = value, .writable = true, .enumerable = true, .configurable = true }));
+        TRY(define_property_or_throw(vm().names.opener, { .value = value, .writable = true, .enumerable = true, .configurable = true }));
     }
 
     return {};

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3954,6 +3954,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
             }
         } else if (auto put_forwards_identifier = attribute.extended_attributes.get("PutForwards"sv); put_forwards_identifier.has_value()) {
             attribute_generator.set("put_forwards_identifier"sv, *put_forwards_identifier);
+            VERIFY(!put_forwards_identifier->is_empty() && !is_ascii_digit(put_forwards_identifier->byte_at(0))); // Ensure `PropertyKey`s are not Numbers.
 
             attribute_generator.append(R"~~~(
 JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
@@ -3963,7 +3964,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.setter_callback@)
     auto value = vm.argument(0);
 
     auto receiver = TRY(throw_dom_exception_if_needed(vm, [&]() { return impl->@attribute.cpp_name@(); }));
-    TRY(receiver->set(JS::PropertyKey { "@put_forwards_identifier@" }, value, JS::Object::ShouldThrowExceptions::Yes));
+    TRY(receiver->set(JS::PropertyKey { "@put_forwards_identifier@", JS::PropertyKey::StringMayBeNumber::No }, value, JS::Object::ShouldThrowExceptions::Yes));
 
     return JS::js_undefined();
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -573,6 +573,7 @@ bool is_animatable_property(PropertyID property_id)
 
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
+        VERIFY(!name.is_empty() && !is_ascii_digit(name[0])); // Ensure `PropertyKey`s are not Numbers.
         if (is_legacy_alias(value.as_object()))
             return;
 

--- a/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Services/WebContent/WebContentConsoleClient.cpp
@@ -152,8 +152,8 @@ JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::L
 
         auto table_args = arguments.get<GC::MarkedVector<JS::Value>>();
         auto& table = table_args.at(0).as_object();
-        auto& columns = TRY(table.get(JS::PropertyKey("columns"))).as_array().indexed_properties();
-        auto& rows = TRY(table.get(JS::PropertyKey("rows"))).as_array().indexed_properties();
+        auto& columns = TRY(table.get(vm.names.columns)).as_array().indexed_properties();
+        auto& rows = TRY(table.get(vm.names.rows)).as_array().indexed_properties();
 
         StringBuilder html;
 

--- a/Utilities/js.cpp
+++ b/Utilities/js.cpp
@@ -344,10 +344,10 @@ void ReplObject::initialize(JS::Realm& realm)
             outln("Disable writing last value to '_'");
 
             // We must delete first otherwise this setter gets called recursively.
-            TRY(global_object.internal_delete(JS::PropertyKey { "_" }));
+            TRY(global_object.internal_delete(vm.names._));
 
             auto value = vm.argument(0);
-            TRY(global_object.internal_set(JS::PropertyKey { "_" }, value, &global_object));
+            TRY(global_object.internal_set(vm.names._, value, &global_object));
             return value;
         },
         attr);


### PR DESCRIPTION
Lazily coercing might have made sense in the past, but since hashing
and comparing requires the `PropertyKey` to be coerced, and since a
`PropertyKey` will be used to index into a hashmap 99% of the time,
which will hash the `PropertyKey` and use it in comparisons, the
extra complexity and branching produced by lazily coercing has
become more trouble than it is worth.

Remove the lazy coercions, which then also neatly allows us to
switch to a `Variant`-based implementation.