### PR TITLE
LibWeb: Fix compile error for popover element internal lambdas

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1023,13 +1023,13 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
     event_init.new_state = "open"_string;
     event_init.cancelable = true;
     if (!dispatch_event(ToggleEvent::create(realm(), HTML::EventNames::beforetoggle, move(event_init)))) {
-        cleanup_showing_flag->function()();
+        cleanup_showing_flag();
         return {};
     }
 
     // 9. If the result of running check popover validity given element, false, throwExceptions, and document is false, then run cleanupShowingFlag and return.
     if (!TRY(check_popover_validity(ExpectedToBeShowing::No, throw_exceptions, nullptr))) {
-        cleanup_showing_flag->function()();
+        cleanup_showing_flag();
         return {};
     }
 
@@ -1137,7 +1137,7 @@ WebIDL::ExceptionOr<void> HTMLElement::hide_popover(FocusPreviousElement, FireEv
 
         // 10.3. If the result of running check popover validity given element, true, throwExceptions, and null is false, then run cleanupSteps and return.
         if (!TRY(check_popover_validity(ExpectedToBeShowing::Yes, throw_exceptions, nullptr))) {
-            cleanup_steps->function()();
+            cleanup_steps();
             return {};
         }
         // 10.4. Request an element to be removed from the top layer given element.


### PR DESCRIPTION
These were converted to lambdas in
6b921e91d4ce4791c67bf467a2ba519b8e3ca88b
But I merged fcf6cc27f2cf0c0d0d3c5bae353e348771d5fb98 without checking that the code had responded to the change.