### PR TITLE
LibWeb: Allocate transparent surface based on surface null check

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -282,7 +282,7 @@ String HTMLCanvasElement::to_data_url(StringView type, JS::Value quality)
     allocate_painting_surface_if_needed();
     auto surface = this->surface();
     auto size = bitmap_size_for_canvas();
-    if (!size.is_empty()) {
+    if (!surface) {
         // If the context is not initialized yet, we need to allocate transparent surface for serialization
         auto skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
         surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
@@ -322,7 +322,7 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackTyp
     allocate_painting_surface_if_needed();
     auto surface = this->surface();
     auto size = bitmap_size_for_canvas();
-    if (!size.is_empty()) {
+    if (!surface) {
         // If the context is not initialized yet, we need to allocate transparent surface for serialization
         auto skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
         surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);


### PR DESCRIPTION
...in HTMLCanvasElement::to_data_url() and HTMLCanvasElement::to_blob().

This fixes the problem when surface is not allocated because context is not initialized yet, even though canvas size is non-zero.

Fixes broken WebDriver screenshot endpoint.