### PR TITLE
Inspector+UI: Close inspector with shortcuts

### DIFF
--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -355,7 +355,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 
     auto* inspector_action = new QAction("Open &Inspector", this);
     inspector_action->setIcon(load_icon_from_uri("resource://icons/browser/dom-tree.png"sv));
-    inspector_action->setShortcuts({ QKeySequence("Ctrl+Shift+I"), QKeySequence("F12") });
+    inspector_action->setShortcuts({ QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_I),
+        QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_C),
+        QKeySequence(Qt::Key_F12) });
     inspect_menu->addAction(inspector_action);
     QObject::connect(inspector_action, &QAction::triggered, this, [this] {
         if (m_current_tab) {
@@ -472,7 +474,6 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     });
 
     auto* clear_cache_action = new QAction("Clear &Cache", this);
-    clear_cache_action->setShortcut(QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_C));
     clear_cache_action->setIcon(load_icon_from_uri("resource://icons/browser/clear-cache.png"sv));
     debug_menu->addAction(clear_cache_action);
     QObject::connect(clear_cache_action, &QAction::triggered, this, [this] {

--- a/UI/Qt/InspectorWidget.cpp
+++ b/UI/Qt/InspectorWidget.cpp
@@ -25,9 +25,17 @@ InspectorWidget::InspectorWidget(QWidget* tab, WebContentView& content_view)
     : QWidget(tab, Qt::Window)
 {
     m_inspector_view = new WebContentView(this);
+    m_inspector_view->on_close = [this] {
+        close();
+    };
 
     if (is_using_dark_system_theme(*this))
         m_inspector_view->update_palette(WebContentView::PaletteMode::Dark);
+
+    auto* inspector_close_action = new QAction("Close Inspector", this);
+    inspector_close_action->setShortcuts({ QKeySequence(Qt::CTRL | Qt::SHIFT | Qt::Key_I), QKeySequence(Qt::CTRL | Qt::Key_W), QKeySequence(Qt::Key_F12) });
+    addAction(inspector_close_action);
+    connect(inspector_close_action, &QAction::triggered, [this]() { close(); });
 
     m_inspector_client = make<WebView::InspectorClient>(content_view, *m_inspector_view);
 
@@ -206,6 +214,7 @@ void InspectorWidget::closeEvent(QCloseEvent* event)
 {
     event->accept();
     m_inspector_client->clear_selection();
+    emit closed();
 }
 
 }

--- a/UI/Qt/InspectorWidget.h
+++ b/UI/Qt/InspectorWidget.h
@@ -35,6 +35,9 @@ public:
 public slots:
     void device_pixel_ratio_changed(qreal dpi);
 
+signals:
+    void closed();
+
 private:
     virtual bool event(QEvent*) override;
     void closeEvent(QCloseEvent*) override;

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -899,10 +899,23 @@ void Tab::recreate_toolbar_icons()
     m_hamburger_button->setIcon(create_tvg_icon_with_theme_colors("hamburger", palette()));
 }
 
+void Tab::recreate_inspector()
+{
+    if (m_inspector_widget)
+        m_inspector_widget->deleteLater();
+
+    m_inspector_widget = new InspectorWidget(this, view());
+
+    QObject::connect(m_inspector_widget, &InspectorWidget::closed, [this] {
+        m_inspector_widget->deleteLater();
+        m_inspector_widget = nullptr;
+    });
+}
+
 void Tab::show_inspector_window(InspectorTarget inspector_target)
 {
     if (!m_inspector_widget)
-        m_inspector_widget = new InspectorWidget(this, view());
+        recreate_inspector();
     else
         m_inspector_widget->inspect();
 

--- a/UI/Qt/Tab.h
+++ b/UI/Qt/Tab.h
@@ -125,6 +125,8 @@ private:
 
     void close_sub_widgets();
 
+    void recreate_inspector();
+
     QBoxLayout* m_layout { nullptr };
     QToolBar* m_toolbar { nullptr };
     QToolButton* m_hamburger_button { nullptr };


### PR DESCRIPTION
This brings keyboard shortcuts for the inspector up with common convention in FF and Chrome: Ctrl+Shift+C now also opens the inspector, and F12, Ctrl+W, and Ctrl+Shift+I now close the inspector when the inspector window is focused.

Resolves #972