### PR TITLE
Tests: Add Ladybird specific testdriver functions

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/infrastructure/testdriver/click.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/infrastructure/testdriver/click.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	TestDriver click method

--- a/Tests/LibWeb/Text/expected/wpt-import/infrastructure/testdriver/send_keys.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/infrastructure/testdriver/send_keys.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	TestDriver send keys method

--- a/Tests/LibWeb/Text/input/wpt-import/infrastructure/testdriver/click.html
+++ b/Tests/LibWeb/Text/input/wpt-import/infrastructure/testdriver/click.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver click method</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+
+<button type="button" id="button">Button</button>
+
+<script>
+async_test(t => {
+  let button = document.getElementById("button");
+  test_driver
+    .click(button)
+    .then(() => t.done())
+    .catch(t.unreached_func("click failed"));
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/infrastructure/testdriver/send_keys.html
+++ b/Tests/LibWeb/Text/input/wpt-import/infrastructure/testdriver/send_keys.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>TestDriver send keys method</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+
+<input type="text" id="text">Text Input</button>
+
+<script>
+async_test(t => {
+  let input_text = "Hello, wpt!";
+  let text_box = document.getElementById("text");
+  test_driver
+    .send_keys(text_box, input_text)
+    .then(() => {
+      assert_equals(text_box.value, input_text);
+      t.done();
+    })
+    .catch(t.unreached_func("send keys failed"));
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testdriver-vendor.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testdriver-vendor.js
@@ -1,3 +1,13 @@
+window.test_driver_internal.click = function(element) {
+    const boundingRect = element.getBoundingClientRect();
+    const centerPoint = {
+        x: boundingRect.left + boundingRect.width / 2,
+        y: boundingRect.top + boundingRect.height / 2
+    };
+    window.internals.click(centerPoint.x, centerPoint.y);
+    return Promise.resolve();
+};
+
 window.test_driver_internal.get_computed_label = async function(element) {
     return await window.internals.getComputedLabel(element);
 };

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testdriver-vendor.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testdriver-vendor.js
@@ -1,1 +1,7 @@
-// This file intentionally left blank
+window.test_driver_internal.get_computed_label = async function(element) {
+    return await window.internals.getComputedLabel(element);
+};
+
+window.test_driver_internal.get_computed_role = async function(element) {
+    return await window.internals.getComputedRole(element);
+};

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testdriver-vendor.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testdriver-vendor.js
@@ -8,6 +8,11 @@ window.test_driver_internal.click = function(element) {
     return Promise.resolve();
 };
 
+window.test_driver_internal.send_keys = function(element, keys) {
+    window.internals.sendText(element, keys);
+    return Promise.resolve();
+}
+
 window.test_driver_internal.get_computed_label = async function(element) {
     return await window.internals.getComputedLabel(element);
 };

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testdriver.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testdriver.js
@@ -233,11 +233,7 @@
          *                    rejected in the cases the WebDriver command errors
          */
         get_computed_label: async function(element) {
-            // XXX: Ladybird-specific change: Upstream WPT calls
-            // window.test_driver_internal.get_computed_label(element) here,
-            // but we’ve changed that to our Ladybird-specific
-            // window.internals.getComputedLabel(el).
-            let label = await window.internals.getComputedLabel(element);
+            let label = await window.test_driver_internal.get_computed_label(element);
             return label;
         },
 
@@ -254,11 +250,7 @@
          *                    rejected in the cases the WebDriver command errors
          */
         get_computed_role: async function(element) {
-            // XXX: Ladybird-specific change: Upstream WPT calls
-            // window.test_driver_internal.get_computed_role(element) here,
-            // but we’ve changed that to our Ladybird-specific
-            // window.internals.getComputedRole(el).
-            let role = await window.internals.getComputedRole(element);
+            let role = await window.test_driver_internal.get_computed_role(element);
             return role;
         },
 


### PR DESCRIPTION
WPT provides `testdriver-vendor.js`, where you can put vendor specific implementations of functions called by `testdriver`.

This PR moves functions that were previously patched in `testdriver.js` to `testdriver-vendor.js` and adds vendor specific implementations of `click()` and `send_keys()`, which are implemented using methods from `Internals`.