### PR TITLE
CI: Disable GNU toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,10 @@ jobs:
         os_name: ['Linux']
         os: [ubuntu-24.04]
         fuzzer: ['NO_FUZZ']
-        toolchain: ['GNU']
-        clang_plugins: [false]
+        toolchain: ['Clang']
+        clang_plugins: [true]
 
         include:
-          - os_name: 'Linux'
-            os: ubuntu-24.04
-            fuzzer: 'NO_FUZZ'
-            toolchain: 'Clang'
-            clang_plugins: true
-
           - os_name: 'macOS'
             os: macos-15
             fuzzer: 'NO_FUZZ'


### PR DESCRIPTION
Motivation:
- Sooner or later we will start using Swift supported only by Clang
- GCC CI runs tests visibly slower than Clang CI
- Less build issues with Clang, e.g. recent attempt to add ANGLE that fails to compile with GCC