### PR TITLE
LibWeb: Implement a whole bunch of WebGL2 calls and parameters

### DIFF
--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -845,6 +845,7 @@ class WebGLRenderingContext;
 class WebGLSampler;
 class WebGLShader;
 class WebGLShaderPrecisionFormat;
+class WebGLSync;
 class WebGLTexture;
 class WebGLUniformLocation;
 class WebGLVertexArrayObject;

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -842,6 +842,7 @@ class WebGLObject;
 class WebGLProgram;
 class WebGLRenderbuffer;
 class WebGLRenderingContext;
+class WebGLSampler;
 class WebGLShader;
 class WebGLShaderPrecisionFormat;
 class WebGLTexture;

--- a/Libraries/LibWeb/WebGL/Types.h
+++ b/Libraries/LibWeb/WebGL/Types.h
@@ -15,4 +15,8 @@ using GLenum = unsigned int;
 using GLuint = unsigned int;
 using GLint = int;
 
+// FIXME: This should really be "struct __GLsync*", but the linker doesn't recognise it.
+//        Since this conflicts with the original definition of GLsync, the suffix "Internal" has been added.
+using GLsyncInternal = void*;
+
 }

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -300,7 +300,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] undefined framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level, GLint layer);
     [FIXME] undefined invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
     [FIXME] undefined invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments, GLint x, GLint y, GLsizei width, GLsizei height);
-    [FIXME] undefined readBuffer(GLenum src);
+    undefined readBuffer(GLenum src);
 
     // Renderbuffer objects
     any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -304,7 +304,7 @@ interface mixin WebGL2RenderingContextBase {
 
     // Renderbuffer objects
     any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
-    [FIXME] undefined renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
+    undefined renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
 
     // Texture objects
     undefined texStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -303,7 +303,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] undefined readBuffer(GLenum src);
 
     // Renderbuffer objects
-    [FIXME] any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
+    any getInternalformatParameter(GLenum target, GLenum internalformat, GLenum pname);
     [FIXME] undefined renderbufferStorageMultisample(GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
 
     // Texture objects

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -7,6 +7,7 @@
 #import <WebGL/WebGLRenderingContextBase.idl>
 #import <WebGL/WebGLRenderingContextOverloads.idl>
 #import <WebGL/WebGLQuery.idl>
+#import <WebGL/WebGLSampler.idl>
 #import <WebGL/WebGLSync.idl>
 #import <WebGL/WebGLTransformFeedback.idl>
 #import <WebGL/WebGLTexture.idl>
@@ -386,7 +387,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] any getQueryParameter(WebGLQuery query, GLenum pname);
 
     // Sampler Objects
-    [FIXME] WebGLSampler createSampler();
+    WebGLSampler createSampler();
     [FIXME] undefined deleteSampler(WebGLSampler? sampler);
     [FIXME] GLboolean isSampler(WebGLSampler? sampler); // [WebGLHandlesContextLoss]
     [FIXME] undefined bindSampler(GLuint unit, WebGLSampler? sampler);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -390,7 +390,7 @@ interface mixin WebGL2RenderingContextBase {
     WebGLSampler createSampler();
     [FIXME] undefined deleteSampler(WebGLSampler? sampler);
     [FIXME] GLboolean isSampler(WebGLSampler? sampler); // [WebGLHandlesContextLoss]
-    [FIXME] undefined bindSampler(GLuint unit, WebGLSampler? sampler);
+    undefined bindSampler(GLuint unit, WebGLSampler? sampler);
     [FIXME] undefined samplerParameteri(WebGLSampler sampler, GLenum pname, GLint param);
     [FIXME] undefined samplerParameterf(WebGLSampler sampler, GLenum pname, GLfloat param);
     [FIXME] any getSamplerParameter(WebGLSampler sampler, GLenum pname);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -399,7 +399,7 @@ interface mixin WebGL2RenderingContextBase {
     WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
     [FIXME] GLboolean isSync(WebGLSync? sync); // [WebGLHandlesContextLoss]
     [FIXME] undefined deleteSync(WebGLSync? sync);
-    [FIXME] GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout);
+    GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout);
     [FIXME] undefined waitSync(WebGLSync sync, GLbitfield flags, GLint64 timeout);
     [FIXME] any getSyncParameter(WebGLSync sync, GLenum pname);
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -316,7 +316,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, TexImageSource source);
 
     undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData);
-    [FIXME] undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
+    undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
 
     [FIXME] undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, GLintptr pboOffset);
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -416,7 +416,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] undefined resumeTransformFeedback();
 
     // Uniform Buffer Objects and Transform Feedback Buffers
-    [FIXME] undefined bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer);
+    undefined bindBufferBase(GLenum target, GLuint index, WebGLBuffer? buffer);
     [FIXME] undefined bindBufferRange(GLenum target, GLuint index, WebGLBuffer? buffer, GLintptr offset, GLsizeiptr size);
     [FIXME] any getIndexedParameter(GLenum target, GLuint index);
     [FIXME] sequence<GLuint>? getUniformIndices(WebGLProgram program, sequence<DOMString> uniformNames);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -396,7 +396,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] any getSamplerParameter(WebGLSampler sampler, GLenum pname);
 
     // Sync objects
-    [FIXME] WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
+    WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
     [FIXME] GLboolean isSync(WebGLSync? sync); // [WebGLHandlesContextLoss]
     [FIXME] undefined deleteSync(WebGLSync? sync);
     [FIXME] GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -323,7 +323,7 @@ interface mixin WebGL2RenderingContextBase {
     // May throw DOMException
     [FIXME] undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, TexImageSource source);
 
-    [FIXME] undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData, optional unsigned long long srcOffset = 0);
+    undefined texSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, [AllowShared] ArrayBufferView? srcData, optional unsigned long long srcOffset = 0);
 
     [FIXME] undefined copyTexSubImage3D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height);
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -296,7 +296,7 @@ interface mixin WebGL2RenderingContextBase {
     [FIXME] undefined getBufferSubData(GLenum target, GLintptr srcByteOffset, [AllowShared] ArrayBufferView dstBuffer, optional unsigned long long dstOffset = 0, optional GLuint length = 0);
 
     // Framebuffer objects
-    [FIXME] undefined blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
+    undefined blitFramebuffer(GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
     [FIXME] undefined framebufferTextureLayer(GLenum target, GLenum attachment, WebGLTexture? texture, GLint level, GLint layer);
     [FIXME] undefined invalidateFramebuffer(GLenum target, sequence<GLenum> attachments);
     [FIXME] undefined invalidateSubFramebuffer(GLenum target, sequence<GLenum> attachments, GLint x, GLint y, GLsizei width, GLsizei height);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -308,7 +308,7 @@ interface mixin WebGL2RenderingContextBase {
 
     // Texture objects
     undefined texStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
-    [FIXME] undefined texStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
+    undefined texStorage3D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
 
     [FIXME] undefined texImage3D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, GLintptr pboOffset);
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextBase.idl
@@ -398,7 +398,7 @@ interface mixin WebGL2RenderingContextBase {
     // Sync objects
     WebGLSync? fenceSync(GLenum condition, GLbitfield flags);
     [FIXME] GLboolean isSync(WebGLSync? sync); // [WebGLHandlesContextLoss]
-    [FIXME] undefined deleteSync(WebGLSync? sync);
+    undefined deleteSync(WebGLSync? sync);
     GLenum clientWaitSync(WebGLSync sync, GLbitfield flags, GLuint64 timeout);
     [FIXME] undefined waitSync(WebGLSync sync, GLbitfield flags, GLint64 timeout);
     [FIXME] any getSyncParameter(WebGLSync sync, GLenum pname);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
@@ -5,9 +5,10 @@
 // https://registry.khronos.org/webgl/specs/latest/2.0/#3.7
 interface mixin WebGL2RenderingContextOverloads {
     // WebGL1:
+    // FIXME: BufferSource is really a AllowSharedBufferSource
     undefined bufferData(GLenum target, GLsizeiptr size, GLenum usage);
     undefined bufferData(GLenum target, BufferSource? srcData, GLenum usage);
-    [FIXME] undefined bufferSubData(GLenum target, GLintptr dstByteOffset, AllowSharedBufferSource srcData);
+    undefined bufferSubData(GLenum target, GLintptr dstByteOffset, BufferSource srcData);
     // WebGL2:
     [FIXME] undefined bufferData(GLenum target, [AllowShared] ArrayBufferView srcData, GLenum usage, unsigned long long srcOffset, optional GLuint length = 0);
     [FIXME] undefined bufferSubData(GLenum target, GLintptr dstByteOffset, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset, optional GLuint length = 0);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
@@ -30,7 +30,7 @@ interface mixin WebGL2RenderingContextOverloads {
     // May throw DOMException
     [FIXME] undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, TexImageSource source);
 
-    [FIXME] undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
+    undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
 
     [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, GLintptr pboOffset);
 

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
@@ -53,9 +53,9 @@ interface mixin WebGL2RenderingContextOverloads {
     undefined uniform3iv(WebGLUniformLocation? location, Int32List v, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
     undefined uniform4iv(WebGLUniformLocation? location, Int32List v, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
 
-    [FIXME] undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
-    [FIXME] undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
-    [FIXME] undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix2fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix3fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
+    undefined uniformMatrix4fv(WebGLUniformLocation? location, GLboolean transpose, Float32List data, optional unsigned long long srcOffset = 0, optional GLuint srcLength = 0);
 
     // Reading back pixels
     // WebGL1:

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
@@ -36,7 +36,7 @@ interface mixin WebGL2RenderingContextOverloads {
 
     // May throw DOMException
     [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, TexImageSource source);
-    [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView srcData, unsigned long long srcOffset);
 
     [FIXME] undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, GLsizei imageSize, GLintptr offset);
     [FIXME] undefined compressedTexImage2D(GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLint border, [AllowShared] ArrayBufferView srcData, optional unsigned long long srcOffset = 0, optional GLuint srcLengthOverride = 0);

--- a/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
+++ b/Libraries/LibWeb/WebGL/WebGL2RenderingContextOverloads.idl
@@ -19,7 +19,7 @@ interface mixin WebGL2RenderingContextOverloads {
     // May throw DOMException
     undefined texImage2D(GLenum target, GLint level, GLint internalformat, GLenum format, GLenum type, TexImageSource source);
 
-    [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
+    undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, [AllowShared] ArrayBufferView? pixels);
 
     // May throw DOMException
     [FIXME] undefined texSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLenum format, GLenum type, TexImageSource source);

--- a/Libraries/LibWeb/WebGL/WebGLSync.cpp
+++ b/Libraries/LibWeb/WebGL/WebGLSync.cpp
@@ -13,13 +13,14 @@ namespace Web::WebGL {
 
 GC_DEFINE_ALLOCATOR(WebGLSync);
 
-GC::Ref<WebGLSync> WebGLSync::create(JS::Realm& realm, GLuint handle)
+GC::Ref<WebGLSync> WebGLSync::create(JS::Realm& realm, GLsyncInternal handle)
 {
     return realm.create<WebGLSync>(realm, handle);
 }
 
-WebGLSync::WebGLSync(JS::Realm& realm, GLuint handle)
-    : WebGLObject(realm, handle)
+WebGLSync::WebGLSync(JS::Realm& realm, GLsyncInternal handle)
+    : WebGLObject(realm, 0)
+    , m_sync_handle(handle)
 {
 }
 

--- a/Libraries/LibWeb/WebGL/WebGLSync.h
+++ b/Libraries/LibWeb/WebGL/WebGLSync.h
@@ -16,14 +16,18 @@ class WebGLSync : public WebGLObject {
     GC_DECLARE_ALLOCATOR(WebGLSync);
 
 public:
-    static GC::Ref<WebGLSync> create(JS::Realm& realm, GLuint handle);
+    static GC::Ref<WebGLSync> create(JS::Realm& realm, GLsyncInternal handle);
 
     virtual ~WebGLSync() override;
 
+    GLsyncInternal sync_handle() const { return m_sync_handle; }
+
 protected:
-    explicit WebGLSync(JS::Realm&, GLuint handle);
+    explicit WebGLSync(JS::Realm&, GLsyncInternal handle);
 
     virtual void initialize(JS::Realm&) override;
+
+    GLsyncInternal m_sync_handle { nullptr };
 };
 
 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -116,6 +116,7 @@ static bool is_platform_object(Type const& type)
         "WebGLSampler"sv,
         "WebGLShader"sv,
         "WebGLShaderPrecisionFormat"sv,
+        "WebGLSync"sv,
         "WebGLTexture"sv,
         "WebGLUniformLocation"sv,
         "WebGLVertexArrayObject"sv,

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -113,6 +113,7 @@ static bool is_platform_object(Type const& type)
         "WebGLProgram"sv,
         "WebGLRenderbuffer"sv,
         "WebGLRenderingContext"sv,
+        "WebGLSampler"sv,
         "WebGLShader"sv,
         "WebGLShaderPrecisionFormat"sv,
         "WebGLTexture"sv,

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -657,6 +657,19 @@ public:
             continue;
         }
 
+        if (webgl_version == 2 && function.name == "texImage2D"sv && function.overload_index == 2) {
+            function_impl_generator.append(R"~~~(
+    void const* pixels_ptr = nullptr;
+    if (src_data) {
+        auto const& viewed_array_buffer = src_data->viewed_array_buffer();
+        auto const& byte_buffer = viewed_array_buffer->buffer();
+        pixels_ptr = byte_buffer.data() + src_offset;
+    }
+    glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels_ptr);
+)~~~");
+            continue;
+        }
+
         if (function.name == "texSubImage2D"sv && function.overload_index == 0) {
             function_impl_generator.append(R"~~~(
     void const* pixels_ptr = nullptr;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -357,6 +357,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #include <LibWeb/WebGL/@class_name@.h>
 #include <LibWeb/WebGL/WebGLSampler.h>
 #include <LibWeb/WebGL/WebGLShader.h>
+#include <LibWeb/WebGL/WebGLSync.h>
 #include <LibWeb/WebGL/WebGLShaderPrecisionFormat.h>
 #include <LibWeb/WebGL/WebGLTexture.h>
 #include <LibWeb/WebGL/WebGLUniformLocation.h>
@@ -515,6 +516,14 @@ public:
     GLuint handle = 0;
     glGenSamplers(1, &handle);
     return WebGLSampler::create(m_realm, handle);
+)~~~");
+            continue;
+        }
+
+        if (function.name == "fenceSync"sv) {
+            function_impl_generator.append(R"~~~(
+    GLsync handle = glFenceSync(condition, flags);
+    return WebGLSync::create(m_realm, handle);
 )~~~");
             continue;
         }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -177,6 +177,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_UNIFORM_BLOCK_SIZE"sv, { "GLint64"sv }, 2 },
         { "MAX_UNIFORM_BUFFER_BINDINGS"sv, { "GLint"sv }, 2 },
         { "UNIFORM_BUFFER_OFFSET_ALIGNMENT"sv, { "GLint"sv }, 2 },
+        { "MAX_DRAW_BUFFERS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -21,6 +21,7 @@ static bool is_webgl_object_type(StringView type_name)
         || type_name == "WebGLFramebuffer"sv
         || type_name == "WebGLProgram"sv
         || type_name == "WebGLRenderbuffer"sv
+        || type_name == "WebGLSampler"sv
         || type_name == "WebGLShader"sv
         || type_name == "WebGLTexture"sv
         || type_name == "WebGLUniformLocation"sv

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -948,6 +948,11 @@ public:
                 gl_call_arguments.append(ByteString::formatted("{} ? {}->handle() : 0", parameter_name, parameter_name));
                 continue;
             }
+            if (parameter.type->name() == "WebGLSync"sv) {
+                // FIXME: Remove the GLsync cast once sync_handle actually returns the proper GLsync type.
+                gl_call_arguments.append(ByteString::formatted("(GLsync)({} ? {}->sync_handle() : nullptr)", parameter_name, parameter_name));
+                continue;
+            }
             if (parameter.type->name() == "BufferSource"sv) {
                 function_impl_generator.set("buffer_source_name", parameter_name);
                 function_impl_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -274,7 +274,9 @@ static void generate_get_buffer_parameter(SourceGenerator& generator)
 
     generator.appendln(R"~~~(
     default:
-        TODO();
+        dbgln("Unknown WebGL buffer parameter name: {:x}", pname);
+        set_error(GL_INVALID_ENUM);
+        return JS::js_null();
     })~~~");
 }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -354,6 +354,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 #include <LibWeb/WebGL/WebGLProgram.h>
 #include <LibWeb/WebGL/WebGLRenderbuffer.h>
 #include <LibWeb/WebGL/@class_name@.h>
+#include <LibWeb/WebGL/WebGLSampler.h>
 #include <LibWeb/WebGL/WebGLShader.h>
 #include <LibWeb/WebGL/WebGLShaderPrecisionFormat.h>
 #include <LibWeb/WebGL/WebGLTexture.h>
@@ -504,6 +505,15 @@ public:
     GLuint handle = 0;
     glGenVertexArrays(1, &handle);
     return WebGLVertexArrayObject::create(m_realm, handle);
+)~~~");
+            continue;
+        }
+
+        if (function.name == "createSampler"sv) {
+            function_impl_generator.append(R"~~~(
+    GLuint handle = 0;
+    glGenSamplers(1, &handle);
+    return WebGLSampler::create(m_realm, handle);
 )~~~");
             continue;
         }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -176,6 +176,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_VERTEX_UNIFORM_COMPONENTS"sv, { "GLint"sv }, 2 },
         { "MAX_UNIFORM_BLOCK_SIZE"sv, { "GLint64"sv }, 2 },
         { "MAX_UNIFORM_BUFFER_BINDINGS"sv, { "GLint"sv }, 2 },
+        { "UNIFORM_BUFFER_OFFSET_ALIGNMENT"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -170,6 +170,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "VERSION"sv, { "DOMString"sv } },
         { "VIEWPORT"sv, { "Int32Array"sv, 4 } },
         { "MAX_SAMPLES"sv, { "GLint"sv }, 2 },
+        { "MAX_3D_TEXTURE_SIZE"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -595,7 +595,7 @@ public:
             continue;
         }
 
-        if (function.name == "texImage3D"sv) {
+        if (function.name == "texImage3D"sv && function.overload_index == 0) {
             // FIXME: If a WebGLBuffer is bound to the PIXEL_UNPACK_BUFFER target, generates an INVALID_OPERATION error.
             // FIXME: If srcData is null, a buffer of sufficient size initialized to 0 is passed.
             // FIXME: If type is specified as FLOAT_32_UNSIGNED_INT_24_8_REV, srcData must be null; otherwise, generates an INVALID_OPERATION error.
@@ -608,6 +608,25 @@ public:
         auto const& viewed_array_buffer = src_data->viewed_array_buffer();
         auto const& byte_buffer = viewed_array_buffer->buffer();
         src_data_ptr = byte_buffer.data();
+    }
+    glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, src_data_ptr);
+)~~~");
+            continue;
+        }
+
+        if (function.name == "texImage3D"sv && function.overload_index == 1) {
+            // FIXME: If a WebGLBuffer is bound to the PIXEL_UNPACK_BUFFER target, generates an INVALID_OPERATION error.
+            // FIXME: If srcData is null, a buffer of sufficient size initialized to 0 is passed.
+            // FIXME: If type is specified as FLOAT_32_UNSIGNED_INT_24_8_REV, srcData must be null; otherwise, generates an INVALID_OPERATION error.
+            // FIXME: If srcData is non-null, the type of srcData must match the type according to the above table; otherwise, generate an INVALID_OPERATION error.
+            // FIXME: If an attempt is made to call this function with no WebGLTexture bound (see above), generates an INVALID_OPERATION error.
+            // FIXME: If there's not enough data in srcData starting at srcOffset, generate INVALID_OPERATION.
+            function_impl_generator.append(R"~~~(
+    void const* src_data_ptr = nullptr;
+    if (src_data) {
+        auto const& viewed_array_buffer = src_data->viewed_array_buffer();
+        auto const& byte_buffer = viewed_array_buffer->buffer();
+        src_data_ptr = byte_buffer.data() + src_offset;
     }
     glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, src_data_ptr);
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -174,6 +174,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_ARRAY_TEXTURE_LAYERS"sv, { "GLint"sv }, 2 },
         { "MAX_COLOR_ATTACHMENTS"sv, { "GLint"sv }, 2 },
         { "MAX_VERTEX_UNIFORM_COMPONENTS"sv, { "GLint"sv }, 2 },
+        { "MAX_UNIFORM_BLOCK_SIZE"sv, { "GLint64"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {
@@ -199,6 +200,12 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         GLint result;
         glGetIntegerv(GL_@parameter_name@, &result);
         return JS::Value(result);
+)~~~");
+        } else if (type_name == "GLint64"sv) {
+            impl_generator.append(R"~~~(
+        GLint64 result;
+        glGetInteger64v(GL_@parameter_name@, &result);
+        return JS::Value(static_cast<double>(result));
 )~~~");
         } else if (type_name == "DOMString"sv) {
             impl_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -175,6 +175,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_COLOR_ATTACHMENTS"sv, { "GLint"sv }, 2 },
         { "MAX_VERTEX_UNIFORM_COMPONENTS"sv, { "GLint"sv }, 2 },
         { "MAX_UNIFORM_BLOCK_SIZE"sv, { "GLint64"sv }, 2 },
+        { "MAX_UNIFORM_BUFFER_BINDINGS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -670,6 +670,19 @@ public:
             continue;
         }
 
+        if (webgl_version == 2 && function.name == "texSubImage2D"sv && function.overload_index == 1) {
+            function_impl_generator.append(R"~~~(
+    void const* pixels_ptr = nullptr;
+    if (src_data) {
+        auto const& viewed_array_buffer = src_data->viewed_array_buffer();
+        auto const& byte_buffer = viewed_array_buffer->buffer();
+        pixels_ptr = byte_buffer.data() + src_offset;
+    }
+    glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels_ptr);
+)~~~");
+            continue;
+        }
+
         if (function.name == "texSubImage3D"sv && function.overload_index == 0) {
             function_impl_generator.append(R"~~~(
     void const* pixels_ptr = nullptr;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -670,6 +670,19 @@ public:
             continue;
         }
 
+        if (function.name == "texSubImage3D"sv && function.overload_index == 0) {
+            function_impl_generator.append(R"~~~(
+    void const* pixels_ptr = nullptr;
+    if (src_data) {
+        auto const& viewed_array_buffer = src_data->viewed_array_buffer();
+        auto const& byte_buffer = viewed_array_buffer->buffer();
+        pixels_ptr = byte_buffer.data() + src_offset;
+    }
+    glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels_ptr);
+)~~~");
+            continue;
+        }
+
         if (function.name == "getShaderParameter"sv) {
             function_impl_generator.append(R"~~~(
     GLint result = 0;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -179,6 +179,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "UNIFORM_BUFFER_OFFSET_ALIGNMENT"sv, { "GLint"sv }, 2 },
         { "MAX_DRAW_BUFFERS"sv, { "GLint"sv }, 2 },
         { "MAX_VERTEX_UNIFORM_BLOCKS"sv, { "GLint"sv }, 2 },
+        { "MAX_FRAGMENT_INPUT_COMPONENTS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -172,6 +172,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_SAMPLES"sv, { "GLint"sv }, 2 },
         { "MAX_3D_TEXTURE_SIZE"sv, { "GLint"sv }, 2 },
         { "MAX_ARRAY_TEXTURE_LAYERS"sv, { "GLint"sv }, 2 },
+        { "MAX_COLOR_ATTACHMENTS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -171,6 +171,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "VIEWPORT"sv, { "Int32Array"sv, 4 } },
         { "MAX_SAMPLES"sv, { "GLint"sv }, 2 },
         { "MAX_3D_TEXTURE_SIZE"sv, { "GLint"sv }, 2 },
+        { "MAX_ARRAY_TEXTURE_LAYERS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -180,6 +180,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_DRAW_BUFFERS"sv, { "GLint"sv }, 2 },
         { "MAX_VERTEX_UNIFORM_BLOCKS"sv, { "GLint"sv }, 2 },
         { "MAX_FRAGMENT_INPUT_COMPONENTS"sv, { "GLint"sv }, 2 },
+        { "MAX_COMBINED_UNIFORM_BLOCKS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -178,6 +178,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_UNIFORM_BUFFER_BINDINGS"sv, { "GLint"sv }, 2 },
         { "UNIFORM_BUFFER_OFFSET_ALIGNMENT"sv, { "GLint"sv }, 2 },
         { "MAX_DRAW_BUFFERS"sv, { "GLint"sv }, 2 },
+        { "MAX_VERTEX_UNIFORM_BLOCKS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateWebGLRenderingContext.cpp
@@ -173,6 +173,7 @@ static void generate_get_parameter(SourceGenerator& generator, int webgl_version
         { "MAX_3D_TEXTURE_SIZE"sv, { "GLint"sv }, 2 },
         { "MAX_ARRAY_TEXTURE_LAYERS"sv, { "GLint"sv }, 2 },
         { "MAX_COLOR_ATTACHMENTS"sv, { "GLint"sv }, 2 },
+        { "MAX_VERTEX_UNIFORM_COMPONENTS"sv, { "GLint"sv }, 2 },
     };
 
     auto is_primitive_type = [](StringView type) {


### PR DESCRIPTION
This is enough to make Unity Web reach the main loop, but sadly not enough for it to progress and render the first frame, either crashing with a Wasm OOB error (e.g. with https://3di70r.itch.io/crusty-proto) or infinitely looping and allocating a _lot_ of memory (e.g. with https://scottts.itch.io/different-strokes). Please note that the validation for these will likely need another look over.