### PR TITLE
LibCore: Do not include math.h in ArgsParser

### DIFF
--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -12,7 +12,6 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Version.h>
 #include <limits.h>
-#include <math.h>
 #include <stdio.h>
 #include <string.h>
 


### PR DESCRIPTION
A bit of history:
isnan() was introduced in b143e604d71a202dafe57a6600a9991b883bffea and later moved to math.h in a45b6dbc0781a3968a730582509e838b370a31cb
It was required for `convert_to_double` to work. However, later on, in e2e7c4d5747, it was replaced with `StringView::to_number<double>`, and no longer unnecessary header has never been removed.