### PR TITLE
CI: Make required checks work with ignored paths, remove `always()` and refactor branch matching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,40 @@
 name: CI
 
-on:
-  push:
-    paths-ignore:
-      - 'Documentation/**'
-      - '*.md'
-  pull_request:
-    paths-ignore:
-      - 'Documentation/**'
-      - '*.md'
+on: [push, pull_request]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || format('{0}-{1}', github.ref, github.run_number) }}
   cancel-in-progress: true
 
 jobs:
+  # Look at changed paths in the commit or PR to determine whether we need to run the complete CI job. If only
+  # documentation or .md files were changed, we wouldn't need to compile and check anything here.
+  path-changes:
+    runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
+    outputs:
+      source_excluding_docs: ${{ steps.filter.outputs.source_excluding_docs }}
+    steps:
+      # Only need a checkout if we're not running as part of a PR
+      - uses: actions/checkout@v4
+        if: github.event_name != 'pull_request'
+
+      # FIXME: change into `dorny/paths-filter@v3` when https://github.com/dorny/paths-filter/pull/226 is merged
+      - uses: petermetz/paths-filter@5ee2f5d4cf5d7bdd998a314a42da307e2ae1639d
+        id: filter
+        with:
+          predicate-quantifier: every  # all globs below must match
+          filters: |
+            source_excluding_docs:
+              - '**'
+              - '!Documentation/**'
+              - '!*.md'
+
+  # CI matrix - runs the job in lagom-template.yml with different configurations.
   Lagom:
-    if: github.repository == 'LadybirdBrowser/ladybird'
+    needs: path-changes
+    if: github.repository == 'LadybirdBrowser/ladybird' && needs.path-changes.outputs.source_excluding_docs == 'true'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ladybird-js-artifacts.yml
+++ b/.github/workflows/ladybird-js-artifacts.yml
@@ -1,6 +1,8 @@
 name: Package the js repl as a binary artifact
 
-on: [push]
+on:
+  push:
+    branches: [master]
 
 env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
@@ -11,7 +13,7 @@ env:
 jobs:
   build-and-package:
     runs-on: ${{ matrix.os }}
-    if: always() && github.repository == 'LadybirdBrowser/ladybird' && github.ref == 'refs/heads/master'
+    if: github.repository == 'LadybirdBrowser/ladybird'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -1,6 +1,8 @@
 name: Run test262 and test-wasm
 
-on: [push]
+on:
+  push:
+    branches: [master]
 
 env:
   LADYBIRD_SOURCE_DIR: ${{ github.workspace }}
@@ -9,7 +11,7 @@ env:
 jobs:
   run_and_update_results:
     runs-on: test262-runner
-    if: always() && github.repository == 'LadybirdBrowser/ladybird' && github.ref == 'refs/heads/master'
+    if: github.repository == 'LadybirdBrowser/ladybird'
 
     concurrency: libjs-test262
 

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -5,7 +5,7 @@ on: [ push, pull_request ]
 jobs:
   lint:
     runs-on: macos-14
-    if: always() && github.repository == 'LadybirdBrowser/ladybird'
+    if: github.repository == 'LadybirdBrowser/ladybird'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -8,7 +8,7 @@ on: [pull_request_target]
 jobs:
   lint:
     runs-on: ubuntu-24.04
-    if: always() && github.repository == 'LadybirdBrowser/ladybird'
+    if: github.repository == 'LadybirdBrowser/ladybird'
 
     steps:
       - name: Lint PR commits

--- a/.github/workflows/nightly-android.yml
+++ b/.github/workflows/nightly-android.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   CI:
     runs-on: ${{ matrix.os }}
-    if: always() && github.repository == 'LadybirdBrowser/ladybird' && github.ref == 'refs/heads/master'
+    if: github.repository == 'LadybirdBrowser/ladybird'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
* GitHub's required checks (that we enabled yesterday) stay in a "pending" state when using `paths-ignore`, so work around this.
* Remove `always()` from conditionals if a job has no dependencies and/or should be cancelable.
* Instead of matching a branch inside the `if` conditional for a job, move it to the `on` section of the workflow.

One side effect of this setup is that the "checks" section of a PR always displays the new "CI / path-changes" job that needs to be run for every PR, regardless of the changed paths.