### PR TITLE
LibWeb: Do not dispatch events to pseudoelement content nodes

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -80,7 +80,7 @@ static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, GC
             continue;
         node = layout_node->dom_node();
     }
-    return node && layout_node;
+    return node && layout_node && !layout_node->is_anonymous();
 }
 
 static Gfx::StandardCursor cursor_css_to_gfx(Optional<CSS::Cursor> cursor)

--- a/Tests/LibWeb/Text/expected/pseudoelement-content-event-dispatch.txt
+++ b/Tests/LibWeb/Text/expected/pseudoelement-content-event-dispatch.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/pseudoelement-content-event-dispatch.html
+++ b/Tests/LibWeb/Text/input/pseudoelement-content-event-dispatch.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<style>
+    div:before {
+        content: "test";
+        translate: 100px;
+    }
+</style>
+<div id="test"></div>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const div = document.getElementById("test");
+        const rect = div.getBoundingClientRect();
+        internals.movePointerTo(rect.x + 100, rect.y);
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
This fixes a crash when scrolling https://github.com.