### PR TITLE
Meta: Identify mismatch tests as ref not text

### DIFF
--- a/Meta/import-wpt-test.py
+++ b/Meta/import-wpt-test.py
@@ -83,7 +83,7 @@ class TestTypeIdentifier(HTMLParser):
     def handle_starttag(self, tag, attrs):
         if tag == "link":
             attr_dict = dict(attrs)
-            if attr_dict["rel"] == "match":
+            if attr_dict["rel"] == "match" or attr_dict["rel"] == "mismatch":
                 self.test_type = TestType.REF
                 self.reference_path = attr_dict["href"]
 


### PR DESCRIPTION
- Look for links with a rel mismatch as well as match, when identifiying

Fixes #2712 