### PR TITLE
LibWeb: Add support for `object-fit: scale-down`

### DIFF
--- a/Tests/LibWeb/Ref/expected/object-fit-scale-down-ref.html
+++ b/Tests/LibWeb/Ref/expected/object-fit-scale-down-ref.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <style>
+.container {
+  border: 1px solid #888;
+  display: inline-block;
+  width: 128px;
+  height: 128px;
+}
+
+.container div {
+  position: relative;
+}
+
+.red {
+  background-color: #f00;
+}
+
+.yellow {
+  background-color: #ff0;
+}
+
+.green {
+  background-color: #0f0;
+}
+
+.blue {
+  background-color: #00f;
+}
+    </style>
+  </head>
+  <body>
+    <!-- square_256x256 -->
+    <div class="container">
+      <div class="red" style="width: 128px; height: 128px; left: 0px; top: 0px">
+        <div class="yellow" style="width: 96px; height: 96px; left: 16px; top: 16px;">
+          <div class="green" style="width: 64px; height: 64px; left: 16px; top: 16px;">
+            <div class="blue" style="width: 32px; height: 32px; left: 16px; top: 16px;">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- square_64x64 -->
+    <div class="container">
+      <div class="red" style="width: 64px; height: 64px; left: 32px; top: 32px;">
+        <div class="yellow" style="width: 48px; height: 48px; left: 8px; top: 8px;">
+          <div class="green" style="width: 32px; height: 32px; left: 8px; top: 8px;">
+            <div class="blue" style="width: 16px; height: 16px; left: 8px; top: 8px;">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- portrait_128x256 -->
+    <div class="container">
+      <div class="red" style="width: 64px; height: 128px; left: 32px; top: 0px;">
+        <div class="yellow" style="width: 48px; height: 96px; left: 8px; top: 16px;">
+          <div class="green" style="width: 32px; height: 64px; left: 8px; top: 16px;">
+            <div class="blue" style="width: 16px; height: 32px; left: 8px; top: 16px;">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- landscape_256x128 -->
+    <div class="container">
+      <div class="red" style="width: 128px; height: 64px; left: 0px; top: 32px;">
+        <div class="yellow" style="width: 96px; height: 48px; left: 16px; top: 8px;">
+          <div class="green" style="width: 64px; height: 32px; left: 16px; top: 8px;">
+            <div class="blue" style="width: 32px; height: 16px; left: 16px; top: 8px;">
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </body>
+</html>

--- a/Tests/LibWeb/Ref/input/object-fit-scale-down.html
+++ b/Tests/LibWeb/Ref/input/object-fit-scale-down.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <link rel="match" href="../expected/object-fit-scale-down-ref.html" />
+    <style>
+img {
+  border: 1px solid #888;
+  width: 128px;
+  height: 128px;
+  object-fit: scale-down;
+}
+    </style>
+  </head>
+  <body>
+    <!-- square_256x256 -->
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEAAgMAAAAhHED1AAAADFBMVEX/AAD//wAA/wAAAP+LkmRfAAAAWklEQVR42u3MMQ0AIAwAsJnEJCbh4SJZgJe1AhoBAJBojwQCgUAgENQJ+oFAIBAIBIK6wdgIBAKBQCAQCAQCgUAgEOxBRiAQCAQCQb3glkAgEAgEgv8DAIBlAquBmQ+mfdtgAAAAAElFTkSuQmCC" />
+
+    <!-- square_64x64 -->
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABAAgMAAADXB5lNAAAADFBMVEX/AAD//wAA/wAAAP+LkmRfAAAAJUlEQVQ4y2NgGDQgFAkMrMAqKBh4gf9AMCow4NGAJjA40umgAABZSCmQoUN9AgAAAABJRU5ErkJggg==" />
+
+    <!-- portrait_128x256 -->
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAIAAAAEAAgMAAAAGl5Y0AAAADFBMVEX/AAD//wAA/wAAAP+LkmRfAAAAQklEQVRo3u3KUQoAEBBAQZd0SZckRW1acoB5f6+mFEl6VC8BAADMaUcAAAAR9BUAAAAAAMAviAEAAGyQBQAAIElJAx6BTIgBlxbYAAAAAElFTkSuQmCC" />
+
+    <!-- landscape_256x128 -->
+    <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAACAAgMAAACZ21+ZAAAADFBMVEX/AAD//wAA/wAAAP+LkmRfAAAAQElEQVRo3u3MMQ0AIAwAsJnEJCbhX0KAd2sFNAIgGZ8EAkH9YF4IBIJ+wUoEAoFAIBAITgQCQZ/glUAgqBsA7W37FUyIPAsIjgAAAABJRU5ErkJggg==" />
+  </body>
+</html>


### PR DESCRIPTION
The `scale-down`  option for the `object-fit` property was previously unimplemented and was incorrectly treated as `objeect-fit: none`.

None of the related WPTs can be imported for this fix. They all still fail for the following unrelated reasons (or pass even though they should't):
* The tests use a dashed border. There seems to be a bug where the borders are rendered differently between the test and the ref page.
* The images are rendered with off-by-one errors in various places, presumably caused by rounding errors/inconsistencies.

Note that as per the `FIXME` comment, the scaling behavior is still not correct when e.g. changing zoom. This however was already the case in the existing code.