### PR TITLE
LibWeb: Fix CSS filters painting

### DIFF
--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -352,11 +352,12 @@ void StackingContext::paint(PaintContext& context) const
         }
     }
 
+    paint_internal(context);
+
     if (!filter.is_none()) {
         context.display_list_recorder().restore();
     }
 
-    paint_internal(context);
     context.display_list_recorder().pop_stacking_context();
     if (paintable_box().scroll_frame_id().has_value()) {
         context.display_list_recorder().pop_scroll_frame_id();


### PR DESCRIPTION
restore() corresponding to ApplyFilters should be called after stacking context content is painted, not before.

Fixes regression introduced in c94b4316e7a2f3d245f9b48f77a7f9f76785218a