### PR TITLE
LibWeb: Assign “orphaned” li elements the default ARIA role “none”

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLIElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
-#include <LibWeb/ARIA/Roles.h>
+#include <AK/GenericShorthands.h>
 #include <LibWeb/HTML/HTMLElement.h>
+#include <LibWeb/HTML/HTMLOListElement.h>
+#include <LibWeb/HTML/HTMLUListElement.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::HTML {
@@ -20,7 +22,18 @@ public:
     virtual ~HTMLLIElement() override;
 
     // https://www.w3.org/TR/html-aria/#el-li
-    virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::listitem; }
+    virtual Optional<ARIA::Role> default_role() const override
+    {
+        for (auto const* ancestor = parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+            if (ancestor->role_or_default() == ARIA::Role::list)
+                return ARIA::Role::listitem;
+        }
+        // https://w3c.github.io/core-aam/#roleMappingComputedRole
+        // When an element has a role but is not contained in the required context (for example, an orphaned listitem
+        // without the required accessible parent of role list), User Agents MUST ignore the role token, and return the
+        // computedrole as if the ignored role token had not been included.
+        return ARIA::Role::none;
+    }
 
     WebIDL::Long value();
     void set_value(WebIDL::Long value)

--- a/Tests/LibWeb/Text/expected/wpt-import/html-aam/roles-generic.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html-aam/roles-generic.tentative.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	el-li-orphaned

--- a/Tests/LibWeb/Text/input/wpt-import/html-aam/roles-generic.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html-aam/roles-generic.tentative.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+<head>
+  <title>Tentative: HTML-AAM Generic Role Verification Tests</title>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+  <script src="../resources/testdriver.js"></script>
+  <script src="../resources/testdriver-vendor.js"></script>
+  <script src="../resources/testdriver-actions.js"></script>
+  <script src="../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<li data-testname="el-li-orphaned" class="ex-generic">x</li><!-- todo: should orphaned roles be tested in a new ./roles-orphaned.html file? -->
+
+<script>
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This change makes Ladybird conform to the current requirements at https://w3c.github.io/core-aam/#roleMappingComputedRole in the “Core Accessibility API Mappings” spec for the case of “orphaned” `li` elements; that is, any `li` element which doesn’t have `role=list` ancestor.

The core-aam spec requires that in such cases, the `li` element must not be assigned the `listitem` role but instead must be treated as if it had no role at all.

This change gets us 100% passing the https://wpt.fyi/results/html-aam/roles-generic.tentative.html?product=ladybird test.