### PR TITLE
LibGfx+LibWeb: Specify bottom left origin for WebGL's PaintingSurface

### DIFF
--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -24,11 +24,16 @@ namespace Gfx {
 
 class PaintingSurface : public RefCounted<PaintingSurface> {
 public:
+    enum class Origin {
+        TopLeft,
+        BottomLeft,
+    };
+
     static NonnullRefPtr<PaintingSurface> create_with_size(RefPtr<SkiaBackendContext> context, Gfx::IntSize size, Gfx::BitmapFormat color_type, Gfx::AlphaType alpha_type);
     static NonnullRefPtr<PaintingSurface> wrap_bitmap(Bitmap&);
 
 #ifdef AK_OS_MACOS
-    static NonnullRefPtr<PaintingSurface> wrap_iosurface(Core::IOSurfaceHandle const&, RefPtr<SkiaBackendContext>);
+    static NonnullRefPtr<PaintingSurface> wrap_iosurface(Core::IOSurfaceHandle const&, RefPtr<SkiaBackendContext>, Origin = Origin::TopLeft);
 #endif
 
     void read_into_bitmap(Bitmap&);
@@ -47,9 +52,6 @@ public:
 
     void flush() const;
 
-    bool flip_vertically() const { return m_flip_vertically; }
-    void set_flip_vertically() { m_flip_vertically = true; }
-
     ~PaintingSurface();
 
 private:
@@ -58,7 +60,6 @@ private:
     PaintingSurface(NonnullOwnPtr<Impl>&&);
 
     NonnullOwnPtr<Impl> m_impl;
-    bool m_flip_vertically { false };
 };
 
 }

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -152,17 +152,7 @@ void DisplayListPlayerSkia::draw_painting_surface(DrawPaintingSurface const& com
     auto& canvas = surface().canvas();
     auto image = sk_surface.makeImageSnapshot();
     SkPaint paint;
-    if (command.surface->flip_vertically()) {
-        canvas.save();
-        SkMatrix matrix;
-        matrix.setIdentity();
-        matrix.preScale(1, -1, dst_rect.centerX(), dst_rect.centerY());
-        canvas.concat(matrix);
-    }
     canvas.drawImageRect(image, src_rect, dst_rect, to_skia_sampling_options(command.scaling_mode), &paint, SkCanvas::kStrict_SrcRectConstraint);
-    if (command.surface->flip_vertically()) {
-        canvas.restore();
-    }
 }
 
 void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitmap const& command)

--- a/Libraries/LibWeb/WebGL/OpenGLContext.cpp
+++ b/Libraries/LibWeb/WebGL/OpenGLContext.cpp
@@ -126,8 +126,7 @@ void OpenGLContext::allocate_painting_surface_if_needed()
     VERIFY(!m_size.is_empty());
 
     auto iosurface = Core::IOSurfaceHandle::create(m_size.width(), m_size.height());
-    m_painting_surface = Gfx::PaintingSurface::wrap_iosurface(iosurface, m_skia_backend_context);
-    m_painting_surface->set_flip_vertically();
+    m_painting_surface = Gfx::PaintingSurface::wrap_iosurface(iosurface, m_skia_backend_context, Gfx::PaintingSurface::Origin::BottomLeft);
 
     auto width = m_size.width();
     auto height = m_size.height();


### PR DESCRIPTION
By doing that we eliminate the need for the vertical flip flag.

As a side effect it fixes the bug when doing:
`canvasContext2d.drawImage(canvasWithWebGLContext, 0, 0);` produced a flipped image because we didn't account for different origin while serializing PaintingSurface into Gfx::Bitmap.

Visual progress on https://ciechanow.ski/curves-and-surfaces/