### PR TITLE
Tests/LibWeb: Fix type for delay_ms property in HTTP echo server

### DIFF
--- a/Tests/LibWeb/Fixtures/http-test-server.py
+++ b/Tests/LibWeb/Fixtures/http-test-server.py
@@ -24,7 +24,7 @@ class Echo:
     status: int
     headers: Optional[Dict[str, str]]
     body: Optional[str]
-    delay_ms: Optional[str]
+    delay_ms: Optional[int]
     reason_phrase: Optional[str]
 
 


### PR DESCRIPTION
This was mistakenly changed from int -> str in a previous commit: 08b8c88ac3ad5f44fcb8d29748480913252bb47b

Thanks @alissonlauffer for spotting this.