### PR TITLE
LibWeb: Implement popover methods

### DIFF
--- a/Libraries/LibWeb/CSS/PseudoClasses.json
+++ b/Libraries/LibWeb/CSS/PseudoClasses.json
@@ -104,6 +104,9 @@
   "open": {
     "argument": ""
   },
+  "popover-open": {
+    "argument": ""
+  },
   "paused": {
     "argument": ""
   },

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -739,6 +739,16 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         // FIXME: fullscreen elements are also modal.
         return false;
     }
+    case CSS::PseudoClass::PopoverOpen: {
+        // https://html.spec.whatwg.org/#selector-popover-open
+        // The :popover-open pseudo-class is defined to match any HTML element whose popover attribute is not in the no popover state and whose popover visibility state is showing.
+        if (is<HTML::HTMLElement>(element) && element.has_attribute(HTML::AttributeNames::popover)) {
+            auto& html_element = static_cast<HTML::HTMLElement const&>(element);
+            return html_element.popover_visibility_state() == HTML::HTMLElement::PopoverVisibilityState::Showing;
+        }
+
+        return false;
+    }
     }
 
     return false;

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -163,7 +163,9 @@ WebIDL::ExceptionOr<void> HTMLDialogElement::show_modal()
     if (!is_connected())
         return WebIDL::InvalidStateError::create(realm(), "Dialog not connected"_string);
 
-    // FIXME: 5. If this is in the popover showing state, then throw an "InvalidStateError" DOMException.
+    // 5. If this is in the popover showing state, then throw an "InvalidStateError" DOMException.
+    if (popover_visibility_state() == PopoverVisibilityState::Showing)
+        return WebIDL::InvalidStateError::create(realm(), "Dialog already open as popover"_string);
 
     // 6. If the result of firing an event named beforetoggle, using ToggleEvent,
     //  with the cancelable attribute initialized to true, the oldState attribute initialized to "closed",
@@ -185,7 +187,9 @@ WebIDL::ExceptionOr<void> HTMLDialogElement::show_modal()
     if (!is_connected())
         return {};
 
-    // FIXME: 9. If this is in the popover showing state, then return.
+    // 9. If this is in the popover showing state, then return.
+    if (popover_visibility_state() == PopoverVisibilityState::Showing)
+        return {};
 
     // 10. Queue a dialog toggle event task given subject, "closed", and "open".
     queue_a_dialog_toggle_event_task("closed"_string, "open"_string);

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -28,6 +28,36 @@ enum class ContentEditableState {
     Inherit,
 };
 
+struct ShowPopoverOptions {
+    GC::Ptr<HTMLElement> source;
+};
+
+struct TogglePopoverOptions : public ShowPopoverOptions {
+    Optional<bool> force {};
+};
+
+using TogglePopoverOptionsOrForceBoolean = Variant<TogglePopoverOptions, bool>;
+
+enum class ThrowExceptions {
+    Yes,
+    No,
+};
+
+enum class FocusPreviousElement {
+    Yes,
+    No,
+};
+
+enum class FireEvents {
+    Yes,
+    No,
+};
+
+enum class ExpectedToBeShowing {
+    Yes,
+    No,
+};
+
 class HTMLElement
     : public DOM::Element
     , public HTML::GlobalEventHandlers
@@ -85,6 +115,21 @@ public:
     WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
     Optional<String> popover() const;
 
+    enum class PopoverVisibilityState {
+        Hidden,
+        Showing,
+    };
+    PopoverVisibilityState popover_visibility_state() const { return m_popover_visibility_state; }
+
+    WebIDL::ExceptionOr<void> show_popover_for_bindings(ShowPopoverOptions const& = {});
+    WebIDL::ExceptionOr<void> hide_popover_for_bindings();
+    WebIDL::ExceptionOr<bool> toggle_popover(TogglePopoverOptionsOrForceBoolean const&);
+
+    WebIDL::ExceptionOr<void> show_popover(ThrowExceptions throw_exceptions, GC::Ptr<HTMLElement> invoker);
+    WebIDL::ExceptionOr<void> hide_popover(FocusPreviousElement focus_previous_element, FireEvents fire_events, ThrowExceptions throw_exceptions);
+
+    WebIDL::ExceptionOr<bool> check_popover_validity(ExpectedToBeShowing expected_to_be_showing, ThrowExceptions throw_exceptions, GC::Ptr<DOM::Document>);
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 
@@ -119,6 +164,17 @@ private:
 
     // https://html.spec.whatwg.org/multipage/interaction.html#click-in-progress-flag
     bool m_click_in_progress { false };
+
+    // Popover API
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-visibility-state
+    PopoverVisibilityState m_popover_visibility_state { PopoverVisibilityState::Hidden };
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-invoker
+    GC::Ptr<HTMLElement> m_popover_invoker;
+
+    // https://html.spec.whatwg.org/multipage/popover.html#popover-showing-or-hiding
+    bool m_popover_showing_or_hiding { false };
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLElement.idl
@@ -34,9 +34,9 @@ interface HTMLElement : Element {
     ElementInternals attachInternals();
 
     // The popover API
-    [FIXME] undefined showPopover();
-    [FIXME] undefined hidePopover();
-    [FIXME] boolean togglePopover(optional boolean force);
+    [ImplementedAs=show_popover_for_bindings] undefined showPopover(optional ShowPopoverOptions options = {});
+    [ImplementedAs=hide_popover_for_bindings] undefined hidePopover();
+    boolean togglePopover(optional (TogglePopoverOptions or boolean) options = {});
     [CEReactions] attribute DOMString? popover;
 
     // https://drafts.csswg.org/cssom-view/#extensions-to-the-htmlelement-interface
@@ -46,6 +46,16 @@ interface HTMLElement : Element {
     readonly attribute long offsetWidth;
     readonly attribute long offsetHeight;
 
+};
+
+// https://html.spec.whatwg.org/multipage/dom.html#showpopoveroptions
+dictionary ShowPopoverOptions {
+    HTMLElement source;
+};
+
+// https://html.spec.whatwg.org/multipage/dom.html#togglepopoveroptions
+dictionary TogglePopoverOptions : ShowPopoverOptions {
+    boolean force;
 };
 
 HTMLElement includes GlobalEventHandlers;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/popover-active-document.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/popover-active-document.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	showPopover should throw when the document isn't active

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/popover-types.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/popover-types.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	manuals do not close popovers

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/togglePopover.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/togglePopover.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 3 tests
+
+2 Pass
+1 Fail
+Pass	togglePopover should toggle the popover and return true or false as specified.
+Fail	togglePopover's return value should reflect what the end state is, not just the force parameter.
+Pass	togglePopover should throw an exception when there is no popover attribute.

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/popover-active-document.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/popover-active-document.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/pull/10705">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<script>
+  test(() => {
+    const doc = document.implementation.createHTMLDocument();
+    const popover = doc.createElement('div');
+    popover.setAttribute('popover','');
+    doc.body.appendChild(popover);
+    assert_throws_dom('InvalidStateError',() => popover.showPopover());
+    assert_false(popover.matches(':popover-open'));
+  },'showPopover should throw when the document isn\'t active');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/popover-types.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/popover-types.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="author" href="mailto:masonf@chromium.org">
+<link rel=help href="https://open-ui.org/components/popover.research.explainer">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<div id="container">
+  <div popover>Popover</div>
+  <div popover=manual>Async</div>
+  <div popover=manual>Async</div>
+</div>
+<script>
+  const auto = container.querySelector('[popover=""]');
+  const manual = container.querySelectorAll('[popover=manual]')[0];
+  const manual2 = container.querySelectorAll('[popover=manual]')[1];
+  function assert_state_1(autoOpen,manualOpen,manual2Open) {
+    assert_equals(auto.matches(':popover-open'),autoOpen,'auto open state is incorrect');
+    assert_equals(manual.matches(':popover-open'),manualOpen,'manual open state is incorrect');
+    assert_equals(manual2.matches(':popover-open'),manual2Open,'manual2 open state is incorrect');
+  }
+  test(() => {
+    assert_state_1(false,false,false);
+    auto.showPopover();
+    assert_state_1(true,false,false);
+    manual.showPopover();
+    assert_state_1(true,true,false);
+    manual2.showPopover();
+    assert_state_1(true,true,true);
+    auto.hidePopover();
+    assert_state_1(false,true,true);
+    manual.hidePopover();
+    assert_state_1(false,false,true);
+    manual2.hidePopover();
+    assert_state_1(false,false,false);
+  }, 'manuals do not close popovers');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/togglePopover.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/togglePopover.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/9043">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<div id=popover popover=auto>popover</div>
+<div id=popover2 popover=auto>popover</div>
+
+<script>
+test(() => {
+  assert_false(popover.matches(':popover-open'),
+    'Popover should be closed when the test starts.');
+
+  assert_true(popover.togglePopover(),
+    'togglePopover() should return true.');
+  assert_true(popover.matches(':popover-open'),
+    'togglePopover() should open the popover.');
+
+  assert_true(popover.togglePopover(/*force=*/true),
+    'togglePopover(true) should return true.');
+  assert_true(popover.matches(':popover-open'),
+    'togglePopover(true) should open the popover.');
+
+  assert_false(popover.togglePopover(),
+    'togglePopover() should return false.');
+  assert_false(popover.matches(':popover-open'),
+    'togglePopover() should close the popover.');
+
+  assert_false(popover.togglePopover(/*force=*/false),
+    'togglePopover(false) should return false.');
+  assert_false(popover.matches(':popover-open'),
+    'togglePopover(false) should close the popover.');
+}, 'togglePopover should toggle the popover and return true or false as specified.');
+
+test(() => {
+  const popover = document.getElementById('popover2');
+  popover.addEventListener('beforetoggle', event => event.preventDefault(), {once: true});
+  assert_false(popover.togglePopover(/*force=*/true),
+    'togglePopover(true) should return false when the popover does not get opened.');
+  assert_false(popover.matches(':popover-open'));
+
+  // We could also add a test for the return value of togglePopover(false),
+  // but every way to prevent that from hiding the popover also throws an
+  // exception, so the return value is not testable.
+}, `togglePopover's return value should reflect what the end state is, not just the force parameter.`);
+
+test(() => {
+  const popover = document.createElement('div');
+  document.body.appendChild(popover);
+
+  assert_throws_dom('NotSupportedError', () => popover.togglePopover(),
+    'togglePopover() should throw an exception when the element has no popover attribute.');
+  assert_throws_dom('NotSupportedError', () => popover.togglePopover(true),
+    'togglePopover(true) should throw an exception when the element has no popover attribute.');
+  assert_throws_dom('NotSupportedError', () => popover.togglePopover(false),
+    'togglePopover(false) should throw an exception when the element has no popover attribute.');
+
+  popover.setAttribute('popover', 'auto');
+  popover.remove();
+
+  assert_throws_dom('InvalidStateError', () => popover.togglePopover(),
+    'togglePopover() should throw an exception when the element is disconnected.');
+  assert_throws_dom('InvalidStateError', () => popover.togglePopover(true),
+    'togglePopover(true) should throw an exception when the element is disconnected.');
+  assert_throws_dom('InvalidStateError', () => popover.togglePopover(false),
+    'togglePopover(false) should throw an exception when the element is disconnected.');
+
+  document.body.appendChild(popover);
+  // togglePopover(false) should not throw just because the popover is already hidden.
+  popover.togglePopover(false);
+  popover.showPopover();
+  // togglePopover(true) should not throw just because the popover is already showing.
+  popover.togglePopover(true);
+
+  // cleanup
+  popover.hidePopover();
+}, 'togglePopover should throw an exception when there is no popover attribute.');
+</script>


### PR DESCRIPTION
Implements basics of showPopover, hidePopover and togglePopover.

Follow on from https://github.com/LadybirdBrowser/ladybird/pull/336

This improves the pass rate of various WPTs inside of wpt.live/html/semantics/popovers/