### PR TITLE
LibWeb: Ignore: “orphaned” ARIA roles, landmark roles which lack required names, role=none for focusable or has-global-ARIA-attribute elements

### DIFF
--- a/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/ARIA/ARIAMixin.h>
 #include <LibWeb/ARIA/Roles.h>
+#include <LibWeb/DOM/Element.h>
 #include <LibWeb/Infra/CharacterTypes.h>
 
 namespace Web::ARIA {

--- a/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -25,7 +25,6 @@ Optional<Role> ARIAMixin::role_from_role_attribute_value() const
 
     // 3. Compare the substrings to all the names of the non-abstract WAI-ARIA roles. Case-sensitivity of the comparison inherits from the case-sensitivity of the host language.
     for (auto const& role_name : role_list) {
-        // 4. Use the first such substring in textual order that matches the name of a non-abstract WAI-ARIA role.
         auto role = role_from_string(role_name);
         if (!role.has_value())
             continue;
@@ -43,6 +42,95 @@ Optional<Role> ARIAMixin::role_from_role_attribute_value() const
         // "synonym presentation role == computedrole none" test that expects "none", not "presentation".
         if (role == Role::presentation)
             return Role::none;
+        // https://w3c.github.io/core-aam/#roleMappingComputedRole
+        // When an element has a role but is not contained in the required context (for example, an orphaned listitem
+        // without the required accessible parent of role list), User Agents MUST ignore the role token, and return the
+        // computedrole as if the ignored role token had not been included.
+        if (role == ARIA::Role::columnheader) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->role_or_default() == ARIA::Role::row)
+                    return ARIA::Role::columnheader;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::gridcell) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->role_or_default() == ARIA::Role::row)
+                    return ARIA::Role::gridcell;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::listitem) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::directory, ARIA::Role::list))
+                    return ARIA::Role::listitem;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::menuitem) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::menu, ARIA::Role::menubar))
+                    return ARIA::Role::menuitem;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::menuitemcheckbox) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::menu, ARIA::Role::menubar))
+                    return ARIA::Role::menuitemcheckbox;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::menuitemradio) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::menu, ARIA::Role::menubar))
+                    return ARIA::Role::menuitemradio;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::option) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->role_or_default() == ARIA::Role::listbox)
+                    return ARIA::Role::option;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::row) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::table, ARIA::Role::grid, ARIA::Role::treegrid))
+                    return ARIA::Role::row;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::rowgroup) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (first_is_one_of(ancestor->role_or_default(), ARIA::Role::table, ARIA::Role::grid, ARIA::Role::treegrid))
+                    return ARIA::Role::rowgroup;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::rowheader) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->role_or_default() == ARIA::Role::row)
+                    return ARIA::Role::rowheader;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::tab) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->role_or_default() == ARIA::Role::tablist)
+                    return ARIA::Role::tab;
+            }
+            continue;
+        }
+        if (role == ARIA::Role::treeitem) {
+            for (auto const* ancestor = to_element()->parent_element(); ancestor; ancestor = ancestor->parent_element()) {
+                if (ancestor->role_or_default() == ARIA::Role::tree)
+                    return ARIA::Role::treeitem;
+            }
+            continue;
+        }
+        // 4. Use the first such substring in textual order that matches the name of a non-abstract WAI-ARIA role.
         if (!is_abstract_role(*role))
             return *role;
     }

--- a/Libraries/LibWeb/ARIA/ARIAMixin.cpp
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.cpp
@@ -130,6 +130,14 @@ Optional<Role> ARIAMixin::role_from_role_attribute_value() const
             }
             continue;
         }
+        // https://w3c.github.io/aria/#document-handling_author-errors_roles
+        // Certain landmark roles require names from authors. In situations where an author has not specified names for
+        // these landmarks, it is considered an authoring error. The user agent MUST treat such elements as if no role
+        // had been provided. If a valid fallback role had been specified, or if the element had an implicit ARIA role,
+        // then user agents would continue to expose that role, instead.
+        if ((role == ARIA::Role::form || role == ARIA::Role::region)
+            && to_element()->accessible_name(to_element()->document(), DOM::ShouldComputeRole::No).value().is_empty())
+            continue;
         // 4. Use the first such substring in textual order that matches the name of a non-abstract WAI-ARIA role.
         if (!is_abstract_role(*role))
             return *role;

--- a/Libraries/LibWeb/ARIA/ARIAMixin.h
+++ b/Libraries/LibWeb/ARIA/ARIAMixin.h
@@ -28,6 +28,8 @@ public:
     // https://www.w3.org/TR/html-aria/#docconformance
     virtual Optional<Role> default_role() const { return {}; }
 
+    virtual DOM::Element const* to_element() const { return {}; }
+
     Optional<Role> role_from_role_attribute_value() const;
     Optional<Role> role_or_default() const;
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -293,6 +293,8 @@ public:
 
     virtual bool include_in_accessibility_tree() const override;
 
+    virtual Element const* to_element() const override { return this; }
+
     bool is_hidden() const;
     bool has_hidden_ancestor() const;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2283,7 +2283,7 @@ void Node::build_accessibility_tree(AccessibilityTreeNode& parent)
 }
 
 // https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_te
-ErrorOr<String> Node::name_or_description(NameOrDescription target, Document const& document, HashTable<UniqueNodeID>& visited_nodes, IsDescendant is_descendant) const
+ErrorOr<String> Node::name_or_description(NameOrDescription target, Document const& document, HashTable<UniqueNodeID>& visited_nodes, IsDescendant is_descendant, ShouldComputeRole should_compute_role) const
 {
     // The text alternative for a given element is computed as follows:
     // 1. Set the root node to the given element, the current node to the root node, and the total accumulated text to the
@@ -2295,7 +2295,15 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
 
     if (is_element()) {
         auto const* element = static_cast<DOM::Element const*>(this);
-        auto role = element->role_from_role_attribute_value();
+        Optional<ARIA::Role> role = OptionalNone {};
+        // Per https://w3c.github.io/aria/#document-handling_author-errors_roles, determining whether to ignore certain
+        // specified landmark roles requires first determining, in the ARIAMixin code, whether the element for which the
+        // role is specified has an accessible name — that is, calling into this name_or_description code. But if we
+        // then try to retrieve a role for such elements here, that’d then end up calling right back into this
+        // name_or_description code — which would cause the calls to loop infinitely. So to avoid that, the caller
+        // in the ARIAMixin code can pass the shouldComputeRole parameter to indicate we must skip the role lookup.
+        if (should_compute_role == ShouldComputeRole::Yes)
+            role = element->role_from_role_attribute_value();
         // Per https://w3c.github.io/html-aam/#el-aside and https://w3c.github.io/html-aam/#el-section, computing a
         // default role for an aside element or section element requires first computing its accessible name — that is,
         // calling into this name_or_description code. But if we then try to determine a default role for the aside
@@ -2614,7 +2622,7 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
                 current_node = child_node;
 
                 // b. Compute the text alternative of the current node beginning with step 2. Set the result to that text alternative.
-                auto result = MUST(current_node->name_or_description(target, document, visited_nodes, IsDescendant::Yes));
+                auto result = MUST(current_node->name_or_description(target, document, visited_nodes, IsDescendant::Yes, should_compute_role));
 
                 // J. Append a space character and the result of each step above to the total accumulated text.
                 // AD-HOC: Doing the space-adding here is in a different order from what the spec states.
@@ -2684,11 +2692,11 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
 }
 
 // https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_name
-ErrorOr<String> Node::accessible_name(Document const& document) const
+ErrorOr<String> Node::accessible_name(Document const& document, ShouldComputeRole should_compute_role) const
 {
     HashTable<UniqueNodeID> visited_nodes;
     // User agents MUST compute an accessible name using the rules outlined below in the section titled Accessible Name and Description Computation.
-    return name_or_description(NameOrDescription::Name, document, visited_nodes);
+    return name_or_description(NameOrDescription::Name, document, visited_nodes, IsDescendant::No, should_compute_role);
 }
 
 // https://www.w3.org/TR/accname-1.2/#mapping_additional_nd_description

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -58,6 +58,11 @@ enum class IsDescendant {
     Yes,
 };
 
+enum class ShouldComputeRole {
+    No,
+    Yes,
+};
+
 #define ENUMERATE_STYLE_INVALIDATION_REASONS(X)     \
     X(ActiveElementChange)                          \
     X(AdoptedStyleSheetsList)                       \
@@ -726,7 +731,7 @@ public:
         return false;
     }
 
-    ErrorOr<String> accessible_name(Document const&) const;
+    ErrorOr<String> accessible_name(Document const&, ShouldComputeRole = ShouldComputeRole::Yes) const;
     ErrorOr<String> accessible_description(Document const&) const;
 
     Optional<String> locate_a_namespace(Optional<String> const& prefix) const;
@@ -756,7 +761,7 @@ protected:
 
     void build_accessibility_tree(AccessibilityTreeNode& parent);
 
-    ErrorOr<String> name_or_description(NameOrDescription, Document const&, HashTable<UniqueNodeID>&, IsDescendant = IsDescendant::No) const;
+    ErrorOr<String> name_or_description(NameOrDescription, Document const&, HashTable<UniqueNodeID>&, IsDescendant = IsDescendant::No, ShouldComputeRole = ShouldComputeRole::Yes) const;
 
 private:
     void queue_tree_mutation_record(Vector<GC::Root<Node>> added_nodes, Vector<GC::Root<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling);

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -92,7 +92,7 @@ void HTMLElement::set_dir(String const& dir)
 
 bool HTMLElement::is_focusable() const
 {
-    return is_editing_host();
+    return is_editing_host() || get_attribute(HTML::AttributeNames::tabindex).has_value();
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#dom-iscontenteditable

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/fallback-roles.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/fallback-roles.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 12 tests
+
+12 Pass
+Pass	fallback role w/ region with no label
+Pass	fallback role w/ region with label
+Pass	aria 1.1 switch role w/ fallback to aria 1.0 checkbox role
+Pass	div[role=button] ignoring invalid foo role token
+Pass	unknown[role=button] ignoring invalid foo role token
+Pass	button ignoring single invalid role token
+Pass	button ignoring multiple invalid role tokens
+Pass	div[role=button] ignoring invalid foo role token including punctuation-contaminated known link role
+Pass	div[role=button] ignoring invalid unicode diacritics etc on link and group role tokens
+Pass	div[role=button] ignoring tab char
+Pass	div[role=button] ignoring line break
+Pass	div[role=button] ignoring braille whitespace char

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/form-roles.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/form-roles.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	form without label
+Pass	form with label

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/grid-roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/grid-roles.tentative.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	orphaned button with gridcell role outside the context of row
+Pass	orphaned row outside the context of table
+Pass	orphaned rowgroup outside the context of row
+Pass	orphaned div with gridcell role outside the context of row
+Pass	orphaned rowheader outside the context of row
+Pass	orphaned columnheader outside the context of row

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/list-roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/list-roles.tentative.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	orphan p with listitem role
+Pass	orphan div with listitem role

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/listbox-roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/listbox-roles.tentative.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	orphaned option outside the context of listbox

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/menu-roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/menu-roles.tentative.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Pass
+Pass	orphaned menuitem outside the context of menu/menubar
+Pass	orphaned menuitemradio outside the context of menu/menubar
+Pass	orphaned menuitemcheckbox outside the context of menu/menubar
+Pass	orphan button with menuitem role
+Pass	orphan button with menuitemcheckbox role
+Pass	orphan button with menuitemradio role
+Pass	orphan div with menuitem role
+Pass	orphan div with menuitemcheckbox role
+Pass	orphan div with menuitemradio role

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/region-roles.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/region-roles.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	region without label
+Pass	region with label

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/role_none_conflict_resolution.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/role_none_conflict_resolution.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 7 tests
+
+7 Pass
+Pass	heading role none with global attr aria-label
+Pass	p role none with global attr aria-label (prohibited role)
+Pass	focusable heading role none with tabindex=0
+Pass	focusable heading role none with tabindex=-1
+Pass	p role none without global attr aria-label (prohibited role)
+Pass	non-focusable heading role none
+Pass	none with non-global

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/tab-roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/tab-roles.tentative.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	orphan button with tab role
+Pass	orphan span with tab role

--- a/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/tree-roles.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/wai-aria/role/tree-roles.tentative.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	orphaned treeitem outside the context of tree
+Pass	orphaned button with treeitem role outside tree context

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/fallback-roles.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/fallback-roles.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Fallback Role Verification Tests</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/testdriver.js"></script>
+    <script src="../../resources/testdriver-vendor.js"></script>
+    <script src="../../resources/testdriver-actions.js"></script>
+    <script src="../../wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+
+  <p>Tests <a href="https://w3c.github.io/aria/#host_general_role">8.1 Role Attribute</a> role token list selection and <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a>.</p>
+
+  <!-- known el and two known ARIA 1.0 roles -->
+  <nav role="region group" data-testname="fallback role w/ region with no label" data-expectedrole="group" class="ex">x</nav>
+  <nav role="region group" data-testname="fallback role w/ region with label" aria-label="x" data-expectedrole="region" class="ex">x</nav>
+
+  <!-- known el and known ARIA 1.1 with 1.0 role backup -->
+  <div role="switch checkbox" aria-checked="true" data-testname="aria 1.1 switch role w/ fallback to aria 1.0 checkbox role" aria-label="x" data-expectedrole="switch" class="ex">x</div>
+
+  <!-- known el and invalid role token with valid backup -->
+  <div role="foo button" data-testname="div[role=button] ignoring invalid foo role token" aria-label="x" data-expectedrole="button" class="ex">x</div>
+
+  <!-- unknown el and invalid role token with valid backup -->
+  <unknown role="foo button" data-testname="unknown[role=button] ignoring invalid foo role token" aria-label="x" data-expectedrole="button" class="ex">x</unknown>
+
+  <!-- known el and invalid role(s) -->
+  <button role="foo" data-testname="button ignoring single invalid role token" aria-label="x" data-expectedrole="button" class="ex">x</unknown>
+  <button role="foo bar" data-testname="button ignoring multiple invalid role tokens" aria-label="x" data-expectedrole="button" class="ex">x</unknown>
+
+  <!-- known el with invalid punctuation -->
+  <div role="invalid, punctuation, tests, link, button" data-testname="div[role=button] ignoring invalid foo role token including punctuation-contaminated known link role" aria-label="x" data-expectedrole="button" class="ex">x</div>
+
+
+
+  <!-- extra line breaks here to account for rendering of unicode diacritic etc char glitch tests -->
+
+
+
+  <div role="l̷̨̢̡̖̻̗̤̺̟̱͚͔͇͍͇̫̫̜͔̗̟̘̫̟̰̼̘͗̌̃͐̔̈́̚͝į̵̡̲̯̠̮͈͖̥̮̲͓̦̗̗̱̞͍̗̪͙͇͚͂̍͐̔̍͌̐̇̏̎͘͝ǹ̶̨̧̢̜̲̫͇̮͉̬͎͎͕̝̱͔̙̱̦̰̦̠̰̣̝͂̓̋̊͜ķ̷̧̧̨̨̨̘̳͕̰͎̮̠̘̪͇͕̥̭̼̼̜̤̫̥̼̤̰̦͖̪̀͒̆͑̒̅͑̓̒͂̽̈́̽̉̀̕͘͜͝ ̷̡̮̦̘͓̫̜͕͖̰̙̘͓̼͎̳̹͇̮͐͂́͛̃́̊̈͌̄̓̌̂̈̇̀̌̈́́̀̈́̍̈́̇̄̊̔͒̾̾̇́͒̽͂̾̕̚͜͜͝͠ͅͅg̸̨̧̧̧̧̛̺̦̣͇͈͙͇͎͕̠̞̳̹̣͋͑̑̓͛̓̉̔̉͑̇́̈́̉̃́̑̍̂̒͐͛͗̑̏̓̾͌̈̅́̇̕̕̚̚͝͝ͅr̶̛̤̲̘̮̟̭̲̋̾̀́́̒̀̀͑̎̀̌̈̀̍̂̏̊̎͐͒͗͗̀͘͘͘͠͠ȍ̴̧̡̢̡̢̞̝̠̙̬̗͍͍͉̺͔͙̫̝̰̮̜̩̙̳͉̻̻̼͍̊͋͐̐͆̈̿̒̊̄͑̈́̔͋̔̃͐̓̓͛́͊̉͑̊̔͆͘͘͜͠ͅu̴̱̯̞̞̞̺̼̳̳͚̞̇̈͒͠p̶̛͉̮̙̯̮̱͉̖͚͉̩̱̺̩̦̺͈̫͍͔̲̣̗̟̜̂̐̌̏͌̈́͗̾͌̿̓͒̋̆͆̾͛̐̈́̓͋̀͘̚͝͝͝ ̶͔͚̩̬͈̍̈́͗͐̀̊̏͛̃̈́͋̅͝  button" data-testname="div[role=button] ignoring invalid unicode diacritics etc on link and group role tokens" aria-label="x" data-expectedrole="button" class="ex">x</div>
+
+
+  <!-- known el and known role with whitespace edge cases -->
+  <div role=" button" data-testname="div[role=button] ignoring tab char" aria-label="x" data-expectedrole="button" class="ex">x</div>
+  <div role="
+button" data-testname="div[role=button] ignoring line break" aria-label="x" data-expectedrole="button" class="ex">x</div>
+  <div role="⠀ button" data-testname="div[role=button] ignoring braille whitespace char" aria-label="x" data-expectedrole="button" class="ex">x</div>
+
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/form-roles.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/form-roles.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+  <title>Form Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Verifies <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a> and the <a href="https://w3c.github.io/aria/#form">form</a> role.</p>
+
+
+<!-- no label -->
+<nav role="form" data-testname="form without label" data-expectedrole="navigation" class="ex">x</nav>
+
+<!-- w/ label -->
+<nav role="form" data-testname="form with label" data-expectedrole="form" aria-label="x" class="ex">x</nav>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/grid-roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/grid-roles.tentative.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Tentative: Grid Role Verification Tests</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/testdriver.js"></script>
+    <script src="../../resources/testdriver-vendor.js"></script>
+    <script src="../../resources/testdriver-actions.js"></script>
+    <script src="../../wai-aria/scripts/aria-utils.js"></script>
+  </head>
+  <body>
+
+  <!--
+    CORE-AAM requires that, for elements with roles not contained in the
+    required context, user agents must ignore the role token and return the
+    computed role as if the ignored role token had not been included.
+    See https://w3c.github.io/core-aam/#roleMappingComputedRole
+  -->
+  <span role="row" data-testname="orphaned row outside the context of table" class="ex-generic">x</span>
+  <span role="rowgroup" data-testname="orphaned rowgroup outside the context of row" class="ex-generic">x</span>
+  <div role="gridcell" data-testname="orphaned div with gridcell role outside the context of row" class="ex-generic">x</div>
+  <button role="gridcell" data-testname="orphaned button with gridcell role outside the context of row" data-expectedrole="button" class="ex">x</button>
+  <div role="rowheader" data-testname="orphaned rowheader outside the context of row" class="ex-generic">x</div>
+  <div role="columnheader" data-testname="orphaned columnheader outside the context of row" class="ex-generic">x</div>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/list-roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/list-roles.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+  <title>Tentative: List-related Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
+<div role="listitem" data-testname="orphan div with listitem role" class="ex-generic">x</div>
+<p role="listitem" data-testname="orphan p with listitem role" data-expectedrole="paragraph" class="ex">x</p>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/listbox-roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/listbox-roles.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+    <title>Tentative: Listbox-related Role Verification Tests</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/testdriver.js"></script>
+    <script src="../../resources/testdriver-vendor.js"></script>
+    <script src="../../resources/testdriver-actions.js"></script>
+    <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
+<nav role="option" data-testname="orphaned option outside the context of listbox" data-expectedrole="navigation"
+     class="ex">x
+</nav>
+
+<script>
+    AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/menu-roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/menu-roles.tentative.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+<head>
+    <title>Tentative: Menu-related Role Verification Tests</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/testdriver.js"></script>
+    <script src="../../resources/testdriver-vendor.js"></script>
+    <script src="../../resources/testdriver-actions.js"></script>
+    <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
+<nav role="menuitem" data-testname="orphaned menuitem outside the context of menu/menubar" data-expectedrole="navigation"
+     class="ex">x
+</nav>
+<nav role="menuitemradio" data-testname="orphaned menuitemradio outside the context of menu/menubar" data-expectedrole="navigation"
+     class="ex">x
+</nav>
+<nav role="menuitemcheckbox" data-testname="orphaned menuitemcheckbox outside the context of menu/menubar" data-expectedrole="navigation"
+     class="ex">x
+</nav>
+
+<button role="menuitem" data-testname="orphan button with menuitem role" data-expectedrole="button" class="ex">x</button>
+<div role="menuitem" data-testname="orphan div with menuitem role" class="ex-generic">x</div>
+
+<button role="menuitemcheckbox" data-testname="orphan button with menuitemcheckbox role" data-expectedrole="button" class="ex">x</button>
+<div role="menuitemcheckbox" data-testname="orphan div with menuitemcheckbox role" class="ex-generic">x</div>
+
+<button role="menuitemradio" data-testname="orphan button with menuitemradio role" data-expectedrole="button" class="ex">x</button>
+<div role="menuitemradio" data-testname="orphan div with menuitemradio role" class="ex-generic">x</div>
+
+<script>
+    AriaUtils.verifyRolesBySelector(".ex");
+    AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/region-roles.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/region-roles.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+<head>
+  <title>Region Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests <a href="https://w3c.github.io/aria/#region">region</a> and related roles, as well as the "name from author" rule in <a href="https://w3c.github.io/aria/#document-handling_author-errors_roles">9.1 Roles - handling author errors</a>.</p>
+
+<!-- no label -->
+<nav role="region" data-testname="region without label" data-expectedrole="navigation" class="ex">x</nav>
+
+<!-- w/ label -->
+<nav role="region" data-testname="region with label" data-expectedrole="region" aria-label="x" class="ex">x</nav>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/role_none_conflict_resolution.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/role_none_conflict_resolution.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html>
+<head>
+  <title>Role None Conflict Resolution Verification Tests</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/testdriver.js"></script>
+    <script src="../../resources/testdriver-vendor.js"></script>
+    <script src="../../resources/testdriver-actions.js"></script>
+    <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Verifies <a href="https://w3c.github.io/aria/#conflict_resolution_presentation_none"></a>conflict resolution</a> requirements for the ARIA <a href="https://w3c.github.io/aria/#none">none</a> and <a href="https://w3c.github.io/aria/#presentation">presentation</a> roles.</p>
+
+<!-- none with label(global) on header -->
+<h1 role="none" data-testname="heading role none with global attr aria-label" data-expectedrole="heading" aria-label="x" class="ex">x</h1>
+
+<!-- none with label(global) on paragraph -->
+<p role="none" data-testname="p role none with global attr aria-label (prohibited role)" data-expectedrole="paragraph" aria-label="x" class="ex">x</p>
+<p role="none" data-testname="p role none without global attr aria-label (prohibited role)" class="ex-generic">x</p>
+
+<!-- none with focusable header -->
+<h1 role="none" data-testname="focusable heading role none with tabindex=0" data-expectedrole="heading" tabindex="0" class="ex">x</h1>
+<h1 role="none" data-testname="focusable heading role none with tabindex=-1" data-expectedrole="heading" tabindex="-1" class="ex">x</h1>
+<h1 role="none" data-testname="non-focusable heading role none" class="ex-generic">x</h1>
+
+<!-- none with non-global-->
+<h1 role="none" data-testname="none with non-global" class="ex-generic" aria-level="2"> Sample Content </h1>
+
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/tab-roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/tab-roles.tentative.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html>
+<head>
+    <title>Tentative: Tab-related Role Verification Tests</title>
+    <script src="../../resources/testharness.js"></script>
+    <script src="../../resources/testharnessreport.js"></script>
+    <script src="../../resources/testdriver.js"></script>
+    <script src="../../resources/testdriver-vendor.js"></script>
+    <script src="../../resources/testdriver-actions.js"></script>
+    <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
+<button role="tab" data-testname="orphan button with tab role" data-expectedrole="button" class="ex">x</button>
+<span role="tab" data-testname="orphan span with tab role" class="ex-generic">x</span>
+
+<script>
+    AriaUtils.verifyRolesBySelector(".ex");
+    AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/tree-roles.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/wai-aria/role/tree-roles.tentative.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+<head>
+  <title>Tentative: Tree related Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<!--
+  CORE-AAM requires that, for elements with roles not contained in the
+  required context, user agents must ignore the role token and return the
+  computed role as if the ignored role token had not been included.
+  See https://w3c.github.io/core-aam/#roleMappingComputedRole
+-->
+<nav role="treeitem" data-testname="orphaned treeitem outside the context of tree" data-expectedrole="navigation" class="ex">x</nav>
+<button role="treeitem" data-testname="orphaned button with treeitem role outside tree context" data-expectedrole="button" class="ex">x</button>
+
+<script>
+  AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This change includes six commits:

- 02d18109a1621869ba5eca0070c158d493f066b0 LibWeb: Ignore “orphaned” ARIA roles
- fe2408c44b324ca69c3070cf60b52c7c19e4660d LibWeb: Ignore name-required landmark roles which lack accessible names
- c8f4f7fe33a27a4a02256ed263db44df63c896f1 LibWeb: Ignore role=none for focusable & has-global-ARIA-attribute cases
- d1cbc22cc08276c7c6d48e1367467d6ecec26d78 LibWeb: Return true for is_focusable() elements with non-null tabindex
- 42d1663e11bf00a27de34c62f8d53be9f16c3221 LibWeb: Allow accessible-name computation to skip role-attribute lookup
- f571b7c9d4722ac4717a052c851e05cc1d52ecf2 LibWeb: Add a to_element function to ARIAMixin