### PR TITLE
LibCrypto: Add `SecureRandom` to generate cryptographically secure random values

### DIFF
--- a/Libraries/LibCrypto/CMakeLists.txt
+++ b/Libraries/LibCrypto/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     NumberTheory/ModularFunctions.cpp
     PK/RSA.cpp
     PK/EC.cpp
+    SecureRandom.cpp
 )
 
 serenity_lib(LibCrypto crypto)

--- a/Libraries/LibCrypto/Curves/Ed25519.cpp
+++ b/Libraries/LibCrypto/Curves/Ed25519.cpp
@@ -8,6 +8,7 @@
 #include <LibCrypto/Curves/Curve25519.h>
 #include <LibCrypto/Curves/Ed25519.h>
 #include <LibCrypto/Hash/SHA2.h>
+#include <LibCrypto/SecureRandom.h>
 
 namespace Crypto::Curves {
 
@@ -19,7 +20,7 @@ ErrorOr<ByteBuffer> Ed25519::generate_private_key()
     // about randomness.
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(key_size()));
-    fill_with_random(buffer);
+    fill_with_secure_random(buffer);
     return buffer;
 }
 

--- a/Libraries/LibCrypto/Curves/SECPxxxr1.h
+++ b/Libraries/LibCrypto/Curves/SECPxxxr1.h
@@ -18,6 +18,7 @@
 #include <AK/UFixedBigIntDivision.h>
 #include <LibCrypto/ASN1/DER.h>
 #include <LibCrypto/Curves/EllipticCurve.h>
+#include <LibCrypto/SecureRandom.h>
 
 namespace {
 // Used by ASN1 macros
@@ -230,7 +231,7 @@ public:
     ErrorOr<ByteBuffer> generate_private_key() override
     {
         auto buffer = TRY(ByteBuffer::create_uninitialized(KEY_BYTE_SIZE));
-        fill_with_random(buffer);
+        fill_with_secure_random(buffer);
         return buffer;
     }
 

--- a/Libraries/LibCrypto/Curves/X25519.cpp
+++ b/Libraries/LibCrypto/Curves/X25519.cpp
@@ -8,6 +8,7 @@
 #include <AK/Random.h>
 #include <LibCrypto/Curves/Curve25519.h>
 #include <LibCrypto/Curves/X25519.h>
+#include <LibCrypto/SecureRandom.h>
 
 namespace Crypto::Curves {
 
@@ -29,7 +30,7 @@ static void conditional_swap(u32* first, u32* second, u32 condition)
 ErrorOr<ByteBuffer> X25519::generate_private_key()
 {
     auto buffer = TRY(ByteBuffer::create_uninitialized(BYTES));
-    fill_with_random(buffer);
+    fill_with_secure_random(buffer);
     return buffer;
 }
 

--- a/Libraries/LibCrypto/Curves/X448.cpp
+++ b/Libraries/LibCrypto/Curves/X448.cpp
@@ -8,6 +8,7 @@
 #include <AK/Endian.h>
 #include <AK/Random.h>
 #include <LibCrypto/Curves/X448.h>
+#include <LibCrypto/SecureRandom.h>
 
 namespace Crypto::Curves {
 
@@ -291,7 +292,7 @@ static void modular_multiply_inverse(u32* state, u32* value)
 ErrorOr<ByteBuffer> X448::generate_private_key()
 {
     auto buffer = TRY(ByteBuffer::create_uninitialized(BYTES));
-    fill_with_random(buffer);
+    fill_with_secure_random(buffer);
     return buffer;
 }
 

--- a/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -8,6 +8,7 @@
 #include <AK/Random.h>
 #include <LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
+#include <LibCrypto/SecureRandom.h>
 
 namespace Crypto::NumberTheory {
 
@@ -172,7 +173,7 @@ UnsignedBigInteger random_number(UnsignedBigInteger const& min, UnsignedBigInteg
     auto buffer = ByteBuffer::create_uninitialized(size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     auto* buf = buffer.data();
 
-    fill_with_random(buffer);
+    fill_with_secure_random(buffer);
     UnsignedBigInteger random { buf, size };
     // At this point, `random` is a large number, in the range [0, 256^size).
     // To get down to the actual range, we could just compute random % range.

--- a/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Libraries/LibCrypto/PK/RSA.cpp
@@ -12,6 +12,7 @@
 #include <LibCrypto/ASN1/PEM.h>
 #include <LibCrypto/Certificate/Certificate.h>
 #include <LibCrypto/PK/RSA.h>
+#include <LibCrypto/SecureRandom.h>
 
 namespace Crypto::PK {
 
@@ -253,7 +254,7 @@ void RSA_PKCS1_EME::encrypt(ReadonlyBytes in, Bytes& out)
     Vector<u8, 8096> ps;
     ps.resize(ps_length);
 
-    fill_with_random(ps);
+    fill_with_secure_random(ps);
     // since fill_with_random can create zeros (shocking!)
     // we have to go through and un-zero the zeros
     for (size_t i = 0; i < ps_length; ++i) {

--- a/Libraries/LibCrypto/SecureRandom.cpp
+++ b/Libraries/LibCrypto/SecureRandom.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCrypto/SecureRandom.h>
+
+#include <openssl/rand.h>
+
+namespace Crypto {
+
+void fill_with_secure_random(Bytes bytes)
+{
+    auto const size = static_cast<int>(bytes.size());
+
+    if (RAND_bytes(bytes.data(), size) != 1)
+        VERIFY_NOT_REACHED();
+}
+
+}

--- a/Libraries/LibCrypto/SecureRandom.h
+++ b/Libraries/LibCrypto/SecureRandom.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2024, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Span.h>
+
+namespace Crypto {
+
+void fill_with_secure_random(Bytes);
+
+}

--- a/Libraries/LibTLS/Handshake.cpp
+++ b/Libraries/LibTLS/Handshake.cpp
@@ -11,13 +11,14 @@
 
 #include <LibCore/Timer.h>
 #include <LibCrypto/ASN1/DER.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibTLS/TLSv12.h>
 
 namespace TLS {
 
 ByteBuffer TLSv12::build_hello()
 {
-    fill_with_random(m_context.local_random);
+    ::Crypto::fill_with_secure_random(m_context.local_random);
 
     auto packet_version = (u16)m_context.options.version;
     auto version = (u16)m_context.options.version;

--- a/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Libraries/LibTLS/HandshakeClient.cpp
@@ -11,6 +11,7 @@
 #include <LibCrypto/ASN1/DER.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibTLS/TLSv12.h>
 
 namespace TLS {
@@ -160,7 +161,7 @@ void TLSv12::build_rsa_pre_master_secret(PacketBuilder& builder)
     u8 random_bytes[48];
     size_t bytes = 48;
 
-    fill_with_random(random_bytes);
+    Crypto::fill_with_secure_random(random_bytes);
 
     // remove zeros from the random bytes
     for (size_t i = 0; i < bytes; ++i) {

--- a/Libraries/LibTLS/Record.cpp
+++ b/Libraries/LibTLS/Record.cpp
@@ -10,6 +10,7 @@
 #include <AK/Random.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Timer.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibTLS/TLSv12.h>
 
 namespace TLS {
@@ -157,7 +158,7 @@ void TLSv12::update_packet(ByteBuffer& packet)
                         u8 iv[12];
                         Bytes iv_bytes { iv, 12 };
                         Bytes { m_context.crypto.local_aead_iv, 4 }.copy_to(iv_bytes);
-                        fill_with_random(iv_bytes.slice(4, 8));
+                        Crypto::fill_with_secure_random(iv_bytes.slice(4, 8));
 
                         // write the random part of the iv out
                         iv_bytes.slice(4, 8).copy_to(ct.bytes().slice(header_size));
@@ -204,7 +205,7 @@ void TLSv12::update_packet(ByteBuffer& packet)
                             VERIFY_NOT_REACHED();
                         }
                         auto iv = iv_buffer_result.release_value();
-                        fill_with_random(iv);
+                        Crypto::fill_with_secure_random(iv);
 
                         // write it into the ciphertext portion of the message
                         ct.overwrite(header_size, iv.data(), iv.size());

--- a/Libraries/LibWeb/Crypto/Crypto.cpp
+++ b/Libraries/LibWeb/Crypto/Crypto.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Random.h>
 #include <AK/StringBuilder.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibJS/Runtime/TypedArray.h>
 #include <LibWeb/Bindings/CryptoPrototype.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
@@ -67,7 +68,7 @@ WebIDL::ExceptionOr<GC::Root<WebIDL::ArrayBufferView>> Crypto::get_random_values
     // FIXME: Handle SharedArrayBuffers
 
     // 3. Overwrite all elements of array with cryptographically strong random values of the appropriate type.
-    fill_with_random(array->viewed_array_buffer()->buffer().bytes().slice(array->byte_offset(), array->byte_length()));
+    ::Crypto::fill_with_secure_random(array->viewed_array_buffer()->buffer().bytes().slice(array->byte_offset(), array->byte_length()));
 
     // 4. Return array.
     return array;
@@ -94,7 +95,7 @@ ErrorOr<String> generate_random_uuid()
     u8 bytes[16];
 
     // 2. Fill bytes with cryptographically secure random bytes.
-    fill_with_random(bytes);
+    ::Crypto::fill_with_secure_random(bytes);
 
     // 3. Set the 4 most significant bits of bytes[6], which represent the UUID version, to 0100.
     bytes[6] &= ~(1 << 7);

--- a/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoAlgorithms.cpp
@@ -29,6 +29,7 @@
 #include <LibCrypto/Hash/SHA2.h>
 #include <LibCrypto/PK/RSA.h>
 #include <LibCrypto/Padding/OAEP.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/DataView.h>
@@ -323,8 +324,7 @@ static WebIDL::ExceptionOr<void> validate_jwk_key_ops(JS::Realm& realm, Bindings
 static WebIDL::ExceptionOr<ByteBuffer> generate_random_key(JS::VM& vm, u16 const size_in_bits)
 {
     auto key_buffer = TRY_OR_THROW_OOM(vm, ByteBuffer::create_uninitialized(size_in_bits / 8));
-    // FIXME: Use a cryptographically secure random generator
-    fill_with_random(key_buffer);
+    ::Crypto::fill_with_secure_random(key_buffer);
     return key_buffer;
 }
 

--- a/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Libraries/LibWebSocket/WebSocket.cpp
@@ -8,6 +8,7 @@
 #include <AK/Base64.h>
 #include <AK/Random.h>
 #include <LibCrypto/Hash/HashManager.h>
+#include <LibCrypto/SecureRandom.h>
 #include <LibWebSocket/Impl/WebSocketImplSerenity.h>
 #include <LibWebSocket/WebSocket.h>
 
@@ -183,7 +184,7 @@ void WebSocket::send_client_handshake()
 
     // 7. 16-byte nonce encoded as Base64
     u8 nonce_data[16];
-    fill_with_random(nonce_data);
+    Crypto::fill_with_secure_random(nonce_data);
     // FIXME: change to TRY() and make method fallible
     m_websocket_key = MUST(encode_base64({ nonce_data, 16 })).to_byte_string();
     builder.appendff("Sec-WebSocket-Key: {}\r\n", m_websocket_key);
@@ -589,7 +590,7 @@ void WebSocket::send_frame(WebSocket::OpCode op_code, ReadonlyBytes payload, boo
         // > Clients MUST choose a new masking key for each frame, using an algorithm
         // > that cannot be predicted by end applications that provide data
         u8 masking_key[4];
-        fill_with_random(masking_key);
+        Crypto::fill_with_secure_random(masking_key);
         m_impl->send(ReadonlyBytes(masking_key, 4));
         // don't try to send empty payload
         if (payload.size() == 0)

--- a/Meta/gn/secondary/Userland/Libraries/LibCrypto/BUILD.gn
+++ b/Meta/gn/secondary/Userland/Libraries/LibCrypto/BUILD.gn
@@ -39,5 +39,6 @@ shared_library("LibCrypto") {
     "Hash/SHA2.cpp",
     "NumberTheory/ModularFunctions.cpp",
     "PK/RSA.cpp",
+    "SecureRandom.cpp",
   ]
 }


### PR DESCRIPTION
See commits. Depends on #2989 to pull in OpenSSL.