### PR TITLE
LibJS+LibUnicode: Designate a sort order for plural rules categories

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,7 +16,7 @@ PluralRules::PluralRules(Object& prototype)
 {
 }
 
-// 16.5.4 ResolvePlural ( pluralRules, n ), https://tc39.es/ecma402/#sec-resolveplural
+// 16.5.2 ResolvePlural ( pluralRules, n ), https://tc39.es/ecma402/#sec-resolveplural
 Unicode::PluralCategory resolve_plural(PluralRules const& plural_rules, Value number)
 {
     // 1. If n is not a finite Number, then
@@ -26,17 +26,16 @@ Unicode::PluralCategory resolve_plural(PluralRules const& plural_rules, Value nu
         return Unicode::PluralCategory::Other;
     }
 
-    // 2. Let locale be pluralRules.[[Locale]].
-    // 3. Let type be pluralRules.[[Type]].
-    // 4. Let res be FormatNumericToString(pluralRules, ℝ(n)).
-    // 5. Let s be res.[[FormattedString]].
-    // 6. Let operands be GetOperands(s).
-    // 7. Let p be PluralRuleSelect(locale, type, n, operands).
-    // 8. Return the Record { [[PluralCategory]]: p, [[FormattedString]]: s }.
+    // 2. Let res be FormatNumericToString(pluralRules, ℝ(n)).
+    // 3. Let s be res.[[FormattedString]].
+    // 4. Let locale be pluralRules.[[Locale]].
+    // 5. Let type be pluralRules.[[Type]].
+    // 6. Let p be PluralRuleSelect(locale, type, s).
+    // 7. Return the Record { [[PluralCategory]]: p, [[FormattedString]]: s }.
     return plural_rules.formatter().select_plural(number.as_double());
 }
 
-// 16.5.6 ResolvePluralRange ( pluralRules, x, y ), https://tc39.es/ecma402/#sec-resolveplural
+// 16.5.4 ResolvePluralRange ( pluralRules, x, y ), https://tc39.es/ecma402/#sec-resolveplural
 ThrowCompletionOr<Unicode::PluralCategory> resolve_plural_range(VM& vm, PluralRules const& plural_rules, Value start, Value end)
 {
     // 1. If x is NaN or y is NaN, throw a RangeError exception.

--- a/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -90,7 +90,8 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
     // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. Let pluralCategories be a List of Strings containing all possible results of PluralRuleSelect for the selected locale pr.[[Locale]].
+    // 4. Let pluralCategories be a List of Strings containing all possible results of PluralRuleSelect for the selected
+    //    locale pr.[[Locale]], sorted according to the following order: "zero", "one", "two", "few", "many", "other".
     auto available_categories = plural_rules->formatter().available_plural_categories();
 
     auto plural_categories = Array::create_from<Unicode::PluralCategory>(realm, available_categories, [&](auto category) {

--- a/Libraries/LibJS/Tests/builtins/Intl/PluralRules/PluralRules.prototype.resolvedOptions.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/PluralRules/PluralRules.prototype.resolvedOptions.js
@@ -79,30 +79,17 @@ describe("correct behavior", () => {
     });
 
     test("plural categories", () => {
-        // The spec doesn't dictate an order of elements, and the generated CLDR data is ordered by
-        // hash map iteration. Instead of using toEqual(), just make sure all elements are the same.
-        const contains = (actual, expected) => {
-            if (actual.length !== expected.length) return false;
-            return expected.every(e => actual.includes(e));
-        };
-
         const enCardinal = new Intl.PluralRules("en", { type: "cardinal" }).resolvedOptions();
-        expect(enCardinal.pluralCategories).toBeDefined();
-        expect(contains(enCardinal.pluralCategories, ["other", "one"])).toBeTrue();
+        expect(enCardinal.pluralCategories).toEqual(["one", "other"]);
 
         const enOrdinal = new Intl.PluralRules("en", { type: "ordinal" }).resolvedOptions();
-        expect(enOrdinal.pluralCategories).toBeDefined();
-        expect(contains(enOrdinal.pluralCategories, ["other", "one", "two", "few"])).toBeTrue();
+        expect(enOrdinal.pluralCategories).toEqual(["one", "two", "few", "other"]);
 
         const gaCardinal = new Intl.PluralRules("ga", { type: "cardinal" }).resolvedOptions();
-        expect(gaCardinal.pluralCategories).toBeDefined();
-        expect(
-            contains(gaCardinal.pluralCategories, ["other", "one", "two", "few", "many"])
-        ).toBeTrue();
+        expect(gaCardinal.pluralCategories).toEqual(["one", "two", "few", "many", "other"]);
 
         const gaOrdinal = new Intl.PluralRules("ga", { type: "ordinal" }).resolvedOptions();
-        expect(gaOrdinal.pluralCategories).toBeDefined();
-        expect(contains(gaOrdinal.pluralCategories, ["other", "one"])).toBeTrue();
+        expect(gaOrdinal.pluralCategories).toEqual(["one", "other"]);
     });
 
     test("rounding priority", () => {

--- a/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Libraries/LibUnicode/NumberFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -733,6 +733,7 @@ public:
             result.append(plural_category_from_string({ category, static_cast<size_t>(length) }));
         }
 
+        quick_sort(result);
         return result;
     }
 

--- a/Libraries/LibUnicode/PluralRules.h
+++ b/Libraries/LibUnicode/PluralRules.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022-2024, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022-2024, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,12 +18,13 @@ PluralForm plural_form_from_string(StringView);
 StringView plural_form_to_string(PluralForm);
 
 enum class PluralCategory {
-    Other,
+    // NOTE: These are sorted in preferred order for Intl.PluralRules.prototype.resolvedOptions.
     Zero,
     One,
     Two,
     Few,
     Many,
+    Other,
 
     // https://unicode.org/reports/tr35/tr35-numbers.html#Explicit_0_1_rules
     ExactlyZero,


### PR DESCRIPTION
This is a normative change in the ECMA-402 spec. See:
https://github.com/tc39/ecma402/commit/62fe5db

test262 diff:
```
test/intl402/PluralRules/prototype/resolvedOptions/plural-categories-order.js ❌ -> ✅
```