### PR TITLE
LibWebView: Improved url sanitizing logic

### DIFF
--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -39,14 +39,11 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
     }
 
     ByteString url_with_scheme = url;
-    if (!(url_with_scheme.starts_with("about:"sv) || url_with_scheme.contains("://"sv) || url_with_scheme.starts_with("data:"sv)))
+    if (!(url_with_scheme.starts_with("about:"sv) || url_with_scheme.contains("://"sv) || url_with_scheme.starts_with("data:"sv) || url_with_scheme.contains("."sv)) {
         url_with_scheme = ByteString::formatted("https://{}"sv, url_with_scheme);
-
-    // FIXME: Fix `is_valid` method in LibURL, this is simply a bandage
-    if (url_with_scheme.contains("."sv)) {
         return URL::create_with_url_or_path(url_with_scheme);
     }
-
+    
     return format_search_engine();;
 }
 

--- a/Libraries/LibWebView/URL.cpp
+++ b/Libraries/LibWebView/URL.cpp
@@ -42,11 +42,12 @@ Optional<URL::URL> sanitize_url(StringView url, Optional<StringView> search_engi
     if (!(url_with_scheme.starts_with("about:"sv) || url_with_scheme.contains("://"sv) || url_with_scheme.starts_with("data:"sv)))
         url_with_scheme = ByteString::formatted("https://{}"sv, url_with_scheme);
 
-    auto result = URL::create_with_url_or_path(url_with_scheme);
-    if (!result.is_valid())
-        return format_search_engine();
+    // FIXME: Fix `is_valid` method in LibURL, this is simply a bandage
+    if (url_with_scheme.contains("."sv)) {
+        return URL::create_with_url_or_path(url_with_scheme);
+    }
 
-    return result;
+    return format_search_engine();;
 }
 
 Vector<URL::URL> sanitize_urls(ReadonlySpan<ByteString> raw_urls, URL::URL const& new_tab_page_url)


### PR DESCRIPTION
When you search a simple word such as "hello" on the browser, it would assume it is a URL and say "cannot find url" when in fact it was supposed to redirect me to the default search engine.

I fixed this by simply checking whether or not the domain has a period. (White spaces are handled automatically)

I also changed the function so the default fallback would be format_search_engine rather than a url. I also think someone should fix the compute_url function in the LibURL file.

But yeah that's all, and it's my first commit here!!