### PR TITLE
LibWeb: Implement the "delete the selection" editing algorithm

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -411,7 +411,7 @@ static bool matches_read_write_pseudo_class(DOM::Element const& element)
         return true;
     }
     // - elements that are editing hosts or editable and are neither input elements nor textarea elements
-    return element.is_editable();
+    return element.is_editable_or_editing_host();
 }
 
 // https://www.w3.org/TR/selectors-4/#open-state

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -335,7 +335,6 @@ public:
     String const& compat_mode() const;
 
     void set_editable(bool editable) { m_editable = editable; }
-    virtual bool is_editable() const final;
 
     Element* focused_element() { return m_focused_element.ptr(); }
     Element const* focused_element() const { return m_focused_element.ptr(); }

--- a/Libraries/LibWeb/DOM/EditingHostManager.cpp
+++ b/Libraries/LibWeb/DOM/EditingHostManager.cpp
@@ -36,14 +36,12 @@ void EditingHostManager::handle_insert(String const& data)
     auto selection = m_document->get_selection();
 
     auto selection_range = selection->range();
-    if (!selection_range) {
+    if (!selection_range)
         return;
-    }
 
     auto node = selection->anchor_node();
-    if (!node || !node->is_editable()) {
+    if (!node || !node->is_editable_or_editing_host())
         return;
-    }
 
     if (!is<DOM::Text>(*node)) {
         auto& realm = node->realm();

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,7 +12,6 @@
 #include <LibGC/DeferGC.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibRegex/Regex.h>
-#include <LibURL/Origin.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Bindings/NodePrototype.h>
 #include <LibWeb/DOM/Attr.h>
@@ -44,16 +44,18 @@
 #include <LibWeb/HTML/HTMLSlotElement.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
 #include <LibWeb/HTML/HTMLTableElement.h>
+#include <LibWeb/HTML/HTMLTextAreaElement.h>
 #include <LibWeb/HTML/Navigable.h>
 #include <LibWeb/HTML/NavigableContainer.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Layout/TextNode.h>
-#include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/MathML/MathMLElement.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/Painting/PaintableBox.h>
+#include <LibWeb/SVG/SVGElement.h>
 #include <LibWeb/SVG/SVGTitleElement.h>
 #include <LibWeb/XLink/AttributeNames.h>
 
@@ -1160,9 +1162,48 @@ void Node::set_document(Badge<Document>, Document& document)
     }
 }
 
+// https://w3c.github.io/editing/docs/execCommand/#editable
 bool Node::is_editable() const
 {
-    return parent() && parent()->is_editable();
+    // Something is editable if it is a node; it is not an editing host;
+    if (is_editing_host())
+        return false;
+
+    // it does not have a contenteditable attribute set to the false state;
+    if (is<HTML::HTMLElement>(this) && static_cast<HTML::HTMLElement const&>(*this).content_editable_state() == HTML::ContentEditableState::False)
+        return false;
+
+    // its parent is an editing host or editable;
+    if (!parent() || !parent()->is_editable_or_editing_host())
+        return false;
+
+    // and either it is an HTML element,
+    if (is<HTML::HTMLElement>(this))
+        return true;
+
+    // or it is an svg or math element,
+    if (is<SVG::SVGElement>(this) || is<MathML::MathMLElement>(this))
+        return true;
+
+    // or it is not an Element and its parent is an HTML element.
+    return !is<Element>(this) && is<HTML::HTMLElement>(parent());
+}
+
+// https://html.spec.whatwg.org/multipage/interaction.html#editing-host
+bool Node::is_editing_host() const
+{
+    // NOTE: Both conditions below require this to be an HTML element.
+    if (!is<HTML::HTMLElement>(this))
+        return false;
+
+    // An editing host is either an HTML element with its contenteditable attribute in the true state or
+    // plaintext-only state,
+    auto state = static_cast<HTML::HTMLElement const&>(*this).content_editable_state();
+    if (state == HTML::ContentEditableState::True || state == HTML::ContentEditableState::PlaintextOnly)
+        return true;
+
+    // or a child HTML element of a Document whose design mode enabled is true.
+    return is<Document>(parent()) && static_cast<Document const&>(*parent()).design_mode_enabled_state();
 }
 
 void Node::set_layout_node(Badge<Layout::Node>, GC::Ref<Layout::Node> layout_node)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -137,7 +137,9 @@ public:
     // NOTE: This is intended for the JS bindings.
     u16 node_type() const { return (u16)m_type; }
 
-    virtual bool is_editable() const;
+    bool is_editable() const;
+    bool is_editing_host() const;
+    bool is_editable_or_editing_host() const { return is_editable() || is_editing_host(); }
 
     virtual bool is_dom_node() const final { return true; }
     virtual bool is_html_element() const { return false; }

--- a/Libraries/LibWeb/DOM/Text.h
+++ b/Libraries/LibWeb/DOM/Text.h
@@ -26,9 +26,6 @@ public:
 
     // ^Node
     virtual FlyString node_name() const override { return "#text"_fly_string; }
-    virtual bool is_editable() const override { return m_always_editable || CharacterData::is_editable(); }
-
-    void set_always_editable(bool b) { m_always_editable = b; }
 
     Optional<size_t> max_length() const { return m_max_length; }
     void set_max_length(Optional<size_t> max_length) { m_max_length = move(max_length); }
@@ -51,7 +48,6 @@ protected:
 private:
     GC::Ptr<Element> m_owner;
 
-    bool m_always_editable { false };
     Optional<size_t> m_max_length {};
     bool m_is_password_input { false };
 };

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -599,8 +599,7 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
         || ((new_line_range->start_container() == new_line_range->end_container() && new_line_range->start_offset() == new_line_range->end_offset() - 1)
             && is<HTML::HTMLBRElement>(*new_line_range->start_container()));
 
-    VERIFY(is<DOM::Element>(*container));
-    auto& container_element = static_cast<DOM::Element&>(*container);
+    auto& container_element = verify_cast<DOM::Element>(*container);
     auto new_container_name = [&] -> FlyString {
         // 18. If the local name of container is "h1", "h2", "h3", "h4", "h5", or "h6", and end of line is true, let new
         //     container name be the default single-line container name.

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -367,8 +367,8 @@ bool command_delete_action(DOM::Document& document, String const&)
     // 18. Call extend(node, offset) on the context object's selection.
     MUST(selection.extend(*node, offset));
 
-    // FIXME: 19. Delete the selection, with direction "backward".
-    delete_the_selection(selection);
+    // 19. Delete the selection, with direction "backward".
+    delete_the_selection(selection, true, true, Selection::Direction::Backwards);
 
     // 20. Return true.
     return true;
@@ -669,28 +669,12 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
 
     // 32. If container has no visible children, call createElement("br") on the context object, and append the result
     //     as the last child of container.
-    bool has_visible_child = false;
-    container->for_each_child([&has_visible_child](GC::Ref<DOM::Node> child) {
-        if (is_visible_node(child)) {
-            has_visible_child = true;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    });
-    if (!has_visible_child)
+    if (!has_visible_children(*container))
         MUST(container->append_child(MUST(DOM::create_element(document, HTML::TagNames::br, Namespace::HTML))));
 
     // 33. If new container has no visible children, call createElement("br") on the context object, and append the
     //     result as the last child of new container.
-    has_visible_child = false;
-    new_container->for_each_child([&has_visible_child](GC::Ref<DOM::Node> child) {
-        if (is_visible_node(child)) {
-            has_visible_child = true;
-            return IterationDecision::Break;
-        }
-        return IterationDecision::Continue;
-    });
-    if (!has_visible_child)
+    if (!has_visible_children(*new_container))
         MUST(new_container->append_child(MUST(DOM::create_element(document, HTML::TagNames::br, Namespace::HTML))));
 
     // 34. Call collapse(new container, 0) on the context object's selection.

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -639,8 +639,9 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
     Vector<GC::Ref<DOM::Node>> contained_nodes;
     auto common_ancestor = new_line_range->common_ancestor_container();
     common_ancestor->for_each_in_subtree([&](GC::Ref<DOM::Node> child_node) {
-        if (new_line_range->contains_node(child_node))
-            contained_nodes.append(child_node);
+        if (!new_line_range->contains_node(child_node))
+            return TraversalDecision::SkipChildrenAndContinue;
+        contained_nodes.append(child_node);
         return TraversalDecision::Continue;
     });
 

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -384,7 +384,7 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
     // 2. If the active range's start node is neither editable nor an editing host, return true.
     auto& active_range = *selection.range();
     GC::Ptr<DOM::Node> node = active_range.start_container();
-    if (!node->is_editable() && !is_editing_host(*node))
+    if (!node->is_editable_or_editing_host())
         return true;
 
     // 3. Let node and offset be the active range's start node and offset.

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -118,7 +118,7 @@ bool Document::query_command_enabled(FlyString const& command)
 
     // its start node is either editable or an editing host,
     auto start_node = active_range->start_container();
-    if (!start_node->is_editable() && !Editing::is_editing_host(start_node))
+    if (!start_node->is_editable_or_editing_host())
         return false;
 
     // FIXME: the editing host of its start node is not an EditContext editing host,
@@ -126,7 +126,7 @@ bool Document::query_command_enabled(FlyString const& command)
 
     // its end node is either editable or an editing host,
     auto& end_node = *active_range->end_container();
-    if (!end_node.is_editable() && !Editing::is_editing_host(end_node))
+    if (!end_node.is_editable_or_editing_host())
         return false;
 
     // FIXME: the editing host of its end node is not an EditContext editing host,

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -873,20 +873,20 @@ bool is_collapsed_whitespace_node(GC::Ref<DOM::Node> node)
         ancestor = ancestor->parent();
 
     // 7. Let reference be node.
-    auto reference = node;
+    GC::Ptr<DOM::Node> reference = node;
 
     // 8. While reference is a descendant of ancestor:
     while (reference->is_descendant_of(*ancestor)) {
         // 1. Let reference be the node before it in tree order.
-        reference = *reference->previous_in_pre_order();
+        reference = reference->previous_in_pre_order();
 
         // 2. If reference is a block node or a br, return true.
-        if (is_block_node(reference) || is<HTML::HTMLBRElement>(*reference))
+        if (is_block_node(*reference) || is<HTML::HTMLBRElement>(*reference))
             return true;
 
         // 3. If reference is a Text node that is not a whitespace node, or is an img, break from
         //    this loop.
-        if ((is<DOM::Text>(*reference) && !is_whitespace_node(reference)) || is<HTML::HTMLImageElement>(*reference))
+        if ((is<DOM::Text>(*reference) && !is_whitespace_node(*reference)) || is<HTML::HTMLImageElement>(*reference))
             break;
     }
 
@@ -896,15 +896,19 @@ bool is_collapsed_whitespace_node(GC::Ref<DOM::Node> node)
     // 10. While reference is a descendant of ancestor:
     while (reference->is_descendant_of(*ancestor)) {
         // 1. Let reference be the node after it in tree order, or null if there is no such node.
-        reference = *reference->next_in_pre_order();
+        reference = reference->next_in_pre_order();
+
+        // NOTE: Both steps below and the loop condition require a reference, so break if it's null.
+        if (!reference)
+            break;
 
         // 2. If reference is a block node or a br, return true.
-        if (is_block_node(reference) || is<HTML::HTMLBRElement>(*reference))
+        if (is_block_node(*reference) || is<HTML::HTMLBRElement>(*reference))
             return true;
 
         // 3. If reference is a Text node that is not a whitespace node, or is an img, break from
         //    this loop.
-        if ((is<DOM::Text>(*reference) && !is_whitespace_node(reference)) || is<HTML::HTMLImageElement>(*reference))
+        if ((is<DOM::Text>(*reference) && !is_whitespace_node(*reference)) || is<HTML::HTMLImageElement>(*reference))
             break;
     }
 

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -201,7 +201,7 @@ String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_br
 void canonicalize_whitespace(GC::Ref<DOM::Node> node, u32 offset, bool fix_collapsed_space)
 {
     // 1. If node is neither editable nor an editing host, abort these steps.
-    if (!node->is_editable() || !is_editing_host(node))
+    if (!node->is_editable_or_editing_host())
         return;
 
     // 2. Let start node equal node and let start offset equal offset.
@@ -914,20 +914,6 @@ bool is_collapsed_whitespace_node(GC::Ref<DOM::Node> node)
 
     // 11. Return false.
     return false;
-}
-
-// https://html.spec.whatwg.org/multipage/interaction.html#editing-host
-bool is_editing_host(GC::Ref<DOM::Node> node)
-{
-    // An editing host is either an HTML element with its contenteditable attribute in the true
-    // state or plaintext-only state, or a child HTML element of a Document whose design mode
-    // enabled is true.
-    if (!is<HTML::HTMLElement>(*node))
-        return false;
-    auto const& html_element = static_cast<HTML::HTMLElement&>(*node);
-    return html_element.content_editable_state() == HTML::ContentEditableState::True
-        || html_element.content_editable_state() == HTML::ContentEditableState::PlaintextOnly
-        || node->document().design_mode_enabled_state();
 }
 
 // https://w3c.github.io/editing/docs/execCommand/#element-with-inline-contents

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -34,7 +34,6 @@ bool is_block_end_point(GC::Ref<DOM::Node>, u32 offset);
 bool is_block_node(GC::Ref<DOM::Node>);
 bool is_block_start_point(GC::Ref<DOM::Node>, u32 offset);
 bool is_collapsed_whitespace_node(GC::Ref<DOM::Node>);
-bool is_editing_host(GC::Ref<DOM::Node>);
 bool is_element_with_inline_contents(GC::Ref<DOM::Node>);
 bool is_extraneous_line_break(GC::Ref<DOM::Node>);
 bool is_in_same_editing_host(GC::Ref<DOM::Node>, GC::Ref<DOM::Node>);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -8,6 +8,7 @@
 
 #include <AK/Vector.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/Selection/Selection.h>
 
 namespace Web::Editing {
 
@@ -18,14 +19,32 @@ struct RecordedNodeValue {
     Optional<String> specified_command_value;
 };
 
+// https://w3c.github.io/editing/docs/execCommand/#record-current-states-and-values
+struct RecordedOverride {
+    FlyString const& command;
+    Variant<String, bool> value;
+};
+
+using Selection::Selection;
+
+// https://dom.spec.whatwg.org/#concept-range-bp
+// FIXME: This should be defined by DOM::Range
+struct BoundaryPoint {
+    GC::Ref<DOM::Node> node;
+    WebIDL::UnsignedLong offset;
+};
+
 // Below algorithms are specified here:
 // https://w3c.github.io/editing/docs/execCommand/#assorted-common-algorithms
 
 GC::Ref<DOM::Range> block_extend_a_range(DOM::Range&);
+GC::Ptr<DOM::Node> block_node_of_node(GC::Ref<DOM::Node>);
 String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_breaking_end);
 void canonicalize_whitespace(GC::Ref<DOM::Node>, u32 offset, bool fix_collapsed_space = true);
-void delete_the_selection(Selection::Selection const&);
+void delete_the_selection(Selection&, bool block_merging = true, bool strip_wrappers = true,
+    Selection::Direction direction = Selection::Direction::Forwards);
 GC::Ptr<DOM::Node> editing_host_of_node(GC::Ref<DOM::Node>);
+BoundaryPoint first_equivalent_point(BoundaryPoint);
 void fix_disallowed_ancestors_of_node(GC::Ref<DOM::Node>);
 bool follows_a_line_break(GC::Ref<DOM::Node>);
 bool is_allowed_child_of_node(Variant<GC::Ref<DOM::Node>, FlyString> child, Variant<GC::Ref<DOM::Node>, FlyString> parent);
@@ -33,6 +52,8 @@ bool is_block_boundary_point(GC::Ref<DOM::Node>, u32 offset);
 bool is_block_end_point(GC::Ref<DOM::Node>, u32 offset);
 bool is_block_node(GC::Ref<DOM::Node>);
 bool is_block_start_point(GC::Ref<DOM::Node>, u32 offset);
+bool is_collapsed_block_prop(GC::Ref<DOM::Node>);
+bool is_collapsed_line_break(GC::Ref<DOM::Node>);
 bool is_collapsed_whitespace_node(GC::Ref<DOM::Node>);
 bool is_element_with_inline_contents(GC::Ref<DOM::Node>);
 bool is_extraneous_line_break(GC::Ref<DOM::Node>);
@@ -46,14 +67,19 @@ bool is_prohibited_paragraph_child_name(FlyString const&);
 bool is_single_line_container(GC::Ref<DOM::Node>);
 bool is_visible_node(GC::Ref<DOM::Node>);
 bool is_whitespace_node(GC::Ref<DOM::Node>);
+BoundaryPoint last_equivalent_point(BoundaryPoint);
 void move_node_preserving_ranges(GC::Ref<DOM::Node>, GC::Ref<DOM::Node> new_parent, u32 new_index);
+Optional<BoundaryPoint> next_equivalent_point(BoundaryPoint);
 void normalize_sublists_in_node(GC::Ref<DOM::Element>);
 bool precedes_a_line_break(GC::Ref<DOM::Node>);
+Optional<BoundaryPoint> previous_equivalent_point(BoundaryPoint);
+Vector<RecordedOverride> record_current_states_and_values(GC::Ref<DOM::Range>);
 Vector<RecordedNodeValue> record_the_values_of_nodes(Vector<GC::Ref<DOM::Node>> const&);
 void remove_extraneous_line_breaks_at_the_end_of_node(GC::Ref<DOM::Node>);
 void remove_extraneous_line_breaks_before_node(GC::Ref<DOM::Node>);
 void remove_extraneous_line_breaks_from_a_node(GC::Ref<DOM::Node>);
 void remove_node_preserving_its_descendants(GC::Ref<DOM::Node>);
+void restore_states_and_values(GC::Ref<DOM::Range>, Vector<RecordedOverride> const&);
 void restore_the_values_of_nodes(Vector<RecordedNodeValue> const&);
 GC::Ref<DOM::Element> set_the_tag_name(GC::Ref<DOM::Element>, FlyString const&);
 Optional<String> specified_command_value(GC::Ref<DOM::Element>, FlyString const& command);
@@ -62,6 +88,7 @@ GC::Ptr<DOM::Node> wrap(Vector<GC::Ref<DOM::Node>>, Function<bool(GC::Ref<DOM::N
 
 // Utility methods:
 
+bool has_visible_children(GC::Ref<DOM::Node>);
 bool is_heading(FlyString const&);
 
 }

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -588,7 +588,7 @@ void FormAssociatedTextControlElement::set_the_selection_range(Optional<WebIDL::
 void FormAssociatedTextControlElement::handle_insert(String const& data)
 {
     auto text_node = form_associated_element_to_text_node();
-    if (!text_node || !text_node->is_editable())
+    if (!text_node || !is_mutable())
         return;
 
     String data_for_insertion = data;
@@ -613,7 +613,7 @@ void FormAssociatedTextControlElement::handle_insert(String const& data)
 void FormAssociatedTextControlElement::handle_delete(DeleteDirection direction)
 {
     auto text_node = form_associated_element_to_text_node();
-    if (!text_node || !text_node->is_editable())
+    if (!text_node || !is_mutable())
         return;
     auto selection_start = this->selection_start();
     auto selection_end = this->selection_end();

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -170,6 +170,9 @@ public:
     bool has_scheduled_selectionchange_event() const { return m_has_scheduled_selectionchange_event; }
     void set_scheduled_selectionchange_event(bool value) { m_has_scheduled_selectionchange_event = value; }
 
+    bool is_mutable() const { return m_is_mutable; }
+    void set_is_mutable(bool is_mutable) { m_is_mutable = is_mutable; }
+
     virtual void did_edit_text_node() = 0;
 
     virtual GC::Ptr<DOM::Text> form_associated_element_to_text_node() = 0;
@@ -205,6 +208,9 @@ private:
 
     // https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event
     bool m_has_scheduled_selectionchange_event { false };
+
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#mutability
+    bool m_is_mutable { true };
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -73,7 +73,6 @@ public:
     StringView dir() const;
     void set_dir(String const&);
 
-    virtual bool is_editable() const final;
     virtual bool is_focusable() const override;
     bool is_content_editable() const;
     StringView content_editable() const;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -100,8 +100,6 @@ public:
     bool indeterminate() const { return m_indeterminate; }
     void set_indeterminate(bool);
 
-    bool is_mutable() const { return m_is_mutable; }
-
     void did_pick_color(Optional<Color> picked_color, ColorPickerUpdateState state);
 
     enum class MultipleHandling {
@@ -338,9 +336,6 @@ private:
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-dirty
     bool m_dirty_value { false };
-
-    // https://html.spec.whatwg.org/multipage/input.html#the-input-element:concept-fe-mutable
-    bool m_is_mutable { true };
 
     // https://html.spec.whatwg.org/multipage/input.html#the-input-element:legacy-pre-activation-behavior
     bool m_before_legacy_pre_activation_behavior_checked { false };

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -394,10 +394,7 @@ void HTMLTextAreaElement::create_shadow_tree_if_needed()
 void HTMLTextAreaElement::handle_readonly_attribute(Optional<String> const& maybe_value)
 {
     // The readonly attribute is a boolean attribute that controls whether or not the user can edit the form control. When specified, the element is not mutable.
-    m_is_mutable = !maybe_value.has_value();
-
-    if (m_text_node)
-        m_text_node->set_always_editable(m_is_mutable);
+    set_is_mutable(!maybe_value.has_value());
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#dom-textarea-maxlength

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -157,9 +157,6 @@ private:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-dirty
     bool m_dirty_value { false };
 
-    // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:concept-fe-mutable
-    bool m_is_mutable { true };
-
     // https://html.spec.whatwg.org/multipage/form-elements.html#concept-textarea-raw-value
     String m_raw_value;
 

--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -124,6 +124,18 @@ void Internals::click(double x, double y, UIEvents::MouseButton button)
     page.handle_mouseup(position, position, button, 0, 0);
 }
 
+void Internals::mouse_down(double x, double y)
+{
+    mouse_down(x, y, UIEvents::MouseButton::Primary);
+}
+
+void Internals::mouse_down(double x, double y, UIEvents::MouseButton button)
+{
+    auto& page = internals_page();
+    auto position = page.css_to_device_point({ x, y });
+    page.handle_mousedown(position, position, button, 0, 0);
+}
+
 void Internals::move_pointer_to(double x, double y)
 {
     auto& page = internals_page();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -32,6 +32,7 @@ public:
     void click(double x, double y);
     void doubleclick(double x, double y);
     void middle_click(double x, double y);
+    void mouse_down(double x, double y);
     void move_pointer_to(double x, double y);
     void wheel(double x, double y, double delta_x, double delta_y);
 
@@ -59,6 +60,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     void click(double x, double y, UIEvents::MouseButton);
+    void mouse_down(double x, double y, UIEvents::MouseButton);
 
     HTML::Window& internals_window() const;
     Page& internals_page() const;

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -23,6 +23,7 @@ interface Internals {
     undefined click(double x, double y);
     undefined doubleclick(double x, double y);
     undefined middleClick(double x, double y);
+    undefined mouseDown(double x, double y);
     undefined movePointerTo(double x, double y);
     undefined wheel(double x, double y, double deltaX, double deltaY);
 

--- a/Libraries/LibWeb/Page/DragAndDropEventHandler.cpp
+++ b/Libraries/LibWeb/Page/DragAndDropEventHandler.cpp
@@ -611,7 +611,7 @@ bool DragAndDropEventHandler::allow_text_drop(GC::Ref<DOM::Node> node) const
     if (!m_drag_data_store->has_text_item())
         return false;
 
-    if (node->is_editable())
+    if (node->is_editable_or_editing_host())
         return true;
 
     if (is<HTML::HTMLTextAreaElement>(*node))

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -596,9 +596,8 @@ EventResult EventHandler::handle_mousemove(CSSPixelPoint viewport_position, CSSP
         if (m_in_mouse_selection) {
             auto hit = paint_root()->hit_test(viewport_position, Painting::HitTestType::TextCursor);
             if (m_mouse_selection_target) {
-                if (hit.has_value()) {
+                if (hit.has_value() && hit->paintable->dom_node())
                     m_mouse_selection_target->set_selection_focus(*hit->paintable->dom_node(), hit->index_in_node);
-                }
             } else {
                 if (start_index.has_value() && hit.has_value() && hit->dom_node()) {
                     if (auto selection = document.get_selection()) {

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -564,7 +564,12 @@ void paint_cursor_if_needed(PaintContext& context, TextPaintable const& paintabl
     if (cursor_position->offset() < (unsigned)fragment.start() || cursor_position->offset() > (unsigned)(fragment.start() + fragment.length()))
         return;
 
-    if (!fragment.layout_node().dom_node() || !fragment.layout_node().dom_node()->is_editable())
+    auto active_element = document.active_element();
+    auto active_element_is_editable = is<HTML::FormAssociatedTextControlElement>(active_element)
+        && dynamic_cast<HTML::FormAssociatedTextControlElement const&>(*active_element).is_mutable();
+
+    auto dom_node = fragment.layout_node().dom_node();
+    if (!dom_node || (!dom_node->is_editable() && !active_element_is_editable))
         return;
 
     auto fragment_rect = fragment.absolute_rect();

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -288,11 +288,7 @@ bool is_element_editable(Web::DOM::Element const& element)
 bool is_element_mutable(Web::DOM::Element const& element)
 {
     // Denotes elements that are editing hosts or content editable.
-    if (!is<HTML::HTMLElement>(element))
-        return false;
-
-    auto const& html_element = static_cast<HTML::HTMLElement const&>(element);
-    return html_element.is_editable();
+    return element.is_editable_or_editing_host();
 }
 
 // https://w3c.github.io/webdriver/#dfn-mutable-form-control-element

--- a/Tests/LibWeb/Text/expected/Editing/selection-in-contenteditable-crash-regression.txt
+++ b/Tests/LibWeb/Text/expected/Editing/selection-in-contenteditable-crash-regression.txt
@@ -1,0 +1,1 @@
+PASS (did not crash)

--- a/Tests/LibWeb/Text/input/Editing/selection-in-contenteditable-crash-regression.html
+++ b/Tests/LibWeb/Text/input/Editing/selection-in-contenteditable-crash-regression.html
@@ -1,0 +1,19 @@
+<script src="../include.js"></script>
+<style>
+    div {
+        font-size: 10px;
+    }
+</style>
+<div contenteditable="true">a<br><br><div id="b">b</div></div>
+<script>
+    test(() => {
+        var bDiv = document.querySelector('div#b');
+        var bBounds = bDiv.getBoundingClientRect();
+
+        // Drag a selection from inside the #b div to just above it.
+        internals.mouseDown(bBounds.x + 2, bBounds.y + 5);
+        internals.movePointerTo(bBounds.x + 2, bBounds.y - 5);
+
+        println('PASS (did not crash)');
+    });
+</script>


### PR DESCRIPTION
We were winging the invocations of "delete the selection" by calling into `DOM::Range::delete_contents()`, but that only got us so far. These changes give us a net +44 WPT subtest passes in `editing`.

* `Node::is_editable()` is completely redefined and made spec-compliant. I've found no regressions.
* A new `Internals` method called `mouseDown` is introduced in order to be able to simulate moving the mouse while keeping a button pressed.
* The "delete the selection" algorithm is almost completely implemented, except for recording and restoring current states & overrides.