### PR TITLE
Tests: Disable crashing css-hover-shadow-dom.html test

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -169,3 +169,7 @@ Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-i
 Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-auto.html
 Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-fixed.html
 Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html
+
+; Crashes inconsistently on CI
+; https://github.com/LadybirdBrowser/ladybird/issues/2900
+Text/input/ShadowDOM/css-hover-shadow-dom.html


### PR DESCRIPTION
I've seen this crashing, no indication of why in the CI logs unfortunately, it just said it crashed and didn't give a stack trace. eg https://github.com/LadybirdBrowser/ladybird/actions/runs/12316913464/job/34378231682?pr=2898#step:17:2098