### PR TITLE
Docs: Add “Is [some particular site] usable in Ladybird” to FAQ

### DIFF
--- a/Documentation/FAQ.md
+++ b/Documentation/FAQ.md
@@ -7,6 +7,10 @@ Independent means:
 - We implement the web platform standards ourselves: Ladybird is not a Blink/Chromium shell, not a WebKit port, not a Firefox fork.
 - We don't take money from anyone with strings attached
 
+## Is [some particular site] usable in Ladybird?
+
+Ladybird is pre-alpha software you have to build from the sources yourself in order to even try. That said, it’s getting better day-by-day at handling some of the most widely-used sites on the web. So, you may find that a given site among the sites you visit daily is already usable in Ladybird. Or you may not. The only way you can really know at this point is to follow the [build instructions](BuildInstructionsLadybird.md) to build Ladybird and try it yourself.
+
 ## Windows support when?
 
 There are very few Windows developers contributing to the project. As such, maintaining a native Windows port would be


### PR DESCRIPTION
I’m not wedded to the particular wording of either the answer or the question here. But we get this question (in some form) frequently enough from people showing up on Discord — for example, see https://discord.com/channels/1247070541085671459/1247070543136690270/1315167861567914047 from just a few hours ago today — that it seems to merit being included in the FAQ.