### PR TITLE
LibWeb: Fix use-after-move in `handle_successful_bitmap_decode`

### DIFF
--- a/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
+++ b/Libraries/LibWeb/HTML/SharedResourceRequest.cpp
@@ -161,7 +161,7 @@ void SharedResourceRequest::handle_successful_fetch(URL::URL const& url_string, 
         Vector<AnimatedBitmapDecodedImageData::Frame> frames;
         for (auto& frame : result.frames) {
             frames.append(AnimatedBitmapDecodedImageData::Frame {
-                .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap, move(result.color_space)),
+                .bitmap = Gfx::ImmutableBitmap::create(*frame.bitmap, result.color_space),
                 .duration = static_cast<int>(frame.duration),
             });
         }


### PR DESCRIPTION
Introduced in bd932858, the code would try to move `result.color_space` into the ImmutableBitmap created for each single frame of an image. For animated images, this would result in a use-after-move from the second frame.

---

Thanks @Lubrsi for pointing that out.