### PR TITLE
LibWeb: Add support for the “suggestion” ARIA role

### DIFF
--- a/Libraries/LibWeb/ARIA/AriaRoles.json
+++ b/Libraries/LibWeb/ARIA/AriaRoles.json
@@ -2046,6 +2046,48 @@
     "childrenArePresentational": false,
     "implicitValueForRole": {}
   },
+  "Suggestion": {
+    "specLink": "https://w3c.github.io/aria/#suggestion",
+    "description": "A single proposed change to content.",
+    "superClassRoles": [
+      "Section"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-errormessage",
+      "aria-grabbed",
+      "aria-haspopup",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-brailleroledescription",
+      "aria-controls",
+      "aria-describedby",
+      "aria-description",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Prohibited",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
   "Superscript": {
     "specLink": "https://www.w3.org/TR/wai-aria-1.2/#superscript",
     "description": "One or more superscripted characters. See related superscript.",

--- a/Libraries/LibWeb/ARIA/RoleType.cpp
+++ b/Libraries/LibWeb/ARIA/RoleType.cpp
@@ -293,6 +293,8 @@ ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool foc
         return adopt_nonnull_own_or_enomem(new (nothrow) Strong(data));
     case Role::subscript:
         return adopt_nonnull_own_or_enomem(new (nothrow) Subscript(data));
+    case Role::suggestion:
+        return adopt_nonnull_own_or_enomem(new (nothrow) Suggestion(data));
     case Role::superscript:
         return adopt_nonnull_own_or_enomem(new (nothrow) Superscript(data));
     case Role::switch_:

--- a/Libraries/LibWeb/ARIA/Roles.cpp
+++ b/Libraries/LibWeb/ARIA/Roles.cpp
@@ -131,6 +131,7 @@ bool is_document_structure_role(Role role)
         Role::separator, // TODO: Only when not focusable
         Role::strong,
         Role::subscript,
+        Role::suggestion,
         Role::superscript,
         Role::table,
         Role::term,

--- a/Libraries/LibWeb/ARIA/Roles.h
+++ b/Libraries/LibWeb/ARIA/Roles.h
@@ -89,6 +89,7 @@ namespace Web::ARIA {
     __ENUMERATE_ARIA_ROLE(strong)           \
     __ENUMERATE_ARIA_ROLE(structure)        \
     __ENUMERATE_ARIA_ROLE(subscript)        \
+    __ENUMERATE_ARIA_ROLE(suggestion)       \
     __ENUMERATE_ARIA_ROLE(superscript)      \
     __ENUMERATE_ARIA_ROLE(switch_)          \
     __ENUMERATE_ARIA_ROLE(tab)              \

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/roles.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/roles.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 54 tests
 
-53 Pass
-1 Fail
+54 Pass
 Pass	role: alert
 Pass	role: alertdialog
 Pass	role: application
@@ -49,7 +48,7 @@ Pass	role: spinbutton
 Pass	role: status
 Pass	role: strong
 Pass	role: subscript
-Fail	role: suggestion
+Pass	role: suggestion
 Pass	role: superscript
 Pass	role: switch
 Pass	role: term


### PR DESCRIPTION
> [!NOTE]
> This PR currently includes a cherry-pick of the d0938d32ad1 commit from https://github.com/LadybirdBrowser/ladybird/pull/2843 — just for convenience so that we can have all PASSES for the expectations for all subtests in the relevant imported WPT test.

…but the d5c210b62fb commit here that adds support for the `suggestion` ARIA role can be reviewed separately here without needing to (re)review here that other commit from https://github.com/LadybirdBrowser/ladybird/pull/2843.

After https://github.com/LadybirdBrowser/ladybird/pull/2843 is merged, I can just rebase this PR branch.

Anyway, after the d5c210b62fb change here, and the d0938d32ad1 change from #2843, we’ll be passing 100% of the subtests in the `roles.html` test at https://wpt.fyi/results/wai-aria/role?product=ladybird.