### PR TITLE
Meta+WebDriver: Add a `--debug-process` option to `WPT.sh`

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -72,6 +72,8 @@ print_help() {
           Run the Web Platform Tests in the 'css' and 'dom' directories and save the output to expectations.log.
       $NAME run --log-wptreport expectations.json --log-wptscreenshot expectations.db css dom
           Run the Web Platform Tests in the 'css' and 'dom' directories; save the output in wptreport format to expectations.json and save screenshots to expectations.db.
+      $NAME run --debug-process WebContent http://wpt.live/dom/historical.html
+          Run the 'dom/historical.html' test, attaching the debugger to the WebContent process when the browser is launched.
       $NAME compare expectations.log
           Run all of the Web Platform Tests comparing the results to the expectations in before.log.
       $NAME compare --log results.log expectations.log css/CSS2
@@ -109,10 +111,15 @@ set_logging_flags()
 
 headless=1
 ARG=$1
-while [[ "$ARG" =~ ^(--show-window|(--log(-(raw|unittest|xunit|html|mach|tbpl|grouped|chromium|wptreport|wptscreenshot))?))$ ]]; do
+while [[ "$ARG" =~ ^(--show-window|--debug-process|(--log(-(raw|unittest|xunit|html|mach|tbpl|grouped|chromium|wptreport|wptscreenshot))?))$ ]]; do
     case "$ARG" in
         --show-window)
             headless=0
+            ;;
+        --debug-process)
+            process_name="${2}"
+            shift
+            WPT_ARGS+=( "--webdriver-arg=--debug-process=${process_name}" )
             ;;
         --log)
             set_logging_flags "--log-raw" "${2}"

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -52,7 +52,6 @@ static Vector<ByteString> create_arguments(ByteString const& socket_path, bool f
     if (force_cpu_painting)
         arguments.append("--force-cpu-painting"sv);
 
-    dbgln("Debug process: {}", debug_process);
     if (debug_process.has_value())
         arguments.append(ByteString::formatted("--debug-process={}", debug_process.value()));
 

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -33,7 +33,7 @@ static ErrorOr<Core::Process> launch_process(StringView application, ReadonlySpa
     return result;
 }
 
-static Vector<ByteString> create_arguments(ByteString const& socket_path, bool force_cpu_painting)
+static Vector<ByteString> create_arguments(ByteString const& socket_path, bool force_cpu_painting, Optional<StringView> debug_process)
 {
     Vector<ByteString> arguments {
         "--webdriver-content-path"sv,
@@ -52,19 +52,23 @@ static Vector<ByteString> create_arguments(ByteString const& socket_path, bool f
     if (force_cpu_painting)
         arguments.append("--force-cpu-painting"sv);
 
+    dbgln("Debug process: {}", debug_process);
+    if (debug_process.has_value())
+        arguments.append(ByteString::formatted("--debug-process={}", debug_process.value()));
+
     arguments.append("about:blank"sv);
     return arguments;
 }
 
-static ErrorOr<Core::Process> launch_browser(ByteString const& socket_path, bool force_cpu_painting)
+static ErrorOr<Core::Process> launch_browser(ByteString const& socket_path, bool force_cpu_painting, Optional<StringView> debug_process)
 {
-    auto arguments = create_arguments(socket_path, force_cpu_painting);
+    auto arguments = create_arguments(socket_path, force_cpu_painting, move(debug_process));
     return launch_process("Ladybird"sv, arguments.span());
 }
 
-static ErrorOr<Core::Process> launch_headless_browser(ByteString const& socket_path, bool force_cpu_painting)
+static ErrorOr<Core::Process> launch_headless_browser(ByteString const& socket_path, bool force_cpu_painting, Optional<StringView> debug_process)
 {
-    auto arguments = create_arguments(socket_path, force_cpu_painting);
+    auto arguments = create_arguments(socket_path, force_cpu_painting, move(debug_process));
     return launch_process("headless-browser"sv, arguments.span());
 }
 
@@ -76,12 +80,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int port = 8000;
     bool force_cpu_painting = false;
     bool headless = false;
+    Optional<StringView> debug_process;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(listen_address, "IP address to listen on", "listen-address", 'l', "listen_address");
     args_parser.add_option(port, "Port to listen on", "port", 'p', "port");
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(force_cpu_painting, "Launch browser with GPU painting disabled", "force-cpu-painting");
+    args_parser.add_option(debug_process, "Wait for a debugger to attach to the given process name (WebContent, RequestServer, etc.)", "debug-process", 0, "process-name");
     args_parser.add_option(headless, "Launch browser without a graphical interface", "headless");
     args_parser.parse(arguments);
 
@@ -121,11 +127,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         auto launch_browser_callback = [&](ByteString const& socket_path) {
-            return launch_browser(socket_path, force_cpu_painting);
+            return launch_browser(socket_path, force_cpu_painting, debug_process);
         };
 
         auto launch_headless_browser_callback = [&](ByteString const& socket_path) {
-            return launch_headless_browser(socket_path, force_cpu_painting);
+            return launch_headless_browser(socket_path, force_cpu_painting, debug_process);
         };
 
         auto maybe_client = WebDriver::Client::try_create(maybe_buffered_socket.release_value(), { move(launch_browser_callback), move(launch_headless_browser_callback) }, server);


### PR DESCRIPTION
This forwards the `debug-process` option to the browser process launched by WebDriver.

Unfortunately, the option must be formatted with a space between the option and the argument name, as `WPT.sh` doesn't understand arguments separated with an `=`.