### PR TITLE
LibJS: Return the allocated dst register from deleting super properties

### DIFF
--- a/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Libraries/LibJS/Bytecode/Generator.cpp
@@ -812,7 +812,7 @@ CodeGenerationErrorOr<Optional<ScopedOperand>> Generator::emit_delete_reference(
                 emit<Bytecode::Op::DeleteByIdWithThis>(dst, *super_reference.base, *super_reference.this_value, identifier_table_ref);
             }
 
-            return Optional<ScopedOperand> {};
+            return dst;
         }
 
         auto object = TRY(expression.object().generate_bytecode(*this)).value();

--- a/Libraries/LibJS/Tests/operators/delete-basic.js
+++ b/Libraries/LibJS/Tests/operators/delete-basic.js
@@ -93,6 +93,13 @@ test("deleting super property", () => {
         }
     }
 
+    class D {
+        static foo() {
+            const deleter = () => delete super.foo;
+            deleter();
+        }
+    }
+
     const obj = new B();
     expect(() => {
         obj.bar();
@@ -105,6 +112,10 @@ test("deleting super property", () => {
     Object.setPrototypeOf(C, null);
     expect(() => {
         C.foo();
+    }).toThrowWithMessage(ReferenceError, "Can't delete a property on 'super'");
+
+    expect(() => {
+        D.foo();
     }).toThrowWithMessage(ReferenceError, "Can't delete a property on 'super'");
 });
 


### PR DESCRIPTION
Even though calling delete on a super property will ultimately throw a ReferenceError, we must return the allocated register for the result of the delete operation (which would normally be a boolean). If the delete operation is used in a return statement, the bytecode generator for the return statement must be able to assume the statement had some output.

test262 diff:
```
test/staging/sm/class/superElemDelete.js  💥 -> ❌
test/staging/sm/class/superPropDelete.js  💥 -> ✅
```

We fail `superElemDelete.js` because in an expression like this:
```js
const key = {};
delete super[key];
```

We call `ToPropertyKey` on `key` before throwing for the invalid `super` deletion, in `delete_by_value_with_this`. We will likely need to change `Reference` to support holding onto the property key as a `Value` to fix this, but for now, this patch fixes the crashes.