### PR TITLE
LibWeb: Add missing attributes in EventHandler.idl

### DIFF
--- a/Libraries/LibWeb/DOM/EventHandler.idl
+++ b/Libraries/LibWeb/DOM/EventHandler.idl
@@ -16,7 +16,9 @@ typedef OnBeforeUnloadEventHandlerNonNull? OnBeforeUnloadEventHandler;
 interface mixin GlobalEventHandlers {
     attribute EventHandler onabort;
     attribute EventHandler onauxclick;
+    attribute EventHandler onbeforeinput;
     // TODO: attribute EventHandler onbeforematch;
+    attribute EventHandler onbeforetoggle;
     attribute EventHandler onblur;
     attribute EventHandler oncancel;
     attribute EventHandler oncanplay;
@@ -27,7 +29,9 @@ interface mixin GlobalEventHandlers {
     // TODO: attribute EventHandler oncontextlost;
     attribute EventHandler oncontextmenu;
     // TODO: attribute EventHandler oncontextrestored;
+    attribute EventHandler oncopy;
     attribute EventHandler oncuechange;
+    attribute EventHandler oncut;
     attribute EventHandler ondblclick;
     attribute EventHandler ondrag;
     attribute EventHandler ondragend;
@@ -60,6 +64,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onmouseout;
     attribute EventHandler onmouseover;
     attribute EventHandler onmouseup;
+    attribute EventHandler onpaste;
     attribute EventHandler onpause;
     attribute EventHandler onplay;
     attribute EventHandler onplaying;
@@ -68,6 +73,7 @@ interface mixin GlobalEventHandlers {
     attribute EventHandler onreset;
     attribute EventHandler onresize;
     attribute EventHandler onscroll;
+    attribute EventHandler onscrollend;
     attribute EventHandler onsecuritypolicyviolation;
     attribute EventHandler onseeked;
     attribute EventHandler onseeking;
@@ -113,7 +119,9 @@ interface mixin WindowEventHandlers {
     attribute EventHandler onoffline;
     attribute EventHandler ononline;
     attribute EventHandler onpagehide;
+    attribute EventHandler onpagereveal;
     attribute EventHandler onpageshow;
+    attribute EventHandler onpageswap;
     attribute EventHandler onpopstate;
     attribute EventHandler onrejectionhandled;
     attribute EventHandler onstorage;

--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -24,17 +24,17 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(allowfullscreen)            \
     __ENUMERATE_HTML_ATTRIBUTE(alt)                        \
     __ENUMERATE_HTML_ATTRIBUTE(archive)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(async)                      \
     __ENUMERATE_HTML_ATTRIBUTE(as)                         \
+    __ENUMERATE_HTML_ATTRIBUTE(async)                      \
     __ENUMERATE_HTML_ATTRIBUTE(autocomplete)               \
     __ENUMERATE_HTML_ATTRIBUTE(autofocus)                  \
     __ENUMERATE_HTML_ATTRIBUTE(autoplay)                   \
     __ENUMERATE_HTML_ATTRIBUTE(axis)                       \
     __ENUMERATE_HTML_ATTRIBUTE(background)                 \
     __ENUMERATE_HTML_ATTRIBUTE(behavior)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(bottommargin)               \
     __ENUMERATE_HTML_ATTRIBUTE(bgcolor)                    \
     __ENUMERATE_HTML_ATTRIBUTE(border)                     \
+    __ENUMERATE_HTML_ATTRIBUTE(bottommargin)               \
     __ENUMERATE_HTML_ATTRIBUTE(cellpadding)                \
     __ENUMERATE_HTML_ATTRIBUTE(cellspacing)                \
     __ENUMERATE_HTML_ATTRIBUTE(char_)                      \
@@ -98,11 +98,11 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(imagesrcset)                \
     __ENUMERATE_HTML_ATTRIBUTE(indeterminate)              \
     __ENUMERATE_HTML_ATTRIBUTE(inert)                      \
+    __ENUMERATE_HTML_ATTRIBUTE(inputmode)                  \
     __ENUMERATE_HTML_ATTRIBUTE(integrity)                  \
     __ENUMERATE_HTML_ATTRIBUTE(is)                         \
     __ENUMERATE_HTML_ATTRIBUTE(iscontenteditable)          \
     __ENUMERATE_HTML_ATTRIBUTE(ismap)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(inputmode)                  \
     __ENUMERATE_HTML_ATTRIBUTE(itemscope)                  \
     __ENUMERATE_HTML_ATTRIBUTE(kind)                       \
     __ENUMERATE_HTML_ATTRIBUTE(label)                      \
@@ -137,7 +137,9 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onabort)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onafterprint)               \
     __ENUMERATE_HTML_ATTRIBUTE(onauxclick)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforeinput)              \
     __ENUMERATE_HTML_ATTRIBUTE(onbeforeprint)              \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforetoggle)             \
     __ENUMERATE_HTML_ATTRIBUTE(onbeforeunload)             \
     __ENUMERATE_HTML_ATTRIBUTE(onblur)                     \
     __ENUMERATE_HTML_ATTRIBUTE(oncancel)                   \
@@ -147,7 +149,9 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onclick)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onclose)                    \
     __ENUMERATE_HTML_ATTRIBUTE(oncontextmenu)              \
+    __ENUMERATE_HTML_ATTRIBUTE(oncopy)                     \
     __ENUMERATE_HTML_ATTRIBUTE(oncuechange)                \
+    __ENUMERATE_HTML_ATTRIBUTE(oncut)                      \
     __ENUMERATE_HTML_ATTRIBUTE(ondblclick)                 \
     __ENUMERATE_HTML_ATTRIBUTE(ondrag)                     \
     __ENUMERATE_HTML_ATTRIBUTE(ondragend)                  \
@@ -189,7 +193,10 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onoffline)                  \
     __ENUMERATE_HTML_ATTRIBUTE(ononline)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onpagehide)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpagereveal)               \
     __ENUMERATE_HTML_ATTRIBUTE(onpageshow)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpageswap)                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpaste)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onpause)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onplay)                     \
     __ENUMERATE_HTML_ATTRIBUTE(onplaying)                  \
@@ -209,6 +216,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(onreset)                    \
     __ENUMERATE_HTML_ATTRIBUTE(onresize)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onscroll)                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onscrollend)                \
     __ENUMERATE_HTML_ATTRIBUTE(onsecuritypolicyviolation)  \
     __ENUMERATE_HTML_ATTRIBUTE(onseeked)                   \
     __ENUMERATE_HTML_ATTRIBUTE(onseeking)                  \

--- a/Libraries/LibWeb/HTML/EventNames.h
+++ b/Libraries/LibWeb/HTML/EventNames.h
@@ -17,11 +17,11 @@ namespace Web::HTML::EventNames {
 #define ENUMERATE_HTML_EVENTS                        \
     __ENUMERATE_HTML_EVENT(abort)                    \
     __ENUMERATE_HTML_EVENT(addtrack)                 \
+    __ENUMERATE_HTML_EVENT(afterprint)               \
     __ENUMERATE_HTML_EVENT(animationcancel)          \
     __ENUMERATE_HTML_EVENT(animationend)             \
     __ENUMERATE_HTML_EVENT(animationiteration)       \
     __ENUMERATE_HTML_EVENT(animationstart)           \
-    __ENUMERATE_HTML_EVENT(afterprint)               \
     __ENUMERATE_HTML_EVENT(beforeprint)              \
     __ENUMERATE_HTML_EVENT(beforetoggle)             \
     __ENUMERATE_HTML_EVENT(beforeunload)             \
@@ -35,13 +35,13 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(close)                    \
     __ENUMERATE_HTML_EVENT(complete)                 \
     __ENUMERATE_HTML_EVENT(connect)                  \
-    __ENUMERATE_HTML_EVENT(controllerchange)         \
     __ENUMERATE_HTML_EVENT(contextmenu)              \
+    __ENUMERATE_HTML_EVENT(controllerchange)         \
     __ENUMERATE_HTML_EVENT(copy)                     \
     __ENUMERATE_HTML_EVENT(cuechange)                \
     __ENUMERATE_HTML_EVENT(currententrychange)       \
-    __ENUMERATE_HTML_EVENT(dispose)                  \
     __ENUMERATE_HTML_EVENT(cut)                      \
+    __ENUMERATE_HTML_EVENT(dispose)                  \
     __ENUMERATE_HTML_EVENT(DOMContentLoaded)         \
     __ENUMERATE_HTML_EVENT(drag)                     \
     __ENUMERATE_HTML_EVENT(dragend)                  \
@@ -67,9 +67,9 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(languagechange)           \
     __ENUMERATE_HTML_EVENT(load)                     \
     __ENUMERATE_HTML_EVENT(loaded)                   \
-    __ENUMERATE_HTML_EVENT(loadend)                  \
     __ENUMERATE_HTML_EVENT(loadeddata)               \
     __ENUMERATE_HTML_EVENT(loadedmetadata)           \
+    __ENUMERATE_HTML_EVENT(loadend)                  \
     __ENUMERATE_HTML_EVENT(loading)                  \
     __ENUMERATE_HTML_EVENT(loadingdone)              \
     __ENUMERATE_HTML_EVENT(loadingerror)             \
@@ -77,10 +77,18 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(message)                  \
     __ENUMERATE_HTML_EVENT(messageerror)             \
     __ENUMERATE_HTML_EVENT(navigate)                 \
-    __ENUMERATE_HTML_EVENT(navigatesuccess)          \
     __ENUMERATE_HTML_EVENT(navigateerror)            \
+    __ENUMERATE_HTML_EVENT(navigatesuccess)          \
     __ENUMERATE_HTML_EVENT(offline)                  \
+    __ENUMERATE_HTML_EVENT(onbeforeinput)            \
+    __ENUMERATE_HTML_EVENT(onbeforetoggle)           \
+    __ENUMERATE_HTML_EVENT(oncopy)                   \
+    __ENUMERATE_HTML_EVENT(oncut)                    \
     __ENUMERATE_HTML_EVENT(online)                   \
+    __ENUMERATE_HTML_EVENT(onpagereveal)             \
+    __ENUMERATE_HTML_EVENT(onpageswap)               \
+    __ENUMERATE_HTML_EVENT(onpaste)                  \
+    __ENUMERATE_HTML_EVENT(onscrollend)              \
     __ENUMERATE_HTML_EVENT(open)                     \
     __ENUMERATE_HTML_EVENT(pagehide)                 \
     __ENUMERATE_HTML_EVENT(pageshow)                 \
@@ -100,10 +108,10 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(scroll)                   \
     __ENUMERATE_HTML_EVENT(scrollend)                \
     __ENUMERATE_HTML_EVENT(securitypolicyviolation)  \
-    __ENUMERATE_HTML_EVENT(selectionchange)          \
     __ENUMERATE_HTML_EVENT(seeked)                   \
     __ENUMERATE_HTML_EVENT(seeking)                  \
     __ENUMERATE_HTML_EVENT(select)                   \
+    __ENUMERATE_HTML_EVENT(selectionchange)          \
     __ENUMERATE_HTML_EVENT(slotchange)               \
     __ENUMERATE_HTML_EVENT(stalled)                  \
     __ENUMERATE_HTML_EVENT(statechange)              \

--- a/Libraries/LibWeb/HTML/GlobalEventHandlers.h
+++ b/Libraries/LibWeb/HTML/GlobalEventHandlers.h
@@ -12,6 +12,8 @@
 #define ENUMERATE_GLOBAL_EVENT_HANDLERS(E)                                    \
     E(onabort, HTML::EventNames::abort)                                       \
     E(onauxclick, UIEvents::EventNames::auxclick)                             \
+    E(onbeforeinput, HTML::EventNames::onbeforeinput)                         \
+    E(onbeforetoggle, HTML::EventNames::onbeforetoggle)                       \
     E(onblur, HTML::EventNames::blur)                                         \
     E(oncancel, HTML::EventNames::cancel)                                     \
     E(oncanplay, HTML::EventNames::canplay)                                   \
@@ -20,7 +22,9 @@
     E(onclick, UIEvents::EventNames::click)                                   \
     E(onclose, HTML::EventNames::close)                                       \
     E(oncontextmenu, HTML::EventNames::contextmenu)                           \
+    E(oncopy, HTML::EventNames::oncopy)                                       \
     E(oncuechange, HTML::EventNames::cuechange)                               \
+    E(oncut, HTML::EventNames::cut)                                           \
     E(ondblclick, UIEvents::EventNames::dblclick)                             \
     E(ondrag, HTML::EventNames::drag)                                         \
     E(ondragend, HTML::EventNames::dragend)                                   \
@@ -55,6 +59,7 @@
     E(onmouseout, UIEvents::EventNames::mouseout)                             \
     E(onmouseover, UIEvents::EventNames::mouseover)                           \
     E(onmouseup, UIEvents::EventNames::mouseup)                               \
+    E(onpaste, HTML::EventNames::paste)                                       \
     E(onpause, HTML::EventNames::pause)                                       \
     E(onplay, HTML::EventNames::play)                                         \
     E(onplaying, HTML::EventNames::playing)                                   \
@@ -72,6 +77,7 @@
     E(onreset, HTML::EventNames::reset)                                       \
     E(onresize, HTML::EventNames::resize)                                     \
     E(onscroll, HTML::EventNames::scroll)                                     \
+    E(onscrollend, HTML::EventNames::onscrollend)                             \
     E(onsecuritypolicyviolation, HTML::EventNames::securitypolicyviolation)   \
     E(onseeked, HTML::EventNames::seeked)                                     \
     E(onseeking, HTML::EventNames::seeking)                                   \

--- a/Libraries/LibWeb/HTML/WindowEventHandlers.h
+++ b/Libraries/LibWeb/HTML/WindowEventHandlers.h
@@ -20,7 +20,9 @@
     E(onoffline, HTML::EventNames::offline)                       \
     E(ononline, HTML::EventNames::online)                         \
     E(onpagehide, HTML::EventNames::pagehide)                     \
+    E(onpagereveal, HTML::EventNames::onpagereveal)               \
     E(onpageshow, HTML::EventNames::pageshow)                     \
+    E(onpageswap, HTML::EventNames::onpageswap)                   \
     E(onpopstate, HTML::EventNames::popstate)                     \
     E(onrejectionhandled, HTML::EventNames::rejectionhandled)     \
     E(onstorage, HTML::EventNames::storage)                       \


### PR DESCRIPTION
Add missing EventHandler attributes from the spec. 