### PR TITLE
LibWeb: Use a standard x-macro to create FlyString ARIA attribute names

### DIFF
--- a/Libraries/LibWeb/ARIA/ARIAMixin.h
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.h
@@ -9,177 +9,21 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWeb/ARIA/AriaData.h>
+#include <LibWeb/ARIA/AttributeNames.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::ARIA {
 
 class ARIAMixin {
-
 public:
     virtual ~ARIAMixin() = default;
 
-    virtual Optional<String> role() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_role(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_active_descendant() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_active_descendant(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_atomic() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_atomic(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_auto_complete() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_auto_complete(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_braille_label() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_braille_label(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_braille_role_description() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_braille_role_description(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_busy() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_busy(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_checked() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_checked(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_col_count() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_col_count(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_col_index() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_col_index(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_col_index_text() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_col_index_text(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_col_span() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_col_span(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_controls() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_controls(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_current() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_current(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_described_by() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_described_by(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_description() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_description(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_details() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_details(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_disabled() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_disabled(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_drop_effect() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_drop_effect(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_error_message() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_error_message(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_expanded() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_expanded(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_flow_to() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_flow_to(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_grabbed() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_grabbed(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_has_popup() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_has_popup(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_hidden() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_hidden(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_invalid() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_invalid(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_key_shortcuts() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_key_shortcuts(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_label() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_label(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_labelled_by() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_labelled_by(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_level() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_level(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_live() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_live(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_modal() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_modal(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_multi_line() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_multi_line(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_multi_selectable() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_multi_selectable(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_orientation() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_orientation(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_owns() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_owns(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_placeholder() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_placeholder(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_pos_in_set() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_pos_in_set(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_pressed() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_pressed(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_read_only() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_read_only(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_relevant() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_relevant(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_required() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_required(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_role_description() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_role_description(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_row_count() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_row_count(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_row_index() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_row_index(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_row_index_text() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_row_index_text(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_row_span() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_row_span(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_selected() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_selected(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_set_size() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_set_size(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_sort() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_sort(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_value_max() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_value_max(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_value_min() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_value_min(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_value_now() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_value_now(Optional<String> const&) = 0;
-
-    virtual Optional<String> aria_value_text() const = 0;
-    virtual WebIDL::ExceptionOr<void> set_aria_value_text(Optional<String> const&) = 0;
+#define __ENUMERATE_ARIA_ATTRIBUTE(name, attribute) \
+    virtual Optional<String> name() const = 0;      \
+    virtual WebIDL::ExceptionOr<void> set_##name(Optional<String> const&) = 0;
+    ENUMERATE_ARIA_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
 
     // https://www.w3.org/TR/html-aria/#docconformance
     virtual Optional<Role> default_role() const { return {}; }

--- a/Libraries/LibWeb/ARIA/AttributeNames.cpp
+++ b/Libraries/LibWeb/ARIA/AttributeNames.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/ARIA/AttributeNames.h>
+
+namespace Web::ARIA::AttributeNames {
+
+#define __ENUMERATE_ARIA_ATTRIBUTE(name, attribute) \
+    FlyString name = attribute##_fly_string;
+ENUMERATE_ARIA_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
+
+}

--- a/Libraries/LibWeb/ARIA/AttributeNames.h
+++ b/Libraries/LibWeb/ARIA/AttributeNames.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+
+namespace Web::ARIA::AttributeNames {
+
+// https://www.w3.org/TR/wai-aria-1.2/#accessibilityroleandproperties-correspondence
+#define ENUMERATE_ARIA_ATTRIBUTES                                                            \
+    __ENUMERATE_ARIA_ATTRIBUTE(role, "role")                                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_active_descendant, "aria-activedescendant")              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_atomic, "aria-atomic")                                   \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_auto_complete, "aria-autocomplete")                      \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_braille_label, "aria-braillelabel")                      \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_braille_role_description, "aria-brailleroledescription") \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_busy, "aria-busy")                                       \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_checked, "aria-checked")                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_col_count, "aria-colcount")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_col_index, "aria-colindex")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_col_index_text, "aria-colindextext")                     \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_col_span, "aria-colspan")                                \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_controls, "aria-controls")                               \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_current, "aria-current")                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_described_by, "aria-describedby")                        \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_description, "aria-description")                         \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_details, "aria-details")                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_drop_effect, "aria-dropeffect")                          \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_error_message, "aria-errormessage")                      \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_disabled, "aria-disabled")                               \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_expanded, "aria-expanded")                               \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_flow_to, "aria-flowto")                                  \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_grabbed, "aria-grabbed")                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_has_popup, "aria-haspopup")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_hidden, "aria-hidden")                                   \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_invalid, "aria-invalid")                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_key_shortcuts, "aria-keyshortcuts")                      \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_label, "aria-label")                                     \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_labelled_by, "aria-labelledby")                          \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_level, "aria-level")                                     \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_live, "aria-live")                                       \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_modal, "aria-modal")                                     \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_multi_line, "aria-multiline")                            \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_multi_selectable, "aria-multiselectable")                \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_orientation, "aria-orientation")                         \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_owns, "aria-owns")                                       \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_placeholder, "aria-placeholder")                         \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_pos_in_set, "aria-posinset")                             \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_pressed, "aria-pressed")                                 \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_read_only, "aria-readonly")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_relevant, "aria-relevant")                               \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_required, "aria-required")                               \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_role_description, "aria-roledescription")                \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_row_count, "aria-rowcount")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_row_index, "aria-rowindex")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_row_index_text, "aria-rowindextext")                     \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_row_span, "aria-rowspan")                                \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_selected, "aria-selected")                               \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_set_size, "aria-setsize")                                \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_sort, "aria-sort")                                       \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_value_max, "aria-valuemax")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_value_min, "aria-valuemin")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_value_now, "aria-valuenow")                              \
+    __ENUMERATE_ARIA_ATTRIBUTE(aria_value_text, "aria-valuetext")
+
+#define __ENUMERATE_ARIA_ATTRIBUTE(name, attribute) \
+    extern FlyString name;
+ENUMERATE_ARIA_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
+
+}

--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     Animations/PseudoElementParsing.cpp
     ARIA/AriaData.cpp
     ARIA/ARIAMixin.cpp
+    ARIA/AttributeNames.cpp
     ARIA/Roles.cpp
     ARIA/RoleType.cpp
     ARIA/StateAndProperties.cpp

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -8,6 +8,7 @@
 
 #include <AK/Optional.h>
 #include <LibWeb/ARIA/ARIAMixin.h>
+#include <LibWeb/ARIA/AttributeNames.h>
 #include <LibWeb/Animations/Animatable.h>
 #include <LibWeb/Bindings/ElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
@@ -271,78 +272,22 @@ public:
     ErrorOr<void> scroll_into_view(Optional<Variant<bool, ScrollIntoViewOptions>> = {});
 
     // https://www.w3.org/TR/wai-aria-1.2/#ARIAMixin
-#define ARIA_IMPL(name, attribute)                                               \
+#define __ENUMERATE_ARIA_ATTRIBUTE(name, attribute)                              \
     Optional<String> name() const override                                       \
     {                                                                            \
-        return get_attribute(attribute);                                         \
+        return get_attribute(ARIA::AttributeNames::name);                        \
     }                                                                            \
                                                                                  \
     WebIDL::ExceptionOr<void> set_##name(Optional<String> const& value) override \
     {                                                                            \
         if (value.has_value())                                                   \
-            TRY(set_attribute(attribute, *value));                               \
+            TRY(set_attribute(ARIA::AttributeNames::name, *value));              \
         else                                                                     \
-            remove_attribute(attribute);                                         \
+            remove_attribute(ARIA::AttributeNames::name);                        \
         return {};                                                               \
     }
-
-    // https://www.w3.org/TR/wai-aria-1.2/#accessibilityroleandproperties-correspondence
-    ARIA_IMPL(role, "role"_fly_string);
-    ARIA_IMPL(aria_active_descendant, "aria-activedescendant"_fly_string);
-    ARIA_IMPL(aria_atomic, "aria-atomic"_fly_string);
-    ARIA_IMPL(aria_auto_complete, "aria-autocomplete"_fly_string);
-    ARIA_IMPL(aria_braille_label, "aria-braillelabel"_fly_string);
-    ARIA_IMPL(aria_braille_role_description, "aria-brailleroledescription"_fly_string);
-    ARIA_IMPL(aria_busy, "aria-busy"_fly_string);
-    ARIA_IMPL(aria_checked, "aria-checked"_fly_string);
-    ARIA_IMPL(aria_col_count, "aria-colcount"_fly_string);
-    ARIA_IMPL(aria_col_index, "aria-colindex"_fly_string);
-    ARIA_IMPL(aria_col_index_text, "aria-colindextext"_fly_string);
-    ARIA_IMPL(aria_col_span, "aria-colspan"_fly_string);
-    ARIA_IMPL(aria_controls, "aria-controls"_fly_string);
-    ARIA_IMPL(aria_current, "aria-current"_fly_string);
-    ARIA_IMPL(aria_described_by, "aria-describedby"_fly_string);
-    ARIA_IMPL(aria_description, "aria-description"_fly_string);
-    ARIA_IMPL(aria_details, "aria-details"_fly_string);
-    ARIA_IMPL(aria_drop_effect, "aria-dropeffect"_fly_string);
-    ARIA_IMPL(aria_error_message, "aria-errormessage"_fly_string);
-    ARIA_IMPL(aria_disabled, "aria-disabled"_fly_string);
-    ARIA_IMPL(aria_expanded, "aria-expanded"_fly_string);
-    ARIA_IMPL(aria_flow_to, "aria-flowto"_fly_string);
-    ARIA_IMPL(aria_grabbed, "aria-grabbed"_fly_string);
-    ARIA_IMPL(aria_has_popup, "aria-haspopup"_fly_string);
-    ARIA_IMPL(aria_hidden, "aria-hidden"_fly_string);
-    ARIA_IMPL(aria_invalid, "aria-invalid"_fly_string);
-    ARIA_IMPL(aria_key_shortcuts, "aria-keyshortcuts"_fly_string);
-    ARIA_IMPL(aria_label, "aria-label"_fly_string);
-    ARIA_IMPL(aria_labelled_by, "aria-labelledby"_fly_string);
-    ARIA_IMPL(aria_level, "aria-level"_fly_string);
-    ARIA_IMPL(aria_live, "aria-live"_fly_string);
-    ARIA_IMPL(aria_modal, "aria-modal"_fly_string);
-    ARIA_IMPL(aria_multi_line, "aria-multiline"_fly_string);
-    ARIA_IMPL(aria_multi_selectable, "aria-multiselectable"_fly_string);
-    ARIA_IMPL(aria_orientation, "aria-orientation"_fly_string);
-    ARIA_IMPL(aria_owns, "aria-owns"_fly_string);
-    ARIA_IMPL(aria_placeholder, "aria-placeholder"_fly_string);
-    ARIA_IMPL(aria_pos_in_set, "aria-posinset"_fly_string);
-    ARIA_IMPL(aria_pressed, "aria-pressed"_fly_string);
-    ARIA_IMPL(aria_read_only, "aria-readonly"_fly_string);
-    ARIA_IMPL(aria_relevant, "aria-relevant"_fly_string);
-    ARIA_IMPL(aria_required, "aria-required"_fly_string);
-    ARIA_IMPL(aria_role_description, "aria-roledescription"_fly_string);
-    ARIA_IMPL(aria_row_count, "aria-rowcount"_fly_string);
-    ARIA_IMPL(aria_row_index, "aria-rowindex"_fly_string);
-    ARIA_IMPL(aria_row_index_text, "aria-rowindextext"_fly_string);
-    ARIA_IMPL(aria_row_span, "aria-rowspan"_fly_string);
-    ARIA_IMPL(aria_selected, "aria-selected"_fly_string);
-    ARIA_IMPL(aria_set_size, "aria-setsize"_fly_string);
-    ARIA_IMPL(aria_sort, "aria-sort"_fly_string);
-    ARIA_IMPL(aria_value_max, "aria-valuemax"_fly_string);
-    ARIA_IMPL(aria_value_min, "aria-valuemin"_fly_string);
-    ARIA_IMPL(aria_value_now, "aria-valuenow"_fly_string);
-    ARIA_IMPL(aria_value_text, "aria-valuetext"_fly_string);
-
-#undef ARIA_IMPL
+    ENUMERATE_ARIA_ATTRIBUTES
+#undef __ENUMERATE_ARIA_ATTRIBUTE
 
     virtual bool exclude_from_accessibility_tree() const override;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2219,7 +2219,8 @@ void Node::build_accessibility_tree(AccessibilityTreeNode& parent)
 ErrorOr<String> Node::name_or_description(NameOrDescription target, Document const& document, HashTable<UniqueNodeID>& visited_nodes, IsDescendant is_descendant) const
 {
     // The text alternative for a given element is computed as follows:
-    // 1. Set the root node to the given element, the current node to the root node, and the total accumulated text to the empty string (""). If the root node's role prohibits naming, return the empty string ("").
+    // 1. Set the root node to the given element, the current node to the root node, and the total accumulated text to the
+    //    empty string (""). If the root node's role prohibits naming, return the empty string ("").
     auto const* root_node = this;
     auto const* current_node = root_node;
     StringBuilder total_accumulated_text;
@@ -2232,13 +2233,13 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
 
         // A. Hidden Not Referenced: If the current node is hidden and is:
         // i. Not part of an aria-labelledby or aria-describedby traversal, where the node directly referenced by that
-        // relation was hidden.
+        //    relation was hidden.
         // ii. Nor part of a native host language text alternative element (e.g. label in HTML) or attribute traversal,
-        // where the root of that traversal was hidden.
+        //     where the root of that traversal was hidden.
         // Return the empty string.
-        // NOTE: Nodes with CSS properties display:none, visibility:hidden, visibility:collapse or
-        // content-visibility:hidden: They are considered hidden, as they match the guidelines "not perceivable" and
-        // "explicitly hidden".
+        //
+        // NOTE: Nodes with CSS properties display:none, visibility:hidden, visibility:collapse or content-visibility:hidden:
+        //       They are considered hidden, as they match the guidelines "not perceivable" and "explicitly hidden".
         //
         // AD-HOC: We don’t implement this step here — because strictly implementing this would cause us to return early
         // whenever encountering a node (element, actually) that “is hidden and is not directly referenced by
@@ -2249,12 +2250,15 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         // https://github.com/w3c/aria/issues/2387
 
         // B. Otherwise:
-        // - if computing a name, and the current node has an aria-labelledby attribute that contains at least one valid IDREF, and the current node is not already part of an aria-labelledby traversal,
-        //   process its IDREFs in the order they occur:
-        // - or, if computing a description, and the current node has an aria-describedby attribute that contains at least one valid IDREF, and the current node is not already part of an aria-describedby traversal,
-        //   process its IDREFs in the order they occur:
+        // - if computing a name, and the current node has an aria-labelledby attribute that contains at least one valid
+        //   IDREF, and the current node is not already part of an aria-labelledby traversal, process its IDREFs in the
+        //   order they occur:
+        // - or, if computing a description, and the current node has an aria-describedby attribute that contains at least
+        //   one valid IDREF, and the current node is not already part of an aria-describedby traversal, process its IDREFs
+        //   in the order they occur:
         auto aria_labelled_by = element->aria_labelled_by();
         auto aria_described_by = element->aria_described_by();
+
         if ((target == NameOrDescription::Name && aria_labelled_by.has_value() && Node::first_valid_id(*aria_labelled_by, document).has_value())
             || (target == NameOrDescription::Description && aria_described_by.has_value() && Node::first_valid_id(*aria_described_by, document).has_value())) {
 
@@ -2267,6 +2271,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
             } else {
                 id_list = aria_described_by->bytes_as_string_view().split_view_if(Infra::is_ascii_whitespace);
             }
+
             // ii. For each IDREF:
             for (auto const& id_ref : id_list) {
                 auto node = document.get_element_by_id(MUST(FlyString::from_utf8(id_ref)));
@@ -2282,6 +2287,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 }
                 if (visited_nodes.contains(node->unique_id()))
                     continue;
+
                 // a. Set the current node to the node referenced by the IDREF.
                 current_node = node;
                 // b. Compute the text alternative of the current node beginning with step 2. Set the result to that text alternative.
@@ -2290,6 +2296,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 total_accumulated_text.append(' ');
                 total_accumulated_text.append(result);
             }
+
             // iii. Return the accumulated text.
             // AD-HOC: This substep in the spec doesn’t seem to explicitly require the following check for an aria-label
             // value; but the “button's hidden referenced name (visibility:hidden) with hidden aria-labelledby traversal
@@ -2302,7 +2309,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         }
 
         // D. AriaLabel: Otherwise, if the current node has an aria-label attribute whose value is not undefined, not
-        // the empty string, nor, when trimmed of whitespace, is not the empty string:
+        //    the empty string, nor, when trimmed of whitespace, is not the empty string:
+        //
         // AD-HOC: We’ve reordered substeps C and D from https://w3c.github.io/accname/#step2 — because
         // the more-specific per-HTML-element requirements at https://w3c.github.io/html-aam/#accname-computation
         // necessitate doing so, and the “input with label for association is superceded by aria-label” subtest at
@@ -2316,8 +2324,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         }
 
         // C. Embedded Control: Otherwise, if the current node is a control embedded within the label (e.g. any element
-        // directly referenced by aria-labelledby) for another widget, where the user can adjust the embedded control's
-        // value, then return the embedded control as part of the text alternative in the following manner:
+        //    directly referenced by aria-labelledby) for another widget, where the user can adjust the embedded control's
+        //    value, then return the embedded control as part of the text alternative in the following manner:
         GC::Ptr<DOM::NodeList> labels;
         if (is<HTML::HTMLElement>(this))
             labels = (const_cast<HTML::HTMLElement&>(static_cast<HTML::HTMLElement const&>(*current_node))).labels();
@@ -2336,9 +2344,11 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                     // https://github.com/w3c/aria/issues/2389
                     if (node == this)
                         continue;
+
                     if (node->is_element()) {
                         auto const& element = static_cast<DOM::Element const&>(*node);
                         auto role = element.role_or_default();
+
                         if (role == ARIA::Role::textbox) {
                             // i. Textbox: If the embedded control has role textbox, return its value.
                             if (is<HTML::HTMLInputElement>(*node)) {
@@ -2348,7 +2358,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                             } else
                                 builder.append(node->text_content().value());
                         } else if (role == ARIA::Role::combobox) {
-                            // ii. Combobox/Listbox: If the embedded control has role combobox or listbox, return the text alternative of the chosen option.
+                            // ii. Combobox/Listbox: If the embedded control has role combobox or listbox, return the text
+                            //     alternative of the chosen option.
                             if (is<HTML::HTMLInputElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLInputElement const&>(*node);
                                 if (element.has_attribute(HTML::AttributeNames::value))
@@ -2359,7 +2370,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                             } else
                                 builder.append(node->text_content().value());
                         } else if (role == ARIA::Role::listbox) {
-                            // ii. Combobox/Listbox: If the embedded control has role combobox or listbox, return the text alternative of the chosen option.
+                            // ii. Combobox/Listbox: If the embedded control has role combobox or listbox, return the text
+                            //     alternative of the chosen option.
                             if (is<HTML::HTMLSelectElement>(*node)) {
                                 auto const& element = static_cast<HTML::HTMLSelectElement const&>(*node);
                                 builder.append(element.value());
@@ -2376,6 +2388,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                         } else if (role == ARIA::Role::spinbutton || role == ARIA::Role::slider) {
                             auto aria_valuenow = element.aria_value_now();
                             auto aria_valuetext = element.aria_value_text();
+
                             // iii. Range: If the embedded control has role range (e.g., a spinbutton or slider):
                             // a. If the aria-valuetext property is present, return its value,
                             if (aria_valuetext.has_value())
@@ -2400,13 +2413,15 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         }
 
         // E. Host Language Label: Otherwise, if the current node's native markup provides an attribute (e.g. alt) or
-        // element (e.g. HTML label or SVG title) that defines a text alternative, return that alternative in the form
-        // of a flat string as defined by the host language, unless the element is marked as presentational
-        // (role="presentation" or role="none").
+        //    element (e.g. HTML label or SVG title) that defines a text alternative, return that alternative in the form
+        //    of a flat string as defined by the host language, unless the element is marked as presentational
+        //    (role="presentation" or role="none").
+        //
         // TODO: Confirm (through existing WPT test cases) whether HTMLLabelElement is already handled (by the code for
         // step C. “Embedded Control” above) in conformance with the spec requirements — and if not, then add handling.
         if (role != ARIA::Role::presentation && role != ARIA::Role::none && is<HTML::HTMLImageElement>(*element))
             return element->alternative_text().release_value();
+
         // https://w3c.github.io/svg-aam/#mapping_additional_nd
         Optional<String> title_element_text;
         if (element->is_svg_element()) {
@@ -2418,18 +2433,23 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
             });
             if (title_element_text.has_value())
                 return title_element_text.release_value();
+
             // If the current node is a link, and there was no child title element, but it has an xlink:title attribute,
             // return the value of that attribute.
             if (auto title_attribute = element->get_attribute_ns(Namespace::XLink, XLink::AttributeNames::title); title_attribute.has_value())
                 return title_attribute.release_value();
         }
+
         // https://w3c.github.io/html-aam/#table-element-accessible-name-computation
-        // if the table element has a child that is a caption element, then use the subtree of the first such element
+        // 2. If the accessible name is still empty, then: if the table element has a child that is a caption element,
+        //    then use the subtree of the first such element.
         if (is<HTML::HTMLTableElement>(*element))
             if (auto& table = (const_cast<HTML::HTMLTableElement&>(static_cast<HTML::HTMLTableElement const&>(*element))); table.caption())
                 return table.caption()->text_content().release_value();
-        // https://w3c.github.io/html-aam/#table-element-accessible-name-computation
-        // if the fieldset element has a child that is a legend element, then use the subtree of the first such element
+
+        // https://w3c.github.io/html-aam/#fieldset-element-accessible-name-computation
+        // 2. If the accessible name is still empty, then: if the fieldset element has a child that is a legend element,
+        //    then use the subtree of the first such element.
         if (is<HTML::HTMLFieldSetElement>(*element)) {
             Optional<String> legend;
             auto& fieldset = (const_cast<HTML::HTMLFieldSetElement&>(static_cast<HTML::HTMLFieldSetElement const&>(*element)));
@@ -2440,56 +2460,63 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
             if (legend.has_value())
                 return legend.release_value();
         }
+
         if (is<HTML::HTMLInputElement>(*element)) {
             auto& input = (const_cast<HTML::HTMLInputElement&>(static_cast<HTML::HTMLInputElement const&>(*element)));
             // https://w3c.github.io/html-aam/#input-type-button-input-type-submit-and-input-type-reset-accessible-name-computation
-            // Otherwise use the value attribute.
+            // 3. Otherwise use the value attribute.
             if (input.type_state() == HTML::HTMLInputElement::TypeAttributeState::Button
                 || input.type_state() == HTML::HTMLInputElement::TypeAttributeState::SubmitButton
                 || input.type_state() == HTML::HTMLInputElement::TypeAttributeState::ResetButton)
                 if (auto value = input.get_attribute(HTML::AttributeNames::value); value.has_value())
                     return value.release_value();
+
             // https://w3c.github.io/html-aam/#input-type-image-accessible-name-computation
-            // Otherwise use alt attribute if present and its value is not the empty string.
+            // 3. Otherwise use alt attribute if present and its value is not the empty string.
             if (input.type_state() == HTML::HTMLInputElement::TypeAttributeState::ImageButton)
                 if (auto alt = element->get_attribute(HTML::AttributeNames::alt); alt.has_value())
                     return alt.release_value();
         }
 
         // F. Name From Content: Otherwise, if the current node's role allows name from content, or if the current node
-        // is referenced by aria-labelledby, aria-describedby, or is a native host language text alternative element
-        // (e.g. label in HTML), or is a descendant of a native host language text alternative element:
+        //    is referenced by aria-labelledby, aria-describedby, or is a native host language text alternative element
+        //    (e.g. label in HTML), or is a descendant of a native host language text alternative element:
         if ((role.has_value() && ARIA::allows_name_from_content(role.value())) || element->is_referenced() || is_descendant == IsDescendant::Yes) {
             // i. Set the accumulated text to the empty string.
             total_accumulated_text.clear();
-            // ii. Name From Generated Content: Check for CSS generated textual content associated with the current node and include
-            // it in the accumulated text. The CSS ::before and ::after pseudo elements [CSS2] can provide textual content for
-            // elements that have a content model.
+
+            // ii. Name From Generated Content: Check for CSS generated textual content associated with the current node
+            //     and include it in the accumulated text. The CSS ::before and ::after pseudo elements [CSS2] can provide
+            //     textual content for elements that have a content model.
             // a. For ::before pseudo elements, User agents MUST prepend CSS textual content, without a space, to the textual
-            // content of the current node.
-            // b. For ::after pseudo elements, User agents MUST append CSS textual content, without a space, to the textual content
-            // of the current node. NOTE: The code for handling the ::after pseudo elements case is further below,
-            // following the “iii. For each child node of the current node” code.
+            //    content of the current node.
+            // b. For ::after pseudo elements, User agents MUST append CSS textual content, without a space, to the textual
+            //    content of the current node. NOTE: The code for handling the ::after pseudo elements case is further below,
+            //    following the “iii. For each child node of the current node” code.
             if (auto before = element->get_pseudo_element_node(CSS::Selector::PseudoElement::Type::Before)) {
                 if (before->computed_values().content().alt_text.has_value())
                     total_accumulated_text.append(before->computed_values().content().alt_text.release_value());
                 else
                     total_accumulated_text.append(before->computed_values().content().data);
             }
+
             // iii. Determine Child Nodes: Determine the rendered child nodes of the current node:
             // iii. Determine Child Nodes: Determine the rendered child nodes of the current node:
             // c. [Otherwise,] set the rendered child nodes to be the child nodes of the current node.
             auto child_nodes = current_node->children_as_vector();
+
             // a. If the current node has an attached shadow root, set the rendered child nodes to be the child nodes of
-            // the shadow root.
+            //    the shadow root.
             if (element->is_shadow_host() && element->shadow_root() && element->shadow_root()->is_connected())
                 child_nodes = element->shadow_root()->children_as_vector();
+
             // b. Otherwise, if the current node is a slot with assigned nodes, set the rendered child nodes to be the
-            // assigned nodes of the current node.
+            //    assigned nodes of the current node.
             if (element->is_html_slot_element()) {
                 total_accumulated_text.append(element->text_content().value());
                 child_nodes = static_cast<HTML::HTMLSlotElement const*>(element)->assigned_nodes();
             }
+
             // iv. Name From Each Child: For each rendered child node of the current node
             for (auto& child_node : child_nodes) {
                 if (!child_node->is_element() && !child_node->is_text())
@@ -2505,17 +2532,22 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 }
                 if (visited_nodes.contains(child_node->unique_id()))
                     continue;
+
                 // a. Set the current node to the child node.
                 current_node = child_node;
+
                 // b. Compute the text alternative of the current node beginning with step 2. Set the result to that text alternative.
                 auto result = MUST(current_node->name_or_description(target, document, visited_nodes, IsDescendant::Yes));
-                // Append a space character and the result of each step above to the total accumulated text.
+
+                // J. Append a space character and the result of each step above to the total accumulated text.
                 // AD-HOC: Doing the space-adding here is in a different order from what the spec states.
                 if (should_add_space)
                     total_accumulated_text.append(' ');
+
                 // c. Append the result to the accumulated text.
                 total_accumulated_text.append(result);
             }
+
             // NOTE: See step ii.b above.
             if (auto after = element->get_pseudo_element_node(CSS::Selector::PseudoElement::Type::After)) {
                 if (after->computed_values().content().alt_text.has_value())
@@ -2523,14 +2555,19 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 else
                     total_accumulated_text.append(after->computed_values().content().data);
             }
+
             // v. Return the accumulated text if it is not the empty string ("").
             if (!total_accumulated_text.is_empty())
                 return total_accumulated_text.to_string();
-            // Important: Each node in the subtree is consulted only once. If text has been collected from a descendant, but is referenced by another IDREF in some descendant node, then that second, or subsequent, reference is not followed. This is done to avoid infinite loops.
+
+            // Important: Each node in the subtree is consulted only once. If text has been collected from a descendant,
+            // but is referenced by another IDREF in some descendant node, then that second, or subsequent, reference is
+            // not followed. This is done to avoid infinite loops.
         }
     }
 
     // G. Text Node: Otherwise, if the current node is a Text Node, return its textual contents.
+    //
     // AD-HOC: The spec doesn’t require ascending through the parent node and ancestor nodes of every text node we
     // reach — the way we’re doing there. But we implement it this way because the spec algorithm as written doesn’t
     // appear to achieve what it seems to be intended to achieve. Specifically, the spec algorithm as written doesn’t
@@ -2543,7 +2580,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
     }
 
     // H. Otherwise, if the current node is a descendant of an element whose Accessible Name or Accessible Description
-    // is being computed, and contains descendants, proceed to 2F.i.
+    //    is being computed, and contains descendants, proceed to 2F.i.
+    //
     // AD-HOC: We don’t implement this step here — because is essentially unreachable code in the spec algorithm.
     // We could never get here without descending through every subtree of an element whose Accessible Name or
     // Accessible Description is being computed. And in our implementation of substep F about, we’re anyway already
@@ -2551,8 +2589,10 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
     // Description is being computed, in a way that never leads to this substep H every being hit.
 
     // I. Otherwise, if the current node has a Tooltip attribute, return its value.
+    //
     // https://www.w3.org/TR/accname-1.2/#dfn-tooltip-attribute
-    // Any host language attribute that would result in a user agent generating a tooltip such as in response to a mouse hover in desktop user agents.
+    // Any host language attribute that would result in a user agent generating a tooltip such as in response to a mouse
+    // hover in desktop user agents.
     // FIXME: Support SVG tooltips and CSS tooltips
     if (is<HTML::HTMLElement>(this)) {
         auto const* element = static_cast<HTML::HTMLElement const*>(this);
@@ -2560,7 +2600,9 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         if (tooltip.has_value() && !tooltip->is_empty())
             return tooltip.release_value();
     }
-    // After all steps are completed, the total accumulated text is used as the accessible name or accessible description of the element that initiated the computation.
+
+    // 3. After all steps are completed, the total accumulated text is used as the accessible name or accessible description
+    //    of the element that initiated the computation.
     return total_accumulated_text.to_string();
 }
 


### PR DESCRIPTION
We are currently constructing the attribute names as `FlyString`s every
time we invoke one of the ARIA attributes getters/setters. If there are
not any other instances of these strings in-memory, then we're thrashing
the `FlyString` cache.

Instead, let's follow suit of all other Web attributes - use an x-macro
to generate the attribute names.