### PR TITLE
LibWeb: Support the `X-Frame-Options` header

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -5573,6 +5573,18 @@ void Document::reset_cursor_blink_cycle()
     m_cursor_blink_timer->restart();
 }
 
+// https://html.spec.whatwg.org/multipage/document-sequences.html#doc-container-document
+GC::Ptr<DOM::Document> Document::container_document() const
+{
+    // 1. If document's node navigable is null, then return null.
+    auto node_navigable = navigable();
+    if (!node_navigable)
+        return nullptr;
+
+    // 2. Return document's node navigable's container document.
+    return node_navigable->container_document();
+}
+
 GC::Ptr<HTML::Navigable> Document::cached_navigable()
 {
     return m_cached_navigable.ptr();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -757,6 +757,8 @@ public:
     bool css_styling_flag() const { return m_css_styling_flag; }
     void set_css_styling_flag(bool flag) { m_css_styling_flag = flag; }
 
+    GC::Ptr<DOM::Document> container_document() const;
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/NavigationParams.cpp
+++ b/Libraries/LibWeb/HTML/NavigationParams.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigationParams.h>
@@ -28,6 +29,69 @@ void NonFetchSchemeNavigationParams::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);
     visitor.visit(navigable);
+}
+
+// https://html.spec.whatwg.org/multipage/document-lifecycle.html#check-a-navigation-response's-adherence-to-x-frame-options
+// FIXME: Add the cspList parameter
+bool check_a_navigation_responses_adherence_to_x_frame_options(GC::Ptr<Fetch::Infrastructure::Response> response, Navigable* navigable, URL::Origin destination_origin)
+{
+    // 1. If navigable is not a child navigable, then return true.
+    if (!navigable->parent()) {
+        return true;
+    }
+
+    // FIXME: 2. For each policy of cspList:
+    //          1. If policy's disposition is not "enforce", then continue.
+    //          2. If policy's directive set contains a frame-ancestors directive, then return true.
+
+    // 3. Let rawXFrameOptions be the result of getting, decoding, and splitting `X-Frame-Options` from response's header list.
+    auto raw_x_frame_options = response->header_list()->get_decode_and_split("X-Frame-Options"sv.bytes());
+
+    // 4. Let xFrameOptions be a new set.
+    auto x_frame_options = AK::OrderedHashTable<String>();
+
+    // 5. For each value of rawXFrameOptions, append value, converted to ASCII lowercase, to xFrameOptions.
+    if (raw_x_frame_options.has_value()) {
+        for (auto const& value : raw_x_frame_options.value()) {
+            x_frame_options.set(value.to_ascii_lowercase());
+        }
+    }
+
+    // 6. If xFrameOptions's size is greater than 1, and xFrameOptions contains any of "deny", "allowall", or "sameorigin", then return false.
+    if (x_frame_options.size() > 1 && (x_frame_options.contains("deny"sv) || x_frame_options.contains("allowall"sv) || x_frame_options.contains("sameorigin"sv))) {
+        return false;
+    }
+
+    // 7. If xFrameOptions's size is greater than 1, then return true.
+    if (x_frame_options.size() > 1) {
+        return true;
+    }
+
+    // 8. If xFrameOptions[0] is "deny", then return false.
+    auto first_x_frame_option = x_frame_options.begin();
+    if (!x_frame_options.is_empty() && *first_x_frame_option == "deny"sv) {
+        return false;
+    }
+
+    // 9. If xFrameOptions[0] is "sameorigin", then:
+    if (!x_frame_options.is_empty() && *first_x_frame_option == "sameorigin"sv) {
+        // 1. Let containerDocument be navigable's container document.
+        auto container_document = navigable->container_document();
+
+        // 2. While containerDocument is not null:
+        while (container_document) {
+            // 1. If containerDocument's origin is not same origin with destinationOrigin, then return false.
+            if (!container_document->origin().is_same_origin(destination_origin)) {
+                return false;
+            }
+
+            // 2. Set containerDocument to containerDocument's container document.
+            container_document = container_document->container_document();
+        }
+    }
+
+    // 10. Return true.
+    return true;
 }
 
 }

--- a/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Libraries/LibWeb/HTML/NavigationParams.h
@@ -97,4 +97,5 @@ struct NonFetchSchemeNavigationParams : JS::Cell {
     void visit_edges(Visitor& visitor) override;
 };
 
+bool check_a_navigation_responses_adherence_to_x_frame_options(GC::Ptr<Fetch::Infrastructure::Response> response, Navigable* navigable, URL::Origin destination_origin);
 }


### PR DESCRIPTION
This PR adds support for the `X-Frame-Options` header. Additionally, the user agent now also acts as if it had stopped parsing once the error page has been set up.

This makes all of the [WPT Tests for X-Frame-Options](https://wpt.fyi/results/x-frame-options) pass, except for those where a combination of CSP and X-Frame-Options is used.