### PR TITLE
LibWeb: Avoid dereferencing an empty optional URL

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -427,7 +427,7 @@ String HTMLHyperlinkElementUtils::href() const
         return String {};
 
     // 4. Otherwise, if url is null, return this element's href content attribute's value.
-    if (!url->is_valid())
+    if (!url.has_value())
         return href_content_attribute.release_value();
 
     // 5. Return url, serialized.

--- a/Tests/LibWeb/Text/expected/HTML/href-invalid.txt
+++ b/Tests/LibWeb/Text/expected/HTML/href-invalid.txt
@@ -1,0 +1,1 @@
+href="http://foo:b/c"

--- a/Tests/LibWeb/Text/input/HTML/href-invalid.html
+++ b/Tests/LibWeb/Text/input/HTML/href-invalid.html
@@ -1,0 +1,8 @@
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const a = document.createElement("a");
+        a.href = "http://foo:b/c";
+        println(`href="${a.href}"`);
+    });
+</script>


### PR DESCRIPTION
Here, "null" means the empty optional. We don't need to also check if the URL is valid; the url will be null if it was originally invalid.