### PR TITLE
LibWeb: Make `WebIDL::invoke_callback()` report exceptions in various places

### DIFF
--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -825,12 +825,8 @@ void invoke_custom_element_reactions(Vector<GC::Root<DOM::Element>>& element_que
                 },
                 [&](DOM::CustomElementCallbackReaction& custom_element_callback_reaction) -> void {
                     // -> callback reaction
-                    //      Invoke reaction's callback function with reaction's arguments, and with element as the callback this value.
-                    auto result = WebIDL::invoke_callback(*custom_element_callback_reaction.callback, element.ptr(), custom_element_callback_reaction.arguments);
-                    // FIXME: The error from CustomElementCallbackReaction is supposed
-                    //     to use the new steps for IDL callback error reporting
-                    if (result.is_abrupt())
-                        HTML::report_exception(result, element->realm());
+                    //      Invoke reaction's callback function with reaction's arguments and "report", and callback this value set to element.
+                    (void)WebIDL::invoke_callback(*custom_element_callback_reaction.callback, element.ptr(), WebIDL::ExceptionBehavior::Report, custom_element_callback_reaction.arguments);
                 });
         }
     }

--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -739,7 +739,7 @@ void queue_mutation_observer_microtask(DOM::Document const& document)
                 }
             }
 
-            // 4. If records is not empty, then invoke mo’s callback with « records, mo », and mo. If this throws an exception, catch it, and report the exception.
+            // 4. If records is not empty, then invoke mo’s callback with « records, mo » and "report", and with callback this value mo.
             if (!records.is_empty()) {
                 auto& callback = mutation_observer->callback();
                 auto& realm = callback.callback_context;
@@ -751,9 +751,7 @@ void queue_mutation_observer_microtask(DOM::Document const& document)
                     MUST(wrapped_records->create_data_property(property_index, record.ptr()));
                 }
 
-                auto result = WebIDL::invoke_callback(callback, mutation_observer, wrapped_records, mutation_observer);
-                if (result.is_abrupt())
-                    HTML::report_exception(result, realm);
+                (void)WebIDL::invoke_callback(callback, mutation_observer, WebIDL::ExceptionBehavior::Report, wrapped_records, mutation_observer);
             }
         }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3983,9 +3983,8 @@ void Document::queue_intersection_observer_task()
             auto& callback = observer->callback();
 
             // 5. Invoke callback with queue as the first argument, observer as the second argument, and observer as the callback this value. If this throws an exception, report the exception.
-            auto completion = WebIDL::invoke_callback(callback, observer.ptr(), wrapped_queue, observer.ptr());
-            if (completion.is_abrupt())
-                HTML::report_exception(completion, realm);
+            // NOTE: This does not follow the spec as written precisely, but this is the same thing we do elsewhere and there is a WPT test that relies on this.
+            (void)WebIDL::invoke_callback(callback, observer.ptr(), WebIDL::ExceptionBehavior::Report, wrapped_queue, observer.ptr());
         }
     }));
 }

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -357,8 +357,8 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackTyp
                 if (file_result.has_value())
                     blob_result = FileAPI::Blob::create(realm(), file_result->buffer, TRY_OR_THROW_OOM(vm(), String::from_utf8(file_result->mime_type)));
 
-                // 2. Invoke callback with « result ».
-                TRY(WebIDL::invoke_callback(*callback, {}, move(blob_result)));
+                // 2. Invoke callback with « result » and "report".
+                TRY(WebIDL::invoke_callback(*callback, {}, WebIDL::ExceptionBehavior::Report, move(blob_result)));
                 return {};
             });
             if (maybe_error.is_throw_completion())

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.cpp
@@ -84,11 +84,9 @@ void UniversalGlobalScopeMixin::queue_microtask(WebIDL::CallbackType& callback)
     if (is<Window>(this_impl()))
         document = &static_cast<Window&>(this_impl()).associated_document();
 
-    // The queueMicrotask(callback) method must queue a microtask to invoke callback, and if callback throws an exception, report the exception.
-    HTML::queue_a_microtask(document, GC::create_function(realm.heap(), [&callback, &realm] {
-        auto result = WebIDL::invoke_callback(callback, {});
-        if (result.is_error())
-            HTML::report_exception(result, realm);
+    // The queueMicrotask(callback) method must queue a microtask to invoke callback with « » and "report".
+    HTML::queue_a_microtask(document, GC::create_function(realm.heap(), [&callback] {
+        (void)WebIDL::invoke_callback(callback, {}, WebIDL::ExceptionBehavior::Report);
     }));
 }
 

--- a/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -109,9 +109,7 @@ void ResizeObserver::invoke_callback(ReadonlySpan<GC::Ref<ResizeObserverEntry>> 
         MUST(wrapped_records->create_data_property(property_index, record.ptr()));
     }
 
-    auto result = WebIDL::invoke_callback(callback, JS::js_undefined(), wrapped_records);
-    if (result.is_abrupt())
-        HTML::report_exception(result, realm);
+    (void)WebIDL::invoke_callback(callback, JS::js_undefined(), WebIDL::ExceptionBehavior::Report, wrapped_records);
 }
 
 }

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -254,8 +254,16 @@ JS::ThrowCompletionOr<String> to_usv_string(JS::VM& vm, JS::Value value)
 
 // https://webidl.spec.whatwg.org/#invoke-a-callback-function
 // https://whatpr.org/webidl/1437.html#invoke-a-callback-function
-JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::MarkedVector<JS::Value> args)
+JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, ExceptionBehavior exception_behavior, GC::MarkedVector<JS::Value> args)
 {
+    // https://webidl.spec.whatwg.org/#js-invoking-callback-functions
+    // The exceptionBehavior argument must be supplied if, and only if, callable’s return type is not a promise type. If callable’s return type is neither undefined nor any, it must be "rethrow".
+    // NOTE: Until call sites are updated to respect this, specifications which fail to provide a value here when it would be mandatory should be understood as supplying "rethrow".
+    if (exception_behavior == ExceptionBehavior::NotSpecified && callback.operation_returns_promise == OperationReturnsPromise::No)
+        exception_behavior = ExceptionBehavior::Rethrow;
+
+    VERIFY(exception_behavior == ExceptionBehavior::NotSpecified || callback.operation_returns_promise == OperationReturnsPromise::No);
+
     // 1. Let completion be an uninitialized variable.
     JS::Completion completion;
 
@@ -275,36 +283,84 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
         return { JS::js_undefined() };
     }
 
-    // 5. Let relevant realm be F’s associated Realm.
+    // 5. Let relevant realm be F’s associated realm.
     auto& relevant_realm = function_object->shape().realm();
 
-    // 6. Let stored realm be value’s callback context.
+    // 6. Let stored realm be callable’s callback context.
     auto& stored_realm = callback.callback_context;
 
-    // 8. Prepare to run script with relevant realm.
+    // 7. Prepare to run script with relevant realm.
     HTML::prepare_to_run_script(relevant_realm);
 
-    // 9. Prepare to run a callback with stored realm.
+    // 8. Prepare to run a callback with stored realm.
     HTML::prepare_to_run_callback(stored_realm);
 
-    // FIXME: 10. Let esArgs be the result of converting args to an ECMAScript arguments list. If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
-    //        For simplicity, we currently make the caller do this. However, this means we can't throw exceptions at this point like the spec wants us to.
+    // FIXME: 9. Let jsArgs be the result of converting args to a JavaScript arguments list.
+    //           If this throws an exception, set completion to the completion value representing the thrown exception and jump to the step labeled return.
 
-    // 11. Let callResult be Call(F, thisArg, esArgs).
+    // 10. Let callResult be Call(F, thisArg, jsArgs).
     auto& vm = function_object->vm();
     auto call_result = JS::call(vm, verify_cast<JS::FunctionObject>(*function_object), this_argument.value(), args.span());
 
-    // 12. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
+    auto return_steps = [&](JS::Completion completion) -> JS::Completion {
+        // 1. Clean up after running a callback with stored realm.
+        HTML::clean_up_after_running_callback(stored_realm);
+
+        // 2. Clean up after running script with relevant realm.
+        // FIXME: This method follows an older version of the spec, which takes a realm, so we use F's associated realm instead.
+        HTML::clean_up_after_running_script(relevant_realm);
+
+        // 3. If completion is an IDL value, return completion.
+        if (!completion.is_abrupt())
+            return completion;
+
+        // 4. Assert: completion is an abrupt completion.
+        VERIFY(completion.is_abrupt());
+
+        // 5. If exceptionBehavior is "rethrow", throw completion.[[Value]].
+        if (exception_behavior == ExceptionBehavior::Rethrow) {
+            TRY(JS::throw_completion(*completion.release_value()));
+        }
+        // 6. Otherwise, if exceptionBehavior is "report":
+        else if (exception_behavior == ExceptionBehavior::Report) {
+            // FIXME: 1. Assert: callable’s return type is undefined or any.
+
+            // 2. Report an exception completion.[[Value]] for relevant realm’s global object.
+            auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&relevant_realm.global_object());
+            VERIFY(window_or_worker);
+            window_or_worker->report_an_exception(*completion.release_value());
+
+            // 3. Return the unique undefined IDL value.
+            return JS::js_undefined();
+        }
+
+        // 7. Assert: callable’s return type is a promise type.
+        VERIFY(callback.operation_returns_promise == OperationReturnsPromise::Yes);
+
+        // 8. Let rejectedPromise be ! Call(%Promise.reject%, %Promise%, «completion.[[Value]]»).
+        auto rejected_promise = create_rejected_promise(relevant_realm, *completion.release_value());
+
+        // 9. Return the result of converting rejectedPromise to the callback function’s return type.
+        return JS::Value { rejected_promise->promise() };
+    };
+
+    // 11. If callResult is an abrupt completion, set completion to callResult and jump to the step labeled return.
     if (call_result.is_throw_completion()) {
         completion = call_result.throw_completion();
-        return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
+        return return_steps(completion);
     }
 
-    // 13. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as the operation’s return type.
+    // 12. Set completion to the result of converting callResult.[[Value]] to an IDL value of the same type as callable’s return type.
+    //     If this throws an exception, set completion to the completion value representing the thrown exception.
     // FIXME: This does no conversion.
     completion = call_result.value();
 
-    return clean_up_on_return(stored_realm, relevant_realm, completion, callback.operation_returns_promise);
+    return return_steps(completion);
+}
+
+JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Value> this_argument, GC::MarkedVector<JS::Value> args)
+{
+    return invoke_callback(callback, move(this_argument), ExceptionBehavior::NotSpecified, move(args));
 }
 
 JS::Completion construct(WebIDL::CallbackType& callback, GC::MarkedVector<JS::Value> args)

--- a/Tests/LibWeb/Text/expected/wpt-import/custom-elements/cross-realm-callback-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/custom-elements/cross-realm-callback-report-exception.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+4 Pass
+1 Fail
+Fail	constructor
+Pass	connectedCallback
+Pass	disconnectedCallback
+Pass	attributeChangedCallback
+Pass	adoptedCallback

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/MutationObserver-cross-realm-callback-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/MutationObserver-cross-realm-callback-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	MutationObserver reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	toBlob() reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/microtask-queuing/queue-microtask-cross-realm-callback-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/microtask-queuing/queue-microtask-cross-realm-callback-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	queueMicrotask() reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/timers/setinterval-cross-realm-callback-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/timers/setinterval-cross-realm-callback-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	window.setInterval() reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/timers/settimeout-cross-realm-callback-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/timers/settimeout-cross-realm-callback-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	window.setTimeout() reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/expected/wpt-import/intersection-observer/callback-cross-realm-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/intersection-observer/callback-cross-realm-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	IntersectionObserver reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/expected/wpt-import/resize-observer/callback-cross-realm-report-exception.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/resize-observer/callback-cross-realm-report-exception.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	ResizeObserver reports the exception from its callback in the callback's global object

--- a/Tests/LibWeb/Text/input/wpt-import/custom-elements/cross-realm-callback-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/custom-elements/cross-realm-callback-report-exception.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Exceptions raised in constructors / lifecycle callbacks are reported in their global objects</title>
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+const sourceThrowError = `throw new parent.frames[2].Error("PASS")`;
+
+test(t => {
+  window.onerrorCalls = [];
+
+  const XFoo = new frames[1].Function(sourceThrowError);
+  frames[0].customElements.define("x-foo-constructor", XFoo);
+
+  frames[0].document.createElement("x-foo-constructor");
+  assert_array_equals(onerrorCalls, ["frame1"]);
+}, "constructor");
+
+test(t => {
+  window.onerrorCalls = [];
+
+  const XFooConnected = class extends frames[0].HTMLElement {};
+  XFooConnected.prototype.connectedCallback = new frames[1].Function(sourceThrowError);
+  frames[0].customElements.define("x-foo-connected", XFooConnected);
+
+  const el = frames[0].document.createElement("x-foo-connected");
+  frames[0].document.body.append(el);
+
+  assert_array_equals(onerrorCalls, ["frame1"]);
+}, "connectedCallback");
+
+test(t => {
+  window.onerrorCalls = [];
+
+  const XFooDisconnected = class extends frames[0].HTMLElement {};
+  XFooDisconnected.prototype.disconnectedCallback = new frames[1].Function(sourceThrowError);
+  frames[0].customElements.define("x-foo-disconnected", XFooDisconnected);
+
+  const el = frames[0].document.createElement("x-foo-disconnected");
+  frames[0].document.body.append(el);
+  el.remove();
+
+  assert_array_equals(onerrorCalls, ["frame1"]);
+}, "disconnectedCallback");
+
+test(t => {
+  window.onerrorCalls = [];
+
+  const XFooAttributeChanged = class extends frames[0].HTMLElement {};
+  XFooAttributeChanged.observedAttributes = ["foo"];
+  XFooAttributeChanged.prototype.attributeChangedCallback = new frames[1].Function(sourceThrowError);
+  frames[0].customElements.define("x-foo-attribute-changed", XFooAttributeChanged);
+
+  const el = frames[0].document.createElement("x-foo-attribute-changed");
+  frames[0].document.body.append(el);
+  el.setAttribute("foo", "bar");
+
+  assert_array_equals(onerrorCalls, ["frame1"]);
+}, "attributeChangedCallback");
+
+test(t => {
+  window.onerrorCalls = [];
+
+  const XFooAdopted = class extends frames[0].HTMLElement {};
+  XFooAdopted.prototype.adoptedCallback = new frames[1].Function(sourceThrowError);
+  frames[0].customElements.define("x-foo-adopted", XFooAdopted);
+
+  const el = frames[0].document.createElement("x-foo-adopted");
+  document.body.append(el);
+
+  assert_array_equals(onerrorCalls, ["frame1"]);
+}, "adoptedCallback");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/MutationObserver-cross-realm-callback-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/MutationObserver-cross-realm-callback-report-exception.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>MutationObserver reports the exception from its callback in the callback's global object</title>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const target = frames[0].document.body;
+    const mo = new frames[0].MutationObserver(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`));
+
+    mo.observe(target, { childList: true, subtree: true });
+    target.append("foo");
+
+    t.step_timeout(() => {
+      assert_array_equals(onerrorCalls, ["frame1"]);
+      t.done();
+    }, 4);
+  });
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/the-canvas-element/toBlob-cross-realm-callback-report-exception.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>toBlob() reports the exception from its callback in the callback's global object</title>
+<script src=../../../../resources/testharness.js></script>
+<script src=../../../../resources/testharnessreport.js></script>
+<iframe srcdoc="<canvas></canvas>"></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const canvas = frames[0].document.querySelector("canvas");
+    canvas.toBlob(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`));
+
+    t.step_timeout(() => {
+      assert_array_equals(onerrorCalls, ["frame1"]);
+      t.done();
+    }, 25);
+  });
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/microtask-queuing/queue-microtask-cross-realm-callback-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/microtask-queuing/queue-microtask-cross-realm-callback-report-exception.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>queueMicrotask() reports the exception from its callback in the callback's global object</title>
+<script src=../../../resources/testharness.js></script>
+<script src=../../../resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    frames[0].queueMicrotask(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`));
+
+    t.step_timeout(() => {
+      assert_array_equals(onerrorCalls, ["frame1"]);
+      t.done();
+    }, 4);
+  });
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/timers/setinterval-cross-realm-callback-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/timers/setinterval-cross-realm-callback-report-exception.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>window.setInterval() reports the exception from its callback in the callback's global object</title>
+<script src=../../../resources/testharness.js></script>
+<script src=../../../resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const id = frames[0].setInterval(new frames[1].Function(`
+      parent.clearThisInterval();
+      throw new parent.frames[2].Error("PASS");
+    `), 4);
+    window.clearThisInterval = () => { frames[0].clearInterval(id); };
+
+    t.step_wait_func_done(() => onerrorCalls.length > 0,
+                          () => assert_array_equals(onerrorCalls, ["frame1"]),
+                          undefined, 1000, 10);
+  });
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/timers/settimeout-cross-realm-callback-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/timers/settimeout-cross-realm-callback-report-exception.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>window.setTimeout() reports the exception from its callback in the callback's global object</title>
+<script src=../../../resources/testharness.js></script>
+<script src=../../../resources/testharnessreport.js></script>
+<iframe></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    frames[0].setTimeout(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`), 4);
+
+    t.step_wait_func_done(() => onerrorCalls.length > 0,
+      () => assert_array_equals(onerrorCalls, ["frame1"]),
+      undefined, 1000, 10);
+  });
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/intersection-observer/callback-cross-realm-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/intersection-observer/callback-cross-realm-report-exception.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>IntersectionObserver reports the exception from its callback in the callback's global object</title>
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<iframe srcdoc='<div style="height: 100px;">foo</div>'></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const target = frames[0].document.querySelector("div");
+    const io = new frames[0].IntersectionObserver(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`));
+    io.observe(target);
+
+    t.step_timeout(() => {
+      assert_array_equals(onerrorCalls, ["frame1"]);
+      t.done();
+    }, 100);
+  });
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/resize-observer/callback-cross-realm-report-exception.html
+++ b/Tests/LibWeb/Text/input/wpt-import/resize-observer/callback-cross-realm-report-exception.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>ResizeObserver reports the exception from its callback in the callback's global object</title>
+<script src=../resources/testharness.js></script>
+<script src=../resources/testharnessreport.js></script>
+<iframe srcdoc='<div style="height: 100px;">foo</div>'></iframe>
+<iframe></iframe>
+<iframe></iframe>
+<script>
+setup({ allow_uncaught_exception: true });
+
+const onerrorCalls = [];
+window.onerror = () => { onerrorCalls.push("top"); };
+frames[0].onerror = () => { onerrorCalls.push("frame0"); };
+frames[1].onerror = () => { onerrorCalls.push("frame1"); };
+frames[2].onerror = () => { onerrorCalls.push("frame2"); };
+
+async_test(t => {
+  window.onload = t.step_func(() => {
+    const target = frames[0].document.querySelector("div");
+    const io = new frames[0].ResizeObserver(new frames[1].Function(`throw new parent.frames[2].Error("PASS");`));
+    io.observe(target);
+
+    t.step_timeout(() => {
+      assert_array_equals(onerrorCalls, ["frame1"]);
+      t.done();
+    }, 25);
+  });
+});
+</script>


### PR DESCRIPTION
This fixes a number of WPT tests, which expect an error to be reported if an exception is thrown in the timer callback.

Seven tests related to exception reporting, which were previously failing have been imported.