### PR TITLE
LibGC: Preallocate space before dumping GC graph

### DIFF
--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -119,6 +119,7 @@ public:
             m_all_live_heap_blocks.set(&block);
             return IterationDecision::Continue;
         });
+        m_work_queue.ensure_capacity(roots.size());
 
         for (auto& [root, root_origin] : roots) {
             auto& graph_node = m_graph.ensure(bit_cast<FlatPtr>(root));


### PR DESCRIPTION
Speeds up the append_gc_graph function by preallocating space. This change reduces the time taken to dump the GC graph by 4% on about:blank on my m1 MacBook Air 

Benchmark:
```diff
diff --git a/Services/WebContent/ConnectionFromClient.cpp b/Services/WebContent/ConnectionFromClient.cpp
index 03944c68bc..e65c2f4d10 100644
--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -933,10 +933,17 @@ static void append_paint_tree(Web::Page& page, StringBuilder& builder)
     Web::dump_tree(builder, *layout_root->first_paintable());
 }

+#include <LibCore/ElapsedTimer.h>
+
 static void append_gc_graph(StringBuilder& builder)
 {
+    Core::ElapsedTimer timer;
+    timer.start();
     auto gc_graph = Web::Bindings::main_thread_vm().heap().dump_graph();
+    auto duration = timer.elapsed_milliseconds();
     gc_graph.serialize(builder);
+
+    dbgln("dump_graph duration: {} ms", duration);
 }

 void ConnectionFromClient::request_internal_page_info(u64 page_id, WebView::PageInfoType type)
 ```