### PR TITLE
LibWeb: Align accname alt-vs-title behavior w/ HTML-AAM spec & WPT tests

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2491,13 +2491,15 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
 
         // E. Host Language Label: Otherwise, if the current node's native markup provides an attribute (e.g. alt) or
         //    element (e.g. HTML label or SVG title) that defines a text alternative, return that alternative in the form
-        //    of a flat string as defined by the host language, unless the element is marked as presentational
-        //    (role="presentation" or role="none").
-        //
+        //    of a flat string as defined by the host language.
         // TODO: Confirm (through existing WPT test cases) whether HTMLLabelElement is already handled (by the code for
         // step C. “Embedded Control” above) in conformance with the spec requirements — and if not, then add handling.
-        if (role != ARIA::Role::presentation && role != ARIA::Role::none && is<HTML::HTMLImageElement>(*element))
-            return element->alternative_text().release_value();
+        //
+        // https://w3c.github.io/html-aam/#img-element-accessible-name-computation
+        // use alt attribute, even if its value is the empty string.
+        // See also https://wpt.fyi/results/accname/name/comp_tooltip.tentative.html.
+        if (is<HTML::HTMLImageElement>(*element) && element->has_attribute(HTML::AttributeNames::alt))
+            return element->get_attribute(HTML::AttributeNames::alt).value();
 
         // https://w3c.github.io/svg-aam/#mapping_additional_nd
         Optional<String> title_element_text;

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_tooltip.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_tooltip.tentative.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	img with tooltip label with empty alt

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_tooltip.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_tooltip.txt
@@ -1,14 +1,13 @@
 Harness status: OK
 
-Found 23 tests
+Found 22 tests
 
-23 Pass
+22 Pass
 Pass	link with img with tooltip label
 Pass	link with text with tooltip label and no contents
 Pass	link with text with tooltip label and contents
 Pass	div with text with tooltip label
 Pass	img with tooltip label without alt
-Pass	img with tooltip label with empty alt
 Pass	img with tooltip label with alt
 Pass	img with tooltip label without title
 Pass	select with tooltip label

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_tooltip.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_tooltip.html
@@ -13,12 +13,11 @@
 
 <p>Tests the <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
 
-<a href="#" title="title" data-expectedlabel="title" data-testname="link with img with tooltip label" class="ex"><img alt="" src="data:image/gif;base65,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a>
+<a href="#" title="title" data-expectedlabel="title" data-testname="link with img with tooltip label" class="ex"><img alt="" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="></a>
 <a href="#" title="title" data-expectedlabel="title" data-testname="link with text with tooltip label and no contents" class="ex"></a>
 <a href="#" title="title" data-expectedlabel="contents" data-testname="link with text with tooltip label and contents" class="ex">contents</a>
 <div title="title" role="group" data-expectedlabel="title" data-testname="div with text with tooltip label" class="ex">contents</div><!-- Note: group role disallows nameFrom:contents -->
 <img title="title" data-expectedlabel="title" data-testname="img with tooltip label without alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
-<img title="title" data-expectedlabel="title" alt="" data-testname="img with tooltip label with empty alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 <img title="title" data-expectedlabel="alt" alt="alt" data-testname="img with tooltip label with alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 <img data-expectedlabel="alt" alt="alt" data-testname="img with tooltip label without title" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
 

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_tooltip.tentative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_tooltip.tentative.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html>
+<head>
+  <title>Name Comp: Tooltip (Tentative)</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests the tentative <a href="https://w3c.github.io/accname/#comp_tooltip">#comp_tooltip</a> portions of the AccName <em>Name Computation</em> algorithm.</p>
+
+<!-- Explanation in https://github.com/w3c/aria/pull/2378#issuecomment-2493635126 -->
+<img title="title" data-expectedlabel="" alt="" data-testname="img with tooltip label with empty alt" class="ex" src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==">
+
+<script>
+AriaUtils.verifyLabelsBySelector(".ex");
+</script>
+</body>
+</html>


### PR DESCRIPTION
The https://wpt.fyi/results/accname/name/comp_tooltip.tentative.html test was recently added by moving an existing subtest out from the test at https://wpt.fyi/results/accname/name/comp_tooltip.html, and changing the test expectations to match the HTML-AAM spec requirements at https://w3c.github.io/html-aam/#img-element-accessible-name-computation.

See https://github.com/web-platform-tests/wpt/pull/49552.

So this code change updates Ladybird to match the updated WPT test expectations — and to match the existing HTML-AAM spec requirements.