### PR TITLE
Serialize getComputedStyle() values in a separate mode so we can simplify StyleComputer

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -811,7 +811,7 @@ WebIDL::ExceptionOr<GC::MarkedVector<JS::Object*>> KeyframeEffect::get_keyframes
             TRY(object->set(vm.names.offset, keyframe.offset.has_value() ? JS::Value(keyframe.offset.value()) : JS::js_null(), ShouldThrowExceptions::Yes));
             TRY(object->set(vm.names.computedOffset, JS::Value(keyframe.computed_offset.value()), ShouldThrowExceptions::Yes));
             auto easing_value = keyframe.easing.get<NonnullRefPtr<CSS::CSSStyleValue const>>();
-            TRY(object->set(vm.names.easing, JS::PrimitiveString::create(vm, easing_value->to_string()), ShouldThrowExceptions::Yes));
+            TRY(object->set(vm.names.easing, JS::PrimitiveString::create(vm, easing_value->to_string(CSS::CSSStyleValue::SerializationMode::Normal)), ShouldThrowExceptions::Yes));
 
             if (keyframe.composite == Bindings::CompositeOperationOrAuto::Replace) {
                 TRY(object->set(vm.names.composite, JS::PrimitiveString::create(vm, "replace"sv), ShouldThrowExceptions::Yes));
@@ -824,7 +824,7 @@ WebIDL::ExceptionOr<GC::MarkedVector<JS::Object*>> KeyframeEffect::get_keyframes
             }
 
             for (auto const& [id, value] : keyframe.parsed_properties()) {
-                auto value_string = JS::PrimitiveString::create(vm, value->to_string());
+                auto value_string = JS::PrimitiveString::create(vm, value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
                 TRY(object->set(JS::PropertyKey { DeprecatedFlyString(CSS::camel_case_string_from_property_id(id)), JS::PropertyKey::StringMayBeNumber::No }, value_string, ShouldThrowExceptions::Yes));
             }
 

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -271,7 +271,7 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
     if (property_id.value() == PropertyID::Custom) {
         auto maybe_custom_property = custom_property(FlyString::from_utf8_without_validation(property_name.bytes()));
         if (maybe_custom_property.has_value()) {
-            return maybe_custom_property.value().value->to_string();
+            return maybe_custom_property.value().value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
         }
         return {};
     }
@@ -302,7 +302,7 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
 
         // 3. If important flags of all declarations in list are same, then return the serialization of list.
         // NOTE: Currently we implement property-specific shorthand serialization in ShorthandStyleValue::to_string().
-        return ShorthandStyleValue::create(property_id.value(), longhand_ids, list)->to_string();
+        return ShorthandStyleValue::create(property_id.value(), longhand_ids, list)->to_string(CSSStyleValue::SerializationMode::Normal);
 
         // 4. Return the empty string.
         // NOTE: This is handled by the loop.
@@ -311,7 +311,7 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
     auto maybe_property = property(property_id.value());
     if (!maybe_property.has_value())
         return {};
-    return maybe_property->value->to_string();
+    return maybe_property->value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority
@@ -427,7 +427,7 @@ String PropertyOwningCSSStyleDeclaration::serialized() const
         // NOTE: There are no shorthands for custom properties.
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = declaration.value.value->to_string();
+        auto value = declaration.value.value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.
@@ -478,7 +478,7 @@ String PropertyOwningCSSStyleDeclaration::serialized() const
         // FIXME: 4. Shorthand loop: For each shorthand in shorthands, follow these substeps: ...
 
         // 5. Let value be the result of invoking serialize a CSS value of declaration.
-        auto value = declaration.value->to_string();
+        auto value = declaration.value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
 
         // 6. Let serialized declaration be the result of invoking serialize a CSS declaration with property name property, value value,
         //    and the important flag set if declaration has its important flag set.

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.cpp
@@ -271,7 +271,9 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
     if (property_id.value() == PropertyID::Custom) {
         auto maybe_custom_property = custom_property(FlyString::from_utf8_without_validation(property_name.bytes()));
         if (maybe_custom_property.has_value()) {
-            return maybe_custom_property.value().value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
+            return maybe_custom_property.value().value->to_string(
+                computed_flag() ? Web::CSS::CSSStyleValue::SerializationMode::ResolvedValue
+                                : Web::CSS::CSSStyleValue::SerializationMode::Normal);
         }
         return {};
     }
@@ -302,7 +304,7 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
 
         // 3. If important flags of all declarations in list are same, then return the serialization of list.
         // NOTE: Currently we implement property-specific shorthand serialization in ShorthandStyleValue::to_string().
-        return ShorthandStyleValue::create(property_id.value(), longhand_ids, list)->to_string(CSSStyleValue::SerializationMode::Normal);
+        return ShorthandStyleValue::create(property_id.value(), longhand_ids, list)->to_string(computed_flag() ? CSSStyleValue::SerializationMode::ResolvedValue : CSSStyleValue::SerializationMode::Normal);
 
         // 4. Return the empty string.
         // NOTE: This is handled by the loop.
@@ -311,7 +313,9 @@ String CSSStyleDeclaration::get_property_value(StringView property_name) const
     auto maybe_property = property(property_id.value());
     if (!maybe_property.has_value())
         return {};
-    return maybe_property->value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
+    return maybe_property->value->to_string(
+        computed_flag() ? Web::CSS::CSSStyleValue::SerializationMode::ResolvedValue
+                        : Web::CSS::CSSStyleValue::SerializationMode::Normal);
 }
 
 // https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-getpropertypriority

--- a/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -50,6 +50,9 @@ public:
 
     virtual GC::Ptr<CSSRule> parent_rule() const;
 
+    // https://drafts.csswg.org/cssom/#cssstyledeclaration-computed-flag
+    [[nodiscard]] virtual bool computed_flag() const { return false; }
+
 protected:
     explicit CSSStyleDeclaration(JS::Realm&);
 

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -360,7 +360,12 @@ public:
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const { return {}; }
     Keyword to_keyword() const;
-    virtual String to_string() const = 0;
+
+    enum class SerializationMode {
+        Normal,
+        ResolvedValue,
+    };
+    virtual String to_string(SerializationMode) const = 0;
 
     [[nodiscard]] int to_font_weight() const;
     [[nodiscard]] int to_font_slope() const;
@@ -399,6 +404,6 @@ template<>
 struct AK::Formatter<Web::CSS::CSSStyleValue> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::CSS::CSSStyleValue const& style_value)
     {
-        return Formatter<StringView>::format(builder, style_value.to_string());
+        return Formatter<StringView>::format(builder, style_value.to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal));
     }
 };

--- a/Libraries/LibWeb/CSS/CalculatedOr.h
+++ b/Libraries/LibWeb/CSS/CalculatedOr.h
@@ -68,7 +68,7 @@ public:
     String to_string() const
     {
         if (is_calculated())
-            return m_value.template get<NonnullRefPtr<CSSMathValue>>()->to_string();
+            return m_value.template get<NonnullRefPtr<CSSMathValue>>()->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
 
         return m_value.template get<T>().to_string();
     }

--- a/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Libraries/LibWeb/CSS/FontFace.cpp
@@ -214,7 +214,7 @@ WebIDL::ExceptionOr<void> FontFace::set_family(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-family property
     }
 
-    m_family = property->to_string();
+    m_family = property->to_string(CSSStyleValue::SerializationMode::Normal);
 
     return {};
 }
@@ -230,7 +230,7 @@ WebIDL::ExceptionOr<void> FontFace::set_style(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-style property
     }
 
-    m_style = property->to_string();
+    m_style = property->to_string(CSSStyleValue::SerializationMode::Normal);
 
     return {};
 }
@@ -246,7 +246,7 @@ WebIDL::ExceptionOr<void> FontFace::set_weight(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-weight property
     }
 
-    m_weight = property->to_string();
+    m_weight = property->to_string(CSSStyleValue::SerializationMode::Normal);
 
     return {};
 }
@@ -263,7 +263,7 @@ WebIDL::ExceptionOr<void> FontFace::set_stretch(String const& string)
         // FIXME: Propagate to the CSSFontFaceRule and update the font-width property
     }
 
-    m_stretch = property->to_string();
+    m_stretch = property->to_string(CSSStyleValue::SerializationMode::Normal);
 
     return {};
 }

--- a/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -31,7 +31,7 @@ String MediaFeatureValue::to_string() const
         [](ResolutionOrCalculated const& resolution) { return resolution.to_string(); },
         [](IntegerOrCalculated const& integer) {
             if (integer.is_calculated())
-                return integer.calculated()->to_string();
+                return integer.calculated()->to_string(CSSStyleValue::SerializationMode::Normal);
             return String::number(integer.value());
         });
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2879,7 +2879,7 @@ RefPtr<CSSStyleValue> Parser::parse_rect_value(TokenStream<ComponentValue>& toke
             if (!maybe_length.has_value())
                 return nullptr;
             if (maybe_length.value().is_calculated()) {
-                dbgln("FIXME: Support calculated lengths in rect(): {}", maybe_length.value().calculated()->to_string());
+                dbgln("FIXME: Support calculated lengths in rect(): {}", maybe_length.value().calculated()->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
                 return nullptr;
             }
             params.append(maybe_length.value().value());

--- a/Libraries/LibWeb/CSS/PercentageOr.h
+++ b/Libraries/LibWeb/CSS/PercentageOr.h
@@ -122,7 +122,7 @@ public:
     String to_string() const
     {
         if (is_calculated())
-            return m_value.template get<NonnullRefPtr<CSSMathValue>>()->to_string();
+            return m_value.template get<NonnullRefPtr<CSSMathValue>>()->to_string(CSSStyleValue::SerializationMode::Normal);
         if (is_percentage())
             return m_value.template get<Percentage>().to_string();
         return m_value.template get<T>().to_string();

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.h
@@ -38,6 +38,8 @@ private:
 
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual bool computed_flag() const override { return true; }
+
     RefPtr<CSSStyleValue const> style_value_for_property(Layout::NodeWithStyle const&, PropertyID) const;
 
     GC::Ref<DOM::Element> m_element;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1095,7 +1095,7 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
         if (!end_property.has_value()) {
             if (resolved_start_property) {
                 style_properties.set_animated_property(it.key, *resolved_start_property);
-                dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "No end property for property {}, using {}", string_from_property_id(it.key), resolved_start_property->to_string());
+                dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "No end property for property {}, using {}", string_from_property_id(it.key), resolved_start_property->to_string(CSSStyleValue::SerializationMode::Normal));
             }
             continue;
         }
@@ -1116,11 +1116,11 @@ void StyleComputer::collect_animation_into(DOM::Element& element, Optional<CSS::
         }
 
         if (auto next_value = interpolate_property(*effect->target(), it.key, *start, *end, progress_in_keyframe)) {
-            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} = {}", string_from_property_id(it.key), progress_in_keyframe, start->to_string(), end->to_string(), next_value->to_string());
+            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} = {}", string_from_property_id(it.key), progress_in_keyframe, start->to_string(CSSStyleValue::SerializationMode::Normal), end->to_string(CSSStyleValue::SerializationMode::Normal), next_value->to_string(CSSStyleValue::SerializationMode::Normal));
             style_properties.set_animated_property(it.key, *next_value);
         } else {
             // If interpolate_property() fails, the element should not be rendered
-            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} is invalid", string_from_property_id(it.key), progress_in_keyframe, start->to_string(), end->to_string());
+            dbgln_if(LIBWEB_CSS_ANIMATION_DEBUG, "Interpolated value for property {} at {}: {} -> {} is invalid", string_from_property_id(it.key), progress_in_keyframe, start->to_string(CSSStyleValue::SerializationMode::Normal), end->to_string(CSSStyleValue::SerializationMode::Normal));
             style_properties.set_animated_property(PropertyID::Visibility, CSSKeywordValue::create(Keyword::Hidden));
         }
     }
@@ -1393,7 +1393,7 @@ void StyleComputer::start_needed_transitions(StyleProperties const& previous_sty
         //    there is a matching transition-property value,
         //    and the end value of the running transition is not equal to the value of the property in the after-change style, then:
         if (has_running_transition && matching_transition_properties.has_value() && !existing_transition->transition_end_value()->equals(after_change_value)) {
-            dbgln_if(CSS_TRANSITIONS_DEBUG, "Transition step 4. existing end value = {}, after change value = {}", existing_transition->transition_end_value()->to_string(), after_change_value.to_string());
+            dbgln_if(CSS_TRANSITIONS_DEBUG, "Transition step 4. existing end value = {}, after change value = {}", existing_transition->transition_end_value()->to_string(CSSStyleValue::SerializationMode::Normal), after_change_value.to_string(CSSStyleValue::SerializationMode::Normal));
             // 1. If the current value of the property in the running transition is equal to the value of the property in the after-change style,
             //    or if these two values are not transitionable,
             //    then implementations must cancel the running transition.
@@ -1577,7 +1577,7 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
             return OptionalNone {};
         if (animation_name->is_string())
             return animation_name->as_string().string_value().to_string();
-        return animation_name->to_string();
+        return animation_name->to_string(CSSStyleValue::SerializationMode::Normal);
     }();
 
     if (animation_name.has_value()) {

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2424,17 +2424,6 @@ Optional<StyleProperties> StyleComputer::compute_style_impl(DOM::Element& elemen
         start_needed_transitions(*previous_style, style, element, pseudo_element);
     }
 
-    // Remove color names from CSS color values. This is needed because computed values cannot be named colors.
-    for (auto i = to_underlying(CSS::first_property_id); i <= to_underlying(CSS::last_property_id); ++i) {
-        auto property_id = (CSS::PropertyID)i;
-        auto* property = style.maybe_null_property(property_id);
-        if (property && property->is_color()) {
-            auto& color_value = property->as_color();
-            if (color_value.color_type() == CSSColorValue::ColorType::RGB)
-                style.set_property(property_id, CSSColorValue::create_from_color(color_value.to_color({})));
-        }
-    }
-
     return style;
 }
 

--- a/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -183,7 +183,7 @@ CSS::Size StyleProperties::size_value(CSS::PropertyID id) const
     }
 
     // FIXME: Support `fit-content(<length>)`
-    dbgln("FIXME: Unsupported size value: `{}`, treating as `auto`", value.to_string());
+    dbgln("FIXME: Unsupported size value: `{}`, treating as `auto`", value.to_string(CSSStyleValue::SerializationMode::Normal));
     return CSS::Size::make_auto();
 }
 
@@ -269,7 +269,7 @@ CSSPixels StyleProperties::compute_line_height(CSSPixelRect const& viewport_rect
         if (line_height.as_math().resolves_to_number()) {
             auto resolved = line_height.as_math().resolve_number();
             if (!resolved.has_value()) {
-                dbgln("FIXME: Failed to resolve calc() line-height (number): {}", line_height.as_math().to_string());
+                dbgln("FIXME: Failed to resolve calc() line-height (number): {}", line_height.as_math().to_string(CSSStyleValue::SerializationMode::Normal));
                 return CSSPixels::nearest_value_for(m_data->m_font_list->first().pixel_metrics().line_spacing());
             }
             return Length(resolved.value(), Length::Type::Em).to_px(viewport_rect, font_metrics, root_font_metrics);
@@ -277,7 +277,7 @@ CSSPixels StyleProperties::compute_line_height(CSSPixelRect const& viewport_rect
 
         auto resolved = line_height.as_math().resolve_length(Length::ResolutionContext { viewport_rect, font_metrics, root_font_metrics });
         if (!resolved.has_value()) {
-            dbgln("FIXME: Failed to resolve calc() line-height: {}", line_height.as_math().to_string());
+            dbgln("FIXME: Failed to resolve calc() line-height: {}", line_height.as_math().to_string(CSSStyleValue::SerializationMode::Normal));
             return CSSPixels::nearest_value_for(m_data->m_font_list->first().pixel_metrics().line_spacing());
         }
         return resolved->to_px(viewport_rect, font_metrics, root_font_metrics);
@@ -316,13 +316,13 @@ float StyleProperties::resolve_opacity_value(CSSStyleValue const& value)
             if (maybe_percentage.has_value())
                 unclamped_opacity = maybe_percentage->as_fraction();
             else
-                dbgln("Unable to resolve calc() as opacity (percentage): {}", value.to_string());
+                dbgln("Unable to resolve calc() as opacity (percentage): {}", value.to_string(CSSStyleValue::SerializationMode::Normal));
         } else if (calculated.resolves_to_number()) {
             auto maybe_number = const_cast<CSSMathValue&>(value.as_math()).resolve_number();
             if (maybe_number.has_value())
                 unclamped_opacity = maybe_number.value();
             else
-                dbgln("Unable to resolve calc() as opacity (number): {}", value.to_string());
+                dbgln("Unable to resolve calc() as opacity (number): {}", value.to_string(CSSStyleValue::SerializationMode::Normal));
         }
     } else if (value.is_percentage()) {
         unclamped_opacity = value.as_percentage().percentage().as_fraction();
@@ -535,7 +535,7 @@ Vector<CSS::Transformation> StyleProperties::transformations_for_style_value(CSS
                 } else if (calculated.resolves_to_angle()) {
                     values.append({ calculated.resolve_angle().value() });
                 } else {
-                    dbgln("FIXME: Unsupported calc value in transform! {}", calculated.to_string());
+                    dbgln("FIXME: Unsupported calc value in transform! {}", calculated.to_string(CSSStyleValue::SerializationMode::Normal));
                 }
             } else if (transformation_value->is_length()) {
                 values.append({ transformation_value->as_length().length() });
@@ -550,7 +550,7 @@ Vector<CSS::Transformation> StyleProperties::transformations_for_style_value(CSS
             } else if (transformation_value->is_angle()) {
                 values.append({ transformation_value->as_angle().angle() });
             } else {
-                dbgln("FIXME: Unsupported value in transform! {}", transformation_value->to_string());
+                dbgln("FIXME: Unsupported value in transform! {}", transformation_value->to_string(CSSStyleValue::SerializationMode::Normal));
             }
             argument_index++;
         }
@@ -947,14 +947,14 @@ StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(DOM::E
                         quote_nesting_level--;
                     break;
                 default:
-                    dbgln("`{}` is not supported in `content` (yet?)", item->to_string());
+                    dbgln("`{}` is not supported in `content` (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
                     break;
                 }
             } else if (item->is_counter()) {
                 builder.append(item->as_counter().resolve(element));
             } else {
                 // TODO: Implement images, and other things.
-                dbgln("`{}` is not supported in `content` (yet?)", item->to_string());
+                dbgln("`{}` is not supported in `content` (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
             }
         }
         content_data.type = ContentData::Type::String;
@@ -968,7 +968,7 @@ StyleProperties::ContentDataAndQuoteNestingLevel StyleProperties::content(DOM::E
                 } else if (item->is_counter()) {
                     alt_text_builder.append(item->as_counter().resolve(element));
                 } else {
-                    dbgln("`{}` is not supported in `content` alt-text (yet?)", item->to_string());
+                    dbgln("`{}` is not supported in `content` alt-text (yet?)", item->to_string(CSSStyleValue::SerializationMode::Normal));
                 }
             }
             content_data.alt_text = MUST(alt_text_builder.to_string());
@@ -1034,7 +1034,7 @@ Vector<CSS::TextDecorationLine> StyleProperties::text_decoration_line() const
     if (value.is_keyword() && value.to_keyword() == Keyword::None)
         return {};
 
-    dbgln("FIXME: Unsupported value for text-decoration-line: {}", value.to_string());
+    dbgln("FIXME: Unsupported value for text-decoration-line: {}", value.to_string(CSSStyleValue::SerializationMode::Normal));
     return {};
 }
 
@@ -1439,7 +1439,7 @@ Vector<CounterData> StyleProperties::counter_data(PropertyID property_id) const
                     if (maybe_int.has_value())
                         data.value = AK::clamp_to<i32>(*maybe_int);
                 } else {
-                    dbgln("Unimplemented type for {} integer value: '{}'", string_from_property_id(property_id), counter.value->to_string());
+                    dbgln("Unimplemented type for {} integer value: '{}'", string_from_property_id(property_id), counter.value->to_string(CSSStyleValue::SerializationMode::Normal));
                 }
             }
             result.append(move(data));
@@ -1450,7 +1450,7 @@ Vector<CounterData> StyleProperties::counter_data(PropertyID property_id) const
     if (value.to_keyword() == Keyword::None)
         return {};
 
-    dbgln("Unhandled type for {} value: '{}'", string_from_property_id(property_id), value.to_string());
+    dbgln("Unhandled type for {} value: '{}'", string_from_property_id(property_id), value.to_string(CSSStyleValue::SerializationMode::Normal));
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AbstractImageStyleValue.h
@@ -32,8 +32,8 @@ public:
         return {};
     }
 
-    virtual void load_any_resources(DOM::Document&) {};
-    virtual void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const {};
+    virtual void load_any_resources(DOM::Document&) { }
+    virtual void resolve_for_size(Layout::NodeWithStyleAndBoxModelMetrics const&, CSSPixelSize) const { }
 
     virtual bool is_paintable() const = 0;
     virtual void paint(PaintContext& context, DevicePixelRect const& dest_rect, ImageRendering) const = 0;
@@ -70,7 +70,7 @@ struct ColorStopListElement {
 using LinearColorStopListElement = ColorStopListElement<LengthPercentage>;
 using AngularColorStopListElement = ColorStopListElement<AnglePercentage>;
 
-static void serialize_color_stop_list(StringBuilder& builder, auto const& color_stop_list)
+static void serialize_color_stop_list(StringBuilder& builder, auto const& color_stop_list, CSSStyleValue::SerializationMode mode)
 {
     bool first = true;
     for (auto const& element : color_stop_list) {
@@ -80,7 +80,7 @@ static void serialize_color_stop_list(StringBuilder& builder, auto const& color_
         if (element.transition_hint.has_value())
             builder.appendff("{}, "sv, element.transition_hint->value.to_string());
 
-        builder.append(element.color_stop.color->to_string());
+        builder.append(element.color_stop.color->to_string(mode));
         for (auto position : Array { &element.color_stop.position, &element.color_stop.second_position }) {
             if (position->has_value())
                 builder.appendff(" {}"sv, (*position)->to_string());

--- a/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.cpp
@@ -19,7 +19,7 @@ AngleStyleValue::AngleStyleValue(Angle angle)
 
 AngleStyleValue::~AngleStyleValue() = default;
 
-String AngleStyleValue::to_string() const
+String AngleStyleValue::to_string(SerializationMode) const
 {
     return m_angle.to_string();
 }

--- a/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/AngleStyleValue.h
@@ -26,7 +26,7 @@ public:
     virtual double value() const override { return m_angle.raw_value(); }
     virtual StringView unit() const override { return m_angle.unit_name(); }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool equals(CSSStyleValue const& other) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.cpp
@@ -20,7 +20,7 @@ BackgroundRepeatStyleValue::BackgroundRepeatStyleValue(Repeat repeat_x, Repeat r
 
 BackgroundRepeatStyleValue::~BackgroundRepeatStyleValue() = default;
 
-String BackgroundRepeatStyleValue::to_string() const
+String BackgroundRepeatStyleValue::to_string(SerializationMode) const
 {
     if (m_properties.repeat_x == m_properties.repeat_y)
         return MUST(String::from_utf8(CSS::to_string(m_properties.repeat_x)));

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h
@@ -25,7 +25,7 @@ public:
     Repeat repeat_x() const { return m_properties.repeat_x; }
     Repeat repeat_y() const { return m_properties.repeat_y; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(BackgroundRepeatStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.cpp
@@ -18,7 +18,7 @@ BackgroundSizeStyleValue::BackgroundSizeStyleValue(LengthPercentage size_x, Leng
 
 BackgroundSizeStyleValue::~BackgroundSizeStyleValue() = default;
 
-String BackgroundSizeStyleValue::to_string() const
+String BackgroundSizeStyleValue::to_string(SerializationMode) const
 {
     return MUST(String::formatted("{} {}", m_properties.size_x.to_string(), m_properties.size_y.to_string()));
 }

--- a/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h
@@ -27,7 +27,7 @@ public:
     LengthPercentage size_x() const { return m_properties.size_x; }
     LengthPercentage size_y() const { return m_properties.size_y; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(BackgroundSizeStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.cpp
@@ -125,7 +125,7 @@ Gfx::Path Circle::to_path(CSSPixelRect reference_box, Layout::Node const& node) 
 
 String Circle::to_string() const
 {
-    return MUST(String::formatted("circle({} at {})", radius_to_string(radius), position->to_string()));
+    return MUST(String::formatted("circle({} at {})", radius_to_string(radius), position->to_string(CSSStyleValue::SerializationMode::Normal)));
 }
 
 Gfx::Path Ellipse::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
@@ -170,7 +170,7 @@ Gfx::Path Ellipse::to_path(CSSPixelRect reference_box, Layout::Node const& node)
 
 String Ellipse::to_string() const
 {
-    return MUST(String::formatted("ellipse({} {} at {})", radius_to_string(radius_x), radius_to_string(radius_y), position->to_string()));
+    return MUST(String::formatted("ellipse({} {} at {})", radius_to_string(radius_x), radius_to_string(radius_y), position->to_string(CSSStyleValue::SerializationMode::Normal)));
 }
 
 Gfx::Path Polygon::to_path(CSSPixelRect reference_box, Layout::Node const& node) const
@@ -220,7 +220,7 @@ Gfx::Path BasicShapeStyleValue::to_path(CSSPixelRect reference_box, Layout::Node
     });
 }
 
-String BasicShapeStyleValue::to_string() const
+String BasicShapeStyleValue::to_string(SerializationMode) const
 {
     return m_basic_shape.visit([](auto const& shape) {
         return shape.to_string();

--- a/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BasicShapeStyleValue.h
@@ -102,7 +102,7 @@ public:
 
     BasicShape const& basic_shape() const { return m_basic_shape; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(BasicShapeStyleValue const& other) const { return m_basic_shape == other.m_basic_shape; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::CSS {
 
-String BorderRadiusStyleValue::to_string() const
+String BorderRadiusStyleValue::to_string(SerializationMode) const
 {
     if (m_properties.horizontal_radius == m_properties.vertical_radius)
         return m_properties.horizontal_radius.to_string();

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h
@@ -27,7 +27,7 @@ public:
     LengthPercentage const& vertical_radius() const { return m_properties.vertical_radius; }
     bool is_elliptical() const { return m_properties.is_elliptical; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(BorderRadiusStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSColor.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSColor.cpp
@@ -60,7 +60,7 @@ bool CSSColor::equals(CSSStyleValue const& other) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-color-function-values
-String CSSColor::to_string() const
+String CSSColor::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));

--- a/Libraries/LibWeb/CSS/StyleValues/CSSColor.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSColor.h
@@ -19,7 +19,7 @@ public:
 
     virtual bool equals(CSSStyleValue const&) const override;
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     static constexpr Array s_supported_color_space = { "a98-rgb"sv, "display-p3"sv, "srgb"sv, "srgb-linear"sv, "prophoto-rgb"sv, "rec2020"sv, "xyz"sv, "xyz-d50"sv, "xyz-d65"sv };
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSHSL.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSHSL.cpp
@@ -32,7 +32,7 @@ bool CSSHSL::equals(CSSStyleValue const& other) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
-String CSSHSL::to_string() const
+String CSSHSL::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));

--- a/Libraries/LibWeb/CSS/StyleValues/CSSHSL.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSHSL.h
@@ -31,7 +31,7 @@ public:
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
 
-    String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     virtual bool equals(CSSStyleValue const& other) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSHWB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSHWB.cpp
@@ -42,7 +42,7 @@ bool CSSHWB::equals(CSSStyleValue const& other) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
-String CSSHWB::to_string() const
+String CSSHWB::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));

--- a/Libraries/LibWeb/CSS/StyleValues/CSSHWB.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSHWB.h
@@ -31,7 +31,7 @@ public:
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
 
-    String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     virtual bool equals(CSSStyleValue const& other) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.cpp
@@ -16,7 +16,7 @@
 
 namespace Web::CSS {
 
-String CSSKeywordValue::to_string() const
+String CSSKeywordValue::to_string(SerializationMode) const
 {
     return MUST(String::from_utf8(string_from_keyword(keyword())));
 }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
@@ -52,7 +52,7 @@ public:
     static bool is_color(Keyword);
     virtual bool has_color() const override;
     virtual Color to_color(Optional<Layout::NodeWithStyle const&> node) const override;
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(CSSKeywordValue const& other) const { return m_keyword == other.m_keyword; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLCHLike.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLCHLike.cpp
@@ -36,7 +36,7 @@ Color CSSLCH::to_color(Optional<Layout::NodeWithStyle const&>) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-lab-lch
-String CSSLCH::to_string() const
+String CSSLCH::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));
@@ -53,7 +53,7 @@ Color CSSOKLCH::to_color(Optional<Layout::NodeWithStyle const&>) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-oklab-oklch
-String CSSOKLCH::to_string() const
+String CSSOKLCH::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLCHLike.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLCHLike.h
@@ -58,7 +58,7 @@ public:
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 };
 
 // https://drafts.css-houdini.org/css-typed-om-1/#cssoklch
@@ -72,7 +72,7 @@ public:
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
 
-    String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 };
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.cpp
@@ -35,7 +35,7 @@ Color CSSOKLab::to_color(Optional<Layout::NodeWithStyle const&>) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-oklab-oklch
-String CSSOKLab::to_string() const
+String CSSOKLab::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));
@@ -52,7 +52,7 @@ Color CSSLab::to_color(Optional<Layout::NodeWithStyle const&>) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-lab-lch
-String CSSLab::to_string() const
+String CSSLab::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     return serialize_a_srgb_value(to_color({}));

--- a/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSLabLike.h
@@ -52,7 +52,7 @@ protected:
 class CSSOKLab final : public CSSLabLike {
 public:
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     CSSOKLab(Badge<CSSLabLike>, ValueComparingNonnullRefPtr<CSSStyleValue> l, ValueComparingNonnullRefPtr<CSSStyleValue> a, ValueComparingNonnullRefPtr<CSSStyleValue> b, ValueComparingNonnullRefPtr<CSSStyleValue> alpha)
         : CSSLabLike(ColorType::OKLab, move(l), move(a), move(b), move(alpha))
@@ -64,7 +64,7 @@ public:
 class CSSLab final : public CSSLabLike {
 public:
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     CSSLab(Badge<CSSLabLike>, ValueComparingNonnullRefPtr<CSSStyleValue> l, ValueComparingNonnullRefPtr<CSSStyleValue> a, ValueComparingNonnullRefPtr<CSSStyleValue> b, ValueComparingNonnullRefPtr<CSSStyleValue> alpha)
         : CSSLabLike(ColorType::Lab, move(l), move(a), move(b), move(alpha))

--- a/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
@@ -2629,7 +2629,7 @@ CSSMathValue::ResolvedType CSSMathValue::CalculationResult::resolved_type() cons
         [](Time const&) { return ResolvedType::Time; });
 }
 
-String CSSMathValue::to_string() const
+String CSSMathValue::to_string(SerializationMode) const
 {
     // FIXME: Implement this according to https://www.w3.org/TR/css-values-4/#calc-serialize once that stabilizes.
     return MUST(String::formatted("calc({})", m_calculation->to_string()));

--- a/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.h
@@ -79,7 +79,7 @@ public:
         return adopt_ref(*new (nothrow) CSSMathValue(move(calculation), resolved_type));
     }
 
-    String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
     virtual bool equals(CSSStyleValue const& other) const override;
 
     bool resolves_to_angle() const { return m_resolved_type.matches_angle(); }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -70,7 +70,7 @@ bool CSSRGB::equals(CSSStyleValue const& other) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
-String CSSRGB::to_string() const
+String CSSRGB::to_string(SerializationMode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
     if (m_properties.name.has_value())

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -70,10 +70,10 @@ bool CSSRGB::equals(CSSStyleValue const& other) const
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
-String CSSRGB::to_string(SerializationMode) const
+String CSSRGB::to_string(SerializationMode mode) const
 {
     // FIXME: Do this properly, taking unresolved calculated values into account.
-    if (m_properties.name.has_value())
+    if (mode != SerializationMode::ResolvedValue && m_properties.name.has_value())
         return m_properties.name.value().to_string().to_ascii_lowercase();
     return serialize_a_srgb_value(to_color({}));
 }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.h
@@ -31,7 +31,7 @@ public:
 
     virtual Color to_color(Optional<Layout::NodeWithStyle const&>) const override;
 
-    String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     virtual bool equals(CSSStyleValue const& other) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -13,7 +13,7 @@
 
 namespace Web::CSS {
 
-String ConicGradientStyleValue::to_string() const
+String ConicGradientStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
     if (is_repeating())
@@ -26,11 +26,11 @@ String ConicGradientStyleValue::to_string() const
     if (has_at_position) {
         if (has_from_angle)
             builder.append(' ');
-        builder.appendff("at {}"sv, m_properties.position->to_string());
+        builder.appendff("at {}"sv, m_properties.position->to_string(mode));
     }
     if (has_from_angle || has_at_position)
         builder.append(", "sv);
-    serialize_color_stop_list(builder, m_properties.color_stop_list);
+    serialize_color_stop_list(builder, m_properties.color_stop_list, mode);
     builder.append(')');
     return MUST(builder.to_string());
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.h
@@ -23,7 +23,7 @@ public:
         return adopt_ref(*new (nothrow) ConicGradientStyleValue(from_angle, move(position), move(color_stop_list), repeating));
     }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     void paint(PaintContext&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.cpp
@@ -12,11 +12,11 @@
 
 namespace Web::CSS {
 
-String ContentStyleValue::to_string() const
+String ContentStyleValue::to_string(SerializationMode mode) const
 {
     if (has_alt_text())
-        return MUST(String::formatted("{} / {}", m_properties.content->to_string(), m_properties.alt_text->to_string()));
-    return m_properties.content->to_string();
+        return MUST(String::formatted("{} / {}", m_properties.content->to_string(mode), m_properties.alt_text->to_string(mode)));
+    return m_properties.content->to_string(mode);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ContentStyleValue.h
@@ -25,7 +25,7 @@ public:
     bool has_alt_text() const { return !m_properties.alt_text.is_null(); }
     StyleValueList const* alt_text() const { return m_properties.alt_text; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(ContentStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::CSS {
 
-String CounterDefinitionsStyleValue::to_string() const
+String CounterDefinitionsStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder stb;
 
@@ -23,7 +23,7 @@ String CounterDefinitionsStyleValue::to_string() const
             stb.append(counter_definition.name);
 
         if (counter_definition.value)
-            stb.appendff(" {}", counter_definition.value->to_string());
+            stb.appendff(" {}", counter_definition.value->to_string(mode));
     }
 
     return stb.to_string_without_validation();

--- a/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterDefinitionsStyleValue.h
@@ -30,7 +30,7 @@ public:
     virtual ~CounterDefinitionsStyleValue() override = default;
 
     auto const& counter_definitions() const { return m_counter_definitions; }
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(CounterDefinitionsStyleValue const& other) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -91,7 +91,7 @@ static String generate_a_counter_representation(CSSStyleValue const& counter_sty
     }
     // FIXME: Handle `symbols()` function for counter_style.
 
-    dbgln("FIXME: Unsupported counter style '{}'", counter_style.to_string());
+    dbgln("FIXME: Unsupported counter style '{}'", counter_style.to_string(CSSStyleValue::SerializationMode::Normal));
     return MUST(String::formatted("{}", value));
 }
 
@@ -131,7 +131,7 @@ String CounterStyleValue::resolve(DOM::Element& element) const
 }
 
 // https://drafts.csswg.org/cssom-1/#ref-for-typedef-counter
-String CounterStyleValue::to_string() const
+String CounterStyleValue::to_string(SerializationMode mode) const
 {
     // The return value of the following algorithm:
     // 1. Let s be the empty string.
@@ -151,13 +151,13 @@ String CounterStyleValue::to_string() const
     list.append(CustomIdentStyleValue::create(m_properties.counter_name));
     if (m_properties.function == CounterFunction::Counters)
         list.append(StringStyleValue::create(m_properties.join_string.to_string()));
-    if (m_properties.counter_style->to_string() != "decimal"sv)
+    if (m_properties.counter_style->to_string(mode) != "decimal"sv)
         list.append(m_properties.counter_style);
 
     // 5. Let each item in list be the result of invoking serialize a CSS component value on that item.
     // 6. Append the result of invoking serialize a comma-separated list on list to s.
-    serialize_a_comma_separated_list(s, list, [](auto& builder, auto& item) {
-        builder.append(item->to_string());
+    serialize_a_comma_separated_list(s, list, [mode](auto& builder, auto& item) {
+        builder.append(item->to_string(mode));
     });
 
     // 7. Append ")" (U+0029) to s.

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.h
@@ -36,7 +36,7 @@ public:
 
     String resolve(DOM::Element&) const;
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(CounterStyleValue const& other) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CustomIdentStyleValue.h
@@ -22,7 +22,7 @@ public:
 
     FlyString const& custom_ident() const { return m_custom_ident; }
 
-    virtual String to_string() const override { return m_custom_ident.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_custom_ident.to_string(); }
 
     bool properties_equal(CustomIdentStyleValue const& other) const { return m_custom_ident == other.m_custom_ident; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/DisplayStyleValue.h
@@ -16,7 +16,7 @@ public:
     static ValueComparingNonnullRefPtr<DisplayStyleValue> create(Display const&);
     virtual ~DisplayStyleValue() override = default;
 
-    virtual String to_string() const override { return m_display.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_display.to_string(); }
 
     Display display() const { return m_display; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.h
@@ -102,7 +102,7 @@ public:
 
     Function const& function() const { return m_function; }
 
-    virtual String to_string() const override { return m_function.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_function.to_string(); }
 
     bool properties_equal(EasingStyleValue const& other) const { return m_function == other.m_function; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::CSS {
 
-String EdgeStyleValue::to_string() const
+String EdgeStyleValue::to_string(SerializationMode) const
 {
     return MUST(String::formatted("{} {}", CSS::to_string(m_properties.edge), m_properties.offset.to_string()));
 }

--- a/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.h
@@ -25,7 +25,7 @@ public:
     PositionEdge edge() const { return m_properties.edge; }
     LengthPercentage const& offset() const { return m_properties.offset; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(EdgeStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.cpp
@@ -53,7 +53,7 @@ float FilterOperation::Color::resolved_amount() const
     VERIFY_NOT_REACHED();
 }
 
-String FilterValueListStyleValue::to_string() const
+String FilterValueListStyleValue::to_string(SerializationMode) const
 {
     StringBuilder builder {};
     bool first = true;

--- a/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FilterValueListStyleValue.h
@@ -73,7 +73,7 @@ public:
 
     Vector<FilterFunction> const& filter_value_list() const { return m_filter_value_list; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     virtual ~FilterValueListStyleValue() override = default;
 

--- a/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FlexStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual double value() const override { return m_flex.raw_value(); }
     virtual StringView unit() const override { return m_flex.unit_name(); }
 
-    virtual String to_string() const override { return m_flex.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_flex.to_string(); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/FrequencyStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FrequencyStyleValue.h
@@ -26,7 +26,7 @@ public:
     virtual double value() const override { return m_frequency.raw_value(); }
     virtual StringView unit() const override { return m_frequency.unit_name(); }
 
-    virtual String to_string() const override { return m_frequency.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_frequency.to_string(); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.cpp
@@ -13,7 +13,7 @@ ValueComparingNonnullRefPtr<GridAutoFlowStyleValue> GridAutoFlowStyleValue::crea
     return adopt_ref(*new GridAutoFlowStyleValue(axis, dense));
 }
 
-String GridAutoFlowStyleValue::to_string() const
+String GridAutoFlowStyleValue::to_string(SerializationMode) const
 {
     StringBuilder builder;
     if (m_row)

--- a/Libraries/LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h
@@ -27,7 +27,7 @@ public:
     [[nodiscard]] bool is_column() const { return !m_row; }
     [[nodiscard]] bool is_dense() const { return m_dense; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
     bool properties_equal(GridAutoFlowStyleValue const& other) const { return m_row == other.m_row && m_dense == other.m_dense; }
 
 private:

--- a/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.cpp
@@ -17,7 +17,7 @@ ValueComparingNonnullRefPtr<GridTemplateAreaStyleValue> GridTemplateAreaStyleVal
     return adopt_ref(*new (nothrow) GridTemplateAreaStyleValue(grid_template_area));
 }
 
-String GridTemplateAreaStyleValue::to_string() const
+String GridTemplateAreaStyleValue::to_string(SerializationMode) const
 {
     if (m_grid_template_area.is_empty())
         return "none"_string;

--- a/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h
@@ -19,7 +19,7 @@ public:
     virtual ~GridTemplateAreaStyleValue() override = default;
 
     Vector<Vector<String>> const& grid_template_area() const { return m_grid_template_area; }
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(GridTemplateAreaStyleValue const& other) const { return m_grid_template_area == other.m_grid_template_area; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.cpp
@@ -16,7 +16,7 @@ ValueComparingNonnullRefPtr<GridTrackPlacementStyleValue> GridTrackPlacementStyl
     return adopt_ref(*new (nothrow) GridTrackPlacementStyleValue(grid_track_placement));
 }
 
-String GridTrackPlacementStyleValue::to_string() const
+String GridTrackPlacementStyleValue::to_string(SerializationMode) const
 {
     return m_grid_track_placement.to_string();
 }

--- a/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h
@@ -20,7 +20,7 @@ public:
     virtual ~GridTrackPlacementStyleValue() override = default;
 
     GridTrackPlacement const& grid_track_placement() const { return m_grid_track_placement; }
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(GridTrackPlacementStyleValue const& other) const { return m_grid_track_placement == other.m_grid_track_placement; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::CSS {
 
-String GridTrackSizeListStyleValue::to_string() const
+String GridTrackSizeListStyleValue::to_string(SerializationMode) const
 {
     return m_grid_track_size_list.to_string();
 }

--- a/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h
@@ -24,7 +24,7 @@ public:
 
     CSS::GridTrackSizeList grid_track_size_list() const { return m_grid_track_size_list; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(GridTrackSizeListStyleValue const& other) const { return m_grid_track_size_list == other.m_grid_track_size_list; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.cpp
@@ -112,7 +112,7 @@ Gfx::ImmutableBitmap const* ImageStyleValue::bitmap(size_t frame_index, Gfx::Int
     return nullptr;
 }
 
-String ImageStyleValue::to_string() const
+String ImageStyleValue::to_string(SerializationMode) const
 {
     return serialize_a_url(m_url.to_string());
 }

--- a/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ImageStyleValue.h
@@ -30,7 +30,7 @@ public:
 
     void visit_edges(JS::Cell::Visitor& visitor) const;
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
     virtual bool equals(CSSStyleValue const& other) const override;
 
     virtual void load_any_resources(DOM::Document&) override;

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.cpp
@@ -8,7 +8,7 @@
 
 namespace Web::CSS {
 
-String IntegerStyleValue::to_string() const
+String IntegerStyleValue::to_string(SerializationMode) const
 {
     return String::number(m_value);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/IntegerStyleValue.h
@@ -21,7 +21,7 @@ public:
     virtual double value() const override { return m_value; }
     virtual StringView unit() const override { return "number"sv; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LengthStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual double value() const override { return m_length.raw_value(); }
     virtual StringView unit() const override { return m_length.unit_name(); }
 
-    virtual String to_string() const override { return m_length.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_length.to_string(); }
     virtual ValueComparingNonnullRefPtr<CSSStyleValue const> absolutized(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const override;
 
     bool equals(CSSStyleValue const& other) const override;

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::CSS {
 
-String LinearGradientStyleValue::to_string() const
+String LinearGradientStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
     auto side_or_corner_to_string = [](SideOrCorner value) {
@@ -50,7 +50,7 @@ String LinearGradientStyleValue::to_string() const
             return builder.appendff("{}, "sv, angle.to_string());
         });
 
-    serialize_color_stop_list(builder, m_properties.color_stop_list);
+    serialize_color_stop_list(builder, m_properties.color_stop_list, mode);
     builder.append(")"sv);
     return MUST(builder.to_string());
 }

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.h
@@ -44,7 +44,7 @@ public:
         return adopt_ref(*new (nothrow) LinearGradientStyleValue(direction, move(color_stop_list), type, repeating));
     }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
     virtual ~LinearGradientStyleValue() override = default;
     virtual bool equals(CSSStyleValue const& other) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/MathDepthStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/MathDepthStyleValue.cpp
@@ -36,15 +36,15 @@ bool MathDepthStyleValue::properties_equal(MathDepthStyleValue const& other) con
         && m_integer_value == other.m_integer_value;
 }
 
-String MathDepthStyleValue::to_string() const
+String MathDepthStyleValue::to_string(SerializationMode mode) const
 {
     switch (m_type) {
     case MathDepthType::AutoAdd:
         return "auto-add"_string;
     case MathDepthType::Add:
-        return MUST(String::formatted("add({})", m_integer_value->to_string()));
+        return MUST(String::formatted("add({})", m_integer_value->to_string(mode)));
     case MathDepthType::Integer:
-        return m_integer_value->to_string();
+        return m_integer_value->to_string(mode);
     }
     VERIFY_NOT_REACHED();
 }

--- a/Libraries/LibWeb/CSS/StyleValues/MathDepthStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/MathDepthStyleValue.h
@@ -25,7 +25,7 @@ public:
         VERIFY(!m_integer_value.is_null());
         return m_integer_value;
     }
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(MathDepthStyleValue const& other) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.cpp
@@ -11,7 +11,7 @@
 
 namespace Web::CSS {
 
-String NumberStyleValue::to_string() const
+String NumberStyleValue::to_string(SerializationMode) const
 {
     return String::number(m_value);
 }

--- a/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/NumberStyleValue.h
@@ -24,7 +24,7 @@ public:
     virtual double value() const override { return m_value; }
     virtual StringView unit() const override { return "number"sv; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.cpp
@@ -9,12 +9,12 @@
 
 namespace Web::CSS {
 
-String OpenTypeTaggedStyleValue::to_string() const
+String OpenTypeTaggedStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
     serialize_a_string(builder, m_tag);
     // FIXME: For font-feature-settings, a 1 value is implicit, so we shouldn't output it.
-    builder.appendff(" {}", m_value->to_string());
+    builder.appendff(" {}", m_value->to_string(mode));
 
     return builder.to_string_without_validation();
 }

--- a/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h
@@ -25,7 +25,7 @@ public:
     FlyString const& tag() const { return m_tag; }
     ValueComparingNonnullRefPtr<CSSStyleValue> const& value() const { return m_value; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(OpenTypeTaggedStyleValue const&) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/PercentageStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/PercentageStyleValue.h
@@ -26,7 +26,7 @@ public:
     virtual double value() const override { return m_percentage.value(); }
     virtual StringView unit() const override { return "percent"sv; }
 
-    virtual String to_string() const override { return m_percentage.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_percentage.to_string(); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.cpp
@@ -31,9 +31,9 @@ CSSPixelPoint PositionStyleValue::resolved(Layout::Node const& node, CSSPixelRec
     return CSSPixelPoint { rect.x() + x, rect.y() + y };
 }
 
-String PositionStyleValue::to_string() const
+String PositionStyleValue::to_string(SerializationMode mode) const
 {
-    return MUST(String::formatted("{} {}", m_properties.edge_x->to_string(), m_properties.edge_y->to_string()));
+    return MUST(String::formatted("{} {}", m_properties.edge_x->to_string(mode), m_properties.edge_y->to_string(mode)));
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/PositionStyleValue.h
@@ -35,7 +35,7 @@ public:
     bool is_center() const;
     CSSPixelPoint resolved(Layout::Node const&, CSSPixelRect const&) const;
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(PositionStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -13,7 +13,7 @@
 
 namespace Web::CSS {
 
-String RadialGradientStyleValue::to_string() const
+String RadialGradientStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
     if (is_repeating())
@@ -46,10 +46,10 @@ String RadialGradientStyleValue::to_string() const
         });
 
     if (!m_properties.position->is_center())
-        builder.appendff(" at {}"sv, m_properties.position->to_string());
+        builder.appendff(" at {}"sv, m_properties.position->to_string(mode));
 
     builder.append(", "sv);
-    serialize_color_stop_list(builder, m_properties.color_stop_list);
+    serialize_color_stop_list(builder, m_properties.color_stop_list, mode);
     builder.append(')');
     return MUST(builder.to_string());
 }

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.h
@@ -49,7 +49,7 @@ public:
         return adopt_ref(*new (nothrow) RadialGradientStyleValue(ending_shape, size, move(position), move(color_stop_list), repeating));
     }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     void paint(PaintContext&, DevicePixelRect const& dest_rect, CSS::ImageRendering) const override;
 

--- a/Libraries/LibWeb/CSS/StyleValues/RatioStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RatioStyleValue.h
@@ -22,7 +22,7 @@ public:
     Ratio const& ratio() const { return m_ratio; }
     Ratio& ratio() { return m_ratio; }
 
-    virtual String to_string() const override { return m_ratio.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_ratio.to_string(); }
 
     bool properties_equal(RatioStyleValue const& other) const { return m_ratio == other.m_ratio; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.cpp
@@ -16,7 +16,7 @@ ValueComparingNonnullRefPtr<RectStyleValue> RectStyleValue::create(EdgeRect rect
     return adopt_ref(*new (nothrow) RectStyleValue(move(rect)));
 }
 
-String RectStyleValue::to_string() const
+String RectStyleValue::to_string(SerializationMode) const
 {
     return MUST(String::formatted("rect({}, {}, {}, {})", m_rect.top_edge, m_rect.right_edge, m_rect.bottom_edge, m_rect.left_edge));
 }

--- a/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RectStyleValue.h
@@ -20,7 +20,7 @@ public:
     virtual ~RectStyleValue() override = default;
 
     EdgeRect rect() const { return m_rect; }
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(RectStyleValue const& other) const { return m_rect == other.m_rect; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ResolutionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ResolutionStyleValue.h
@@ -23,7 +23,7 @@ public:
     virtual double value() const override { return m_resolution.raw_value(); }
     virtual StringView unit() const override { return m_resolution.unit_name(); }
 
-    virtual String to_string() const override { return m_resolution.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_resolution.to_string(); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/RotationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RotationStyleValue.cpp
@@ -13,7 +13,7 @@
 namespace Web::CSS {
 
 // https://www.w3.org/TR/2021/WD-css-transforms-2-20211109/#individual-transform-serialization
-String RotationStyleValue::to_string() const
+String RotationStyleValue::to_string(SerializationMode mode) const
 {
     auto resolve_to_number = [](ValueComparingNonnullRefPtr<CSSStyleValue const> const& value) -> Optional<double> {
         if (value->is_number())
@@ -30,20 +30,20 @@ String RotationStyleValue::to_string() const
 
     // If the axis is parallel with the x or y axes, it must serialize as the appropriate keyword.
     if (x_value > 0.0 && y_value == 0 && z_value == 0)
-        return MUST(String::formatted("x {}", m_properties.angle->to_string()));
+        return MUST(String::formatted("x {}", m_properties.angle->to_string(mode)));
 
     if (x_value == 0 && y_value > 0.0 && z_value == 0)
-        return MUST(String::formatted("y {}", m_properties.angle->to_string()));
+        return MUST(String::formatted("y {}", m_properties.angle->to_string(mode)));
 
     // If a rotation about the z axis (that is, in 2D) is specified, the property must serialize as just an <angle>.
     if (x_value == 0 && y_value == 0 && z_value > 0.0)
-        return m_properties.angle->to_string();
+        return m_properties.angle->to_string(mode);
 
     // It must serialize as the keyword none if and only if none was originally specified.
     // NOTE: This is handled by returning a keyword from the parser.
 
     // If any other rotation is specified, the property must serialize with an axis specified.
-    return MUST(String::formatted("{} {} {} {}", m_properties.rotation_x->to_string(), m_properties.rotation_y->to_string(), m_properties.rotation_z->to_string(), m_properties.angle->to_string()));
+    return MUST(String::formatted("{} {} {} {}", m_properties.rotation_x->to_string(mode), m_properties.rotation_y->to_string(mode), m_properties.rotation_z->to_string(mode), m_properties.angle->to_string(mode)));
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/RotationStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/RotationStyleValue.h
@@ -24,7 +24,7 @@ public:
     ValueComparingNonnullRefPtr<CSSStyleValue const> const& rotation_y() const { return m_properties.rotation_y; }
     ValueComparingNonnullRefPtr<CSSStyleValue const> const& rotation_z() const { return m_properties.rotation_z; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(RotationStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ScaleStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ScaleStyleValue.cpp
@@ -10,7 +10,7 @@
 namespace Web::CSS {
 
 // https://www.w3.org/TR/2021/WD-css-transforms-2-20211109/#individual-transform-serialization
-String ScaleStyleValue::to_string() const
+String ScaleStyleValue::to_string(SerializationMode) const
 {
     auto resolve_to_string = [](NumberPercentage const& value) -> String {
         if (value.is_number()) {

--- a/Libraries/LibWeb/CSS/StyleValues/ScaleStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ScaleStyleValue.h
@@ -23,7 +23,7 @@ public:
     NumberPercentage const& x() const { return m_properties.x; }
     NumberPercentage const& y() const { return m_properties.y; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(ScaleStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ScrollbarGutterStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ScrollbarGutterStyleValue.h
@@ -20,7 +20,7 @@ public:
 
     ScrollbarGutter value() const { return m_value; }
 
-    virtual String to_string() const override
+    virtual String to_string(SerializationMode) const override
     {
         switch (m_value) {
         case ScrollbarGutter::Auto:

--- a/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.cpp
@@ -12,10 +12,10 @@
 
 namespace Web::CSS {
 
-String ShadowStyleValue::to_string() const
+String ShadowStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
-    builder.appendff("{} {} {} {} {}", m_properties.color->to_string(), m_properties.offset_x->to_string(), m_properties.offset_y->to_string(), m_properties.blur_radius->to_string(), m_properties.spread_distance->to_string());
+    builder.appendff("{} {} {} {} {}", m_properties.color->to_string(mode), m_properties.offset_x->to_string(mode), m_properties.offset_y->to_string(mode), m_properties.blur_radius->to_string(mode), m_properties.spread_distance->to_string(mode));
     if (m_properties.placement == ShadowPlacement::Inner)
         builder.append(" inset"sv);
     return MUST(builder.to_string());

--- a/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ShadowStyleValue.h
@@ -41,7 +41,7 @@ public:
     ValueComparingNonnullRefPtr<CSSStyleValue const> const& spread_distance() const { return m_properties.spread_distance; }
     ShadowPlacement placement() const { return m_properties.placement; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(ShadowStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -36,7 +36,7 @@ ValueComparingRefPtr<CSSStyleValue const> ShorthandStyleValue::longhand(Property
     return nullptr;
 }
 
-String ShorthandStyleValue::to_string() const
+String ShorthandStyleValue::to_string(SerializationMode mode) const
 {
     // If all the longhands are the same CSS-wide keyword, just return that once.
     Optional<Keyword> built_in_keyword;
@@ -57,7 +57,7 @@ String ShorthandStyleValue::to_string() const
         }
     }
     if (all_same_keyword && built_in_keyword.has_value())
-        return m_properties.values.first()->to_string();
+        return m_properties.values.first()->to_string(mode);
 
     // Then special cases
     switch (m_properties.shorthand_property) {
@@ -78,13 +78,13 @@ String ShorthandStyleValue::to_string() const
         auto layer_count = max(get_layer_count(image), max(get_layer_count(position), max(get_layer_count(size), max(get_layer_count(repeat), max(get_layer_count(attachment), max(get_layer_count(origin), get_layer_count(clip)))))));
 
         if (layer_count == 1) {
-            return MUST(String::formatted("{} {} {} {} {} {} {} {}", color->to_string(), image->to_string(), position->to_string(), size->to_string(), repeat->to_string(), attachment->to_string(), origin->to_string(), clip->to_string()));
+            return MUST(String::formatted("{} {} {} {} {} {} {} {}", color->to_string(mode), image->to_string(mode), position->to_string(mode), size->to_string(mode), repeat->to_string(mode), attachment->to_string(mode), origin->to_string(mode), clip->to_string(mode)));
         }
 
-        auto get_layer_value_string = [](ValueComparingRefPtr<CSSStyleValue const> const& style_value, size_t index) {
+        auto get_layer_value_string = [mode](ValueComparingRefPtr<CSSStyleValue const> const& style_value, size_t index) {
             if (style_value->is_value_list())
-                return style_value->as_value_list().value_at(index, true)->to_string();
-            return style_value->to_string();
+                return style_value->as_value_list().value_at(index, true)->to_string(mode);
+            return style_value->to_string(mode);
         };
 
         StringBuilder builder;
@@ -92,7 +92,7 @@ String ShorthandStyleValue::to_string() const
             if (i)
                 builder.append(", "sv);
             if (i == layer_count - 1)
-                builder.appendff("{} ", color->to_string());
+                builder.appendff("{} ", color->to_string(mode));
             builder.appendff("{} {} {} {} {} {} {}", get_layer_value_string(image, i), get_layer_value_string(position, i), get_layer_value_string(size, i), get_layer_value_string(repeat, i), get_layer_value_string(attachment, i), get_layer_value_string(origin, i), get_layer_value_string(clip, i));
         }
 
@@ -115,8 +115,8 @@ String ShorthandStyleValue::to_string() const
             bottom_left.vertical_radius().to_string()));
     }
     case PropertyID::Columns: {
-        auto column_width = longhand(PropertyID::ColumnWidth)->to_string();
-        auto column_count = longhand(PropertyID::ColumnCount)->to_string();
+        auto column_width = longhand(PropertyID::ColumnWidth)->to_string(mode);
+        auto column_count = longhand(PropertyID::ColumnCount)->to_string(mode);
 
         if (column_width == column_count)
             return column_width;
@@ -128,18 +128,18 @@ String ShorthandStyleValue::to_string() const
         return MUST(String::formatted("{} {}", column_width, column_count));
     }
     case PropertyID::Flex:
-        return MUST(String::formatted("{} {} {}", longhand(PropertyID::FlexGrow)->to_string(), longhand(PropertyID::FlexShrink)->to_string(), longhand(PropertyID::FlexBasis)->to_string()));
+        return MUST(String::formatted("{} {} {}", longhand(PropertyID::FlexGrow)->to_string(mode), longhand(PropertyID::FlexShrink)->to_string(mode), longhand(PropertyID::FlexBasis)->to_string(mode)));
     case PropertyID::FlexFlow:
-        return MUST(String::formatted("{} {}", longhand(PropertyID::FlexDirection)->to_string(), longhand(PropertyID::FlexWrap)->to_string()));
+        return MUST(String::formatted("{} {}", longhand(PropertyID::FlexDirection)->to_string(mode), longhand(PropertyID::FlexWrap)->to_string(mode)));
     case PropertyID::Font:
         return MUST(String::formatted("{} {} {} {} {} / {} {}",
-            longhand(PropertyID::FontStyle)->to_string(),
-            longhand(PropertyID::FontVariant)->to_string(),
-            longhand(PropertyID::FontWeight)->to_string(),
-            longhand(PropertyID::FontWidth)->to_string(),
-            longhand(PropertyID::FontSize)->to_string(),
-            longhand(PropertyID::LineHeight)->to_string(),
-            longhand(PropertyID::FontFamily)->to_string()));
+            longhand(PropertyID::FontStyle)->to_string(mode),
+            longhand(PropertyID::FontVariant)->to_string(mode),
+            longhand(PropertyID::FontWeight)->to_string(mode),
+            longhand(PropertyID::FontWidth)->to_string(mode),
+            longhand(PropertyID::FontSize)->to_string(mode),
+            longhand(PropertyID::LineHeight)->to_string(mode),
+            longhand(PropertyID::FontFamily)->to_string(mode)));
     case PropertyID::GridArea: {
         auto& row_start = longhand(PropertyID::GridRowStart)->as_grid_track_placement();
         auto& column_start = longhand(PropertyID::GridColumnStart)->as_grid_track_placement();
@@ -192,43 +192,43 @@ String ShorthandStyleValue::to_string() const
         auto start = longhand(PropertyID::GridColumnStart);
         auto end = longhand(PropertyID::GridColumnEnd);
         if (end->as_grid_track_placement().grid_track_placement().is_auto())
-            return start->to_string();
-        return MUST(String::formatted("{} / {}", start->to_string(), end->to_string()));
+            return start->to_string(mode);
+        return MUST(String::formatted("{} / {}", start->to_string(mode), end->to_string(mode)));
     }
     case PropertyID::GridRow: {
         auto start = longhand(PropertyID::GridRowStart);
         auto end = longhand(PropertyID::GridRowEnd);
         if (end->as_grid_track_placement().grid_track_placement().is_auto())
-            return start->to_string();
-        return MUST(String::formatted("{} / {}", start->to_string(), end->to_string()));
+            return start->to_string(mode);
+        return MUST(String::formatted("{} / {}", start->to_string(mode), end->to_string(mode)));
     }
     case PropertyID::ListStyle:
-        return MUST(String::formatted("{} {} {}", longhand(PropertyID::ListStylePosition)->to_string(), longhand(PropertyID::ListStyleImage)->to_string(), longhand(PropertyID::ListStyleType)->to_string()));
+        return MUST(String::formatted("{} {} {}", longhand(PropertyID::ListStylePosition)->to_string(mode), longhand(PropertyID::ListStyleImage)->to_string(mode), longhand(PropertyID::ListStyleType)->to_string(mode)));
     case PropertyID::Overflow: {
         auto overflow_x = longhand(PropertyID::OverflowX);
         auto overflow_y = longhand(PropertyID::OverflowY);
         if (overflow_x == overflow_y)
-            return overflow_x->to_string();
+            return overflow_x->to_string(mode);
 
-        return MUST(String::formatted("{} {}", overflow_x->to_string(), overflow_y->to_string()));
+        return MUST(String::formatted("{} {}", overflow_x->to_string(mode), overflow_y->to_string(mode)));
     }
     case PropertyID::PlaceContent: {
-        auto align_content = longhand(PropertyID::AlignContent)->to_string();
-        auto justify_content = longhand(PropertyID::JustifyContent)->to_string();
+        auto align_content = longhand(PropertyID::AlignContent)->to_string(mode);
+        auto justify_content = longhand(PropertyID::JustifyContent)->to_string(mode);
         if (align_content == justify_content)
             return align_content;
         return MUST(String::formatted("{} {}", align_content, justify_content));
     }
     case PropertyID::PlaceItems: {
-        auto align_items = longhand(PropertyID::AlignItems)->to_string();
-        auto justify_items = longhand(PropertyID::JustifyItems)->to_string();
+        auto align_items = longhand(PropertyID::AlignItems)->to_string(mode);
+        auto justify_items = longhand(PropertyID::JustifyItems)->to_string(mode);
         if (align_items == justify_items)
             return align_items;
         return MUST(String::formatted("{} {}", align_items, justify_items));
     }
     case PropertyID::PlaceSelf: {
-        auto align_self = longhand(PropertyID::AlignSelf)->to_string();
-        auto justify_self = longhand(PropertyID::JustifySelf)->to_string();
+        auto align_self = longhand(PropertyID::AlignSelf)->to_string(mode);
+        auto justify_self = longhand(PropertyID::JustifySelf)->to_string(mode);
         if (align_self == justify_self)
             return align_self;
         return MUST(String::formatted("{} {}", align_self, justify_self));
@@ -242,7 +242,7 @@ String ShorthandStyleValue::to_string() const
             if (!value->equals(property_initial_value(property_id))) {
                 if (!builder.is_empty())
                     builder.append(' ');
-                builder.append(value->to_string());
+                builder.append(value->to_string(mode));
             }
         };
 
@@ -252,7 +252,7 @@ String ShorthandStyleValue::to_string() const
         append_if_non_default(PropertyID::TextDecorationColor);
 
         if (builder.is_empty())
-            return longhand(PropertyID::TextDecorationLine)->to_string();
+            return longhand(PropertyID::TextDecorationLine)->to_string(mode);
 
         return builder.to_string_without_validation();
     }
@@ -264,7 +264,7 @@ String ShorthandStyleValue::to_string() const
                 first = false;
             else
                 builder.append(' ');
-            builder.append(value->to_string());
+            builder.append(value->to_string(mode));
         }
         return MUST(builder.to_string());
     }

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.h
@@ -23,7 +23,7 @@ public:
 
     ValueComparingRefPtr<CSSStyleValue const> longhand(PropertyID) const;
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(ShorthandStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StringStyleValue.h
@@ -20,7 +20,7 @@ public:
     virtual ~StringStyleValue() override = default;
 
     FlyString const& string_value() const { return m_string; }
-    String to_string() const override { return serialize_a_string(m_string); }
+    virtual String to_string(SerializationMode) const override { return serialize_a_string(m_string); }
 
     bool properties_equal(StringStyleValue const& other) const { return m_string == other.m_string; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.cpp
@@ -16,7 +16,7 @@ bool StyleValueList::Properties::operator==(Properties const& other) const
     return separator == other.separator && values.span() == other.values.span();
 }
 
-String StyleValueList::to_string() const
+String StyleValueList::to_string(SerializationMode mode) const
 {
     auto separator = ""sv;
     switch (m_properties.separator) {
@@ -32,7 +32,7 @@ String StyleValueList::to_string() const
 
     StringBuilder builder;
     for (size_t i = 0; i < m_properties.values.size(); ++i) {
-        builder.append(m_properties.values[i]->to_string());
+        builder.append(m_properties.values[i]->to_string(mode));
         if (i != m_properties.values.size() - 1)
             builder.append(separator);
     }

--- a/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
+++ b/Libraries/LibWeb/CSS/StyleValues/StyleValueList.h
@@ -33,7 +33,7 @@ public:
         return m_properties.values[i];
     }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(StyleValueList const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/TimeStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TimeStyleValue.h
@@ -26,7 +26,7 @@ public:
     virtual double value() const override { return m_time.raw_value(); }
     virtual StringView unit() const override { return m_time.unit_name(); }
 
-    virtual String to_string() const override { return m_time.to_string(); }
+    virtual String to_string(SerializationMode) const override { return m_time.to_string(); }
 
     bool equals(CSSStyleValue const& other) const override
     {

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.cpp
@@ -13,7 +13,7 @@
 
 namespace Web::CSS {
 
-String TransformationStyleValue::to_string() const
+String TransformationStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
     builder.append(CSS::to_string(m_properties.transform_function));
@@ -32,7 +32,7 @@ String TransformationStyleValue::to_string() const
             && value->is_percentage()) {
             builder.append(String::number(value->as_percentage().percentage().as_fraction()));
         } else {
-            builder.append(value->to_string());
+            builder.append(value->to_string(mode));
         }
 
         if (i != m_properties.values.size() - 1)

--- a/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TransformationStyleValue.h
@@ -25,7 +25,7 @@ public:
     CSS::TransformFunction transform_function() const { return m_properties.transform_function; }
     StyleValueVector values() const { return m_properties.values; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(TransformationStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/TransitionStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TransitionStyleValue.cpp
@@ -9,7 +9,7 @@
 
 namespace Web::CSS {
 
-String TransitionStyleValue::to_string() const
+String TransitionStyleValue::to_string(SerializationMode mode) const
 {
     StringBuilder builder;
     bool first = true;
@@ -17,7 +17,7 @@ String TransitionStyleValue::to_string() const
         if (!first)
             builder.append(", "sv);
         first = false;
-        builder.appendff("{} {} {} {}", transition.property_name->to_string(), transition.duration, transition.easing->to_string(), transition.delay);
+        builder.appendff("{} {} {} {}", transition.property_name->to_string(mode), transition.duration, transition.easing->to_string(mode), transition.delay);
     }
 
     return MUST(builder.to_string());

--- a/Libraries/LibWeb/CSS/StyleValues/TransitionStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TransitionStyleValue.h
@@ -34,7 +34,7 @@ public:
 
     auto const& transitions() const { return m_transitions; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(TransitionStyleValue const& other) const;
 

--- a/Libraries/LibWeb/CSS/StyleValues/TranslationStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/TranslationStyleValue.cpp
@@ -14,7 +14,7 @@
 namespace Web::CSS {
 
 // https://www.w3.org/TR/2021/WD-css-transforms-2-20211109/#individual-transform-serialization
-String TranslationStyleValue::to_string() const
+String TranslationStyleValue::to_string(SerializationMode) const
 {
     auto resolve_to_string = [](LengthPercentage const& value) -> Optional<String> {
         if (value.is_length()) {

--- a/Libraries/LibWeb/CSS/StyleValues/TranslationStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/TranslationStyleValue.h
@@ -23,7 +23,7 @@ public:
     LengthPercentage const& x() const { return m_properties.x; }
     LengthPercentage const& y() const { return m_properties.y; }
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     bool properties_equal(TranslationStyleValue const& other) const { return m_properties == other.m_properties; }
 

--- a/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/URLStyleValue.h
@@ -25,7 +25,7 @@ public:
 
     bool properties_equal(URLStyleValue const& other) const { return m_url == other.m_url; }
 
-    virtual String to_string() const override
+    virtual String to_string(SerializationMode) const override
     {
         return serialize_a_url(m_url.to_string());
     }

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.cpp
@@ -12,7 +12,7 @@
 
 namespace Web::CSS {
 
-String UnresolvedStyleValue::to_string() const
+String UnresolvedStyleValue::to_string(SerializationMode) const
 {
     if (m_original_source_text.has_value())
         return *m_original_source_text;
@@ -25,7 +25,7 @@ bool UnresolvedStyleValue::equals(CSSStyleValue const& other) const
     if (type() != other.type())
         return false;
     // This is a case where comparing the strings actually makes sense.
-    return to_string() == other.to_string();
+    return to_string(SerializationMode::Normal) == other.to_string(SerializationMode::Normal);
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/UnresolvedStyleValue.h
@@ -23,7 +23,7 @@ public:
     }
     virtual ~UnresolvedStyleValue() override = default;
 
-    virtual String to_string() const override;
+    virtual String to_string(SerializationMode) const override;
 
     Vector<Parser::ComponentValue> const& values() const { return m_values; }
     bool contains_var_or_attr() const { return m_contains_var_or_attr; }

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -404,7 +404,7 @@ void dump_tree(StringBuilder& builder, Layout::Node const& layout_node, bool sho
         };
         Vector<NameAndValue> properties;
         verify_cast<DOM::Element>(*layout_node.dom_node()).computed_css_values()->for_each_property([&](auto property_id, auto& value) {
-            properties.append({ CSS::string_from_property_id(property_id), value.to_string() });
+            properties.append({ CSS::string_from_property_id(property_id), value.to_string(CSS::CSSStyleValue::SerializationMode::Normal) });
         });
         quick_sort(properties, [](auto& a, auto& b) { return a.name < b.name; });
 
@@ -827,14 +827,14 @@ void dump_declaration(StringBuilder& builder, CSS::PropertyOwningCSSStyleDeclara
     builder.appendff("Declarations ({}):\n", declaration.length());
     for (auto& property : declaration.properties()) {
         indent(builder, indent_levels);
-        builder.appendff("  {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string());
+        builder.appendff("  {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
         if (property.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');
     }
     for (auto& property : declaration.custom_properties()) {
         indent(builder, indent_levels);
-        builder.appendff("  {}: '{}'", property.key, property.value.value->to_string());
+        builder.appendff("  {}: '{}'", property.key, property.value.value->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
         if (property.value.important == CSS::Important::Yes)
             builder.append(" \033[31;1m!important\033[0m"sv);
         builder.append('\n');

--- a/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
+++ b/Libraries/LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h
@@ -33,7 +33,11 @@ public:
         auto font_weight = font_style_value.longhand(CSS::PropertyID::FontWeight);
         auto font_size = font_style_value.longhand(CSS::PropertyID::FontSize);
         auto font_family = font_style_value.longhand(CSS::PropertyID::FontFamily);
-        return ByteString::formatted("{} {} {} {}", font_style->to_string(), font_weight->to_string(), font_size->to_string(), font_family->to_string());
+        return ByteString::formatted("{} {} {} {}",
+            font_style->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
+            font_weight->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
+            font_size->to_string(CSS::CSSStyleValue::SerializationMode::Normal),
+            font_family->to_string(CSS::CSSStyleValue::SerializationMode::Normal));
     }
 
     void set_font(StringView font)

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1142,7 +1142,7 @@ void HTMLInputElement::computed_css_values_changed()
 
     auto const& accent_color_property = computed_css_values()->property(CSS::PropertyID::AccentColor);
     if (accent_color_property.has_color())
-        accent_color = accent_color_property.to_string();
+        accent_color = accent_color_property.to_string(CSS::CSSStyleValue::SerializationMode::Normal);
 
     if (m_slider_progress_element)
         MUST(m_slider_progress_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -137,7 +137,7 @@ void HTMLProgressElement::computed_css_values_changed()
 
     auto const& accent_color_property = computed_css_values()->property(CSS::PropertyID::AccentColor);
     if (accent_color_property.has_color())
-        accent_color = accent_color_property.to_string();
+        accent_color = accent_color_property.to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
 
     if (m_progress_value_element)
         MUST(m_progress_value_element->style_for_bindings()->set_property(CSS::PropertyID::BackgroundColor, accent_color));

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -354,7 +354,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
                     dbgln("+ Element {}", element->debug_description());
                     for (size_t i = 0; i < Web::CSS::StyleProperties::number_of_properties; ++i) {
                         auto property = styles.maybe_null_property(static_cast<Web::CSS::PropertyID>(i));
-                        dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string() : ""_string);
+                        dbgln("|  {} = {}", Web::CSS::string_from_property_id(static_cast<Web::CSS::PropertyID>(i)), property ? property->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal) : ""_string);
                     }
                     dbgln("---");
                 }
@@ -516,7 +516,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
 
             auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
             properties.for_each_property([&](auto property_id, auto& value) {
-                MUST(serializer.add(Web::CSS::string_from_property_id(property_id), value.to_string().to_byte_string()));
+                MUST(serializer.add(Web::CSS::string_from_property_id(property_id), value.to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal).to_byte_string()));
             });
             MUST(serializer.finish());
 
@@ -533,7 +533,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
                 for (auto const& property : element_to_check->custom_properties(pseudo_element)) {
                     if (!seen_properties.contains(property.key)) {
                         seen_properties.set(property.key);
-                        MUST(serializer.add(property.key, property.value.value->to_string()));
+                        MUST(serializer.add(property.key, property.value.value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal)));
                     }
                 }
 

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -1387,7 +1387,7 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
             // computed value of parameter URL variables["property name"] from element's style declarations.
             if (auto property = Web::CSS::property_id_from_string(name); property.has_value()) {
                 if (auto computed_values = element->computed_css_values(); computed_values.has_value())
-                    computed_value = computed_values->property(property.value()).to_string();
+                    computed_value = computed_values->property(property.value()).to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal);
             }
         }
         // -> Otherwise


### PR DESCRIPTION
`CSSStyleValue::to_string()` now takes a `SerializationMode` which can be either `Normal` or `ResolvedValue`.

The only difference in `ResolvedValue` mode is that we serialize RGB/RGBA color values as `rgb()` or `rgba()`, but never as the original named color string, even if they originated from one.

This allows us to remove an ad-hoc pass in `StyleComputer` that would rewrite all colors in an element's computed style.