### PR TITLE
Tests: Re-enable some tests that were slow on CI

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -29,10 +29,6 @@ Text/input/Worker/Worker-module.html
 Text/input/Worker/Worker-performance.html
 Text/input/Worker/Worker-postMessage-transfer.html
 
-; Too slow for GCC CI
-Text/input/wpt-import/css/css-flexbox/abspos/position-absolute-001.html
-Text/input/wpt-import/html/rendering/pixel-length-attributes.html
-
 ; Skipped due to assertion failures
 Text/input/wpt-import/html/syntax/parsing/html5lib_entities01.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_plain-text-unsafe.html
@@ -164,15 +160,3 @@ Text/input/wpt-import/css/css-backgrounds/animations/discrete-no-interpolation.h
 
 ; https://github.com/LadybirdBrowser/ladybird/issues/2314
 Text/input/test-http-test-server.html
-
-; Too slow for CI
-Text/input/wpt-import/dom/nodes/ParentNode-querySelector-All.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-fixed.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-auto.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-fixed.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-auto.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-percentage.html
-
-; https://github.com/LadybirdBrowser/ladybird/issues/2659
-Text/input/wpt-import/css/cssom/serialize-values.html


### PR DESCRIPTION
Since #2714, they should run faster and (hopefully) not time out.