### PR TITLE
LibWeb: Bring whitespace handling closer to spec

### DIFF
--- a/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Libraries/LibWeb/Layout/TextNode.cpp
@@ -279,26 +279,26 @@ static String apply_math_auto_text_transform(String const& string)
     return MUST(builder.to_string());
 }
 
-static ErrorOr<String> apply_text_transform(String const& string, CSS::TextTransform text_transform, Optional<StringView> const& locale)
+static String apply_text_transform(String const& string, CSS::TextTransform text_transform, Optional<StringView> const& locale)
 {
     switch (text_transform) {
     case CSS::TextTransform::Uppercase:
-        return string.to_uppercase(locale);
+        return MUST(string.to_uppercase(locale));
     case CSS::TextTransform::Lowercase:
-        return string.to_lowercase(locale);
+        return MUST(string.to_lowercase(locale));
     case CSS::TextTransform::None:
         return string;
     case CSS::TextTransform::MathAuto:
         return apply_math_auto_text_transform(string);
     case CSS::TextTransform::Capitalize: {
-        return string.to_titlecase(locale, TrailingCodePointTransformation::PreserveExisting);
+        return MUST(string.to_titlecase(locale, TrailingCodePointTransformation::PreserveExisting));
     }
     case CSS::TextTransform::FullSizeKana: {
         // FIXME: Implement this!
         return string;
     }
     case CSS::TextTransform::FullWidth: {
-        return string.to_fullwidth();
+        return MUST(string.to_fullwidth());
     }
     }
 
@@ -346,7 +346,7 @@ void TextNode::compute_text_for_rendering()
     auto const maybe_lang = parent_element ? parent_element->lang() : Optional<String> {};
     auto const lang = maybe_lang.has_value() ? maybe_lang.value() : Optional<StringView> {};
 
-    auto data = apply_text_transform(dom_node().data(), computed_values().text_transform(), lang).release_value_but_fixme_should_propagate_errors();
+    auto data = apply_text_transform(dom_node().data(), computed_values().text_transform(), lang);
 
     auto data_view = data.bytes_as_string_view();
 

--- a/Libraries/LibWeb/Layout/TextNode.h
+++ b/Libraries/LibWeb/Layout/TextNode.h
@@ -61,7 +61,7 @@ public:
     };
 
     void invalidate_text_for_rendering();
-    void compute_text_for_rendering();
+    String compute_text_for_rendering() const;
 
     Unicode::Segmenter& grapheme_segmenter() const;
 
@@ -70,7 +70,7 @@ public:
 private:
     virtual bool is_text_node() const final { return true; }
 
-    Optional<String> m_text_for_rendering;
+    Optional<String> mutable m_text_for_rendering;
     mutable OwnPtr<Unicode::Segmenter> m_grapheme_segmenter;
 };
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/the-innertext-and-outertext-properties/getter.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/the-innertext-and-outertext-properties/getter.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 271 tests
 
-210 Pass
-61 Fail
+217 Pass
+54 Fail
 Pass	Simplest possible test ("<div>abc")
 Fail	Leading whitespace removed ("<div> abc")
 Fail	Trailing whitespace removed ("<div>abc ")
@@ -35,8 +35,8 @@ Pass	\t preserved ("<span style='white-space:pre'>abc\tdef")
 Fail	Leading whitespace removed ("<div style='white-space:pre-line'> abc")
 Fail	Trailing whitespace removed ("<div style='white-space:pre-line'>abc ")
 Pass	Internal whitespace collapsed ("<div style='white-space:pre-line'>abc  def")
-Fail	\n preserved ("<div style='white-space:pre-line'>abc\ndef")
-Fail	\r converted to newline ("<div style='white-space:pre-line'>abc\rdef")
+Pass	\n preserved ("<div style='white-space:pre-line'>abc\ndef")
+Pass	\r converted to newline ("<div style='white-space:pre-line'>abc\rdef")
 Pass	\t converted to space ("<div style='white-space:pre-line'>abc\tdef")
 Fail	Whitespace collapses across element boundaries ("<div><span>abc </span> def")
 Fail	Whitespace collapses across element boundaries ("<div><span>abc </span><span></span> def")
@@ -215,13 +215,13 @@ Fail	 ("<table><tfoot><tr><td>footer</tfoot><thead><tr><td style='visibility:col
 Pass	No tab on table-cell itself ("<table><tr><td id=target>abc</td><td>def</td>")
 Pass	No newline on table-row itself ("<table><tr id=target><td>abc</td><td>def</td></tr><tr id=target><td>ghi</td><td>jkl</td></tr>")
 Pass	Newline between cells and caption ("<div><table><tr><td>abc<caption>def</caption></table>")
-Fail	Tab-separated table cells ("<div><div class='table'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>")
-Fail	Newline-separated table rows ("<div><div class='table'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>")
+Pass	Tab-separated table cells ("<div><div class='table'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>")
+Pass	Newline-separated table rows ("<div><div class='table'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>")
 Pass	Newlines around table ("<div>abc<div class='table'><span class='cell'>def</span></div>ghi")
-Fail	Tab-separated table cells ("<div><div class='itable'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>")
-Fail	Newline-separated table rows ("<div><div class='itable'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>")
+Pass	Tab-separated table cells ("<div><div class='itable'><span class='cell'>abc</span>\n<span class='cell'>def</span></div>")
+Pass	Newline-separated table rows ("<div><div class='itable'><span class='row'><span class='cell'>abc</span></span>\n<span class='row'><span class='cell'>def</span></span></div>")
 Pass	No newlines around inline-table ("<div>abc<div class='itable'><span class='cell'>def</span></div>ghi")
-Fail	Single newline in two-row inline-table ("<div>abc<div class='itable'><span class='row'><span class='cell'>def</span></span>\n<span class='row'><span class='cell'>123</span></span></div>ghi")
+Pass	Single newline in two-row inline-table ("<div>abc<div class='itable'><span class='row'><span class='cell'>def</span></span>\n<span class='row'><span class='cell'>123</span></span></div>ghi")
 Pass	display:table-row on the element itself ("<div style='display:table-row'>")
 Pass	display:table-cell on the element itself ("<div style='display:table-cell'>")
 Pass	display:table-caption on the element itself ("<div style='display:table-caption'>")

--- a/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/the-innertext-and-outertext-properties/innertext-whitespace-pre-line.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/dom/elements/the-innertext-and-outertext-properties/innertext-whitespace-pre-line.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	innerText should be the same for the pre-line and pre examples
+1 Pass
+1 Fail
+Pass	innerText should be the same for the pre-line and pre examples
 Fail	innerText has collapsed whitespace but preserved newlines with pre-line


### PR DESCRIPTION
This replaces our ad-hoc code for collapsing whitespace, with the spec algorithm.

It doesn't quite do what I wanted, which is to fix innerText. To quote the [spec](https://html.spec.whatwg.org/multipage/dom.html#rendered-text-collection-steps):

> If node is a [Text](https://dom.spec.whatwg.org/#interface-text) node, then for each CSS text box produced by node, in content order, compute the text of the box after application of the CSS ['white-space'](https://drafts.csswg.org/css-text/#white-space-property) processing rules and ['text-transform'](https://drafts.csswg.org/css-text/#text-transform-property) rules, set items to the [list](https://infra.spec.whatwg.org/#list) of the resulting strings, and return items. The CSS ['white-space'](https://drafts.csswg.org/css-text/#white-space-property) processing rules are slightly modified: collapsible spaces at the end of lines are always collapsed, but they are only removed if the line is the last line of the block, or it ends with a [br](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-br-element) element. Soft hyphens should be preserved.

It's not clear to me how this could be implemented. I think we need to actually do all of this text processing at a different level - elsewhere the spec describes processing an entire inline formatting context at once, which would make it more possible to know if a `<br>` element is there, or to collapse whitespace across element boundaries. For now I've had enough. :sweat_smile: 