### PR TITLE
WebContent+headless-browser: Implement mismatch conditions for ref tests

### DIFF
--- a/Meta/import-wpt-test.py
+++ b/Meta/import-wpt-test.py
@@ -79,13 +79,17 @@ class TestTypeIdentifier(HTMLParser):
         self.url = url
         self.test_type = TestType.TEXT
         self.reference_path = None
+        self.ref_test_link_found = False
 
     def handle_starttag(self, tag, attrs):
         if tag == "link":
             attr_dict = dict(attrs)
             if attr_dict["rel"] == "match" or attr_dict["rel"] == "mismatch":
+                if self.ref_test_link_found:
+                    raise RuntimeError("Ref tests with multiple match or mismatch links are not currently supported")
                 self.test_type = TestType.REF
                 self.reference_path = attr_dict["href"]
+                self.ref_test_link_found = True
 
 
 def map_to_path(sources, is_resource=True, resource_path=None):

--- a/Meta/import-wpt-test.py
+++ b/Meta/import-wpt-test.py
@@ -83,7 +83,7 @@ class TestTypeIdentifier(HTMLParser):
     def handle_starttag(self, tag, attrs):
         if tag == "link":
             attr_dict = dict(attrs)
-            if attr_dict["rel"] == "match":
+            if attr_dict["rel"] == "match" or attr_dict["rel"] == "mismatch":
                 self.test_type = TestType.REF
                 self.reference_path = attr_dict["href"]
 

--- a/Tests/LibWeb/Ref/expected/mismatch-test-ref.html
+++ b/Tests/LibWeb/Ref/expected/mismatch-test-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        background-color: red;
+    }
+</style>

--- a/Tests/LibWeb/Ref/input/mismatch-test.html
+++ b/Tests/LibWeb/Ref/input/mismatch-test.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<link rel="mismatch" href="../expected/mismatch-test-ref.html" />
+<style>
+    :root {
+        background-color: green;
+    }
+</style>

--- a/UI/Headless/Test.h
+++ b/UI/Headless/Test.h
@@ -37,6 +37,11 @@ enum class TestResult {
     Crashed,
 };
 
+enum class RefTestExpectationType {
+    Match,
+    Mismatch,
+};
+
 static constexpr StringView test_result_to_string(TestResult result)
 {
     switch (result) {
@@ -68,6 +73,8 @@ struct Test {
     String text {};
     bool did_finish_test { false };
     bool did_finish_loading { false };
+
+    Optional<RefTestExpectationType> ref_test_expectation_type {};
 
     RefPtr<Gfx::Bitmap> actual_screenshot {};
     RefPtr<Gfx::Bitmap> expectation_screenshot {};


### PR DESCRIPTION
Ref tests can now have a `<link rel="mismatch">` condition. The test will pass if the expectation page doesn't match the test page.

The WPT test importer has also been modified to allow importing WPT reftests with mismatch conditions. Note that we currently don't support multiple conditions, the first condition found will be the only one that's checked.

NOTE: This change won't be able to detect certain types of issues that we may have with WPT reftests, since the mechanism the WPT test runner uses to compare reftests is significantly different to ours.

Fixes #2712