### PR TITLE
LibWeb: Catch us up to some module related spec changes

### DIFF
--- a/Libraries/LibJS/Runtime/ModuleRequest.h
+++ b/Libraries/LibJS/Runtime/ModuleRequest.h
@@ -22,6 +22,8 @@ struct ModuleWithSpecifier {
 struct ImportAttribute {
     ByteString key;
     ByteString value;
+
+    bool operator==(ImportAttribute const&) const = default;
 };
 
 // https://tc39.es/proposal-import-attributes/#modulerequest-record
@@ -42,6 +44,8 @@ struct ModuleRequest {
 
     DeprecatedFlyString module_specifier; // [[Specifier]]
     Vector<ImportAttribute> attributes;   // [[Attributes]]
+
+    bool operator==(ModuleRequest const&) const = default;
 };
 
 }

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -380,7 +380,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
         return JS::JobCallback::create(*s_main_thread_vm, callable, move(host_defined));
     };
 
-    // 8.1.5.5.1 HostGetImportMetaProperties(moduleRecord), https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties
+    // 8.1.6.7.1 HostGetImportMetaProperties(moduleRecord), https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties
     s_main_thread_vm->host_get_import_meta_properties = [](JS::SourceTextModule& module_record) {
         auto& realm = module_record.realm();
         auto& vm = realm.vm();
@@ -421,10 +421,7 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
         return meta;
     };
 
-    // FIXME: Implement 8.1.5.5.2 HostImportModuleDynamically(referencingScriptOrModule, moduleRequest, promiseCapability), https://html.spec.whatwg.org/multipage/webappapis.html#hostimportmoduledynamically(referencingscriptormodule,-modulerequest,-promisecapability)
-    // FIXME: Implement 8.1.5.5.3 HostResolveImportedModule(referencingScriptOrModule, moduleRequest), https://html.spec.whatwg.org/multipage/webappapis.html#hostresolveimportedmodule(referencingscriptormodule,-modulerequest)
-
-    // 8.1.6.5.2 HostGetSupportedImportAttributes(), https://html.spec.whatwg.org/multipage/webappapis.html#hostgetsupportedimportassertions
+    // 8.1.6.7.2 HostGetSupportedImportAttributes(), https://html.spec.whatwg.org/multipage/webappapis.html#hostgetsupportedimportassertions
     s_main_thread_vm->host_get_supported_import_attributes = []() -> Vector<ByteString> {
         // 1. Return « "type" ».
         return { "type"sv };

--- a/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ModuleScript.cpp
@@ -63,52 +63,10 @@ WebIDL::ExceptionOr<GC::Ptr<JavaScriptModuleScript>> JavaScriptModuleScript::cre
         return script;
     }
 
-    // 9. For each ModuleRequest record requested of result.[[RequestedModules]]:
-    for (auto const& requested : result.value()->requested_modules()) {
-        // FIXME: Clarify if this should be checked for all requested before running the steps below.
-        // 1. If requested.[[Attributes]] contains a Record entry such that entry.[[Key]] is not "type", then:
-        for (auto const& attribute : requested.attributes) {
-            if (attribute.key != "type"sv) {
-                // 1. Let error be a new SyntaxError exception.
-                auto error = JS::SyntaxError::create(realm, "Module request attributes must only contain a type attribute"_string);
-
-                // 2. Set script's parse error to error.
-                script->set_parse_error(error);
-
-                // 3. Return script.
-                return script;
-            }
-        }
-
-        // 2. Let url be the result of resolving a module specifier given script and requested.[[Specifier]], catching any exceptions.
-        auto url = resolve_module_specifier(*script, requested.module_specifier);
-
-        // 3. If the previous step threw an exception, then:
-        if (url.is_exception()) {
-            // FIXME: 1. Set script's parse error to that exception.
-
-            // 2. Return script.
-            return script;
-        }
-
-        // 4. Let moduleType be the result of running the module type from module request steps given requested.
-        auto module_type = module_type_from_module_request(requested);
-
-        // 5. If the result of running the module type allowed steps given moduleType and realm is false, then:
-        if (!module_type_allowed(realm, module_type)) {
-            // FIXME: 1. Let error be a new TypeError exception.
-
-            // FIXME: 2. Set script's parse error to error.
-
-            // 3. Return script.
-            return script;
-        }
-    }
-
-    // 10. Set script's record to result.
+    // 9. Set script's record to result.
     script->m_record = result.value();
 
-    // 11. Return script.
+    // 10. Return script.
     return script;
 }
 


### PR DESCRIPTION
The begins the process of catching us up to various module related changes made in the spec

Edit: just noticed https://github.com/LadybirdBrowser/ladybird/issues/1549 after making this, I think this fixes #1549? We can't combine the two implementations, the 'ad-hoc' one is needed as the standalone JS implementation which is overridden in MainTheadVM for the HTML integration. Definitely more module catchup that we need to do though in general - e.g to fix the many crashes that we have in WPT and test262 tests.