### PR TITLE
LibWeb: Add missing empty size check before allocating PaintingSurface

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -282,7 +282,7 @@ String HTMLCanvasElement::to_data_url(StringView type, JS::Value quality)
     allocate_painting_surface_if_needed();
     auto surface = this->surface();
     auto size = bitmap_size_for_canvas();
-    if (!surface) {
+    if (!surface && !size.is_empty()) {
         // If the context is not initialized yet, we need to allocate transparent surface for serialization
         auto skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
         surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);
@@ -322,7 +322,7 @@ WebIDL::ExceptionOr<void> HTMLCanvasElement::to_blob(GC::Ref<WebIDL::CallbackTyp
     allocate_painting_surface_if_needed();
     auto surface = this->surface();
     auto size = bitmap_size_for_canvas();
-    if (!surface) {
+    if (!surface && !size.is_empty()) {
         // If the context is not initialized yet, we need to allocate transparent surface for serialization
         auto skia_backend_context = navigable()->traversable_navigable()->skia_backend_context();
         surface = Gfx::PaintingSurface::create_with_size(skia_backend_context, size, Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied);

--- a/Tests/LibWeb/Text/expected/canvas/fill-0-height-canvas-should-not-crash.txt
+++ b/Tests/LibWeb/Text/expected/canvas/fill-0-height-canvas-should-not-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash!)

--- a/Tests/LibWeb/Text/input/canvas/fill-0-height-canvas-should-not-crash.html
+++ b/Tests/LibWeb/Text/input/canvas/fill-0-height-canvas-should-not-crash.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        let c = document.createElement("canvas");
+        c.width = 300;
+        c.height = 0;
+        c.toDataURL();
+        println("PASS (didn't crash!)");
+    });
+</script>


### PR DESCRIPTION
Fixes crashing when Gfx::PaintingSurface::create_with_size() is called with a size of 0.