### PR TITLE
LibWeb: Code cleanup for attribute getting in Node::name_or_description

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2362,13 +2362,15 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                                 }
                             }
                         } else if (role == ARIA::Role::spinbutton || role == ARIA::Role::slider) {
+                            auto aria_valuenow = element.aria_value_now();
+                            auto aria_valuetext = element.aria_value_text();
                             // iii. Range: If the embedded control has role range (e.g., a spinbutton or slider):
                             // a. If the aria-valuetext property is present, return its value,
-                            if (element.has_attribute("aria-valuetext"_string))
-                                builder.append(element.get_attribute("aria-valuetext"_string).value());
+                            if (aria_valuetext.has_value())
+                                builder.append(aria_valuetext.value());
                             // b. Otherwise, if the aria-valuenow property is present, return its value
-                            else if (element.has_attribute("aria-valuenow"_string))
-                                builder.append(element.get_attribute("aria-valuenow"_string).value());
+                            else if (aria_valuenow.has_value())
+                                builder.append(aria_valuenow.value());
                             // c. Otherwise, use the value as specified by a host language attribute.
                             else if (is<HTML::HTMLInputElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLInputElement const&>(*node);

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2331,7 +2331,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                             // i. Textbox: If the embedded control has role textbox, return its value.
                             if (is<HTML::HTMLInputElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLInputElement const&>(*node);
-                                if (element.has_attribute("value"_string))
+                                if (element.has_attribute(HTML::AttributeNames::value))
                                     builder.append(element.value());
                             } else
                                 builder.append(node->text_content().value());
@@ -2339,7 +2339,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                             // ii. Combobox/Listbox: If the embedded control has role combobox or listbox, return the text alternative of the chosen option.
                             if (is<HTML::HTMLInputElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLInputElement const&>(*node);
-                                if (element.has_attribute("value"_string))
+                                if (element.has_attribute(HTML::AttributeNames::value))
                                     builder.append(element.value());
                             } else if (is<HTML::HTMLSelectElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLSelectElement const&>(*node);
@@ -2372,7 +2372,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                             // c. Otherwise, use the value as specified by a host language attribute.
                             else if (is<HTML::HTMLInputElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLInputElement const&>(*node);
-                                if (element.has_attribute("value"_string))
+                                if (element.has_attribute(HTML::AttributeNames::value))
                                     builder.append(element.value());
                             }
                         }


### PR DESCRIPTION
This change includes two commits:

- 5e65b07c37d LibWeb: Minor code cleanup; use HTML::AttributeNames::value, not string
- 55c8088d01f3e3313101e99f807d577870d0e492 LibWeb: Use element.aria_foo(), not element.has_attribute("aria-foo"_string)