### PR TITLE
LibWeb: Add statusText validation for Response constructor

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/fetch/api/response/response-error.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/fetch/api/response/response-error.any.txt
@@ -1,0 +1,16 @@
+Harness status: OK
+
+Found 10 tests
+
+10 Pass
+Pass	Throws RangeError when responseInit's status is 0
+Pass	Throws RangeError when responseInit's status is 100
+Pass	Throws RangeError when responseInit's status is 199
+Pass	Throws RangeError when responseInit's status is 600
+Pass	Throws RangeError when responseInit's status is 1000
+Pass	Throws TypeError when responseInit's statusText is 
+
+Pass	Throws TypeError when responseInit's statusText is Ā
+Pass	Throws TypeError when building a response with body and a body status of 204
+Pass	Throws TypeError when building a response with body and a body status of 205
+Pass	Throws TypeError when building a response with body and a body status of 304

--- a/Tests/LibWeb/Text/input/wpt-import/fetch/api/response/response-error.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/fetch/api/response/response-error.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Response error</title>
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../../fetch/api/response/response-error.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/fetch/api/response/response-error.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/fetch/api/response/response-error.any.js
@@ -1,0 +1,27 @@
+// META: global=window,worker
+// META: title=Response error
+
+var invalidStatus = [0, 100, 199, 600, 1000];
+invalidStatus.forEach(function(status) {
+  test(function() {
+    assert_throws_js(RangeError, function() { new Response("", { "status" : status }); },
+      "Expect RangeError exception when status is " + status);
+  },"Throws RangeError when responseInit's status is " + status);
+});
+
+var invalidStatusText = ["\n", "Ā"];
+invalidStatusText.forEach(function(statusText) {
+  test(function() {
+    assert_throws_js(TypeError, function() { new Response("", { "statusText" : statusText }); },
+      "Expect TypeError exception " + statusText);
+  },"Throws TypeError when responseInit's statusText is " + statusText);
+});
+
+var nullBodyStatus = [204, 205, 304];
+nullBodyStatus.forEach(function(status) {
+  test(function() {
+    assert_throws_js(TypeError,
+      function() { new Response("body", {"status" : status }); },
+      "Expect TypeError exception ");
+  },"Throws TypeError when building a response with body and a body status of " + status);
+});


### PR DESCRIPTION
Implemented validation to ensure `statusText` matches the `reason-phrase` token production.

This change fixes a WPT subtest which I have imported.