### PR TITLE
LibWeb: Layout standalone SVG document with specified dimensions

### DIFF
--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -18,6 +18,7 @@
 #include <LibWeb/Layout/SVGGeometryBox.h>
 #include <LibWeb/Layout/SVGImageBox.h>
 #include <LibWeb/Layout/SVGMaskBox.h>
+#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/SVG/SVGAElement.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
@@ -178,6 +179,18 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
 
     auto& svg_viewport = dynamic_cast<SVG::SVGViewport const&>(*context_box().dom_node());
     auto& svg_box_state = m_state.get_mutable(context_box());
+
+    if (!this->context_box().root().document().is_decoded_svg()) {
+        // Overwrite the content width/height with the styled node width/height (from <svg width height ...>)
+
+        // NOTE: If a height had not been provided by the svg element, it was set to the height of the container
+        //       (see BlockFormattingContext::layout_viewport)
+        if (svg_box_state.node().computed_values().width().is_length())
+            svg_box_state.set_content_width(svg_box_state.node().computed_values().width().length().to_px(svg_box_state.node()));
+        if (svg_box_state.node().computed_values().height().is_length())
+            svg_box_state.set_content_height(svg_box_state.node().computed_values().height().length().to_px(svg_box_state.node()));
+        // FIXME: In SVG 2, length can also be a percentage. We'll need to support that.
+    }
 
     // NOTE: We consider all SVG root elements to have definite size in both axes.
     //       I'm not sure if this is good or bad, but our viewport transform logic depends on it.

--- a/Tests/LibWeb/Layout/expected/svg/standalone-h.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-h.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 128x600 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (0,172) content-size 128x256 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (0,172) content-size 128x256 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (0,172) content-size 128x256 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 128x600]
+    SVGPathPaintable (SVGGeometryBox<rect>) [0,172 128x256]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,172 128x256]
+      SVGPathPaintable (SVGGeometryBox<path>) [0,172 128x256]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-h.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-h.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 128x600 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (0,0) content-size 32x64 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (0,0) content-size 32x64 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (0,0) content-size 32x64 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 128x600]
+    SVGPathPaintable (SVGGeometryBox<rect>) [0,0 32x64]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
+      SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-w.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-w.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 800x256 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (0,0) content-size 32x64 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (0,0) content-size 32x64 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (0,0) content-size 32x64 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 800x256]
+    SVGPathPaintable (SVGGeometryBox<rect>) [0,0 32x64]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
+      SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb-wh.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb-wh.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 800x600 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (0,0) content-size 32x64 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (0,0) content-size 32x64 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (0,0) content-size 32x64 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 800x600]
+    SVGPathPaintable (SVGGeometryBox<rect>) [0,0 32x64]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
+      SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone-vb.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-vb.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 128x256 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (0,0) content-size 32x64 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (0,0) content-size 32x64 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (0,0) content-size 32x64 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 128x256]
+    SVGPathPaintable (SVGGeometryBox<rect>) [0,0 32x64]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 32x64]
+      SVGPathPaintable (SVGGeometryBox<path>) [0,0 32x64]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone-w.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-w.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 800x256 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (336,0) content-size 128x256 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (336,0) content-size 128x256 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (336,0) content-size 128x256 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 800x256]
+    SVGPathPaintable (SVGGeometryBox<rect>) [336,0 128x256]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [336,0 128x256]
+      SVGPathPaintable (SVGGeometryBox<path>) [336,0 128x256]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone-wh.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone-wh.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 800x600 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (250,0) content-size 300x600 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (250,0) content-size 300x600 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (250,0) content-size 300x600 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 800x600]
+    SVGPathPaintable (SVGGeometryBox<rect>) [250,0 300x600]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [250,0 300x600]
+      SVGPathPaintable (SVGGeometryBox<path>) [250,0 300x600]
+

--- a/Tests/LibWeb/Layout/expected/svg/standalone.txt
+++ b/Tests/LibWeb/Layout/expected/svg/standalone.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 [BFC] children: not-inline
+  SVGSVGBox <svg> at (0,0) content-size 128x256 [SVG] children: inline
+    TextNode <#text>
+    TextNode <#text>
+    SVGGeometryBox <rect> at (0,0) content-size 128x256 children: not-inline
+    TextNode <#text>
+    SVGGraphicsBox <g> at (0,0) content-size 128x256 children: inline
+      TextNode <#text>
+      SVGGeometryBox <path> at (0,0) content-size 128x256 children: not-inline
+      TextNode <#text>
+    TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  SVGSVGPaintable (SVGSVGBox<svg>) [0,0 128x256]
+    SVGPathPaintable (SVGGeometryBox<rect>) [0,0 128x256]
+    SVGGraphicsPaintable (SVGGraphicsBox<g>) [0,0 128x256]
+      SVGPathPaintable (SVGGeometryBox<path>) [0,0 128x256]

--- a/Tests/LibWeb/Layout/input/svg/standalone-h.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-h.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 32 64" width="128" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no height</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone-vb-h.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-vb-h.svg
@@ -1,0 +1,7 @@
+<svg width="128" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no viewBox; no height</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone-vb-w.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-vb-w.svg
@@ -1,0 +1,7 @@
+<svg height="256" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no viewBox; no width</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone-vb-wh.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-vb-wh.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no viewBox; no width; no height</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone-vb.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-vb.svg
@@ -1,0 +1,7 @@
+<svg width="128" height="256" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no viewBox</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone-w.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-w.svg
@@ -1,0 +1,13 @@
+<!--
+    This will display identical on Ladybird and Chromium (131.0.6778.85) (centered), but left-aligned on Firefox (129.0.2)
+    Guessing Firefox has it right; no reason why missing height should align center (see standalone.svg where all left align)
+    Suggestion: not a priority, since it works the same as chromium
+    Likely a result of settings in Default.css
+-->
+<svg viewBox="0 0 32 64" height="256" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no width</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone-wh.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone-wh.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 32 64" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue; no width ; no height</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>

--- a/Tests/LibWeb/Layout/input/svg/standalone.svg
+++ b/Tests/LibWeb/Layout/input/svg/standalone.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 32 64" width="128" height="256" xmlns="http://www.w3.org/2000/svg">
+    <title>white diamond on blue</title>
+    <rect x="0" y="0" width="32" height="64" fill="blue"/>
+    <g fill="white">
+        <path d="M16 0 L32 32 L16 64 L0 32 Z" />
+    </g>
+</svg>


### PR DESCRIPTION
Fixes #2668 

Before:  standalone SVG documents were stretched to fit the agent
viewport, ignoring specified width / height attributes.

After this: SVG documents with specified width/height attributes are
laid out respecting these attributes.

Regarding layout of standalone SVG documents, this brings Ladybird to:
- parity with Chromium (131.0.6778.85)
- almost parity with Firefox (129.0.2) -- difference not material
