### PR TITLE
CMake: Add workaround for binutils+patchelf incompatability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,9 @@ if (VCPKG_TARGET_ANDROID)
     include("UI/Android/vcpkg_android.cmake")
 endif()
 
+# vcpkg flags depend on what linker we are using
+include("Meta/CMake/use_linker.cmake")
+
 # Pass additional information to vcpkg toolchain files if we are using vcpkg.
 if (CMAKE_TOOLCHAIN_FILE MATCHES "vcpkg.cmake$")
     set(CMAKE_PROJECT_ladybird_INCLUDE_BEFORE "Meta/CMake/vcpkg/generate_vcpkg_toolchain_variables.cmake")
@@ -29,7 +32,6 @@ set(LADYBIRD_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 list(APPEND CMAKE_MODULE_PATH "${LADYBIRD_SOURCE_DIR}/Meta/CMake")
 
 include(UI/cmake/EnableLagom.cmake)
-include(use_linker)
 include(lagom_options NO_POLICY_SCOPE)
 include(lagom_compile_options)
 

--- a/Meta/CMake/vcpkg/generate_vcpkg_toolchain_variables.cmake
+++ b/Meta/CMake/vcpkg/generate_vcpkg_toolchain_variables.cmake
@@ -8,4 +8,13 @@ if (NOT "${CMAKE_CXX_COMPILER}" STREQUAL "")
     string(APPEND EXTRA_VCPKG_VARIABLES "set(ENV{CXX} ${CMAKE_CXX_COMPILER})\n")
 endif()
 
+# Workaround for bad patchelf interaction with binutils 2.43.50
+# https://github.com/LadybirdBrowser/ladybird/issues/2149
+# https://github.com/microsoft/vcpkg/issues/41576
+# https://github.com/NixOS/patchelf/issues/568
+# https://bugzilla.redhat.com/show_bug.cgi?id=2319341
+if (LINUX AND NOT LAGOM_USE_LINKER)
+    string(APPEND EXTRA_VCPKG_VARIABLES "set(ENV{LDFLAGS} -Wl,-z,noseparate-code)\n")
+endif()
+
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/build-vcpkg-variables.cmake" "${EXTRA_VCPKG_VARIABLES}")


### PR DESCRIPTION
Reference #2149

I'd rather not close that issue until there's a patchelf patch that fixes the underlying inconsistency.