### PR TITLE
LibGC: Mark GC::Function and create_function as ESCAPING 

### DIFF
--- a/Libraries/LibGC/Function.h
+++ b/Libraries/LibGC/Function.h
@@ -17,7 +17,7 @@ class Function final : public Cell {
     GC_CELL(Function, Cell);
 
 public:
-    static Ref<Function> create(Heap& heap, AK::Function<T> function)
+    static Ref<Function> create(Heap& heap, ESCAPING AK::Function<T> function)
     {
         return heap.allocate<Function>(move(function));
     }
@@ -42,7 +42,7 @@ private:
 };
 
 template<typename Callable, typename T = EquivalentFunctionType<Callable>>
-static Ref<Function<T>> create_function(Heap& heap, Callable&& function)
+static Ref<Function<T>> create_function(Heap& heap, ESCAPING Callable&& function)
 {
     return Function<T>::create(heap, AK::Function<T> { forward<Callable>(function) });
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3470,7 +3470,7 @@ void Document::destroy_a_document_and_its_descendants(GC::Ptr<GC::Function<void(
     }
 
     // 2. Let childNavigables be document's child navigables.
-    auto child_navigables = document_tree_child_navigables();
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto child_navigables = document_tree_child_navigables();
 
     // 3. Let numberDestroyed be 0.
     IGNORE_USE_IN_ESCAPING_LAMBDA size_t number_destroyed = 0;
@@ -3698,7 +3698,7 @@ void Document::unload_a_document_and_its_descendants(GC::Ptr<Document> new_docum
             descendant_navigables.append(other_navigable);
     }
 
-    auto unloaded_documents_count = descendant_navigables.size() + 1;
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto unloaded_documents_count = descendant_navigables.size() + 1;
 
     HTML::queue_global_task(HTML::Task::Source::NavigationAndTraversal, HTML::relevant_global_object(*this), GC::create_function(heap(), [&number_unloaded, this, new_document] {
         unload(new_document);

--- a/Libraries/LibWeb/HTML/EventSource.cpp
+++ b/Libraries/LibWeb/HTML/EventSource.cpp
@@ -280,7 +280,7 @@ void EventSource::announce_the_connection()
 // https://html.spec.whatwg.org/multipage/server-sent-events.html#reestablish-the-connection
 void EventSource::reestablish_the_connection()
 {
-    bool initial_task_has_run { false };
+    IGNORE_USE_IN_ESCAPING_LAMBDA bool initial_task_has_run { false };
 
     // 1. Queue a task to run the following steps:
     HTML::queue_a_task(HTML::Task::Source::RemoteEvent, nullptr, nullptr, GC::create_function(heap(), [&]() {

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1014,11 +1014,11 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
     m_popover_showing_or_hiding = true;
 
     // 7. Let cleanupShowingFlag be the following steps:
-    auto cleanup_showing_flag = GC::create_function(this->heap(), [&nested_show, this] {
+    auto cleanup_showing_flag = [&nested_show, this] {
         // 7.1. If nestedShow is false, then set element's popover showing or hiding to false.
         if (!nested_show)
             m_popover_showing_or_hiding = false;
-    });
+    };
 
     // FIXME: 8. If the result of firing an event named beforetoggle, using ToggleEvent, with the cancelable attribute initialized to true, the oldState attribute initialized to "closed", and the newState attribute initialized to "open" at element is false, then run cleanupShowingFlag and return.
 
@@ -1062,7 +1062,7 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
 
     // FIXME: 20. Queue a popover toggle event task given element, "closed", and "open".
     // 21. Run cleanupShowingFlag.
-    cleanup_showing_flag->function()();
+    cleanup_showing_flag();
 
     return {};
 }
@@ -1095,14 +1095,14 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement, FireEv
         fire_events = FireEvents::No;
 
     // 6. Let cleanupSteps be the following steps:
-    auto cleanup_steps = GC::create_function(this->heap(), [&nested_hide, this] {
+    auto cleanup_steps = [&nested_hide, this] {
         // 6.1. If nestedHide is false, then set element's popover showing or hiding to false.
         if (nested_hide)
             m_popover_showing_or_hiding = false;
         // FIXME: 6.2. If element's popover close watcher is not null, then:
         // FIXME: 6.2.1. Destroy element's popover close watcher.
         // FIXME: 6.2.2. Set element's popover close watcher to null.
-    });
+    };
 
     // 7. If element's popover attribute is in the auto state, then:
     if (popover().has_value() && popover().value() == "auto"sv) {
@@ -1138,7 +1138,7 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement, FireEv
     // FIXME: 15.2. If focusPreviousElement is true and document's focused area of the document's DOM anchor is a shadow-including inclusive descendant of element, then run the focusing steps for previouslyFocusedElement; the viewport should not be scrolled by doing this step.
 
     // 16. Run cleanupSteps.
-    cleanup_steps->function()();
+    cleanup_steps();
 
     return {};
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -352,8 +352,8 @@ WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> HTMLImageElement::decode() const
 
         // 3. Otherwise, in parallel wait for one of the following cases to occur, and perform the corresponding actions:
         Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(heap(), [this, promise, &realm, &global] {
-            Platform::EventLoopPlugin::the().spin_until(GC::create_function(heap(), [&] {
-                auto queue_reject_task = [&](String const& message) {
+            Platform::EventLoopPlugin::the().spin_until(GC::create_function(heap(), [this, promise, &realm, &global] {
+                auto queue_reject_task = [promise, &realm, &global](String const& message) {
                     queue_global_task(Task::Source::DOMManipulation, global, GC::create_function(realm.heap(), [&realm, promise, message = String(message)] {
                         auto exception = WebIDL::EncodingError::create(realm, message);
                         HTML::TemporaryExecutionContext context(realm);

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -889,7 +889,7 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
         }
 
         // 7. Wait until either response is non-null, or navigable's ongoing navigation changes to no longer equal navigationId.
-        HTML::main_thread_event_loop().spin_until(GC::create_function(vm.heap(), [&]() {
+        HTML::main_thread_event_loop().spin_until(GC::create_function(vm.heap(), [navigation_id, navigable, response_holder]() {
             if (response_holder->response() != nullptr)
                 return true;
 

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -298,7 +298,7 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
     while (!document->scripts_to_execute_when_parsing_has_finished().is_empty()) {
         // 1. Spin the event loop until the first script in the list of scripts that will execute when the document has finished parsing
         //    has its "ready to be parser-executed" flag set and the parser's Document has no style sheet that is blocking scripts.
-        main_thread_event_loop().spin_until(GC::create_function(heap, [&] {
+        main_thread_event_loop().spin_until(GC::create_function(heap, [document] {
             return document->scripts_to_execute_when_parsing_has_finished().first()->is_ready_to_be_parser_executed()
                 && !document->has_a_style_sheet_that_is_blocking_scripts();
         }));
@@ -311,7 +311,7 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
     }
 
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
-    queue_global_task(HTML::Task::Source::DOMManipulation, *document, GC::create_function(heap, [document = document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, *document, GC::create_function(heap, [document] {
         // 1. Set the Document's load timing info's DOM content loaded event start time to the current high resolution time given the Document's relevant global object.
         document->load_timing_info().dom_content_loaded_event_start_time = HighResolutionTime::current_high_resolution_time(relevant_global_object(*document));
 
@@ -329,17 +329,17 @@ void HTMLParser::the_end(GC::Ref<DOM::Document> document, GC::Ptr<HTMLParser> pa
     }));
 
     // 7. Spin the event loop until the set of scripts that will execute as soon as possible and the list of scripts that will execute in order as soon as possible are empty.
-    main_thread_event_loop().spin_until(GC::create_function(heap, [&] {
+    main_thread_event_loop().spin_until(GC::create_function(heap, [document] {
         return document->scripts_to_execute_as_soon_as_possible().is_empty();
     }));
 
     // 8. Spin the event loop until there is nothing that delays the load event in the Document.
-    main_thread_event_loop().spin_until(GC::create_function(heap, [&] {
+    main_thread_event_loop().spin_until(GC::create_function(heap, [document] {
         return !document->anything_is_delaying_the_load_event();
     }));
 
     // 9. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following steps:
-    queue_global_task(HTML::Task::Source::DOMManipulation, *document, GC::create_function(document->heap(), [document = document] {
+    queue_global_task(HTML::Task::Source::DOMManipulation, *document, GC::create_function(document->heap(), [document] {
         // 1. Update the current document readiness to "complete".
         document->update_readiness(HTML::DocumentReadyState::Complete);
 

--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -475,7 +475,7 @@ WebIDL::ExceptionOr<GC::Ref<ClassicScript>> fetch_a_classic_worker_imported_scri
     auto& vm = realm.vm();
 
     // 1. Let response be null.
-    GC::Ptr<Fetch::Infrastructure::Response> response = nullptr;
+    IGNORE_USE_IN_ESCAPING_LAMBDA GC::Ptr<Fetch::Infrastructure::Response> response = nullptr;
 
     // 2. Let bodyBytes be null.
     Fetch::Infrastructure::FetchAlgorithms::BodyBytes body_bytes;
@@ -510,6 +510,7 @@ WebIDL::ExceptionOr<GC::Ref<ClassicScript>> fetch_a_classic_worker_imported_scri
     }
 
     // 5. Pause until response is not null.
+    // FIXME: Consider using a "response holder" to avoid needing to annotate response as IGNORE_USE_IN_ESCAPING_LAMBDA.
     auto& event_loop = settings_object.responsible_event_loop();
     event_loop.spin_until(GC::create_function(vm.heap(), [&]() -> bool {
         return response;

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -917,7 +917,7 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
 
             // 5. Queue a global task on the navigation and traversal task source given traversable's active window to perform the following steps:
             VERIFY(traversable->active_window());
-            queue_global_task(Task::Source::NavigationAndTraversal, *traversable->active_window(), GC::create_function(heap(), [&] {
+            queue_global_task(Task::Source::NavigationAndTraversal, *traversable->active_window(), GC::create_function(heap(), [needs_beforeunload, user_involvement_for_navigate_events, traversable, target_entry, &final_status, &unload_prompt_shown, &events_fired] {
                 // 1. if needsBeforeunload is true, then:
                 if (needs_beforeunload) {
                     // 1. Let (unloadPromptShownForThisDocument, unloadPromptCanceledByThisDocument) be the result of running the steps to fire beforeunload given traversable's active document and false.
@@ -971,7 +971,7 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
 
     // 7. For each document of documents, queue a global task on the navigation and traversal task source given document's relevant global object to run the steps:
     for (auto& document : documents_to_fire_beforeunload) {
-        queue_global_task(Task::Source::NavigationAndTraversal, relevant_global_object(*document), GC::create_function(heap(), [&] {
+        queue_global_task(Task::Source::NavigationAndTraversal, relevant_global_object(*document), GC::create_function(heap(), [document, &final_status, &completed_tasks, &unload_prompt_shown] {
             // 1. Let (unloadPromptShownForThisDocument, unloadPromptCanceledByThisDocument) be the result of running the steps to fire beforeunload given document and unloadPromptShown.
             auto [unload_prompt_shown_for_this_document, unload_prompt_canceled_by_this_document] = document->steps_to_fire_beforeunload(unload_prompt_shown);
 

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -429,7 +429,7 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     bool check_for_cancelation,
     IGNORE_USE_IN_ESCAPING_LAMBDA Optional<SourceSnapshotParams> source_snapshot_params,
     GC::Ptr<Navigable> initiator_to_check,
-    Optional<UserNavigationInvolvement> user_involvement_for_navigate_events,
+    IGNORE_USE_IN_ESCAPING_LAMBDA Optional<UserNavigationInvolvement> user_involvement_for_navigate_events,
     IGNORE_USE_IN_ESCAPING_LAMBDA Optional<Bindings::NavigationType> navigation_type,
     IGNORE_USE_IN_ESCAPING_LAMBDA SynchronousNavigation synchronous_navigation)
 {
@@ -487,7 +487,7 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     }
 
     // 9. Let totalChangeJobs be the size of changingNavigables.
-    auto total_change_jobs = changing_navigables.size();
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto total_change_jobs = changing_navigables.size();
 
     // 10. Let completedChangeJobs be 0.
     IGNORE_USE_IN_ESCAPING_LAMBDA size_t completed_change_jobs = 0;
@@ -799,7 +799,7 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     }));
 
     // 15. Let totalNonchangingJobs be the size of nonchangingNavigablesThatStillNeedUpdates.
-    auto total_non_changing_jobs = non_changing_navigables_that_still_need_updates.size();
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto total_non_changing_jobs = non_changing_navigables_that_still_need_updates.size();
 
     // 16. Let completedNonchangingJobs be 0.
     IGNORE_USE_IN_ESCAPING_LAMBDA auto completed_non_changing_jobs = 0u;
@@ -880,10 +880,10 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
         documents_to_fire_beforeunload.append(navigable->active_document());
 
     // 2. Let unloadPromptShown be false.
-    auto unload_prompt_shown = false;
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto unload_prompt_shown = false;
 
     // 3. Let finalStatus be "continue".
-    auto final_status = CheckIfUnloadingIsCanceledResult::Continue;
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto final_status = CheckIfUnloadingIsCanceledResult::Continue;
 
     // 4. If traversable was given, then:
     if (traversable) {
@@ -900,7 +900,7 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
             VERIFY(user_involvement_for_navigate_events.has_value());
 
             // 2. Let eventsFired be false.
-            auto events_fired = false;
+            IGNORE_USE_IN_ESCAPING_LAMBDA auto events_fired = false;
 
             // 3. Let needsBeforeunload be true if navigablesThatNeedBeforeUnload contains traversable; otherwise false.
             auto it = navigables_that_need_before_unload.find_if([&traversable](GC::Root<Navigable> navigable) {
@@ -964,10 +964,10 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
     }
 
     // 5. Let totalTasks be the size of documentsThatNeedBeforeunload.
-    auto total_tasks = documents_to_fire_beforeunload.size();
+    IGNORE_USE_IN_ESCAPING_LAMBDA auto total_tasks = documents_to_fire_beforeunload.size();
 
     // 6. Let completedTasks be 0.
-    size_t completed_tasks = 0;
+    IGNORE_USE_IN_ESCAPING_LAMBDA size_t completed_tasks = 0;
 
     // 7. For each document of documents, queue a global task on the navigation and traversal task source given document's relevant global object to run the steps:
     for (auto& document : documents_to_fire_beforeunload) {

--- a/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/IndexedDB/Internal/Algorithms.cpp
@@ -79,8 +79,8 @@ WebIDL::ExceptionOr<GC::Ref<IDBDatabase>> open_a_database_connection(JS::Realm& 
 
         // 2. For each entry of openConnections that does not have its close pending flag set to true,
         //    queue a task to fire a version change event named versionchange at entry with db’s version and version.
-        u32 events_to_fire = open_connections.size();
-        u32 events_fired = 0;
+        IGNORE_USE_IN_ESCAPING_LAMBDA u32 events_to_fire = open_connections.size();
+        IGNORE_USE_IN_ESCAPING_LAMBDA u32 events_fired = 0;
         for (auto& entry : open_connections) {
             if (!entry->close_pending()) {
                 HTML::queue_a_task(HTML::Task::Source::DatabaseAccess, nullptr, nullptr, GC::create_function(realm.vm().heap(), [&realm, entry, db, version, &events_fired]() {

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -892,7 +892,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
         }
     } else {
         // 1. Let processedResponse be false.
-        bool processed_response = false;
+        IGNORE_USE_IN_ESCAPING_LAMBDA bool processed_response = false;
 
         // 2. Let processResponseConsumeBody, given a response and nullOrFailureOrBytes, be these steps:
         auto process_response_consume_body = [this, &processed_response](GC::Ref<Fetch::Infrastructure::Response> response, Variant<Empty, Fetch::Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag, ByteBuffer> null_or_failure_or_bytes) {
@@ -927,7 +927,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
 
         // 4. Let now be the present time.
         // 5. Pause until either processedResponse is true or this’s timeout is not 0 and this’s timeout milliseconds have passed since now.
-        bool did_time_out = false;
+        IGNORE_USE_IN_ESCAPING_LAMBDA bool did_time_out = false;
 
         if (m_timeout != 0) {
             auto timer = Platform::Timer::create_single_shot(heap(), m_timeout, nullptr);

--- a/Meta/Lagom/ClangPlugins/LambdaCapturePluginAction.cpp
+++ b/Meta/Lagom/ClangPlugins/LambdaCapturePluginAction.cpp
@@ -84,12 +84,7 @@ public:
                                 unless(hasParent(
                                     // <lambda struct>::operator()(...)
                                     cxxOperatorCallExpr(has(declRefExpr(to(equalsBoundNode("lambda")))))))))),
-                        parmVarDecl(
-                            allOf(
-                                // It's important that the parameter has a RecordType, as a templated type can never escape its function
-                                hasType(cxxRecordDecl()),
-                                hasAnnotation("serenity::escaping")))
-                            .bind("lambda-param-ref")))),
+                        parmVarDecl(hasAnnotation("serenity::escaping")).bind("lambda-param-ref")))),
             this);
     }
 


### PR DESCRIPTION
Whenever we create a GC function, it should always be so that we can
pass it to a platform event loop spin, HTML event loop spin, or some
queued task on the HTML event loop. For every use case, any local
variables will be out of scope by the time the function executes.