### PR TITLE
Meta+Tests: Remove last use of VLAs and enable warning for them

### DIFF
--- a/Meta/CMake/common_compile_options.cmake
+++ b/Meta/CMake/common_compile_options.cmake
@@ -96,12 +96,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND NOT CMAKE_CXX_SIMULATE_ID  MATCHES
 
     add_cxx_compile_options(-Wno-implicit-const-int-float-conversion)
     add_cxx_compile_options(-Wno-user-defined-literals)
-    add_cxx_compile_options(-Wno-vla-cxx-extension)
     add_cxx_compile_options(-Wno-unqualified-std-cast-call)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # Only ignore expansion-to-defined for g++, clang's implementation doesn't complain about function-like macros
     add_cxx_compile_options(-Wno-expansion-to-defined)
     add_cxx_compile_options(-Wno-literal-suffix)
+    add_cxx_compile_options(-Wvla)
 
     # FIXME: This warning seems useful but has too many false positives with GCC 13.
     add_cxx_compile_options(-Wno-dangling-reference)

--- a/Tests/LibCrypto/TestRSA.cpp
+++ b/Tests/LibCrypto/TestRSA.cpp
@@ -25,8 +25,9 @@ TEST_CASE(test_RSA_raw_encrypt)
         "8126832723025844890518845777858816391166654950553329127845898924164623511718747856014227624997335860970996746552094406240834082304784428582653994490504519"_bigint,
         "65537"_bigint,
     });
-    u8 buffer[rsa.output_size()];
-    auto buf = Bytes { buffer, sizeof(buffer) };
+    ByteBuffer buffer = {};
+    buffer.resize(rsa.output_size());
+    auto buf = buffer.bytes();
     rsa.encrypt(data, buf);
     EXPECT(memcmp(result, buf.data(), buf.size()) == 0);
 }
@@ -36,8 +37,9 @@ TEST_CASE(test_RSA_PKCS_1_encrypt)
 {
     ByteBuffer data { "hellohellohellohellohellohellohellohellohello123-"_b };
     Crypto::PK::RSA_PKCS1_EME rsa(Crypto::PK::RSA::generate_key_pair(1024));
-    u8 buffer[rsa.output_size()];
-    auto buf = Bytes { buffer, sizeof(buffer) };
+    ByteBuffer buffer = {};
+    buffer.resize(rsa.output_size());
+    auto buf = buffer.bytes();
     rsa.encrypt(data, buf);
     rsa.decrypt(buf, buf);
 
@@ -134,11 +136,14 @@ c8yGzl89pYST
 
     EXPECT_EQ(keypem, StringView(priv_pem));
 
-    u8 enc_buffer[rsa_from_pair.output_size()];
-    u8 dec_buffer[rsa_from_pair.output_size()];
+    ByteBuffer enc_buffer = {};
+    enc_buffer.resize(rsa_from_pair.output_size());
 
-    auto enc = Bytes { enc_buffer, rsa_from_pair.output_size() };
-    auto dec = Bytes { dec_buffer, rsa_from_pair.output_size() };
+    ByteBuffer dec_buffer = {};
+    dec_buffer.resize(rsa_from_pair.output_size());
+
+    auto enc = enc_buffer.bytes();
+    auto dec = dec_buffer.bytes();
 
     dec.overwrite(0, "WellHelloFriends", 16);
 
@@ -152,11 +157,14 @@ TEST_CASE(test_RSA_encrypt_decrypt)
 {
     Crypto::PK::RSA rsa(Crypto::PK::RSA::generate_key_pair(1024));
 
-    u8 enc_buffer[rsa.output_size()];
-    u8 dec_buffer[rsa.output_size()];
+    ByteBuffer enc_buffer = {};
+    enc_buffer.resize(rsa.output_size());
 
-    auto enc = Bytes { enc_buffer, rsa.output_size() };
-    auto dec = Bytes { dec_buffer, rsa.output_size() };
+    ByteBuffer dec_buffer = {};
+    dec_buffer.resize(rsa.output_size());
+
+    auto enc = enc_buffer.bytes();
+    auto dec = dec_buffer.bytes();
 
     enc.overwrite(0, "WellHelloFriendsWellHelloFriendsWellHelloFriendsWellHelloFriends", 64);
 


### PR DESCRIPTION
This pull request removes the use of variable length arrays from Tests/LibCrypto/TestRSA.cpp and enables warnings when using VLAs. 