### PR TITLE
LibGfx+IPCCompiler: Treat PNG files with invalid frame data as transparent

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -512,8 +512,7 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
         auto result = m_connection.template send_sync_but_allow_failure<Messages::@endpoint.name@::@message.pascal_name@>()~~~");
         } else {
             message_generator.append(R"~~~(
-        // FIXME: Handle post_message failures.
-        (void) m_connection.post_message(Messages::@endpoint.name@::@message.pascal_name@ { )~~~");
+        MUST(m_connection.post_message(Messages::@endpoint.name@::@message.pascal_name@ { )~~~");
         }
 
         for (size_t i = 0; i < parameters.size(); ++i) {
@@ -555,7 +554,7 @@ void do_message_for_proxy(SourceGenerator message_generator, Endpoint const& end
         return { };)~~~");
             }
         } else {
-            message_generator.appendln(" });");
+            message_generator.appendln(" }));");
         }
 
         message_generator.appendln(R"~~~(

--- a/Tests/LibWeb/Text/expected/HTML/png-without-IDAT-should-still-load.txt
+++ b/Tests/LibWeb/Text/expected/HTML/png-without-IDAT-should-still-load.txt
@@ -1,0 +1,1 @@
+loaded, width=62, height=97

--- a/Tests/LibWeb/Text/input/HTML/png-without-IDAT-should-still-load.html
+++ b/Tests/LibWeb/Text/input/HTML/png-without-IDAT-should-still-load.html
@@ -1,0 +1,16 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const image = document.createElement("img");
+        image.onload = () => {
+            println(`loaded, width=${image.width}, height=${image.height}`);
+            done();
+        };
+        image.onerror = () => {
+            println("error :^(");
+            done();
+        };
+
+        image.src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAD4AAABhCAIAAAABe4UxAAAABElEQVQAAAABnSTXkQAAAABJRU5ErkJggg==";
+    });
+</script>


### PR DESCRIPTION
This matches the behavior of other browsers, and is something that Cloudflare Turnstile checks for.

Also stop silently ignoring un-encodable IPC messages. I spent a lot of time being confused by this 😅 