### PR TITLE
UI/Headless: Clear pending data when a test completes

### DIFF
--- a/UI/Headless/HeadlessWebView.cpp
+++ b/UI/Headless/HeadlessWebView.cpp
@@ -184,6 +184,10 @@ void HeadlessWebView::did_receive_screenshot(Badge<WebView::WebContentClient>, G
 
 void HeadlessWebView::on_test_complete(TestCompletion completion)
 {
+    m_pending_screenshot.clear();
+    m_pending_dialog = Web::Page::PendingDialog::None;
+    m_pending_prompt_text.clear();
+
     m_test_promise->resolve(move(completion));
 }
 


### PR DESCRIPTION
Without this, a crashing ref test is able to take down the entire process because of the `VERIFY(!m_pending_screenshot);` in `take_screenshot()`. The dialog/prompt fields were not causing crashes but clearing them feels more hygienic.