### PR TITLE
LibWeb: Re-disable SVG rendering tests

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -163,3 +163,12 @@ Text/input/wpt-import/css/css-backgrounds/animations/discrete-no-interpolation.h
 
 ; https://github.com/LadybirdBrowser/ladybird/issues/2314
 Text/input/test-http-test-server.html
+
+; Frequently time out on macOS
+; https://github.com/LadybirdBrowser/ladybird/issues/2792
+Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-auto.html
+Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-fixed.html
+Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-percentage.html
+Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-auto.html
+Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-fixed.html
+Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html


### PR DESCRIPTION
This partially reverts commit f1bbba2ba54913876830c1de2a293d6faee20535.

These tests are frequently timing out on macOS CI.