### PR TITLE
LibWeb/CSS: Don't overwrite active font load when requesting a pt size

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -228,7 +228,8 @@ void FontLoader::resource_did_load_or_fail()
 RefPtr<Gfx::Font> FontLoader::font_with_point_size(float point_size)
 {
     if (!m_vector_font) {
-        start_loading_next_url();
+        if (!resource())
+            start_loading_next_url();
         return nullptr;
     }
     return m_vector_font->scaled_font(point_size);


### PR DESCRIPTION
start_loading_next_url() is a no-op if there's a pending resource load, but not if that resource load has successfully loaded already. There is a delay between the font resource loading, and it being processed into a vector font. Calling font_with_point_size() in that gap would previously erase the previously-loaded font, if the font had multiple URLs to choose from.

This fixes the icon font on mods.factorio.com :^)

## Before
![Screenshot_20241220_144943 fontawesome before](https://github.com/user-attachments/assets/af1c35be-c755-4307-acc7-5c7deed08346)

## After
![Screenshot_20241220_144902 fontawesome after](https://github.com/user-attachments/assets/132c7b29-3071-43e7-93ce-6f5d714c4244)
