### PR TITLE
LibJS: Round of Temporal editorial updates, and a spec issue workaround

### DIFF
--- a/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -578,8 +578,8 @@ ThrowCompletionOr<RelativeTo> get_temporal_relative_to_option(VM& vm, Object con
         // g. Let timeZone be fields.[[TimeZone]].
         time_zone = move(fields.time_zone);
 
-        // h. Let offsetString be fields.[[Offset]].
-        offset_string = move(fields.offset);
+        // h. Let offsetString be fields.[[OffsetString]].
+        offset_string = move(fields.offset_string);
 
         // i. If offsetString is UNSET, then
         if (!offset_string.has_value()) {

--- a/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/AbstractOperations.cpp
@@ -1201,16 +1201,10 @@ ThrowCompletionOr<ParsedISODateTime> parse_iso_date_time(VM& vm, StringView iso_
                     return vm.throw_completion<RangeError>(ErrorType::TemporalInvalidCalendarIdentifier, *calendar);
             }
 
-            // 4. If goal is TemporalMonthDayString and parseResult does not contain a DateYear Parse Node, then
-            if (goal == Production::TemporalMonthDayString && !parse_result->date_year.has_value()) {
-                // a. Assert: goal is the last element of allowedFormats.
-                // FIXME: Spec issue: This assertion is possibly incorrect.
-                //        https://github.com/tc39/proposal-temporal/issues/3045
-                // VERIFY(goal == allowed_formats.last());
-
-                // b. Set yearAbsent to true.
+            // 4. If goal is TemporalMonthDayString and parseResult does not contain a DateYear Parse Node, set
+            //    yearAbsent to true.
+            if (goal == Production::TemporalMonthDayString && !parse_result->date_year.has_value())
                 year_absent = true;
-            }
         }
     }
 

--- a/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Calendar.cpp
@@ -49,7 +49,7 @@ enum class CalendarFieldConversion {
     __JS_ENUMERATE(CalendarField::Millisecond, millisecond, vm.names.millisecond, CalendarFieldConversion::ToIntegerWithTruncation) \
     __JS_ENUMERATE(CalendarField::Microsecond, microsecond, vm.names.microsecond, CalendarFieldConversion::ToIntegerWithTruncation) \
     __JS_ENUMERATE(CalendarField::Nanosecond, nanosecond, vm.names.nanosecond, CalendarFieldConversion::ToIntegerWithTruncation)    \
-    __JS_ENUMERATE(CalendarField::Offset, offset, vm.names.offset, CalendarFieldConversion::ToOffsetString)                         \
+    __JS_ENUMERATE(CalendarField::Offset, offset_string, vm.names.offset, CalendarFieldConversion::ToOffsetString)                  \
     __JS_ENUMERATE(CalendarField::TimeZone, time_zone, vm.names.timeZone, CalendarFieldConversion::ToTemporalTimeZoneIdentifier)
 
 struct CalendarFieldData {

--- a/Libraries/LibJS/Runtime/Temporal/Calendar.h
+++ b/Libraries/LibJS/Runtime/Temporal/Calendar.h
@@ -71,7 +71,7 @@ struct CalendarFields {
             .millisecond = {},
             .microsecond = {},
             .nanosecond = {},
-            .offset = {},
+            .offset_string = {},
             .time_zone = {},
         };
     }
@@ -88,7 +88,7 @@ struct CalendarFields {
     Optional<u16> millisecond { 0 };
     Optional<u16> microsecond { 0 };
     Optional<u16> nanosecond { 0 };
-    Optional<String> offset;
+    Optional<String> offset_string;
     Optional<String> time_zone;
 };
 

--- a/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -110,7 +110,7 @@ InternalDuration to_internal_duration_record_with_24_hour_days(VM& vm, Duration 
 }
 
 // 7.5.7 ToDateDurationRecordWithoutTime ( duration ), https://tc39.es/proposal-temporal/#sec-temporal-todatedurationrecordwithouttime
-ThrowCompletionOr<DateDuration> to_date_duration_record_without_time(VM& vm, Duration const& duration)
+DateDuration to_date_duration_record_without_time(VM& vm, Duration const& duration)
 {
     // 1. Let internalDuration be ToInternalDurationRecordWith24HourDays(duration).
     auto internal_duration = to_internal_duration_record_with_24_hour_days(vm, duration);
@@ -118,8 +118,8 @@ ThrowCompletionOr<DateDuration> to_date_duration_record_without_time(VM& vm, Dur
     // 2. Let days be truncate(internalDuration.[[Time]] / nsPerDay).
     auto days = internal_duration.time.divided_by(NANOSECONDS_PER_DAY).quotient;
 
-    // 3. Return ? CreateDateDurationRecord(internalDuration.[[Date]].[[Years]], internalDuration.[[Date]].[[Months]], internalDuration.[[Date]].[[Weeks]], days).
-    return TRY(create_date_duration_record(vm, duration.years(), duration.months(), duration.weeks(), days.to_double()));
+    // 3. Return ! CreateDateDurationRecord(internalDuration.[[Date]].[[Years]], internalDuration.[[Date]].[[Months]], internalDuration.[[Date]].[[Weeks]], days).
+    return MUST(create_date_duration_record(vm, duration.years(), duration.months(), duration.weeks(), days.to_double()));
 }
 
 // 7.5.8 TemporalDurationFromInternal ( internalDuration, largestUnit ), https://tc39.es/proposal-temporal/#sec-temporal-temporaldurationfrominternal

--- a/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -1111,9 +1111,9 @@ ThrowCompletionOr<DurationNudgeResult> nudge_to_zoned_time(VM& vm, i8 sign, Inte
     auto unit_length_multiplied_by_increment = unit_length.multiplied_by(Crypto::UnsignedBigInteger { increment });
     auto rounded_time_duration = TRY(round_time_duration_to_increment(vm, duration.time, unit_length_multiplied_by_increment, rounding_mode));
 
-    // 11. Let beyondDaySpan be ? AddTimeDuration(roundedTimeDuration, -daySpan).
+    // 11. Let beyondDaySpan be ! AddTimeDuration(roundedTimeDuration, -daySpan).
     day_span.negate();
-    auto beyond_day_span = TRY(add_time_duration(vm, rounded_time_duration, day_span));
+    auto beyond_day_span = MUST(add_time_duration(vm, rounded_time_duration, day_span));
 
     auto did_round_beyond_day = false;
     Crypto::SignedBigInteger nudged_epoch_ns;
@@ -1145,11 +1145,11 @@ ThrowCompletionOr<DurationNudgeResult> nudge_to_zoned_time(VM& vm, i8 sign, Inte
         nudged_epoch_ns = add_time_duration_to_epoch_nanoseconds(rounded_time_duration, start_epoch_ns);
     }
 
-    // 14. Let dateDuration be ? AdjustDateDurationRecord(duration.[[Date]], duration.[[Date]].[[Days]] + dayDelta).
-    auto date_duration = TRY(adjust_date_duration_record(vm, duration.date, duration.date.days + day_delta));
+    // 14. Let dateDuration be ! AdjustDateDurationRecord(duration.[[Date]], duration.[[Date]].[[Days]] + dayDelta).
+    auto date_duration = MUST(adjust_date_duration_record(vm, duration.date, duration.date.days + day_delta));
 
-    // 15. Let resultDuration be ? CombineDateAndTimeDuration(dateDuration, roundedTimeDuration).
-    auto result_duration = TRY(combine_date_and_time_duration(vm, date_duration, move(rounded_time_duration)));
+    // 15. Let resultDuration be ! CombineDateAndTimeDuration(dateDuration, roundedTimeDuration).
+    auto result_duration = MUST(combine_date_and_time_duration(vm, date_duration, move(rounded_time_duration)));
 
     // 16. Return Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didRoundBeyondDay }.
     return DurationNudgeResult { .duration = move(result_duration), .nudged_epoch_ns = move(nudged_epoch_ns), .did_expand_calendar_unit = did_round_beyond_day };
@@ -1208,11 +1208,11 @@ ThrowCompletionOr<DurationNudgeResult> nudge_to_day_or_time(VM& vm, InternalDura
         remainder = move(rounded_time);
     }
 
-    // 14. Let dateDuration be ? AdjustDateDurationRecord(duration.[[Date]], days).
-    auto date_duration = TRY(adjust_date_duration_record(vm, duration.date, days));
+    // 14. Let dateDuration be ! AdjustDateDurationRecord(duration.[[Date]], days).
+    auto date_duration = MUST(adjust_date_duration_record(vm, duration.date, days));
 
-    // 15. Let resultDuration be ? CombineDateAndTimeDuration(dateDuration, remainder).
-    auto result_duration = TRY(combine_date_and_time_duration(vm, date_duration, move(remainder)));
+    // 15. Let resultDuration be ! CombineDateAndTimeDuration(dateDuration, remainder).
+    auto result_duration = MUST(combine_date_and_time_duration(vm, date_duration, move(remainder)));
 
     // 16. Return Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didExpandDays }.
     return DurationNudgeResult { .duration = move(result_duration), .nudged_epoch_ns = move(nudged_epoch_ns), .did_expand_calendar_unit = did_expand_days };

--- a/Libraries/LibJS/Runtime/Temporal/Duration.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.cpp
@@ -734,7 +734,7 @@ ThrowCompletionOr<TimeDuration> add_24_hour_days_to_time_duration(VM& vm, TimeDu
 }
 
 // 7.5.24 AddTimeDurationToEpochNanoseconds ( d, epochNs ), https://tc39.es/proposal-temporal/#sec-temporal-addtimedurationtoepochnanoseconds
-TimeDuration add_time_duration_to_epoch_nanoseconds(TimeDuration const& duration, TimeDuration const& epoch_nanoseconds)
+Crypto::SignedBigInteger add_time_duration_to_epoch_nanoseconds(TimeDuration const& duration, Crypto::SignedBigInteger const& epoch_nanoseconds)
 {
     // 1. Return epochNs + ℤ(d).
     return epoch_nanoseconds.plus(duration);

--- a/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -116,7 +116,7 @@ DateDuration to_date_duration_record_without_time(VM&, Duration const&);
 ThrowCompletionOr<GC::Ref<Duration>> temporal_duration_from_internal(VM&, InternalDuration const&, Unit largest_unit);
 ThrowCompletionOr<DateDuration> create_date_duration_record(VM&, double years, double months, double weeks, double days);
 ThrowCompletionOr<DateDuration> adjust_date_duration_record(VM&, DateDuration const&, double days, Optional<double> weeks = {}, Optional<double> months = {});
-ThrowCompletionOr<InternalDuration> combine_date_and_time_duration(VM&, DateDuration, TimeDuration);
+InternalDuration combine_date_and_time_duration(DateDuration, TimeDuration);
 ThrowCompletionOr<GC::Ref<Duration>> to_temporal_duration(VM&, Value);
 i8 duration_sign(Duration const&);
 i8 date_duration_sign(DateDuration const&);

--- a/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -129,7 +129,7 @@ GC::Ref<Duration> create_negated_temporal_duration(VM&, Duration const&);
 TimeDuration time_duration_from_components(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
 ThrowCompletionOr<TimeDuration> add_time_duration(VM&, TimeDuration const&, TimeDuration const&);
 ThrowCompletionOr<TimeDuration> add_24_hour_days_to_time_duration(VM&, TimeDuration const&, double days);
-TimeDuration add_time_duration_to_epoch_nanoseconds(TimeDuration const& duration, TimeDuration const& epoch_nanoseconds);
+Crypto::SignedBigInteger add_time_duration_to_epoch_nanoseconds(TimeDuration const& duration, Crypto::SignedBigInteger const& epoch_nanoseconds);
 i8 compare_time_duration(TimeDuration const&, TimeDuration const&);
 TimeDuration time_duration_from_epoch_nanoseconds_difference(Crypto::SignedBigInteger const&, Crypto::SignedBigInteger const&);
 ThrowCompletionOr<TimeDuration> round_time_duration_to_increment(VM&, TimeDuration const&, Crypto::UnsignedBigInteger const& increment, RoundingMode);

--- a/Libraries/LibJS/Runtime/Temporal/Duration.h
+++ b/Libraries/LibJS/Runtime/Temporal/Duration.h
@@ -112,7 +112,7 @@ struct CalendarNudgeResult {
 DateDuration zero_date_duration(VM&);
 InternalDuration to_internal_duration_record(VM&, Duration const&);
 InternalDuration to_internal_duration_record_with_24_hour_days(VM&, Duration const&);
-ThrowCompletionOr<DateDuration> to_date_duration_record_without_time(VM&, Duration const&);
+DateDuration to_date_duration_record_without_time(VM&, Duration const&);
 ThrowCompletionOr<GC::Ref<Duration>> temporal_duration_from_internal(VM&, InternalDuration const&, Unit largest_unit);
 ThrowCompletionOr<DateDuration> create_date_duration_record(VM&, double years, double months, double weeks, double days);
 ThrowCompletionOr<DateDuration> adjust_date_duration_record(VM&, DateDuration const&, double days, Optional<double> weeks = {}, Optional<double> months = {});

--- a/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -424,16 +424,16 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::round)
         // c. Let dateDuration be ? CreateDateDurationRecord(0, 0, 0, days).
         auto date_duration = TRY(create_date_duration_record(vm, 0, 0, 0, days));
 
-        // d. Set internalDuration to ! CombineDateAndTimeDuration(dateDuration, 0).
-        internal_duration = MUST(combine_date_and_time_duration(vm, date_duration, TimeDuration { 0 }));
+        // d. Set internalDuration to CombineDateAndTimeDuration(dateDuration, 0).
+        internal_duration = combine_date_and_time_duration(date_duration, TimeDuration { 0 });
     }
     // 32. Else,
     else {
         // a. Let timeDuration be ? RoundTimeDuration(internalDuration.[[Time]], roundingIncrement, smallestUnit, roundingMode).
         auto time_duration = TRY(round_time_duration(vm, internal_duration.time, Crypto::UnsignedBigInteger { rounding_increment }, smallest_unit_value, rounding_mode));
 
-        // b. Set internalDuration to ! CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
-        internal_duration = MUST(combine_date_and_time_duration(vm, zero_date_duration(vm), move(time_duration)));
+        // b. Set internalDuration to CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
+        internal_duration = combine_date_and_time_duration(zero_date_duration(vm), move(time_duration));
     }
 
     // 33. Return ? TemporalDurationFromInternal(internalDuration, largestUnit).
@@ -600,8 +600,8 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::to_string)
     // 13. Let timeDuration be ? RoundTimeDuration(internalDuration.[[Time]], precision.[[Increment]], precision.[[Unit]], roundingMode).
     auto time_duration = TRY(round_time_duration(vm, internal_duration.time, precision.increment, precision.unit, rounding_mode));
 
-    // 14. Set internalDuration to ! CombineDateAndTimeDuration(internalDuration.[[Date]], timeDuration).
-    internal_duration = MUST(combine_date_and_time_duration(vm, internal_duration.date, move(time_duration)));
+    // 14. Set internalDuration to CombineDateAndTimeDuration(internalDuration.[[Date]], timeDuration).
+    internal_duration = combine_date_and_time_duration(internal_duration.date, move(time_duration));
 
     // 15. Let roundedLargestUnit be LargerOfTwoTemporalUnits(largestUnit, SECOND).
     auto rounded_largest_unit = larger_of_two_temporal_units(largest_unit, Unit::Second);

--- a/Libraries/LibJS/Runtime/Temporal/Instant.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/Instant.cpp
@@ -189,8 +189,8 @@ InternalDuration difference_instant(VM& vm, Crypto::SignedBigInteger const& nano
     // 2. Set timeDuration to ! RoundTimeDuration(timeDuration, roundingIncrement, smallestUnit, roundingMode).
     time_duration = MUST(round_time_duration(vm, time_duration, Crypto::UnsignedBigInteger { rounding_increment }, smallest_unit, rounding_mode));
 
-    // 3. Return ! CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
-    return MUST(combine_date_and_time_duration(vm, zero_date_duration(vm), move(time_duration)));
+    // 3. Return CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
+    return combine_date_and_time_duration(zero_date_duration(vm), move(time_duration));
 }
 
 // 8.5.7 RoundTemporalInstant ( ns, increment, unit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-roundtemporalinstant

--- a/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -407,8 +407,8 @@ ThrowCompletionOr<GC::Ref<PlainDate>> add_duration_to_date(VM& vm, ArithmeticOpe
     if (operation == ArithmeticOperation::Subtract)
         duration = create_negated_temporal_duration(vm, duration);
 
-    // 4. Let dateDuration be ? ToDateDurationRecordWithoutTime(duration).
-    auto date_duration = TRY(to_date_duration_record_without_time(vm, duration));
+    // 4. Let dateDuration be ToDateDurationRecordWithoutTime(duration).
+    auto date_duration = to_date_duration_record_without_time(vm, duration);
 
     // 5. Let resolvedOptions be ? GetOptionsObject(options).
     auto resolved_options = TRY(get_options_object(vm, options));

--- a/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -365,8 +365,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_date(VM& vm, Dura
     // 6. Let dateDifference be CalendarDateUntil(temporalDate.[[Calendar]], temporalDate.[[ISODate]], other.[[ISODate]], settings.[[LargestUnit]]).
     auto date_difference = calendar_date_until(vm, temporal_date.calendar(), temporal_date.iso_date(), other->iso_date(), settings.largest_unit);
 
-    // 7. Let duration be ! CombineDateAndTimeDuration(dateDifference, 0).
-    auto duration = MUST(combine_date_and_time_duration(vm, date_difference, TimeDuration { 0 }));
+    // 7. Let duration be CombineDateAndTimeDuration(dateDifference, 0).
+    auto duration = combine_date_and_time_duration(date_difference, TimeDuration { 0 });
 
     // 8. If settings.[[SmallestUnit]] is not DAY or settings.[[RoundingIncrement]] ≠ 1, then
     if (settings.smallest_unit != Unit::Day || settings.rounding_increment != 1) {

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -405,8 +405,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_date_time(VM& vm,
     // 6. Let internalDuration be ? DifferencePlainDateTimeWithRounding(dateTime.[[ISODateTime]], other.[[ISODateTime]], dateTime.[[Calendar]], settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
     auto internal_duration = TRY(difference_plain_date_time_with_rounding(vm, date_time.iso_date_time(), other->iso_date_time(), date_time.calendar(), settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
 
-    // 7. Let result be ? TemporalDurationFromInternal(internalDuration, settings.[[LargestUnit]]).
-    auto result = TRY(temporal_duration_from_internal(vm, internal_duration, settings.largest_unit));
+    // 7. Let result be ! TemporalDurationFromInternal(internalDuration, settings.[[LargestUnit]]).
+    auto result = MUST(temporal_duration_from_internal(vm, internal_duration, settings.largest_unit));
 
     // 8. If operation is SINCE, set result to CreateNegatedTemporalDuration(result).
     if (operation == DurationOperation::Since)

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -330,8 +330,8 @@ InternalDuration difference_iso_date_time(VM& vm, ISODateTime const& iso_date_ti
         date_difference.days = 0;
     }
 
-    // 11. Return ! CombineDateAndTimeDuration(dateDifference, timeDuration).
-    return MUST(combine_date_and_time_duration(vm, date_difference, move(time_duration)));
+    // 11. Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+    return combine_date_and_time_duration(date_difference, move(time_duration));
 }
 
 // 5.5.13 DifferencePlainDateTimeWithRounding ( isoDateTime1, isoDateTime2, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differenceplaindatetimewithrounding
@@ -339,8 +339,8 @@ ThrowCompletionOr<InternalDuration> difference_plain_date_time_with_rounding(VM&
 {
     // 1. If CompareISODateTime(isoDateTime1, isoDateTime2) = 0, then
     if (compare_iso_date_time(iso_date_time1, iso_date_time2) == 0) {
-        // a. Return ! CombineDateAndTimeDuration(ZeroDateDuration(), 0).
-        return MUST(combine_date_and_time_duration(vm, zero_date_duration(vm), TimeDuration { 0 }));
+        // a. Return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
+        return combine_date_and_time_duration(zero_date_duration(vm), TimeDuration { 0 });
     }
 
     // 2. Let diff be DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit).

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -300,14 +300,14 @@ InternalDuration difference_iso_date_time(VM& vm, ISODateTime const& iso_date_ti
     // 4. Let timeSign be TimeDurationSign(timeDuration).
     auto time_sign = time_duration_sign(time_duration);
 
-    // 5. Let dateSign be CompareISODate(isoDateTime2.[[ISODate]], isoDateTime1.[[ISODate]]).
-    auto date_sign = compare_iso_date(iso_date_time2.iso_date, iso_date_time1.iso_date);
+    // 5. Let dateSign be CompareISODate(isoDateTime1.[[ISODate]], isoDateTime2.[[ISODate]]).
+    auto date_sign = compare_iso_date(iso_date_time1.iso_date, iso_date_time2.iso_date);
 
     // 6. Let adjustedDate be isoDateTime2.[[ISODate]].
     auto adjusted_date = iso_date_time2.iso_date;
 
-    // 7. If timeSign = -dateSign, then
-    if (time_sign == -date_sign) {
+    // 7. If timeSign = dateSign, then
+    if (time_sign == date_sign) {
         // a. Set adjustedDate to BalanceISODate(adjustedDate.[[Year]], adjustedDate.[[Month]], adjustedDate.[[Day]] + timeSign).
         adjusted_date = balance_iso_date(adjusted_date.year, adjusted_date.month, static_cast<double>(adjusted_date.day) + time_sign);
 

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -286,7 +286,7 @@ ISODateTime round_iso_date_time(ISODateTime const& iso_date_time, u64 increment,
 }
 
 // 5.5.12 DifferenceISODateTime ( isoDateTime1, isoDateTime2, calendar, largestUnit ), https://tc39.es/proposal-temporal/#sec-temporal-differenceisodatetime
-ThrowCompletionOr<InternalDuration> difference_iso_date_time(VM& vm, ISODateTime const& iso_date_time1, ISODateTime const& iso_date_time2, StringView calendar, Unit largest_unit)
+InternalDuration difference_iso_date_time(VM& vm, ISODateTime const& iso_date_time1, ISODateTime const& iso_date_time2, StringView calendar, Unit largest_unit)
 {
     // 1. Assert: ISODateTimeWithinLimits(isoDateTime1) is true.
     VERIFY(iso_date_time_within_limits(iso_date_time1));
@@ -311,8 +311,8 @@ ThrowCompletionOr<InternalDuration> difference_iso_date_time(VM& vm, ISODateTime
         // a. Set adjustedDate to BalanceISODate(adjustedDate.[[Year]], adjustedDate.[[Month]], adjustedDate.[[Day]] + timeSign).
         adjusted_date = balance_iso_date(adjusted_date.year, adjusted_date.month, static_cast<double>(adjusted_date.day) + time_sign);
 
-        // b. Set timeDuration to ? Add24HourDaysToTimeDuration(timeDuration, -timeSign).
-        time_duration = TRY(add_24_hour_days_to_time_duration(vm, time_duration, -time_sign));
+        // b. Set timeDuration to ! Add24HourDaysToTimeDuration(timeDuration, -timeSign).
+        time_duration = MUST(add_24_hour_days_to_time_duration(vm, time_duration, -time_sign));
     }
 
     // 8. Let dateLargestUnit be LargerOfTwoTemporalUnits(DAY, largestUnit).
@@ -323,15 +323,15 @@ ThrowCompletionOr<InternalDuration> difference_iso_date_time(VM& vm, ISODateTime
 
     // 10. If largestUnit is not dateLargestUnit, then
     if (largest_unit != date_largest_unit) {
-        // a. Set timeDuration to ? Add24HourDaysToTimeDuration(timeDuration, dateDifference.[[Days]]).
-        time_duration = TRY(add_24_hour_days_to_time_duration(vm, time_duration, date_difference.days));
+        // a. Set timeDuration to ! Add24HourDaysToTimeDuration(timeDuration, dateDifference.[[Days]]).
+        time_duration = MUST(add_24_hour_days_to_time_duration(vm, time_duration, date_difference.days));
 
         // b. Set dateDifference.[[Days]] to 0.
         date_difference.days = 0;
     }
 
-    // 11. Return ? CombineDateAndTimeDuration(dateDifference, timeDuration).
-    return TRY(combine_date_and_time_duration(vm, date_difference, move(time_duration)));
+    // 11. Return ! CombineDateAndTimeDuration(dateDifference, timeDuration).
+    return MUST(combine_date_and_time_duration(vm, date_difference, move(time_duration)));
 }
 
 // 5.5.13 DifferencePlainDateTimeWithRounding ( isoDateTime1, isoDateTime2, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differenceplaindatetimewithrounding
@@ -343,8 +343,8 @@ ThrowCompletionOr<InternalDuration> difference_plain_date_time_with_rounding(VM&
         return MUST(combine_date_and_time_duration(vm, zero_date_duration(vm), TimeDuration { 0 }));
     }
 
-    // 2. Let diff be ? DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit).
-    auto diff = TRY(difference_iso_date_time(vm, iso_date_time1, iso_date_time2, calendar, largest_unit));
+    // 2. Let diff be DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit).
+    auto diff = difference_iso_date_time(vm, iso_date_time1, iso_date_time2, calendar, largest_unit);
 
     // 3. If smallestUnit is NANOSECOND and roundingIncrement = 1, return diff.
     if (smallest_unit == Unit::Nanosecond && rounding_increment == 1)
@@ -366,8 +366,8 @@ ThrowCompletionOr<Crypto::BigFraction> difference_plain_date_time_with_total(VM&
         return Crypto::BigFraction {};
     }
 
-    // 2. Let diff be ? DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit).
-    auto diff = TRY(difference_iso_date_time(vm, iso_date_time1, iso_date_time2, calendar, unit));
+    // 2. Let diff be DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, unit).
+    auto diff = difference_iso_date_time(vm, iso_date_time1, iso_date_time2, calendar, unit);
 
     // 3. If unit is NANOSECOND, return diff.[[Time]].
     if (unit == Unit::Nanosecond)

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -41,7 +41,7 @@ ThrowCompletionOr<GC::Ref<PlainDateTime>> create_temporal_date_time(VM&, ISODate
 String iso_date_time_to_string(ISODateTime const&, StringView calendar, SecondsStringPrecision::Precision, ShowCalendar);
 i8 compare_iso_date_time(ISODateTime const&, ISODateTime const&);
 ISODateTime round_iso_date_time(ISODateTime const&, u64 increment, Unit, RoundingMode);
-InternalDuration difference_iso_date_time(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit);
+ThrowCompletionOr<InternalDuration> difference_iso_date_time(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit);
 ThrowCompletionOr<InternalDuration> difference_plain_date_time_with_rounding(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit, u64 rounding_increment, Unit smallest_unit, RoundingMode);
 ThrowCompletionOr<Crypto::BigFraction> difference_plain_date_time_with_total(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit);
 ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_date_time(VM&, DurationOperation, PlainDateTime const&, Value other, Value options);

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -41,7 +41,7 @@ ThrowCompletionOr<GC::Ref<PlainDateTime>> create_temporal_date_time(VM&, ISODate
 String iso_date_time_to_string(ISODateTime const&, StringView calendar, SecondsStringPrecision::Precision, ShowCalendar);
 i8 compare_iso_date_time(ISODateTime const&, ISODateTime const&);
 ISODateTime round_iso_date_time(ISODateTime const&, u64 increment, Unit, RoundingMode);
-ThrowCompletionOr<InternalDuration> difference_iso_date_time(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit);
+InternalDuration difference_iso_date_time(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit);
 ThrowCompletionOr<InternalDuration> difference_plain_date_time_with_rounding(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit, u64 rounding_increment, Unit smallest_unit, RoundingMode);
 ThrowCompletionOr<Crypto::BigFraction> difference_plain_date_time_with_total(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit);
 ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_date_time(VM&, DurationOperation, PlainDateTime const&, Value other, Value options);

--- a/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainTime.cpp
@@ -647,8 +647,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_time(VM& vm, Dura
     // 5. Set timeDuration to ! RoundTimeDuration(timeDuration, settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
     time_duration = MUST(round_time_duration(vm, time_duration, Crypto::UnsignedBigInteger { settings.rounding_increment }, settings.smallest_unit, settings.rounding_mode));
 
-    // 6. Let duration be ! CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
-    auto duration = MUST(combine_date_and_time_duration(vm, zero_date_duration(vm), move(time_duration)));
+    // 6. Let duration be CombineDateAndTimeDuration(ZeroDateDuration(), timeDuration).
+    auto duration = combine_date_and_time_duration(zero_date_duration(vm), move(time_duration));
 
     // 7. Let result be ! TemporalDurationFromInternal(duration, settings.[[LargestUnit]]).
     auto result = MUST(temporal_duration_from_internal(vm, duration, settings.largest_unit));

--- a/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -241,8 +241,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_year_month(VM& vm
     // 14. Let yearsMonthsDifference be ! AdjustDateDurationRecord(dateDifference, 0, 0).
     auto years_months_difference = MUST(adjust_date_duration_record(vm, date_difference, 0, 0));
 
-    // 15. Let duration be ! CombineDateAndTimeDuration(yearsMonthsDifference, 0).
-    auto duration = MUST(combine_date_and_time_duration(vm, years_months_difference, TimeDuration { 0 }));
+    // 15. Let duration be CombineDateAndTimeDuration(yearsMonthsDifference, 0).
+    auto duration = combine_date_and_time_duration(years_months_difference, TimeDuration { 0 });
 
     // 16. If settings.[[SmallestUnit]] is not MONTH or settings.[[RoundingIncrement]] ≠ 1, then
     if (settings.smallest_unit != Unit::Month || settings.rounding_increment != 1) {

--- a/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -259,8 +259,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_year_month(VM& vm
         duration = TRY(round_relative_duration(vm, move(duration), dest_epoch_ns, iso_date_time, {}, calendar, settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
     }
 
-    // 17. Let result be ? TemporalDurationFromInternal(duration, DAY).
-    auto result = TRY(temporal_duration_from_internal(vm, duration, Unit::Day));
+    // 17. Let result be ! TemporalDurationFromInternal(duration, DAY).
+    auto result = MUST(temporal_duration_from_internal(vm, duration, Unit::Day));
 
     // 18. If operation is SINCE, set result to CreateNegatedTemporalDuration(result).
     if (operation == DurationOperation::Since)

--- a/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -323,8 +323,8 @@ ThrowCompletionOr<GC::Ref<PlainYearMonth>> add_duration_to_year_month(VM& vm, Ar
         date = intermediate_date;
     }
 
-    // 12. Let durationToAdd be ? ToDateDurationRecordWithoutTime(duration).
-    auto duration_to_add = TRY(to_date_duration_record_without_time(vm, duration));
+    // 12. Let durationToAdd be ToDateDurationRecordWithoutTime(duration).
+    auto duration_to_add = to_date_duration_record_without_time(vm, duration);
 
     // 13. Let addedDate be ? CalendarDateAdd(calendar, date, durationToAdd, overflow).
     auto added_date = TRY(calendar_date_add(vm, calendar, date, duration_to_add, overflow));

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -475,8 +475,8 @@ ThrowCompletionOr<InternalDuration> difference_zoned_date_time(VM& vm, Crypto::S
     // 13. Let dateDifference be CalendarDateUntil(calendar, startDateTime.[[ISODate]], intermediateDateTime.[[ISODate]], dateLargestUnit).
     auto date_difference = calendar_date_until(vm, calendar, start_date_time.iso_date, intermediate_date_time.iso_date, date_largest_unit);
 
-    // 14. Return ? CombineDateAndTimeDuration(dateDifference, timeDuration).
-    return TRY(combine_date_and_time_duration(vm, date_difference, move(time_duration)));
+    // 14. Return ! CombineDateAndTimeDuration(dateDifference, timeDuration).
+    return MUST(combine_date_and_time_duration(vm, date_difference, move(time_duration)));
 }
 
 // 6.5.7 DifferenceZonedDateTimeWithRounding ( ns1, ns2, timeZone, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetimewithrounding

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -542,8 +542,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_zoned_date_time(VM& vm,
     // 4. Let settings be ? GetDifferenceSettings(operation, resolvedOptions, DATETIME, « », NANOSECOND, HOUR).
     auto settings = TRY(get_difference_settings(vm, operation, resolved_options, UnitGroup::DateTime, {}, Unit::Nanosecond, Unit::Hour));
 
-    // 5. If TemporalUnitCategory(settings.[[LargestUnit]]) is not DATE, then
-    if (temporal_unit_category(settings.largest_unit) != UnitCategory::Date) {
+    // 5. If TemporalUnitCategory(settings.[[LargestUnit]]) is TIME, then
+    if (temporal_unit_category(settings.largest_unit) == UnitCategory::Time) {
         // a. Let internalDuration be DifferenceInstant(zonedDateTime.[[EpochNanoseconds]], other.[[EpochNanoseconds]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
         auto internal_duration = difference_instant(vm, zoned_date_time.epoch_nanoseconds()->big_integer(), other->epoch_nanoseconds()->big_integer(), settings.rounding_increment, settings.smallest_unit, settings.rounding_mode);
 

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -191,7 +191,7 @@ ThrowCompletionOr<GC::Ref<ZonedDateTime>> to_temporal_zoned_date_time(VM& vm, Va
         time_zone = fields.time_zone.release_value();
 
         // e. Let offsetString be fields.[[OffsetString]].
-        offset_string = move(fields.offset);
+        offset_string = move(fields.offset_string);
 
         // f. If offsetString is UNSET, then
         if (!offset_string.has_value()) {

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -408,9 +408,9 @@ ThrowCompletionOr<Crypto::SignedBigInteger> add_zoned_date_time(VM& vm, Crypto::
 // 6.5.6 DifferenceZonedDateTime ( ns1, ns2, timeZone, calendar, largestUnit ), https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetime
 ThrowCompletionOr<InternalDuration> difference_zoned_date_time(VM& vm, Crypto::SignedBigInteger const& nanoseconds1, Crypto::SignedBigInteger const& nanoseconds2, StringView time_zone, StringView calendar, Unit largest_unit)
 {
-    // 1. If ns1 = ns2, return ! CombineDateAndTimeDuration(ZeroDateDuration(), 0).
+    // 1. If ns1 = ns2, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
     if (nanoseconds1 == nanoseconds2)
-        return MUST(combine_date_and_time_duration(vm, zero_date_duration(vm), TimeDuration { 0 }));
+        return combine_date_and_time_duration(zero_date_duration(vm), TimeDuration { 0 });
 
     // 2. Let startDateTime be GetISODateTimeFor(timeZone, ns1).
     auto start_date_time = get_iso_date_time_for(time_zone, nanoseconds1);
@@ -475,8 +475,8 @@ ThrowCompletionOr<InternalDuration> difference_zoned_date_time(VM& vm, Crypto::S
     // 13. Let dateDifference be CalendarDateUntil(calendar, startDateTime.[[ISODate]], intermediateDateTime.[[ISODate]], dateLargestUnit).
     auto date_difference = calendar_date_until(vm, calendar, start_date_time.iso_date, intermediate_date_time.iso_date, date_largest_unit);
 
-    // 14. Return ! CombineDateAndTimeDuration(dateDifference, timeDuration).
-    return MUST(combine_date_and_time_duration(vm, date_difference, move(time_duration)));
+    // 14. Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+    return combine_date_and_time_duration(date_difference, move(time_duration));
 }
 
 // 6.5.7 DifferenceZonedDateTimeWithRounding ( ns1, ns2, timeZone, calendar, largestUnit, roundingIncrement, smallestUnit, roundingMode ), https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetimewithrounding

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -576,8 +576,8 @@ ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_zoned_date_time(VM& vm,
     // 9. Let internalDuration be ? DifferenceZonedDateTimeWithRounding(zonedDateTime.[[EpochNanoseconds]], other.[[EpochNanoseconds]], zonedDateTime.[[TimeZone]], zonedDateTime.[[Calendar]], settings.[[LargestUnit]], settings.[[RoundingIncrement]], settings.[[SmallestUnit]], settings.[[RoundingMode]]).
     auto internal_duration = TRY(difference_zoned_date_time_with_rounding(vm, zoned_date_time.epoch_nanoseconds()->big_integer(), other->epoch_nanoseconds()->big_integer(), zoned_date_time.time_zone(), zoned_date_time.calendar(), settings.largest_unit, settings.rounding_increment, settings.smallest_unit, settings.rounding_mode));
 
-    // 10. Let result be ? TemporalDurationFromInternal(internalDuration, HOUR).
-    auto result = TRY(temporal_duration_from_internal(vm, internal_duration, Unit::Hour));
+    // 10. Let result be ! TemporalDurationFromInternal(internalDuration, HOUR).
+    auto result = MUST(temporal_duration_from_internal(vm, internal_duration, Unit::Hour));
 
     // 11. If operation is SINCE, set result to CreateNegatedTemporalDuration(result).
     if (operation == DurationOperation::Since)

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -415,7 +415,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::with)
     fields.nanosecond = iso_date_time.time.nanosecond;
 
     // 16. Set fields.[[OffsetString]] to FormatUTCOffsetNanoseconds(offsetNanoseconds).
-    fields.offset = format_utc_offset_nanoseconds(offset_nanoseconds);
+    fields.offset_string = format_utc_offset_nanoseconds(offset_nanoseconds);
 
     // 17. Let partialZonedDateTime be ? PrepareCalendarFields(calendar, temporalZonedDateTimeLike, « YEAR, MONTH, MONTH-CODE, DAY », « HOUR, MINUTE, SECOND, MILLISECOND, MICROSECOND, NANOSECOND, OFFSET », PARTIAL).
     static constexpr auto calendar_field_names = to_array({ CalendarField::Year, CalendarField::Month, CalendarField::MonthCode, CalendarField::Day });
@@ -441,7 +441,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::with)
     auto date_time_result = TRY(interpret_temporal_date_time_fields(vm, calendar, fields, overflow));
 
     // 24. Let newOffsetNanoseconds be ! ParseDateTimeUTCOffset(fields.[[OffsetString]]).
-    auto new_offset_nanoseconds = parse_date_time_utc_offset(*fields.offset);
+    auto new_offset_nanoseconds = parse_date_time_utc_offset(*fields.offset_string);
 
     // 25. Let epochNanoseconds be ? InterpretISODateTimeOffset(dateTimeResult.[[ISODate]], dateTimeResult.[[Time]], OPTION, newOffsetNanoseconds, timeZone, disambiguation, offset, MATCH-EXACTLY).
     auto new_epoch_nanoseconds = TRY(interpret_iso_date_time_offset(vm, date_time_result.iso_date, date_time_result.time, OffsetBehavior::Option, new_offset_nanoseconds, time_zone, disambiguation, offset, MatchBehavior::MatchExactly));

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -703,8 +703,8 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::round)
         // i. Let roundedDayNs be ! RoundTimeDurationToIncrement(dayProgressNs, dayLengthNs, roundingMode).
         auto rounded_day_nanoseconds = MUST(round_time_duration_to_increment(vm, day_progress_nanoseconds, day_length_nanoseconds.unsigned_value(), rounding_mode));
 
-        // j. Let epochNanoseconds be AddTimeDurationToEpochNanoseconds(startNs, roundedDayNs).
-        epoch_nanoseconds = add_time_duration_to_epoch_nanoseconds(start_nanoseconds, rounded_day_nanoseconds);
+        // j. Let epochNanoseconds be AddTimeDurationToEpochNanoseconds(roundedDayNs, startNs).
+        epoch_nanoseconds = add_time_duration_to_epoch_nanoseconds(rounded_day_nanoseconds, start_nanoseconds);
     }
     // 19. Else,
     else {

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -970,7 +970,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::to_plain_date)
     // 3. Let isoDateTime be GetISODateTimeFor(zonedDateTime.[[TimeZone]], zonedDateTime.[[EpochNanoseconds]]).
     auto iso_date_time = get_iso_date_time_for(zoned_date_time->time_zone(), zoned_date_time->epoch_nanoseconds()->big_integer());
 
-    // 4. Return ! CreateTemporalDate(isoDateTime.[[ISODate]], zonedDateTime.[[Calendar]].).
+    // 4. Return ! CreateTemporalDate(isoDateTime.[[ISODate]], zonedDateTime.[[Calendar]]).
     return MUST(create_temporal_date(vm, iso_date_time.iso_date, zoned_date_time->calendar()));
 }
 

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.round.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.round.js
@@ -185,6 +185,14 @@ describe("errors", () => {
         }).toThrowWithMessage(RangeError, "Largest unit must not be year");
     });
 
+    test("relativeTo with invalid date", () => {
+        const duration = new Temporal.Duration(0, 0, 0, 31);
+
+        expect(() => {
+            duration.round({ smallestUnit: "minutes", relativeTo: "-271821-04-19" });
+        }).toThrowWithMessage(RangeError, "Invalid ISO date time");
+    });
+
     // Spec Issue: https://github.com/tc39/proposal-temporal/issues/2124
     // Spec Fix: https://github.com/tc39/proposal-temporal/commit/66f7464aaec64d3cd21fb2ec37f6502743b9a730
     test("balancing calendar units with largestUnit set to 'year' and relativeTo unset throws instead of crashing", () => {

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
@@ -85,4 +85,12 @@ describe("errors", () => {
             duration.total({ unit: "second" });
         }).toThrowWithMessage(RangeError, "Largest unit must not be year");
     });
+
+    test("relativeTo with invalid date", () => {
+        const duration = new Temporal.Duration(0, 0, 0, 31);
+
+        expect(() => {
+            duration.total({ unit: "minute", relativeTo: "-271821-04-19" });
+        }).toThrowWithMessage(RangeError, "Invalid ISO date time");
+    });
 });


### PR DESCRIPTION
The last commit is a workaround for a [spec issue](https://github.com/tc39/proposal-temporal/issues/3015), for which a test has been added to test262 already that `master` now crashes on.

test262 diff:
```
Diff Tests:
    test/built-ins/Temporal/Duration/prototype/round/relativeto-string-limits.js 💥 -> ✅
    test/built-ins/Temporal/Duration/prototype/total/relativeto-string-limits.js 💥 -> ✅
```