### PR TITLE
LibGfx: Unify bitmap set_pixel() using templates

### DIFF
--- a/Libraries/LibGfx/PaintStyle.h
+++ b/Libraries/LibGfx/PaintStyle.h
@@ -12,7 +12,6 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
-#include <LibGfx/Bitmap.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Gradients.h>


### PR DESCRIPTION
This ensures some compile-time assertions (all possible color storage formats are implemented) and fixes
> FIXME: There's a lot of inaccurately named functions in the Color class right now (RGBA vs BGRA).