### PR TITLE
Tests: Minor cleanup; Move window.internals.getComputedLabel, and import accname/basic.html

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/accname/basic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/basic.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	tests labelFrom: author
+Pass	tests labelFrom: contents

--- a/Tests/LibWeb/Text/input/wpt-import/accname/basic.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/basic.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="../resources/testdriver.js"></script>
+<script src="../resources/testdriver-vendor.js"></script>
+<script src="../resources/testdriver-actions.js"></script>
+
+<!--
+
+These tests should remain solid and passing in any implementation that supports get_computed_label.
+
+It uses a standard promise_test (rather than aria-util.js) to reduce other dependencies.
+
+If you're adding something you expect to fail in one or more implementations, you probably want a different file.
+
+-->
+
+<div id='d' style='height: 100px; width: 100px' role="group" aria-label="test label"></div>
+<h1 id="h">test heading</h1>
+<script>
+
+promise_test(async t => {
+  const label = await test_driver.get_computed_label(document.getElementById('d'));
+  assert_equals(label, "test label");
+}, "tests labelFrom: author");
+
+promise_test(async t => {
+  const label = await test_driver.get_computed_label(document.getElementById('h'));
+  assert_equals(label, "test heading");
+}, "tests labelFrom: contents");
+
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testdriver.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testdriver.js
@@ -233,7 +233,11 @@
          *                    rejected in the cases the WebDriver command errors
          */
         get_computed_label: async function(element) {
-            let label = await window.test_driver_internal.get_computed_label(element);
+            // XXX: Ladybird-specific change: Upstream WPT calls
+            // window.test_driver_internal.get_computed_label(element) here,
+            // but we’ve changed that to our Ladybird-specific
+            // window.internals.getComputedLabel(el).
+            let label = await window.internals.getComputedLabel(element);
             return label;
         },
 

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/scripts/aria-utils.js
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/scripts/aria-utils.js
@@ -143,9 +143,7 @@ const AriaUtils = {
       }
       promise_test(async t => {
         const expectedLabel = el.getAttribute("data-expectedlabel");
-        // XXX: Ladybird-specific change: upstream WPT has test_driver.get_computed_label(el) here,
-        // but we’ve changed that to the Ladybird-specific window.internals.getComputedLabel(el).
-        let computedLabel = await window.internals.getComputedLabel(el);
+        let computedLabel = await test_driver.get_computed_label(el);
         assert_not_equals(computedLabel, null, `get_computed_label(el) shouldn't return null for ${el.outerHTML}`);
 
         // See:


### PR DESCRIPTION
This change includes two commits:

- 835e11fbcf3 Tests: Move `window.internals.getComputedLabel` into `testdriver.js` file
- 292681db665 Tests: Import the WPT `accname/basic.html` test