### PR TITLE
LibGfx: Define destructor for TypefaceSkia

### DIFF
--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -64,9 +64,11 @@ SkTypeface const* TypefaceSkia::sk_typeface() const
 TypefaceSkia::TypefaceSkia(NonnullOwnPtr<Impl> impl, ReadonlyBytes buffer, int ttc_index)
     : m_impl(move(impl))
     , m_buffer(buffer)
-    , m_ttc_index(ttc_index) {
+    , m_ttc_index(ttc_index)
+{
+}
 
-    };
+TypefaceSkia::~TypefaceSkia() = default;
 
 u32 TypefaceSkia::glyph_count() const
 {

--- a/Libraries/LibGfx/Font/TypefaceSkia.h
+++ b/Libraries/LibGfx/Font/TypefaceSkia.h
@@ -34,7 +34,8 @@ private:
     Impl& impl() const { return *m_impl; }
     NonnullOwnPtr<Impl> m_impl;
 
-    explicit TypefaceSkia(NonnullOwnPtr<Impl>, ReadonlyBytes, int ttc_index = 0);
+    TypefaceSkia(NonnullOwnPtr<Impl>, ReadonlyBytes, int ttc_index = 0);
+    virtual ~TypefaceSkia() override;
 
     ReadonlyBytes m_buffer;
     unsigned m_ttc_index { 0 };


### PR DESCRIPTION
We rely on TypefaceSkia to unref the SkTypeface on destruction, so define a default destructor that gets called when the base class Gfx::Typeface gets destructed.