### PR TITLE
LibWeb: Limit tabular element properties to allowed values

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1849,7 +1849,7 @@ WebIDL::Long HTMLInputElement::min_length() const
 {
     // The minLength IDL attribute must reflect the minlength content attribute, limited to only non-negative numbers.
     if (auto minlength_string = get_attribute(HTML::AttributeNames::minlength); minlength_string.has_value()) {
-        if (auto minlength = parse_non_negative_integer(*minlength_string); minlength.has_value())
+        if (auto minlength = parse_non_negative_integer(*minlength_string); minlength.has_value() && *minlength <= 2147483647)
             return *minlength;
     }
     return -1;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1832,7 +1832,7 @@ WebIDL::Long HTMLInputElement::max_length() const
 {
     // The maxLength IDL attribute must reflect the maxlength content attribute, limited to only non-negative numbers.
     if (auto maxlength_string = get_attribute(HTML::AttributeNames::maxlength); maxlength_string.has_value()) {
-        if (auto maxlength = parse_non_negative_integer(*maxlength_string); maxlength.has_value())
+        if (auto maxlength = parse_non_negative_integer(*maxlength_string); maxlength.has_value() && *maxlength <= 2147483647)
             return *maxlength;
     }
     return -1;

--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.h
@@ -18,10 +18,10 @@ class HTMLTableCellElement final : public HTMLElement {
 public:
     virtual ~HTMLTableCellElement() override;
 
-    unsigned col_span() const;
+    WebIDL::UnsignedLong col_span() const;
     unsigned row_span() const;
 
-    WebIDL::ExceptionOr<void> set_col_span(unsigned);
+    WebIDL::ExceptionOr<void> set_col_span(WebIDL::UnsignedLong);
     WebIDL::ExceptionOr<void> set_row_span(unsigned);
 
     WebIDL::Long cell_index() const;

--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.h
@@ -19,10 +19,10 @@ public:
     virtual ~HTMLTableCellElement() override;
 
     WebIDL::UnsignedLong col_span() const;
-    unsigned row_span() const;
+    WebIDL::UnsignedLong row_span() const;
 
     WebIDL::ExceptionOr<void> set_col_span(WebIDL::UnsignedLong);
-    WebIDL::ExceptionOr<void> set_row_span(unsigned);
+    WebIDL::ExceptionOr<void> set_row_span(WebIDL::UnsignedLong);
 
     WebIDL::Long cell_index() const;
 

--- a/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableColElement.cpp
@@ -29,18 +29,25 @@ void HTMLTableColElement::initialize(JS::Realm& realm)
 }
 
 // https://html.spec.whatwg.org/multipage/tables.html#dom-colgroup-span
-unsigned int HTMLTableColElement::span() const
+WebIDL::UnsignedLong HTMLTableColElement::span() const
 {
     // The span IDL attribute must reflect the content attribute of the same name. It is clamped to the range [1, 1000], and its default value is 1.
     if (auto span_string = get_attribute(HTML::AttributeNames::span); span_string.has_value()) {
-        if (auto span = parse_non_negative_integer(*span_string); span.has_value())
+        if (auto span_digits = parse_non_negative_integer_digits(*span_string); span_digits.has_value()) {
+            auto span = AK::StringUtils::convert_to_int<i64>(*span_digits);
+            // NOTE: If span has no value at this point, the value must be larger than NumericLimits<i64>::max(), so return the maximum value of 1000.
+            if (!span.has_value())
+                return 1000;
             return clamp(*span, 1, 1000);
+        }
     }
     return 1;
 }
 
 WebIDL::ExceptionOr<void> HTMLTableColElement::set_span(unsigned int value)
 {
+    if (value > 2147483647)
+        value = 1;
     return set_attribute(HTML::AttributeNames::span, String::number(value));
 }
 

--- a/Libraries/LibWeb/HTML/HTMLTableColElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTableColElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
 
@@ -17,8 +18,8 @@ class HTMLTableColElement final : public HTMLElement {
 public:
     virtual ~HTMLTableColElement() override;
 
-    unsigned span() const;
-    WebIDL::ExceptionOr<void> set_span(unsigned);
+    WebIDL::UnsignedLong span() const;
+    WebIDL::ExceptionOr<void> set_span(WebIDL::UnsignedLong);
 
 private:
     HTMLTableColElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -259,7 +259,7 @@ WebIDL::Long HTMLTextAreaElement::max_length() const
 {
     // The maxLength IDL attribute must reflect the maxlength content attribute, limited to only non-negative numbers.
     if (auto maxlength_string = get_attribute(HTML::AttributeNames::maxlength); maxlength_string.has_value()) {
-        if (auto maxlength = parse_non_negative_integer(*maxlength_string); maxlength.has_value())
+        if (auto maxlength = parse_non_negative_integer(*maxlength_string); maxlength.has_value() && *maxlength <= 2147483647)
             return *maxlength;
     }
     return -1;

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -276,7 +276,7 @@ WebIDL::Long HTMLTextAreaElement::min_length() const
 {
     // The minLength IDL attribute must reflect the minlength content attribute, limited to only non-negative numbers.
     if (auto minlength_string = get_attribute(HTML::AttributeNames::minlength); minlength_string.has_value()) {
-        if (auto minlength = parse_non_negative_integer(*minlength_string); minlength.has_value())
+        if (auto minlength = parse_non_negative_integer(*minlength_string); minlength.has_value() && *minlength <= 2147483647)
             return *minlength;
     }
     return -1;

--- a/Libraries/LibWeb/HTML/Numbers.h
+++ b/Libraries/LibWeb/HTML/Numbers.h
@@ -14,8 +14,10 @@
 namespace Web::HTML {
 
 Optional<i32> parse_integer(StringView string);
+Optional<StringView> parse_integer_digits(StringView string);
 
 Optional<u32> parse_non_negative_integer(StringView string);
+Optional<StringView> parse_non_negative_integer_digits(StringView string);
 
 Optional<double> parse_floating_point_number(StringView string);
 

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -253,6 +253,24 @@ select.getAttribute("size") after select.setAttribute("size", "4294967295"): 429
 select.size after select.setAttribute("size", "4294967295"): 0
 select.getAttribute("size") after select.size = 4294967295: 0
 select.size after select.size = 4294967295: 0
+textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "0"): 0
+textarea.maxLength after textarea.setAttribute("maxlength", "0"): 0
+textarea.getAttribute("maxlength") after textarea.maxLength = 0: 0
+textarea.maxLength after textarea.maxLength = 0: 0
+textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "1"): 1
+textarea.maxLength after textarea.setAttribute("maxlength", "1"): 1
+textarea.getAttribute("maxlength") after textarea.maxLength = 1: 1
+textarea.maxLength after textarea.maxLength = 1: 1
+textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "2147483647"): 2147483647
+textarea.maxLength after textarea.setAttribute("maxlength", "2147483647"): 2147483647
+textarea.getAttribute("maxlength") after textarea.maxLength = 2147483647: 2147483647
+textarea.maxLength after textarea.maxLength = 2147483647: 2147483647
+textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "2147483648"): 2147483648
+textarea.maxLength after textarea.setAttribute("maxlength", "2147483648"): -1
+textarea.maxLength = 2147483648 threw exception of type IndexSizeError
+textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "4294967295"): 4294967295
+textarea.maxLength after textarea.setAttribute("maxlength", "4294967295"): -1
+textarea.maxLength = 4294967295 threw exception of type IndexSizeError
 textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "0"): 0
 textarea.minLength after textarea.setAttribute("minlength", "0"): 0
 textarea.getAttribute("minlength") after textarea.minLength = 0: 0
@@ -266,7 +284,7 @@ textarea.minLength after textarea.setAttribute("minlength", "2147483647"): 21474
 textarea.getAttribute("minlength") after textarea.minLength = 2147483647: 2147483647
 textarea.minLength after textarea.minLength = 2147483647: 2147483647
 textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "2147483648"): 2147483648
-textarea.minLength after textarea.setAttribute("minlength", "2147483648"): -2147483648
+textarea.minLength after textarea.setAttribute("minlength", "2147483648"): -1
 textarea.minLength = 2147483648 threw exception of type IndexSizeError
 textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "4294967295"): 4294967295
 textarea.minLength after textarea.setAttribute("minlength", "4294967295"): -1

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -328,6 +328,30 @@ td.getAttribute("colspan") after td.setAttribute("colSpan", "4294967296"): 42949
 td.colSpan after td.setAttribute("colspan", "4294967296"): 1000
 td.getAttribute("colspan") after td.colSpan = 4294967296: 0
 td.colSpan after td.colSpan = 4294967296: 1
+td.getAttribute("rowspan") after td.setAttribute("rowSpan", "0"): 0
+td.rowSpan after td.setAttribute("rowspan", "0"): 0
+td.getAttribute("rowspan") after td.rowSpan = 0: 0
+td.rowSpan after td.rowSpan = 0: 0
+td.getAttribute("rowspan") after td.setAttribute("rowSpan", "1"): 1
+td.rowSpan after td.setAttribute("rowspan", "1"): 1
+td.getAttribute("rowspan") after td.rowSpan = 1: 1
+td.rowSpan after td.rowSpan = 1: 1
+td.getAttribute("rowspan") after td.setAttribute("rowSpan", "2147483647"): 2147483647
+td.rowSpan after td.setAttribute("rowspan", "2147483647"): 65534
+td.getAttribute("rowspan") after td.rowSpan = 2147483647: 2147483647
+td.rowSpan after td.rowSpan = 2147483647: 65534
+td.getAttribute("rowspan") after td.setAttribute("rowSpan", "2147483648"): 2147483648
+td.rowSpan after td.setAttribute("rowspan", "2147483648"): 65534
+td.getAttribute("rowspan") after td.rowSpan = 2147483648: 1
+td.rowSpan after td.rowSpan = 2147483648: 1
+td.getAttribute("rowspan") after td.setAttribute("rowSpan", "4294967295"): 4294967295
+td.rowSpan after td.setAttribute("rowspan", "4294967295"): 65534
+td.getAttribute("rowspan") after td.rowSpan = 4294967295: 1
+td.rowSpan after td.rowSpan = 4294967295: 1
+td.getAttribute("rowspan") after td.setAttribute("rowSpan", "4294967296"): 4294967296
+td.rowSpan after td.setAttribute("rowspan", "4294967296"): 65534
+td.getAttribute("rowspan") after td.rowSpan = 4294967296: 0
+td.rowSpan after td.rowSpan = 4294967296: 0
 textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "0"): 0
 textarea.maxLength after textarea.setAttribute("maxlength", "0"): 0
 textarea.getAttribute("maxlength") after textarea.maxLength = 0: 0

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -116,6 +116,24 @@ input.maxLength = 2147483648 threw exception of type IndexSizeError
 input.getAttribute("maxlength") after input.setAttribute("maxLength", "4294967295"): 4294967295
 input.maxLength after input.setAttribute("maxlength", "4294967295"): -1
 input.maxLength = 4294967295 threw exception of type IndexSizeError
+input.getAttribute("minlength") after input.setAttribute("minLength", "0"): 0
+input.minLength after input.setAttribute("minlength", "0"): 0
+input.getAttribute("minlength") after input.minLength = 0: 0
+input.minLength after input.minLength = 0: 0
+input.getAttribute("minlength") after input.setAttribute("minLength", "1"): 1
+input.minLength after input.setAttribute("minlength", "1"): 1
+input.getAttribute("minlength") after input.minLength = 1: 1
+input.minLength after input.minLength = 1: 1
+input.getAttribute("minlength") after input.setAttribute("minLength", "2147483647"): 2147483647
+input.minLength after input.setAttribute("minlength", "2147483647"): 2147483647
+input.getAttribute("minlength") after input.minLength = 2147483647: 2147483647
+input.minLength after input.minLength = 2147483647: 2147483647
+input.getAttribute("minlength") after input.setAttribute("minLength", "2147483648"): 2147483648
+input.minLength after input.setAttribute("minlength", "2147483648"): -1
+input.minLength = 2147483648 threw exception of type IndexSizeError
+input.getAttribute("minlength") after input.setAttribute("minLength", "4294967295"): 4294967295
+input.minLength after input.setAttribute("minlength", "4294967295"): -1
+input.minLength = 4294967295 threw exception of type IndexSizeError
 input.getAttribute("size") after input.setAttribute("size", "0"): 0
 input.size after input.setAttribute("size", "0"): 20
 input.size = 0 threw exception of type IndexSizeError

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -98,6 +98,24 @@ img.getAttribute("width") after img.setAttribute("width", "4294967295"): 4294967
 img.width after img.setAttribute("width", "4294967295"): 0
 img.getAttribute("width") after img.width = 4294967295: 0
 img.width after img.width = 4294967295: 0
+input.getAttribute("maxlength") after input.setAttribute("maxLength", "0"): 0
+input.maxLength after input.setAttribute("maxlength", "0"): 0
+input.getAttribute("maxlength") after input.maxLength = 0: 0
+input.maxLength after input.maxLength = 0: 0
+input.getAttribute("maxlength") after input.setAttribute("maxLength", "1"): 1
+input.maxLength after input.setAttribute("maxlength", "1"): 1
+input.getAttribute("maxlength") after input.maxLength = 1: 1
+input.maxLength after input.maxLength = 1: 1
+input.getAttribute("maxlength") after input.setAttribute("maxLength", "2147483647"): 2147483647
+input.maxLength after input.setAttribute("maxlength", "2147483647"): 2147483647
+input.getAttribute("maxlength") after input.maxLength = 2147483647: 2147483647
+input.maxLength after input.maxLength = 2147483647: 2147483647
+input.getAttribute("maxlength") after input.setAttribute("maxLength", "2147483648"): 2147483648
+input.maxLength after input.setAttribute("maxlength", "2147483648"): -1
+input.maxLength = 2147483648 threw exception of type IndexSizeError
+input.getAttribute("maxlength") after input.setAttribute("maxLength", "4294967295"): 4294967295
+input.maxLength after input.setAttribute("maxlength", "4294967295"): -1
+input.maxLength = 4294967295 threw exception of type IndexSizeError
 input.getAttribute("size") after input.setAttribute("size", "0"): 0
 input.size after input.setAttribute("size", "0"): 20
 input.size = 0 threw exception of type IndexSizeError

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -46,6 +46,30 @@ canvas.getAttribute("height") after canvas.setAttribute("height", "4294967296"):
 canvas.height after canvas.setAttribute("height", "4294967296"): 150
 canvas.getAttribute("height") after canvas.height = 4294967296: 0
 canvas.height after canvas.height = 4294967296: 0
+colgroup.getAttribute("span") after colgroup.setAttribute("span", "0"): 0
+colgroup.span after colgroup.setAttribute("span", "0"): 1
+colgroup.getAttribute("span") after colgroup.span = 0: 0
+colgroup.span after colgroup.span = 0: 1
+colgroup.getAttribute("span") after colgroup.setAttribute("span", "1"): 1
+colgroup.span after colgroup.setAttribute("span", "1"): 1
+colgroup.getAttribute("span") after colgroup.span = 1: 1
+colgroup.span after colgroup.span = 1: 1
+colgroup.getAttribute("span") after colgroup.setAttribute("span", "2147483647"): 2147483647
+colgroup.span after colgroup.setAttribute("span", "2147483647"): 1000
+colgroup.getAttribute("span") after colgroup.span = 2147483647: 2147483647
+colgroup.span after colgroup.span = 2147483647: 1000
+colgroup.getAttribute("span") after colgroup.setAttribute("span", "2147483648"): 2147483648
+colgroup.span after colgroup.setAttribute("span", "2147483648"): 1000
+colgroup.getAttribute("span") after colgroup.span = 2147483648: 1
+colgroup.span after colgroup.span = 2147483648: 1
+colgroup.getAttribute("span") after colgroup.setAttribute("span", "4294967295"): 4294967295
+colgroup.span after colgroup.setAttribute("span", "4294967295"): 1000
+colgroup.getAttribute("span") after colgroup.span = 4294967295: 1
+colgroup.span after colgroup.span = 4294967295: 1
+colgroup.getAttribute("span") after colgroup.setAttribute("span", "4294967296"): 4294967296
+colgroup.span after colgroup.setAttribute("span", "4294967296"): 1000
+colgroup.getAttribute("span") after colgroup.span = 4294967296: 0
+colgroup.span after colgroup.span = 4294967296: 1
 img.getAttribute("height") after img.setAttribute("height", "0"): 0
 img.height after img.setAttribute("height", "0"): 0
 img.getAttribute("height") after img.height = 0: 0

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -253,6 +253,24 @@ select.getAttribute("size") after select.setAttribute("size", "4294967295"): 429
 select.size after select.setAttribute("size", "4294967295"): 0
 select.getAttribute("size") after select.size = 4294967295: 0
 select.size after select.size = 4294967295: 0
+textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "0"): 0
+textarea.minLength after textarea.setAttribute("minlength", "0"): 0
+textarea.getAttribute("minlength") after textarea.minLength = 0: 0
+textarea.minLength after textarea.minLength = 0: 0
+textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "1"): 1
+textarea.minLength after textarea.setAttribute("minlength", "1"): 1
+textarea.getAttribute("minlength") after textarea.minLength = 1: 1
+textarea.minLength after textarea.minLength = 1: 1
+textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "2147483647"): 2147483647
+textarea.minLength after textarea.setAttribute("minlength", "2147483647"): 2147483647
+textarea.getAttribute("minlength") after textarea.minLength = 2147483647: 2147483647
+textarea.minLength after textarea.minLength = 2147483647: 2147483647
+textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "2147483648"): 2147483648
+textarea.minLength after textarea.setAttribute("minlength", "2147483648"): -2147483648
+textarea.minLength = 2147483648 threw exception of type IndexSizeError
+textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "4294967295"): 4294967295
+textarea.minLength after textarea.setAttribute("minlength", "4294967295"): -1
+textarea.minLength = 4294967295 threw exception of type IndexSizeError
 textarea.getAttribute("rows") after textarea.setAttribute("rows", "0"): 0
 textarea.rows after textarea.setAttribute("rows", "0"): 2
 textarea.getAttribute("rows") after textarea.rows = 0: 2

--- a/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/unsigned-long-reflection.txt
@@ -18,6 +18,10 @@ canvas.getAttribute("width") after canvas.setAttribute("width", "4294967295"): 4
 canvas.width after canvas.setAttribute("width", "4294967295"): 300
 canvas.getAttribute("width") after canvas.width = 4294967295: 300
 canvas.width after canvas.width = 4294967295: 300
+canvas.getAttribute("width") after canvas.setAttribute("width", "4294967296"): 4294967296
+canvas.width after canvas.setAttribute("width", "4294967296"): 300
+canvas.getAttribute("width") after canvas.width = 4294967296: 0
+canvas.width after canvas.width = 4294967296: 0
 canvas.getAttribute("height") after canvas.setAttribute("height", "0"): 0
 canvas.height after canvas.setAttribute("height", "0"): 0
 canvas.getAttribute("height") after canvas.height = 0: 0
@@ -38,6 +42,10 @@ canvas.getAttribute("height") after canvas.setAttribute("height", "4294967295"):
 canvas.height after canvas.setAttribute("height", "4294967295"): 150
 canvas.getAttribute("height") after canvas.height = 4294967295: 150
 canvas.height after canvas.height = 4294967295: 150
+canvas.getAttribute("height") after canvas.setAttribute("height", "4294967296"): 4294967296
+canvas.height after canvas.setAttribute("height", "4294967296"): 150
+canvas.getAttribute("height") after canvas.height = 4294967296: 0
+canvas.height after canvas.height = 4294967296: 0
 img.getAttribute("height") after img.setAttribute("height", "0"): 0
 img.height after img.setAttribute("height", "0"): 0
 img.getAttribute("height") after img.height = 0: 0
@@ -58,6 +66,10 @@ img.getAttribute("height") after img.setAttribute("height", "4294967295"): 42949
 img.height after img.setAttribute("height", "4294967295"): 0
 img.getAttribute("height") after img.height = 4294967295: 0
 img.height after img.height = 4294967295: 0
+img.getAttribute("height") after img.setAttribute("height", "4294967296"): 4294967296
+img.height after img.setAttribute("height", "4294967296"): 0
+img.getAttribute("height") after img.height = 4294967296: 0
+img.height after img.height = 4294967296: 0
 img.getAttribute("hspace") after img.setAttribute("hspace", "0"): 0
 img.hspace after img.setAttribute("hspace", "0"): 0
 img.getAttribute("hspace") after img.hspace = 0: 0
@@ -78,6 +90,10 @@ img.getAttribute("hspace") after img.setAttribute("hspace", "4294967295"): 42949
 img.hspace after img.setAttribute("hspace", "4294967295"): 0
 img.getAttribute("hspace") after img.hspace = 4294967295: 0
 img.hspace after img.hspace = 4294967295: 0
+img.getAttribute("hspace") after img.setAttribute("hspace", "4294967296"): 4294967296
+img.hspace after img.setAttribute("hspace", "4294967296"): 0
+img.getAttribute("hspace") after img.hspace = 4294967296: 0
+img.hspace after img.hspace = 4294967296: 0
 img.getAttribute("width") after img.setAttribute("width", "0"): 0
 img.width after img.setAttribute("width", "0"): 0
 img.getAttribute("width") after img.width = 0: 0
@@ -98,6 +114,10 @@ img.getAttribute("width") after img.setAttribute("width", "4294967295"): 4294967
 img.width after img.setAttribute("width", "4294967295"): 0
 img.getAttribute("width") after img.width = 4294967295: 0
 img.width after img.width = 4294967295: 0
+img.getAttribute("width") after img.setAttribute("width", "4294967296"): 4294967296
+img.width after img.setAttribute("width", "4294967296"): 0
+img.getAttribute("width") after img.width = 4294967296: 0
+img.width after img.width = 4294967296: 0
 input.getAttribute("maxlength") after input.setAttribute("maxLength", "0"): 0
 input.maxLength after input.setAttribute("maxlength", "0"): 0
 input.getAttribute("maxlength") after input.maxLength = 0: 0
@@ -116,6 +136,10 @@ input.maxLength = 2147483648 threw exception of type IndexSizeError
 input.getAttribute("maxlength") after input.setAttribute("maxLength", "4294967295"): 4294967295
 input.maxLength after input.setAttribute("maxlength", "4294967295"): -1
 input.maxLength = 4294967295 threw exception of type IndexSizeError
+input.getAttribute("maxlength") after input.setAttribute("maxLength", "4294967296"): 4294967296
+input.maxLength after input.setAttribute("maxlength", "4294967296"): -1
+input.getAttribute("maxlength") after input.maxLength = 4294967296: 0
+input.maxLength after input.maxLength = 4294967296: 0
 input.getAttribute("minlength") after input.setAttribute("minLength", "0"): 0
 input.minLength after input.setAttribute("minlength", "0"): 0
 input.getAttribute("minlength") after input.minLength = 0: 0
@@ -134,6 +158,10 @@ input.minLength = 2147483648 threw exception of type IndexSizeError
 input.getAttribute("minlength") after input.setAttribute("minLength", "4294967295"): 4294967295
 input.minLength after input.setAttribute("minlength", "4294967295"): -1
 input.minLength = 4294967295 threw exception of type IndexSizeError
+input.getAttribute("minlength") after input.setAttribute("minLength", "4294967296"): 4294967296
+input.minLength after input.setAttribute("minlength", "4294967296"): -1
+input.getAttribute("minlength") after input.minLength = 4294967296: 0
+input.minLength after input.minLength = 4294967296: 0
 input.getAttribute("size") after input.setAttribute("size", "0"): 0
 input.size after input.setAttribute("size", "0"): 20
 input.size = 0 threw exception of type IndexSizeError
@@ -153,6 +181,9 @@ input.getAttribute("size") after input.setAttribute("size", "4294967295"): 42949
 input.size after input.setAttribute("size", "4294967295"): 20
 input.getAttribute("size") after input.size = 4294967295: 20
 input.size after input.size = 4294967295: 20
+input.getAttribute("size") after input.setAttribute("size", "4294967296"): 4294967296
+input.size after input.setAttribute("size", "4294967296"): 20
+input.size = 4294967296 threw exception of type IndexSizeError
 input.getAttribute("height") after input.setAttribute("height", "0"): 0
 input.height after input.setAttribute("height", "0"): 0
 input.getAttribute("height") after input.height = 0: 0
@@ -173,6 +204,10 @@ input.getAttribute("height") after input.setAttribute("height", "4294967295"): 4
 input.height after input.setAttribute("height", "4294967295"): 0
 input.getAttribute("height") after input.height = 4294967295: 0
 input.height after input.height = 4294967295: 0
+input.getAttribute("height") after input.setAttribute("height", "4294967296"): 4294967296
+input.height after input.setAttribute("height", "4294967296"): 0
+input.getAttribute("height") after input.height = 4294967296: 0
+input.height after input.height = 4294967296: 0
 input.getAttribute("width") after input.setAttribute("width", "0"): 0
 input.width after input.setAttribute("width", "0"): 0
 input.getAttribute("width") after input.width = 0: 0
@@ -193,6 +228,10 @@ input.getAttribute("width") after input.setAttribute("width", "4294967295"): 429
 input.width after input.setAttribute("width", "4294967295"): 0
 input.getAttribute("width") after input.width = 4294967295: 0
 input.width after input.width = 4294967295: 0
+input.getAttribute("width") after input.setAttribute("width", "4294967296"): 4294967296
+input.width after input.setAttribute("width", "4294967296"): 0
+input.getAttribute("width") after input.width = 4294967296: 0
+input.width after input.width = 4294967296: 0
 marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "0"): 0
 marquee.scrollAmount after marquee.setAttribute("scrollamount", "0"): 0
 marquee.getAttribute("scrollamount") after marquee.scrollAmount = 0: 0
@@ -213,6 +252,10 @@ marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", 
 marquee.scrollAmount after marquee.setAttribute("scrollamount", "4294967295"): 6
 marquee.getAttribute("scrollamount") after marquee.scrollAmount = 4294967295: 6
 marquee.scrollAmount after marquee.scrollAmount = 4294967295: 6
+marquee.getAttribute("scrollamount") after marquee.setAttribute("scrollAmount", "4294967296"): 4294967296
+marquee.scrollAmount after marquee.setAttribute("scrollamount", "4294967296"): 6
+marquee.getAttribute("scrollamount") after marquee.scrollAmount = 4294967296: 0
+marquee.scrollAmount after marquee.scrollAmount = 4294967296: 0
 marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "0"): 0
 marquee.scrollDelay after marquee.setAttribute("scrolldelay", "0"): 0
 marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 0: 0
@@ -233,6 +276,10 @@ marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "4
 marquee.scrollDelay after marquee.setAttribute("scrolldelay", "4294967295"): 85
 marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 4294967295: 85
 marquee.scrollDelay after marquee.scrollDelay = 4294967295: 85
+marquee.getAttribute("scrolldelay") after marquee.setAttribute("scrollDelay", "4294967296"): 4294967296
+marquee.scrollDelay after marquee.setAttribute("scrolldelay", "4294967296"): 85
+marquee.getAttribute("scrolldelay") after marquee.scrollDelay = 4294967296: 0
+marquee.scrollDelay after marquee.scrollDelay = 4294967296: 0
 select.getAttribute("size") after select.setAttribute("size", "0"): 0
 select.size after select.setAttribute("size", "0"): 0
 select.getAttribute("size") after select.size = 0: 0
@@ -253,6 +300,34 @@ select.getAttribute("size") after select.setAttribute("size", "4294967295"): 429
 select.size after select.setAttribute("size", "4294967295"): 0
 select.getAttribute("size") after select.size = 4294967295: 0
 select.size after select.size = 4294967295: 0
+select.getAttribute("size") after select.setAttribute("size", "4294967296"): 4294967296
+select.size after select.setAttribute("size", "4294967296"): 0
+select.getAttribute("size") after select.size = 4294967296: 0
+select.size after select.size = 4294967296: 0
+td.getAttribute("colspan") after td.setAttribute("colSpan", "0"): 0
+td.colSpan after td.setAttribute("colspan", "0"): 1
+td.getAttribute("colspan") after td.colSpan = 0: 0
+td.colSpan after td.colSpan = 0: 1
+td.getAttribute("colspan") after td.setAttribute("colSpan", "1"): 1
+td.colSpan after td.setAttribute("colspan", "1"): 1
+td.getAttribute("colspan") after td.colSpan = 1: 1
+td.colSpan after td.colSpan = 1: 1
+td.getAttribute("colspan") after td.setAttribute("colSpan", "2147483647"): 2147483647
+td.colSpan after td.setAttribute("colspan", "2147483647"): 1000
+td.getAttribute("colspan") after td.colSpan = 2147483647: 2147483647
+td.colSpan after td.colSpan = 2147483647: 1000
+td.getAttribute("colspan") after td.setAttribute("colSpan", "2147483648"): 2147483648
+td.colSpan after td.setAttribute("colspan", "2147483648"): 1000
+td.getAttribute("colspan") after td.colSpan = 2147483648: 1
+td.colSpan after td.colSpan = 2147483648: 1
+td.getAttribute("colspan") after td.setAttribute("colSpan", "4294967295"): 4294967295
+td.colSpan after td.setAttribute("colspan", "4294967295"): 1000
+td.getAttribute("colspan") after td.colSpan = 4294967295: 1
+td.colSpan after td.colSpan = 4294967295: 1
+td.getAttribute("colspan") after td.setAttribute("colSpan", "4294967296"): 4294967296
+td.colSpan after td.setAttribute("colspan", "4294967296"): 1000
+td.getAttribute("colspan") after td.colSpan = 4294967296: 0
+td.colSpan after td.colSpan = 4294967296: 1
 textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "0"): 0
 textarea.maxLength after textarea.setAttribute("maxlength", "0"): 0
 textarea.getAttribute("maxlength") after textarea.maxLength = 0: 0
@@ -271,6 +346,10 @@ textarea.maxLength = 2147483648 threw exception of type IndexSizeError
 textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "4294967295"): 4294967295
 textarea.maxLength after textarea.setAttribute("maxlength", "4294967295"): -1
 textarea.maxLength = 4294967295 threw exception of type IndexSizeError
+textarea.getAttribute("maxlength") after textarea.setAttribute("maxLength", "4294967296"): 4294967296
+textarea.maxLength after textarea.setAttribute("maxlength", "4294967296"): -1
+textarea.getAttribute("maxlength") after textarea.maxLength = 4294967296: 0
+textarea.maxLength after textarea.maxLength = 4294967296: 0
 textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "0"): 0
 textarea.minLength after textarea.setAttribute("minlength", "0"): 0
 textarea.getAttribute("minlength") after textarea.minLength = 0: 0
@@ -289,6 +368,10 @@ textarea.minLength = 2147483648 threw exception of type IndexSizeError
 textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "4294967295"): 4294967295
 textarea.minLength after textarea.setAttribute("minlength", "4294967295"): -1
 textarea.minLength = 4294967295 threw exception of type IndexSizeError
+textarea.getAttribute("minlength") after textarea.setAttribute("minLength", "4294967296"): 4294967296
+textarea.minLength after textarea.setAttribute("minlength", "4294967296"): -1
+textarea.getAttribute("minlength") after textarea.minLength = 4294967296: 0
+textarea.minLength after textarea.minLength = 4294967296: 0
 textarea.getAttribute("rows") after textarea.setAttribute("rows", "0"): 0
 textarea.rows after textarea.setAttribute("rows", "0"): 2
 textarea.getAttribute("rows") after textarea.rows = 0: 2
@@ -309,6 +392,10 @@ textarea.getAttribute("rows") after textarea.setAttribute("rows", "4294967295"):
 textarea.rows after textarea.setAttribute("rows", "4294967295"): 2
 textarea.getAttribute("rows") after textarea.rows = 4294967295: 2
 textarea.rows after textarea.rows = 4294967295: 2
+textarea.getAttribute("rows") after textarea.setAttribute("rows", "4294967296"): 4294967296
+textarea.rows after textarea.setAttribute("rows", "4294967296"): 2
+textarea.getAttribute("rows") after textarea.rows = 4294967296: 2
+textarea.rows after textarea.rows = 4294967296: 2
 textarea.getAttribute("cols") after textarea.setAttribute("cols", "0"): 0
 textarea.cols after textarea.setAttribute("cols", "0"): 20
 textarea.getAttribute("cols") after textarea.cols = 0: 20
@@ -329,3 +416,7 @@ textarea.getAttribute("cols") after textarea.setAttribute("cols", "4294967295"):
 textarea.cols after textarea.setAttribute("cols", "4294967295"): 20
 textarea.getAttribute("cols") after textarea.cols = 4294967295: 20
 textarea.cols after textarea.cols = 4294967295: 20
+textarea.getAttribute("cols") after textarea.setAttribute("cols", "4294967296"): 4294967296
+textarea.cols after textarea.setAttribute("cols", "4294967296"): 20
+textarea.getAttribute("cols") after textarea.cols = 4294967296: 20
+textarea.cols after textarea.cols = 4294967296: 20

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -48,6 +48,7 @@
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
         testProperty("img", "width", (img) => img.width, (img, value) => img.width = value);
         testProperty("input", "maxLength", (input) => input.maxLength, (input, value) => input.maxLength = value);
+        testProperty("input", "minLength", (input) => input.minLength, (input, value) => input.minLength = value);
         testProperty("input", "size", (input) => input.size, (input, value) => input.size = value);
         testProperty(imageButtonInputFactory, "height", (input) => input.height, (input, value) => input.height = value);
         testProperty(imageButtonInputFactory, "width", (input) => input.width, (input, value) => input.width = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -34,6 +34,7 @@
             setValue(2147483647);
             setValue(2147483648);
             setValue(4294967295);
+            setValue(4294967296);
         }
 
         const imageButtonInputFactory = () => {
@@ -55,6 +56,7 @@
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
         testProperty("select", "size", (select) => select.size, (select, value) => select.size = value);
+        testProperty("td", "colSpan", (tableCell) => tableCell.colSpan, (tableCell, value) => tableCell.colSpan = value);
         testProperty("textarea", "maxLength", (textarea) => textarea.maxLength, (textarea, value) => textarea.maxLength = value);
         testProperty("textarea", "minLength", (textarea) => textarea.minLength, (textarea, value) => textarea.minLength = value);
         testProperty("textarea", "rows", (textarea) => textarea.rows, (textarea, value) => textarea.rows = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -55,6 +55,7 @@
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
         testProperty("select", "size", (select) => select.size, (select, value) => select.size = value);
+        testProperty("textarea", "maxLength", (textarea) => textarea.maxLength, (textarea, value) => textarea.maxLength = value);
         testProperty("textarea", "minLength", (textarea) => textarea.minLength, (textarea, value) => textarea.minLength = value);
         testProperty("textarea", "rows", (textarea) => textarea.rows, (textarea, value) => textarea.rows = value);
         testProperty("textarea", "cols", (textarea) => textarea.cols, (textarea, value) => textarea.cols = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -57,6 +57,7 @@
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
         testProperty("select", "size", (select) => select.size, (select, value) => select.size = value);
         testProperty("td", "colSpan", (tableCell) => tableCell.colSpan, (tableCell, value) => tableCell.colSpan = value);
+        testProperty("td", "rowSpan", (tableCell) => tableCell.rowSpan, (tableCell, value) => tableCell.rowSpan = value);
         testProperty("textarea", "maxLength", (textarea) => textarea.maxLength, (textarea, value) => textarea.maxLength = value);
         testProperty("textarea", "minLength", (textarea) => textarea.minLength, (textarea, value) => textarea.minLength = value);
         testProperty("textarea", "rows", (textarea) => textarea.rows, (textarea, value) => textarea.rows = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -47,6 +47,7 @@
         testProperty("img", "height", (img) => img.height, (img, value) => img.height = value);
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
         testProperty("img", "width", (img) => img.width, (img, value) => img.width = value);
+        testProperty("input", "maxLength", (input) => input.maxLength, (input, value) => input.maxLength = value);
         testProperty("input", "size", (input) => input.size, (input, value) => input.size = value);
         testProperty(imageButtonInputFactory, "height", (input) => input.height, (input, value) => input.height = value);
         testProperty(imageButtonInputFactory, "width", (input) => input.width, (input, value) => input.width = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -45,6 +45,7 @@
 
         testProperty("canvas", "width", (canvas) => canvas.width, (canvas, value) => canvas.width = value);
         testProperty("canvas", "height", (canvas) => canvas.height, (canvas, value) => canvas.height = value);
+        testProperty("colgroup", "span", (colgroup) => colgroup.span, (colgroup, value) => colgroup.span = value);
         testProperty("img", "height", (img) => img.height, (img, value) => img.height = value);
         testProperty("img", "hspace", (img) => img.hspace, (img, value) => img.hspace = value);
         testProperty("img", "width", (img) => img.width, (img, value) => img.width = value);

--- a/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
+++ b/Tests/LibWeb/Text/input/HTML/unsigned-long-reflection.html
@@ -55,6 +55,7 @@
         testProperty("marquee", "scrollAmount", (marquee) => marquee.scrollAmount, (marquee, value) => marquee.scrollAmount = value);
         testProperty("marquee", "scrollDelay", (marquee) => marquee.scrollDelay, (marquee, value) => marquee.scrollDelay = value);
         testProperty("select", "size", (select) => select.size, (select, value) => select.size = value);
+        testProperty("textarea", "minLength", (textarea) => textarea.minLength, (textarea, value) => textarea.minLength = value);
         testProperty("textarea", "rows", (textarea) => textarea.rows, (textarea, value) => textarea.rows = value);
         testProperty("textarea", "cols", (textarea) => textarea.cols, (textarea, value) => textarea.cols = value);
     });


### PR DESCRIPTION
See individual commits for details.

Note: The first 4 commits have no impact on any tests - they are required to prevent regressions that would otherwise be introduced by the 5th commit that introduces `parse_integer_digits`.

This fixes all 30 failing subtests in: http://wpt.live/html/dom/reflection-tabular.html