### PR TITLE
Revert "AK: Work around Apple Clang `__builtin_subc` codegen issue"

### DIFF
--- a/AK/BigIntBase.h
+++ b/AK/BigIntBase.h
@@ -231,7 +231,7 @@ template<typename WordType>
 ALWAYS_INLINE constexpr WordType sub_words(WordType word1, WordType word2, bool& carry)
 {
     if (!is_constant_evaluated()) {
-#if __has_builtin(__builtin_subc) && !defined(AK_BUILTIN_SUBC_BROKEN)
+#if __has_builtin(__builtin_subc)
         WordType ncarry, output;
         if constexpr (SameAs<WordType, unsigned int>)
             output = __builtin_subc(word1, word2, carry, reinterpret_cast<unsigned int*>(&ncarry));

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -180,13 +180,6 @@
 #    define VALIDATE_IS_RISCV64() static_assert(false, "Trying to include riscv64 only header on non riscv64 platform");
 #endif
 
-// Apple Clang 14.0.3 (shipped in Xcode 14.3) has a bug that causes __builtin_subc{,l,ll}
-// to incorrectly return whether a borrow occurred on AArch64. See our writeup for the Qemu
-// issue also caused by it: https://gitlab.com/qemu-project/qemu/-/issues/1659#note_1408275831
-#if ARCH(AARCH64) && defined(__apple_build_version__) && __clang_major__ == 14
-#    define AK_BUILTIN_SUBC_BROKEN
-#endif
-
 #ifdef ALWAYS_INLINE
 #    undef ALWAYS_INLINE
 #endif


### PR DESCRIPTION
This reverts commit 9d4dfc1061d9a1ac95654e4d5349d556aad71c5d.
As far as I know, we do not support apple clang 14 due to Swift interop requirements. If we still do, let's keep this PR around until we don't :)