### PR TITLE
Add lightweight inheritance-only style updates, and use them for style attribute mutation

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2331,10 +2331,13 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
     for (auto i = to_underlying(first_longhand_property_id); i <= to_underlying(last_longhand_property_id); ++i) {
         auto property_id = static_cast<CSS::PropertyID>(i);
         auto value = cascaded_properties.property(property_id);
+        auto inherited = ComputedProperties::Inherited::No;
+
         if ((!value && is_inherited_property(property_id))
             || (value && value->is_inherit())) {
             if (auto inheritance_parent = element_to_inherit_style_from(&element, pseudo_element)) {
                 value = inheritance_parent->computed_properties()->property(property_id);
+                inherited = ComputedProperties::Inherited::Yes;
             } else {
                 value = property_initial_value(property_id);
             }
@@ -2350,7 +2353,7 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
                 value = CSSKeywordValue::create(Keyword::Initial);
         }
 
-        computed_style->set_property(property_id, value.release_nonnull());
+        computed_style->set_property(property_id, value.release_nonnull(), inherited);
 
         if (property_id == PropertyID::AnimationName) {
             computed_style->set_animation_name_source(cascaded_properties.property_source(property_id));

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -169,7 +169,8 @@ public:
     };
     void collect_animation_into(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, GC::Ref<Animations::KeyframeEffect> animation, ComputedProperties&, AnimationRefresh = AnimationRefresh::No) const;
 
-    [[nodiscard]] bool has_has_selectors() const { return m_has_has_selectors; }
+    [[nodiscard]] bool has_has_selectors() const;
+    [[nodiscard]] bool has_attribute_selector(FlyString const& attribute_name) const;
 
     size_t number_of_css_font_faces_with_loading_in_progress() const;
 
@@ -247,6 +248,11 @@ private:
 
     GC::Ref<DOM::Document> m_document;
 
+    struct SelectorInsights {
+        bool has_has_selectors { false };
+        HashTable<FlyString> all_names_used_in_attribute_selectors;
+    };
+
     struct RuleCache {
         HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
         HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
@@ -257,15 +263,15 @@ private:
         Vector<MatchingRule> other_rules;
 
         HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
-
-        bool has_has_selectors { false };
     };
 
-    NonnullOwnPtr<RuleCache> make_rule_cache_for_cascade_origin(CascadeOrigin);
+    NonnullOwnPtr<RuleCache> make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&);
 
     RuleCache const& rule_cache_for_cascade_origin(CascadeOrigin) const;
 
-    bool m_has_has_selectors { false };
+    static void collect_selector_insights(Selector const&, SelectorInsights&);
+
+    OwnPtr<SelectorInsights> m_selector_insights;
     OwnPtr<RuleCache> m_author_rule_cache;
     OwnPtr<RuleCache> m_user_rule_cache;
     OwnPtr<RuleCache> m_user_agent_rule_cache;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -175,6 +175,8 @@ public:
 
     [[nodiscard]] GC::Ref<ComputedProperties> compute_properties(DOM::Element&, Optional<Selector::PseudoElement::Type>, CascadedProperties&) const;
 
+    void absolutize_values(ComputedProperties&) const;
+
 private:
     enum class ComputeStyleMode {
         Normal,
@@ -194,7 +196,6 @@ private:
     void compute_math_depth(ComputedProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void compute_defaulted_values(ComputedProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
     void start_needed_transitions(ComputedProperties const& old_style, ComputedProperties& new_style, DOM::Element&, Optional<Selector::PseudoElement::Type>) const;
-    void absolutize_values(ComputedProperties&) const;
     void resolve_effective_overflow_values(ComputedProperties&) const;
     void transform_box_type_if_needed(ComputedProperties&, DOM::Element const&, Optional<CSS::Selector::PseudoElement::Type>) const;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1297,10 +1297,13 @@ void Document::update_layout()
     if (is<Element>(node)) {
         if (needs_full_style_update || node.needs_style_update()) {
             invalidation |= static_cast<Element&>(node).recompute_style();
+        } else if (node.needs_inherited_style_update()) {
+            invalidation |= static_cast<Element&>(node).recompute_inherited_style();
         }
         is_display_none = static_cast<Element&>(node).computed_properties()->display().is_none();
     }
     node.set_needs_style_update(false);
+    node.set_needs_inherited_style_update(false);
 
     if (needs_full_style_update || node.child_needs_style_update()) {
         if (node.is_element()) {
@@ -1314,7 +1317,7 @@ void Document::update_layout()
         }
 
         node.for_each_child([&](auto& child) {
-            if (needs_full_style_update || child.needs_style_update() || child.child_needs_style_update()) {
+            if (needs_full_style_update || child.needs_style_update() || child.needs_inherited_style_update() || child.child_needs_style_update()) {
                 auto subtree_invalidation = update_style_recursively(child, style_computer);
                 if (!is_display_none)
                     invalidation |= subtree_invalidation;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -178,6 +178,7 @@ public:
     void run_attribute_change_steps(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_);
 
     CSS::RequiredInvalidationAfterStyleChange recompute_style();
+    CSS::RequiredInvalidationAfterStyleChange recompute_inherited_style();
 
     Optional<CSS::Selector::PseudoElement::Type> use_pseudo_element() const { return m_use_pseudo_element; }
     void set_use_pseudo_element(Optional<CSS::Selector::PseudoElement::Type> use_pseudo_element) { m_use_pseudo_element = move(use_pseudo_element); }

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1249,6 +1249,22 @@ EventTarget* Node::get_parent(Event const&)
     return parent();
 }
 
+void Node::set_needs_inherited_style_update(bool value)
+{
+    if (m_needs_inherited_style_update == value)
+        return;
+    m_needs_inherited_style_update = value;
+
+    if (m_needs_inherited_style_update) {
+        for (auto* ancestor = parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host()) {
+            if (ancestor->m_child_needs_style_update)
+                break;
+            ancestor->m_child_needs_style_update = true;
+        }
+        document().schedule_style_update();
+    }
+}
+
 void Node::set_needs_style_update(bool value)
 {
     if (m_needs_style_update == value)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -275,6 +275,9 @@ public:
     bool needs_style_update() const { return m_needs_style_update; }
     void set_needs_style_update(bool);
 
+    bool needs_inherited_style_update() const { return m_needs_inherited_style_update; }
+    void set_needs_inherited_style_update(bool);
+
     bool child_needs_style_update() const { return m_child_needs_style_update; }
     void set_child_needs_style_update(bool b) { m_child_needs_style_update = b; }
 
@@ -746,6 +749,7 @@ protected:
     GC::Ptr<Painting::Paintable> m_paintable;
     NodeType m_type { NodeType::INVALID };
     bool m_needs_style_update { false };
+    bool m_needs_inherited_style_update { false };
     bool m_child_needs_style_update { false };
 
     UniqueNodeID m_unique_id;


### PR DESCRIPTION
When an element's `style` attribute is changed, we now mark the element for style update, but we don't do the same to all of its descendants.

Instead, we mark descendants as "needs inherited style update", which only goes through properties that were inherited from another element and updates those.

This means we don't run selector matching at all for all those descendants, drastically reducing the workload.