### PR TITLE
LibWeb: Remove :closed pseudo class

### DIFF
--- a/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -11,9 +11,6 @@
   "checked": {
     "argument": ""
   },
-  "closed": {
-    "argument": ""
-  },
   "defined": {
     "argument": ""
   },

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -728,7 +728,6 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         return false;
     }
     case CSS::PseudoClass::Open:
-    case CSS::PseudoClass::Closed:
         return matches_open_state_pseudo_class(element, pseudo_class.type == CSS::PseudoClass::Open);
     case CSS::PseudoClass::Modal: {
         // https://drafts.csswg.org/selectors/#modal-state

--- a/Tests/LibWeb/Ref/expected/css-open-closed-selectors-ref.html
+++ b/Tests/LibWeb/Ref/expected/css-open-closed-selectors-ref.html
@@ -3,15 +3,12 @@
     .open {
         color: green;
     }
-    .closed {
-        color: red;
-    }
 </style>
 <details open class="open">
     <summary>Hi</summary>
     Well hello friends!
 </details>
-<details class="closed">
+<details>
     <summary>Hi</summary>
     Well hello friends!
 </details>

--- a/Tests/LibWeb/Ref/input/css-open-closed-selectors.html
+++ b/Tests/LibWeb/Ref/input/css-open-closed-selectors.html
@@ -4,9 +4,6 @@
 :open {
     color: green;
 }
-:closed {
-    color: red;
-}
 </style>
 <details open>
     <summary>Hi</summary>


### PR DESCRIPTION
This was removed from the spec.

See https://drafts.csswg.org/selectors-4/#open-state