### PR TITLE
LibWeb: Serialization for resizable/shared array buffers

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/infrastructure/safe-passing-of-structured-data/window-postmessage.window.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 150 tests
 
-133 Pass
-16 Fail
+134 Pass
+15 Fail
 1 Optional Feature Unsupported
 Pass	primitive undefined
 Pass	primitive null
@@ -137,7 +137,7 @@ Pass	ObjectPrototype must lose its exotic-ness when cloned
 Pass	Serializing a non-serializable platform object fails
 Pass	An object whose interface is deleted from the global must still deserialize
 Pass	A subclass instance will deserialize as its closest serializable superclass
-Fail	Resizable ArrayBuffer
+Pass	Resizable ArrayBuffer
 Fail	Growable SharedArrayBuffer
 Pass	Length-tracking TypedArray
 Pass	Length-tracking DataView


### PR DESCRIPTION
Add serialization for the following array buffer types:
* ResizableArrayBuffer
* SharedArrayBuffer
* GrowableSharedArrayBuffer

I haven't added tests to cover shared array buffers, since they are hard to implement due to cross-origin isolation. See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements