### PR TITLE
LibWeb/CSS: Parse calc() as intermediate types instead of UnparsedCalculationNode

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Dimension.h
+++ b/Libraries/LibWeb/CSS/Parser/Dimension.h
@@ -107,6 +107,11 @@ public:
         return percentage();
     }
 
+    String to_string() const
+    {
+        return m_value.visit([](auto const& it) { return it.to_string(); });
+    }
+
 private:
     Variant<Angle, Flex, Frequency, Length, Percentage, Resolution, Time> m_value;
 };

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -15,7 +15,6 @@
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
 #include <AK/GenericLexer.h>
-#include <AK/NonnullRawPtr.h>
 #include <AK/SourceLocation.h>
 #include <AK/TemporaryChange.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
@@ -8536,39 +8535,6 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
     return OptionalNone {};
 }
 
-class UnparsedCalculationNode final : public CalculationNode {
-public:
-    static NonnullOwnPtr<UnparsedCalculationNode> create(ComponentValue component_value)
-    {
-        return adopt_own(*new (nothrow) UnparsedCalculationNode(move(component_value)));
-    }
-    virtual ~UnparsedCalculationNode() = default;
-
-    ComponentValue& component_value() { return m_component_value; }
-
-    virtual String to_string() const override { VERIFY_NOT_REACHED(); }
-    virtual Optional<CSSMathValue::ResolvedType> resolved_type() const override { VERIFY_NOT_REACHED(); }
-    virtual Optional<CSSNumericType> determine_type(Web::CSS::PropertyID) const override { VERIFY_NOT_REACHED(); }
-    virtual bool contains_percentage() const override { VERIFY_NOT_REACHED(); }
-    virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override { VERIFY_NOT_REACHED(); }
-    virtual void for_each_child_node(AK::Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override { }
-
-    virtual void dump(StringBuilder& builder, int indent) const override
-    {
-        builder.appendff("{: >{}}UNPARSED({})\n", "", indent, m_component_value.to_debug_string());
-    }
-    virtual bool equals(CalculationNode const&) const override { return false; }
-
-private:
-    UnparsedCalculationNode(ComponentValue component_value)
-        : CalculationNode(Type::Unparsed)
-        , m_component_value(move(component_value))
-    {
-    }
-
-    ComponentValue m_component_value;
-};
-
 // https://html.spec.whatwg.org/multipage/images.html#parsing-a-sizes-attribute
 LengthOrCalculated Parser::Parser::parse_as_sizes_attribute(DOM::Element const& element, HTML::HTMLImageElement const* img)
 {
@@ -8671,26 +8637,130 @@ LengthOrCalculated Parser::Parser::parse_as_sizes_attribute(DOM::Element const& 
     return Length(100, Length::Type::Vw);
 }
 
-// https://www.w3.org/TR/css-values-4/#parse-a-calculation
+OwnPtr<CalculationNode> Parser::convert_to_calculation_node(CalcParsing::Node const& node)
+{
+    return node.visit(
+        [this](NonnullOwnPtr<CalcParsing::ProductNode> const& product_node) -> OwnPtr<CalculationNode> {
+            Vector<NonnullOwnPtr<CalculationNode>> children;
+            children.ensure_capacity(product_node->children.size());
+
+            for (auto const& child : product_node->children) {
+                if (auto child_as_node = convert_to_calculation_node(child)) {
+                    children.append(child_as_node.release_nonnull());
+                } else {
+                    return nullptr;
+                }
+            }
+
+            return ProductCalculationNode::create(move(children));
+        },
+        [this](NonnullOwnPtr<CalcParsing::SumNode> const& sum_node) -> OwnPtr<CalculationNode> {
+            Vector<NonnullOwnPtr<CalculationNode>> children;
+            children.ensure_capacity(sum_node->children.size());
+
+            for (auto const& child : sum_node->children) {
+                if (auto child_as_node = convert_to_calculation_node(child)) {
+                    children.append(child_as_node.release_nonnull());
+                } else {
+                    return nullptr;
+                }
+            }
+
+            return SumCalculationNode::create(move(children));
+        },
+        [this](NonnullOwnPtr<CalcParsing::InvertNode> const& invert_node) -> OwnPtr<CalculationNode> {
+            if (auto child_as_node = convert_to_calculation_node(invert_node->child))
+                return InvertCalculationNode::create(child_as_node.release_nonnull());
+            return nullptr;
+        },
+        [this](NonnullOwnPtr<CalcParsing::NegateNode> const& negate_node) -> OwnPtr<CalculationNode> {
+            if (auto child_as_node = convert_to_calculation_node(negate_node->child))
+                return NegateCalculationNode::create(child_as_node.release_nonnull());
+            return nullptr;
+        },
+        [](Number const& number) -> OwnPtr<CalculationNode> {
+            return NumericCalculationNode::create(number);
+        },
+        [](Dimension const& dimension) -> OwnPtr<CalculationNode> {
+            if (dimension.is_angle())
+                return NumericCalculationNode::create(dimension.angle());
+            if (dimension.is_frequency())
+                return NumericCalculationNode::create(dimension.frequency());
+            if (dimension.is_length())
+                return NumericCalculationNode::create(dimension.length());
+            if (dimension.is_percentage())
+                return NumericCalculationNode::create(dimension.percentage());
+            if (dimension.is_resolution())
+                return NumericCalculationNode::create(dimension.resolution());
+            if (dimension.is_time())
+                return NumericCalculationNode::create(dimension.time());
+            if (dimension.is_flex()) {
+                // https://www.w3.org/TR/css3-grid-layout/#fr-unit
+                // NOTE: <flex> values are not <length>s (nor are they compatible with <length>s, like some <percentage> values),
+                //       so they cannot be represented in or combined with other unit types in calc() expressions.
+                // FIXME: Flex is allowed in calc(), so figure out what this spec text means and how to implement it.
+                dbgln_if(CSS_PARSER_DEBUG, "Rejecting <flex> in calc()");
+                return nullptr;
+            }
+            dbgln_if(CSS_PARSER_DEBUG, "Unrecognized dimension type in calc() expression: {}", dimension.to_string());
+            return nullptr;
+        },
+        [](CalculationNode::ConstantType const& constant_type) -> OwnPtr<CalculationNode> {
+            return ConstantCalculationNode::create(constant_type);
+        },
+        [this](NonnullRawPtr<ComponentValue const> const& component_value) -> OwnPtr<CalculationNode> {
+            // NOTE: This is the "process the leaf nodes" part of step 5 of https://drafts.csswg.org/css-values-4/#parse-a-calculation
+            //       We divert a little from the spec: Rather than modify an existing tree of values, we construct a new one from that source tree.
+            //       This lets us make CalculationNodes immutable.
+
+            // 1. If leaf is a parenthesized simple block, replace leaf with the result of parsing a calculation from leaf’s contents.
+            if (component_value->is_block() && component_value->block().is_paren()) {
+                auto leaf_calculation = parse_a_calculation(component_value->block().value);
+                if (!leaf_calculation)
+                    return nullptr;
+
+                return leaf_calculation.release_nonnull();
+            }
+
+            // 2. If leaf is a math function, replace leaf with the internal representation of that math function.
+            // NOTE: All function tokens at this point should be math functions.
+            if (component_value->is_function()) {
+                auto const& function = component_value->function();
+                auto leaf_calculation = parse_a_calc_function_node(function);
+                if (!leaf_calculation)
+                    return nullptr;
+
+                return leaf_calculation.release_nonnull();
+            }
+
+            // NOTE: If we get here, then we have a ComponentValue that didn't get replaced with something else,
+            //       so the calc() is invalid.
+            dbgln_if(CSS_PARSER_DEBUG, "Leftover ComponentValue in calc tree! That probably means the syntax is invalid, but maybe we just didn't implement `{}` yet.", component_value->to_debug_string());
+            return nullptr;
+        },
+        [](CalcParsing::Operator const& op) -> OwnPtr<CalculationNode> {
+            dbgln_if(CSS_PARSER_DEBUG, "Leftover Operator {} in calc tree!", op.delim);
+            return nullptr;
+        });
+}
+
+// https://drafts.csswg.org/css-values-4/#parse-a-calculation
 OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const& original_values)
 {
     // 1. Discard any <whitespace-token>s from values.
     // 2. An item in values is an “operator” if it’s a <delim-token> with the value "+", "-", "*", or "/". Otherwise, it’s a “value”.
-    struct Operator {
-        char delim;
-    };
-    using Value = Variant<NonnullOwnPtr<CalculationNode>, Operator>;
-    Vector<Value> values;
+
+    Vector<CalcParsing::Node> values;
     for (auto const& value : original_values) {
         if (value.is(Token::Type::Whitespace))
             continue;
         if (value.is(Token::Type::Delim)) {
             if (first_is_one_of(value.token().delim(), static_cast<u32>('+'), static_cast<u32>('-'), static_cast<u32>('*'), static_cast<u32>('/'))) {
                 // NOTE: Sequential operators are invalid syntax.
-                if (!values.is_empty() && values.last().has<Operator>())
+                if (!values.is_empty() && values.last().has<CalcParsing::Operator>())
                     return nullptr;
 
-                values.append(Operator { static_cast<char>(value.token().delim()) });
+                values.append(CalcParsing::Operator { static_cast<char>(value.token().delim()) });
                 continue;
             }
         }
@@ -8698,41 +8768,22 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
         if (value.is(Token::Type::Ident)) {
             auto maybe_constant = CalculationNode::constant_type_from_string(value.token().ident());
             if (maybe_constant.has_value()) {
-                values.append({ ConstantCalculationNode::create(maybe_constant.value()) });
+                values.append(maybe_constant.value());
                 continue;
             }
         }
 
         if (value.is(Token::Type::Number)) {
-            values.append({ NumericCalculationNode::create(value.token().number()) });
+            values.append(value.token().number());
             continue;
         }
 
         if (auto dimension = parse_dimension(value); dimension.has_value()) {
-            if (dimension->is_angle())
-                values.append({ NumericCalculationNode::create(dimension->angle()) });
-            else if (dimension->is_frequency())
-                values.append({ NumericCalculationNode::create(dimension->frequency()) });
-            else if (dimension->is_length())
-                values.append({ NumericCalculationNode::create(dimension->length()) });
-            else if (dimension->is_percentage())
-                values.append({ NumericCalculationNode::create(dimension->percentage()) });
-            else if (dimension->is_resolution())
-                values.append({ NumericCalculationNode::create(dimension->resolution()) });
-            else if (dimension->is_time())
-                values.append({ NumericCalculationNode::create(dimension->time()) });
-            else if (dimension->is_flex()) {
-                // https://www.w3.org/TR/css3-grid-layout/#fr-unit
-                // NOTE: <flex> values are not <length>s (nor are they compatible with <length>s, like some <percentage> values),
-                //       so they cannot be represented in or combined with other unit types in calc() expressions.
-                return nullptr;
-            } else {
-                VERIFY_NOT_REACHED();
-            }
+            values.append(dimension.release_value());
             continue;
         }
 
-        values.append({ UnparsedCalculationNode::create(value) });
+        values.append(NonnullRawPtr { value });
     }
 
     // If we have no values, the syntax is invalid.
@@ -8740,15 +8791,15 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
         return nullptr;
 
     // NOTE: If the first or last value is an operator, the syntax is invalid.
-    if (values.first().has<Operator>() || values.last().has<Operator>())
+    if (values.first().has<CalcParsing::Operator>() || values.last().has<CalcParsing::Operator>())
         return nullptr;
 
     // 3. Collect children into Product and Invert nodes.
     //    For every consecutive run of value items in values separated by "*" or "/" operators:
     while (true) {
         Optional<size_t> first_product_operator = values.find_first_index_if([](auto const& item) {
-            return item.template has<Operator>()
-                && first_is_one_of(item.template get<Operator>().delim, '*', '/');
+            return item.template has<CalcParsing::Operator>()
+                && first_is_one_of(item.template get<CalcParsing::Operator>().delim, '*', '/');
         });
 
         if (!first_product_operator.has_value())
@@ -8758,12 +8809,12 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
         auto end_of_run = first_product_operator.value() + 1;
         for (auto i = start_of_run + 1; i < values.size(); i += 2) {
             auto& item = values[i];
-            if (!item.has<Operator>()) {
+            if (!item.has<CalcParsing::Operator>()) {
                 end_of_run = i - 1;
                 break;
             }
 
-            auto delim = item.get<Operator>().delim;
+            auto delim = item.get<CalcParsing::Operator>().delim;
             if (!first_is_one_of(delim, '*', '/')) {
                 end_of_run = i - 1;
                 break;
@@ -8771,37 +8822,34 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
         }
 
         // 1. For each "/" operator in the run, replace its right-hand value item rhs with an Invert node containing rhs as its child.
-        Vector<NonnullOwnPtr<CalculationNode>> run_values;
-        run_values.append(move(values[start_of_run].get<NonnullOwnPtr<CalculationNode>>()));
+        Vector<CalcParsing::Node> run_values;
+        run_values.append(move(values[start_of_run]));
         for (auto i = start_of_run + 1; i <= end_of_run; i += 2) {
-            auto& operator_ = values[i].get<Operator>().delim;
+            auto& operator_ = values[i].get<CalcParsing::Operator>().delim;
             auto& rhs = values[i + 1];
             if (operator_ == '/') {
-                run_values.append(InvertCalculationNode::create(move(rhs.get<NonnullOwnPtr<CalculationNode>>())));
+                run_values.append(make<CalcParsing::InvertNode>(move(rhs)));
                 continue;
             }
             VERIFY(operator_ == '*');
-            run_values.append(move(rhs.get<NonnullOwnPtr<CalculationNode>>()));
+            run_values.append(move(rhs));
         }
         // 2. Replace the entire run with a Product node containing the value items of the run as its children.
-        auto product_node = ProductCalculationNode::create(move(run_values));
         values.remove(start_of_run, end_of_run - start_of_run + 1);
-        values.insert(start_of_run, { move(product_node) });
+        values.insert(start_of_run, make<CalcParsing::ProductNode>(move(run_values)));
     }
 
     // 4. Collect children into Sum and Negate nodes.
-    Optional<NonnullOwnPtr<CalculationNode>> single_value;
+    Optional<CalcParsing::Node> single_value;
     {
         // 1. For each "-" operator item in values, replace its right-hand value item rhs with a Negate node containing rhs as its child.
         for (auto i = 0u; i < values.size(); ++i) {
             auto& maybe_minus_operator = values[i];
-            if (!maybe_minus_operator.has<Operator>() || maybe_minus_operator.get<Operator>().delim != '-')
+            if (!maybe_minus_operator.has<CalcParsing::Operator>() || maybe_minus_operator.get<CalcParsing::Operator>().delim != '-')
                 continue;
 
             auto rhs_index = ++i;
-            auto& rhs = values[rhs_index];
-
-            NonnullOwnPtr<CalculationNode> negate_node = NegateCalculationNode::create(move(rhs.get<NonnullOwnPtr<CalculationNode>>()));
+            auto negate_node = make<CalcParsing::NegateNode>(move(values[rhs_index]));
             values.remove(rhs_index);
             values.insert(rhs_index, move(negate_node));
         }
@@ -8809,77 +8857,31 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
         // 2. If values has only one item, and it is a Product node or a parenthesized simple block, replace values with that item.
         if (values.size() == 1) {
             values.first().visit(
-                [&](ComponentValue& component_value) {
+                [&](ComponentValue const& component_value) {
                     if (component_value.is_block() && component_value.block().is_paren())
-                        single_value = UnparsedCalculationNode::create(move(component_value));
+                        single_value = NonnullRawPtr { component_value };
                 },
-                [&](NonnullOwnPtr<CalculationNode>& node) {
-                    if (node->type() == CalculationNode::Type::Product)
-                        single_value = move(node);
+                [&](NonnullOwnPtr<CalcParsing::ProductNode>& node) {
+                    single_value = move(node);
                 },
                 [](auto&) {});
         }
         //    Otherwise, replace values with a Sum node containing the value items of values as its children.
         if (!single_value.has_value()) {
-            values.remove_all_matching([](Value& value) { return value.has<Operator>(); });
-            Vector<NonnullOwnPtr<CalculationNode>> value_items;
-            value_items.ensure_capacity(values.size());
-            for (auto& value : values) {
-                if (value.has<Operator>())
-                    continue;
-                value_items.unchecked_append(move(value.get<NonnullOwnPtr<CalculationNode>>()));
-            }
-            single_value = SumCalculationNode::create(move(value_items));
+            values.remove_all_matching([](CalcParsing::Node& value) { return value.has<CalcParsing::Operator>(); });
+            single_value = make<CalcParsing::SumNode>(move(values));
         }
     }
+    VERIFY(single_value.has_value());
 
     // 5. At this point values is a tree of Sum, Product, Negate, and Invert nodes, with other types of values at the leaf nodes. Process the leaf nodes.
-    //     For every leaf node leaf in values:
-    bool parsing_failed_for_child_node = false;
-    single_value.value()->for_each_child_node([&](NonnullOwnPtr<CalculationNode>& node) {
-        if (node->type() != CalculationNode::Type::Unparsed)
-            return;
-
-        auto& unparsed_node = static_cast<UnparsedCalculationNode&>(*node);
-        auto& component_value = unparsed_node.component_value();
-
-        // 1. If leaf is a parenthesized simple block, replace leaf with the result of parsing a calculation from leaf’s contents.
-        if (component_value.is_block() && component_value.block().is_paren()) {
-            auto leaf_calculation = parse_a_calculation(component_value.block().value);
-            if (!leaf_calculation) {
-                parsing_failed_for_child_node = true;
-                return;
-            }
-            node = leaf_calculation.release_nonnull();
-            return;
-        }
-
-        // 2. If leaf is a math function, replace leaf with the internal representation of that math function.
-        // NOTE: All function tokens at this point should be math functions.
-        else if (component_value.is_function()) {
-            auto& function = component_value.function();
-            auto leaf_calculation = parse_a_calc_function_node(function);
-            if (!leaf_calculation) {
-                parsing_failed_for_child_node = true;
-                return;
-            }
-
-            node = leaf_calculation.release_nonnull();
-            return;
-        }
-
-        // NOTE: If we get here, then we have an UnparsedCalculationNode that didn't get replaced with something else.
-        //       So, the calc() is invalid.
-        dbgln_if(CSS_PARSER_DEBUG, "Leftover UnparsedCalculationNode in calc tree! That probably means the syntax is invalid, but maybe we just didn't implement `{}` yet.", component_value.to_debug_string());
-        parsing_failed_for_child_node = true;
-        return;
-    });
-
-    if (parsing_failed_for_child_node)
+    // NOTE: We process leaf nodes as part of this conversion.
+    auto calculation_tree = convert_to_calculation_node(*single_value);
+    if (!calculation_tree)
         return nullptr;
 
     // FIXME: 6. Return the result of simplifying a calculation tree from values.
-    return single_value.release_value();
+    return calculation_tree.release_nonnull();
 }
 
 bool Parser::has_ignored_vendor_prefix(StringView string)

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/NonnullRawPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Vector.h>
 #include <LibGfx/Font/UnicodeRange.h>
@@ -33,6 +34,29 @@
 namespace Web::CSS::Parser {
 
 class PropertyDependencyNode;
+
+namespace CalcParsing {
+struct Operator {
+    char delim;
+};
+struct ProductNode;
+struct SumNode;
+struct InvertNode;
+struct NegateNode;
+using Node = Variant<Operator, Number, Dimension, CalculationNode::ConstantType, NonnullOwnPtr<ProductNode>, NonnullOwnPtr<SumNode>, NonnullOwnPtr<InvertNode>, NonnullOwnPtr<NegateNode>, NonnullRawPtr<ComponentValue const>>;
+struct ProductNode {
+    Vector<Node> children;
+};
+struct SumNode {
+    Vector<Node> children;
+};
+struct InvertNode {
+    Node child;
+};
+struct NegateNode {
+    Node child;
+};
+}
 
 class Parser {
 public:
@@ -364,6 +388,7 @@ private:
     RefPtr<CSSStyleValue> parse_grid_area_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_grid_shorthand_value(TokenStream<ComponentValue>&);
 
+    OwnPtr<CalculationNode> convert_to_calculation_node(CalcParsing::Node const&);
     OwnPtr<CalculationNode> parse_a_calculation(Vector<ComponentValue> const&);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);

--- a/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.cpp
@@ -366,14 +366,6 @@ CSSMathValue::CalculationResult SumCalculationNode::resolve(Optional<Length::Res
     return total.value();
 }
 
-void SumCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    for (auto& item : m_values) {
-        item->for_each_child_node(callback);
-        callback(item);
-    }
-}
-
 void SumCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}SUM:\n", "", indent);
@@ -504,14 +496,6 @@ CSSMathValue::CalculationResult ProductCalculationNode::resolve(Optional<Length:
     return total.value();
 }
 
-void ProductCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    for (auto& item : m_values) {
-        item->for_each_child_node(callback);
-        callback(item);
-    }
-}
-
 void ProductCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}PRODUCT:\n", "", indent);
@@ -576,12 +560,6 @@ CSSMathValue::CalculationResult NegateCalculationNode::resolve(Optional<Length::
     return child_value;
 }
 
-void NegateCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
-}
-
 void NegateCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}NEGATE:\n", "", indent);
@@ -644,12 +622,6 @@ CSSMathValue::CalculationResult InvertCalculationNode::resolve(Optional<Length::
     auto child_value = m_value->resolve(context, percentage_basis);
     child_value.invert();
     return child_value;
-}
-
-void InvertCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void InvertCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -732,14 +704,6 @@ CSSMathValue::CalculationResult MinCalculationNode::resolve(Optional<Length::Res
     }
 
     return smallest_node;
-}
-
-void MinCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    for (auto& value : m_values) {
-        value->for_each_child_node(callback);
-        callback(value);
-    }
 }
 
 void MinCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -829,14 +793,6 @@ CSSMathValue::CalculationResult MaxCalculationNode::resolve(Optional<Length::Res
     }
 
     return largest_node;
-}
-
-void MaxCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    for (auto& value : m_values) {
-        value->for_each_child_node(callback);
-        callback(value);
-    }
 }
 
 void MaxCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -939,16 +895,6 @@ CSSMathValue::CalculationResult ClampCalculationNode::resolve(Optional<Length::R
     VERIFY_NOT_REACHED();
 }
 
-void ClampCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_min_value->for_each_child_node(callback);
-    m_center_value->for_each_child_node(callback);
-    m_max_value->for_each_child_node(callback);
-    callback(m_min_value);
-    callback(m_center_value);
-    callback(m_max_value);
-}
-
 void ClampCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}CLAMP:\n", "", indent);
@@ -1019,12 +965,6 @@ CSSMathValue::CalculationResult AbsCalculationNode::resolve(Optional<Length::Res
     return node_a;
 }
 
-void AbsCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
-}
-
 void AbsCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}ABS: {}\n", "", indent, to_string());
@@ -1090,12 +1030,6 @@ CSSMathValue::CalculationResult SignCalculationNode::resolve(Optional<Length::Re
         return { Number(Number::Type::Integer, 1) };
 
     return { Number(Number::Type::Integer, 0) };
-}
-
-void SignCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void SignCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1237,12 +1171,6 @@ CSSMathValue::CalculationResult SinCalculationNode::resolve(Optional<Length::Res
     return { Number(Number::Type::Number, result) };
 }
 
-void SinCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
-}
-
 void SinCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}SIN: {}\n", "", indent, to_string());
@@ -1303,12 +1231,6 @@ CSSMathValue::CalculationResult CosCalculationNode::resolve(Optional<Length::Res
     auto result = cos(node_a_value);
 
     return { Number(Number::Type::Number, result) };
-}
-
-void CosCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void CosCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1373,12 +1295,6 @@ CSSMathValue::CalculationResult TanCalculationNode::resolve(Optional<Length::Res
     return { Number(Number::Type::Number, result) };
 }
 
-void TanCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
-}
-
 void TanCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}TAN: {}\n", "", indent, to_string());
@@ -1439,12 +1355,6 @@ CSSMathValue::CalculationResult AsinCalculationNode::resolve(Optional<Length::Re
     auto result = asin(node_a_value);
 
     return { Angle(result, Angle::Type::Rad) };
-}
-
-void AsinCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void AsinCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1509,12 +1419,6 @@ CSSMathValue::CalculationResult AcosCalculationNode::resolve(Optional<Length::Re
     return { Angle(result, Angle::Type::Rad) };
 }
 
-void AcosCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
-}
-
 void AcosCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}ACOS: {}\n", "", indent, to_string());
@@ -1575,12 +1479,6 @@ CSSMathValue::CalculationResult AtanCalculationNode::resolve(Optional<Length::Re
     auto result = atan(node_a_value);
 
     return { Angle(result, Angle::Type::Rad) };
-}
-
-void AtanCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void AtanCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1652,14 +1550,6 @@ CSSMathValue::CalculationResult Atan2CalculationNode::resolve(Optional<Length::R
     return { Angle(result, Angle::Type::Rad) };
 }
 
-void Atan2CalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_y->for_each_child_node(callback);
-    m_x->for_each_child_node(callback);
-    callback(m_y);
-    callback(m_x);
-}
-
 void Atan2CalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}ATAN2: {}\n", "", indent, to_string());
@@ -1725,14 +1615,6 @@ CSSMathValue::CalculationResult PowCalculationNode::resolve(Optional<Length::Res
     return { Number(Number::Type::Number, result) };
 }
 
-void PowCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_x->for_each_child_node(callback);
-    m_y->for_each_child_node(callback);
-    callback(m_x);
-    callback(m_y);
-}
-
 void PowCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}POW: {}\n", "", indent, to_string());
@@ -1789,12 +1671,6 @@ CSSMathValue::CalculationResult SqrtCalculationNode::resolve(Optional<Length::Re
     auto result = sqrt(node_a_value);
 
     return { Number(Number::Type::Number, result) };
-}
-
-void SqrtCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void SqrtCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -1876,14 +1752,6 @@ CSSMathValue::CalculationResult HypotCalculationNode::resolve(Optional<Length::R
     return to_resolved_type(resolved_type().value(), result);
 }
 
-void HypotCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    for (auto& value : m_values) {
-        value->for_each_child_node(callback);
-        callback(value);
-    }
-}
-
 void HypotCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}HYPOT:\n", "", indent);
@@ -1954,14 +1822,6 @@ CSSMathValue::CalculationResult LogCalculationNode::resolve(Optional<Length::Res
     return { Number(Number::Type::Number, result) };
 }
 
-void LogCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_x->for_each_child_node(callback);
-    m_y->for_each_child_node(callback);
-    callback(m_x);
-    callback(m_y);
-}
-
 void LogCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}LOG: {}\n", "", indent, to_string());
@@ -2018,12 +1878,6 @@ CSSMathValue::CalculationResult ExpCalculationNode::resolve(Optional<Length::Res
     auto result = exp(node_a_value);
 
     return { Number(Number::Type::Number, result) };
-}
-
-void ExpCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_value->for_each_child_node(callback);
-    callback(m_value);
 }
 
 void ExpCalculationNode::dump(StringBuilder& builder, int indent) const
@@ -2130,14 +1984,6 @@ CSSMathValue::CalculationResult RoundCalculationNode::resolve(Optional<Length::R
     VERIFY_NOT_REACHED();
 }
 
-void RoundCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_x->for_each_child_node(callback);
-    m_y->for_each_child_node(callback);
-    callback(m_x);
-    callback(m_y);
-}
-
 void RoundCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}ROUND: {}\n", "", indent, to_string());
@@ -2217,14 +2063,6 @@ CSSMathValue::CalculationResult ModCalculationNode::resolve(Optional<Length::Res
     return to_resolved_type(resolved_type, value);
 }
 
-void ModCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_x->for_each_child_node(callback);
-    m_y->for_each_child_node(callback);
-    callback(m_x);
-    callback(m_y);
-}
-
 void ModCalculationNode::dump(StringBuilder& builder, int indent) const
 {
     builder.appendff("{: >{}}MOD: {}\n", "", indent, to_string());
@@ -2300,14 +2138,6 @@ CSSMathValue::CalculationResult RemCalculationNode::resolve(Optional<Length::Res
 
     auto value = fmod(node_a_value, node_b_value);
     return to_resolved_type(resolved_type, value);
-}
-
-void RemCalculationNode::for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const& callback)
-{
-    m_x->for_each_child_node(callback);
-    m_y->for_each_child_node(callback);
-    callback(m_x);
-    callback(m_y);
 }
 
 void RemCalculationNode::dump(StringBuilder& builder, int indent) const

--- a/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSMathValue.h
@@ -264,7 +264,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const = 0;
     virtual bool contains_percentage() const = 0;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const = 0;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) = 0;
 
     virtual void dump(StringBuilder&, int indent) const = 0;
     virtual bool equals(CalculationNode const&) const = 0;
@@ -286,7 +285,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override { }
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -306,7 +304,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -326,7 +323,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -346,7 +342,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -366,7 +361,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -386,7 +380,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -406,7 +399,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -426,7 +418,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -448,7 +439,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -468,7 +458,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -488,7 +477,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&> context, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override { }
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -508,7 +496,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -528,7 +515,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -548,7 +534,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -568,7 +553,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -588,7 +572,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -608,7 +591,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -628,7 +610,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -649,7 +630,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -670,7 +650,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -690,7 +669,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -710,7 +688,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -731,7 +708,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override { return false; }
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -751,7 +727,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -773,7 +748,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;
@@ -794,7 +768,6 @@ public:
     virtual Optional<CSSNumericType> determine_type(PropertyID) const override;
     virtual bool contains_percentage() const override;
     virtual CSSMathValue::CalculationResult resolve(Optional<Length::ResolutionContext const&>, CSSMathValue::PercentageBasis const&) const override;
-    virtual void for_each_child_node(Function<void(NonnullOwnPtr<CalculationNode>&)> const&) override;
 
     virtual void dump(StringBuilder&, int indent) const override;
     virtual bool equals(CalculationNode const&) const override;


### PR DESCRIPTION
Previously we created a tree of CalculationNodes with dummy
UnparsedCalculationNode children, and then swapped those with the real
children. This matched the spec closely but had the unfortunate
downside that CalculationNodes couldn't be immutable, and couldn't know
their properties at construct-time. UnparsedCalculationNode is also a
footgun, as if it gets left in the tree accidentally we would VERIFY().

So instead, let's parse the calc() tree into an intermediate format, and
then convert each node in that tree, depth-first, into its
corresponding CalculationNode. This means each CalculationNode knows
what its children are when it is constructed, and they never change.

Apart from deleting UnparsedCalculationNode, we can also get rid of the
for_each_child_node() method that was only used by this "replace the
children" code.