### PR TITLE
LibWeb: Treat min{max}-height as none if available is intrinsic [GFC]

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1965,6 +1965,12 @@ bool FormattingContext::should_treat_max_height_as_none(Box const& box, Availabl
         if (!m_state.get(*box.non_anonymous_containing_block()).has_definite_height())
             return true;
     }
+    if (max_height.is_fit_content() && available_height.is_intrinsic_sizing_constraint())
+        return true;
+    if (max_height.is_max_content() && available_height.is_max_content())
+        return true;
+    if (max_height.is_min_content() && available_height.is_min_content())
+        return true;
     return false;
 }
 

--- a/Tests/LibWeb/Layout/expected/grid/max-height-fit-content.txt
+++ b/Tests/LibWeb/Layout/expected/grid/max-height-fit-content.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x17 [GFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x17 [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
+    PaintableBox (Box<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/grid/max-height-fit-content.html
+++ b/Tests/LibWeb/Layout/input/grid/max-height-fit-content.html
@@ -1,0 +1,6 @@
+<!doctype html><style>
+    body {
+        display: grid;
+        max-height: fit-content;
+    }
+</style>hello


### PR DESCRIPTION
Fixes infinite recursion in following cases:
- max-height: fit-content
- max-height: min-content
- max-height: max-content