### PR TITLE
Tests: Import remaining HTML-AAM tests (no code)

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/html-aam/fragile/area-role.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html-aam/fragile/area-role.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	el-area
+Pass	el-area-no-href

--- a/Tests/LibWeb/Text/expected/wpt-import/html-aam/fragile/optgroup-role.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html-aam/fragile/optgroup-role.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	el-optgroup

--- a/Tests/LibWeb/Text/input/wpt-import/html-aam/fragile/area-role.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html-aam/fragile/area-role.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTMLAreaElement Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<map name="areamap">
+  <area shape="rect" coords="0,0,15,15" href="#" alt="x" data-testname="el-area" data-expectedrole="link" class="ex">
+  <area shape="rect" coords="15,15,31,31" alt="x" data-testname="el-area-no-href" class="ex-generic">
+</map>
+<img usemap="#areamap" style="width: 32px; height: 32px;" alt="x" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html-aam/fragile/optgroup-role.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html-aam/fragile/optgroup-role.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html>
+<head>
+  <title>HTMLOptGroupElement Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<select>
+  <optgroup label="x" data-testname="el-optgroup" data-expectedrole="group" class="ex">
+    <option>x1</option>
+    <option>x2</option>
+  </optgroup>
+  <optgroup data-testname="el-optgroup-no-label" data-expectedrole="not defined in spec?" class="ex-todo">
+    <option>y1</option>
+    <option>y2</option>
+  </optgroup>
+</select>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This change imports the remaining HTML-AAM tests from WPT that haven’t yet been imported in any previous PRs — giving us complete in-tree regression-testing coverage for all available WPT tests for the requirements in the HTML-AAM spec.

Reviewers: This change is tests-only, no code changes.