### PR TITLE
 LibWeb: Commit pull-into descriptors after filling from queue

### DIFF
--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -5353,6 +5353,38 @@ bool is_non_negative_number(JS::Value value)
     return true;
 }
 
+// https://streams.spec.whatwg.org/#abstract-opdef-cancopydatablockbytes
+bool can_copy_data_block_bytes_buffer(JS::ArrayBuffer const& to_buffer, u64 to_index, JS::ArrayBuffer const& from_buffer, u64 from_index, u64 count)
+{
+    // 1. Assert: toBuffer is an Object.
+    // 2. Assert: toBuffer has an [[ArrayBufferData]] internal slot.
+    // 3. Assert: fromBuffer is an Object.
+    // 4. Assert: fromBuffer has an [[ArrayBufferData]] internal slot.
+
+    // 5. If toBuffer is fromBuffer, return false.
+    if (&to_buffer == &from_buffer)
+        return false;
+
+    // 6. If ! IsDetachedBuffer(toBuffer) is true, return false.
+    if (to_buffer.is_detached())
+        return false;
+
+    // 7. If ! IsDetachedBuffer(fromBuffer) is true, return false.
+    if (from_buffer.is_detached())
+        return false;
+
+    // 8. If toIndex + count > toBuffer.[[ArrayBufferByteLength]], return false.
+    if (to_index + count > to_buffer.byte_length())
+        return false;
+
+    // 9. If fromIndex + count > fromBuffer.[[ArrayBufferByteLength]], return false.
+    if (from_index + count > from_buffer.byte_length())
+        return false;
+
+    // 10. Return true.
+    return true;
+}
+
 // https://streams.spec.whatwg.org/#can-transfer-array-buffer
 bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer)
 {

--- a/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -188,6 +188,7 @@ void transform_stream_set_up(TransformStream&, GC::Ref<TransformAlgorithm>, GC::
 void transform_stream_unblock_write(TransformStream&);
 
 bool is_non_negative_number(JS::Value);
+bool can_copy_data_block_bytes_buffer(JS::ArrayBuffer const& to_buffer, u64 to_index, JS::ArrayBuffer const& from_buffer, u64 from_index, u64 count);
 bool can_transfer_array_buffer(JS::ArrayBuffer const& array_buffer);
 WebIDL::ExceptionOr<JS::Value> clone_as_uint8_array(JS::Realm&, WebIDL::ArrayBufferView&);
 WebIDL::ExceptionOr<JS::Value> structured_clone(JS::Realm&, JS::Value value);

--- a/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -101,7 +101,7 @@ WebIDL::ExceptionOr<GC::Ref<JS::ArrayBuffer>> transfer_array_buffer(JS::Realm& r
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_detached_pull_into_queue(ReadableByteStreamController& controller, PullIntoDescriptor& pull_into_descriptor);
 void readable_byte_stream_controller_commit_pull_into_descriptor(ReadableStream&, PullIntoDescriptor const&);
 void readable_byte_stream_controller_process_read_requests_using_queue(ReadableByteStreamController& controller);
-void readable_byte_stream_controller_process_pull_into_descriptors_using_queue(ReadableByteStreamController&);
+[[nodiscard]] SinglyLinkedList<PullIntoDescriptor> readable_byte_stream_controller_process_pull_into_descriptors_using_queue(ReadableByteStreamController&);
 void readable_byte_stream_controller_enqueue_chunk_to_queue(ReadableByteStreamController& controller, GC::Ref<JS::ArrayBuffer> buffer, u32 byte_offset, u32 byte_length);
 WebIDL::ExceptionOr<void> readable_byte_stream_controller_enqueue_cloned_chunk_to_queue(ReadableByteStreamController& controller, JS::ArrayBuffer& buffer, u64 byte_offset, u64 byte_length);
 PullIntoDescriptor readable_byte_stream_controller_shift_pending_pull_into(ReadableByteStreamController& controller);

--- a/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/patched-global.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/streams/readable-byte-streams/patched-global.any.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Patched then() sees byobRequest after filling all pending pull-into descriptors

--- a/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/patched-global.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/patched-global.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../resources/test-utils.js"></script>
+<div id=log></div>
+<script src="../../streams/readable-byte-streams/patched-global.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/patched-global.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/streams/readable-byte-streams/patched-global.any.js
@@ -1,0 +1,54 @@
+// META: global=window,worker,shadowrealm
+// META: script=../resources/test-utils.js
+'use strict';
+
+// Tests which patch the global environment are kept separate to avoid
+// interfering with other tests.
+
+promise_test(async (t) => {
+  let controller;
+  const rs = new ReadableStream({
+    type: 'bytes',
+    start(c) {
+      controller = c;
+    }
+  });
+  const reader = rs.getReader({mode: 'byob'});
+
+  const length = 0x4000;
+  const buffer = new ArrayBuffer(length);
+  const bigArray = new BigUint64Array(buffer, length - 8, 1);
+
+  const read1 = reader.read(new Uint8Array(new ArrayBuffer(0x100)));
+  const read2 = reader.read(bigArray);
+
+  let flag = false;
+  Object.defineProperty(Object.prototype, 'then', {
+    get: t.step_func(() => {
+      if (!flag) {
+        flag = true;
+        assert_equals(controller.byobRequest, null, 'byobRequest should be null after filling both views');
+      }
+    }),
+    configurable: true
+  });
+  t.add_cleanup(() => {
+    delete Object.prototype.then;
+  });
+
+  controller.enqueue(new Uint8Array(0x110).fill(0x42));
+  assert_true(flag, 'patched then() should be called');
+
+  // The first read() is filled entirely with 0x100 bytes
+  const result1 = await read1;
+  assert_false(result1.done, 'result1.done');
+  assert_typed_array_equals(result1.value, new Uint8Array(0x100).fill(0x42), 'result1.value');
+
+  // The second read() is filled with the remaining 0x10 bytes
+  const result2 = await read2;
+  assert_false(result2.done, 'result2.done');
+  assert_equals(result2.value.constructor, BigUint64Array, 'result2.value constructor');
+  assert_equals(result2.value.byteOffset, length - 8, 'result2.value byteOffset');
+  assert_equals(result2.value.length, 1, 'result2.value length');
+  assert_array_equals([...result2.value], [0x42424242_42424242n], 'result2.value contents');
+}, 'Patched then() sees byobRequest after filling all pending pull-into descriptors');


### PR DESCRIPTION
This aligns us with the latest streams specification changes to accommodate for the security advisor GHSA-p5g2-876g-95h9.
See relevant links:
https://github.com/whatwg/streams/security/advisories/GHSA-p5g2-876g-95h9
https://github.com/whatwg/streams/pull/1326

Previously we would just crash on an assert in ReadableByteStreamControllerFillHeadPullIntoDescriptor which verifies that controller controller.raw_byob_request() should be null.

These changes make sure that we postpone calls to ReadableByteStreamControllerCommitPullIntoDescriptor until after all
pull-into descriptors have been filled up by ReadableByteStreamControllerProcessPullIntoDescriptorsUsingQueue.

The attached test verifies that a patched then() will see a null byobRequest.