### PR TITLE
Toolchain: Actually disable vcpkg metrics

### DIFF
--- a/Toolchain/BuildVcpkg.py
+++ b/Toolchain/BuildVcpkg.py
@@ -31,7 +31,7 @@ def main() -> int:
     subprocess.check_call(args=["git", "checkout", git_rev], cwd=vcpkg_checkout)
 
     bootstrap_script = "bootstrap-vcpkg.bat" if os.name == 'nt' else "bootstrap-vcpkg.sh"
-    subprocess.check_call(args=[vcpkg_checkout / bootstrap_script, "-disableMetrics"], cwd=vcpkg_checkout, shell=True)
+    subprocess.check_call(args=[vcpkg_checkout / bootstrap_script, "-disableMetrics"], cwd=vcpkg_checkout)
 
     return 0
 


### PR DESCRIPTION
In the move to a python version of this script, I didn't notice that running the bootstrap script in shell mode precluded it from actually accepting the -disableMetrics argument.

Existing vcpkg installs can be un-metrics'd by re-running the bootstrap script with the disable argument, or by adding a vcpkg.disable-metrics file in $VCPKG_ROOT

thanks to @BenWiederhake for pointing this out 😅 