### PR TITLE
Tests: Don't display imported WPT test output if browser is headless 

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -227,4 +227,9 @@ void Internals::set_echo_server_port(u16 const port)
     s_echo_server_port = port;
 }
 
+bool Internals::headless()
+{
+    return internals_page().client().is_headless();
+}
+
 }

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -54,6 +54,8 @@ public:
     static u16 get_echo_server_port();
     static void set_echo_server_port(u16 port);
 
+    bool headless();
+
 private:
     explicit Internals(JS::Realm&);
     virtual void initialize(JS::Realm&) override;

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -41,4 +41,6 @@ interface Internals {
     DOMString getComputedRole(Element element);
     DOMString getComputedLabel(Element element);
     unsigned short getEchoServerPort();
+
+    readonly attribute boolean headless;
 };

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -393,6 +393,8 @@ public:
 
     virtual DisplayListPlayerType display_list_player_type() const = 0;
 
+    virtual bool is_headless() const = 0;
+
 protected:
     virtual ~PageClient() = default;
 };

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -82,6 +82,7 @@ public:
     virtual bool is_ready_to_paint() const override { return true; }
 
     virtual DisplayListPlayerType display_list_player_type() const override { return m_host_page->client().display_list_player_type(); }
+    virtual bool is_headless() const override { return m_host_page->client().is_headless(); }
 
 private:
     explicit SVGPageClient(Page& host_page)

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -108,6 +108,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
         arguments.append("--force-fontconfig"sv);
     if (web_content_options.collect_garbage_on_every_allocation == WebView::CollectGarbageOnEveryAllocation::Yes)
         arguments.append("--collect-garbage-on-every-allocation"sv);
+    if (web_content_options.is_headless == WebView::IsHeadless::Yes)
+        arguments.append("--headless"sv);
 
     if (auto const maybe_echo_server_port = web_content_options.echo_server_port; maybe_echo_server_port.has_value()) {
         arguments.append("--echo-server-port"sv);

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -113,6 +113,11 @@ enum class CollectGarbageOnEveryAllocation {
     Yes,
 };
 
+enum class IsHeadless {
+    No,
+    Yes,
+};
+
 struct WebContentOptions {
     String command_line;
     String executable_path;
@@ -128,6 +133,7 @@ struct WebContentOptions {
     EnableAutoplay enable_autoplay { EnableAutoplay::No };
     CollectGarbageOnEveryAllocation collect_garbage_on_every_allocation { CollectGarbageOnEveryAllocation::No };
     Optional<u16> echo_server_port {};
+    IsHeadless is_headless { IsHeadless::No };
 };
 
 }

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -32,12 +32,23 @@
 namespace WebContent {
 
 static PageClient::UseSkiaPainter s_use_skia_painter = PageClient::UseSkiaPainter::GPUBackendIfAvailable;
+static bool s_is_headless { false };
 
 GC_DEFINE_ALLOCATOR(PageClient);
 
 void PageClient::set_use_skia_painter(UseSkiaPainter use_skia_painter)
 {
     s_use_skia_painter = use_skia_painter;
+}
+
+bool PageClient::is_headless() const
+{
+    return s_is_headless;
+}
+
+void PageClient::set_is_headless(bool is_headless)
+{
+    s_is_headless = is_headless;
 }
 
 GC::Ref<PageClient> PageClient::create(JS::VM& vm, PageHost& page_host, u64 id)

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -34,6 +34,9 @@ public:
     };
     static void set_use_skia_painter(UseSkiaPainter);
 
+    virtual bool is_headless() const override;
+    static void set_is_headless(bool);
+
     virtual bool is_ready_to_paint() const override;
 
     virtual Web::Page& page() override { return *m_page; }

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -107,6 +107,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool force_cpu_painting = false;
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
+    bool is_headless = false;
     StringView echo_server_port_string_view {};
 
     Core::ArgsParser args_parser;
@@ -127,6 +128,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation");
     args_parser.add_option(echo_server_port_string_view, "Echo server port used in test internals", "echo-server-port", 0, "echo_server_port");
+    args_parser.add_option(is_headless, "Report that the browser is running in headless mode", "headless");
 
     args_parser.parse(arguments);
 
@@ -151,6 +153,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // Always use the CPU backend for layout tests, as the GPU backend is not deterministic
     WebContent::PageClient::set_use_skia_painter(force_cpu_painting ? WebContent::PageClient::UseSkiaPainter::CPUBackend : WebContent::PageClient::UseSkiaPainter::GPUBackendIfAvailable);
+
+    WebContent::PageClient::set_is_headless(is_headless);
 
     if (enable_http_cache) {
         Web::Fetch::Fetching::g_http_cache_enabled = true;

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -37,6 +37,7 @@ public:
     virtual void request_file(Web::FileRequest) override;
     virtual bool is_ready_to_paint() const override { return true; }
     virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }
+    virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }
 
 private:
     explicit PageHost(ConnectionFromClient&);

--- a/Tests/LibWeb/Text/expected/Internals/headless.txt
+++ b/Tests/LibWeb/Text/expected/Internals/headless.txt
@@ -1,0 +1,1 @@
+Browser is running headlessly: true

--- a/Tests/LibWeb/Text/input/Internals/headless.html
+++ b/Tests/LibWeb/Text/input/Internals/headless.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        println(`Browser is running headlessly: ${internals.headless}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
@@ -9,7 +9,7 @@
     // default timeout is 10 seconds, test can override if needed
     var settings = {
         // Assume we are running tests if the internals object is exposed.
-        output:!window.hasOwnProperty("internals"),
+        output: !(window.internals && window.internals.headless),
         harness_timeout:{
             "normal":150000, // NOTE: Overridden for Ladybird due to slow GCC CI
             "long":300000 // NOTE: Overridden for Ladybird due to slow GCC CI
@@ -4549,7 +4549,7 @@
     AssertionError.prototype = Object.create(Error.prototype);
 
     const get_stack = function() {
-        if (window.internals) {
+        if (window.internals && window.internals.headless) {
             return "(Stack traces disabled in Ladybird test mode)";
         }
 

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -85,6 +85,7 @@ void Application::create_platform_options(WebView::ChromeOptions& chrome_options
     }
 
     web_content_options.is_layout_test_mode = is_layout_test_mode ? WebView::IsLayoutTestMode::Yes : WebView::IsLayoutTestMode::No;
+    web_content_options.is_headless = WebView::IsHeadless::Yes;
 }
 
 ErrorOr<void> Application::launch_test_fixtures()


### PR DESCRIPTION
This PR adds an `internals.headless` attribute that returns true if the browser is running headlessly and uses it to determine whether imported WPT test output should be shown.

Previously, imported WPT tests didn't display any output if the internals object was exposed. This change adds the condition that the browser must also be running headlessly for test output to not be displayed.

This can be useful when debugging imported WPT tests in cases where the internals object needs to be exposed.