### PR TITLE
Flake: Add outputs.apps.default

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,5 +10,9 @@
     pkgs = import nixpkgs { inherit system; };
   in {
     devShells.default = import ./UI { inherit pkgs; };
+    apps.default = {
+      type = "app";
+      program = "${pkgs.ladybird}/bin/Ladybird";
+    };
   });
 }


### PR DESCRIPTION
This change allows running Ladybird directly with nix by running

```bash
nix run github:LadybirdBrowser/ladybird
```