### PR TITLE
LibWeb: Fix NavigationType enum to string conversion

### DIFF
--- a/Libraries/LibWeb/HTML/NavigationType.h
+++ b/Libraries/LibWeb/HTML/NavigationType.h
@@ -21,13 +21,13 @@ inline String idl_enum_to_string(NavigationType value)
 {
     switch (value) {
     case NavigationType::Push:
-        return "Push"_string;
+        return "push"_string;
     case NavigationType::Replace:
-        return "Replace"_string;
+        return "replace"_string;
     case NavigationType::Reload:
-        return "Reload"_string;
+        return "reload"_string;
     case NavigationType::Traverse:
-        return "Traverse"_string;
+        return "traverse"_string;
     default:
         return "<unknown>"_string;
     }

--- a/Tests/LibWeb/Text/expected/navigation/navigation-navigate.txt
+++ b/Tests/LibWeb/Text/expected/navigation/navigation-navigate.txt
@@ -1,6 +1,6 @@
 Initial history length is 1
-NavigateEvent for Push navigation-navigate-iframe.html#1 (Same document? true) with info: 42
-currententrychange for change to navigation-navigate-iframe.html#1 of type Push from navigation-navigate-iframe.html
+NavigateEvent for push navigation-navigate-iframe.html#1 (Same document? true) with info: 42
+currententrychange for change to navigation-navigate-iframe.html#1 of type push from navigation-navigate-iframe.html
 Committed to navigation to navigation-navigate-iframe.html#1
 Finished navigation to navigation-navigate-iframe.html#1
 History length after navigate is 2

--- a/Tests/LibWeb/Text/expected/wpt-import/navigation-api/navigate-event/event-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/navigation-api/navigate-event/event-constructor.txt
@@ -1,0 +1,16 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 6 tests
+
+6 Pass
+Details
+Result	Test Name	MessagePass	can't bypass required members by omitting the dictionary entirely	
+Pass	destination is required	
+Pass	signal is required	
+Pass	all properties are reflected back	
+Pass	defaults are as expected	
+Pass	hasUAVisualTransition is default false	

--- a/Tests/LibWeb/Text/input/wpt-import/navigation-api/navigate-event/event-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/navigation-api/navigate-event/event-constructor.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  assert_throws_js(TypeError, () => {
+    new NavigateEvent("navigate");
+  });
+}, "can't bypass required members by omitting the dictionary entirely");
+
+test(() => {
+  assert_throws_js(TypeError, () => {
+    new NavigateEvent("navigate", {
+      navigationType: "push",
+      canIntercept: false,
+      userInitiated: false,
+      hashChange: false,
+      signal: (new AbortController()).signal,
+      formData: null,
+      downloadRequest: null,
+      info: null,
+      sourceElement: null
+    });
+  });
+}, "destination is required");
+
+async_test(t => {
+  // We need to grab an NavigationDestination.
+  navigation.onnavigate = t.step_func_done(e => {
+    assert_throws_js(TypeError, () => {
+      new NavigateEvent("navigate", {
+        navigationType: "push",
+        destination: e.destination,
+        canIntercept: false,
+        userInitiated: false,
+        hashChange: false,
+        formData: null,
+        downloadRequest: null,
+        info: null,
+        sourceElement: null
+      });
+    });
+  });
+  history.pushState(1, null, "#1");
+}, "signal is required");
+
+async_test(t => {
+  // We need to grab an NavigationDestination.
+  navigation.onnavigate = t.step_func_done(e => {
+    const info = { some: "object with identity" };
+    const formData = new FormData();
+    const signal = (new AbortController()).signal;
+    const downloadRequest = "abc";
+    const hasUAVisualTransition = true;
+    const sourceElement = document.createElement("a");
+
+    const event = new NavigateEvent("navigate", {
+      navigationType: "replace",
+      destination: e.destination,
+      canIntercept: true,
+      userInitiated: true,
+      hashChange: true,
+      signal,
+      formData,
+      downloadRequest,
+      info,
+      hasUAVisualTransition,
+      sourceElement
+    });
+
+    assert_equals(event.navigationType, "replace");
+    assert_equals(event.destination, e.destination);
+    assert_equals(event.canIntercept, true);
+    assert_equals(event.userInitiated, true);
+    assert_equals(event.hashChange, true);
+    assert_equals(event.signal, signal);
+    assert_equals(event.formData, formData);
+    assert_equals(event.downloadRequest, downloadRequest);
+    assert_equals(event.info, info);
+    assert_equals(event.hasUAVisualTransition, hasUAVisualTransition);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(event.sourceElement, sourceElement);
+  });
+  history.pushState(2, null, "#2");
+}, "all properties are reflected back");
+
+async_test(t => {
+  // We need to grab an NavigationDestination.
+  navigation.onnavigate = t.step_func_done(e => {
+    const event = new NavigateEvent("navigate", {
+      destination: e.destination,
+      signal: (new AbortController()).signal
+    });
+
+    assert_equals(event.navigationType, "push");
+    assert_equals(event.canIntercept, false);
+    assert_equals(event.userInitiated, false);
+    assert_equals(event.hashChange, false);
+    assert_equals(event.formData, null);
+    assert_equals(event.downloadRequest, null);
+    assert_equals(event.info, undefined);
+    // NavigateEvent sourceElement is still in development, so test whether it is available.
+    if ("sourceElement" in e) assert_equals(event.sourceElement, null);
+  });
+  history.pushState(3, null, "#3");
+}, "defaults are as expected");
+
+async_test(t => {
+  navigation.onnavigate = t.step_func_done(e => {
+    const event = new NavigateEvent("navigate", {
+      destination: e.destination,
+      signal: (new AbortController()).signal
+    });
+
+    assert_false(event.hasUAVisualTransition);
+  });
+  history.pushState(3, null, "#3");
+}, "hasUAVisualTransition is default false");
+</script>


### PR DESCRIPTION
Fix a typo in `NavigationType` enum. Convert it to lowercase strings, as described in the spec.

This PR fixes 2 WPT sub-tests in `event-constructor.html`.