### PR TITLE
LibWeb/CSS: Add valid default font if no font can be found

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -36,6 +36,7 @@
 #include <LibWeb/CSS/CSSNestedDeclarations.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSTransition.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Interpolation.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/SelectorEngine.h>
@@ -2016,8 +2017,8 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
         font_list->add(*emoji_font);
     }
 
-    auto found_font = ComputedProperties::font_fallback(monospace, bold);
-    font_list->set_last_resort_font(found_font->with_size(font_size_in_pt));
+    auto last_resort_font = ComputedProperties::font_fallback(monospace, bold);
+    font_list->set_last_resort_font(last_resort_font->with_size(font_size_in_pt));
 
     return font_list;
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2006,6 +2006,12 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
             font_list->extend(*other_font_list);
     }
 
+    auto fallback_font = Platform::FontPlugin::the().default_font().with_size(font_size_in_pt);
+    if (font_list->is_empty()) {
+        // FIXME: Opinion: Platform::FontPlugin::the().default_font() (now: 'sans') should match the 'html' (top) style in Default.css ('serif')
+        font_list->add(*fallback_font);
+    }
+
     if (auto emoji_font = Platform::FontPlugin::the().default_emoji_font(font_size_in_pt); emoji_font) {
         font_list->add(*emoji_font);
     }

--- a/Tests/LibWeb/Layout/expected/invalid-font-name.txt
+++ b/Tests/LibWeb/Layout/expected/invalid-font-name.txt
@@ -1,0 +1,12 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 19, rect: [8,8 142.140625x17] baseline: 13.296875
+          "Well hello friends!"
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      TextPaintable (TextNode<#text>)
+

--- a/Tests/LibWeb/Layout/input/invalid-font-name.html
+++ b/Tests/LibWeb/Layout/input/invalid-font-name.html
@@ -1,0 +1,13 @@
+<style>
+html { font-family: lololol; }
+</style>
+<!--
+    This should just show in one full fragment in a TextNode.
+    Before, when the font 'lololol' was not found, the default emoji font was picked for rendering.
+    The text was split into five separate fragments.
+
+    NOTE:
+     - this may fail CI on Apple (the default font metrics may be different).
+     - the layout metrics reported by `headless-browser -R` vs. `headless-browser -d` are different.
+-->
+Well hello friends!


### PR DESCRIPTION
Fixes #2787 

- Before: If a font cannot be computed based on style values, e.g. if the family is incorrect (try 'lolol'), then the list of found fonts contains only the default emoji font. Text styled with an invalid font is rendered using the metrics of the emoji font (weird spacing).
- After:  The default font of the Font plugin is added to the top of an empty list of computed fonts, before the emoji font. This way, we're failing gracefully on author error, and we still display emojis :]m
