### PR TITLE
Docs: Add info about --enable-idl-tracing flag

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -66,3 +66,11 @@ You can take your reduced test case and post it online at a site such as the fol
 That will give you a URL which you can then include in the issue you raise for the problem.
 
 *[Credits: The “How you can write a reduced test case” details above are largely taken from https://webkit.org/test-case-reduction/.]*
+
+## Debugging
+
+When investigating a bug, it can be helpful to use the `--enable-idl-tracing` command-line flag when running Ladybird. This will output detailed information about the calls being made to the browser's internal interfaces, which can help pinpoint where a problem is occurring.
+
+```bash
+./Meta/ladybird.sh run ladybird --enable-idl-tracing
+```


### PR DESCRIPTION
This PR updates the `ISSUES.md` file to include information about the `--enable-idl-tracing` flag. This switch helped me resolve issue #2936, and I believe that if it were included in the Issues guidelines, it would assist others in similar situations.

This change aims to help contributors more effectively debug issues and provide better test cases when reporting bugs.

If this is not the right place for this information, please feel free to comment.