### PR TITLE
LibWeb: Compute default ARIA roles context-sensitively where required

### DIFF
--- a/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -11,12 +11,12 @@
 namespace Web::ARIA {
 
 // https://www.w3.org/TR/wai-aria-1.2/#introroles
-Optional<Role> ARIAMixin::role_or_default() const
+Optional<Role> ARIAMixin::role_from_role_attribute_value() const
 {
     // 1. Use the rules of the host language to detect that an element has a role attribute and to identify the attribute value string for it.
     auto maybe_role_string = role();
     if (!maybe_role_string.has_value())
-        return default_role();
+        return OptionalNone {};
 
     // 2. Separate the attribute value string for that attribute into a sequence of whitespace-free substrings by separating on whitespace.
     auto role_string = maybe_role_string.value();
@@ -35,6 +35,13 @@ Optional<Role> ARIAMixin::role_or_default() const
     // https://www.w3.org/TR/wai-aria-1.2/#document-handling_author-errors_roles
     // If the role attribute contains no tokens matching the name of a non-abstract WAI-ARIA role, the user agent MUST treat the element as if no role had been provided.
     // https://www.w3.org/TR/wai-aria-1.2/#implicit_semantics
+    return OptionalNone {};
+}
+
+Optional<Role> ARIAMixin::role_or_default() const
+{
+    if (auto role = role_from_role_attribute_value(); role.has_value())
+        return role;
     return default_role();
 }
 

--- a/Libraries/LibWeb/ARIA/ARIAMixin.h
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.h
@@ -28,6 +28,7 @@ public:
     // https://www.w3.org/TR/html-aria/#docconformance
     virtual Optional<Role> default_role() const { return {}; }
 
+    Optional<Role> role_from_role_attribute_value() const;
     Optional<Role> role_or_default() const;
 
     // https://www.w3.org/TR/wai-aria-1.2/#tree_exclusion

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -732,8 +732,16 @@ Optional<ARIA::Role> HTMLElement::default_role() const
     if (local_name() == TagNames::article)
         return ARIA::Role::article;
     // https://www.w3.org/TR/html-aria/#el-aside
-    if (local_name() == TagNames::aside)
+    if (local_name() == TagNames::aside) {
+        // https://w3c.github.io/html-aam/#el-aside
+        for (auto const* ancestor = parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+            if (first_is_one_of(ancestor->local_name(), TagNames::article, TagNames::aside, TagNames::nav, TagNames::section)
+                && accessible_name(document()).value().is_empty())
+                return ARIA::Role::generic;
+        }
+        // https://w3c.github.io/html-aam/#el-aside-ancestorbodymain
         return ARIA::Role::complementary;
+    }
     // https://www.w3.org/TR/html-aria/#el-b
     if (local_name() == TagNames::b)
         return ARIA::Role::generic;
@@ -756,16 +764,22 @@ Optional<ARIA::Role> HTMLElement::default_role() const
     if (local_name() == TagNames::figure)
         return ARIA::Role::figure;
     // https://www.w3.org/TR/html-aria/#el-footer
-    if (local_name() == TagNames::footer) {
-        // TODO: If not a descendant of an article, aside, main, nav or section element, or an element with role=article, complementary, main, navigation or region then role=contentinfo
-        // Otherwise, role=generic
-        return ARIA::Role::generic;
-    }
     // https://www.w3.org/TR/html-aria/#el-header
-    if (local_name() == TagNames::header) {
-        // TODO: If not a descendant of an article, aside, main, nav or section element, or an element with role=article, complementary, main, navigation or region then role=banner
-        // Otherwise, role=generic
-        return ARIA::Role::generic;
+    if (local_name() == TagNames::footer || local_name() == TagNames::header) {
+        // If not a descendant of an article, aside, main, nav or section element, or an element with role=article,
+        // complementary, main, navigation or region then (footer) role=contentinfo (header) role=banner. Otherwise,
+        // role=generic.
+        for (auto const* ancestor = parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+            if (first_is_one_of(ancestor->local_name(), TagNames::article, TagNames::aside, TagNames::main, TagNames::nav, TagNames::section))
+                return ARIA::Role::generic;
+            if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::article, ARIA::Role::complementary, ARIA::Role::main, ARIA::Role::navigation, ARIA::Role::region))
+                return ARIA::Role::generic;
+        }
+        // then (footer) role=contentinfo.
+        if (local_name() == TagNames::footer)
+            return ARIA::Role::contentinfo;
+        // (header) role=banner
+        return ARIA::Role::banner;
     }
     // https://www.w3.org/TR/html-aria/#el-hgroup
     if (local_name() == TagNames::hgroup)
@@ -790,9 +804,11 @@ Optional<ARIA::Role> HTMLElement::default_role() const
         return ARIA::Role::search;
     // https://www.w3.org/TR/html-aria/#el-section
     if (local_name() == TagNames::section) {
-        // TODO:  role=region if the section element has an accessible name
-        //        Otherwise, no corresponding role
-        return ARIA::Role::region;
+        // role=region if the section element has an accessible name
+        if (!accessible_name(document()).value().is_empty())
+            return ARIA::Role::region;
+        // Otherwise, role=generic
+        return ARIA::Role::generic;
     }
     // https://www.w3.org/TR/html-aria/#el-small
     if (local_name() == TagNames::small)

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -203,6 +203,14 @@ void Internals::expire_cookies_with_time_offset(WebIDL::LongLong seconds)
     internals_page().client().page_did_expire_cookies_with_time_offset(AK::Duration::from_seconds(seconds));
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static
+String Internals::get_computed_role(DOM::Element& element)
+{
+    if (auto role = element.role_or_default(); role.has_value())
+        return MUST(String::from_utf8(ARIA::role_name(role.value())));
+    return String {};
+}
+
 String Internals::get_computed_label(DOM::Element& element)
 {
     auto& active_document = internals_window().associated_document();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -48,6 +48,7 @@ public:
     void enable_cookies_on_file_domains();
     void expire_cookies_with_time_offset(WebIDL::LongLong seconds);
 
+    String get_computed_role(DOM::Element& element);
     String get_computed_label(DOM::Element& element);
 
     static u16 get_echo_server_port();

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -38,6 +38,7 @@ interface Internals {
     undefined enableCookiesOnFileDomains();
     undefined expireCookiesWithTimeOffset(long long seconds);
 
+    DOMString getComputedRole(Element element);
     DOMString getComputedLabel(Element element);
     unsigned short getEchoServerPort();
 };

--- a/Tests/LibWeb/Text/expected/wpt-import/html-aam/roles-contextual.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html-aam/roles-contextual.txt
@@ -1,0 +1,24 @@
+Harness status: OK
+
+Found 19 tests
+
+19 Pass
+Pass	el-a
+Pass	el-aside
+Pass	el-aside-in-main
+Pass	el-aside-in-article-in-main-with-name
+Pass	el-aside-in-article-with-name
+Pass	el-aside-in-aside-with-name
+Pass	el-aside-in-nav-with-name
+Pass	el-aside-in-nav-with-role
+Pass	el-aside-in-section-with-name
+Pass	el-footer-ancestorbody
+Pass	el-header-ancestorbody
+Pass	el-section
+Pass	el-a-no-href
+Pass	el-aside-in-article-in-main
+Pass	el-aside-in-article
+Pass	el-aside-in-aside
+Pass	el-aside-in-nav
+Pass	el-aside-in-section
+Pass	el-section-no-name

--- a/Tests/LibWeb/Text/input/wpt-import/html-aam/roles-contextual.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html-aam/roles-contextual.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTML-AAM Contextual-Specific Role Verification Tests</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+  <script src="../resources/testdriver.js"></script>
+  <script src="../resources/testdriver-vendor.js"></script>
+  <script src="../resources/testdriver-actions.js"></script>
+  <script src="../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Tests contextual computedrole mappings defined in <a href="https://w3c.github.io/html-aam/">HTML-AAM</a>, where the returned computed role is expected to change based on the context. Most test names correspond to a unique ID defined in the spec.<p>
+
+<p>These should remain in alphabetical order.</code></p>
+
+
+<!-- el-a -->
+<a href="#" data-testname="el-a" data-expectedrole="link" class="ex">x</a>
+<a data-testname="el-a-no-href" class="ex-generic">x</a>
+
+<!-- el-aside -->
+<aside data-testname="el-aside" data-expectedrole="complementary" class="ex">x</aside>
+<main>
+  <aside data-testname="el-aside-in-main" data-expectedrole="complementary" class="ex">x</aside>
+  <article>
+    <aside data-testname="el-aside-in-article-in-main" class="ex-generic">x</aside>
+    <aside data-testname="el-aside-in-article-in-main-with-name" data-expectedrole="complementary" aria-label="x" class="ex">x</aside>
+  </article>
+</main>
+<article>
+  <aside data-testname="el-aside-in-article" class="ex-generic">x</aside>
+  <aside data-testname="el-aside-in-article-with-name" data-expectedrole="complementary" aria-label="x" class="ex">x</aside>
+</article>
+<aside>
+  <aside data-testname="el-aside-in-aside" class="ex-generic">x</aside>
+  <aside data-testname="el-aside-in-aside-with-name" data-expectedrole="complementary" aria-label="x" class="ex">x</aside>
+</aside>
+<nav>
+  <aside data-testname="el-aside-in-nav" class="ex-generic">x</aside>
+  <aside data-testname="el-aside-in-nav-with-name" data-expectedrole="complementary" aria-label="x" class="ex">x</aside>
+  <aside data-testname="el-aside-in-nav-with-role" data-expectedrole="complementary" class="ex" role="complementary">x</aside>
+</nav>
+<!-- Spec says that the conditional aside mapping happens when nested in a sectioning content element.
+  However, this doesn't make sense if the parent <section> isn't a landmark in the first place.
+  Let's force the section to always be a landmark for now, but we should probably expand on this test
+  case pending discussions in https://github.com/w3c/html-aam/pull/484 -->
+<section aria-label="x">
+  <aside data-testname="el-aside-in-section" class="ex-generic">x</aside>
+  <aside data-testname="el-aside-in-section-with-name" data-expectedrole="complementary" aria-label="x" class="ex">x</aside>
+</section>
+
+<!-- el-footer -->
+<!-- nav>footer -> ./roles-contextual.tentative.html -->
+<footer data-testname="el-footer-ancestorbody" data-expectedrole="contentinfo" class="ex">x</footer>
+<!-- main>footer -> ./roles-contextual.tentative.html -->
+
+<!-- el-header -->
+<!-- nav>header -> ./roles-contextual.tentative.html -->
+<header data-testname="el-header-ancestorbody" data-expectedrole="banner" class="ex">x</header>
+<!-- main>header -> ./roles-contextual.tentative.html -->
+
+<!-- el-section -->
+<section data-testname="el-section" aria-label="x" data-expectedrole="region" class="ex">x</section>
+<section data-testname="el-section-no-name" class="ex-generic">x</section>
+
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testdriver.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testdriver.js
@@ -250,7 +250,11 @@
          *                    rejected in the cases the WebDriver command errors
          */
         get_computed_role: async function(element) {
-            let role = await window.test_driver_internal.get_computed_role(element);
+            // XXX: Ladybird-specific change: Upstream WPT calls
+            // window.test_driver_internal.get_computed_role(element) here,
+            // but we’ve changed that to our Ladybird-specific
+            // window.internals.getComputedRole(el).
+            let role = await window.internals.getComputedRole(element);
             return role;
         },
 


### PR DESCRIPTION
This change implements spec-conformant computation of default ARIA roles for elements whose expected default role depends on the element’s context — specifically, either on the element’s ancestry, or on whether the element has an accessible name, or both. This affects the `aside`, `footer`, `header`, and `section` elements.

Otherwise, without this change, `aside`, `footer`, `header`, and `section` elements may unexpectedly end up with the wrong default roles.

This gets us passing 100% of the subtests in the `roles-contextual.html` test at https://wpt.fyi/results/html-aam?product=ladybird.

This change includes an additional commit that adds a `window.internals.getComputedLabel(element)` function, for use in our imported copies of the WPT tests related to the behavior in this change.