### PR TITLE
LibWeb: Use separate restore() for each ApplyFilters display list item

### DIFF
--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -55,9 +55,9 @@ void SVGSVGPaintable::paint_svg_box(PaintContext& context, PaintableBox const& s
 {
     auto const& computed_values = svg_box.computed_values();
 
-    auto filters = svg_box.computed_values().filter();
+    auto const& filter = svg_box.computed_values().filter();
     auto masking_area = svg_box.get_masking_area();
-    auto needs_to_save_state = computed_values.opacity() < 1 || svg_box.has_css_transform() || svg_box.get_masking_area().has_value() || !filters.is_none();
+    auto needs_to_save_state = computed_values.opacity() < 1 || svg_box.has_css_transform() || svg_box.get_masking_area().has_value();
 
     if (needs_to_save_state) {
         context.display_list_recorder().save();
@@ -67,7 +67,9 @@ void SVGSVGPaintable::paint_svg_box(PaintContext& context, PaintableBox const& s
         context.display_list_recorder().apply_opacity(computed_values.opacity());
     }
 
-    context.display_list_recorder().apply_filters(filters);
+    if (!filter.is_none()) {
+        context.display_list_recorder().apply_filters(filter);
+    }
 
     if (svg_box.has_css_transform()) {
         auto transform_matrix = svg_box.transform();
@@ -92,6 +94,10 @@ void SVGSVGPaintable::paint_svg_box(PaintContext& context, PaintableBox const& s
     svg_box.after_paint(context, PaintPhase::Foreground);
 
     paint_descendants(context, svg_box, phase);
+
+    if (!filter.is_none()) {
+        context.display_list_recorder().restore();
+    }
 
     if (needs_to_save_state) {
         context.display_list_recorder().restore();

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -327,7 +327,11 @@ void StackingContext::paint(PaintContext& context) const
         context.display_list_recorder().push_scroll_frame_id(*paintable_box().scroll_frame_id());
     }
     context.display_list_recorder().push_stacking_context(push_stacking_context_params);
-    context.display_list_recorder().apply_filters(paintable_box().computed_values().filter());
+
+    auto const& filter = computed_values.filter();
+    if (!filter.is_none()) {
+        context.display_list_recorder().apply_filters(paintable_box().computed_values().filter());
+    }
 
     if (auto mask_image = computed_values.mask_image()) {
         auto mask_display_list = DisplayList::create();
@@ -346,6 +350,10 @@ void StackingContext::paint(PaintContext& context) const
             auto masking_area_rect = context.enclosing_device_rect(*masking_area).to_type<int>();
             context.display_list_recorder().apply_mask_bitmap(masking_area_rect.location(), mask_bitmap.release_nonnull(), *paintable_box().get_mask_type());
         }
+    }
+
+    if (!filter.is_none()) {
+        context.display_list_recorder().restore();
     }
 
     paint_internal(context);


### PR DESCRIPTION
ApplyFilter internally calls canvas.saveLayer() which requires a matching canvas.restore() to be called.

Fixes painting on https://supabase.com/ regressed by 8562b0e33bd057d9aa5be1b6ce66db039bc99576