### PR TITLE
LibGfx: Set png interlace handling on interlaced images

### DIFF
--- a/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -115,7 +115,8 @@ ErrorOr<void> PNGImageDecoderPlugin::initialize()
     u32 height = 0;
     int bit_depth = 0;
     int color_type = 0;
-    png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, nullptr, nullptr, nullptr);
+    int interlace_type = 0;
+    png_get_IHDR(png_ptr, info_ptr, &width, &height, &bit_depth, &color_type, &interlace_type, nullptr, nullptr);
     m_context->size = { static_cast<int>(width), static_cast<int>(height) };
 
     if (color_type == PNG_COLOR_TYPE_PALETTE)
@@ -132,6 +133,9 @@ ErrorOr<void> PNGImageDecoderPlugin::initialize()
 
     if (color_type == PNG_COLOR_TYPE_GRAY || color_type == PNG_COLOR_TYPE_GRAY_ALPHA)
         png_set_gray_to_rgb(png_ptr);
+
+    if (interlace_type != PNG_INTERLACE_NONE)
+        png_set_interlace_handling(png_ptr);
 
     png_set_filler(png_ptr, 0xFF, PNG_FILLER_AFTER);
     png_set_bgr(png_ptr);


### PR DESCRIPTION
Fixes #2185

This makes [this image](https://www.db.yugioh-card.com/yugiohdb/external/image/00_logo_DuelLinks.png) and some others (found on https://www.db.yugioh-card.com/yugiohdb/card_search.action?ope=1 ) load without printing `libpng warning: Interlace handling should be turned on when using png_read_image` to the console.

To be honest, I am not sure what exactly this does, since the images load fine without, but if libpng says it should be turned on, it's probably correct.

Also, more notably, this triggers on http://acid2.acidtests.org/#top, due to the eyes.