### PR TITLE
LibWeb: Use Fetch to retrieve HTMLObjectElement data URLs

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -464,7 +464,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         if (!matches_link_pseudo_class(element))
             return false;
         auto document_url = element.document().url();
-        URL::URL target_url = element.document().parse_url(element.attribute(HTML::AttributeNames::href).value_or({}));
+        URL::URL target_url = element.document().encoding_parse_url(element.attribute(HTML::AttributeNames::href).value_or({}));
         if (target_url.fragment().has_value())
             return document_url.equals(target_url, URL::ExcludeFragment::No);
         return document_url.equals(target_url, URL::ExcludeFragment::Yes);

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2825,7 +2825,7 @@ Optional<FontLoader&> StyleComputer::load_font_face(ParsedFontFace const& font_f
     for (auto const& source : font_face.sources()) {
         // FIXME: These should be loaded relative to the stylesheet URL instead of the document URL.
         if (source.local_or_url.has<URL::URL>())
-            urls.append(m_document->parse_url(source.local_or_url.get<URL::URL>().to_string()));
+            urls.append(m_document->encoding_parse_url(source.local_or_url.get<URL::URL>().to_string()));
         // FIXME: Handle local()
     }
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1081,7 +1081,38 @@ URL::URL Document::parse_url(StringView url) const
     auto base_url = this->base_url();
 
     // 2. Return the result of applying the URL parser to url, with baseURL.
-    return DOMURL::parse(url, base_url, Optional<StringView> { m_encoding });
+    return DOMURL::parse(url, base_url);
+}
+
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-a-url
+URL::URL Document::encoding_parse_url(StringView url) const
+{
+    // 1. Let encoding be UTF-8.
+    // 2. If environment is a Document object, then set encoding to environment's character encoding.
+    auto encoding = encoding_or_default();
+
+    // 3. Otherwise, if environment's relevant global object is a Window object, set encoding to environment's relevant
+    //    global object's associated Document's character encoding.
+
+    // 4. Let baseURL be environment's base URL, if environment is a Document object; otherwise environment's API base URL.
+    auto base_url = this->base_url();
+
+    // 5. Return the result of applying the URL parser to url, with baseURL and encoding.
+    return DOMURL::parse(url, base_url, encoding);
+}
+
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#encoding-parsing-and-serializing-a-url
+Optional<String> Document::encoding_parse_and_serialize_url(StringView url) const
+{
+    // 1. Let url be the result of encoding-parsing a URL given url, relative to environment.
+    auto parsed_url = encoding_parse_url(url);
+
+    // 2. If url is failure, then return failure.
+    if (!parsed_url.is_valid())
+        return {};
+
+    // 3. Return the result of applying the URL serializer to url.
+    return parsed_url.serialize();
 }
 
 void Document::set_needs_layout()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -157,6 +157,8 @@ public:
     void set_opener_policy(HTML::OpenerPolicy policy) { m_opener_policy = move(policy); }
 
     URL::URL parse_url(StringView) const;
+    URL::URL encoding_parse_url(StringView) const;
+    Optional<String> encoding_parse_and_serialize_url(StringView) const;
 
     CSS::StyleComputer& style_computer() { return *m_style_computer; }
     const CSS::StyleComputer& style_computer() const { return *m_style_computer; }

--- a/Libraries/LibWeb/HTML/EventSource.cpp
+++ b/Libraries/LibWeb/HTML/EventSource.cpp
@@ -43,7 +43,7 @@ WebIDL::ExceptionOr<GC::Ref<EventSource>> EventSource::construct_impl(JS::Realm&
     auto& settings = relevant_settings_object(event_source);
 
     // 3. Let urlRecord be the result of encoding-parsing a URL given url, relative to settings.
-    auto url_record = settings.parse_url(url);
+    auto url_record = settings.encoding_parse_url(url);
 
     // 4. If urlRecord is failure, then throw a "SyntaxError" DOMException.
     if (!url_record.is_valid())

--- a/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBodyElement.cpp
@@ -113,7 +113,8 @@ void HTMLBodyElement::attribute_changed(FlyString const& name, Optional<String> 
         if (color.has_value())
             document().set_visited_link_color(color.value());
     } else if (name.equals_ignoring_ascii_case("background"sv)) {
-        m_background_style_value = CSS::ImageStyleValue::create(document().parse_url(value.value_or(String {})));
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-page:attr-background
+        m_background_style_value = CSS::ImageStyleValue::create(document().encoding_parse_url(value.value_or(String {})));
         m_background_style_value->on_animate = [this] {
             if (paintable()) {
                 paintable()->set_needs_display();

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -222,7 +222,7 @@ WebIDL::ExceptionOr<void> HTMLFormElement::submit_form(GC::Ref<HTMLElement> subm
 
     // 14. Parse a URL given action, relative to the submitter element's node document. If this fails, return.
     // 15. Let parsed action be the resulting URL record.
-    auto parsed_action = document().parse_url(action);
+    auto parsed_action = submitter->document().parse_url(action);
     if (!parsed_action.is_valid()) {
         dbgln("Failed to submit form: Invalid URL: {}", action);
         return {};

--- a/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -486,22 +486,15 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
 
     // 8. Let urlString be the result of encoding-parsing-and-serializing a URL given subject's href attribute value,
     //    relative to subject's node document.
-    auto url = hyperlink_element_utils_document().parse_url(href());
+    auto url_string = hyperlink_element_utils_document().encoding_parse_and_serialize_url(href());
 
     // 9. If urlString is failure, then return.
-    if (!url.is_valid())
+    if (!url_string.has_value())
         return;
 
-    auto url_string = url.to_string();
-
     // 10. If hyperlinkSuffix is non-null, then append it to urlString.
-    if (hyperlink_suffix.has_value()) {
-        StringBuilder url_builder;
-        url_builder.append(url_string);
-        url_builder.append(*hyperlink_suffix);
-
-        url_string = MUST(url_builder.to_string());
-    }
+    if (hyperlink_suffix.has_value())
+        url_string = MUST(String::formatted("{}{}", *url_string, *hyperlink_suffix));
 
     // 11. Let referrerPolicy be the current state of subject's referrerpolicy content attribute.
     auto referrer_policy = ReferrerPolicy::from_string(hyperlink_element_utils_referrerpolicy().value_or({})).value_or(ReferrerPolicy::ReferrerPolicy::EmptyString);
@@ -509,7 +502,7 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // FIXME: 12. If subject's link types includes the noreferrer keyword, then set referrerPolicy to "no-referrer".
 
     // 13. Navigate targetNavigable to urlString using subject's node document, with referrerPolicy set to referrerPolicy and userInvolvement set to userInvolvement.
-    MUST(target_navigable->navigate({ .url = url_string, .source_document = hyperlink_element_utils_document(), .referrer_policy = referrer_policy, .user_involvement = user_involvement }));
+    MUST(target_navigable->navigate({ .url = *url_string, .source_document = hyperlink_element_utils_document(), .referrer_policy = referrer_policy, .user_involvement = user_involvement }));
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1319,7 +1319,7 @@ WebIDL::ExceptionOr<void> HTMLInputElement::handle_src_attribute(String const& v
 
     // 1. Let url be the result of encoding-parsing a URL given the src attribute's value, relative to the element's
     //    node document.
-    auto url = document().parse_url(value);
+    auto url = document().encoding_parse_url(value);
 
     // 2. If url is failure, then return.
     if (!url.is_valid())

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -78,14 +78,14 @@ void HTMLLinkElement::inserted()
     if (m_relationship & Relationship::Preload) {
         // FIXME: Respect the "as" attribute.
         LoadRequest request;
-        request.set_url(document().parse_url(get_attribute_value(HTML::AttributeNames::href)));
+        request.set_url(document().encoding_parse_url(get_attribute_value(HTML::AttributeNames::href)));
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
     } else if (m_relationship & Relationship::DNSPrefetch) {
-        ResourceLoader::the().prefetch_dns(document().parse_url(get_attribute_value(HTML::AttributeNames::href)));
+        ResourceLoader::the().prefetch_dns(document().encoding_parse_url(get_attribute_value(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Preconnect) {
-        ResourceLoader::the().preconnect(document().parse_url(get_attribute_value(HTML::AttributeNames::href)));
+        ResourceLoader::the().preconnect(document().encoding_parse_url(get_attribute_value(HTML::AttributeNames::href)));
     } else if (m_relationship & Relationship::Icon) {
-        auto favicon_url = document().parse_url(href());
+        auto favicon_url = document().encoding_parse_url(href());
         auto favicon_request = LoadRequest::create_for_url_on_page(favicon_url, &document().page());
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, favicon_request));
     }
@@ -261,6 +261,8 @@ GC::Ptr<Fetch::Infrastructure::Request> HTMLLinkElement::create_link_request(HTM
     // FIXME: 2. If options's destination is null, then return null.
 
     // 3. Let url be the result of encoding-parsing a URL given options's href, relative to options's base URL.
+    // FIXME: Spec issue: We should be parsing this URL relative to a document or environment settings object.
+    //        https://github.com/whatwg/html/issues/9715
     auto url = options.base_url.complete_url(options.href);
 
     // 4. If url is failure, then return null.

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -11,8 +11,12 @@
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/DocumentLoadEventDelayer.h>
 #include <LibWeb/DOM/DocumentLoading.h>
 #include <LibWeb/DOM/Event.h>
+#include <LibWeb/Fetch/Fetching/Fetching.h>
+#include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/HTML/DecodedImageData.h>
 #include <LibWeb/HTML/HTMLMediaElement.h>
 #include <LibWeb/HTML/HTMLObjectElement.h>
@@ -39,8 +43,8 @@ HTMLObjectElement::HTMLObjectElement(DOM::Document& document, DOM::QualifiedName
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element
     // Whenever one of the following conditions occur:
     // - the element is created,
-    // ...the user agent must queue an element task on the DOM manipulation task source given
-    // the object element to run the following steps to (re)determine what the object element represents.
+    // ...the user agent must queue an element task on the DOM manipulation task source given the object element to run
+    // the following steps to (re)determine what the object element represents.
     queue_element_task_to_run_object_representation_steps();
 }
 
@@ -69,10 +73,8 @@ void HTMLObjectElement::form_associated_element_attribute_changed(FlyString cons
         (!has_attribute(HTML::AttributeNames::classid) && name == HTML::AttributeNames::data) ||
         // - neither the element's classid attribute nor its data attribute are present, and its type attribute is set, changed, or removed,
         (!has_attribute(HTML::AttributeNames::classid) && !has_attribute(HTML::AttributeNames::data) && name == HTML::AttributeNames::type)) {
-
-        // ...the user agent must queue an element task on the DOM manipulation task source given
-        // the object element to run the following steps to (re)determine what the object element represents.
-        // This task being queued or actively running must delay the load event of the element's node document.
+        // ...the user agent must queue an element task on the DOM manipulation task source given the object element to run
+        // the following steps to (re)determine what the object element represents.
         queue_element_task_to_run_object_representation_steps();
     }
 }
@@ -145,7 +147,7 @@ GC::Ptr<Layout::Node> HTMLObjectElement::create_layout_node(CSS::StyleProperties
     switch (m_representation) {
     case Representation::Children:
         return NavigableContainer::create_layout_node(move(style));
-    case Representation::NestedBrowsingContext:
+    case Representation::ContentNavigable:
         return heap().allocate<Layout::NavigableContainerViewport>(document(), *this, move(style));
     case Representation::Image:
         if (image_data())
@@ -184,152 +186,213 @@ bool HTMLObjectElement::has_ancestor_media_element_or_object_element_not_showing
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element:queue-an-element-task
 void HTMLObjectElement::queue_element_task_to_run_object_representation_steps()
 {
-    queue_an_element_task(HTML::Task::Source::DOMManipulation, [&]() {
-        // FIXME: 1. If the user has indicated a preference that this object element's fallback content be shown instead of the element's usual behavior, then jump to the step below labeled fallback.
+    // This task being queued or actively running must delay the load event of the element's node document.
+    m_document_load_event_delayer_for_object_representation_task.emplace(document());
 
-        // 2. If the element has an ancestor media element, or has an ancestor object element that is not showing its fallback content, or if the element is not in a document whose browsing context is non-null, or if the element's node document is not fully active, or if the element is still in the stack of open elements of an HTML parser or XML parser, or if the element is not being rendered, then jump to the step below labeled fallback.
-        if (!document().browsing_context() || !document().is_fully_active())
-            return run_object_representation_fallback_steps();
-        if (has_ancestor_media_element_or_object_element_not_showing_fallback_content())
-            return run_object_representation_fallback_steps();
+    queue_an_element_task(HTML::Task::Source::DOMManipulation, [this]() {
+        ScopeGuard guard { [&]() { m_document_load_event_delayer_for_object_representation_task.clear(); } };
 
-        // FIXME: 3. If the classid attribute is present, and has a value that isn't the empty string, then: if the user agent can find a plugin suitable according to the value of the classid attribute, and plugins aren't being sandboxed, then that plugin should be used, and the value of the data attribute, if any, should be passed to the plugin. If no suitable plugin can be found, or if the plugin reports an error, jump to the step below labeled fallback.
+        auto& realm = this->realm();
+        auto& vm = realm.vm();
 
-        // 4. If the data attribute is present and its value is not the empty string, then:
-        if (auto maybe_data = get_attribute(HTML::AttributeNames::data); maybe_data.has_value() && !maybe_data->is_empty()) {
-            // 1. If the type attribute is present and its value is not a type that the user agent supports, and is not a type that the user agent can find a plugin for, then the user agent may jump to the step below labeled fallback without fetching the content to examine its real type.
+        // FIXME: 1. If the user has indicated a preference that this object element's fallback content be shown instead of the
+        //           element's usual behavior, then jump to the step below labeled fallback.
 
-            // 2. Parse a URL given the data attribute, relative to the element's node document.
-            auto url = document().parse_url(*maybe_data);
-
-            // 3. If that failed, fire an event named error at the element, then jump to the step below labeled fallback.
-            if (!url.is_valid()) {
-                dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
-                return run_object_representation_fallback_steps();
-            }
-
-            // 4. Let request be a new request whose URL is the resulting URL record, client is the element's node document's relevant settings object, destination is "object", credentials mode is "include", mode is "navigate", and whose use-URL-credentials flag is set.
-            auto request = LoadRequest::create_for_url_on_page(url, &document().page());
-
-            // 5. Fetch request, with processResponseEndOfBody given response res set to finalize and report timing with res, the element's node document's relevant global object, and "object".
-            //    Fetching the resource must delay the load event of the element's node document until the task that is queued by the networking task source once the resource has been fetched (defined next) has been run.
-            set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
-            m_document_load_event_delayer_for_resource_load.emplace(document());
-
-            // 6. If the resource is not yet available (e.g. because the resource was not available in the cache, so that loading the resource required making a request over the network), then jump to the step below labeled fallback. The task that is queued by the networking task source once the resource is available must restart this algorithm from this step. Resources can load incrementally; user agents may opt to consider a resource "available" whenever enough data has been obtained to begin processing the resource.
-
-            // NOTE: The request is always asynchronous, even if it is cached or succeeded/failed immediately. Allow the callbacks below to invoke
-            //       the fallback steps. This prevents the fallback layout from flashing very briefly between here and the resource loading.
+        // 2. If the element has an ancestor media element, or has an ancestor object element that is not showing its
+        //    fallback content, or if the element is not in a document whose browsing context is non-null, or if the
+        //    element's node document is not fully active, or if the element is still in the stack of open elements of
+        //    an HTML parser or XML parser, or if the element is not being rendered, then jump to the step below labeled
+        //    fallback.
+        // FIXME: Handle the element being in the stack of open elements.
+        // FIXME: Handle the element not being rendered.
+        if (!document().browsing_context() || !document().is_fully_active()) {
+            run_object_representation_fallback_steps();
+            return;
+        }
+        if (has_ancestor_media_element_or_object_element_not_showing_fallback_content()) {
+            run_object_representation_fallback_steps();
             return;
         }
 
-        // 5. If the data attribute is absent but the type attribute is present, and the user agent can find a plugin suitable according to the value of the type attribute, and plugins aren't being sandboxed, then that plugin should be used. If these conditions cannot be met, or if the plugin reports an error, jump to the step below labeled fallback. Otherwise return; once the plugin is completely loaded, queue an element task on the DOM manipulation task source given the object element to fire an event named load at the element.
-        run_object_representation_fallback_steps();
+        // 3. If the data attribute is present and its value is not the empty string, then:
+        if (auto data = get_attribute(HTML::AttributeNames::data); data.has_value() && !data->is_empty()) {
+            // 1. If the type attribute is present and its value is not a type that the user agent supports, then the user
+            //    agent may jump to the step below labeled fallback without fetching the content to examine its real type.
+
+            // 2. Let url be the result of encoding-parsing a URL given the data attribute's value, relative to the element's node document.
+            auto url = document().encoding_parse_url(*data);
+
+            // 3. If url is failure, then fire an event named error at the element and jump to the step below labeled fallback.
+            if (!url.is_valid()) {
+                dispatch_event(DOM::Event::create(realm, HTML::EventNames::error));
+                run_object_representation_fallback_steps();
+                return;
+            }
+
+            // 4. Let request be a new request whose URL is url, client is the element's node document's relevant settings
+            //    object, destination is "object", credentials mode is "include", mode is "navigate", initiator type is
+            //    "object", and whose use-URL-credentials flag is set.
+            auto request = Fetch::Infrastructure::Request::create(vm);
+            request->set_url(move(url));
+            request->set_client(&document().relevant_settings_object());
+            request->set_destination(Fetch::Infrastructure::Request::Destination::Object);
+            request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::Include);
+            request->set_mode(Fetch::Infrastructure::Request::Mode::Navigate);
+            request->set_initiator_type(Fetch::Infrastructure::Request::InitiatorType::Object);
+            request->set_use_url_credentials(true);
+
+            Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+            fetch_algorithms_input.process_response = [this](GC::Ref<Fetch::Infrastructure::Response> response) {
+                auto& realm = this->realm();
+                auto& global = document().realm().global_object();
+
+                if (response->is_network_error()) {
+                    resource_did_fail();
+                    return;
+                }
+
+                if (response->type() == Fetch::Infrastructure::Response::Type::Opaque || response->type() == Fetch::Infrastructure::Response::Type::OpaqueRedirect) {
+                    auto& filtered_response = static_cast<Fetch::Infrastructure::FilteredResponse&>(*response);
+                    response = filtered_response.internal_response();
+                }
+
+                auto on_data_read = GC::create_function(realm.heap(), [this, response](ByteBuffer data) {
+                    resource_did_load(response, data);
+                });
+                auto on_error = GC::create_function(realm.heap(), [this](JS::Value) {
+                    resource_did_fail();
+                });
+
+                VERIFY(response->body());
+                response->body()->fully_read(realm, on_data_read, on_error, GC::Ref { global });
+            };
+
+            // 5. Fetch request.
+            auto result = Fetch::Fetching::fetch(realm, request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
+            if (result.is_error()) {
+                resource_did_fail();
+                return;
+            }
+
+            //    Fetching the resource must delay the load event of the element's node document until the task that is
+            //    queued by the networking task source once the resource has been fetched (defined next) has been run.
+            m_document_load_event_delayer_for_resource_load.emplace(document());
+
+            // 6. If the resource is not yet available (e.g. because the resource was not available in the cache, so that
+            //    loading the resource required making a request over the network), then jump to the step below labeled
+            //    fallback. The task that is queued by the networking task source once the resource is available must
+            //    restart this algorithm from this step. Resources can load incrementally; user agents may opt to consider
+            //    a resource "available" whenever enough data has been obtained to begin processing the resource.
+
+            // NOTE: The request is always asynchronous, even if it is cached or succeeded/failed immediately. Allow the
+            //       response callback to invoke the fallback steps. This prevents the fallback layout from flashing very
+            //       briefly between here and the resource loading.
+        }
     });
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element:concept-event-fire-2
 void HTMLObjectElement::resource_did_fail()
 {
-    // 4.7. If the load failed (e.g. there was an HTTP 404 error, there was a DNS error), fire an event named error at the element, then jump to the step below labeled fallback.
+    ScopeGuard guard { [&]() { m_document_load_event_delayer_for_resource_load.clear(); } };
+
+    // 3.7. If the load failed (e.g. there was an HTTP 404 error, there was a DNS error), fire an event named error at
+    //      the element, then jump to the step below labeled fallback.
     dispatch_event(DOM::Event::create(realm(), HTML::EventNames::error));
     run_object_representation_fallback_steps();
-    m_document_load_event_delayer_for_resource_load.clear();
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#object-type-detection
-void HTMLObjectElement::resource_did_load()
+void HTMLObjectElement::resource_did_load(Fetch::Infrastructure::Response const& response, ReadonlyBytes data)
 {
-    ScopeGuard load_event_delayer_guard = [&] {
-        m_document_load_event_delayer_for_resource_load.clear();
-    };
+    ScopeGuard guard { [&]() { m_document_load_event_delayer_for_resource_load.clear(); } };
 
-    // 4.8. Determine the resource type, as follows:
+    // 3.8. Determine the resource type, as follows:
 
     // 1. Let the resource type be unknown.
-    Optional<String> resource_type;
+    Optional<MimeSniff::MimeType> resource_type;
 
-    // FIXME: 2. If the user agent is configured to strictly obey Content-Type headers for this resource, and the resource has associated Content-Type metadata, then let the resource type be the type specified in the resource's Content-Type metadata, and jump to the step below labeled handler.
-    // FIXME: 3. If there is a type attribute present on the object element, and that attribute's value is not a type that the user agent supports, but it is a type that a plugin supports, then let the resource type be the type specified in that type attribute, and jump to the step below labeled handler.
+    // FIXME: 3. If the user agent is configured to strictly obey Content-Type headers for this resource, and the resource has
+    //           associated Content-Type metadata, then let the resource type be the type specified in the resource's Content-Type
+    //           metadata, and jump to the step below labeled handler.
 
-    // 4. Run the appropriate set of steps from the following list:
-    // * If the resource has associated Content-Type metadata
-    if (auto maybe_content_type = resource()->response_headers().get("Content-Type"sv); maybe_content_type.has_value()) {
-        auto& content_type = maybe_content_type.value();
-
+    // 3. Run the appropriate set of steps from the following list:
+    // -> If the resource has associated Content-Type metadata
+    if (auto content_type = response.header_list()->extract_mime_type(); content_type.has_value()) {
         // 1. Let binary be false.
         bool binary = false;
 
-        // 2. If the type specified in the resource's Content-Type metadata is "text/plain", and the result of applying the rules for distinguishing if a resource is text or binary to the resource is that the resource is not text/plain, then set binary to true.
-        if (content_type == "text/plain"sv) {
-            auto supplied_type = MimeSniff::MimeType::parse(content_type);
-            auto computed_type = MimeSniff::Resource::sniff(resource()->encoded_data(), MimeSniff::SniffingConfiguration {
-                                                                                            .sniffing_context = MimeSniff::SniffingContext::TextOrBinary,
-                                                                                            .supplied_type = move(supplied_type),
-                                                                                        });
+        // 2. If the type specified in the resource's Content-Type metadata is "text/plain", and the result of applying
+        //    the rules for distinguishing if a resource is text or binary to the resource is that the resource is not
+        //    text/plain, then set binary to true.
+        if (content_type->essence() == "text/plain"sv) {
+            auto computed_type = MimeSniff::Resource::sniff(
+                data,
+                MimeSniff::SniffingConfiguration {
+                    .sniffing_context = MimeSniff::SniffingContext::TextOrBinary,
+                    .supplied_type = content_type,
+                });
+
             if (computed_type.essence() != "text/plain"sv)
                 binary = true;
         }
 
         // 3. If the type specified in the resource's Content-Type metadata is "application/octet-stream", then set binary to true.
-        if (content_type == "application/octet-stream"sv)
+        else if (content_type->essence() == "application/octet-stream"sv) {
             binary = true;
+        }
 
-        // 4. If binary is false, then let the resource type be the type specified in the resource's Content-Type metadata, and jump to the step below labeled handler.
-        if (!binary)
-            return run_object_representation_handler_steps(content_type);
+        // 4. If binary is false, then let the resource type be the type specified in the resource's Content-Type metadata,
+        //    and jump to the step below labeled handler.
+        if (!binary) {
+            resource_type = move(content_type);
+        }
 
-        // 5. If there is a type attribute present on the object element, and its value is not application/octet-stream, then run the following steps:
-        if (auto type = this->type(); !type.is_empty() && (type != "application/octet-stream"sv)) {
-            // 1. If the attribute's value is a type that a plugin supports, or the attribute's value is a type that starts with "image/" that is not also an XML MIME type, then let the resource type be the type specified in that type attribute.
-            // FIXME: This only partially implements this step.
-            if (type.starts_with_bytes("image/"sv))
-                resource_type = move(type);
+        // 5. If there is a type attribute present on the object element, and its value is not application/octet-stream,
+        //    then run the following steps:
+        else if (auto type = this->type(); !type.is_empty() && (type != "application/octet-stream"sv)) {
+            // 1. If the attribute's value is a type that starts with "image/" that is not also an XML MIME type, then
+            //    let the resource type be the type specified in that type attribute.
+            if (type.starts_with_bytes("image/"sv)) {
+                auto parsed_type = MimeSniff::MimeType::parse(type);
+
+                if (parsed_type.has_value() && !parsed_type->is_xml())
+                    resource_type = move(parsed_type);
+            }
 
             // 2. Jump to the step below labeled handler.
         }
     }
-    // * Otherwise, if the resource does not have associated Content-Type metadata
+    // -> Otherwise, if the resource does not have associated Content-Type metadata
     else {
-        Optional<String> tentative_type;
+        Optional<MimeSniff::MimeType> tentative_type;
 
         // 1. If there is a type attribute present on the object element, then let the tentative type be the type specified in that type attribute.
         //    Otherwise, let tentative type be the computed type of the resource.
         if (auto type = this->type(); !type.is_empty())
-            tentative_type = move(type);
+            tentative_type = MimeSniff::MimeType::parse(type);
+        else
+            tentative_type = MimeSniff::Resource::sniff(data);
 
-        // FIXME: For now, ignore application/ MIME types as we cannot render yet them anyways. We will need to implement the MIME type sniffing
-        //        algorithm in order to map all unknown MIME types to "application/octet-stream".
-        else if (auto type = resource()->mime_type(); !type.starts_with("application/"sv))
-            tentative_type = MUST(String::from_byte_string(type));
-
-        // 2. If tentative type is not application/octet-stream, then let resource type be tentative type and jump to the step below labeled handler.
-        if (tentative_type.has_value() && tentative_type != "application/octet-stream"sv)
+        // 2. If tentative type is not application/octet-stream, then let resource type be tentative type and jump to the
+        //    step below labeled handler.
+        if (tentative_type.has_value() && tentative_type->essence() != "application/octet-stream"sv)
             resource_type = move(tentative_type);
     }
 
-    // FIXME: 5. If applying the URL parser algorithm to the URL of the specified resource (after any redirects) results in a URL record whose path component matches a pattern that a plugin supports, then let resource type be the type that that plugin can handle.
-    run_object_representation_handler_steps(resource_type.has_value() ? resource_type->to_byte_string() : ByteString::empty());
+    if (resource_type.has_value())
+        run_object_representation_handler_steps(response, *resource_type, data);
+    else
+        run_object_representation_fallback_steps();
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element:plugin-11
-void HTMLObjectElement::run_object_representation_handler_steps(Optional<ByteString> resource_type)
+void HTMLObjectElement::run_object_representation_handler_steps(Fetch::Infrastructure::Response const& response, MimeSniff::MimeType const& resource_type, ReadonlyBytes data)
 {
-    // 4.9. Handler: Handle the content as given by the first of the following cases that matches:
+    // 3.9. Handler: Handle the content as given by the first of the following cases that matches:
 
-    // * FIXME: If the resource type is not a type that the user agent supports, but it is a type that a plugin supports
-    //     If the object element's nested browsing context is non-null, then it must be discarded and then set to null.
-    //     If plugins are being sandboxed, then jump to the step below labeled fallback.
-    //     Otherwise, the user agent should use the plugin that supports resource type and pass the content of the resource to that plugin. If the plugin reports an error, then jump to the step below labeled fallback.
-
-    if (!resource_type.has_value()) {
-        run_object_representation_fallback_steps();
-        return;
-    }
-    auto mime_type = MimeSniff::MimeType::parse(*resource_type);
-
-    // * If the resource type is an XML MIME type, or if the resource type does not start with "image/"
-    if (mime_type.has_value() && can_load_document_with_type(*mime_type) && (mime_type->is_xml() || !mime_type->is_image())) {
+    // -> If the resource type is an XML MIME type, or if the resource type does not start with "image/"
+    if (can_load_document_with_type(resource_type) && (resource_type.is_xml() || !resource_type.is_image())) {
         // If the object element's content navigable is null, then create a new child navigable for the element.
         if (!m_content_navigable && in_a_document_tree()) {
             MUST(create_new_child_navigable());
@@ -340,32 +403,41 @@ void HTMLObjectElement::run_object_representation_handler_steps(Optional<ByteStr
         if (!m_content_navigable)
             return;
 
-        // If the URL of the given resource does not match about:blank, then navigate the element's nested browsing context to that resource, with historyHandling set to "replace" and the source browsing context set to the object element's node document's browsing context. (The data attribute of the object element doesn't get updated if the browsing context gets further navigated to other locations.)
-        if (auto const& url = resource()->url(); url != "about:blank"sv)
-            MUST(m_content_navigable->navigate({ .url = url,
-                .source_document = document(),
-                .history_handling = Bindings::NavigationHistoryBehavior::Replace }));
+        // Let response be the response from fetch.
 
-        // The object element represents its nested browsing context.
-        run_object_representation_completed_steps(Representation::NestedBrowsingContext);
+        // If response's URL does not match about:blank, then navigate the element's content navigable to response's URL
+        // using the element's node document, with historyHandling set to "replace".
+        if (response.url().has_value() && !url_matches_about_blank(*response.url())) {
+            MUST(m_content_navigable->navigate({
+                .url = *response.url(),
+                .source_document = document(),
+                .history_handling = Bindings::NavigationHistoryBehavior::Replace,
+            }));
+        }
+
+        // The object element represents its content navigable.
+        run_object_representation_completed_steps(Representation::ContentNavigable);
     }
 
-    // * If the resource type starts with "image/", and support for images has not been disabled
+    // -> If the resource type starts with "image/", and support for images has not been disabled
     // FIXME: Handle disabling image support.
-    else if (resource_type.has_value() && resource_type->starts_with("image/"sv)) {
-        // Destroy the child navigable of the object element.
+    else if (resource_type.is_image()) {
+        // Destroy a child navigable given the object element.
         destroy_the_child_navigable();
 
         // Apply the image sniffing rules to determine the type of the image.
         // The object element represents the specified image.
-        // If the image cannot be rendered, e.g. because it is malformed or in an unsupported format, jump to the step below labeled fallback.
-        if (!resource()->has_encoded_data())
-            return run_object_representation_fallback_steps();
+        // If the image cannot be rendered, e.g. because it is malformed or in an unsupported format, jump to the step
+        // below labeled fallback.
+        if (data.is_empty()) {
+            run_object_representation_fallback_steps();
+            return;
+        }
 
         load_image();
     }
 
-    // * Otherwise
+    // -> Otherwise
     else {
         // The given resource type is not supported. Jump to the step below labeled fallback.
         run_object_representation_fallback_steps();
@@ -375,9 +447,12 @@ void HTMLObjectElement::run_object_representation_handler_steps(Optional<ByteStr
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element:the-object-element-19
 void HTMLObjectElement::run_object_representation_completed_steps(Representation representation)
 {
-    // 4.10. The element's contents are not part of what the object element represents.
-    // 4.11. If the object element does not represent its nested browsing context, then once the resource is completely loaded, queue an element task on the DOM manipulation task source given the object element to fire an event named load at the element.
-    if (representation != Representation::NestedBrowsingContext) {
+    // 3.10. The element's contents are not part of what the object element represents.
+
+    // 3.11. If the object element does not represent its content navigable, then once the resource is completely loaded,
+    //       queue an element task on the DOM manipulation task source given the object element to fire an event named
+    //       load at the element.
+    if (representation != Representation::ContentNavigable) {
         queue_an_element_task(HTML::Task::Source::DOMManipulation, [&]() {
             dispatch_event(DOM::Event::create(realm(), HTML::EventNames::load));
         });
@@ -385,13 +460,14 @@ void HTMLObjectElement::run_object_representation_completed_steps(Representation
 
     update_layout_and_child_objects(representation);
 
-    // 4.12. Return.
+    // 3.12. Return.
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element:the-object-element-23
 void HTMLObjectElement::run_object_representation_fallback_steps()
 {
-    // 4. Fallback: The object element represents the element's children. This is the element's fallback content. Destroy the child navigable for the element.
+    // 4. Fallback: The object element represents the element's children. This is the element's fallback content.
+    //    Destroy a child navigable given the element.
     destroy_the_child_navigable();
 
     update_layout_and_child_objects(Representation::Children);
@@ -399,7 +475,7 @@ void HTMLObjectElement::run_object_representation_fallback_steps()
 
 void HTMLObjectElement::load_image()
 {
-    // NOTE: This currently reloads the image instead of reusing the resource we've already downloaded.
+    // FIXME: This currently reloads the image instead of reusing the resource we've already downloaded.
     auto data = get_attribute_value(HTML::AttributeNames::data);
     auto url = document().encoding_parse_url(data);
     m_resource_request = HTML::SharedResourceRequest::get_or_create(realm(), document().page(), url);
@@ -420,8 +496,7 @@ void HTMLObjectElement::load_image()
 
 void HTMLObjectElement::update_layout_and_child_objects(Representation representation)
 {
-    if ((m_representation == Representation::Children && representation != Representation::Children)
-        || (m_representation != Representation::Children && representation == Representation::Children)) {
+    if (representation == Representation::Children) {
         for_each_child_of_type<HTMLObjectElement>([](auto& object) {
             object.queue_element_task_to_run_object_representation_steps();
             return IterationDecision::Continue;

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -137,7 +137,7 @@ String HTMLObjectElement::data() const
     if (!data.has_value())
         return {};
 
-    return document().parse_url(*data).to_string();
+    return document().encoding_parse_url(*data).to_string();
 }
 
 GC::Ptr<Layout::Node> HTMLObjectElement::create_layout_node(CSS::StyleProperties style)
@@ -401,7 +401,7 @@ void HTMLObjectElement::load_image()
 {
     // NOTE: This currently reloads the image instead of reusing the resource we've already downloaded.
     auto data = get_attribute_value(HTML::AttributeNames::data);
-    auto url = document().parse_url(data);
+    auto url = document().encoding_parse_url(data);
     m_resource_request = HTML::SharedResourceRequest::get_or_create(realm(), document().page(), url);
     m_resource_request->add_callbacks(
         [this] {

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -12,14 +12,12 @@
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/NavigableContainer.h>
 #include <LibWeb/Layout/ImageProvider.h>
-#include <LibWeb/Loader/Resource.h>
 
 namespace Web::HTML {
 
 class HTMLObjectElement final
     : public NavigableContainer
     , public FormAssociatedElement
-    , public ResourceClient
     , public Layout::ImageProvider {
     WEB_PLATFORM_OBJECT(HTMLObjectElement, NavigableContainer)
     GC_DECLARE_ALLOCATOR(HTMLObjectElement);
@@ -28,7 +26,7 @@ class HTMLObjectElement final
     enum class Representation {
         Unknown,
         Image,
-        NestedBrowsingContext,
+        ContentNavigable,
         Children,
     };
 
@@ -64,16 +62,15 @@ private:
     bool has_ancestor_media_element_or_object_element_not_showing_fallback_content() const;
 
     void queue_element_task_to_run_object_representation_steps();
-    void run_object_representation_handler_steps(Optional<ByteString> resource_type);
+    void run_object_representation_handler_steps(Fetch::Infrastructure::Response const&, MimeSniff::MimeType const&, ReadonlyBytes);
     void run_object_representation_completed_steps(Representation);
     void run_object_representation_fallback_steps();
 
     void load_image();
     void update_layout_and_child_objects(Representation);
 
-    // ^ResourceClient
-    virtual void resource_did_load() override;
-    virtual void resource_did_fail() override;
+    void resource_did_load(Fetch::Infrastructure::Response const&, ReadonlyBytes);
+    void resource_did_fail();
 
     // ^DOM::Element
     virtual i32 default_tab_index_value() const override;
@@ -87,13 +84,12 @@ private:
     virtual void set_visible_in_viewport(bool) override;
     virtual GC::Ref<DOM::Element const> to_html_element() const override { return *this; }
 
-    Representation m_representation { Representation::Unknown };
-
     GC::Ptr<DecodedImageData> image_data() const;
+
+    Representation m_representation { Representation::Unknown };
 
     GC::Ptr<SharedResourceRequest> m_resource_request;
 
-public:
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer_for_object_representation_task;
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer_for_resource_load;
 };

--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -74,7 +74,8 @@ void HTMLTableCellElement::apply_presentational_hints(CSS::StyleProperties& styl
                 style.set_property(CSS::PropertyID::Height, parsed_value.release_nonnull());
             return;
         } else if (name == HTML::AttributeNames::background) {
-            if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:encoding-parsing-and-serializing-a-url
+            if (auto parsed_value = document().encoding_parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
             return;
         }

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -74,7 +74,8 @@ void HTMLTableElement::apply_presentational_hints(CSS::StyleProperties& style) c
             return;
         }
         if (name == HTML::AttributeNames::background) {
-            if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:encoding-parsing-and-serializing-a-url
+            if (auto parsed_value = document().encoding_parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
             return;
         }

--- a/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -49,7 +49,8 @@ void HTMLTableRowElement::apply_presentational_hints(CSS::StyleProperties& style
             if (color.has_value())
                 style.set_property(CSS::PropertyID::BackgroundColor, CSS::CSSColorValue::create_from_color(color.value()));
         } else if (name == HTML::AttributeNames::background) {
-            if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:encoding-parsing-and-serializing-a-url
+            if (auto parsed_value = document().encoding_parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
         } else if (name == HTML::AttributeNames::height) {
             if (auto parsed_value = parse_dimension_value(value))

--- a/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -105,7 +105,7 @@ void HTMLTableSectionElement::apply_presentational_hints(CSS::StyleProperties& s
     for_each_attribute([&](auto& name, auto& value) {
         // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:encoding-parsing-and-serializing-a-url
         if (name == HTML::AttributeNames::background) {
-            if (auto parsed_value = document().parse_url(value); parsed_value.is_valid())
+            if (auto parsed_value = document().encoding_parse_url(value); parsed_value.is_valid())
                 style.set_property(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(parsed_value));
         }
         // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:rules-for-parsing-a-legacy-colour-value

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -108,22 +108,21 @@ WebIDL::ExceptionOr<String> Location::href() const
 WebIDL::ExceptionOr<void> Location::set_href(String const& new_href)
 {
     auto& realm = this->realm();
-    auto& window = verify_cast<HTML::Window>(HTML::current_principal_global_object());
 
     // 1. If this's relevant Document is null, then return.
     auto const relevant_document = this->relevant_document();
     if (!relevant_document)
         return {};
 
-    // FIXME: 2. Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
-    auto href_url = window.associated_document().parse_url(new_href.to_byte_string());
+    // 2. Let url be the result of encoding-parsing a URL given the given value, relative to the entry settings object.
+    auto url = entry_settings_object().encoding_parse_url(new_href.to_byte_string());
 
     // 3. If url is failure, then throw a "SyntaxError" DOMException.
-    if (!href_url.is_valid())
+    if (!url.is_valid())
         return WebIDL::SyntaxError::create(realm, MUST(String::formatted("Invalid URL '{}'", new_href)));
 
     // 4. Location-object navigate this to url.
-    TRY(navigate(href_url));
+    TRY(navigate(url));
 
     return {};
 }

--- a/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -88,6 +88,8 @@ public:
     virtual CanUseCrossOriginIsolatedAPIs cross_origin_isolated_capability() const = 0;
 
     URL::URL parse_url(StringView);
+    URL::URL encoding_parse_url(StringView);
+    Optional<String> encoding_parse_and_serialize_url(StringView);
 
     JS::Realm& realm();
     JS::Object& global_object();

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -197,8 +197,8 @@ WebIDL::ExceptionOr<Window::OpenedWindow> Window::window_open_steps_internal(Str
 
     // 4. If url is not the empty string, then:
     if (!url.is_empty()) {
-        // FIXME: 1. Set urlRecord to the result of encoding-parsing a URL given url, relative to sourceDocument.
-        url_record = entry_settings_object().parse_url(url);
+        // 1. Set urlRecord to the result of encoding-parsing a URL given url, relative to sourceDocument.
+        url_record = source_document.encoding_parse_url(url);
 
         // 2. If urlRecord is failure, then throw a "SyntaxError" DOMException.
         if (!url_record->is_valid())

--- a/Libraries/LibWeb/HTML/Worker.cpp
+++ b/Libraries/LibWeb/HTML/Worker.cpp
@@ -60,7 +60,7 @@ WebIDL::ExceptionOr<GC::Ref<Worker>> Worker::create(String const& script_url, Wo
     auto& outside_settings = current_principal_settings_object();
 
     // 3. Parse the scriptURL argument relative to outside settings.
-    auto url = document.parse_url(script_url);
+    auto url = outside_settings.parse_url(script_url);
 
     // 4. If this fails, throw a "SyntaxError" DOMException.
     if (!url.is_valid()) {

--- a/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WorkerGlobalScope.cpp
@@ -103,7 +103,7 @@ WebIDL::ExceptionOr<void> WorkerGlobalScope::import_scripts(Vector<String> const
     // 5. For each url of urls:
     for (auto const& url : urls) {
         // 1. Let urlRecord be the result of encoding-parsing a URL given url, relative to settings object.
-        auto url_record = settings_object.parse_url(url);
+        auto url_record = settings_object.encoding_parse_url(url);
 
         // 2. If urlRecord is failure, then throw a "SyntaxError" DOMException.
         if (!url_record.is_valid())

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -331,7 +331,7 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
                 if (GC::Ptr<HTML::HTMLAnchorElement const> link = node->enclosing_link_element()) {
                     GC::Ref<DOM::Document> document = *m_navigable->active_document();
                     auto href = link->href();
-                    auto url = document->parse_url(href);
+                    auto url = document->encoding_parse_url(href);
 
                     if (button == UIEvents::MouseButton::Primary && (modifiers & UIEvents::Mod_PlatformCtrl) != 0) {
                         m_navigable->page().client().page_did_click_link(url, link->target().to_byte_string(), modifiers);
@@ -343,13 +343,13 @@ EventResult EventHandler::handle_mouseup(CSSPixelPoint viewport_position, CSSPix
                 } else if (button == UIEvents::MouseButton::Secondary) {
                     if (is<HTML::HTMLImageElement>(*node)) {
                         auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
-                        auto image_url = image_element.document().parse_url(image_element.src());
+                        auto image_url = image_element.document().encoding_parse_url(image_element.src());
                         m_navigable->page().client().page_did_request_image_context_menu(viewport_position, image_url, "", modifiers, image_element.immutable_bitmap()->bitmap());
                     } else if (is<HTML::HTMLMediaElement>(*node)) {
                         auto& media_element = verify_cast<HTML::HTMLMediaElement>(*node);
 
                         Page::MediaContextMenu menu {
-                            .media_url = media_element.document().parse_url(media_element.current_src()),
+                            .media_url = media_element.document().encoding_parse_url(media_element.current_src()),
                             .is_video = is<HTML::HTMLVideoElement>(*node),
                             .is_playing = media_element.potentially_playing(),
                             .is_muted = media_element.muted(),
@@ -636,7 +636,7 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint viewport_position, CSSP
 
         if (is_hovering_link) {
             page.set_is_hovering_link(true);
-            page.client().page_did_hover_link(document.parse_url(hovered_link_element->href()));
+            page.client().page_did_hover_link(document.encoding_parse_url(hovered_link_element->href()));
         } else if (page.is_hovering_link()) {
             page.set_is_hovering_link(false);
             page.client().page_did_unhover_link();

--- a/Libraries/LibWeb/SVG/SVGGradientElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGGradientElement.cpp
@@ -128,7 +128,7 @@ GC::Ptr<SVGGradientElement const> SVGGradientElement::linked_gradient(HashTable<
 
     auto link = has_attribute(AttributeNames::href) ? get_attribute(AttributeNames::href) : get_attribute("xlink:href"_fly_string);
     if (auto href = link; href.has_value() && !link->is_empty()) {
-        auto url = document().parse_url(*href);
+        auto url = document().encoding_parse_url(*href);
         auto id = url.fragment();
         if (!id.has_value() || id->is_empty())
             return {};

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3620,7 +3620,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
         }
     }
 
-    if (!has_keyword && !did_set_to_missing_value) 
+    if (!has_keyword && !did_set_to_missing_value)
         retval = "@invalid_enum_default_value@"_string;
     )~~~");
 
@@ -3776,9 +3776,9 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
     if (!content_attribute_value.has_value())
         return JS::PrimitiveString::create(vm, String {});
 
-    auto url_string = impl->document().parse_url(*content_attribute_value);
-    if (url_string.is_valid())
-        return JS::PrimitiveString::create(vm, url_string.to_string());
+    auto url_string = impl->document().encoding_parse_and_serialize_url(*content_attribute_value);
+    if (url_string.has_value())
+        return JS::PrimitiveString::create(vm, url_string.release_value());
 )~~~");
                 }
 

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -432,7 +432,7 @@ void ConnectionFromClient::debug_request(u64 page_id, ByteString const& request,
                 load_html(page_id, "<h1>Failed to find &lt;link rel=&quot;match&quot; /&gt; or &lt;link rel=&quot;mismatch&quot; /&gt; in ref test page!</h1> Make sure you added it.");
             } else {
                 auto link = maybe_link.release_value();
-                auto url = document->parse_url(link->get_attribute_value(Web::HTML::AttributeNames::href));
+                auto url = document->encoding_parse_url(link->get_attribute_value(Web::HTML::AttributeNames::href));
                 if (url.query().has_value() && !url.query()->is_empty()) {
                     load_html(page_id, "<h1>Invalid ref test link - query string must be empty</h1>");
                     return;

--- a/Tests/LibWeb/Text/input/object-with-unsupported-type-in-data-attribute.html
+++ b/Tests/LibWeb/Text/input/object-with-unsupported-type-in-data-attribute.html
@@ -1,10 +1,19 @@
 <!DOCTYPE html>
 <script src="include.js"></script>
 <object id="object" data="data:application/x-unknown,ERROR">
-<div id="fallback">Fallback</div>
+    <div id="fallback">Fallback</div>
 </object>
 <script>
-test(() => {
-    println(document.body.innerText);
-});
+    asyncTest(done => {
+        // Fetching the data: URL is performed on the following deferred tasks:
+        // 1. The element task to trigger the fetch.
+        // 2. The fetch task to parse the data URL.
+        // So we must churn the event loop twice to reliably let the fallback representation be chosen.
+        setTimeout(() => {
+            setTimeout(() => {
+                println(document.body.innerText);
+                done();
+            });
+        });
+    });
 </script>


### PR DESCRIPTION
This eliminates the use of `ResourceLoader` in `HTMLObjectElement`. The spec steps around fetching have been slightly updated since we've last looked at this, so those are updated here.

Ref #2634