### PR TITLE
LibWeb/ARIA: Add missing `menuitemradio` widget role

### DIFF
--- a/Libraries/LibWeb/ARIA/Roles.cpp
+++ b/Libraries/LibWeb/ARIA/Roles.cpp
@@ -69,6 +69,7 @@ bool is_widget_role(Role role)
         Role::link,
         Role::menuitem,
         Role::menuitemcheckbox,
+        Role::menuitemradio,
         Role::option,
         Role::progressbar,
         Role::radio,


### PR DESCRIPTION
# Why

* https://wpt.fyi/results/wai-aria/role/menu-roles.html?product=ladybird&product=chrome&q=aria
* https://www.w3.org/TR/wai-aria-1.2/#widget_roles

<img src="https://github.com/user-attachments/assets/09984658-7d63-4131-b0df-61ceea202586" width="400" />

# How

Add missing `menuitemradio` widget role to the list.

Make sure that correct accessibility role is set but running test DOM locally and verifying with build-in inspector.

<img src="https://github.com/user-attachments/assets/ce62c3d9-7a82-4e05-963a-021b9efafc83" width="400" />

