### PR TITLE
LibWasm: Respect instance.types() bounds

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.cpp
@@ -17,7 +17,7 @@ namespace Wasm {
 Optional<FunctionAddress> Store::allocate(ModuleInstance& instance, Module const& module, CodeSection::Code const& code, TypeIndex type_index)
 {
     FunctionAddress address { m_functions.size() };
-    if (type_index.value() > instance.types().size())
+    if (type_index.value() >= instance.types().size())
         return {};
 
     auto& type = instance.types()[type_index.value()];


### PR DESCRIPTION
This looks like the right thing to do, but PLEASE be careful merging this, as I am not sure if I'm getting things right.
This is not a security issue, as Validator doesn't allow wasm apps to pass out-of-bounds value here anyway