### PR TITLE
LibJS: Apply recent editorial updates to Intl.DurationFormat, and use MVs for large computations

### DIFF
--- a/Libraries/LibCrypto/BigFraction/BigFraction.cpp
+++ b/Libraries/LibCrypto/BigFraction/BigFraction.cpp
@@ -185,7 +185,7 @@ void BigFraction::reduce()
     m_denominator = denominator_divide.quotient;
 }
 
-ByteString BigFraction::to_byte_string(unsigned rounding_threshold) const
+String BigFraction::to_string(unsigned rounding_threshold) const
 {
     StringBuilder builder;
     if (m_numerator.is_negative() && m_numerator != "0"_bigint)
@@ -240,7 +240,7 @@ ByteString BigFraction::to_byte_string(unsigned rounding_threshold) const
             builder.append(fractional_value);
     }
 
-    return builder.to_byte_string();
+    return MUST(builder.to_string());
 }
 
 BigFraction BigFraction::sqrt() const

--- a/Libraries/LibCrypto/BigFraction/BigFraction.cpp
+++ b/Libraries/LibCrypto/BigFraction/BigFraction.cpp
@@ -140,6 +140,11 @@ double BigFraction::to_double() const
     return m_numerator.to_double() / m_denominator.to_double();
 }
 
+bool BigFraction::is_zero() const
+{
+    return m_numerator.is_zero();
+}
+
 void BigFraction::set_to_0()
 {
     m_numerator.set_to_0();

--- a/Libraries/LibCrypto/BigFraction/BigFraction.h
+++ b/Libraries/LibCrypto/BigFraction/BigFraction.h
@@ -55,7 +55,7 @@ public:
     //      - m_denominator = 10000
     BigFraction rounded(unsigned rounding_threshold) const;
 
-    ByteString to_byte_string(unsigned rounding_threshold) const;
+    String to_string(unsigned rounding_threshold) const;
     double to_double() const;
 
     Crypto::SignedBigInteger const& numerator() const& { return m_numerator; }

--- a/Libraries/LibCrypto/BigFraction/BigFraction.h
+++ b/Libraries/LibCrypto/BigFraction/BigFraction.h
@@ -44,6 +44,7 @@ public:
     BigFraction invert() const;
     BigFraction sqrt() const;
 
+    bool is_zero() const;
     void set_to_0();
 
     // Return a BigFraction in "scientific notation", as an example with:

--- a/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -586,6 +586,7 @@ namespace JS {
     P(weekday)                               \
     P(weekend)                               \
     P(weekOfYear)                            \
+    P(week)                                  \
     P(weeks)                                 \
     P(weeksDisplay)                          \
     P(with)                                  \

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -24,8 +24,10 @@ public:
         Long,
         Short,
         Narrow,
-        Digital
+        Digital,
     };
+    static Style style_from_string(StringView style);
+    static StringView style_to_string(Style);
 
     enum class ValueStyle {
         Long,
@@ -35,13 +37,31 @@ public:
         TwoDigit,
         Fractional,
     };
+    static ValueStyle value_style_from_string(StringView);
+    static StringView value_style_to_string(ValueStyle);
+
     static_assert(to_underlying(ValueStyle::Long) == to_underlying(Unicode::Style::Long));
     static_assert(to_underlying(ValueStyle::Short) == to_underlying(Unicode::Style::Short));
     static_assert(to_underlying(ValueStyle::Narrow) == to_underlying(Unicode::Style::Narrow));
 
     enum class Display {
         Auto,
-        Always
+        Always,
+    };
+    static Display display_from_string(StringView display);
+    static StringView display_to_string(Display);
+
+    enum class Unit {
+        Years,
+        Months,
+        Weeks,
+        Days,
+        Hours,
+        Minutes,
+        Seconds,
+        Milliseconds,
+        Microseconds,
+        Nanoseconds,
     };
 
     static constexpr auto relevant_extension_keys()
@@ -69,83 +89,83 @@ public:
     Style style() const { return m_style; }
     StringView style_string() const { return style_to_string(m_style); }
 
-    void set_years_style(StringView years_style) { m_years_style = date_style_from_string(years_style); }
+    void set_years_style(ValueStyle years_style) { m_years_style = years_style; }
     ValueStyle years_style() const { return m_years_style; }
     StringView years_style_string() const { return value_style_to_string(m_years_style); }
 
-    void set_years_display(StringView years_display) { m_years_display = display_from_string(years_display); }
+    void set_years_display(Display years_display) { m_years_display = years_display; }
     Display years_display() const { return m_years_display; }
     StringView years_display_string() const { return display_to_string(m_years_display); }
 
-    void set_months_style(StringView months_style) { m_months_style = date_style_from_string(months_style); }
+    void set_months_style(ValueStyle months_style) { m_months_style = months_style; }
     ValueStyle months_style() const { return m_months_style; }
     StringView months_style_string() const { return value_style_to_string(m_months_style); }
 
-    void set_months_display(StringView months_display) { m_months_display = display_from_string(months_display); }
+    void set_months_display(Display months_display) { m_months_display = months_display; }
     Display months_display() const { return m_months_display; }
     StringView months_display_string() const { return display_to_string(m_months_display); }
 
-    void set_weeks_style(StringView weeks_style) { m_weeks_style = date_style_from_string(weeks_style); }
+    void set_weeks_style(ValueStyle weeks_style) { m_weeks_style = weeks_style; }
     ValueStyle weeks_style() const { return m_weeks_style; }
     StringView weeks_style_string() const { return value_style_to_string(m_weeks_style); }
 
-    void set_weeks_display(StringView weeks_display) { m_weeks_display = display_from_string(weeks_display); }
+    void set_weeks_display(Display weeks_display) { m_weeks_display = weeks_display; }
     Display weeks_display() const { return m_weeks_display; }
     StringView weeks_display_string() const { return display_to_string(m_weeks_display); }
 
-    void set_days_style(StringView days_style) { m_days_style = date_style_from_string(days_style); }
+    void set_days_style(ValueStyle days_style) { m_days_style = days_style; }
     ValueStyle days_style() const { return m_days_style; }
     StringView days_style_string() const { return value_style_to_string(m_days_style); }
 
-    void set_days_display(StringView days_display) { m_days_display = display_from_string(days_display); }
+    void set_days_display(Display days_display) { m_days_display = days_display; }
     Display days_display() const { return m_days_display; }
     StringView days_display_string() const { return display_to_string(m_days_display); }
 
-    void set_hours_style(StringView hours_style) { m_hours_style = time_style_from_string(hours_style); }
+    void set_hours_style(ValueStyle hours_style) { m_hours_style = hours_style; }
     ValueStyle hours_style() const { return m_hours_style; }
     StringView hours_style_string() const { return value_style_to_string(m_hours_style); }
 
-    void set_hours_display(StringView hours_display) { m_hours_display = display_from_string(hours_display); }
+    void set_hours_display(Display hours_display) { m_hours_display = hours_display; }
     Display hours_display() const { return m_hours_display; }
     StringView hours_display_string() const { return display_to_string(m_hours_display); }
 
-    void set_minutes_style(StringView minutes_style) { m_minutes_style = time_style_from_string(minutes_style); }
+    void set_minutes_style(ValueStyle minutes_style) { m_minutes_style = minutes_style; }
     ValueStyle minutes_style() const { return m_minutes_style; }
     StringView minutes_style_string() const { return value_style_to_string(m_minutes_style); }
 
-    void set_minutes_display(StringView minutes_display) { m_minutes_display = display_from_string(minutes_display); }
+    void set_minutes_display(Display minutes_display) { m_minutes_display = minutes_display; }
     Display minutes_display() const { return m_minutes_display; }
     StringView minutes_display_string() const { return display_to_string(m_minutes_display); }
 
-    void set_seconds_style(StringView seconds_style) { m_seconds_style = time_style_from_string(seconds_style); }
+    void set_seconds_style(ValueStyle seconds_style) { m_seconds_style = seconds_style; }
     ValueStyle seconds_style() const { return m_seconds_style; }
     StringView seconds_style_string() const { return value_style_to_string(m_seconds_style); }
 
-    void set_seconds_display(StringView seconds_display) { m_seconds_display = display_from_string(seconds_display); }
+    void set_seconds_display(Display seconds_display) { m_seconds_display = seconds_display; }
     Display seconds_display() const { return m_seconds_display; }
     StringView seconds_display_string() const { return display_to_string(m_seconds_display); }
 
-    void set_milliseconds_style(StringView milliseconds_style) { m_milliseconds_style = sub_second_style_from_string(milliseconds_style); }
+    void set_milliseconds_style(ValueStyle milliseconds_style) { m_milliseconds_style = milliseconds_style; }
     ValueStyle milliseconds_style() const { return m_milliseconds_style; }
     StringView milliseconds_style_string() const { return value_style_to_string(m_milliseconds_style); }
 
-    void set_milliseconds_display(StringView milliseconds_display) { m_milliseconds_display = display_from_string(milliseconds_display); }
+    void set_milliseconds_display(Display milliseconds_display) { m_milliseconds_display = milliseconds_display; }
     Display milliseconds_display() const { return m_milliseconds_display; }
     StringView milliseconds_display_string() const { return display_to_string(m_milliseconds_display); }
 
-    void set_microseconds_style(StringView microseconds_style) { m_microseconds_style = sub_second_style_from_string(microseconds_style); }
+    void set_microseconds_style(ValueStyle microseconds_style) { m_microseconds_style = microseconds_style; }
     ValueStyle microseconds_style() const { return m_microseconds_style; }
     StringView microseconds_style_string() const { return value_style_to_string(m_microseconds_style); }
 
-    void set_microseconds_display(StringView microseconds_display) { m_microseconds_display = display_from_string(microseconds_display); }
+    void set_microseconds_display(Display microseconds_display) { m_microseconds_display = microseconds_display; }
     Display microseconds_display() const { return m_microseconds_display; }
     StringView microseconds_display_string() const { return display_to_string(m_microseconds_display); }
 
-    void set_nanoseconds_style(StringView nanoseconds_style) { m_nanoseconds_style = sub_second_style_from_string(nanoseconds_style); }
+    void set_nanoseconds_style(ValueStyle nanoseconds_style) { m_nanoseconds_style = nanoseconds_style; }
     ValueStyle nanoseconds_style() const { return m_nanoseconds_style; }
     StringView nanoseconds_style_string() const { return value_style_to_string(m_nanoseconds_style); }
 
-    void set_nanoseconds_display(StringView nanoseconds_display) { m_nanoseconds_display = display_from_string(nanoseconds_display); }
+    void set_nanoseconds_display(Display nanoseconds_display) { m_nanoseconds_display = nanoseconds_display; }
     Display nanoseconds_display() const { return m_nanoseconds_display; }
     StringView nanoseconds_display_string() const { return display_to_string(m_nanoseconds_display); }
 
@@ -155,15 +175,6 @@ public:
 
 private:
     explicit DurationFormat(Object& prototype);
-
-    static Style style_from_string(StringView style);
-    static StringView style_to_string(Style);
-    static ValueStyle date_style_from_string(StringView date_style);
-    static ValueStyle time_style_from_string(StringView time_style);
-    static ValueStyle sub_second_style_from_string(StringView sub_second_style);
-    static StringView value_style_to_string(ValueStyle);
-    static Display display_from_string(StringView display);
-    static StringView display_to_string(Display);
 
     String m_locale;                  // [[Locale]]
     String m_numbering_system;        // [[NumberingSystem]]
@@ -211,13 +222,12 @@ struct DurationRecord {
 struct DurationInstanceComponent {
     double DurationRecord::*value_slot;
     DurationFormat::ValueStyle (DurationFormat::*get_style_slot)() const;
-    void (DurationFormat::*set_style_slot)(StringView);
+    void (DurationFormat::*set_style_slot)(DurationFormat::ValueStyle);
     DurationFormat::Display (DurationFormat::*get_display_slot)() const;
-    void (DurationFormat::*set_display_slot)(StringView);
-    StringView unit;
-    StringView number_format_unit;
+    void (DurationFormat::*set_display_slot)(DurationFormat::Display);
+    DurationFormat::Unit unit;
     ReadonlySpan<StringView> values;
-    StringView digital_default;
+    DurationFormat::ValueStyle digital_default;
 };
 
 // Table 2: DurationFormat instance internal slots and properties relevant to PartitionDurationFormatPattern, https://tc39.es/proposal-intl-duration-format/#table-partition-duration-format-pattern
@@ -225,22 +235,23 @@ struct DurationInstanceComponent {
 static constexpr auto date_values = AK::Array { "long"sv, "short"sv, "narrow"sv };
 static constexpr auto time_values = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv, "2-digit"sv };
 static constexpr auto sub_second_values = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv };
+
 static constexpr auto duration_instances_components = to_array<DurationInstanceComponent>({
-    { &DurationRecord::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, "years"sv, "year"sv, date_values, "short"sv },
-    { &DurationRecord::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, "months"sv, "month"sv, date_values, "short"sv },
-    { &DurationRecord::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, "weeks"sv, "week"sv, date_values, "short"sv },
-    { &DurationRecord::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, "days"sv, "day"sv, date_values, "short"sv },
-    { &DurationRecord::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, "hours"sv, "hour"sv, time_values, "numeric"sv },
-    { &DurationRecord::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, "minutes"sv, "minute"sv, time_values, "numeric"sv },
-    { &DurationRecord::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, "seconds"sv, "second"sv, time_values, "numeric"sv },
-    { &DurationRecord::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, "milliseconds"sv, "millisecond"sv, sub_second_values, "numeric"sv },
-    { &DurationRecord::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, "microseconds"sv, "microsecond"sv, sub_second_values, "numeric"sv },
-    { &DurationRecord::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, "nanoseconds"sv, "nanosecond"sv, sub_second_values, "numeric"sv },
+    { &DurationRecord::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, DurationFormat::Unit::Years, date_values, DurationFormat::ValueStyle::Short },
+    { &DurationRecord::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, DurationFormat::Unit::Months, date_values, DurationFormat::ValueStyle::Short },
+    { &DurationRecord::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, DurationFormat::Unit::Weeks, date_values, DurationFormat::ValueStyle::Short },
+    { &DurationRecord::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, DurationFormat::Unit::Days, date_values, DurationFormat::ValueStyle::Short },
+    { &DurationRecord::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, DurationFormat::Unit::Hours, time_values, DurationFormat::ValueStyle::Numeric },
+    { &DurationRecord::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, DurationFormat::Unit::Minutes, time_values, DurationFormat::ValueStyle::Numeric },
+    { &DurationRecord::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, DurationFormat::Unit::Seconds, time_values, DurationFormat::ValueStyle::Numeric },
+    { &DurationRecord::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, DurationFormat::Unit::Milliseconds, sub_second_values, DurationFormat::ValueStyle::Numeric },
+    { &DurationRecord::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, DurationFormat::Unit::Microseconds, sub_second_values, DurationFormat::ValueStyle::Numeric },
+    { &DurationRecord::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, DurationFormat::Unit::Nanoseconds, sub_second_values, DurationFormat::ValueStyle::Numeric },
 });
 
 struct DurationUnitOptions {
-    String style;
-    String display;
+    DurationFormat::ValueStyle style;
+    DurationFormat::Display display;
 };
 
 struct DurationFormatPart {
@@ -251,13 +262,13 @@ struct DurationFormatPart {
 
 ThrowCompletionOr<DurationRecord> to_duration_record(VM&, Value input);
 i8 duration_sign(DurationRecord const&);
-ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, String const& unit, Object const& options, StringView base_style, ReadonlySpan<StringView> styles_list, StringView digital_base, StringView previous_style, bool two_digit_hours);
+ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, DurationFormat::Unit unit, Object const& options, DurationFormat::Style base_style, ReadonlySpan<StringView> styles_list, DurationFormat::ValueStyle digital_base, Optional<DurationFormat::ValueStyle> previous_style, bool two_digit_hours);
 double compute_fractional_digits(DurationFormat const&, DurationRecord const&);
-bool next_unit_fractional(DurationFormat const&, StringView unit);
+bool next_unit_fractional(DurationFormat const&, DurationFormat::Unit unit);
 Vector<DurationFormatPart> format_numeric_hours(VM&, DurationFormat const&, double hours_value, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_minutes(VM&, DurationFormat const&, double minutes_value, bool hours_displayed, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_seconds(VM&, DurationFormat const&, double seconds_value, bool minutes_displayed, bool sign_displayed);
-Vector<DurationFormatPart> format_numeric_units(VM&, DurationFormat const&, DurationRecord const&, StringView first_numeric_unit, bool sign_displayed);
+Vector<DurationFormatPart> format_numeric_units(VM&, DurationFormat const&, DurationRecord const&, DurationFormat::Unit first_numeric_unit, bool sign_displayed);
 Vector<DurationFormatPart> list_format_parts(VM&, DurationFormat const&, Vector<Vector<DurationFormatPart>>& partitioned_parts_list);
 Vector<DurationFormatPart> partition_duration_format_pattern(VM&, DurationFormat const&, DurationRecord const&);
 

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -59,14 +59,11 @@ public:
     void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }
     String const& numbering_system() const { return m_numbering_system; }
 
-    void set_hours_minutes_separator(String hours_minutes_separator) { m_hours_minutes_separator = move(hours_minutes_separator); }
-    String const& hours_minutes_separator() const { return m_hours_minutes_separator; }
+    void set_hour_minute_separator(String hour_minute_separator) { m_hour_minute_separator = move(hour_minute_separator); }
+    String const& hour_minute_separator() const { return m_hour_minute_separator; }
 
-    void set_minutes_seconds_separator(String minutes_seconds_separator) { m_minutes_seconds_separator = move(minutes_seconds_separator); }
-    String const& minutes_seconds_separator() const { return m_minutes_seconds_separator; }
-
-    void set_two_digit_hours(bool two_digit_hours) { m_two_digit_hours = two_digit_hours; }
-    bool two_digit_hours() const { return m_two_digit_hours; }
+    void set_minute_second_separator(String minute_second_separator) { m_minute_second_separator = move(minute_second_separator); }
+    String const& minute_second_separator() const { return m_minute_second_separator; }
 
     void set_style(StringView style) { m_style = style_from_string(style); }
     Style style() const { return m_style; }
@@ -168,11 +165,10 @@ private:
     static Display display_from_string(StringView display);
     static StringView display_to_string(Display);
 
-    String m_locale;                    // [[Locale]]
-    String m_numbering_system;          // [[NumberingSystem]]
-    String m_hours_minutes_separator;   // [[HourMinutesSeparator]]
-    String m_minutes_seconds_separator; // [[MinutesSecondsSeparator]]
-    bool m_two_digit_hours { false };   // [[TwoDigitHours]]
+    String m_locale;                  // [[Locale]]
+    String m_numbering_system;        // [[NumberingSystem]]
+    String m_hour_minute_separator;   // [[HourMinutesSeparator]]
+    String m_minute_second_separator; // [[MinutesSecondsSeparator]]
 
     Style m_style { Style::Long };                        // [[Style]]
     ValueStyle m_years_style { ValueStyle::Long };        // [[YearsStyle]]
@@ -224,22 +220,23 @@ struct DurationInstanceComponent {
     StringView digital_default;
 };
 
-// Table 1: Components of Duration Instances, https://tc39.es/proposal-intl-duration-format/#table-duration-component
-static constexpr AK::Array<StringView, 3> date_values = { "long"sv, "short"sv, "narrow"sv };
-static constexpr AK::Array<StringView, 5> time_values = { "long"sv, "short"sv, "narrow"sv, "numeric"sv, "2-digit"sv };
-static constexpr AK::Array<StringView, 4> sub_second_values = { "long"sv, "short"sv, "narrow"sv, "numeric"sv };
-static constexpr AK::Array<DurationInstanceComponent, 10> duration_instances_components {
-    DurationInstanceComponent { &DurationRecord::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, "years"sv, "year"sv, date_values, "short"sv },
-    DurationInstanceComponent { &DurationRecord::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, "months"sv, "month"sv, date_values, "short"sv },
-    DurationInstanceComponent { &DurationRecord::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, "weeks"sv, "week"sv, date_values, "short"sv },
-    DurationInstanceComponent { &DurationRecord::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, "days"sv, "day"sv, date_values, "short"sv },
-    DurationInstanceComponent { &DurationRecord::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, "hours"sv, "hour"sv, time_values, "numeric"sv },
-    DurationInstanceComponent { &DurationRecord::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, "minutes"sv, "minute"sv, time_values, "numeric"sv },
-    DurationInstanceComponent { &DurationRecord::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, "seconds"sv, "second"sv, time_values, "numeric"sv },
-    DurationInstanceComponent { &DurationRecord::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, "milliseconds"sv, "millisecond"sv, sub_second_values, "numeric"sv },
-    DurationInstanceComponent { &DurationRecord::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, "microseconds"sv, "microsecond"sv, sub_second_values, "numeric"sv },
-    DurationInstanceComponent { &DurationRecord::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, "nanoseconds"sv, "nanosecond"sv, sub_second_values, "numeric"sv },
-};
+// Table 2: DurationFormat instance internal slots and properties relevant to PartitionDurationFormatPattern, https://tc39.es/proposal-intl-duration-format/#table-partition-duration-format-pattern
+// Table 3: Internal slots and property names of DurationFormat instances relevant to Intl.DurationFormat constructor, https://tc39.es/proposal-intl-duration-format/#table-durationformat
+static constexpr auto date_values = AK::Array { "long"sv, "short"sv, "narrow"sv };
+static constexpr auto time_values = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv, "2-digit"sv };
+static constexpr auto sub_second_values = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv };
+static constexpr auto duration_instances_components = to_array<DurationInstanceComponent>({
+    { &DurationRecord::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, "years"sv, "year"sv, date_values, "short"sv },
+    { &DurationRecord::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, "months"sv, "month"sv, date_values, "short"sv },
+    { &DurationRecord::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, "weeks"sv, "week"sv, date_values, "short"sv },
+    { &DurationRecord::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, "days"sv, "day"sv, date_values, "short"sv },
+    { &DurationRecord::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, "hours"sv, "hour"sv, time_values, "numeric"sv },
+    { &DurationRecord::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, "minutes"sv, "minute"sv, time_values, "numeric"sv },
+    { &DurationRecord::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, "seconds"sv, "second"sv, time_values, "numeric"sv },
+    { &DurationRecord::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, "milliseconds"sv, "millisecond"sv, sub_second_values, "numeric"sv },
+    { &DurationRecord::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, "microseconds"sv, "microsecond"sv, sub_second_values, "numeric"sv },
+    { &DurationRecord::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, "nanoseconds"sv, "nanosecond"sv, sub_second_values, "numeric"sv },
+});
 
 struct DurationUnitOptions {
     String style;
@@ -255,7 +252,7 @@ struct DurationFormatPart {
 ThrowCompletionOr<DurationRecord> to_duration_record(VM&, Value input);
 i8 duration_sign(DurationRecord const&);
 ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, String const& unit, Object const& options, StringView base_style, ReadonlySpan<StringView> styles_list, StringView digital_base, StringView previous_style, bool two_digit_hours);
-double add_fractional_digits(DurationFormat const&, DurationRecord const&);
+double compute_fractional_digits(DurationFormat const&, DurationRecord const&);
 bool next_unit_fractional(DurationFormat const&, StringView unit);
 Vector<DurationFormatPart> format_numeric_hours(VM&, DurationFormat const&, double hours_value, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_minutes(VM&, DurationFormat const&, double minutes_value, bool hours_displayed, bool sign_displayed);

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -9,6 +9,7 @@
 
 #include <AK/Array.h>
 #include <AK/String.h>
+#include <LibCrypto/BigFraction/BigFraction.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibUnicode/Locale.h>
@@ -263,11 +264,11 @@ struct DurationFormatPart {
 ThrowCompletionOr<DurationRecord> to_duration_record(VM&, Value input);
 i8 duration_sign(DurationRecord const&);
 ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, DurationFormat::Unit unit, Object const& options, DurationFormat::Style base_style, ReadonlySpan<StringView> styles_list, DurationFormat::ValueStyle digital_base, Optional<DurationFormat::ValueStyle> previous_style, bool two_digit_hours);
-double compute_fractional_digits(DurationFormat const&, DurationRecord const&);
+Crypto::BigFraction compute_fractional_digits(DurationFormat const&, DurationRecord const&);
 bool next_unit_fractional(DurationFormat const&, DurationFormat::Unit unit);
-Vector<DurationFormatPart> format_numeric_hours(VM&, DurationFormat const&, double hours_value, bool sign_displayed);
-Vector<DurationFormatPart> format_numeric_minutes(VM&, DurationFormat const&, double minutes_value, bool hours_displayed, bool sign_displayed);
-Vector<DurationFormatPart> format_numeric_seconds(VM&, DurationFormat const&, double seconds_value, bool minutes_displayed, bool sign_displayed);
+Vector<DurationFormatPart> format_numeric_hours(VM&, DurationFormat const&, MathematicalValue const& hours_value, bool sign_displayed);
+Vector<DurationFormatPart> format_numeric_minutes(VM&, DurationFormat const&, MathematicalValue const& minutes_value, bool hours_displayed, bool sign_displayed);
+Vector<DurationFormatPart> format_numeric_seconds(VM&, DurationFormat const&, MathematicalValue const& seconds_value, bool minutes_displayed, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_units(VM&, DurationFormat const&, DurationRecord const&, DurationFormat::Unit first_numeric_unit, bool sign_displayed);
 Vector<DurationFormatPart> list_format_parts(VM&, DurationFormat const&, Vector<Vector<DurationFormatPart>>& partitioned_parts_list);
 Vector<DurationFormatPart> partition_duration_format_pattern(VM&, DurationFormat const&, DurationRecord const&);

--- a/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormatPrototype.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -52,7 +52,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format)
     // 5. Let result be a new empty String.
     StringBuilder result;
 
-    // 6. For each Record { [[Type]], [[Value]] } part in parts, do
+    // 6. For each Record { [[Type]], [[Value]], [[Unit]] } part in parts, do
     for (auto const& part : parts) {
         // a. Set result to the string-concatenation of result and part.[[Value]].
         result.append(part.value);
@@ -81,9 +81,9 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
     auto result = MUST(Array::create(realm, 0));
 
     // 6. Let n be 0.
-    // 7. For each { [[Type]], [[Value]] } part in parts, do
+    // 7. For each Record { [[Type]], [[Value]], [[Unit]] } part in parts, do
     for (auto [n, part] : enumerate(parts)) {
-        // a. Let obj be OrdinaryObjectCreate(%ObjectPrototype%).
+        // a. Let obj be OrdinaryObjectCreate(%Object.prototype%).
         auto object = Object::create(realm, realm.intrinsics().object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(obj, "type", part.[[Type]]).
@@ -99,7 +99,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationFormatPrototype::format_to_parts)
         // e. Perform ! CreateDataPropertyOrThrow(result, ! ToString(n), obj).
         MUST(result->create_data_property_or_throw(n, object));
 
-        // f. Increment n by 1.
+        // f. Set n to n + 1.
     }
 
     // 8. Return result.

--- a/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DurationFormat/DurationFormat.prototype.format.js
@@ -145,6 +145,24 @@ describe("correct behavior", () => {
         const de = new Intl.DurationFormat("de", { style: "digital" });
         expect(de.format(duration)).toBe("123456:456789:789123");
     });
+
+    test("precise mathematical values", () => {
+        const en = new Intl.DurationFormat("en", { style: "digital" });
+
+        let duration = {
+            seconds: 10000000,
+            nanoseconds: 1,
+        };
+        expect(en.format(duration)).toBe("0:00:10000000.000000001");
+
+        duration = {
+            seconds: 1,
+            milliseconds: 2,
+            microseconds: 3,
+            nanoseconds: Number.MAX_SAFE_INTEGER,
+        };
+        expect(en.format(duration)).toBe("0:00:9007200.256743991");
+    });
 });
 
 describe("errors", () => {

--- a/Tests/LibCrypto/TestBigFraction.cpp
+++ b/Tests/LibCrypto/TestBigFraction.cpp
@@ -23,6 +23,6 @@ TEST_CASE(roundtrip_from_string)
     for (auto valid_number_string : valid_number_strings) {
         auto result = TRY_OR_FAIL(Crypto::BigFraction::from_string(valid_number_string));
         auto precision = valid_number_string.length() - valid_number_string.find('.').value();
-        EXPECT_EQ(result.to_byte_string(precision), valid_number_string);
+        EXPECT_EQ(result.to_string(precision), valid_number_string);
     }
 }


### PR DESCRIPTION
test262 diff (from the last commit):
```
Diff Tests:
    test/intl402/DurationFormat/prototype/format/negative-zero.js                       ❌ -> ✅
    test/intl402/DurationFormat/prototype/format/precision-exact-mathematical-values.js ❌ -> ✅
```

We now pass all Intl.DurationFormat tests:
```
test/intl402/DurationFormat    102/102   (100.00%) [ ✅ 102   ]
```