### PR TITLE
LibWeb: Use paintables when calculating mouse event offset

### DIFF
--- a/Tests/LibWeb/Text/expected/CSSOMView/mouse-event-transformed-pseudoelement-crash.txt
+++ b/Tests/LibWeb/Text/expected/CSSOMView/mouse-event-transformed-pseudoelement-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/CSSOMView/mouse-event-transformed-pseudoelement-crash.html
+++ b/Tests/LibWeb/Text/input/CSSOMView/mouse-event-transformed-pseudoelement-crash.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<style>
+    div::before {
+        content: "";
+        display: block;
+        width: 100px;
+        height: 100px;
+        background-color: gray;
+        transform: rotate(45deg);
+    }
+</style>
+<div></div>
+
+<script src="../include.js"></script>
+
+<script>
+    test(() => {
+        internals.click(50, 60);
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
Fixes #2985.

This avoids a crash.