### PR TITLE
WebContent+LibWeb: Add an option to disable painting viewport scrollbars

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -31,6 +31,8 @@
 
 namespace Web::Painting {
 
+bool g_paint_viewport_scrollbars = true;
+
 GC::Ref<PaintableWithLines> PaintableWithLines::create(Layout::BlockContainer const& block_container)
 {
     return block_container.heap().allocate<PaintableWithLines>(block_container);
@@ -381,13 +383,15 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         }
     }
 
-    auto scrollbar_width = computed_values().scrollbar_width();
-    if (phase == PaintPhase::Overlay && scrollbar_width != CSS::ScrollbarWidth::None) {
-        if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Vertical); scrollbar_data.has_value()) {
-            context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(), scrollbar_data->scroll_length, true);
-        }
-        if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Horizontal); scrollbar_data.has_value()) {
-            context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(), scrollbar_data->scroll_length, false);
+    if (g_paint_viewport_scrollbars || !is_viewport()) {
+        auto scrollbar_width = computed_values().scrollbar_width();
+        if (phase == PaintPhase::Overlay && scrollbar_width != CSS::ScrollbarWidth::None) {
+            if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Vertical); scrollbar_data.has_value()) {
+                context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(), scrollbar_data->scroll_length, true);
+            }
+            if (auto scrollbar_data = compute_scrollbar_data(ScrollDirection::Horizontal); scrollbar_data.has_value()) {
+                context.display_list_recorder().paint_scrollbar(own_scroll_frame_id().value(), context.rounded_device_rect(scrollbar_data->thumb_rect).to_type<int>(), scrollbar_data->scroll_length, false);
+            }
         }
     }
 

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -21,6 +21,8 @@
 
 namespace Web::Painting {
 
+extern bool g_paint_viewport_scrollbars;
+
 class PaintableBox : public Paintable
     , public ClippableAndScrollable {
     GC_CELL(PaintableBox, Paintable);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -83,6 +83,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     bool force_cpu_painting = false;
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
+    bool disable_scrollbar_painting = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("The Ladybird web browser :^)");
@@ -104,6 +105,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation", 'g');
+    args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical scrollbars on the main viewport", "disable-scrollbar-painting");
     args_parser.add_option(dns_server_address, "Set the DNS server address", "dns-server", 0, "host|address");
     args_parser.add_option(dns_server_port, "Set the DNS server port", "dns-port", 0, "port (default: 53 or 853 if --dot)");
     args_parser.add_option(use_dns_over_tls, "Use DNS over TLS", "dot");
@@ -171,6 +173,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
         .force_fontconfig = force_fontconfig ? ForceFontconfig::Yes : ForceFontconfig::No,
         .enable_autoplay = enable_autoplay ? EnableAutoplay::Yes : EnableAutoplay::No,
         .collect_garbage_on_every_allocation = collect_garbage_on_every_allocation ? CollectGarbageOnEveryAllocation::Yes : CollectGarbageOnEveryAllocation::No,
+        .paint_viewport_scrollbars = disable_scrollbar_painting ? PaintViewportScrollbars::No : PaintViewportScrollbars::Yes,
     };
 
     create_platform_options(m_chrome_options, m_web_content_options);

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -110,6 +110,8 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
         arguments.append("--collect-garbage-on-every-allocation"sv);
     if (web_content_options.is_headless == WebView::IsHeadless::Yes)
         arguments.append("--headless"sv);
+    if (web_content_options.paint_viewport_scrollbars == PaintViewportScrollbars::No)
+        arguments.append("--disable-scrollbar-painting"sv);
 
     if (auto const maybe_echo_server_port = web_content_options.echo_server_port; maybe_echo_server_port.has_value()) {
         arguments.append("--echo-server-port"sv);

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -118,6 +118,11 @@ enum class IsHeadless {
     Yes,
 };
 
+enum class PaintViewportScrollbars {
+    Yes,
+    No,
+};
+
 struct WebContentOptions {
     String command_line;
     String executable_path;
@@ -134,6 +139,7 @@ struct WebContentOptions {
     CollectGarbageOnEveryAllocation collect_garbage_on_every_allocation { CollectGarbageOnEveryAllocation::No };
     Optional<u16> echo_server_port {};
     IsHeadless is_headless { IsHeadless::No };
+    PaintViewportScrollbars paint_viewport_scrollbars { PaintViewportScrollbars::Yes };
 };
 
 }

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -24,6 +24,7 @@
 #include <LibWeb/Loader/ContentFilter.h>
 #include <LibWeb/Loader/GeneratedPagesLoader.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+#include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/PermissionsPolicy/AutoplayAllowlist.h>
 #include <LibWeb/Platform/AudioCodecPluginAgnostic.h>
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
@@ -105,6 +106,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool force_fontconfig = false;
     bool collect_garbage_on_every_allocation = false;
     bool is_headless = false;
+    bool disable_scrollbar_painting = false;
     StringView echo_server_port_string_view {};
 
     Core::ArgsParser args_parser;
@@ -124,6 +126,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
     args_parser.add_option(force_fontconfig, "Force using fontconfig for font loading", "force-fontconfig");
     args_parser.add_option(collect_garbage_on_every_allocation, "Collect garbage after every JS heap allocation", "collect-garbage-on-every-allocation");
+    args_parser.add_option(disable_scrollbar_painting, "Don't paint horizontal or vertical viewport scrollbars", "disable-scrollbar-painting");
     args_parser.add_option(echo_server_port_string_view, "Echo server port used in test internals", "echo-server-port", 0, "echo_server_port");
     args_parser.add_option(is_headless, "Report that the browser is running in headless mode", "headless");
 
@@ -156,6 +159,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (enable_http_cache) {
         Web::Fetch::Fetching::g_http_cache_enabled = true;
     }
+
+    Web::Painting::g_paint_viewport_scrollbars = !disable_scrollbar_painting;
 
     if (!echo_server_port_string_view.is_empty()) {
         if (auto maybe_echo_server_port = echo_server_port_string_view.to_number<u16>(); maybe_echo_server_port.has_value())

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -49,6 +49,7 @@ static Vector<ByteString> create_arguments(ByteString const& socket_path, bool f
     arguments.append("--allow-popups"sv);
     arguments.append("--force-new-process"sv);
     arguments.append("--enable-autoplay"sv);
+    arguments.append("--disable-scrollbar-painting"sv);
     if (force_cpu_painting)
         arguments.append("--force-cpu-painting"sv);
 


### PR DESCRIPTION
This PR adds a `--disable-scrollbar-painting` option, which stops the scrollbars of viewport paintables from being painted. This option is then used by WebDriver when launching the browser.

This gives us 115 additional WPT passes.