### PR TITLE
LibWeb: Align mfrac Padding with Updated MathML Core Spec

### DIFF
--- a/Libraries/LibWeb/MathML/Default.css
+++ b/Libraries/LibWeb/MathML/Default.css
@@ -71,8 +71,7 @@ mtd {
 
 /* Fractions */
 mfrac {
-  padding-inline-start: 1px;
-  padding-inline-end: 1px;
+  padding-inline: 1px;
 }
 mfrac > * {
   math-depth: auto-add;


### PR DESCRIPTION
Proposed by bean at Discord
### Summary
Updates `mfrac` styling in `MathML/Default.css` to align with the MathML Core Editor's Draft (26 November 2024).

### Spec Links
- 2023 Working Draft: https://www.w3.org/TR/2023/WD-mathml-core-20231127/#fractions-mfrac
- 2024 Editor's Draft: https://w3c.github.io/mathml-core/#fractions-mfrac