### PR TITLE
CI: Select Xcode 16.1 explicitly instead of `latest-stable`

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -49,7 +49,7 @@ runs:
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest-stable
+        xcode-version: 16.1
 
     - name: 'Install Dependencies'
       if: ${{ inputs.os == 'macOS' || inputs.os == 'Android' }}


### PR DESCRIPTION
What `latest-stable` means exactly also depends on the image version we're running the workflow on, and unfortunately this can vary wildly between GitHub runners.

Fixate the version to 16.1 for now. This version will need to be updated as soon as we want to increase the minimum supported compiler version.

This should improve cache coherency between different workflow runs.