### PR TITLE
LibWeb/CSS: Fix crash resolving `calc` with only percentages

### DIFF
--- a/Tests/LibWeb/Text/expected/css/singular-percentage-calc-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/singular-percentage-calc-crash.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/css/singular-percentage-calc-crash.html
+++ b/Tests/LibWeb/Text/input/css/singular-percentage-calc-crash.html
@@ -1,0 +1,12 @@
+<script src="../include.js"></script>
+<style>
+    div {
+        transform: translateX(calc(10%))
+    }
+</style>
+<div></div>
+<script>
+    test(() => {
+        println(`PASS! (Didn't crash)`);
+    });
+</script>


### PR DESCRIPTION
Fixes #3006 , (relates to) #648

From some analysis, it seems as if this issue only occurs with a only percentages in a `calc`.
- `calc(10%)` crashes.
- `calc(10% + 10%)` crashes.
- `calc(10% + 0px)` doesn't crash.
- `calc(10vw)` doesn't crash.

The `resolve` function returns a `Length` in the general case, but returns a `Percentage` if only percentages are provided.

As a sanity check, I looked at the code before it was changed (commit before change was [here](https://github.com/LadybirdBrowser/ladybird/commit/8d40550478b213bceb1b95f44197df5b8e02fb8a)), and it only handled the case of percentages and lengths, as I do in this commit.

The old code being:
```cpp
Optional<Length> CalculatedStyleValue::resolve_length_percentage(Length::ResolutionContext const& resolution_context, Length const& percentage_basis) const
{
    auto result = m_calculation->resolve(resolution_context, percentage_basis);

    return result.value().visit(
        [&](Length const& length) -> Optional<Length> {
            return length;
        },
        [&](Percentage const& percentage) -> Optional<Length> {
            return percentage_basis.percentage_of(percentage);
        },
        [&](auto const&) -> Optional<Length> {
            return {};
        });
}
```

Not sure if this is perfect, very open to constructive criticism.