### PR TITLE
LibWeb: Use Fetch for CSS `@import` rules

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -71,6 +71,7 @@ set(SOURCES
     CSS/CSSTransition.cpp
     CSS/Display.cpp
     CSS/EdgeRect.cpp
+    CSS/Fetch.cpp
     CSS/FontFace.cpp
     CSS/FontFaceSet.cpp
     CSS/Flex.cpp

--- a/Libraries/LibWeb/CSS/CSSImportRule.h
+++ b/Libraries/LibWeb/CSS/CSSImportRule.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2022, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -12,13 +12,11 @@
 #include <LibWeb/CSS/CSSRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/DOM/DocumentLoadEventDelayer.h>
-#include <LibWeb/Loader/Resource.h>
 
 namespace Web::CSS {
 
 class CSSImportRule final
-    : public CSSRule
-    , public ResourceClient {
+    : public CSSRule {
     WEB_PLATFORM_OBJECT(CSSImportRule, CSSRule);
     GC_DECLARE_ALLOCATOR(CSSImportRule);
 
@@ -34,7 +32,6 @@ public:
     CSSStyleSheet* loaded_style_sheet() { return m_style_sheet; }
     CSSStyleSheet const* loaded_style_sheet() const { return m_style_sheet; }
     CSSStyleSheet* style_sheet_for_bindings() { return m_style_sheet; }
-    void set_style_sheet(CSSStyleSheet* style_sheet) { m_style_sheet = style_sheet; }
 
 private:
     CSSImportRule(URL::URL, DOM::Document&);
@@ -42,11 +39,12 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
 
+    virtual void set_parent_style_sheet(CSSStyleSheet*) override;
+
     virtual String serialized() const override;
 
-    // ^ResourceClient
-    virtual void resource_did_fail() override;
-    virtual void resource_did_load() override;
+    void fetch();
+    void set_style_sheet(GC::Ref<CSSStyleSheet>);
 
     URL::URL m_url;
     GC::Ptr<DOM::Document> m_document;

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibURL/Parser.h>
+#include <LibWeb/CSS/CSSStyleSheet.h>
+#include <LibWeb/CSS/Fetch.h>
+#include <LibWeb/Fetch/Fetching/Fetching.h>
+
+namespace Web::CSS {
+
+// https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
+void fetch_a_style_resource(String const& url_value, CSSStyleSheet const& sheet, Fetch::Infrastructure::Request::Destination destination, CorsMode cors_mode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response)
+{
+    auto& vm = sheet.vm();
+
+    // 1. Let environmentSettings be sheet’s relevant settings object.
+    auto& environment_settings = HTML::relevant_settings_object(sheet);
+
+    // 2. Let base be sheet’s stylesheet base URL if it is not null, otherwise environmentSettings’s API base URL. [CSSOM]
+    auto base = sheet.base_url().value_or(environment_settings.api_base_url());
+
+    // 3. Let parsedUrl be the result of the URL parser steps with urlValue’s url and base. If the algorithm returns an error, return.
+    auto parsed_url = URL::Parser::basic_parse(url_value, base);
+    if (!parsed_url.is_valid())
+        return;
+
+    // 4. Let req be a new request whose url is parsedUrl, whose destination is destination, mode is corsMode,
+    //    origin is environmentSettings’s origin, credentials mode is "same-origin", use-url-credentials flag is set,
+    //    client is environmentSettings, and whose referrer is environmentSettings’s API base URL.
+    auto request = Fetch::Infrastructure::Request::create(vm);
+    request->set_url(parsed_url);
+    request->set_destination(destination);
+    request->set_mode(cors_mode == CorsMode::Cors ? Fetch::Infrastructure::Request::Mode::CORS : Fetch::Infrastructure::Request::Mode::NoCORS);
+    request->set_origin(environment_settings.origin());
+    request->set_credentials_mode(Fetch::Infrastructure::Request::CredentialsMode::SameOrigin);
+    request->set_use_url_credentials(true);
+    request->set_client(&environment_settings);
+    request->set_referrer(environment_settings.api_base_url());
+
+    // 5. Apply any URL request modifier steps that apply to this request.
+    // FIXME: No specs seem to define these yet. When they do, implement them.
+
+    // 6. If req’s mode is "cors", set req’s referrer to sheet’s location. [CSSOM]
+    if (request->mode() == Fetch::Infrastructure::Request::Mode::CORS) {
+        // FIXME: sheet's location is an optional string, what do we do here?
+    }
+
+    // 7. If sheet’s origin-clean flag is set, set req’s initiator type to "css". [CSSOM]
+    if (sheet.is_origin_clean())
+        request->set_initiator_type(Fetch::Infrastructure::Request::InitiatorType::CSS);
+
+    // 8. Fetch req, with processresponseconsumebody set to processResponse.
+    Fetch::Infrastructure::FetchAlgorithms::Input fetch_algorithms_input {};
+    fetch_algorithms_input.process_response_consume_body = move(process_response);
+
+    (void)Fetch::Fetching::fetch(environment_settings.realm(), request, Fetch::Infrastructure::FetchAlgorithms::create(vm, move(fetch_algorithms_input)));
+}
+
+}

--- a/Libraries/LibWeb/CSS/Fetch.h
+++ b/Libraries/LibWeb/CSS/Fetch.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
+
+namespace Web::CSS {
+
+enum class CorsMode {
+    NoCors,
+    Cors,
+};
+
+// https://drafts.csswg.org/css-values-4/#fetch-a-style-resource
+void fetch_a_style_resource(String const& url, CSSStyleSheet const&, Fetch::Infrastructure::Request::Destination, CorsMode, Fetch::Infrastructure::FetchAlgorithms::ProcessResponseConsumeBodyFunction process_response);
+
+}

--- a/Libraries/LibWeb/CSS/StyleSheet.h
+++ b/Libraries/LibWeb/CSS/StyleSheet.h
@@ -48,6 +48,7 @@ public:
     bool is_alternate() const { return m_alternate; }
     void set_alternate(bool alternate) { m_alternate = alternate; }
 
+    bool is_origin_clean() const { return m_origin_clean; }
     void set_origin_clean(bool origin_clean) { m_origin_clean = origin_clean; }
 
     bool disabled() const { return m_disabled; }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.cpp
@@ -201,6 +201,20 @@ GC::Ref<Response> Response::unsafe_response()
     return *this;
 }
 
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-same-origin
+bool Response::is_cors_same_origin() const
+{
+    // A response whose type is "basic", "cors", or "default" is CORS-same-origin. [FETCH]
+    switch (type()) {
+    case Type::Basic:
+    case Type::CORS:
+    case Type::Default:
+        return true;
+    default:
+        return false;
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#cors-cross-origin
 bool Response::is_cors_cross_origin() const
 {

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Responses.h
@@ -116,6 +116,7 @@ public:
 
     [[nodiscard]] GC::Ref<Response> unsafe_response();
 
+    [[nodiscard]] bool is_cors_same_origin() const;
     [[nodiscard]] bool is_cors_cross_origin() const;
 
     [[nodiscard]] bool is_fresh() const;

--- a/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
+++ b/Libraries/LibWeb/WebAssembly/WebAssembly.cpp
@@ -685,9 +685,7 @@ GC::Ref<WebIDL::Promise> compile_potential_webassembly_response(JS::VM& vm, GC::
         }
 
         // 6. If response is not CORS-same-origin, reject returnValue with a TypeError and abort these substeps.
-        // https://html.spec.whatwg.org/#cors-same-origin
-        auto type = response_object.type();
-        if (type != Bindings::ResponseType::Basic && type != Bindings::ResponseType::Cors && type != Bindings::ResponseType::Default) {
+        if (!response->is_cors_same_origin()) {
             WebIDL::reject_promise(realm, return_value, *vm.throw_completion<JS::TypeError>("Response is not CORS-same-origin"sv).value());
             return JS::js_undefined();
         }


### PR DESCRIPTION
Contributes to #2634.

This "fetch a style resource" algorithm is used in a few places - notably font loading. But this is what I had time for before being off work for a week. :^)

There are a few areas here left as FIXMEs, mostly related to other parts of the code needing refactoring. (*cough* CSS parser entry points *cough*) But also the whole "load event" stuff, and storing things as URLs too early, and however we're supposed to get a content-type from a Fetch Response.

But yeah, it's Fetch-ified, and nothing seems broken! :tada: