### PR TITLE
Meta: Consolidate checking for the system audio backend

### DIFF
--- a/Libraries/LibMedia/Audio/PlaybackStream.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStream.cpp
@@ -6,32 +6,11 @@
 
 #include "PlaybackStream.h"
 
-#include <AK/Platform.h>
-
-#if defined(HAVE_PULSEAUDIO)
-#    include "PlaybackStreamPulseAudio.h"
-#elif defined(AK_OS_MACOS)
-#    include "PlaybackStreamAudioUnit.h"
-#elif defined(AK_OS_ANDROID)
-#    include "PlaybackStreamOboe.h"
-#endif
-
 namespace Audio {
 
-ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStream::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
+ErrorOr<NonnullRefPtr<PlaybackStream>> __attribute__((weak)) PlaybackStream::create(OutputState, u32, u8, u32, AudioDataRequestCallback&&)
 {
-    VERIFY(data_request_callback);
-    // Create the platform-specific implementation for this stream.
-#if defined(HAVE_PULSEAUDIO)
-    return PlaybackStreamPulseAudio::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
-#elif defined(AK_OS_MACOS)
-    return PlaybackStreamAudioUnit::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
-#elif defined(AK_OS_ANDROID)
-    return PlaybackStreamOboe::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
-#else
-    (void)initial_output_state, (void)sample_rate, (void)channels, (void)target_latency_ms;
     return Error::from_string_literal("Audio output is not available for this platform");
-#endif
 }
 
 }

--- a/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamAudioUnit.cpp
@@ -215,6 +215,11 @@ private:
     Atomic<i64> m_last_sample_time { 0 };
 };
 
+ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStream::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
+{
+    return PlaybackStreamAudioUnit::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
+}
+
 ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamAudioUnit::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32, AudioDataRequestCallback&& data_request_callback)
 {
     AudioStreamBasicDescription description {};

--- a/Libraries/LibMedia/Audio/PlaybackStreamOboe.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamOboe.cpp
@@ -80,9 +80,9 @@ private:
     std::shared_ptr<OboeCallback> m_oboe_callback;
 };
 
-PlaybackStreamOboe::PlaybackStreamOboe(NonnullRefPtr<Storage> storage)
-    : m_storage(move(storage))
+ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStream::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
 {
+    return PlaybackStreamOboe::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
 }
 
 ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamOboe::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32, AudioDataRequestCallback&& data_request_callback)
@@ -106,6 +106,11 @@ ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamOboe::create(OutputState in
 
     auto storage = TRY(adopt_nonnull_ref_or_enomem(new PlaybackStreamOboe::Storage(move(stream), move(oboe_callback))));
     return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) PlaybackStreamOboe(move(storage))));
+}
+
+PlaybackStreamOboe::PlaybackStreamOboe(NonnullRefPtr<Storage> storage)
+    : m_storage(move(storage))
+{
 }
 
 PlaybackStreamOboe::~PlaybackStreamOboe() = default;

--- a/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
+++ b/Libraries/LibMedia/Audio/PlaybackStreamPulseAudio.cpp
@@ -21,6 +21,11 @@ namespace Audio {
         __temporary_result.release_value();                                                                  \
     })
 
+ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStream::create(OutputState initial_output_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
+{
+    return PlaybackStreamPulseAudio::create(initial_output_state, sample_rate, channels, target_latency_ms, move(data_request_callback));
+}
+
 ErrorOr<NonnullRefPtr<PlaybackStream>> PlaybackStreamPulseAudio::create(OutputState initial_state, u32 sample_rate, u8 channels, u32 target_latency_ms, AudioDataRequestCallback&& data_request_callback)
 {
     VERIFY(data_request_callback);

--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -1,6 +1,7 @@
+include(audio)
+
 if (NOT ANDROID AND NOT WIN32)
     include(ffmpeg)
-    include(pulseaudio)
 endif()
 
 set(SOURCES
@@ -30,23 +31,20 @@ else()
     target_sources(LibMedia PRIVATE FFmpeg/FFmpegVideoDecoderStub.cpp)
 endif()
 
-# Audio backend -- how we output audio to the speakers
-if (HAVE_PULSEAUDIO)
+if (LADYBIRD_AUDIO_BACKEND STREQUAL "PULSE")
     target_sources(LibMedia PRIVATE
         Audio/PlaybackStreamPulseAudio.cpp
         Audio/PulseAudioWrappers.cpp
     )
     target_link_libraries(LibMedia PRIVATE PkgConfig::PULSEAUDIO)
-    target_compile_definitions(LibMedia PUBLIC HAVE_PULSEAUDIO=1)
-elseif (APPLE AND NOT IOS)
+elseif (LADYBIRD_AUDIO_BACKEND STREQUAL "AUDIO_UNIT")
     target_sources(LibMedia PRIVATE Audio/PlaybackStreamAudioUnit.cpp)
-
     find_library(AUDIO_UNIT AudioUnit REQUIRED)
     target_link_libraries(LibMedia PRIVATE ${AUDIO_UNIT})
-elseif (ANDROID)
+elseif (LADYBIRD_AUDIO_BACKEND STREQUAL "OBOE")
     target_sources(LibMedia PRIVATE Audio/PlaybackStreamOboe.cpp)
     find_package(oboe REQUIRED CONFIG)
     target_link_libraries(LibMedia PRIVATE log oboe::oboe)
-else()
-    message(WARNING "No audio backend available")
+elseif (DEFINED LADYBIRD_AUDIO_BACKEND)
+    message(FATAL_ERROR "Please update ${CMAKE_CURRENT_LIST_FILE} for audio backend ${LADYBIRD_AUDIO_BACKEND}")
 endif()

--- a/Meta/CMake/audio.cmake
+++ b/Meta/CMake/audio.cmake
@@ -1,0 +1,20 @@
+include_guard()
+
+# Audio backend -- how we output audio to the speakers.
+if (APPLE AND NOT IOS)
+    set(LADYBIRD_AUDIO_BACKEND "AUDIO_UNIT")
+    return()
+elseif (ANDROID)
+    set(LADYBIRD_AUDIO_BACKEND "OBOE")
+    return()
+elseif (NOT WIN32)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(PULSEAUDIO IMPORTED_TARGET libpulse)
+
+    if (PULSEAUDIO_FOUND)
+        set(LADYBIRD_AUDIO_BACKEND "PULSE")
+        return()
+    endif()
+endif()
+
+message(WARNING "No audio backend available")

--- a/Meta/CMake/pulseaudio.cmake
+++ b/Meta/CMake/pulseaudio.cmake
@@ -1,8 +1,0 @@
-include_guard()
-
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(PULSEAUDIO IMPORTED_TARGET libpulse)
-
-if (PULSEAUDIO_FOUND)
-    set(HAVE_PULSEAUDIO ON CACHE BOOL "" FORCE)
-endif()

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -1,4 +1,4 @@
-include(pulseaudio)
+include(audio)
 
 set(SOURCES
     ConnectionFromClient.cpp
@@ -35,7 +35,7 @@ if (ENABLE_QT)
     target_link_libraries(WebContent PRIVATE Qt::Core)
     target_compile_definitions(WebContent PRIVATE HAVE_QT=1)
 
-    if (NOT HAVE_PULSEAUDIO)
+    if (NOT DEFINED LADYBIRD_AUDIO_BACKEND)
         find_package(Qt6 REQUIRED COMPONENTS Multimedia)
 
         target_sources(WebContent PRIVATE

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -83,11 +83,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Web::Platform::AudioCodecPlugin::install_creation_hook([](auto loader) {
 #if defined(HAVE_QT_MULTIMEDIA)
         return Ladybird::AudioCodecPluginQt::create(move(loader));
-#elif defined(AK_OS_MACOS) || defined(HAVE_PULSEAUDIO)
-        return Web::Platform::AudioCodecPluginAgnostic::create(move(loader));
 #else
-        (void)loader;
-        return Error::from_string_literal("Don't know how to initialize audio in this configuration!");
+        return Web::Platform::AudioCodecPluginAgnostic::create(move(loader));
 #endif
     });
 

--- a/Tests/LibMedia/CMakeLists.txt
+++ b/Tests/LibMedia/CMakeLists.txt
@@ -1,3 +1,5 @@
+include(audio)
+
 set(TEST_SOURCES
     TestH264Decode.cpp
     TestParseMatroska.cpp
@@ -10,3 +12,7 @@ set(TEST_SOURCES
 foreach(source IN LISTS TEST_SOURCES)
     lagom_test("${source}" LibMedia LIBS LibMedia LibFileSystem WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
 endforeach()
+
+if (LADYBIRD_AUDIO_BACKEND STREQUAL "PULSE")
+    target_compile_definitions(TestPlaybackStream PRIVATE HAVE_PULSEAUDIO=1)
+endif()

--- a/Tests/LibMedia/TestPlaybackStream.cpp
+++ b/Tests/LibMedia/TestPlaybackStream.cpp
@@ -16,14 +16,7 @@
 #    include <LibMedia/Audio/PulseAudioWrappers.h>
 #endif
 
-// FIXME: CI doesn't run an AudioServer currently. Creating one in /etc/SystemServer.ini does not
-//        allow this test to pass since CI runs in a Shell that will setsid() if it finds that the
-//        current session ID is 0, and AudioServer's socket address depends on the current sid.
-//        If we can fix that, this test can run on CI.
-//        https://github.com/SerenityOS/serenity/issues/20538
-#define STREAM_TEST TEST_CASE
-
-STREAM_TEST(create_and_destroy_playback_stream)
+TEST_CASE(create_and_destroy_playback_stream)
 {
     Core::EventLoop event_loop;
 

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -132,6 +132,10 @@
       "version": "8.10.1#0"
     },
     {
+      "name": "dirent",
+      "version": "1.24#0"
+    },
+    {
       "name": "ffmpeg",
       "version": "6.1.1#11"
     },
@@ -166,6 +170,14 @@
     {
       "name": "libwebp",
       "version": "1.4.0#1"
+    },
+    {
+      "name": "mman",
+      "version": "git-f5ff813#5"
+    },
+    {
+      "name": "openssl",
+      "version": "3.4.0#0"
     },
     {
       "name": "simdutf",


### PR DESCRIPTION
The goal here is to ensure we check for audio backends in a way that
makes sense. On macOS, let's just always use Audio Unit (and thus avoid
any checks for Pulse, to reduce needless/confusing build log noise). We
will also only use the Qt audio backend if no other backend was found,
rather than only checking for Pulse.