### PR TITLE
LibJS: Implement the `RegExp.escape` proposal

### DIFF
--- a/Libraries/LibJS/Lexer.h
+++ b/Libraries/LibJS/Lexer.h
@@ -91,4 +91,8 @@ private:
     RefPtr<ParsedIdentifiers> m_parsed_identifiers;
 };
 
+bool is_syntax_character(u32 code_point);
+bool is_whitespace(u32 code_point);
+bool is_line_terminator(u32 code_point);
+
 }

--- a/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -29,6 +29,7 @@ private:
 
     virtual bool has_constructor() const override { return true; }
 
+    JS_DECLARE_NATIVE_FUNCTION(escape);
     JS_DECLARE_NATIVE_FUNCTION(symbol_species_getter);
     JS_DECLARE_NATIVE_FUNCTION(input_getter);
     JS_DECLARE_NATIVE_FUNCTION(input_alias_getter);

--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.escape.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.escape.js
@@ -1,0 +1,68 @@
+describe("errors", () => {
+    test("invalid string", () => {
+        expect(() => {
+            RegExp.escape(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Symbol(Symbol.hasInstance) is not a string");
+    });
+});
+
+describe("normal behavior", () => {
+    test("first character is alphanumeric", () => {
+        const alphanumeric = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+        for (const ch of alphanumeric) {
+            const string = `${ch}${ch}${ch}`;
+            const expected = `\\x${ch.codePointAt(0).toString(16)}${ch}${ch}`;
+
+            expect(RegExp.escape(string)).toBe(expected);
+        }
+    });
+
+    test("syntax characters", () => {
+        const syntaxCharacters = "^$\\.*+?()[]{}|/";
+
+        for (const ch of syntaxCharacters) {
+            const string = `_${ch}_`;
+            const expected = `_\\${ch}_`;
+
+            expect(RegExp.escape(string)).toBe(expected);
+        }
+    });
+
+    test("control characters", () => {
+        expect(RegExp.escape("_\t_")).toBe("_\\t_");
+        expect(RegExp.escape("_\n_")).toBe("_\\n_");
+        expect(RegExp.escape("_\v_")).toBe("_\\v_");
+        expect(RegExp.escape("_\f_")).toBe("_\\f_");
+        expect(RegExp.escape("_\r_")).toBe("_\\r_");
+    });
+
+    test("punctuators", () => {
+        const punctuators = ",-=<>#&!%:;@~'`\"";
+
+        for (const ch of punctuators) {
+            const string = `_${ch}_`;
+            const expected = `_\\x${ch.codePointAt(0).toString(16)}_`;
+
+            expect(RegExp.escape(string)).toBe(expected);
+        }
+    });
+
+    test("non-ASCII whitespace", () => {
+        const nbsp = "\u00A0";
+
+        expect(RegExp.escape("\u00A0")).toBe("\\xa0");
+        expect(RegExp.escape("\uFEFF")).toBe("\\ufeff");
+        expect(RegExp.escape("\u2028")).toBe("\\u2028");
+        expect(RegExp.escape("\u2029")).toBe("\\u2029");
+    });
+
+    test("Unicode surrogates", () => {
+        for (let ch = 0xd800; ch <= 0xdfff; ++ch) {
+            const string = String.fromCodePoint(ch);
+            const expected = `\\u${ch.toString(16)}`;
+
+            expect(RegExp.escape(string)).toBe(expected);
+        }
+    });
+});


### PR DESCRIPTION
https://tc39.es/proposal-regex-escaping/

test262 diff:
```
Diff Tests:
    +20 ✅    -20 ❌

Diff Tests:
    test/built-ins/RegExp/escape/cross-realm.js                      ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-control-characters.js       ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-lineterminator.js           ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-otherpunctuators.js         ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-solidus-character-mixed.js  ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-solidus-character-simple.js ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-surrogates.js               ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-syntax-characters-mixed.js  ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-syntax-characters-simple.js ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-utf16encodecodepoint.js     ❌ -> ✅
    test/built-ins/RegExp/escape/escaped-whitespace.js               ❌ -> ✅
    test/built-ins/RegExp/escape/initial-char-escape.js              ❌ -> ✅
    test/built-ins/RegExp/escape/is-function.js                      ❌ -> ✅
    test/built-ins/RegExp/escape/length.js                           ❌ -> ✅
    test/built-ins/RegExp/escape/name.js                             ❌ -> ✅
    test/built-ins/RegExp/escape/non-string-inputs.js                ❌ -> ✅
    test/built-ins/RegExp/escape/not-a-constructor.js                ❌ -> ✅
    test/built-ins/RegExp/escape/not-escaped-underscore.js           ❌ -> ✅
    test/built-ins/RegExp/escape/not-escaped.js                      ❌ -> ✅
    test/built-ins/RegExp/escape/prop-desc.js                        ❌ -> ✅
```
(which are all `RegExp.escape` tests)