### PR TITLE
LibJS: Temporal editorials, part two

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -373,11 +373,9 @@ Optional<Unicode::CalendarPattern> get_date_time_format(Unicode::CalendarPattern
 
     // 17. If needDefaults is true, then
     if (need_defaults) {
-        // a. If anyPresent is true, return null.
-        if (any_present) {
-            // FIXME: Spec issue: We can hit this when setting `bestFormat`, which should never be null. Don't return for now.
-            //        https://github.com/tc39/proposal-temporal/issues/3049
-        }
+        // a. If anyPresent is true and inherit is RELEVANT, return null.
+        if (any_present && inherit == OptionInherit::Relevant)
+            return {};
 
         // b. For each property name prop of defaultOptions, do
         options.for_each_calendar_field_zipped_with(format_options, default_options, [&](auto const&, auto& format_option) {

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -371,15 +371,15 @@ Optional<Unicode::CalendarPattern> get_date_time_format(Unicode::CalendarPattern
         return IterationDecision::Continue;
     });
 
-    // 17. If anyPresent is true and needDefaults is true, return null.
-    if (any_present && need_defaults) {
-        // FIXME: Spec issue: We can hit this when setting `bestFormat`, which should never be null. Don't return for now.
-        //        https://github.com/tc39/proposal-temporal/issues/3049
-    }
-
-    // 18. If needDefaults is true, then
+    // 17. If needDefaults is true, then
     if (need_defaults) {
-        // a. For each property name prop of defaultOptions, do
+        // a. If anyPresent is true, return null.
+        if (any_present) {
+            // FIXME: Spec issue: We can hit this when setting `bestFormat`, which should never be null. Don't return for now.
+            //        https://github.com/tc39/proposal-temporal/issues/3049
+        }
+
+        // b. For each property name prop of defaultOptions, do
         options.for_each_calendar_field_zipped_with(format_options, default_options, [&](auto const&, auto& format_option) {
             using ValueType = typename RemoveCVReference<decltype(format_option)>::ValueType;
 
@@ -391,18 +391,18 @@ Optional<Unicode::CalendarPattern> get_date_time_format(Unicode::CalendarPattern
             return IterationDecision::Continue;
         });
 
-        // b. If defaults is ZONED-DATE-TIME, then
+        // c. If defaults is ZONED-DATE-TIME, then
         if (defaults == OptionDefaults::ZonedDateTime) {
             // i. Set formatOptions.[[timeZoneName]] to "short".
             format_options.time_zone_name = Unicode::CalendarPatternStyle::Short;
         }
     }
 
-    // 19. If matcher is "basic", then
+    // 18. If matcher is "basic", then
     //     a. Let bestFormat be BasicFormatMatcher(formatOptions, formats).
-    // 20. Else,
+    // 19. Else,
     //     a. Let bestFormat be BestFitFormatMatcher(formatOptions, formats).
-    // 21. Return bestFormat.
+    // 20. Return bestFormat.
     return format_options;
 }
 

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTime.h
@@ -41,7 +41,7 @@ ThrowCompletionOr<GC::Ref<PlainDateTime>> create_temporal_date_time(VM&, ISODate
 String iso_date_time_to_string(ISODateTime const&, StringView calendar, SecondsStringPrecision::Precision, ShowCalendar);
 i8 compare_iso_date_time(ISODateTime const&, ISODateTime const&);
 ISODateTime round_iso_date_time(ISODateTime const&, u64 increment, Unit, RoundingMode);
-ThrowCompletionOr<InternalDuration> difference_iso_date_time(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit);
+InternalDuration difference_iso_date_time(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit);
 ThrowCompletionOr<InternalDuration> difference_plain_date_time_with_rounding(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit largest_unit, u64 rounding_increment, Unit smallest_unit, RoundingMode);
 ThrowCompletionOr<Crypto::BigFraction> difference_plain_date_time_with_total(VM&, ISODateTime const&, ISODateTime const&, StringView calendar, Unit);
 ThrowCompletionOr<GC::Ref<Duration>> difference_temporal_plain_date_time(VM&, DurationOperation, PlainDateTime const&, Value other, Value options);

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -75,6 +75,22 @@ describe("errors", () => {
             "Cannot format Temporal.ZonedDateTime, use Temporal.ZonedDateTime.prototype.toLocaleString"
         );
     });
+
+    test("Temporal fields must overlap formatter", () => {
+        const yearFormatter = new Intl.DateTimeFormat([], { year: "numeric", calendar: "iso8601" });
+        const plainMonthDay = new Temporal.PlainMonthDay(1, 1);
+
+        const dayFormatter = new Intl.DateTimeFormat([], { day: "numeric", calendar: "iso8601" });
+        const plainYearMonth = new Temporal.PlainYearMonth(1972, 1);
+
+        expect(() => {
+            yearFormatter.format(plainMonthDay);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainMonthDay");
+
+        expect(() => {
+            dayFormatter.format(plainYearMonth);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainYearMonth");
+    });
 });
 
 const d0 = Date.UTC(2021, 11, 7, 17, 40, 50, 456);

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
@@ -112,6 +112,22 @@ describe("errors", () => {
             "Cannot format a date-time range with different date-time types"
         );
     });
+
+    test("Temporal fields must overlap formatter", () => {
+        const yearFormatter = new Intl.DateTimeFormat([], { year: "numeric", calendar: "iso8601" });
+        const plainMonthDay = new Temporal.PlainMonthDay(1, 1);
+
+        const dayFormatter = new Intl.DateTimeFormat([], { day: "numeric", calendar: "iso8601" });
+        const plainYearMonth = new Temporal.PlainYearMonth(1972, 1);
+
+        expect(() => {
+            yearFormatter.formatRange(plainMonthDay, plainMonthDay);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainMonthDay");
+
+        expect(() => {
+            dayFormatter.formatRange(plainYearMonth, plainYearMonth);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainYearMonth");
+    });
 });
 
 const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
@@ -112,6 +112,22 @@ describe("errors", () => {
             "Cannot format a date-time range with different date-time types"
         );
     });
+
+    test("Temporal fields must overlap formatter", () => {
+        const yearFormatter = new Intl.DateTimeFormat([], { year: "numeric", calendar: "iso8601" });
+        const plainMonthDay = new Temporal.PlainMonthDay(1, 1);
+
+        const dayFormatter = new Intl.DateTimeFormat([], { day: "numeric", calendar: "iso8601" });
+        const plainYearMonth = new Temporal.PlainYearMonth(1972, 1);
+
+        expect(() => {
+            yearFormatter.formatRangeToParts(plainMonthDay, plainMonthDay);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainMonthDay");
+
+        expect(() => {
+            dayFormatter.formatRangeToParts(plainYearMonth, plainYearMonth);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainYearMonth");
+    });
 });
 
 const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
@@ -71,6 +71,22 @@ describe("errors", () => {
             "Cannot format Temporal.ZonedDateTime, use Temporal.ZonedDateTime.prototype.toLocaleString"
         );
     });
+
+    test("Temporal fields must overlap formatter", () => {
+        const yearFormatter = new Intl.DateTimeFormat([], { year: "numeric", calendar: "iso8601" });
+        const plainMonthDay = new Temporal.PlainMonthDay(1, 1);
+
+        const dayFormatter = new Intl.DateTimeFormat([], { day: "numeric", calendar: "iso8601" });
+        const plainYearMonth = new Temporal.PlainYearMonth(1972, 1);
+
+        expect(() => {
+            yearFormatter.formatToParts(plainMonthDay);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainMonthDay");
+
+        expect(() => {
+            dayFormatter.formatToParts(plainYearMonth);
+        }).toThrowWithMessage(TypeError, "Unable to determine format for Temporal.PlainYearMonth");
+    });
 });
 
 const d = Date.UTC(1989, 0, 23, 7, 8, 9, 45);


### PR DESCRIPTION
...electric boogaloo

test262 diff (from the fix in the last commit):
```
test/intl402/DateTimeFormat/prototype/format/temporal-objects-not-overlapping-options.js             ❌ -> ✅
test/intl402/DateTimeFormat/prototype/formatRange/temporal-objects-not-overlapping-options.js        ❌ -> ✅
test/intl402/DateTimeFormat/prototype/formatRangeToParts/temporal-objects-not-overlapping-options.js ❌ -> ✅
test/intl402/DateTimeFormat/prototype/formatToParts/temporal-objects-not-overlapping-options.js      ❌ -> ✅
```