### PR TITLE
LibWeb: Assortment of Editing API related fixes and improvements

### DIFF
--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -203,7 +203,7 @@ RefPtr<CSSStyleValue const> ResolvedCSSStyleDeclaration::style_value_for_propert
     // A limited number of properties have special rules for producing their "resolved value".
     // We also have to manually construct shorthands from their longhands here.
     // Everything else uses the computed value.
-    // https://www.w3.org/TR/cssom-1/#resolved-values
+    // https://drafts.csswg.org/cssom/#resolved-values
 
     // The resolved value for a given longhand property can be determined as follows:
     switch (property_id) {

--- a/Libraries/LibWeb/DOM/AbstractRange.h
+++ b/Libraries/LibWeb/DOM/AbstractRange.h
@@ -13,6 +13,12 @@
 
 namespace Web::DOM {
 
+// https://dom.spec.whatwg.org/#concept-range-bp
+struct BoundaryPoint {
+    GC::Ref<Node> node;
+    WebIDL::UnsignedLong offset;
+};
+
 // https://dom.spec.whatwg.org/#abstractrange
 class AbstractRange : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(AbstractRange, Bindings::PlatformObject);
@@ -20,9 +26,11 @@ class AbstractRange : public Bindings::PlatformObject {
 public:
     virtual ~AbstractRange() override;
 
+    BoundaryPoint start() const { return { m_start_container, m_start_offset }; }
     GC::Ref<Node> start_container() const { return m_start_container; }
     WebIDL::UnsignedLong start_offset() const { return m_start_offset; }
 
+    BoundaryPoint end() const { return { m_end_container, m_end_offset }; }
     GC::Ref<Node> end_container() const { return m_end_container; }
     WebIDL::UnsignedLong end_offset() const { return m_end_offset; }
 

--- a/Libraries/LibWeb/DOM/Range.h
+++ b/Libraries/LibWeb/DOM/Range.h
@@ -22,7 +22,7 @@ enum class RelativeBoundaryPointPosition {
 };
 
 // https://dom.spec.whatwg.org/#concept-range-bp-position
-RelativeBoundaryPointPosition position_of_boundary_point_relative_to_other_boundary_point(GC::Ref<Node> node_a, u32 offset_a, GC::Ref<Node> node_b, u32 offset_b);
+RelativeBoundaryPointPosition position_of_boundary_point_relative_to_other_boundary_point(BoundaryPoint a, BoundaryPoint b);
 
 class Range final : public AbstractRange {
     WEB_PLATFORM_OBJECT(Range, AbstractRange);

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -214,7 +214,7 @@ bool command_delete_action(DOM::Document& document, String const&)
         //    start node to its parent.
         if (start_offset == 0) {
             start_offset = start_node->index();
-            start_node = *start_node->parent();
+            start_node = start_node->parent();
             continue;
         }
 

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -320,26 +320,37 @@ bool command_delete_action(DOM::Document& document, String const&)
         }
     }
 
-    // FIXME: 15. If start node's child with index start offset is an li or dt or dd, and that child's
+    // 15. If start node's child with index start offset is an li or dt or dd, and that child's
     //     previousSibling is also an li or dt or dd:
-    if (false) {
-        // FIXME: 1. Call cloneRange() on the active range, and let original range be the result.
+    if (is<DOM::Element>(start_offset_child) && is_li_dt_or_dd(static_cast<DOM::Element&>(*start_offset_child))
+        && is<DOM::Element>(start_offset_child->previous_sibling())
+        && is_li_dt_or_dd(static_cast<DOM::Element&>(*start_offset_child->previous_sibling()))) {
+        // 1. Call cloneRange() on the active range, and let original range be the result.
+        auto original_range = active_range.clone_range();
 
-        // FIXME: 2. Set start node to its child with index start offset − 1.
+        // 2. Set start node to its child with index start offset − 1.
+        start_node = start_node->child_at_index(start_offset - 1);
 
-        // FIXME: 3. Set start offset to start node's length.
+        // 3. Set start offset to start node's length.
+        start_offset = start_node->length();
 
-        // FIXME: 4. Set node to start node's nextSibling.
+        // 4. Set node to start node's nextSibling.
+        node = start_node->next_sibling();
 
-        // FIXME: 5. Call collapse(start node, start offset) on the context object's selection.
+        // 5. Call collapse(start node, start offset) on the context object's selection.
+        MUST(selection.collapse(start_node, start_offset));
 
-        // FIXME: 6. Call extend(node, 0) on the context object's selection.
+        // 6. Call extend(node, 0) on the context object's selection.
+        MUST(selection.extend(*node, 0));
 
-        // FIXME: 7. Delete the selection.
+        // 7. Delete the selection.
+        delete_the_selection(selection);
 
-        // FIXME: 8. Call removeAllRanges() on the context object's selection.
+        // 8. Call removeAllRanges() on the context object's selection.
+        selection.remove_all_ranges();
 
-        // FIXME: 9. Call addRange(original range) on the context object's selection.
+        // 9. Call addRange(original range) on the context object's selection.
+        selection.add_range(original_range);
 
         // 10. Return true.
         return true;

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -781,11 +781,28 @@ bool command_style_with_css_state(DOM::Document const& document)
 }
 
 static Array const commands {
-    CommandDefinition { CommandNames::delete_, command_delete_action, {}, {}, {} },
-    CommandDefinition { CommandNames::defaultParagraphSeparator, command_default_paragraph_separator_action, {}, {}, command_default_paragraph_separator_value },
-    CommandDefinition { CommandNames::insertLineBreak, command_insert_linebreak_action, {}, {}, {} },
-    CommandDefinition { CommandNames::insertParagraph, command_insert_paragraph_action, {}, {}, {} },
-    CommandDefinition { CommandNames::styleWithCSS, command_style_with_css_action, {}, command_style_with_css_state, {} },
+    CommandDefinition {
+        .command = CommandNames::delete_,
+        .action = command_delete_action,
+    },
+    CommandDefinition {
+        .command = CommandNames::defaultParagraphSeparator,
+        .action = command_default_paragraph_separator_action,
+        .value = command_default_paragraph_separator_value,
+    },
+    CommandDefinition {
+        .command = CommandNames::insertLineBreak,
+        .action = command_insert_linebreak_action,
+    },
+    CommandDefinition {
+        .command = CommandNames::insertParagraph,
+        .action = command_insert_paragraph_action,
+    },
+    CommandDefinition {
+        .command = CommandNames::styleWithCSS,
+        .action = command_style_with_css_action,
+        .state = command_style_with_css_state,
+    },
 };
 
 Optional<CommandDefinition const&> find_command_definition(FlyString const& command)

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -697,7 +697,7 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
     }();
 
     // 22. Let new container be the result of calling createElement(new container name) on the context object.
-    GC::Ptr<DOM::Element> new_container = MUST(DOM::create_element(document, new_container_name, Namespace::HTML));
+    auto new_container = MUST(DOM::create_element(document, new_container_name, Namespace::HTML));
 
     // 23. Copy all attributes of container to new container.
     container_element.for_each_attribute([&new_container](FlyString const& name, String const& value) {
@@ -742,7 +742,7 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
     // 31. While new container's lastChild is a prohibited paragraph child, set new container to its lastChild.
     while (new_container->last_child() && is_prohibited_paragraph_child(*new_container->last_child())) {
         // NOTE: is_prohibited_paragraph_child() ensures that last_child() is an HTML::HTMLElement
-        new_container = static_cast<HTML::HTMLElement*>(new_container->last_child());
+        new_container = static_cast<HTML::HTMLElement&>(*new_container->last_child());
     }
 
     // 32. If container has no visible children, call createElement("br") on the context object, and append the result

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -293,12 +293,12 @@ bool command_delete_action(DOM::Document& document, String const&)
 
     // 14. If the child of start node with index start offset is an li or dt or dd, and that child's
     //     firstChild is an inline node, and start offset is not zero:
+    // NOTE: step 9 above guarantees start_offset cannot be 0 here.
     auto is_li_dt_or_dd = [](DOM::Element const& node) {
         return node.local_name().is_one_of(HTML::TagNames::li, HTML::TagNames::dt, HTML::TagNames::dd);
     };
     auto* start_offset_child = start_node->child_at_index(start_offset);
-    if (start_offset != 0 && is<DOM::Element>(start_offset_child)
-        && is_li_dt_or_dd(static_cast<DOM::Element&>(*start_offset_child))
+    if (is<DOM::Element>(start_offset_child) && is_li_dt_or_dd(static_cast<DOM::Element&>(*start_offset_child))
         && start_offset_child->has_children() && is_inline_node(*start_offset_child->first_child())) {
         // 1. Let previous item be the child of start node with index start offset minus one.
         GC::Ref<DOM::Node> previous_item = *start_node->child_at_index(start_offset - 1);

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/DOM/Comment.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentFragment.h>
@@ -417,10 +418,11 @@ bool command_insert_linebreak_action(DOM::Document& document, String const&)
     //         * Insert another newline (\n) character if the active range's start offset is equal to the length of the
     //           active range's start node.
     //         * Return true.
-    if (is<DOM::Text>(*start_node) && start_node->layout_node()) {
+    if (is<DOM::Text>(*start_node)) {
         auto& text_node = static_cast<DOM::Text&>(*start_node);
-        auto white_space = text_node.layout_node()->computed_values().white_space();
-        if (first_is_one_of(white_space, CSS::WhiteSpace::Pre, CSS::WhiteSpace::PreLine, CSS::WhiteSpace::PreWrap)) {
+        auto resolved_white_space = resolved_keyword(*start_node, CSS::PropertyID::WhiteSpace);
+        if (resolved_white_space.has_value()
+            && first_is_one_of(resolved_white_space.value(), CSS::Keyword::Pre, CSS::Keyword::PreLine, CSS::Keyword::PreWrap)) {
             MUST(text_node.insert_data(active_range.start_offset(), "\n"_string));
             MUST(selection.collapse(start_node, active_range.start_offset() + 1));
             if (selection.range()->start_offset() == start_node->length())

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -65,7 +65,7 @@ bool command_delete_action(DOM::Document& document, String const&)
     }
 
     // 2. Canonicalize whitespace at the active range's start.
-    canonicalize_whitespace(active_range.start_container(), active_range.start_offset());
+    canonicalize_whitespace(active_range.start());
 
     // 3. Let node and offset be the active range's start node and offset.
     GC::Ptr<DOM::Node> node = active_range.start_container();

--- a/Libraries/LibWeb/Editing/Commands.h
+++ b/Libraries/LibWeb/Editing/Commands.h
@@ -10,12 +10,17 @@
 
 namespace Web::Editing {
 
+// https://w3c.github.io/editing/docs/execCommand/#properties-of-commands
 struct CommandDefinition {
     FlyString const& command;
     Function<bool(DOM::Document&, String const&)> action {};
     Function<bool(DOM::Document const&)> indeterminate {};
     Function<bool(DOM::Document const&)> state {};
     Function<String(DOM::Document const&)> value {};
+    Optional<CSS::PropertyID> relevant_css_property {};
+
+    // https://w3c.github.io/editing/docs/execCommand/#inline-command-activated-values
+    Vector<String> inline_activated_values {};
 };
 
 Optional<CommandDefinition const&> find_command_definition(FlyString const&);

--- a/Libraries/LibWeb/Editing/Commands.h
+++ b/Libraries/LibWeb/Editing/Commands.h
@@ -12,10 +12,10 @@ namespace Web::Editing {
 
 struct CommandDefinition {
     FlyString const& command;
-    Function<bool(DOM::Document&, String const&)> action;
-    Function<bool(DOM::Document const&)> indeterminate;
-    Function<bool(DOM::Document const&)> state;
-    Function<String(DOM::Document const&)> value;
+    Function<bool(DOM::Document&, String const&)> action {};
+    Function<bool(DOM::Document const&)> indeterminate {};
+    Function<bool(DOM::Document const&)> state {};
+    Function<String(DOM::Document const&)> value {};
 };
 
 Optional<CommandDefinition const&> find_command_definition(FlyString const&);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -2294,12 +2294,12 @@ void restore_the_values_of_nodes(Vector<RecordedNodeValue> const& values)
 
         // 2. If ancestor is not an Element, set it to its parent.
         if (!is<DOM::Element>(*ancestor))
-            ancestor = *ancestor->parent();
+            ancestor = ancestor->parent();
 
         // 3. While ancestor is an Element and its specified command value for command is null, set it to its parent.
         auto const& command = recorded_node_value.command;
-        while (is<DOM::Element>(*ancestor) && !specified_command_value(static_cast<DOM::Element&>(*ancestor), command).has_value())
-            ancestor = *ancestor->parent();
+        while (is<DOM::Element>(ancestor.ptr()) && !specified_command_value(static_cast<DOM::Element&>(*ancestor), command).has_value())
+            ancestor = ancestor->parent();
 
         // FIXME: 4. If value is null and ancestor is an Element, push down values on node for command, with new value null.
 

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -2638,23 +2638,23 @@ GC::Ptr<DOM::Node> wrap(
         //    of node list are both inline nodes, and the last child of new parent is not a br, call createElement("br")
         //    on the ownerDocument of new parent and append the result as the last child of new parent.
         if (!is_inline_node(*new_parent)) {
-            auto last_visible_child = [&] -> GC::Ref<DOM::Node> {
+            auto last_visible_child = [&] -> GC::Ptr<DOM::Node> {
                 GC::Ptr<DOM::Node> child = new_parent->last_child();
                 while (child) {
                     if (is_visible_node(*child))
                         return *child;
                     child = child->previous_sibling();
                 }
-                VERIFY_NOT_REACHED();
+                return {};
             }();
-            auto first_visible_member = [&] -> GC::Ref<DOM::Node> {
+            auto first_visible_member = [&] -> GC::Ptr<DOM::Node> {
                 for (auto& member : node_list) {
                     if (is_visible_node(member))
                         return member;
                 }
-                VERIFY_NOT_REACHED();
+                return {};
             }();
-            if (is_inline_node(last_visible_child) && is_inline_node(first_visible_member)
+            if (last_visible_child && is_inline_node(*last_visible_child) && first_visible_member && is_inline_node(*first_visible_member)
                 && !is<HTML::HTMLBRElement>(new_parent->last_child())) {
                 auto br_element = MUST(DOM::create_element(*new_parent->owner_document(), HTML::TagNames::br, Namespace::HTML));
                 MUST(new_parent->append_child(br_element));

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -15,13 +15,13 @@ namespace Web::Editing {
 // https://w3c.github.io/editing/docs/execCommand/#record-the-values
 struct RecordedNodeValue {
     GC::Ref<DOM::Node> node;
-    FlyString const& command;
+    FlyString command;
     Optional<String> specified_command_value;
 };
 
 // https://w3c.github.io/editing/docs/execCommand/#record-current-states-and-values
 struct RecordedOverride {
-    FlyString const& command;
+    FlyString command;
     Variant<String, bool> value;
 };
 
@@ -44,6 +44,7 @@ void canonicalize_whitespace(GC::Ref<DOM::Node>, u32 offset, bool fix_collapsed_
 void delete_the_selection(Selection&, bool block_merging = true, bool strip_wrappers = true,
     Selection::Direction direction = Selection::Direction::Forwards);
 GC::Ptr<DOM::Node> editing_host_of_node(GC::Ref<DOM::Node>);
+Optional<String> effective_command_value(GC::Ptr<DOM::Node>, FlyString const& command);
 BoundaryPoint first_equivalent_point(BoundaryPoint);
 void fix_disallowed_ancestors_of_node(GC::Ref<DOM::Node>);
 bool follows_a_line_break(GC::Ref<DOM::Node>);
@@ -55,8 +56,10 @@ bool is_block_start_point(GC::Ref<DOM::Node>, u32 offset);
 bool is_collapsed_block_prop(GC::Ref<DOM::Node>);
 bool is_collapsed_line_break(GC::Ref<DOM::Node>);
 bool is_collapsed_whitespace_node(GC::Ref<DOM::Node>);
+bool is_effectively_contained_in_range(GC::Ref<DOM::Node>, GC::Ref<DOM::Range>);
 bool is_element_with_inline_contents(GC::Ref<DOM::Node>);
 bool is_extraneous_line_break(GC::Ref<DOM::Node>);
+bool is_formattable_node(GC::Ref<DOM::Node>);
 bool is_in_same_editing_host(GC::Ref<DOM::Node>, GC::Ref<DOM::Node>);
 bool is_inline_node(GC::Ref<DOM::Node>);
 bool is_invisible_node(GC::Ref<DOM::Node>);

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -90,5 +90,8 @@ GC::Ptr<DOM::Node> wrap(Vector<GC::Ref<DOM::Node>>, Function<bool(GC::Ref<DOM::N
 
 bool has_visible_children(GC::Ref<DOM::Node>);
 bool is_heading(FlyString const&);
+Optional<CSS::Display> resolved_display(GC::Ref<DOM::Node>);
+Optional<CSS::Keyword> resolved_keyword(GC::Ref<DOM::Node>, CSS::PropertyID);
+Optional<NonnullRefPtr<CSS::CSSStyleValue const>> resolved_value(GC::Ref<DOM::Node>, CSS::PropertyID);
 
 }

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.h
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.h
@@ -8,6 +8,7 @@
 
 #include <AK/Vector.h>
 #include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/Range.h>
 #include <LibWeb/Selection/Selection.h>
 
 namespace Web::Editing {
@@ -27,32 +28,25 @@ struct RecordedOverride {
 
 using Selection::Selection;
 
-// https://dom.spec.whatwg.org/#concept-range-bp
-// FIXME: This should be defined by DOM::Range
-struct BoundaryPoint {
-    GC::Ref<DOM::Node> node;
-    WebIDL::UnsignedLong offset;
-};
-
 // Below algorithms are specified here:
 // https://w3c.github.io/editing/docs/execCommand/#assorted-common-algorithms
 
 GC::Ref<DOM::Range> block_extend_a_range(DOM::Range&);
 GC::Ptr<DOM::Node> block_node_of_node(GC::Ref<DOM::Node>);
 String canonical_space_sequence(u32 length, bool non_breaking_start, bool non_breaking_end);
-void canonicalize_whitespace(GC::Ref<DOM::Node>, u32 offset, bool fix_collapsed_space = true);
+void canonicalize_whitespace(DOM::BoundaryPoint, bool fix_collapsed_space = true);
 void delete_the_selection(Selection&, bool block_merging = true, bool strip_wrappers = true,
     Selection::Direction direction = Selection::Direction::Forwards);
 GC::Ptr<DOM::Node> editing_host_of_node(GC::Ref<DOM::Node>);
 Optional<String> effective_command_value(GC::Ptr<DOM::Node>, FlyString const& command);
-BoundaryPoint first_equivalent_point(BoundaryPoint);
+DOM::BoundaryPoint first_equivalent_point(DOM::BoundaryPoint);
 void fix_disallowed_ancestors_of_node(GC::Ref<DOM::Node>);
 bool follows_a_line_break(GC::Ref<DOM::Node>);
 bool is_allowed_child_of_node(Variant<GC::Ref<DOM::Node>, FlyString> child, Variant<GC::Ref<DOM::Node>, FlyString> parent);
-bool is_block_boundary_point(GC::Ref<DOM::Node>, u32 offset);
-bool is_block_end_point(GC::Ref<DOM::Node>, u32 offset);
+bool is_block_boundary_point(DOM::BoundaryPoint);
+bool is_block_end_point(DOM::BoundaryPoint);
 bool is_block_node(GC::Ref<DOM::Node>);
-bool is_block_start_point(GC::Ref<DOM::Node>, u32 offset);
+bool is_block_start_point(DOM::BoundaryPoint);
 bool is_collapsed_block_prop(GC::Ref<DOM::Node>);
 bool is_collapsed_line_break(GC::Ref<DOM::Node>);
 bool is_collapsed_whitespace_node(GC::Ref<DOM::Node>);
@@ -70,12 +64,12 @@ bool is_prohibited_paragraph_child_name(FlyString const&);
 bool is_single_line_container(GC::Ref<DOM::Node>);
 bool is_visible_node(GC::Ref<DOM::Node>);
 bool is_whitespace_node(GC::Ref<DOM::Node>);
-BoundaryPoint last_equivalent_point(BoundaryPoint);
+DOM::BoundaryPoint last_equivalent_point(DOM::BoundaryPoint);
 void move_node_preserving_ranges(GC::Ref<DOM::Node>, GC::Ref<DOM::Node> new_parent, u32 new_index);
-Optional<BoundaryPoint> next_equivalent_point(BoundaryPoint);
+Optional<DOM::BoundaryPoint> next_equivalent_point(DOM::BoundaryPoint);
 void normalize_sublists_in_node(GC::Ref<DOM::Element>);
 bool precedes_a_line_break(GC::Ref<DOM::Node>);
-Optional<BoundaryPoint> previous_equivalent_point(BoundaryPoint);
+Optional<DOM::BoundaryPoint> previous_equivalent_point(DOM::BoundaryPoint);
 Vector<RecordedOverride> record_current_states_and_values(GC::Ref<DOM::Range>);
 Vector<RecordedNodeValue> record_the_values_of_nodes(Vector<GC::Ref<DOM::Node>> const&);
 void remove_extraneous_line_breaks_at_the_end_of_node(GC::Ref<DOM::Node>);

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -239,8 +239,8 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_start()
     auto new_range = DOM::Range::create(*m_document);
 
     // 3. Set the start both its start and end to the start of this's range
-    TRY(new_range->set_start(*anchor_node(), m_range->start_offset()));
-    TRY(new_range->set_end(*anchor_node(), m_range->start_offset()));
+    TRY(new_range->set_start(*m_range->start_container(), m_range->start_offset()));
+    TRY(new_range->set_end(*m_range->start_container(), m_range->start_offset()));
 
     // 4. Then set this's range to the newly-created range.
     set_range(new_range);
@@ -259,8 +259,8 @@ WebIDL::ExceptionOr<void> Selection::collapse_to_end()
     auto new_range = DOM::Range::create(*m_document);
 
     // 3. Set the start both its start and end to the start of this's range
-    TRY(new_range->set_start(*anchor_node(), m_range->end_offset()));
-    TRY(new_range->set_end(*anchor_node(), m_range->end_offset()));
+    TRY(new_range->set_start(*m_range->end_container(), m_range->end_offset()));
+    TRY(new_range->set_end(*m_range->end_container(), m_range->end_offset()));
 
     // 4. Then set this's range to the newly-created range.
     set_range(new_range);

--- a/Tests/LibWeb/Text/expected/selection-collapseToEnd.txt
+++ b/Tests/LibWeb/Text/expected/selection-collapseToEnd.txt
@@ -1,0 +1,2 @@
+[object HTMLDivElement] 0 [object HTMLUListElement] 3
+[object HTMLUListElement] 3 [object HTMLUListElement] 3

--- a/Tests/LibWeb/Text/input/selection-collapseToEnd.html
+++ b/Tests/LibWeb/Text/input/selection-collapseToEnd.html
@@ -1,0 +1,29 @@
+<script src="include.js"></script>
+<div>
+    Well
+    <ul>
+        <li>Hello</li>
+        <li>Friends</li>
+        <li>!</li>
+    </ul>
+</div>
+<script>
+    test(() => {
+        const anchor = document.querySelector('div');
+
+        const range = document.createRange();
+        range.setStart(anchor, 0);
+        range.setEnd(anchor.childNodes[1], 3);
+        getSelection().addRange(range);
+
+        const printRange = () => {
+            let activeRange = getSelection().getRangeAt(0);
+            println(`${activeRange.startContainer} ${activeRange.startOffset} ${activeRange.endContainer} ${activeRange.endOffset}`);
+        };
+        printRange();
+
+        getSelection().collapseToEnd();
+
+        printRange();
+    })
+</script>


### PR DESCRIPTION
No new commands, but improvements to the existing commands and algorithms. Also squashes a particularly nasty bug in `Selection::collapse_to_end/start()`.

Measured locally:
* WPT `editing`: ~369 new subtest passes
* WPT `selection`: ~10 new subtest passes