### PR TITLE
LibWeb: Implement `PopoverInvokerElement` attribute change steps

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -441,6 +441,7 @@ set(SOURCES
     HTML/Numbers.cpp
     HTML/PageTransitionEvent.cpp
     HTML/PolicyContainers.cpp
+    HTML/PopoverInvokerElement.cpp
     HTML/PopStateEvent.cpp
     HTML/Parser/Entities.cpp
     HTML/Parser/HTMLEncodingDetection.cpp

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -49,7 +49,7 @@ private:                                                                        
     {                                                                                                                                                                       \
         ElementBaseClass::attribute_changed(name, old_value, value, namespace_);                                                                                            \
         form_node_attribute_changed(name, value);                                                                                                                           \
-        form_associated_element_attribute_changed(name, value);                                                                                                             \
+        form_associated_element_attribute_changed(name, value, namespace_);                                                                                                 \
     }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#selection-direction
@@ -110,7 +110,7 @@ protected:
 
     virtual void form_associated_element_was_inserted() { }
     virtual void form_associated_element_was_removed(DOM::Node*) { }
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&) { }
+    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) { }
 
     void form_node_was_inserted();
     void form_node_was_removed();

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -45,6 +45,11 @@ WebIDL::ExceptionOr<void> HTMLButtonElement::set_type(String const& type)
     return set_attribute(HTML::AttributeNames::type, type);
 }
 
+void HTMLButtonElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    PopoverInvokerElement::associated_attribute_changed(name, value, namespace_);
+}
+
 void HTMLButtonElement::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -40,6 +40,8 @@ public:
     TypeAttributeState type_state() const;
     WebIDL::ExceptionOr<void> set_type(String const&);
 
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-button-element
     // https://html.spec.whatwg.org/multipage/interaction.html#focusable-area

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -113,7 +113,7 @@ void HTMLImageElement::apply_presentational_hints(CSS::StyleProperties& style) c
     });
 }
 
-void HTMLImageElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value)
+void HTMLImageElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::crossorigin) {
         m_cors_setting = cors_setting_attribute_from_keyword(value);

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -38,7 +38,7 @@ class HTMLImageElement final
 public:
     virtual ~HTMLImageElement() override;
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&) override;
 
     Optional<String> alternative_text() const override
     {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1195,7 +1195,7 @@ void HTMLInputElement::did_lose_focus()
     commit_pending_changes();
 }
 
-void HTMLInputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value)
+void HTMLInputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::checked) {
         if (!value.has_value()) {

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -185,7 +185,7 @@ public:
 
     virtual void form_associated_element_was_inserted() override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
 

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -78,7 +78,7 @@ void HTMLObjectElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_document_observer);
 }
 
-void HTMLObjectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&)
+void HTMLObjectElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const&, Optional<FlyString> const&)
 {
     // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element
     // Whenever one of the following conditions occur:

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -33,7 +33,7 @@ class HTMLObjectElement final
 public:
     virtual ~HTMLObjectElement() override;
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;
 
     String data() const;

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -32,7 +32,7 @@ void HTMLOutputElement::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_html_for);
 }
 
-void HTMLOutputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value)
+void HTMLOutputElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::for_) {
         if (m_html_for)

--- a/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -63,7 +63,7 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor& visitor) override;
 
-    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value) override;
+    virtual void form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&) override;
 
     GC::Ptr<DOM::DOMTokenList> m_html_for;
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -439,7 +439,7 @@ void HTMLTextAreaElement::children_changed()
     }
 }
 
-void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value)
+void HTMLTextAreaElement::form_associated_element_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const&)
 {
     if (name == HTML::AttributeNames::placeholder) {
         if (m_placeholder_text_node)

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -68,7 +68,7 @@ public:
 
     virtual void form_associated_element_was_inserted() override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;
-    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&) override;
+    virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
     virtual void children_changed() override;
 

--- a/Libraries/LibWeb/HTML/PopoverInvokerElement.cpp
+++ b/Libraries/LibWeb/HTML/PopoverInvokerElement.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/DOM/Element.h>
+#include <LibWeb/HTML/AttributeNames.h>
+#include <LibWeb/HTML/PopoverInvokerElement.h>
+
+namespace Web::HTML {
+
+void PopoverInvokerElement::associated_attribute_changed(FlyString const& name, Optional<String> const&, Optional<FlyString> const& namespace_)
+{
+    // From: https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributess
+    // For element reflected targets only: the following attribute change steps, given element, localName, oldValue, value, and namespace,
+    // are used to synchronize between the content attribute and the IDL attribute:
+
+    // 1. If localName is not attr or namespace is not null, then return.
+    if (name != HTML::AttributeNames::popovertarget || namespace_.has_value())
+        return;
+
+    // 2. Set element's explicitly set attr-elements to null.
+    m_popover_target_element = nullptr;
+}
+
+void PopoverInvokerElement::visit_edges(JS::Cell::Visitor& visitor)
+{
+    visitor.visit(m_popover_target_element);
+}
+
+}

--- a/Libraries/LibWeb/HTML/PopoverInvokerElement.h
+++ b/Libraries/LibWeb/HTML/PopoverInvokerElement.h
@@ -22,10 +22,8 @@ public:
     void set_popover_target_element(GC::Ptr<DOM::Element> value) { m_popover_target_element = value; }
 
 protected:
-    void visit_edges(JS::Cell::Visitor& visitor)
-    {
-        visitor.visit(m_popover_target_element);
-    }
+    void visit_edges(JS::Cell::Visitor&);
+    void associated_attribute_changed(FlyString const& name, Optional<String> const& value, Optional<FlyString> const& namespace_);
 
 private:
     GC::Ptr<DOM::Element> m_popover_target_element;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/popovertarget-reflection.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/popovers/popovertarget-reflection.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Element attribute reflection of popoverTargetElement/popovertarget should be kept in sync.

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/popovertarget-reflection.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/popovers/popovertarget-reflection.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://bugs.chromium.org/p/chromium/issues/detail?id=1523410">
+<link rel=help href="https://bugzilla.mozilla.org/show_bug.cgi?id=1879001">
+<link rel=help href="https://html.spec.whatwg.org/multipage/common-dom-interfaces.html#reflecting-content-attributes-in-idl-attributes:element">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<button id=mybutton popovertarget="mypopover">toggle popover</button>
+<div id=mypopover popover=auto>popover</div>
+
+<script>
+test(() => {
+  assert_equals(mybutton.popoverTargetElement.id, "mypopover",
+    'Setting element.popoverTargetElement to a valid element should work');
+
+  mybutton.popoverTargetElement = null;
+  assert_false(mybutton.hasAttribute('popovertarget'),
+    'Setting element.popoverTargetElement to null should unset popovertarget attribute.');
+  assert_equals(mybutton.popoverTargetElement, null,
+    'Setting element.popoverTargetElement to null should remove the existing element from element.popoverTargetElement.');
+
+  mybutton.popoverTargetElement = mypopover;
+  assert_true(mybutton.hasAttribute('popovertarget'),
+    'Assigning to element.popoverTargetElement should set the popovertarget attribute.');
+
+  mybutton.removeAttribute('popovertarget');
+  assert_equals(mybutton.popoverTargetElement, null,
+    'Removing the popovertarget attribute should remove the element from element.popoverTargetElement.');
+
+  mybutton.popoverTargetElement = mypopover;
+  assert_true(mybutton.hasAttribute('popovertarget'),
+    'Assigning to element.popoverTargetElement should set the popovertarget attribute.');
+
+  mybutton.setAttribute("popovertarget", 'invalid');
+  assert_equals(mybutton.popoverTargetElement, null,
+    'Setting the popovertarget attribute to a localName that is not attr should remove the existing element from element.popoverTargetElement.');
+
+  mybutton.popoverTargetElement = mypopover;
+  mybutton.setAttribute("popovertarget", "");
+  assert_equals(mybutton.popoverTargetElement, null,
+    'Setting the popovertarget attribute to empty string right after setting explicit element does remove the explicit element.');
+
+  mybutton.setAttribute("popovertarget", "mypopover");
+  assert_equals(mybutton.popoverTargetElement.id, "mypopover",
+    'Setting the popovertarget attribute to a value should set the popover target element.');
+  mybutton.setAttribute("popovertarget", "");
+  assert_equals(mybutton.getAttribute('popovertarget'), "",
+    'Assigning to element.popoverTargetElement to empty string should update the attribute value to empty string.');
+  assert_equals(mybutton.popoverTargetElement, null,
+    'Setting the popovertarget attribute to empty string should remove the existing element from element.popoverTargetElement.');
+}, 'Element attribute reflection of popoverTargetElement/popovertarget should be kept in sync.');
+</script>


### PR DESCRIPTION
PopoverInvokerElement's explicitly set attr-element should be set to null whenever the value of the `popovertarget` content attribute is changed.

NOTE: Since this should be done for all Element reflected targets, it may be worth investigating if this could be implemented in the IDL code generator.

Fixes: https://wpt.live/html/semantics/popovers/popovertarget-reflection.html