### PR TITLE
LibWeb: Implement "plaintext-only" state for contenteditable

### DIFF
--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -96,12 +96,10 @@ bool Document::query_command_enabled(FlyString const& command)
         return false;
 
     // https://w3c.github.io/editing/docs/execCommand/#enabled
-    // Among commands defined in this specification, those listed in Miscellaneous commands are
-    // always enabled, except for the cut command and the paste command.
-    // AD-HOC: Cut and Paste are not in the Miscellaneous commands section; so Copy is assumed
-    // AD-HOC: DefaultParagraphSeparator is also in the Miscellaneous commands section
+    // Among commands defined in this specification, those listed in Miscellaneous commands are always enabled, except
+    // for the cut command and the paste command.
+    // NOTE: cut and paste are actually in the Clipboard commands section
     if (command.is_one_of(
-            Editing::CommandNames::copy,
             Editing::CommandNames::defaultParagraphSeparator,
             Editing::CommandNames::redo,
             Editing::CommandNames::selectAll,

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -137,7 +137,7 @@ bool Document::query_command_enabled(FlyString const& command)
     // NOTE: Commands can define additional conditions for being enabled, and currently the only condition mentioned in
     //       the spec is that certain commands must not be enabled if the editing host is in the plaintext-only state.
     if (is<HTML::HTMLElement>(start_node_editing_host.ptr())
-        && static_cast<HTML::HTMLElement&>(*start_node_editing_host).content_editable() == "plaintext-only"sv
+        && static_cast<HTML::HTMLElement&>(*start_node_editing_host).content_editable_state() == HTML::ContentEditableState::PlaintextOnly
         && command.is_one_of(
             Editing::CommandNames::backColor,
             Editing::CommandNames::bold,

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -819,7 +819,9 @@ bool is_editing_host(GC::Ref<DOM::Node> node)
     if (!is<HTML::HTMLElement>(*node))
         return false;
     auto const& html_element = static_cast<HTML::HTMLElement&>(*node);
-    return html_element.content_editable().is_one_of("true"sv, "plaintext-only"sv) || node->document().design_mode_enabled_state();
+    return html_element.content_editable_state() == HTML::ContentEditableState::True
+        || html_element.content_editable_state() == HTML::ContentEditableState::PlaintextOnly
+        || node->document().design_mode_enabled_state();
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#element-with-inline-contents

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -261,14 +261,8 @@ void canonicalize_whitespace(GC::Ref<DOM::Node> node, u32 offset, bool fix_colla
             auto* layout_node = end_node->parent()->layout_node();
             if (layout_node && is<DOM::Text>(*end_node) && end_offset == end_node->length() && precedes_a_line_break(end_node)) {
                 auto parent_white_space = layout_node->computed_values().white_space();
-
-                // FIXME: Find a way to get code points directly from the UTF-8 string
-                auto end_node_data = *end_node->text_content();
-                auto utf16_code_units = MUST(AK::utf8_to_utf16(end_node_data));
-                auto utf16_view = Utf16View { utf16_code_units };
-                auto last_code_point = utf16_view.code_point_at(utf16_view.length_in_code_points() - 1);
                 if (parent_white_space != CSS::WhiteSpace::Pre && parent_white_space != CSS::WhiteSpace::PreWrap
-                    && last_code_point == 0x20) {
+                    && end_node->text_content().value().ends_with_bytes(" "sv)) {
                     // 1. Subtract one from end offset.
                     --end_offset;
 

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -816,11 +816,10 @@ bool is_editing_host(GC::Ref<DOM::Node> node)
     // An editing host is either an HTML element with its contenteditable attribute in the true
     // state or plaintext-only state, or a child HTML element of a Document whose design mode
     // enabled is true.
-    // FIXME: check contenteditable "plaintext-only"
     if (!is<HTML::HTMLElement>(*node))
         return false;
     auto const& html_element = static_cast<HTML::HTMLElement&>(*node);
-    return html_element.content_editable() == "true"sv || node->document().design_mode_enabled_state();
+    return html_element.content_editable().is_one_of("true"sv, "plaintext-only"sv) || node->document().design_mode_enabled_state();
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#element-with-inline-contents

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -20,6 +20,14 @@ namespace Web::HTML {
     __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(rtl) \
     __ENUMERATE_HTML_ELEMENT_DIR_ATTRIBUTE(auto)
 
+// https://html.spec.whatwg.org/#attr-contenteditable
+enum class ContentEditableState {
+    True,
+    False,
+    PlaintextOnly,
+    Inherit,
+};
+
 class HTMLElement
     : public DOM::Element
     , public HTML::GlobalEventHandlers
@@ -39,6 +47,7 @@ public:
     virtual bool is_focusable() const override;
     bool is_content_editable() const;
     StringView content_editable() const;
+    ContentEditableState content_editable_state() const { return m_content_editable_state; }
     WebIDL::ExceptionOr<void> set_content_editable(StringView);
 
     String inner_text();
@@ -106,12 +115,6 @@ private:
     GC::Ptr<ElementInternals> m_attached_internals;
 
     // https://html.spec.whatwg.org/#attr-contenteditable
-    enum class ContentEditableState {
-        True,
-        False,
-        PlaintextOnly,
-        Inherit,
-    };
     ContentEditableState m_content_editable_state { ContentEditableState::Inherit };
 
     // https://html.spec.whatwg.org/multipage/interaction.html#click-in-progress-flag

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -105,9 +105,11 @@ private:
     // https://html.spec.whatwg.org/multipage/custom-elements.html#attached-internals
     GC::Ptr<ElementInternals> m_attached_internals;
 
+    // https://html.spec.whatwg.org/#attr-contenteditable
     enum class ContentEditableState {
         True,
         False,
+        PlaintextOnly,
         Inherit,
     };
     ContentEditableState m_content_editable_state { ContentEditableState::Inherit };

--- a/Tests/LibWeb/Text/expected/wpt-import/html/editing/editing-0/contenteditable/contenteditable-enumerated-ascii-case-insensitive.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/editing/editing-0/contenteditable/contenteditable-enumerated-ascii-case-insensitive.txt
@@ -1,0 +1,34 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 24 tests
+
+24 Pass
+Details
+Result	Test Name	MessagePass	IDL attribute getter for attribute value "true"	
+Pass	IDL attribute setter for value "true"	
+Pass	IDL attribute getter for attribute value "TRUE"	
+Pass	IDL attribute setter for value "TRUE"	
+Pass	IDL attribute getter for attribute value "false"	
+Pass	IDL attribute setter for value "false"	
+Pass	IDL attribute getter for attribute value "FALSE"	
+Pass	IDL attribute setter for value "FALSE"	
+Pass	IDL attribute getter for attribute value "inherit"	
+Pass	IDL attribute setter for value "inherit"	
+Pass	IDL attribute getter for attribute value "INHERIT"	
+Pass	IDL attribute setter for value "INHERIT"	
+Pass	IDL attribute getter for attribute value "plaintext-only"	
+Pass	IDL attribute setter for value "plaintext-only"	
+Pass	IDL attribute getter for attribute value "PLAINTEXT-ONLY"	
+Pass	IDL attribute setter for value "PLAINTEXT-ONLY"	
+Pass	IDL attribute getter for attribute value "foobar"	
+Pass	IDL attribute setter for value "foobar"	
+Pass	IDL attribute getter for attribute value "falſe"	
+Pass	IDL attribute setter for value "falſe"	
+Pass	IDL attribute getter for attribute value "plaıntext-only"	
+Pass	IDL attribute setter for value "plaıntext-only"	
+Pass	IDL attribute getter for attribute value "plaİntext-only"	
+Pass	IDL attribute setter for value "plaİntext-only"	

--- a/Tests/LibWeb/Text/input/wpt-import/html/editing/editing-0/contenteditable/contenteditable-enumerated-ascii-case-insensitive.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/editing/editing-0/contenteditable/contenteditable-enumerated-ascii-case-insensitive.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/#attr-contenteditable">
+<link rel="help" href="https://html.spec.whatwg.org/#enumerated-attribute">
+<meta name="assert" content="@contenteditable values are ASCII case-insensitive">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<script>
+function testValue(value, isValid) {
+  const valueLower = value.toLowerCase();
+
+  test(() => {
+    const el = document.createElement('div');
+    if (valueLower !== "inherit") {
+      el.setAttribute('contenteditable', value);
+    }
+    assert_equals(el.contentEditable, isValid ? valueLower : "inherit");
+  }, `IDL attribute getter for attribute value "${value}"`);
+
+  test(() => {
+    const el = document.createElement('div');
+    if (isValid) {
+      el.contentEditable = value;
+      assert_equals(el.getAttribute('contenteditable'), valueLower === "inherit" ? null : valueLower);
+    } else {
+      assert_throws_dom("SyntaxError", () => {
+        el.contentEditable = value;
+      });
+    }
+  }, `IDL attribute setter for value "${value}"`);
+}
+
+const valid = ["true", "false", "inherit", "plaintext-only"]; // "inherit" is treated specially
+const invalid = ["foobar", "falſe", "plaıntext-only", "plaİntext-only"];
+
+for (const value of valid) {
+  testValue(value, true);
+  testValue(value.toUpperCase(), true);
+}
+
+for (const value of invalid) {
+  testValue(value, false);
+}
+</script>


### PR DESCRIPTION
Adds at least 191 WPT passes from `editing/plaintext-only` to our total.