### PR TITLE
LibWeb: Register Wasm memory grow hook in constructor of Memory objects

### DIFF
--- a/Libraries/LibWeb/WebAssembly/Memory.cpp
+++ b/Libraries/LibWeb/WebAssembly/Memory.cpp
@@ -39,10 +39,6 @@ WebIDL::ExceptionOr<GC::Ref<Memory>> Memory::construct_impl(JS::Realm& realm, Me
 
     auto memory_object = realm.create<Memory>(realm, *address, shared ? Shared::Yes : Shared::No);
 
-    cache.abstract_machine().store().get(*address)->successful_grow_hook = [memory_object] {
-        MUST(memory_object->reset_the_memory_buffer());
-    };
-
     return memory_object;
 }
 
@@ -51,6 +47,11 @@ Memory::Memory(JS::Realm& realm, Wasm::MemoryAddress address, Shared shared)
     , m_address(address)
     , m_shared(shared)
 {
+    auto& cache = Detail::get_cache(realm);
+
+    cache.abstract_machine().store().get(address)->successful_grow_hook = [this] {
+        MUST(reset_the_memory_buffer());
+    };
 }
 
 void Memory::initialize(JS::Realm& realm)

--- a/Tests/LibWeb/Text/expected/Wasm/WebAssembly-grow-hook.txt
+++ b/Tests/LibWeb/Text/expected/Wasm/WebAssembly-grow-hook.txt
@@ -1,0 +1,3 @@
+Size before grow: 65536
+Size after grow, before refresh: 0
+Size after grow, after refresh: 131072

--- a/Tests/LibWeb/Text/input/Wasm/WebAssembly-grow-hook.html
+++ b/Tests/LibWeb/Text/input/Wasm/WebAssembly-grow-hook.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const arrayBuffer = new Uint8Array([
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00, 0x03, 0x02,
+            0x01, 0x00, 0x05, 0x04, 0x01, 0x01, 0x01, 0x02, 0x07, 0x11, 0x02, 0x06, 0x6d, 0x65, 0x6d, 0x6f,
+            0x72, 0x79, 0x02, 0x00, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x00, 0x00, 0x0a, 0x09, 0x01, 0x07, 0x00,
+            0x41, 0x01, 0x40, 0x00, 0x1a, 0x0b
+        ]).buffer;
+
+        const wasm = await WebAssembly.instantiate(arrayBuffer, {});
+        let wasmMemoryBuffer = wasm.instance.exports.memory.buffer;
+
+        println(`Size before grow: ${wasmMemoryBuffer.byteLength}`);
+        wasm.instance.exports.main();
+        println(`Size after grow, before refresh: ${wasmMemoryBuffer.byteLength}`);
+        wasmMemoryBuffer = wasm.instance.exports.memory.buffer;
+        println(`Size after grow, after refresh: ${wasmMemoryBuffer.byteLength}`);
+        done();
+    });
+</script>


### PR DESCRIPTION
Previously it would only register the hook for JavaScript constructed Memory objects. This allows Ruffle to load again.

https://github.com/user-attachments/assets/1c6c75ff-3bb5-4fc3-94cd-89f9a1a5eb3b

(The logo on their homepage is a SWF of their logo running in Ruffle :^))