### PR TITLE
Meta+Documentation: Update config for QtCreator

### DIFF
--- a/Documentation/EditorConfiguration/QtCreatorConfiguration.md
+++ b/Documentation/EditorConfiguration/QtCreatorConfiguration.md
@@ -19,14 +19,14 @@ First, make sure you have a working toolchain and can build and run Ladybird. Go
     #define SANITIZE_PTRS 1
     ```
 * Edit the `ladybird.cxxflags` file to say `-std=c++23 -fsigned-char -fconcepts -fno-exceptions -fno-semantic-interposition -fPIC`
-* Edit the `ladybird.includes` file to list the following lines:
+* Edit the `ladybird.includes` file to list the following lines (adapt to the actual path of your skia folder):
     ```
     ./
     Libraries/
     Services/
-    Build/release/
-    Build/release/Libraries/
-    Build/release/Services/
+    Build/release/Lagom/Libraries/
+    Build/release/Lagom/Services/
+    Build/release/vcpkg_installed/x64-linux/include/skia/
     AK/
     ```
 

--- a/Meta/refresh-ladybird-qtcreator.sh
+++ b/Meta/refresh-ladybird-qtcreator.sh
@@ -11,4 +11,4 @@ fi
 
 cd "${LADYBIRD_SOURCE_DIR}"
 
-find . \( -name Base -o -name Patches -o -name Ports -o -name Root -o -name Toolchain -o -name Build \) -prune -o \( -name '*.ipc' -or -name '*.cpp' -or -name '*.idl' -or -name '*.c' -or -name '*.h' -or -name '*.in' -or -name '*.S' -or -name '*.css' -or -name '*.cmake' -or -name '*.json' -or -name '*.gml' -or -name 'CMakeLists.txt' \) -print > ladybird.files
+find . \( -name Base -o -name Patches -o -name Ports -o -name Root -o -name Toolchain -o -name Build \) -prune -o \( -name '*.ipc' -or -name '*.cpp' -or -name '*.idl' -or -name '*.h' -or -name '*.in' -or -name '*.css' -or -name '*.cmake' -or -name '*.json' -or -name 'CMakeLists.txt' \) -print > ladybird.files


### PR DESCRIPTION
We no longer use C or raw assembly (*.S), and generated include files have moved to Build/release/Lagom/.

EDIT: Whoops, I thought the char limit per line in the commit body was 78, apparently it's 72. Fixed.