### PR TITLE
LibJS: Cache source code positions more often

### DIFF
--- a/Libraries/LibJS/Position.h
+++ b/Libraries/LibJS/Position.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <AK/Types.h>
+
 namespace JS {
 
 struct Position {


### PR DESCRIPTION
The source code position cache was moved from a line based approach to a "chunk"-based approach to improve performance on large, minified JavaScript files with few lines, but this has had an adverse effect on _multi-line_ source files.

Reintroduce some of the old behaviour by caching lines again, with some added sanity limits to avoid caching empty/overly small lines.

Source code positions in files with few lines will still be cached less often, since minified JavaScript files can be assumed to be unusually large, and since stack traces for minified JavaScript are less useful as well.

On WPT tests with large JavaScript dependencies like `css/css-masking/animations/clip-interpolation.html` this reduces the amount of time spent in `SourceCode::range_from_offsets` by as much as 99.98%, for the small small price of 80KB extra memory usage.