### PR TITLE
LibGfx: Let Painter care about TinyVG transforms

### DIFF
--- a/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
+++ b/Libraries/LibGfx/ImageFormats/TinyVGLoader.h
@@ -53,7 +53,7 @@ public:
         return m_size;
     }
 
-    virtual void draw_transformed(Painter&, AffineTransform) const override;
+    virtual void draw(Painter&) const override;
 
     ReadonlySpan<DrawCommand> draw_commands() const
     {

--- a/Libraries/LibGfx/VectorGraphic.cpp
+++ b/Libraries/LibGfx/VectorGraphic.cpp
@@ -9,26 +9,25 @@
 
 namespace Gfx {
 
-void VectorGraphic::draw_into(Painter& painter, IntRect const& dest, AffineTransform transform) const
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> VectorGraphic::bitmap(IntSize size, AffineTransform transform) const
 {
+    auto bitmap = TRY(Bitmap::create(Gfx::BitmapFormat::BGRA8888, size));
+    auto painter = PainterSkia::create(bitmap);
+
     // Apply the transform then center within destination rectangle (this ignores any translation from the transform):
     // This allows you to easily rotate or flip the image before painting.
-    auto transformed_rect = transform.map(FloatRect { {}, size() });
-    auto scale = min(float(dest.width()) / transformed_rect.width(), float(dest.height()) / transformed_rect.height());
-    auto centered = FloatRect { {}, transformed_rect.size().scaled(scale) }.centered_within(dest.to_type<float>());
+    auto transformed_rect = transform.map(FloatRect { {}, this->size() });
+    auto scale = min(float(size.width()) / transformed_rect.width(), float(size.height()) / transformed_rect.height());
+    auto centered = FloatRect { {}, transformed_rect.size().scaled(scale) }.centered_within(IntRect { {}, size }.to_type<float>());
     auto view_transform = AffineTransform {}
                               .translate(centered.location())
                               .multiply(AffineTransform {}.scale(scale, scale))
                               .multiply(AffineTransform {}.translate(-transformed_rect.location()))
                               .multiply(transform);
-    draw_transformed(painter, view_transform);
-}
 
-ErrorOr<NonnullRefPtr<Gfx::Bitmap>> VectorGraphic::bitmap(IntSize size, AffineTransform transform) const
-{
-    auto bitmap = TRY(Bitmap::create(Gfx::BitmapFormat::BGRA8888, size));
-    auto painter = PainterSkia::create(bitmap);
-    draw_into(*painter, IntRect { {}, size }, transform);
+    painter->set_transform(view_transform);
+    draw(*painter);
+
     return bitmap;
 }
 

--- a/Libraries/LibGfx/VectorGraphic.h
+++ b/Libraries/LibGfx/VectorGraphic.h
@@ -17,13 +17,12 @@ namespace Gfx {
 class VectorGraphic : public RefCounted<VectorGraphic> {
 public:
     virtual IntSize intrinsic_size() const = 0;
-    virtual void draw_transformed(Painter&, AffineTransform) const = 0;
+    virtual void draw(Painter&) const = 0;
 
     IntSize size() const { return intrinsic_size(); }
     IntRect rect() const { return { {}, size() }; }
 
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap(IntSize size, AffineTransform = {}) const;
-    void draw_into(Painter& painter, IntRect const& dest, AffineTransform = {}) const;
 
     virtual ~VectorGraphic() = default;
 };

--- a/UI/Qt/TVGIconEngine.cpp
+++ b/UI/Qt/TVGIconEngine.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/MemoryStream.h>
 #include <AK/String.h>
-#include <LibGfx/PainterSkia.h>
 #include <LibGfx/Rect.h>
 #include <UI/Qt/StringUtils.h>
 #include <UI/Qt/TVGIconEngine.h>
@@ -34,12 +33,7 @@ QPixmap TVGIconEngine::pixmap(QSize const& size, QIcon::Mode mode, QIcon::State 
     auto key = pixmap_cache_key(size, mode, state);
     if (QPixmapCache::find(key, &pixmap))
         return pixmap;
-    auto bitmap = MUST(Gfx::Bitmap::create(Gfx::BitmapFormat::BGRA8888, { size.width(), size.height() }));
-
-    auto painter = Gfx::PainterSkia::create(bitmap);
-    painter->clear_rect(bitmap->rect().to_type<float>(), Gfx::Color::Transparent);
-
-    m_image_data->draw_into(*painter, bitmap->rect());
+    auto bitmap = MUST(m_image_data->bitmap({ size.width(), size.height() }));
 
     for (auto const& filter : m_filters) {
         if (filter->mode() == mode) {


### PR DESCRIPTION
This helps us with non-uniform scales, and makes things simple