### PR TITLE
LibWeb: Implement post connection steps for HTML <script> elements

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -248,6 +248,7 @@ public:
     Element const* parent_element() const;
 
     virtual void inserted();
+    virtual void post_connection();
     virtual void removed_from(Node*);
     virtual void children_changed() { }
     virtual void adopted_from(Document&) { }

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -43,7 +43,8 @@ public:
 
     bool is_parser_inserted() const { return !!m_parser_document; }
 
-    virtual void inserted() override;
+    virtual void children_changed() override;
+    virtual void post_connection() override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports
     static bool supports(JS::VM&, StringView type)

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/change-src-attr-prepare-a-script.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/change-src-attr-prepare-a-script.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Mutating `src` attribute from an already-valid value does 'prepare' the script

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/change-src-attr-prepare-a-script.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/change-src-attr-prepare-a-script.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<meta charset=utf-8>
+<link rel=help href=https://github.com/whatwg/html/pull/10188#discussion_r1719338657>
+<title>Adding/changing src attribute does "prepare the script"</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<body>
+<script>
+// The "old" HTML Standard specification text around `src` attribute mutation
+// for non-parser-inserted scripts *ONLY* "prepared"/run the script iff the src
+// attribute "previously had no such attribute". This changed in
+// https://github.com/whatwg/html/pull/10188 to align with a majority of
+// browsers. This test ensures that `src` mutations on these kinds of scripts
+// *where a previous valid `src` attribute existed* do indeed "prepare" the
+// script.
+promise_test(async () => {
+  window.didExecute = false;
+
+  const script = document.createElement('script');
+  // Invalid type, so the script won't execute upon insertion.
+  script.type = 'invalid';
+  script.src = 'resources/flag-setter.js';
+  document.body.append(script);
+  assert_false(window.didExecute);
+
+  // Make script valid, but don't immediately execute it.
+  script.type = '';
+
+  const scriptPromise = new Promise(resolve => {
+    script.onload = resolve;
+  });
+
+  // Mutating the `src` attribute, which has an existing valid value, triggers
+  // the "prepare a script" algorithm via the post-connection steps.
+  script.src = 'resources/flag-setter-different.js';
+
+  await scriptPromise;
+  assert_true(window.didExecute);
+}, "Mutating `src` attribute from an already-valid value does 'prepare' the script");
+</script>
+</body>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/resources/flag-setter-different.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/resources/flag-setter-different.js
@@ -1,0 +1,3 @@
+"use strict";
+
+window.didExecute = true;

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/resources/flag-setter.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/resources/flag-setter.js
@@ -1,0 +1,3 @@
+"use strict";
+
+window.didExecute = true;


### PR DESCRIPTION
Changed in the spec to align with Chrome and Webkit behavior.

(note: minor manual changes were needed for the WPT import as it was relying on the python service ?different query)