### PR TITLE
CI: Prevent test artifacts disappearing from naming conflicts, and keep them around for longer

### DIFF
--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -192,7 +192,7 @@ jobs:
         with:
           name: libweb-test-artifacts-${{ inputs.os_name }}-${{inputs.fuzzer}}-${{inputs.toolchain}}-${{inputs.clang-plugins}}
           path: ${{ github.workspace }}/Build/UI/Headless/test-dumps
-          retention-days: 7
+          retention-days: 0
           if-no-files-found: ignore
 
       - name: Lints

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -190,7 +190,7 @@ jobs:
         if: ${{ always() && inputs.fuzzer == 'NO_FUZZ' }}
         uses: actions/upload-artifact@v4
         with:
-          name: libweb-test-artifacts-${{ inputs.os_name }}
+          name: libweb-test-artifacts-${{ inputs.os_name }}-${{inputs.fuzzer}}-${{inputs.toolchain}}-${{inputs.clang-plugins}}
           path: ${{ github.workspace }}/Build/UI/Headless/test-dumps
           retention-days: 7
           if-no-files-found: ignore


### PR DESCRIPTION
I noticed that we had some CI runs where one set of test artifacts would be lost because of the naming conflict:

> Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
> https://github.com/LadybirdBrowser/ladybird/actions/runs/12107691399/job/33754854370?pr=2663#step:18:30

So, let's make that impossible by using all the run's input values in the file name. And while I'm at it, correct the retention settings to use the default ones, instead of hard-coding it at 7 days, which is not very long.