### PR TITLE
UI/Qt: Add customisable scrolling speed & invert scroll directions

### DIFF
--- a/UI/Qt/Settings.cpp
+++ b/UI/Qt/Settings.cpp
@@ -153,6 +153,36 @@ void Settings::set_enable_autoplay(bool enable)
     emit enable_autoplay_changed(enable);
 }
 
+int Settings::scrolling_speed()
+{
+    return m_qsettings->value("scrolling_speed", (int)100).toInt();
+}
+
+void Settings::set_scrolling_speed(int value)
+{
+    m_qsettings->setValue("scrolling_speed", value);
+}
+
+bool Settings::invert_vertical_scrolling()
+{
+    return m_qsettings->value("invert_vertical_scrolling", false).toBool();
+}
+
+void Settings::set_invert_vertical_scrolling(bool enable)
+{
+    m_qsettings->setValue("invert_vertical_scrolling", enable);
+}
+
+bool Settings::invert_horizontal_scrolling()
+{
+    return m_qsettings->value("invert_horizontal_scrolling", false).toBool();
+}
+
+void Settings::set_invert_horizontal_scrolling(bool enable)
+{
+    m_qsettings->setValue("invert_horizontal_scrolling", enable);
+}
+
 bool Settings::show_menubar()
 {
     return m_qsettings->value("show_menubar", false).toBool();

--- a/UI/Qt/Settings.h
+++ b/UI/Qt/Settings.h
@@ -71,6 +71,15 @@ public:
     bool enable_autoplay();
     void set_enable_autoplay(bool enable);
 
+    int scrolling_speed();
+    void set_scrolling_speed(int value);
+
+    bool invert_vertical_scrolling();
+    void set_invert_vertical_scrolling(bool enable);
+
+    bool invert_horizontal_scrolling();
+    void set_invert_horizontal_scrolling(bool enable);
+
     bool show_menubar();
     void set_show_menubar(bool show_menubar);
 

--- a/UI/Qt/SettingsDialog.cpp
+++ b/UI/Qt/SettingsDialog.cpp
@@ -86,6 +86,47 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
         Settings::the()->set_enable_autoplay(state == Qt::Checked);
     });
 
+    m_scrolling_speed = new QSlider( Qt::Horizontal, this);
+    m_scrolling_speed->setRange(0, 300);
+    m_scrolling_speed->setValue(Settings::the()->scrolling_speed());
+
+    m_reset_scrolling_speed = new QPushButton("Reset", this);
+    m_reset_scrolling_speed->setEnabled(m_scrolling_speed->value() != 100);
+    QObject::connect(m_reset_scrolling_speed, &QPushButton::pressed, this, [&]() {
+        m_scrolling_speed->setValue(100);
+    });
+
+    QHBoxLayout* scroll_speed_layout = new QHBoxLayout();
+    scroll_speed_layout->addWidget(m_scrolling_speed);
+    scroll_speed_layout->addWidget(m_reset_scrolling_speed);
+
+    m_scrolling_speed_label = new QLabel(QString("Scrolling Speed (%1%)").arg(m_scrolling_speed->value()), this);
+    QObject::connect(m_scrolling_speed, &QSlider::valueChanged, this, [&](int value) {
+        Settings::the()->set_scrolling_speed(value);
+        m_scrolling_speed_label->setText(QString("Scrolling Speed (%1%)").arg(value));
+        m_reset_scrolling_speed->setEnabled(value != 100);
+    });
+
+    m_invert_vertical_scrolling = new QCheckBox(this);
+    m_invert_vertical_scrolling->setChecked(Settings::the()->invert_vertical_scrolling());
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    QObject::connect(m_invert_vertical_scrolling, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
+    QObject::connect(m_invert_vertical_scrolling, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
+        Settings::the()->set_invert_vertical_scrolling(state == Qt::Checked);
+    });
+
+    m_invert_horizontal_scrolling = new QCheckBox(this);
+    m_invert_horizontal_scrolling->setChecked(Settings::the()->invert_horizontal_scrolling());
+#if (QT_VERSION > QT_VERSION_CHECK(6, 7, 0))
+    QObject::connect(m_invert_horizontal_scrolling, &QCheckBox::checkStateChanged, this, [&](int state) {
+#else
+    QObject::connect(m_invert_horizontal_scrolling, &QCheckBox::stateChanged, this, [&](int state) {
+#endif
+        Settings::the()->set_invert_horizontal_scrolling(state == Qt::Checked);
+    });
+
     setup_search_engines();
 
     m_layout->addRow(new QLabel("Page on New Tab", this), m_new_tab_page);
@@ -96,6 +137,9 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
     m_layout->addRow(new QLabel("Autocomplete Engine", this), m_autocomplete_engine_dropdown);
     m_layout->addRow(new QLabel("Send web sites a \"Do Not Track\" request", this), m_enable_do_not_track);
     m_layout->addRow(new QLabel("Enable autoplay on all websites", this), m_enable_autoplay);
+    m_layout->addRow(m_scrolling_speed_label, scroll_speed_layout);
+    m_layout->addRow(new QLabel("Invert Vertical Scrolling", this), m_invert_vertical_scrolling);
+    m_layout->addRow(new QLabel("Invert Horizontal Scrolling", this), m_invert_horizontal_scrolling);
 
     setWindowTitle("Settings");
     setLayout(m_layout);

--- a/UI/Qt/SettingsDialog.h
+++ b/UI/Qt/SettingsDialog.h
@@ -8,9 +8,11 @@
 #include <QCheckBox>
 #include <QDialog>
 #include <QFormLayout>
+#include <QLabel>
 #include <QLineEdit>
 #include <QMainWindow>
 #include <QPushButton>
+#include <qslider.h>
 
 #pragma once
 
@@ -35,6 +37,11 @@ private:
     QPushButton* m_autocomplete_engine_dropdown { nullptr };
     QCheckBox* m_enable_do_not_track { nullptr };
     QCheckBox* m_enable_autoplay { nullptr };
+    QPushButton* m_reset_scrolling_speed { nullptr };
+    QLabel* m_scrolling_speed_label { nullptr };
+    QSlider* m_scrolling_speed { nullptr };
+    QCheckBox* m_invert_vertical_scrolling { nullptr };
+    QCheckBox* m_invert_horizontal_scrolling { nullptr };
 };
 
 }

--- a/UI/Qt/WebContentView.cpp
+++ b/UI/Qt/WebContentView.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "Settings.h"
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Format.h>
@@ -769,6 +770,17 @@ void WebContentView::enqueue_native_event(Web::MouseEvent::Type type, QSinglePoi
 
             wheel_delta_x = static_cast<int>(step_x * scroll_step_size);
             wheel_delta_y = static_cast<int>(step_y * scroll_step_size);
+        }
+
+        wheel_delta_x = static_cast<int>(static_cast<double>(wheel_delta_x) * Settings::the()->scrolling_speed() / 100.0);
+        wheel_delta_y = static_cast<int>(static_cast<double>(wheel_delta_y) * Settings::the()->scrolling_speed() / 100.0);
+
+        if (Settings::the()->invert_vertical_scrolling()) {
+            wheel_delta_y = -wheel_delta_y;
+        }
+
+        if (Settings::the()->invert_horizontal_scrolling()) {
+            wheel_delta_x = -wheel_delta_x;
         }
     }
 


### PR DESCRIPTION
Adds:
- Edit > Settings > Scrolling Speed
- Edit > Settings > Invert Vertical Scrolling
- Edit > Settings > Invert Horizontal Scrolling

Which allows the user to specify whether they would like inverted or non-inverted scrolling for each direction, as well as specifying the generic scroll speed multiplier.