### PR TITLE
LibWeb/CSS: Create a MediaQueryListEvent when calling MQLE::create()

### DIFF
--- a/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
+++ b/Libraries/LibWeb/CSS/MediaQueryListEvent.cpp
@@ -12,6 +12,13 @@ namespace Web::CSS {
 
 GC_DEFINE_ALLOCATOR(MediaQueryListEvent);
 
+GC::Ref<MediaQueryListEvent> MediaQueryListEvent::create(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
+{
+    auto event = realm.create<MediaQueryListEvent>(realm, event_name, event_init);
+    event->set_is_trusted(true);
+    return event;
+}
+
 GC::Ref<MediaQueryListEvent> MediaQueryListEvent::construct_impl(JS::Realm& realm, FlyString const& event_name, MediaQueryListEventInit const& event_init)
 {
     return realm.create<MediaQueryListEvent>(realm, event_name, event_init);

--- a/Libraries/LibWeb/CSS/MediaQueryListEvent.h
+++ b/Libraries/LibWeb/CSS/MediaQueryListEvent.h
@@ -21,6 +21,7 @@ class MediaQueryListEvent final : public DOM::Event {
     GC_DECLARE_ALLOCATOR(MediaQueryListEvent);
 
 public:
+    [[nodiscard]] static GC::Ref<MediaQueryListEvent> create(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& = {});
     [[nodiscard]] static GC::Ref<MediaQueryListEvent> construct_impl(JS::Realm&, FlyString const& event_name, MediaQueryListEventInit const& = {});
 
     virtual ~MediaQueryListEvent() override;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryList-addListener-handleEvent.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryList-addListener-handleEvent.txt
@@ -2,9 +2,9 @@ Harness status: OK
 
 Found 6 tests
 
-3 Pass
-3 Fail
-Fail	calls handleEvent method of event listener
+4 Pass
+2 Fail
+Pass	calls handleEvent method of event listener
 Pass	looks up handleEvent method on every event dispatch
 Pass	doesn't look up handleEvent method on callable event listeners
 Pass	rethrows errors when getting handleEvent

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryList-addListener-removeListener.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryList-addListener-removeListener.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 8 tests
 
-7 Pass
-1 Fail
+8 Pass
 Pass	EventListener parameter is optional
-Fail	listeners are called when <iframe> is resized
+Pass	listeners are called when <iframe> is resized
 Pass	listeners are called correct number of times
 Pass	listeners are called in order they were added
 Pass	listener that was added twice is called only once

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryList-extends-EventTarget.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryList-extends-EventTarget.txt
@@ -2,9 +2,8 @@ Harness status: OK
 
 Found 7 tests
 
-6 Pass
-1 Fail
-Fail	onchange adds listener
+7 Pass
+Pass	onchange adds listener
 Pass	onchange removes listener
 Pass	listeners for "change" type are called
 Pass	listeners with different type are not called

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryListEvent.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom-view/MediaQueryListEvent.txt
@@ -2,11 +2,10 @@ Harness status: OK
 
 Found 6 tests
 
-3 Pass
-3 Fail
+6 Pass
 Pass	type can be different from "change"
 Pass	init dictionary default values
 Pass	init dictionary overrides
-Fail	argument of addListener
-Fail	argument of onchange
-Fail	constructor of "change" event
+Pass	argument of addListener
+Pass	argument of onchange
+Pass	constructor of "change" event


### PR DESCRIPTION
Otherwise, if not implemented, `MediaQueryListEvent::create()` would result in a call to `DOM::Event::create()`. This issue exists here: https://github.com/LadybirdBrowser/ladybird/blob/673537b26bbc239bdaf4d8026d916fea020bc1a0/Libraries/LibWeb/DOM/Document.cpp#L2865