### PR TITLE
LibWeb: Use GlyphRun fonts, not the first available font, for more things

### DIFF
--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -1199,9 +1199,8 @@ GC::Ref<Geometry::DOMRectList> Range::get_client_rects()
                 if (is<Painting::PaintableWithLines>(*containing_block)) {
                     auto const& paintable_lines = static_cast<Painting::PaintableWithLines const&>(*containing_block);
                     auto fragments = paintable_lines.fragments();
-                    auto const& font = paintable->layout_node().first_available_font();
                     for (auto frag = fragments.begin(); frag != fragments.end(); frag++) {
-                        auto rect = frag->range_rect(font, start_offset(), end_offset());
+                        auto rect = frag->range_rect(start_offset(), end_offset());
                         if (rect.is_empty())
                             continue;
                         rects.append(Geometry::DOMRect::create(realm(),

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1207,6 +1207,7 @@ void BlockFormattingContext::ensure_sizes_correct_for_left_offset_calculation(Li
     if (marker_text.is_empty()) {
         marker_state.set_content_width(image_width + default_marker_width);
     } else {
+        // FIXME: Use per-code-point fonts to measure text.
         auto text_width = marker.first_available_font().width(marker_text);
         marker_state.set_content_width(image_width + CSSPixels::nearest_value_for(text_width));
     }

--- a/Libraries/LibWeb/Layout/LineBox.cpp
+++ b/Libraries/LibWeb/Layout/LineBox.cpp
@@ -92,8 +92,8 @@ void LineBox::trim_trailing_whitespace()
         if (!is_ascii_space(last_character))
             break;
 
-        // FIXME: Use fragment's glyph run to determine the width of the last character.
-        int last_character_width = last_fragment->layout_node().first_available_font().glyph_width(last_character);
+        auto const& font = last_fragment->glyph_run() ? last_fragment->glyph_run()->font() : last_fragment->layout_node().first_available_font();
+        int last_character_width = font.glyph_width(last_character);
         last_fragment->m_length -= 1;
         last_fragment->set_inline_length(last_fragment->inline_length() - last_character_width);
         m_inline_length -= last_character_width;

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -307,6 +307,7 @@ void SVGFormattingContext::layout_nested_viewport(Box const& viewport)
 Gfx::Path SVGFormattingContext::compute_path_for_text(SVGTextBox const& text_box)
 {
     auto& text_element = static_cast<SVG::SVGTextPositioningElement const&>(text_box.dom_node());
+    // FIXME: Use per-code-point fonts.
     auto& font = text_box.first_available_font();
     auto text_contents = text_element.text_contents();
     Utf8View text_utf8 { text_contents };
@@ -349,6 +350,7 @@ Gfx::Path SVGFormattingContext::compute_path_for_text_path(SVGTextPathBox const&
     if (!path_or_shape)
         return {};
 
+    // FIXME: Use per-code-point fonts.
     auto& font = text_path_box.first_available_font();
     auto text_contents = text_path_element.text_contents();
     Utf8View text_utf8 { text_contents };

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -681,7 +681,7 @@ void paint_text_fragment(PaintContext& context, TextPaintable const& paintable, 
         auto scale = context.device_pixels_per_css_pixel();
         painter.draw_text_run(baseline_start.to_type<int>(), *glyph_run, paintable.computed_values().webkit_text_fill_color(), fragment_absolute_device_rect.to_type<int>(), scale, fragment.orientation());
 
-        auto selection_rect = context.enclosing_device_rect(fragment.selection_rect(paintable.layout_node().first_available_font())).to_type<int>();
+        auto selection_rect = context.enclosing_device_rect(fragment.selection_rect()).to_type<int>();
         if (!selection_rect.is_empty()) {
             painter.fill_rect(selection_rect, CSS::SystemColor::highlight());
             DisplayListRecorderStateSaver saver(painter);

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -570,8 +570,9 @@ void paint_cursor_if_needed(PaintContext& context, TextPaintable const& paintabl
     auto fragment_rect = fragment.absolute_rect();
 
     auto text = fragment.string_view();
+    auto const& font = fragment.glyph_run() ? fragment.glyph_run()->font() : fragment.layout_node().first_available_font();
     CSSPixelRect cursor_rect {
-        fragment_rect.x() + CSSPixels::nearest_value_for(paintable.layout_node().first_available_font().width(text.substring_view(0, document.cursor_position()->offset() - fragment.start()))),
+        fragment_rect.x() + CSSPixels::nearest_value_for(font.width(text.substring_view(0, document.cursor_position()->offset() - fragment.start()))),
         fragment_rect.top(),
         1,
         fragment_rect.height()

--- a/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -70,7 +70,8 @@ int PaintableFragment::text_index_at(CSSPixelPoint position) const
 
     return m_start + m_length;
 }
-CSSPixelRect PaintableFragment::range_rect(Gfx::Font const& font, size_t start_offset, size_t end_offset) const
+
+CSSPixelRect PaintableFragment::range_rect(size_t start_offset, size_t end_offset) const
 {
     if (paintable().selection_state() == Paintable::SelectionState::None)
         return {};
@@ -82,6 +83,7 @@ CSSPixelRect PaintableFragment::range_rect(Gfx::Font const& font, size_t start_o
     auto const start_index = static_cast<unsigned>(m_start);
     auto const end_index = static_cast<unsigned>(m_start) + static_cast<unsigned>(m_length);
 
+    auto const& font = glyph_run() ? glyph_run()->font() : layout_node().first_available_font();
     auto text = string_view();
 
     if (paintable().selection_state() == Paintable::SelectionState::StartAndEnd) {
@@ -185,7 +187,7 @@ Gfx::Orientation PaintableFragment::orientation() const
     }
 }
 
-CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
+CSSPixelRect PaintableFragment::selection_rect() const
 {
     if (auto const* focused_element = paintable().document().focused_element(); focused_element && is<HTML::FormAssociatedTextControlElement>(*focused_element)) {
         HTML::FormAssociatedTextControlElement const* text_control_element = nullptr;
@@ -200,7 +202,7 @@ CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
         auto selection_end = text_control_element->selection_end();
         if (!selection_start.has_value() || !selection_end.has_value())
             return {};
-        return range_rect(font, selection_start.value(), selection_end.value());
+        return range_rect(selection_start.value(), selection_end.value());
     }
     auto selection = paintable().document().get_selection();
     if (!selection)
@@ -209,7 +211,7 @@ CSSPixelRect PaintableFragment::selection_rect(Gfx::Font const& font) const
     if (!range)
         return {};
 
-    return range_rect(font, range->start_offset(), range->end_offset());
+    return range_rect(range->start_offset(), range->end_offset());
 }
 
 StringView PaintableFragment::string_view() const

--- a/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -39,8 +39,8 @@ public:
     RefPtr<Gfx::GlyphRun> glyph_run() const { return m_glyph_run; }
     Gfx::Orientation orientation() const;
 
-    CSSPixelRect selection_rect(Gfx::Font const&) const;
-    CSSPixelRect range_rect(Gfx::Font const&, size_t start_offset, size_t end_offset) const;
+    CSSPixelRect selection_rect() const;
+    CSSPixelRect range_rect(size_t start_offset, size_t end_offset) const;
 
     CSSPixels width() const { return m_size.width(); }
     CSSPixels height() const { return m_size.height(); }


### PR DESCRIPTION
Partly addresses #2787.

I found a few places where we're calling `first_available_font()` for things where we *actually* want to know the exact font used by these particular code-points. And, I've fixed some. Specifically, selection rectangles and text-editing cursor positions.

## Before
[Screencast_20241205_200256.webm](https://github.com/user-attachments/assets/c057ecb7-d70e-488e-b150-37053b6bd04a)

## After
[Screencast_20241205_200448.webm](https://github.com/user-attachments/assets/c68a29c4-072c-46b3-897a-654ca10e990a)

## Source

```html
<style>
html, textarea { font-family: lololol; }
</style>
<textarea>Well hello friends! 😅😅😅😅😅😅😅😅😅😅</textarea>
```

It is *absolutely* not perfect still. A couple of issues:
1. Somehow, _Noto Emoji_ has a space character, and since that's the first font, that's the space character we use - hence the comically large spaces between words.
2. Selecting multiple emojis near the end of the textarea still jumps the selection around. But it's better than it was.

The remaining spots we don't handle, which I've FIXME'd:
- SVG text paths just use the first available font, instead of identifying which font per code-point like regular text painting.
-  The text in list-item markers use the first available font too.

(There are also several places where using the first available font is appropriate as far as I can tell, so I've left those.)

We might have other places we do the wrong thing like this, but I'm sure we'll notice those eventually.