### PR TITLE
Tests/LibWeb: Remove some support files from TestConfig.ini

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -42,11 +42,6 @@ Text/input/wpt-import/html/syntax/parsing/html5lib_webkit01.html
 Text/input/wpt-import/html/syntax/parsing/named-character-references.html
 
 ; Support files (not tests themselves)
-Text/input/wpt-import/html/syntax/parsing/support/no-doctype-name-eof.html
-Text/input/wpt-import/html/syntax/parsing/support/no-doctype-name-line.html
-Text/input/wpt-import/html/syntax/parsing/support/no-doctype-name-space.html
-Text/input/wpt-import/html/semantics/embedded-content/the-iframe-element/support/sandbox_allow_script.html
-Text/input/wpt-import/html/semantics/embedded-content/the-iframe-element/support/blank.htm
 Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-frame.html
 Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
 


### PR DESCRIPTION
Since 8e34efd4b533bf8c6aee660b0383e3eb73f3d5be, these files are detected by the runner and already skipped.