### PR TITLE
LibWeb: Fix crash accessing 'empty' PromiseRejectionEvent reason

### DIFF
--- a/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
+++ b/Libraries/LibWeb/HTML/PromiseRejectionEvent.h
@@ -17,7 +17,7 @@ namespace Web::HTML {
 
 struct PromiseRejectionEventInit : public DOM::EventInit {
     GC::Root<JS::Object> promise;
-    JS::Value reason;
+    JS::Value reason { JS::js_undefined() };
 };
 
 class PromiseRejectionEvent final : public DOM::Event {

--- a/Libraries/LibWeb/HTML/ShadowRealmGlobalScope.h
+++ b/Libraries/LibWeb/HTML/ShadowRealmGlobalScope.h
@@ -26,8 +26,8 @@ public:
 
     static GC::Ref<ShadowRealmGlobalScope> create(JS::Realm&);
 
-    virtual Bindings::PlatformObject& this_impl() override { return *this; }
-    virtual Bindings::PlatformObject const& this_impl() const override { return *this; }
+    virtual DOM::EventTarget& this_impl() override { return *this; }
+    virtual DOM::EventTarget const& this_impl() const override { return *this; }
 
     // https://whatpr.org/html/9893/webappapis.html#dom-shadowrealmglobalscope-self
     GC::Ref<ShadowRealmGlobalScope> self()

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -198,8 +198,7 @@ void UniversalGlobalScopeMixin::notify_about_rejected_promises(Badge<EventLoop>)
     m_about_to_be_notified_rejected_promises_list.clear();
 
     // 4. Let global be settings object's global object.
-    // We need this as an event target for the unhandledrejection event below
-    auto& global = verify_cast<DOM::EventTarget>(this_impl());
+    auto& global = this_impl();
 
     // 5. Queue a global task on the DOM manipulation task source given global to run the following substep:
     queue_global_task(Task::Source::DOMManipulation, global, GC::create_function(realm.heap(), [this, &global, list = move(list)] {

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.h
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.h
@@ -21,8 +21,8 @@ class UniversalGlobalScopeMixin {
 public:
     virtual ~UniversalGlobalScopeMixin();
 
-    virtual Bindings::PlatformObject& this_impl() = 0;
-    virtual Bindings::PlatformObject const& this_impl() const = 0;
+    virtual DOM::EventTarget& this_impl() = 0;
+    virtual DOM::EventTarget const& this_impl() const = 0;
 
     WebIDL::ExceptionOr<String> btoa(String const& data) const;
     WebIDL::ExceptionOr<String> atob(String const& data) const;

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -76,8 +76,8 @@ public:
     virtual bool dispatch_event(DOM::Event&) override;
 
     // ^WindowOrWorkerGlobalScopeMixin
-    virtual Bindings::PlatformObject& this_impl() override { return *this; }
-    virtual Bindings::PlatformObject const& this_impl() const override { return *this; }
+    virtual DOM::EventTarget& this_impl() override { return *this; }
+    virtual DOM::EventTarget const& this_impl() const override { return *this; }
 
     // ^JS::Object
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -29,8 +29,8 @@ class WindowOrWorkerGlobalScopeMixin {
 public:
     virtual ~WindowOrWorkerGlobalScopeMixin();
 
-    virtual Bindings::PlatformObject& this_impl() = 0;
-    virtual Bindings::PlatformObject const& this_impl() const = 0;
+    virtual DOM::EventTarget& this_impl() = 0;
+    virtual DOM::EventTarget const& this_impl() const = 0;
 
     // JS API functions
     String origin() const;

--- a/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -43,8 +43,8 @@ public:
     virtual ~WorkerGlobalScope() override;
 
     // ^WindowOrWorkerGlobalScopeMixin
-    virtual Bindings::PlatformObject& this_impl() override { return *this; }
-    virtual Bindings::PlatformObject const& this_impl() const override { return *this; }
+    virtual DOM::EventTarget& this_impl() override { return *this; }
+    virtual DOM::EventTarget const& this_impl() const override { return *this; }
 
     using UniversalGlobalScopeMixin::atob;
     using UniversalGlobalScopeMixin::btoa;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.txt
@@ -1,0 +1,11 @@
+Summary
+
+Harness status: OK
+
+Rerun
+
+Found 1 tests
+
+1 Pass
+Details
+Result	Test Name	MessagePass	This tests the constructor for the PromiseRejectionEvent DOM class.	

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/processing-model-2/unhandled-promise-rejections/promise-rejection-event-constructor.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<script src="../../../../../resources/testharness.js"></script>
+<script src="../../../../../resources/testharnessreport.js"></script>
+<link rel="help" href="https://html.spec.whatwg.org/#the-promiserejectionevent-interface">
+<script>
+'use strict';
+
+test(function() {
+  var p = new Promise(function(resolve, reject) {});
+
+  assert_throws_js(TypeError,
+                   function() {
+                     PromiseRejectionEvent('', { promise: p });
+                   },
+                   "Calling PromiseRejectionEvent constructor without 'new' must throw");
+
+  // No custom options are passed (besides required promise).
+  assert_equals(new PromiseRejectionEvent('eventType', { promise: p }).bubbles, false);
+  assert_equals(new PromiseRejectionEvent('eventType', { promise: p }).cancelable, false);
+  assert_equals(new PromiseRejectionEvent('eventType', { promise: p }).promise, p);
+  assert_equals(new PromiseRejectionEvent('eventType', { promise: p }).reason, undefined);
+
+  // No promise is passed.
+  assert_throws_js(TypeError,
+                   function() {
+                     new PromiseRejectionEvent('eventType', { bubbles: false });
+                   },
+                   'Cannot construct PromiseRejectionEventInit without promise');
+
+  // bubbles is passed.
+  assert_equals(new PromiseRejectionEvent('eventType', { bubbles: false, promise: p }).bubbles, false);
+  assert_equals(new PromiseRejectionEvent('eventType', { bubbles: true, promise: p }).bubbles, true);
+
+  // cancelable is passed.
+  assert_equals(new PromiseRejectionEvent('eventType', { cancelable: false, promise: p }).cancelable, false);
+  assert_equals(new PromiseRejectionEvent('eventType', { cancelable: true, promise: p }).cancelable, true);
+
+  // reason is passed.
+  var r = new Error();
+  assert_equals(new PromiseRejectionEvent('eventType', { promise: p, reason: r }).reason, r);
+  assert_equals(new PromiseRejectionEvent('eventType', { promise: p, reason: null }).reason, null);
+
+  // All initializers are passed.
+  assert_equals(new PromiseRejectionEvent('eventType', { bubbles: true, cancelable: true, promise: p, reason: r }).bubbles, true);
+  assert_equals(new PromiseRejectionEvent('eventType', { bubbles: true, cancelable: true, promise: p, reason: r }).cancelable, true);
+  assert_equals(new PromiseRejectionEvent('eventType', { bubbles: true, cancelable: true, promise: p, reason: r }).promise, p);
+  assert_equals(new PromiseRejectionEvent('eventType', { bubbles: true, cancelable: true, promise: p, reason: r }).reason, r);
+}, "This tests the constructor for the PromiseRejectionEvent DOM class.");
+</script>


### PR DESCRIPTION
The 'reason' was getting initialized to 'empty' state when not
provided through the constructor, which results in a crash when
accessed through throw_dom_exception_if_needed in the generated
IDL getter.