### PR TITLE
LibWeb: Assign ARIA role “switch” to <input type=checkbox switch>

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2355,8 +2355,12 @@ Optional<ARIA::Role> HTMLInputElement::default_role() const
     if (type_state() == TypeAttributeState::Button)
         return ARIA::Role::button;
     // https://www.w3.org/TR/html-aria/#el-input-checkbox
-    if (type_state() == TypeAttributeState::Checkbox)
+    if (type_state() == TypeAttributeState::Checkbox) {
+        // https://github.com/w3c/html-aam/issues/496
+        if (has_attribute("switch"_string))
+            return ARIA::Role::switch_;
         return ARIA::Role::checkbox;
+    }
     // https://www.w3.org/TR/html-aria/#el-input-email
     if (type_state() == TypeAttributeState::Email && !has_attribute(AttributeNames::list))
         return ARIA::Role::textbox;

--- a/Tests/LibWeb/Text/expected/wpt-import/html-aam/roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html-aam/roles.tentative.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	el-input-checkbox-switch
+Pass	el-thead
+Pass	el-tbody
+Pass	el-tfoot

--- a/Tests/LibWeb/Text/input/wpt-import/html-aam/roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html-aam/roles.tentative.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTML-AAM Role Verification Tests</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+  <script src="../resources/testdriver.js"></script>
+  <script src="../resources/testdriver-vendor.js"></script>
+  <script src="../resources/testdriver-actions.js"></script>
+  <script src="../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Tests the computedrole mappings defined in <a href="https://w3c.github.io/html-aam/">HTML-AAM</a>. Most test names correspond to a unique ID defined in the spec.<p>
+
+<p>These should remain in alphabetical order, and include all HTML tagnames. If a tag is not tested here, include a pointer to the file where it is tested, such as: <code>&lt;!-- caption -&gt; ./table-roles.html --&gt;</code></p>
+
+<input type="checkbox" switch data-testname="el-input-checkbox-switch" data-expectedrole="switch" class="ex">
+
+<!--
+  These thead, tbody, and tfoot role tests are pending spec discussion.
+  See https://github.com/w3c/html-aam/issues/474
+-->
+<table>
+  <thead data-testname="el-thead" data-expectedrole="rowgroup" class="ex">
+    <tr>
+      <th>a</th>
+      <th>b</th>
+      <th>c</th>
+    </tr>
+  </thead>
+  <tbody data-testname="el-tbody" data-expectedrole="rowgroup" class="ex">
+    <tr>
+      <th>1</th>
+      <td>2</td>
+      <td>3</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>5</td>
+      <td>6</td>
+    </tr>
+  </tbody>
+  <tfoot data-testname="el-tfoot" data-expectedrole="rowgroup" class="ex">
+    <tr>
+      <th>x</th>
+      <th>y</th>
+      <th>z</th>
+    </tr>
+  </tfoot>
+</table>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Merging this would get us 100% passing the WPT test at https://wpt.fyi/results/html-aam/roles.tentative.html?product=ladybird