### PR TITLE
AK: Simplify usage of windows.h and winsock2.h

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -8,9 +8,7 @@
 #include <AK/Time.h>
 
 #ifdef AK_OS_WINDOWS
-#    define timeval dummy_timeval
-#    include <windows.h>
-#    undef timeval
+#    include <AK/Windows.h>
 #endif
 
 namespace AK {

--- a/AK/Windows.h
+++ b/AK/Windows.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, stasoid <stasoid@yahoo.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+// This header should be included only in cpp files.
+// It should be included after all other files and should be separated from them by a non-#include line to prevent clang-format from changing header order.
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#ifdef AK_OS_WINDOWS // needed for Swift
+#    define timeval dummy_timeval
+#    include <winsock2.h>
+#    undef timeval
+#    undef IN
+#    pragma comment(lib, "ws2_32.lib")
+#    include <io.h>
+#endif

--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -110,7 +110,3 @@ endif()
 if (ANDROID)
     target_link_libraries(LibCore PRIVATE log)
 endif()
-
-if (WIN32)
-    target_link_libraries(LibCore PRIVATE ws2_32.lib)
-endif()

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -8,8 +8,8 @@
 #include <LibCore/EventLoopImplementationWindows.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/ThreadEventQueue.h>
-#include <WinSock2.h>
-#include <io.h>
+
+#include <AK/Windows.h>
 
 struct Handle {
     HANDLE handle = NULL;


### PR DESCRIPTION
Use <AK/windows.h> instead of windows.h/winsock2.h to avoid timeval-related errors.