### PR TITLE
Meta: Strip query string from WPT test variants before importing them

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -228,23 +228,27 @@ import_wpt()
         INPUT_PATHS[i]="$item"
     done
 
-    TESTS=()
+    RAW_TESTS=()
     while IFS= read -r test_file; do
-        TESTS+=("$test_file")
+        RAW_TESTS+=("${test_file%%\?*}")
     done < <(
         "${ARG0}" list-tests "${INPUT_PATHS[@]}"
     )
-    if [ "${#TESTS[@]}" -eq 0 ]; then
+    if [ "${#RAW_TESTS[@]}" -eq 0 ]; then
         echo "No tests found for the given paths"
         exit 1
     fi
+
+    TESTS=()
+    while IFS= read -r test_file; do
+        TESTS+=("$test_file")
+    done < <(printf "%s\n" "${RAW_TESTS[@]}" | sort -u)
 
     pushd "${LADYBIRD_SOURCE_DIR}" > /dev/null
         ./Meta/ladybird.sh build headless-browser
         set +e
         for path in "${TESTS[@]}"; do
             echo "Importing test from ${path}"
-
             if ! ./Meta/import-wpt-test.py https://wpt.live/"${path}"; then
                 continue
             fi

--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -244,7 +244,8 @@ import_wpt()
         set +e
         for path in "${TESTS[@]}"; do
             echo "Importing test from ${path}"
-            if [ ! "$(./Meta/import-wpt-test.py https://wpt.live/"${path}")" ]; then
+
+            if ! ./Meta/import-wpt-test.py https://wpt.live/"${path}"; then
                 continue
             fi
             "${HEADLESS_BROWSER_BINARY}" --run-tests ./Tests/LibWeb --rebaseline -f "$path"


### PR DESCRIPTION
The output of `WPT.sh list-tests` includes test variants, which vary only by their query string. Since we don't care about this when importing tests, ignore any query strings and ensure duplicates are removed from the given test paths.

I've also included a commit to ensure we don't swallow the output of the python importer script.

Fixes: #2976