### PR TITLE
CMake: Fix Windows exceptions flag.

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -56,7 +56,7 @@ endif()
 if (MSVC)
     add_cxx_compile_options(/W4)
     # disable exceptions
-    add_cxx_compile_options(/EHsc)
+    add_cxx_compile_options(/EHs-)
     # disable floating-point expression contraction
     add_cxx_compile_options(/fp:precise)
 else()


### PR DESCRIPTION
This commit changes the exception flag to match the description and turn off exceptions. This matches the behavior of -fno-exceptions. However, on Windows SEH exceptions are always available, and there's no easy way to turn them off. This flag should also suppress previous /EHsc flags, if they get automatically set by cmake. Reference: https://learn.microsoft.com/en-us/cpp/build/reference/eh-exception-handling-model?view=msvc-170