### PR TITLE
LibWeb: Null-check surface before allocating painter for context2d

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -199,8 +199,9 @@ void CanvasRenderingContext2D::did_draw(Gfx::FloatRect const&)
 
 Gfx::Painter* CanvasRenderingContext2D::painter()
 {
-    if (!canvas_element().surface()) {
-        allocate_painting_surface_if_needed();
+    allocate_painting_surface_if_needed();
+    auto surface = canvas_element().surface();
+    if (!m_painter && surface) {
         canvas_element().document().invalidate_display_list();
         m_painter = make<Gfx::PainterSkia>(*canvas_element().surface());
     }
@@ -217,7 +218,7 @@ void CanvasRenderingContext2D::set_size(Gfx::IntSize const& size)
 
 void CanvasRenderingContext2D::allocate_painting_surface_if_needed()
 {
-    if (m_surface)
+    if (m_surface || m_size.is_empty())
         return;
     auto skia_backend_context = canvas_element().navigable()->traversable_navigable()->skia_backend_context();
     m_surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, canvas_element().bitmap_size_for_canvas(), Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);

--- a/Tests/LibWeb/Text/expected/canvas/fill-0x0-canvas-should-not-crash.txt
+++ b/Tests/LibWeb/Text/expected/canvas/fill-0x0-canvas-should-not-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash!)

--- a/Tests/LibWeb/Text/input/canvas/fill-0x0-canvas-should-not-crash.html
+++ b/Tests/LibWeb/Text/input/canvas/fill-0x0-canvas-should-not-crash.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<canvas id="myCanvas" width="0" height="0"></canvas>
+<script>
+    test(() => {
+        const canvas = document.getElementById('myCanvas');
+        const ctx = canvas.getContext('2d');
+        ctx.fillStyle = 'red';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        println("PASS (didn't crash!)");
+    });
+</script>


### PR DESCRIPTION
Fixes https://github.com/LadybirdBrowser/ladybird/issues/2755