### PR TITLE
LibWeb: Ensure Headers API can handle non-ascii characters

### DIFF
--- a/Libraries/LibWeb/Fetch/HeadersIterator.cpp
+++ b/Libraries/LibWeb/Fetch/HeadersIterator.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Bindings/HeadersIteratorPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Fetch/HeadersIterator.h>
+#include <LibWeb/Infra/Strings.h>
 
 namespace Web::Bindings {
 
@@ -65,8 +66,8 @@ GC::Ref<JS::Object> HeadersIterator::next()
         return create_iterator_result_object(vm(), JS::js_undefined(), true);
 
     auto const& pair = pairs[m_index++];
-    StringView pair_name { pair.name };
-    StringView pair_value { pair.value };
+    auto pair_name = Infra::isomorphic_decode(pair.name);
+    auto pair_value = Infra::isomorphic_decode(pair.value);
 
     switch (m_iteration_kind) {
     case JS::Object::PropertyKind::Key:

--- a/Tests/LibWeb/Text/expected/Fetch/fetch-headers-non-ascii.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/fetch-headers-non-ascii.txt
@@ -1,0 +1,34 @@
+--------------------------------
+Headers constructor
+--------------------------------
+Accept: before-æøå-after
+X-Test: before-ß-after
+
+--------------------------------
+Headers.append()
+--------------------------------
+Accept: before-æøå-after
+X-Test: before-ß-after
+
+--------------------------------
+Headers.set()
+--------------------------------
+Accept: before-æøå-after
+X-Test: before-ß-after
+
+--------------------------------
+Headers.getSetCookie()
+--------------------------------
+Set-Cookie: before-æøå-after
+
+--------------------------------
+Headers iterator
+--------------------------------
+accept: before-æøå-after
+x-test: before-ß-after
+
+--------------------------------
+Headers.forEach()
+--------------------------------
+accept: before-æøå-after
+x-test: before-ß-after

--- a/Tests/LibWeb/Text/expected/wpt-import/fetch/api/headers/headers-normalize.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/fetch/api/headers/headers-normalize.any.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	Create headers with not normalized values
+Pass	Check append method with not normalized values
+Pass	Check set method with not normalized values

--- a/Tests/LibWeb/Text/input/Fetch/fetch-headers-non-ascii.html
+++ b/Tests/LibWeb/Text/input/Fetch/fetch-headers-non-ascii.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    // This test ensures that the Headers get() methods can handle non-ASCII latin1 characters: code points U+0080-U+00FF.
+    test(() => {
+      println("--------------------------------");
+      println("Headers constructor")
+      println("--------------------------------");
+      const headers = new Headers({
+        "Accept": "before-æøå-after",
+        "X-Test": "before-ß-after"
+      });
+      println("Accept: " + headers.get("Accept"));
+      println("X-Test: " + headers.get("X-Test"));
+
+      println("\n--------------------------------");
+      println("Headers.append()")
+      println("--------------------------------");
+      const headers2 = new Headers();
+      headers2.append("Accept", "before-æøå-after");
+      headers2.append("X-Test", "before-ß-after");
+      println("Accept: " + headers2.get("Accept"));
+      println("X-Test: " + headers2.get("X-Test"));
+
+      println("\n--------------------------------");
+      println("Headers.set()")
+      println("--------------------------------");
+      const headers3 = new Headers({
+        "X-Test": "should be overwritten"
+      });
+      headers3.set("Accept", "before-æøå-after");
+      headers3.set("X-Test", "before-ß-after");
+      println("Accept: " + headers3.get("Accept"));
+      println("X-Test: " + headers3.get("X-Test"));
+
+      println("\n--------------------------------");
+      println("Headers.getSetCookie()")
+      println("--------------------------------");
+      const headers4 = new Headers({
+        "Set-Cookie": "before-æøå-after",
+      });
+      println("Set-Cookie: " + headers4.getSetCookie());
+
+      println("\n--------------------------------");
+      println("Headers iterator")
+      println("--------------------------------");
+      const headers5 = new Headers({
+        "Accept": "before-æøå-after",
+        "X-Test": "before-ß-after"
+      });
+      for (const [key, value] of headers5) {
+        println(`${key}: ${value}`);
+      }
+
+      println("\n--------------------------------");
+      println("Headers.forEach()")
+      println("--------------------------------");
+      const headers6 = new Headers({
+        "Accept": "before-æøå-after",
+        "X-Test": "before-ß-after"
+      });
+      headers6.forEach((value, key) => {
+        println(`${key}: ${value}`);
+      });
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/fetch/api/headers/headers-normalize.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/fetch/api/headers/headers-normalize.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Headers normalize values</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../../fetch/api/headers/headers-normalize.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/fetch/api/headers/headers-normalize.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/fetch/api/headers/headers-normalize.any.js
@@ -1,0 +1,56 @@
+// META: title=Headers normalize values
+// META: global=window,worker
+
+"use strict";
+
+const expectations = {
+  "name1": [" space ", "space"],
+  "name2": ["\ttab\t", "tab"],
+  "name3": [" spaceAndTab\t", "spaceAndTab"],
+  "name4": ["\r\n newLine", "newLine"], //obs-fold cases
+  "name5": ["newLine\r\n ", "newLine"],
+  "name6": ["\r\n\tnewLine", "newLine"],
+  "name7": ["\t\f\tnewLine\n", "\f\tnewLine"],
+  "name8": ["newLine\xa0", "newLine\xa0"], // \xa0 == non breaking space
+};
+
+test(function () {
+  const headerDict = Object.fromEntries(
+    Object.entries(expectations).map(([name, [actual]]) => [name, actual]),
+  );
+  var headers = new Headers(headerDict);
+  for (const name in expectations) {
+    const expected = expectations[name][1];
+    assert_equals(
+      headers.get(name),
+      expected,
+      "name: " + name + " has normalized value: " + expected,
+    );
+  }
+}, "Create headers with not normalized values");
+
+test(function () {
+  var headers = new Headers();
+  for (const name in expectations) {
+    headers.append(name, expectations[name][0]);
+    const expected = expectations[name][1];
+    assert_equals(
+      headers.get(name),
+      expected,
+      "name: " + name + " has value: " + expected,
+    );
+  }
+}, "Check append method with not normalized values");
+
+test(function () {
+  var headers = new Headers();
+  for (const name in expectations) {
+    headers.set(name, expectations[name][0]);
+    const expected = expectations[name][1];
+    assert_equals(
+      headers.get(name),
+      expected,
+      "name: " + name + " has value: " + expected,
+    );
+  }
+}, "Check set method with not normalized values");


### PR DESCRIPTION
Ensure the Headers object's associated header list is ISO-8859-1 encoded
when set using `Infra::isomorphic_encode` and correctly decoded using
`Infra::isomorphic_decode`.

Follow-up of https://github.com/LadybirdBrowser/ladybird/pull/1893