### PR TITLE
LibWeb: Don't try to wait for HTTP server to exit if kill call fails

### DIFF
--- a/Libraries/LibCore/Process.cpp
+++ b/Libraries/LibCore/Process.cpp
@@ -346,7 +346,7 @@ ErrorOr<int> Process::wait_for_termination()
     int exit_code = -1;
     int status;
     if (waitpid(m_pid, &status, 0) == -1)
-        return Error::from_syscall("waitpid"sv, errno);
+        return Error::from_syscall("waitpid"sv, -errno);
 
     if (WIFEXITED(status)) {
         exit_code = WEXITSTATUS(status);

--- a/UI/Headless/Fixture.cpp
+++ b/UI/Headless/Fixture.cpp
@@ -92,13 +92,9 @@ void HttpEchoServerFixture::teardown_impl()
     if (auto kill_or_error = Core::System::kill(m_process->pid(), SIGINT); kill_or_error.is_error()) {
         if (kill_or_error.error().code() != ESRCH) {
             warnln("Failed to kill HTTP echo server, error: {}", kill_or_error.error());
-            m_process = {};
-            return;
+        } else if (auto termination_or_error = m_process->wait_for_termination(); termination_or_error.is_error()) {
+            warnln("Failed to terminate HTTP echo server, error: {}", termination_or_error.error());
         }
-    }
-
-    if (auto termination_or_error = m_process->wait_for_termination(); termination_or_error.is_error()) {
-        warnln("Failed to terminate HTTP echo server, error: {}", termination_or_error.error());
     }
 
     m_process = {};


### PR DESCRIPTION
This change fixes a crash I saw locally where `headless-browser` would always crash with the following error just prior to exit:
```
VERIFICATION FAILED: !_temporary_result.is_error() at /home/tim/repos/ladybird/UI/Headless/Fixture.cpp:83
/home/tim/repos/ladybird/Build/release/lib/liblagom-ak.so.0(ak_verification_failed+0xef) [0x7032bd52790f]
/home/tim/repos/ladybird/Build/release/bin/headless-browser(+0x143e0) [0x56277a50a3e0]
/home/tim/repos/ladybird/Build/release/bin/headless-browser(+0x12658) [0x56277a508658]
/home/tim/repos/ladybird/Build/release/bin/headless-browser(+0x127f9) [0x56277a5087f9]
/home/tim/repos/ladybird/Build/release/bin/headless-browser(+0x268ee) [0x56277a51c8ee]
/home/tim/repos/ladybird/Build/release/bin/headless-browser(+0x27542) [0x56277a51d542]
/lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca) [0x7032bce2a1ca]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b) [0x7032bce2a28b]
```

This happened because the call to `waitpid` failed for the HTTP server process. This was because the HTTP server failed to start on my local machine because the address it wanted to use was already in use.

We now don't call `waitpid` if the prior call to `kill` failed.

I've also included a small fix to LibCore to return the correct error code from `Process::wait_for_termination()` if `waitpid` fails.