### PR TITLE
LibCore: Fix SocketAddress.h compilation errors on Windows

### DIFF
--- a/Libraries/LibCore/SocketAddress.h
+++ b/Libraries/LibCore/SocketAddress.h
@@ -9,11 +9,15 @@
 
 #include <AK/IPv4Address.h>
 #include <AK/IPv6Address.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-#include <string.h>
-#include <sys/socket.h>
-#include <sys/un.h>
+
+#ifndef AK_OS_WINDOWS
+#    include <arpa/inet.h>
+#    include <netinet/in.h>
+#    include <sys/socket.h>
+#    include <sys/un.h>
+#else
+#    include "SocketAddressWindows.h"
+#endif
 
 namespace Core {
 

--- a/Libraries/LibCore/SocketAddressWindows.h
+++ b/Libraries/LibCore/SocketAddressWindows.h
@@ -29,6 +29,11 @@ typedef USHORT ADDRESS_FAMILY;
 #define AF_INET 2
 #define AF_INET6 23
 
+#define SOCK_STREAM 1
+#define SOCK_DGRAM 2
+
+#define INADDR_LOOPBACK 0x7f000001
+
 enum IPPROTO {
     IPPROTO_TCP = 6
 };

--- a/Libraries/LibCore/SocketAddressWindows.h
+++ b/Libraries/LibCore/SocketAddressWindows.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, stasoid <stasoid@yahoo.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+// This header is needed because winsock2.h and windows.h are banned from including from headers and SocketAddress.h needs some struct definitions from those headers.
+// These definitions were copied from Windows SDK headers. Comments, #ifdefs and special annotations like _Field_size_bytes_ were removed. This is fair use, see Oracle v. Google.
+
+#pragma once
+
+typedef unsigned long ULONG;
+typedef unsigned short USHORT;
+typedef char CHAR;
+typedef unsigned char UCHAR;
+typedef USHORT ADDRESS_FAMILY;
+
+#define WINAPI_FAMILY_PARTITION(x) 1
+#define FAR
+#include <inaddr.h>
+#undef WINAPI_FAMILY_PARTITION
+#undef FAR
+
+#include <afunix.h>
+
+#define AF_UNSPEC 0
+#define AF_LOCAL 1 // AF_UNIX
+#define AF_INET 2
+#define AF_INET6 23
+
+struct in6_addr {
+    union {
+        UCHAR Byte[16];
+        USHORT Word[8];
+    } u;
+};
+
+struct SCOPE_ID {
+    union {
+        struct {
+            ULONG Zone : 28;
+            ULONG Level : 4;
+        } u;
+        ULONG Value;
+    } u;
+};
+
+struct sockaddr_in6 {
+    ADDRESS_FAMILY sin6_family;
+    USHORT sin6_port;
+    ULONG sin6_flowinfo;
+    in6_addr sin6_addr;
+    union {
+        ULONG sin6_scope_id;
+        SCOPE_ID sin6_scope_struct;
+    };
+};
+
+struct sockaddr_in {
+    ADDRESS_FAMILY sin_family;
+    USHORT sin_port;
+    IN_ADDR sin_addr;
+    CHAR sin_zero[8];
+};
+
+struct sockaddr {
+    ADDRESS_FAMILY sa_family;
+    CHAR sa_data[14];
+};
+
+struct addrinfo {
+    int ai_flags;
+    int ai_family;
+    int ai_socktype;
+    int ai_protocol;
+    size_t ai_addrlen;
+    char* ai_canonname;
+    sockaddr* ai_addr;
+    addrinfo* ai_next;
+};
+
+extern "C" USHORT __stdcall htons(USHORT hostshort);

--- a/Libraries/LibCore/SocketAddressWindows.h
+++ b/Libraries/LibCore/SocketAddressWindows.h
@@ -14,6 +14,7 @@ typedef unsigned long ULONG;
 typedef unsigned short USHORT;
 typedef char CHAR;
 typedef unsigned char UCHAR;
+typedef const CHAR* PCSTR;
 typedef USHORT ADDRESS_FAMILY;
 
 #define WINAPI_FAMILY_PARTITION(x) 1
@@ -27,6 +28,13 @@ typedef USHORT ADDRESS_FAMILY;
 #define AF_LOCAL 1 // AF_UNIX
 #define AF_INET 2
 #define AF_INET6 23
+
+enum IPPROTO {
+    IPPROTO_TCP = 6
+};
+
+#define INET_ADDRSTRLEN 22
+#define INET6_ADDRSTRLEN 65
 
 struct in6_addr {
     union {
@@ -67,6 +75,7 @@ struct sockaddr {
     ADDRESS_FAMILY sa_family;
     CHAR sa_data[14];
 };
+using SOCKADDR = sockaddr;
 using LPSOCKADDR = sockaddr*;
 
 struct addrinfo {
@@ -79,6 +88,8 @@ struct addrinfo {
     sockaddr* ai_addr;
     addrinfo* ai_next;
 };
+using ADDRINFOA = addrinfo;
+using PADDRINFOA = addrinfo*;
 
 struct SOCKET_ADDRESS {
     sockaddr* lpSockaddr;
@@ -115,6 +126,9 @@ struct WSAMSG {
 };
 using LPWSAMSG = WSAMSG*;
 
-extern "C" USHORT __stdcall htons(USHORT hostshort);
+extern "C" __stdcall INT getaddrinfo(PCSTR pNodeName, PCSTR pServiceName, const ADDRINFOA* pHints, PADDRINFOA* ppResult);
+extern "C" __stdcall void freeaddrinfo(PADDRINFOA pAddrInfo);
+extern "C" __stdcall PCSTR inet_ntop(int Family, void const* pAddr, char* pStringBuf, size_t StringBufSize);
+extern "C" __stdcall USHORT htons(USHORT hostshort);
 
 #define _WS2DEF_ // don't include ws2def.h

--- a/Libraries/LibCore/SocketAddressWindows.h
+++ b/Libraries/LibCore/SocketAddressWindows.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+typedef int INT;
 typedef unsigned long ULONG;
 typedef unsigned short USHORT;
 typedef char CHAR;
@@ -19,7 +20,6 @@ typedef USHORT ADDRESS_FAMILY;
 #define FAR
 #include <inaddr.h>
 #undef WINAPI_FAMILY_PARTITION
-#undef FAR
 
 #include <afunix.h>
 
@@ -67,6 +67,7 @@ struct sockaddr {
     ADDRESS_FAMILY sa_family;
     CHAR sa_data[14];
 };
+using LPSOCKADDR = sockaddr*;
 
 struct addrinfo {
     int ai_flags;
@@ -79,4 +80,41 @@ struct addrinfo {
     addrinfo* ai_next;
 };
 
+struct SOCKET_ADDRESS {
+    sockaddr* lpSockaddr;
+    INT iSockaddrLength;
+};
+
+struct SOCKET_ADDRESS_LIST {
+    INT iAddressCount;
+    SOCKET_ADDRESS Address[1];
+};
+using PSOCKET_ADDRESS_LIST = SOCKET_ADDRESS_LIST*;
+
+struct CSADDR_INFO {
+    SOCKET_ADDRESS LocalAddr;
+    SOCKET_ADDRESS RemoteAddr;
+    INT iSocketType;
+    INT iProtocol;
+};
+using LPCSADDR_INFO = CSADDR_INFO*;
+
+struct WSABUF {
+    ULONG len;
+    CHAR* buf;
+};
+using LPWSABUF = WSABUF*;
+
+struct WSAMSG {
+    LPSOCKADDR name;
+    INT namelen;
+    LPWSABUF lpBuffers;
+    ULONG dwBufferCount;
+    WSABUF Control;
+    ULONG dwFlags;
+};
+using LPWSAMSG = WSAMSG*;
+
 extern "C" USHORT __stdcall htons(USHORT hostshort);
+
+#define _WS2DEF_ // don't include ws2def.h


### PR DESCRIPTION
Including winsock2.h in a header file is undesirable for architectural reasons, so I pulled the needed types from ws2def.h and ws2ipdef.h into a separate header.

Files inaddr.h and afunix.h are tiny and can be included directly. They each define a single struct (`in_addr` and `sockaddr_un` respectively).

I removed the `#if (_WIN32_WINNT < 0x0600)` code because it is not relevant for us. It is [intended](https://learn.microsoft.com/en-us/cpp/porting/modifying-winver-and-win32-winnt) for Windows XP/Windows Server 2003 and earlier, but Ladybird doesn't support 32-bit, and 64-bit Windows XP is very rare.