### PR TITLE
AK: Store JSON keys and values as WTF-8 strings

### DIFF
--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -108,7 +108,7 @@ Optional<bool> JsonObject::get_bool(StringView key) const
     return {};
 }
 
-Optional<ByteString> JsonObject::get_byte_string(StringView key) const
+Optional<String> JsonObject::get_string(StringView key) const
 {
     auto maybe_value = get(key);
     if (maybe_value.has_value() && maybe_value->is_string())
@@ -237,7 +237,7 @@ bool JsonObject::has_object(StringView key) const
     return value.has_value() && value->is_object();
 }
 
-void JsonObject::set(ByteString const& key, JsonValue value)
+void JsonObject::set(FlyString const& key, JsonValue value)
 {
     m_members.set(key, move(value));
 }

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -42,36 +42,6 @@ public:
         return {};
     }
 
-    ErrorOr<void> add(StringView key, StringView value)
-    {
-        TRY(begin_item(key));
-        if constexpr (IsLegacyBuilder<Builder>) {
-            TRY(m_builder.try_append('"'));
-            TRY(m_builder.try_append_escaped_for_json(value));
-            TRY(m_builder.try_append('"'));
-        } else {
-            TRY(m_builder.append('"'));
-            TRY(m_builder.append_escaped_for_json(value));
-            TRY(m_builder.append('"'));
-        }
-        return {};
-    }
-
-    ErrorOr<void> add(StringView key, ByteString const& value)
-    {
-        TRY(begin_item(key));
-        if constexpr (IsLegacyBuilder<Builder>) {
-            TRY(m_builder.try_append('"'));
-            TRY(m_builder.try_append_escaped_for_json(value));
-            TRY(m_builder.try_append('"'));
-        } else {
-            TRY(m_builder.append('"'));
-            TRY(m_builder.append_escaped_for_json(value));
-            TRY(m_builder.append('"'));
-        }
-        return {};
-    }
-
     ErrorOr<void> add(StringView key, char const* value)
     {
         TRY(begin_item(key));

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -31,7 +31,7 @@ constexpr bool is_space(int ch)
 //                             │                       │
 //                             ╰─── u[0-9A-Za-z]{4}  ──╯
 //
-ErrorOr<ByteString> JsonParser::consume_and_unescape_string()
+ErrorOr<String> JsonParser::consume_and_unescape_string()
 {
     if (!consume_specific('"'))
         return Error::from_string_literal("JsonParser: Expected '\"'");
@@ -126,7 +126,7 @@ ErrorOr<ByteString> JsonParser::consume_and_unescape_string()
         }
     }
 
-    return final_sb.to_byte_string();
+    return final_sb.to_string();
 }
 
 ErrorOr<JsonValue> JsonParser::parse_object()

--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -23,7 +23,7 @@ public:
 private:
     ErrorOr<JsonValue> parse_helper();
 
-    ErrorOr<ByteString> consume_and_unescape_string();
+    ErrorOr<String> consume_and_unescape_string();
     ErrorOr<JsonValue> parse_array();
     ErrorOr<JsonValue> parse_object();
     ErrorOr<JsonValue> parse_number();

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -20,7 +20,7 @@ using JsonValueStorage = Variant<
     i64,
     u64,
     double,
-    ByteString,
+    String,
     NonnullOwnPtr<JsonArray>,
     NonnullOwnPtr<JsonObject>>;
 
@@ -165,7 +165,7 @@ JsonValue::JsonValue(long long unsigned value)
 }
 
 JsonValue::JsonValue(char const* cstring)
-    : m_value(ByteString { cstring })
+    : m_value(MUST(String::from_utf8({ cstring, strlen(cstring) })))
 {
 }
 
@@ -174,13 +174,23 @@ JsonValue::JsonValue(double value)
 {
 }
 
+JsonValue::JsonValue(String value)
+    : m_value(move(value))
+{
+}
+
+JsonValue::JsonValue(FlyString const& value)
+    : m_value(value.to_string())
+{
+}
+
 JsonValue::JsonValue(ByteString const& value)
-    : m_value(value)
+    : m_value(MUST(String::from_byte_string(value)))
 {
 }
 
 JsonValue::JsonValue(StringView value)
-    : m_value(ByteString { value })
+    : m_value(MUST(String::from_utf8(value)))
 {
 }
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -56,6 +56,15 @@ public:
     {
     }
 
+    template<typename T>
+    requires(Detail::IsConstructible<JsonValue, T>)
+    JsonValue(Optional<T> value)
+        : JsonValue()
+    {
+        if (value.has_value())
+            exchange(*this, value.release_value());
+    }
+
     JsonValue(JsonArray const&);
     JsonValue(JsonObject const&);
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/Forward.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 
 namespace AK {
@@ -46,6 +46,8 @@ public:
 
     JsonValue(double);
     JsonValue(char const*);
+    JsonValue(String);
+    JsonValue(FlyString const&);
     JsonValue(ByteString const&);
     JsonValue(StringView);
 
@@ -82,18 +84,11 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    ByteString as_string_or(ByteString const& alternative) const
+    String as_string_or(String const& alternative) const
     {
         if (is_string())
             return as_string();
         return alternative;
-    }
-
-    ByteString deprecated_to_byte_string() const
-    {
-        if (is_string())
-            return as_string();
-        return serialized<StringBuilder>();
     }
 
     Optional<int> get_int() const { return get_integer<int>(); }
@@ -133,9 +128,9 @@ public:
         return m_value.get<bool>();
     }
 
-    ByteString const& as_string() const
+    String const& as_string() const
     {
-        return m_value.get<ByteString>();
+        return m_value.get<String>();
     }
 
     JsonObject& as_object()
@@ -169,14 +164,14 @@ public:
             [](Empty const&) { return Type::Null; },
             [](bool const&) { return Type::Bool; },
             [](Arithmetic auto const&) { return Type::Number; },
-            [](ByteString const&) { return Type::String; },
+            [](String const&) { return Type::String; },
             [](NonnullOwnPtr<JsonArray> const&) { return Type::Array; },
             [](NonnullOwnPtr<JsonObject> const&) { return Type::Object; });
     }
 
     bool is_null() const { return m_value.has<Empty>(); }
     bool is_bool() const { return m_value.has<bool>(); }
-    bool is_string() const { return m_value.has<ByteString>(); }
+    bool is_string() const { return m_value.has<String>(); }
     bool is_array() const { return m_value.has<NonnullOwnPtr<JsonArray>>(); }
     bool is_object() const { return m_value.has<NonnullOwnPtr<JsonObject>>(); }
     bool is_number() const
@@ -237,7 +232,7 @@ private:
         i64,
         u64,
         double,
-        ByteString,
+        String,
         NonnullOwnPtr<JsonArray>,
         NonnullOwnPtr<JsonObject>>
         m_value;

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/FlyString.h>
 #include <AK/GenericLexer.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
@@ -54,6 +55,11 @@ public:
             VERIFY_NOT_REACHED();
         }
         m_mapping.set(key, move(value));
+    }
+
+    void set(StringView key, FlyString const& value)
+    {
+        set(key, value.to_string());
     }
 
     String get(StringView key) const
@@ -116,7 +122,13 @@ public:
     template<size_t N>
     void set(char const (&key)[N], String value)
     {
-        set(StringView { key, N - 1 }, value);
+        set(StringView { key, N - 1 }, move(value));
+    }
+
+    template<size_t N>
+    void set(char const (&key)[N], FlyString const& value)
+    {
+        set(key, value.to_string());
     }
 
     template<size_t N>

--- a/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Libraries/LibJS/Runtime/JSONObject.h
@@ -39,7 +39,7 @@ private:
     static ThrowCompletionOr<Optional<ByteString>> serialize_json_property(VM&, StringifyState&, PropertyKey const& key, Object* holder);
     static ThrowCompletionOr<ByteString> serialize_json_object(VM&, StringifyState&, Object&);
     static ThrowCompletionOr<ByteString> serialize_json_array(VM&, StringifyState&, Object&);
-    static ByteString quote_json_string(ByteString);
+    static ByteString quote_json_string(StringView);
 
     // Parse helpers
     static Object* parse_json_object(VM&, JsonObject const&);

--- a/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Libraries/LibTest/JavaScriptTestRunner.h
@@ -370,18 +370,18 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
         file_result.logged_messages.append(message.to_string_without_side_effects().to_byte_string());
     }
 
-    test_json.value().as_object().for_each_member([&](ByteString const& suite_name, JsonValue const& suite_value) {
+    test_json.value().as_object().for_each_member([&](FlyString const& suite_name, JsonValue const& suite_value) {
         Test::Suite suite { test_path, suite_name };
 
         VERIFY(suite_value.is_object());
 
-        suite_value.as_object().for_each_member([&](ByteString const& test_name, JsonValue const& test_value) {
-            Test::Case test { test_name, Test::Result::Fail, "", 0 };
+        suite_value.as_object().for_each_member([&](FlyString const& test_name, JsonValue const& test_value) {
+            Test::Case test { test_name, Test::Result::Fail, ""_string, 0 };
 
             VERIFY(test_value.is_object());
             VERIFY(test_value.as_object().has("result"sv));
 
-            auto result = test_value.as_object().get_byte_string("result"sv);
+            auto result = test_value.as_object().get_string("result"sv);
             VERIFY(result.has_value());
             auto result_string = result.value();
             if (result_string == "pass") {
@@ -392,7 +392,7 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
                 m_counts.tests_failed++;
                 suite.most_severe_test_result = Test::Result::Fail;
                 VERIFY(test_value.as_object().has("details"sv));
-                auto details = test_value.as_object().get_byte_string("details"sv);
+                auto details = test_value.as_object().get_string("details"sv);
                 VERIFY(result.has_value());
                 test.details = details.value();
             } else if (result_string == "xfail") {
@@ -427,10 +427,10 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
     });
 
     if (top_level_result.is_error()) {
-        Test::Suite suite { test_path, "<top-level>" };
+        Test::Suite suite { test_path, "<top-level>"_string };
         suite.most_severe_test_result = Result::Crashed;
 
-        Test::Case test_case { "<top-level>", Test::Result::Fail, "", 0 };
+        Test::Case test_case { "<top-level>"_string, Test::Result::Fail, ""_string, 0 };
         auto error = top_level_result.release_error().release_value().release_value();
         if (error.is_object()) {
             StringBuilder detail_builder;
@@ -453,9 +453,9 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
                 detail_builder.append(error_as_error.stack_string());
             }
 
-            test_case.details = detail_builder.to_byte_string();
+            test_case.details = MUST(detail_builder.to_string());
         } else {
-            test_case.details = error.to_string_without_side_effects().to_byte_string();
+            test_case.details = error.to_string_without_side_effects();
         }
 
         suite.tests.append(move(test_case));

--- a/Libraries/LibTest/Results.h
+++ b/Libraries/LibTest/Results.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/FlyString.h>
 #include <AK/Vector.h>
 
 namespace Test {
@@ -23,15 +24,15 @@ enum class Result {
 };
 
 struct Case {
-    ByteString name;
+    FlyString name;
     Result result;
-    ByteString details;
+    String details;
     u64 duration_us;
 };
 
 struct Suite {
     ByteString path;
-    ByteString name;
+    FlyString name;
     // A failed test takes precedence over a skipped test, which both have
     // precedence over a passed test
     Result most_severe_test_result { Result::Pass };

--- a/Libraries/LibTest/TestRunner.h
+++ b/Libraries/LibTest/TestRunner.h
@@ -243,7 +243,7 @@ inline void TestRunner::print_test_results_as_json() const
 
                 auto name = suite.name;
                 if (name == "__$$TOP_LEVEL$$__"sv)
-                    name = ByteString::empty();
+                    name = String {};
 
                 auto path = *LexicalPath::relative_path(suite.path, m_test_root);
 

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -105,7 +105,7 @@ static Optional<ActionObject::Origin> determine_origin(ActionsOptions const& act
 
     if (origin->is_object()) {
         if (actions_options.is_element_origin(origin->as_object()))
-            return MUST(String::from_byte_string(extract_web_element_reference(origin->as_object())));
+            return extract_web_element_reference(origin->as_object());
     }
 
     return {};
@@ -554,7 +554,7 @@ static ErrorOr<Vector<ActionObject>, WebDriver::Error> process_input_source_acti
 
     // 3. Let id be the result of getting the property "id" from action sequence.
     // 4. If id is undefined or is not a String, return error with error code invalid argument.
-    auto const id = MUST(String::from_byte_string(TRY(get_property(action_sequence, "id"sv))));
+    auto const id = TRY(get_property(action_sequence, "id"sv));
 
     // 5. If type is equal to "pointer", let parameters data be the result of getting the property "parameters" from
     //    action sequence. Then let parameters be the result of trying to process pointer parameters with argument

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -279,8 +279,8 @@ static bool matches_platform_name(StringView requested_platform_name, StringView
 // https://w3c.github.io/webdriver/#dfn-matching-capabilities
 static JsonValue match_capabilities(JsonObject const& capabilities)
 {
-    static auto browser_name = StringView { BROWSER_NAME, strlen(BROWSER_NAME) }.to_lowercase_string();
-    static auto platform_name = StringView { OS_STRING, strlen(OS_STRING) }.to_lowercase_string();
+    static auto browser_name = MUST(String::from_byte_string(StringView { BROWSER_NAME, strlen(BROWSER_NAME) }.to_lowercase_string()));
+    static auto platform_name = MUST(String::from_byte_string(StringView { OS_STRING, strlen(OS_STRING) }.to_lowercase_string()));
 
     // 1. Let matched capabilities be a JSON Object with the following entries:
     JsonObject matched_capabilities;
@@ -314,20 +314,20 @@ static JsonValue match_capabilities(JsonObject const& capabilities)
         // -> "browserName"
         if (name == "browserName"sv) {
             // If value is not a string equal to the "browserName" entry in matched capabilities, return success with data null.
-            if (value.as_string() != matched_capabilities.get_byte_string(name).value())
+            if (value.as_string() != matched_capabilities.get_string(name).value())
                 return AK::Error::from_string_literal("browserName");
         }
         // -> "browserVersion"
         else if (name == "browserVersion"sv) {
             // Compare value to the "browserVersion" entry in matched capabilities using an implementation-defined comparison algorithm. The comparison is to accept a value that places constraints on the version using the "<", "<=", ">", and ">=" operators.
             // If the two values do not match, return success with data null.
-            if (!matches_browser_version(value.as_string(), matched_capabilities.get_byte_string(name).value()))
+            if (!matches_browser_version(value.as_string(), matched_capabilities.get_string(name).value()))
                 return AK::Error::from_string_literal("browserVersion");
         }
         // -> "platformName"
         else if (name == "platformName"sv) {
             // If value is not a string equal to the "platformName" entry in matched capabilities, return success with data null.
-            if (!matches_platform_name(value.as_string(), matched_capabilities.get_byte_string(name).value()))
+            if (!matches_platform_name(value.as_string(), matched_capabilities.get_string(name).value()))
                 return AK::Error::from_string_literal("platformName");
         }
         // -> "acceptInsecureCerts"

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -192,9 +192,9 @@ ErrorOr<GC::Ref<Web::DOM::Element>, WebDriver::Error> deserialize_web_element(We
     return element;
 }
 
-ByteString extract_web_element_reference(JsonObject const& object)
+String extract_web_element_reference(JsonObject const& object)
 {
-    return object.get_byte_string(web_element_identifier).release_value();
+    return object.get_string(web_element_identifier).release_value();
 }
 
 // https://w3c.github.io/webdriver/#dfn-get-a-webelement-origin
@@ -459,7 +459,7 @@ ErrorOr<GC::Ref<Web::DOM::ShadowRoot>, WebDriver::Error> deserialize_shadow_root
         return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Object is not a Shadow Root");
 
     // 2. Let reference be the result of getting the shadow root identifier property from object.
-    auto reference = object.get_byte_string(shadow_root_identifier).release_value();
+    auto reference = object.get_string(shadow_root_identifier).release_value();
 
     // 3. Let shadow be the result of trying to get a known shadow root with session and reference.
     auto shadow = TRY(get_known_shadow_root(browsing_context, reference));

--- a/Libraries/LibWeb/WebDriver/ElementReference.h
+++ b/Libraries/LibWeb/WebDriver/ElementReference.h
@@ -28,7 +28,7 @@ bool represents_a_web_element(JsonValue const&);
 bool represents_a_web_element(JS::Value);
 ErrorOr<GC::Ref<Web::DOM::Element>, WebDriver::Error> deserialize_web_element(Web::HTML::BrowsingContext const&, JsonObject const&);
 ErrorOr<GC::Ref<Web::DOM::Element>, WebDriver::Error> deserialize_web_element(Web::HTML::BrowsingContext const&, JS::Object const&);
-ByteString extract_web_element_reference(JsonObject const&);
+String extract_web_element_reference(JsonObject const&);
 ErrorOr<GC::Ref<Web::DOM::Element>, Web::WebDriver::Error> get_web_element_origin(Web::HTML::BrowsingContext const&, StringView origin);
 ErrorOr<GC::Ref<Web::DOM::Element>, Web::WebDriver::Error> get_known_element(Web::HTML::BrowsingContext const&, StringView reference);
 

--- a/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -22,7 +22,7 @@
 namespace Web::WebDriver {
 
 // https://w3c.github.io/webdriver/#dfn-execute-a-function-body
-static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingContext const& browsing_context, ByteString const& body, ReadonlySpan<JS::Value> parameters)
+static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingContext const& browsing_context, String const& body, ReadonlySpan<JS::Value> parameters)
 {
     // 1. Let window be the associated window of the current browsing context’s active document.
     auto window = browsing_context.active_document()->window();
@@ -84,7 +84,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingCo
     return completion;
 }
 
-void execute_script(HTML::BrowsingContext const& browsing_context, ByteString body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
+void execute_script(HTML::BrowsingContext const& browsing_context, String body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
 {
     auto const* document = browsing_context.active_document();
     auto& realm = document->realm();
@@ -141,7 +141,7 @@ void execute_script(HTML::BrowsingContext const& browsing_context, ByteString bo
     WebIDL::react_to_promise(promise, reaction_steps, reaction_steps);
 }
 
-void execute_async_script(HTML::BrowsingContext const& browsing_context, ByteString body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
+void execute_async_script(HTML::BrowsingContext const& browsing_context, String body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
 {
     auto const* document = browsing_context.active_document();
     auto& realm = document->realm();

--- a/Libraries/LibWeb/WebDriver/ExecuteScript.h
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.h
@@ -23,7 +23,7 @@ struct ExecutionResult {
 
 using OnScriptComplete = GC::Function<void(ExecutionResult)>;
 
-void execute_script(HTML::BrowsingContext const&, ByteString body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
-void execute_async_script(HTML::BrowsingContext const&, ByteString body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
+void execute_script(HTML::BrowsingContext const&, String body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
+void execute_async_script(HTML::BrowsingContext const&, String body, GC::MarkedVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
 
 }

--- a/Libraries/LibWeb/WebDriver/JSON.cpp
+++ b/Libraries/LibWeb/WebDriver/JSON.cpp
@@ -183,7 +183,7 @@ static Response internal_json_clone(HTML::BrowsingContext const& browsing_contex
     if (value.is_number())
         return JsonValue { value.as_double() };
     if (value.is_string())
-        return JsonValue { value.as_string().byte_string() };
+        return JsonValue { value.as_string().utf8_string() };
 
     // AD-HOC: BigInt and Symbol not mentioned anywhere in the WebDriver spec, as it references ES5.
     //         It assumes that all primitives are handled above, and the value is an object for the remaining steps.
@@ -257,7 +257,7 @@ static Response internal_json_clone(HTML::BrowsingContext const& browsing_contex
         if (!to_json_result.is_string())
             return WebDriver::Error::from_code(ErrorCode::JavascriptError, "toJSON did not return a String"sv);
 
-        return JsonValue { to_json_result.as_string().byte_string() };
+        return JsonValue { to_json_result.as_string().utf8_string() };
     }
 
     // -> Otherwise

--- a/Libraries/LibWeb/WebDriver/Properties.h
+++ b/Libraries/LibWeb/WebDriver/Properties.h
@@ -15,7 +15,7 @@
 
 namespace Web::WebDriver {
 
-template<typename PropertyType = ByteString>
+template<typename PropertyType = String>
 static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& payload, StringView key)
 {
     auto property = payload.get(key);
@@ -37,7 +37,7 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& pa
         return true;
     };
 
-    if constexpr (IsSame<PropertyType, ByteString>) {
+    if constexpr (IsSame<PropertyType, String>) {
         if (!property->is_string())
             return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a String", key));
         return property->as_string();
@@ -67,7 +67,7 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& pa
     }
 }
 
-template<typename PropertyType = ByteString>
+template<typename PropertyType = String>
 static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonValue const& payload, StringView key)
 {
     if (!payload.is_object())
@@ -75,7 +75,7 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonValue const& pay
     return get_property<PropertyType>(payload.as_object(), key);
 }
 
-template<typename PropertyType = ByteString>
+template<typename PropertyType = String>
 static ErrorOr<Optional<PropertyType>, WebDriver::Error> get_optional_property(JsonObject const& object, StringView key)
 {
     if (!object.has(key))

--- a/Libraries/LibWebView/Attribute.cpp
+++ b/Libraries/LibWebView/Attribute.cpp
@@ -11,7 +11,7 @@
 template<>
 ErrorOr<void> IPC::encode(Encoder& encoder, WebView::Attribute const& attribute)
 {
-    TRY(encoder.encode(attribute.name));
+    TRY(encoder.encode(attribute.name.to_string()));
     TRY(encoder.encode(attribute.value));
     return {};
 }
@@ -22,5 +22,5 @@ ErrorOr<WebView::Attribute> IPC::decode(Decoder& decoder)
     auto name = TRY(decoder.decode<String>());
     auto value = TRY(decoder.decode<String>());
 
-    return WebView::Attribute { move(name), move(value) };
+    return WebView::Attribute { name, move(value) };
 }

--- a/Libraries/LibWebView/Attribute.h
+++ b/Libraries/LibWebView/Attribute.h
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <AK/FlyString.h>
 #include <AK/String.h>
 #include <LibIPC/Forward.h>
 
 namespace WebView {
 
 struct Attribute {
-    String name;
+    FlyString name;
     String value;
 };
 

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -309,9 +309,9 @@ void ViewImplementation::add_dom_node_attributes(Web::UniqueNodeID node_id, Vect
     client().async_add_dom_node_attributes(page_id(), node_id, move(attributes));
 }
 
-void ViewImplementation::replace_dom_node_attribute(Web::UniqueNodeID node_id, String name, Vector<Attribute> replacement_attributes)
+void ViewImplementation::replace_dom_node_attribute(Web::UniqueNodeID node_id, FlyString name, Vector<Attribute> replacement_attributes)
 {
-    client().async_replace_dom_node_attribute(page_id(), node_id, move(name), move(replacement_attributes));
+    client().async_replace_dom_node_attribute(page_id(), node_id, name.to_string(), move(replacement_attributes));
 }
 
 void ViewImplementation::create_child_element(Web::UniqueNodeID node_id)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -100,7 +100,7 @@ public:
     void set_dom_node_text(Web::UniqueNodeID node_id, String text);
     void set_dom_node_tag(Web::UniqueNodeID node_id, String name);
     void add_dom_node_attributes(Web::UniqueNodeID node_id, Vector<Attribute> attributes);
-    void replace_dom_node_attribute(Web::UniqueNodeID node_id, String name, Vector<Attribute> replacement_attributes);
+    void replace_dom_node_attribute(Web::UniqueNodeID node_id, FlyString name, Vector<Attribute> replacement_attributes);
     void create_child_element(Web::UniqueNodeID node_id);
     void create_child_text_node(Web::UniqueNodeID node_id);
     void clone_dom_node(Web::UniqueNodeID node_id);

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateAriaRoles.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateAriaRoles.cpp
@@ -29,8 +29,8 @@ namespace Web::ARIA {
         JsonObject const& value_object = value.as_object();
 
         auto class_definition_generator = generator.fork();
-        class_definition_generator.set("spec_link"sv, value_object.get_byte_string("specLink"sv).value());
-        class_definition_generator.set("description"sv, value_object.get_byte_string("description"sv).value());
+        class_definition_generator.set("spec_link"sv, value_object.get_string("specLink"sv).value());
+        class_definition_generator.set("description"sv, value_object.get_string("description"sv).value());
         class_definition_generator.set("name"sv, name);
         class_definition_generator.append(R"~~~(
 // @spec_link@

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -128,7 +128,7 @@ Optional<@name:titlecase@> keyword_to_@name:snakecase@(Keyword keyword)
             auto member_generator = enum_generator.fork();
             auto member_name = member.as_string();
             if (member_name.contains('=')) {
-                auto parts = member_name.split_view('=');
+                auto parts = member_name.bytes_as_string_view().split_view('=');
                 member_generator.set("valueid:titlecase", title_casify(parts[0]));
                 member_generator.set("member:titlecase", title_casify(parts[1]));
             } else {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
@@ -155,7 +155,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(PropertyID property_id, Func
             // Generate some type checks
             VERIFY(parameters.size() == 1);
             auto& parameter_data = parameters[0].as_object();
-            auto parameter_type_string = parameter_data.get_byte_string("type"sv).value();
+            auto parameter_type_string = parameter_data.get_string("type"sv).value();
             function_generator.set("type_check", generate_calculation_type_check("argument_type"sv, parameter_type_string));
             function_generator.append(R"~~~(
             if (!(@type_check@)) {
@@ -204,11 +204,11 @@ OwnPtr<CalculationNode> Parser::parse_math_function(PropertyID property_id, Func
             StringView previous_parameter_type_string;
             parameters.for_each([&](JsonValue const& parameter_value) {
                 auto& parameter = parameter_value.as_object();
-                auto parameter_type_string = parameter.get_byte_string("type"sv).value();
+                auto parameter_type_string = parameter.get_string("type"sv).value();
                 auto parameter_required = parameter.get_bool("required"sv).value();
 
                 auto parameter_generator = function_generator.fork();
-                parameter_generator.set("parameter_name", parameter.get_byte_string("name"sv).value());
+                parameter_generator.set("parameter_name", parameter.get_string("name"sv).value());
                 parameter_generator.set("parameter_index", String::number(parameter_index));
 
                 bool parameter_is_calculation;
@@ -218,7 +218,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(PropertyID property_id, Func
                     parameter_generator.set("parse_function", "parse_rounding_strategy(arguments[argument_index])"_string);
                     parameter_generator.set("check_function", ".has_value()"_string);
                     parameter_generator.set("release_function", ".release_value()"_string);
-                    if (auto default_value = parameter.get_byte_string("default"sv); default_value.has_value()) {
+                    if (auto default_value = parameter.get_string("default"sv); default_value.has_value()) {
                         parameter_generator.set("parameter_default", MUST(String::formatted(" = RoundingStrategy::{}", title_casify(default_value.value()))));
                     } else {
                         parameter_generator.set("parameter_default", ""_string);
@@ -233,7 +233,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(PropertyID property_id, Func
 
                     // NOTE: We have exactly one default value in the data right now, and it's a `<calc-constant>`,
                     //       so that's all we handle.
-                    if (auto default_value = parameter.get_byte_string("default"sv); default_value.has_value()) {
+                    if (auto default_value = parameter.get_string("default"sv); default_value.has_value()) {
                         parameter_generator.set("parameter_default", MUST(String::formatted(" = ConstantCalculationNode::create(CalculationNode::constant_type_from_string(\"{}\"sv).value())", default_value.value())));
                     } else {
                         parameter_generator.set("parameter_default", ""_string);
@@ -316,7 +316,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(PropertyID property_id, Func
             parameter_index = 0;
             parameters.for_each([&](JsonValue const& parameter_value) {
                 auto& parameter = parameter_value.as_object();
-                auto parameter_type_string = parameter.get_byte_string("type"sv).value();
+                auto parameter_type_string = parameter.get_string("type"sv).value();
 
                 auto parameter_generator = function_generator.fork();
                 parameter_generator.set("parameter_index"sv, String::number(parameter_index));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -140,7 +140,7 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
         auto member_generator = generator.fork();
         member_generator.set("name:titlecase", title_casify(name));
         VERIFY(feature.has("type"sv));
-        auto feature_type = feature.get_byte_string("type"sv);
+        auto feature_type = feature.get_string("type"sv);
         VERIFY(feature_type.has_value());
         member_generator.set("is_range", feature_type.value() == "range" ? "true"_string : "false"_string);
         member_generator.append(R"~~~(
@@ -182,7 +182,7 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
                 VERIFY(type.is_string());
                 auto type_name = type.as_string();
                 // Skip keywords.
-                if (type_name[0] != '<')
+                if (!type_name.starts_with_bytes("<"sv))
                     continue;
                 if (type_name == "<mq-boolean>") {
                     append_value_type_switch_if_needed();
@@ -260,7 +260,7 @@ bool media_feature_accepts_keyword(MediaFeatureID media_feature_id, Keyword keyw
                 VERIFY(keyword.is_string());
                 auto keyword_name = keyword.as_string();
                 // Skip types.
-                if (keyword_name[0] == '<')
+                if (keyword_name.starts_with_bytes("<"sv))
                     continue;
                 append_keyword_switch_if_needed();
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -149,14 +149,14 @@ PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
     pseudo_classes_data.for_each_member([&](auto& name, JsonValue const& value) {
         auto member_generator = generator.fork();
         auto& pseudo_class = value.as_object();
-        auto argument_string = pseudo_class.get_byte_string("argument"sv).value();
+        auto argument_string = pseudo_class.get_string("argument"sv).value();
 
         bool is_valid_as_identifier = argument_string.is_empty();
         bool is_valid_as_function = !argument_string.is_empty();
 
         if (argument_string.ends_with('?')) {
             is_valid_as_identifier = true;
-            argument_string = argument_string.substring(0, argument_string.length() - 1);
+            argument_string = MUST(argument_string.substring_from_byte_offset(0, argument_string.bytes_as_string_view().length() - 1));
         }
 
         String parameter_type = "None"_string;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSStyleProperties.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSStyleProperties.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     return 0;
 }
 
-static String get_snake_case_function_name_for_css_property_name(ByteString const& name)
+static String get_snake_case_function_name_for_css_property_name(FlyString const& name)
 {
     auto snake_case_name = snake_casify(name);
     if (snake_case_name.starts_with('_'))
@@ -182,7 +182,7 @@ interface mixin GeneratedCSSStyleProperties {
         // For each CSS property property that is a supported CSS property and that begins with the string -webkit-,
         // the following partial interface applies where webkit-cased attribute is obtained by running the CSS property
         // to IDL attribute algorithm for property, with the lowercase first flag set.
-        if (name.starts_with("-webkit-"sv)) {
+        if (name.starts_with_bytes("-webkit-"sv)) {
             member_generator.set("name:webkit", css_property_to_idl_attribute(name, /* lowercase_first= */ true));
             member_generator.append(R"~~~(
     [CEReactions, LegacyNullToEmptyString, AttributeCallbackName=@name:snakecase@_webkit, ImplementedAs=@name:acceptable_cpp@] attribute CSSOMString @name:webkit@;
@@ -195,7 +195,7 @@ interface mixin GeneratedCSSStyleProperties {
         // partial interface CSSStyleProperties {
         //     [CEReactions] attribute [LegacyNullToEmptyString] CSSOMString _dashed_attribute;
         // };
-        if (name.contains('-')) {
+        if (name.bytes_as_string_view().contains('-')) {
             member_generator.append(R"~~~(
     [CEReactions, LegacyNullToEmptyString, AttributeCallbackName=@name:snakecase@_dashed, ImplementedAs=@name:acceptable_cpp@] attribute CSSOMString @name@;
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -171,7 +171,8 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
         JsonArray const& parameters = value.as_object().get_array("parameters"sv).value();
         bool first = true;
         parameters.for_each([&](JsonValue const& value) {
-            GenericLexer lexer { value.as_object().get_byte_string("type"sv).value() };
+            auto buffer = value.as_object().get_string("type"sv).value();
+            GenericLexer lexer { buffer };
             VERIFY(lexer.consume_specific('<'));
             auto parameter_type_name = lexer.consume_until('>');
             VERIFY(lexer.consume_specific('>'));

--- a/Services/WebContent/WebDriverConnection.h
+++ b/Services/WebContent/WebDriverConnection.h
@@ -124,7 +124,7 @@ private:
 
     Web::WebDriver::Response element_click_impl(String const& element_id);
     Web::WebDriver::Response element_clear_impl(String const& element_id);
-    Web::WebDriver::Response element_send_keys_impl(String const& element_id, ByteString const& text);
+    Web::WebDriver::Response element_send_keys_impl(String const& element_id, String const& text);
     Web::WebDriver::Response add_cookie_impl(JsonObject const&);
 
     void handle_any_user_prompts(Function<void()> on_dialog_closed);
@@ -142,10 +142,10 @@ private:
 
     using GetStartNode = GC::Ref<GC::Function<ErrorOr<GC::Ref<Web::DOM::ParentNode>, Web::WebDriver::Error>()>>;
     using OnFindComplete = GC::Ref<GC::Function<void(Web::WebDriver::Response)>>;
-    void find(Web::WebDriver::LocationStrategy, ByteString, GetStartNode, OnFindComplete);
+    void find(Web::WebDriver::LocationStrategy, String, GetStartNode, OnFindComplete);
 
     struct ScriptArguments {
-        ByteString script;
+        String script;
         GC::MarkedVector<JS::Value> arguments;
     };
     ErrorOr<ScriptArguments, Web::WebDriver::Error> extract_the_script_arguments_from_a_request(JS::VM&, JsonValue const& payload);

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -58,7 +58,7 @@ void Session::initialize_from_capabilities(JsonObject& capabilities)
     auto& connection = web_content_connection();
 
     // 1. Let strategy be the result of getting property "pageLoadStrategy" from capabilities.
-    auto strategy = capabilities.get_byte_string("pageLoadStrategy"sv);
+    auto strategy = capabilities.get_string("pageLoadStrategy"sv);
 
     // 2. If strategy is a string, set the current session’s page loading strategy to strategy. Otherwise, set the page loading strategy to normal and set a property of capabilities with name "pageLoadStrategy" and value "normal".
     if (strategy.has_value()) {
@@ -98,7 +98,7 @@ void Session::initialize_from_capabilities(JsonObject& capabilities)
     }
 
     // 8. Apply changes to the user agent for any implementation-defined capabilities selected during the capabilities processing step.
-    if (auto behavior = capabilities.get_byte_string("unhandledPromptBehavior"sv); behavior.has_value()) {
+    if (auto behavior = capabilities.get_string("unhandledPromptBehavior"sv); behavior.has_value()) {
         m_unhandled_prompt_behavior = Web::WebDriver::unhandled_prompt_behavior_from_string(*behavior);
         connection.async_set_unhandled_prompt_behavior(m_unhandled_prompt_behavior);
     } else {
@@ -133,7 +133,7 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<S
             return;
         }
 
-        auto window_handle = MUST(String::from_byte_string(maybe_window_handle.value().as_string()));
+        auto window_handle = maybe_window_handle.value().as_string();
 
         web_content_connection->on_close = [this, window_handle]() {
             dbgln_if(WEBDRIVER_DEBUG, "Window {} was closed remotely.", window_handle);

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -40,7 +40,7 @@ TEST_CASE(load_form)
 
     EXPECT(form_json.is_object());
 
-    auto name = form_json.as_object().get_byte_string("name"sv);
+    auto name = form_json.as_object().get_string("name"sv);
     EXPECT(name.has_value());
 
     EXPECT_EQ(name.value(), "Form1");
@@ -50,7 +50,7 @@ TEST_CASE(load_form)
 
     widgets->for_each([&](JsonValue const& widget_value) {
         auto& widget_object = widget_value.as_object();
-        auto widget_class = widget_object.get_byte_string("class"sv).value();
+        auto widget_class = widget_object.get_string("class"sv).value();
         widget_object.for_each_member([&]([[maybe_unused]] auto& property_name, [[maybe_unused]] JsonValue const& property_value) {
         });
     });
@@ -67,7 +67,7 @@ TEST_CASE(json_string)
 {
     auto json = JsonValue::from_string("\"A\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().length(), size_t { 1 });
+    EXPECT_EQ(json.as_string().bytes_as_string_view().length(), size_t { 1 });
     EXPECT_EQ(json.as_string() == "A", true);
 }
 
@@ -75,7 +75,7 @@ TEST_CASE(json_utf8_character)
 {
     auto json = JsonValue::from_string("\"\\u0041\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().length(), size_t { 1 });
+    EXPECT_EQ(json.as_string().bytes_as_string_view().length(), size_t { 1 });
     EXPECT_EQ(json.as_string() == "A", true);
 }
 
@@ -84,19 +84,19 @@ TEST_CASE(json_encoded_surrogates)
     {
         auto json = JsonValue::from_string("\"\\uD83E\\uDD13\""sv).value();
         EXPECT_EQ(json.type(), JsonValue::Type::String);
-        EXPECT_EQ(json.as_string().length(), 4u);
+        EXPECT_EQ(json.as_string().bytes_as_string_view().length(), 4u);
         EXPECT_EQ(json.as_string(), "🤓"sv);
     }
     {
         auto json = JsonValue::from_string("\"\\uD83E\""sv).value();
         EXPECT_EQ(json.type(), JsonValue::Type::String);
-        EXPECT_EQ(json.as_string().length(), 3u);
+        EXPECT_EQ(json.as_string().bytes_as_string_view().length(), 3u);
         EXPECT_EQ(json.as_string(), "\xED\xA0\xBE"sv);
     }
     {
         auto json = JsonValue::from_string("\"\\uDD13\""sv).value();
         EXPECT_EQ(json.type(), JsonValue::Type::String);
-        EXPECT_EQ(json.as_string().length(), 3u);
+        EXPECT_EQ(json.as_string().bytes_as_string_view().length(), 3u);
         EXPECT_EQ(json.as_string(), "\xED\xB4\x93"sv);
     }
 }

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -165,23 +165,23 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
         parse_succeeded = !Test::JS::parse_script(test_file, realm).is_error();
 
     bool test_passed = true;
-    ByteString message;
-    ByteString expectation_string;
+    String message;
+    String expectation_string;
 
     switch (expectation) {
     case Early:
     case Fail:
-        expectation_string = "File should not parse";
+        expectation_string = "File should not parse"_string;
         test_passed = !parse_succeeded;
         if (!test_passed)
-            message = "Expected the file to fail parsing, but it did not";
+            message = "Expected the file to fail parsing, but it did not"_string;
         break;
     case Pass:
     case ExplicitPass:
-        expectation_string = "File should parse";
+        expectation_string = "File should parse"_string;
         test_passed = parse_succeeded;
         if (!test_passed)
-            message = "Expected the file to parse, but it did not";
+            message = "Expected the file to parse, but it did not"_string;
         break;
     }
 
@@ -193,6 +193,6 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
         {},
         duration_ms,
         test_result,
-        { Test::Suite { test_path, "Parse file", test_result, { { expectation_string, test_result, message, static_cast<u64>(duration_ms) * 1000u } } } }
+        { Test::Suite { test_path, "Parse file"_fly_string, test_result, { { expectation_string, test_result, message, static_cast<u64>(duration_ms) * 1000u } } } }
     };
 }

--- a/UI/Qt/AutoComplete.cpp
+++ b/UI/Qt/AutoComplete.cpp
@@ -45,7 +45,7 @@ ErrorOr<Vector<String>> AutoComplete::parse_google_autocomplete(Vector<JsonValue
 
     if (!json[0].is_string())
         return Error::from_string_literal("Invalid JSON, expected first element to be a string");
-    auto query = TRY(String::from_byte_string(json[0].as_string()));
+    auto query = json[0].as_string();
 
     if (!json[1].is_array())
         return Error::from_string_literal("Invalid JSON, expected second element to be an array");
@@ -57,7 +57,7 @@ ErrorOr<Vector<String>> AutoComplete::parse_google_autocomplete(Vector<JsonValue
     Vector<String> results;
     results.ensure_capacity(suggestions_array.size());
     for (auto& suggestion : suggestions_array)
-        results.unchecked_append(MUST(String::from_byte_string(suggestion.as_string())));
+        results.unchecked_append(suggestion.as_string());
 
     return results;
 }
@@ -69,7 +69,7 @@ ErrorOr<Vector<String>> AutoComplete::parse_duckduckgo_autocomplete(Vector<JsonV
         auto maybe_value = suggestion.as_object().get("phrase"sv);
         if (!maybe_value.has_value())
             continue;
-        results.append(MUST(String::from_byte_string(maybe_value->as_string())));
+        results.append(maybe_value->as_string());
     }
 
     return results;
@@ -79,7 +79,7 @@ ErrorOr<Vector<String>> AutoComplete::parse_yahoo_autocomplete(JsonObject const&
 {
     if (!json.get("q"sv).has_value() || !json.get("q"sv)->is_string())
         return Error::from_string_view("Invalid JSON, expected \"q\" to be a string"sv);
-    auto query = TRY(String::from_byte_string(json.get("q"sv)->as_string()));
+    auto query = json.get("q"sv)->as_string();
 
     if (!json.get("r"sv).has_value() || !json.get("r"sv)->is_array())
         return Error::from_string_view("Invalid JSON, expected \"r\" to be an object"sv);
@@ -98,7 +98,7 @@ ErrorOr<Vector<String>> AutoComplete::parse_yahoo_autocomplete(JsonObject const&
         if (!suggestion.get("k"sv).has_value() || !suggestion.get("k"sv)->is_string())
             return Error::from_string_view("Invalid JSON, expected \"k\" to be a string"sv);
 
-        results.unchecked_append(MUST(String::from_byte_string(suggestion.get("k"sv)->as_string())));
+        results.unchecked_append(suggestion.get("k"sv)->as_string());
     }
 
     return results;


### PR DESCRIPTION
JSON can only contain WTF-8 encoded text, so it makes sense to type them as such. Also turn JSON keys into `FlyString`s, to reduce memory usage and increase performance of lookups.

Part of the improvements made in #2493. 