### PR TITLE
headless-browser: Let tests configure a custom timeout

### DIFF
--- a/Libraries/LibWeb/Internals/Internals.cpp
+++ b/Libraries/LibWeb/Internals/Internals.cpp
@@ -53,6 +53,11 @@ void Internals::signal_text_test_is_done(String const& text)
     internals_page().client().page_did_finish_text_test(text);
 }
 
+void Internals::set_test_timeout(double milliseconds)
+{
+    internals_page().client().page_did_set_test_timeout(milliseconds);
+}
+
 void Internals::gc()
 {
     vm().heap().collect_garbage();

--- a/Libraries/LibWeb/Internals/Internals.h
+++ b/Libraries/LibWeb/Internals/Internals.h
@@ -21,6 +21,7 @@ public:
     virtual ~Internals() override;
 
     void signal_text_test_is_done(String const& text);
+    void set_test_timeout(double milliseconds);
 
     void gc();
     JS::Object* hit_test(double x, double y);

--- a/Libraries/LibWeb/Internals/Internals.idl
+++ b/Libraries/LibWeb/Internals/Internals.idl
@@ -6,6 +6,8 @@
 interface Internals {
 
     undefined signalTextTestIsDone(DOMString text);
+    undefined setTestTimeout(double milliseconds);
+
     undefined gc();
     object hitTest(double x, double y);
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -382,6 +382,7 @@ public:
     virtual void page_did_request_select_dropdown([[maybe_unused]] Web::CSSPixelPoint content_position, [[maybe_unused]] Web::CSSPixels minimum_width, [[maybe_unused]] Vector<Web::HTML::SelectItem> items) { }
 
     virtual void page_did_finish_text_test([[maybe_unused]] String const& text) { }
+    virtual void page_did_set_test_timeout([[maybe_unused]] double milliseconds) { }
 
     virtual void page_did_change_theme_color(Gfx::Color) { }
 

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -215,6 +215,7 @@ public:
     Function<void(Web::KeyEvent const&)> on_finish_handling_key_event;
     Function<void(Web::DragEvent const&)> on_finish_handling_drag_event;
     Function<void(String const&)> on_text_test_finish;
+    Function<void(double milliseconds)> on_set_test_timeout;
     Function<void(size_t current_match_index, Optional<size_t> const& total_match_count)> on_find_in_page;
     Function<void(Gfx::Color)> on_theme_color_change;
     Function<void(String const&, String const&, String const&)> on_insert_clipboard_entry;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -93,6 +93,14 @@ void WebContentClient::did_finish_text_test(u64 page_id, String const& text)
     }
 }
 
+void WebContentClient::did_set_test_timeout(u64 page_id, double milliseconds)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_set_test_timeout)
+            view->on_set_test_timeout(milliseconds);
+    }
+}
+
 void WebContentClient::did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> const& total_match_count)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -108,6 +108,7 @@ private:
     virtual void did_request_select_dropdown(u64 page_id, Gfx::IntPoint content_position, i32 minimum_width, Vector<Web::HTML::SelectItem> const& items) override;
     virtual void did_finish_handling_input_event(u64 page_id, Web::EventResult event_result) override;
     virtual void did_finish_text_test(u64 page_id, String const& text) override;
+    virtual void did_set_test_timeout(u64 page_id, double milliseconds) override;
     virtual void did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> const& total_match_count) override;
     virtual void did_change_theme_color(u64 page_id, Gfx::Color color) override;
     virtual void did_insert_clipboard_entry(u64 page_id, String const& data, String const& presentation_style, String const& mime_type) override;

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -366,6 +366,11 @@ void PageClient::page_did_finish_text_test(String const& text)
     client().async_did_finish_text_test(m_id, text);
 }
 
+void PageClient::page_did_set_test_timeout(double milliseconds)
+{
+    client().async_did_set_test_timeout(m_id, milliseconds);
+}
+
 void PageClient::page_did_request_context_menu(Web::CSSPixelPoint content_position)
 {
     client().async_did_request_context_menu(m_id, page().css_to_device_point(content_position).to_type<int>());

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -158,6 +158,7 @@ private:
     virtual void page_did_request_file_picker(Web::HTML::FileFilter accepted_file_types, Web::HTML::AllowMultipleFiles) override;
     virtual void page_did_request_select_dropdown(Web::CSSPixelPoint content_position, Web::CSSPixels minimum_width, Vector<Web::HTML::SelectItem> items) override;
     virtual void page_did_finish_text_test(String const& text) override;
+    virtual void page_did_set_test_timeout(double milliseconds) override;
     virtual void page_did_change_theme_color(Gfx::Color color) override;
     virtual void page_did_insert_clipboard_entry(String data, String presentation_style, String mime_type) override;
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -95,6 +95,7 @@ endpoint WebContentClient
     did_get_js_console_messages(u64 page_id, i32 start_index, Vector<ByteString> message_types, Vector<ByteString> messages) =|
 
     did_finish_text_test(u64 page_id, String text) =|
+    did_set_test_timeout(u64 page_id, double milliseconds) =|
 
     did_find_in_page(u64 page_id, size_t current_match_index, Optional<size_t> total_match_count) =|
 

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -161,15 +161,6 @@ Text/input/wpt-import/css/css-backgrounds/animations/box-shadow-composition.html
 Text/input/wpt-import/css/css-backgrounds/animations/box-shadow-interpolation.html
 Text/input/wpt-import/css/css-backgrounds/animations/discrete-no-interpolation.html
 
-; Frequently time out on macOS
-; https://github.com/LadybirdBrowser/ladybird/issues/2792
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-auto.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-fixed.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-iframe-percentage.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-auto.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-fixed.html
-Text/input/wpt-import/html/rendering/replaced-elements/svg-embedded-sizing/svg-in-object-percentage.html
-
 ; Crashes inconsistently on CI
 ; https://github.com/LadybirdBrowser/ladybird/issues/2900
 Text/input/ShadowDOM/css-hover-shadow-dom.html

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
@@ -556,6 +556,13 @@
 
     var test_environment = create_test_environment();
 
+    // Tell the ladybird test runner what our preferred timeout is
+    {
+        let timeout = test_environment.test_timeout();
+        if (timeout)
+            window.internals.setTestTimeout(timeout);
+    }
+
     function is_shared_worker(worker) {
         return 'SharedWorker' in global_scope && worker instanceof SharedWorker;
     }

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -112,6 +112,7 @@ void run_dump_test(HeadlessWebView& view, Test& test, URL::URL const& url, int t
     auto timer = Core::Timer::create_single_shot(timeout_in_milliseconds, [&view, &test]() {
         view.on_load_finish = {};
         view.on_text_test_finish = {};
+        view.on_set_test_timeout = {};
 
         view.on_test_complete({ test, TestResult::Timeout });
     });
@@ -233,6 +234,13 @@ void run_dump_test(HeadlessWebView& view, Test& test, URL::URL const& url, int t
         };
     }
 
+    view.on_set_test_timeout = [timer, timeout_in_milliseconds](double milliseconds) {
+        if (milliseconds <= timeout_in_milliseconds)
+            return;
+        timer->stop();
+        timer->start(milliseconds);
+    };
+
     view.load(url);
     timer->start();
 }
@@ -242,6 +250,7 @@ static void run_ref_test(HeadlessWebView& view, Test& test, URL::URL const& url,
     auto timer = Core::Timer::create_single_shot(timeout_in_milliseconds, [&view, &test]() {
         view.on_load_finish = {};
         view.on_text_test_finish = {};
+        view.on_set_test_timeout = {};
 
         view.on_test_complete({ test, TestResult::Timeout });
     });
@@ -313,6 +322,13 @@ static void run_ref_test(HeadlessWebView& view, Test& test, URL::URL const& url,
 
     view.on_text_test_finish = [&](auto const&) {
         dbgln("Unexpected text test finished during ref test for {}", url);
+    };
+
+    view.on_set_test_timeout = [timer, timeout_in_milliseconds](double milliseconds) {
+        if (milliseconds <= timeout_in_milliseconds)
+            return;
+        timer->stop();
+        timer->start(milliseconds);
     };
 
     view.load(url);


### PR DESCRIPTION
This is implemented for WPT's `<meta name=timeout content=long>`, but we could always use this if particular home-grown tests take slightly too long for our default timeout.

This should solve the issue I was seeing in #2966, where `Text/input/wpt-import/html/rendering/pixel-length-attributes.html`  (which is a user of that meta tag) would intermittently time out.

Also, I've re-enabled the tests from #2792 as they all use the meta tag. Hopefully they'll now not time out!