### PR TITLE
LibWeb: Use helper methods on stream instances instead of directly invoking AOs

### DIFF
--- a/Libraries/LibWeb/Compression/DecompressionStream.cpp
+++ b/Libraries/LibWeb/Compression/DecompressionStream.cpp
@@ -133,7 +133,7 @@ WebIDL::ExceptionOr<void> DecompressionStream::decompress_and_enqueue_chunk(JS::
     auto array = JS::Uint8Array::create(realm, array_buffer->byte_length(), *array_buffer);
 
     // 5. For each Uint8Array array, enqueue array in ds's transform.
-    TRY(Streams::transform_stream_default_controller_enqueue(*m_transform->controller(), array));
+    m_transform->enqueue(array);
     return {};
 }
 
@@ -159,7 +159,7 @@ WebIDL::ExceptionOr<void> DecompressionStream::decompress_flush_and_enqueue()
     auto array = JS::Uint8Array::create(realm, array_buffer->byte_length(), *array_buffer);
 
     // 5. For each Uint8Array array, enqueue array in ds's transform.
-    TRY(Streams::transform_stream_default_controller_enqueue(*m_transform->controller(), array));
+    m_transform->enqueue(array);
     return {};
 }
 

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -744,7 +744,7 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         transform_stream->set_up(identity_transform_algorithm, flush_algorithm);
 
         // 4. Set internalResponse’s body’s stream to the result of internalResponse’s body’s stream piped through transformStream.
-        auto promise = Streams::readable_stream_pipe_to(internal_response->body()->stream(), transform_stream->writable(), false, false, false, {});
+        auto promise = internal_response->body()->stream()->piped_through(transform_stream->writable());
         WebIDL::mark_promise_as_handled(*promise);
         internal_response->body()->set_stream(transform_stream->readable());
     }

--- a/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
+++ b/Libraries/LibWeb/Fetch/Infrastructure/HTTP/Bodies.cpp
@@ -90,7 +90,7 @@ void Body::fully_read(JS::Realm& realm, Web::Fetch::Infrastructure::Body::Proces
 
     // 4. Let reader be the result of getting a reader for body’s stream. If that threw an exception, then run errorSteps
     //    with that exception and return.
-    auto reader = Streams::acquire_readable_stream_default_reader(m_stream);
+    auto reader = m_stream->get_a_reader();
 
     if (reader.is_exception()) {
         auto throw_completion = Bindings::exception_to_throw_completion(realm.vm(), reader.release_error());
@@ -113,7 +113,7 @@ void Body::incrementally_read(ProcessBodyChunkCallback process_body_chunk, Proce
 
     // 2. Let reader be the result of getting a reader for body’s stream.
     // NOTE: This operation will not throw an exception.
-    auto reader = MUST(Streams::acquire_readable_stream_default_reader(m_stream));
+    auto reader = MUST(m_stream->get_a_reader());
 
     // 3. Perform the incrementally-read loop given reader, taskDestination, processBodyChunk, processEndOfBody, and processBodyError.
     incrementally_read_loop(reader, task_destination.get<GC::Ref<JS::Object>>(), process_body_chunk, process_end_of_body, process_body_error);

--- a/Libraries/LibWeb/FileAPI/Blob.cpp
+++ b/Libraries/LibWeb/FileAPI/Blob.cpp
@@ -376,7 +376,7 @@ GC::Ref<WebIDL::Promise> Blob::text()
     auto stream = get_stream();
 
     // 2. Let reader be the result of getting a reader from stream. If that threw an exception, return a new promise rejected with that exception.
-    auto reader_or_exception = acquire_readable_stream_default_reader(*stream);
+    auto reader_or_exception = stream->get_a_reader();
     if (reader_or_exception.is_exception())
         return WebIDL::create_rejected_promise_from_exception(realm, reader_or_exception.release_error());
     auto reader = reader_or_exception.release_value();
@@ -405,7 +405,7 @@ GC::Ref<WebIDL::Promise> Blob::array_buffer()
     auto stream = get_stream();
 
     // 2. Let reader be the result of getting a reader from stream. If that threw an exception, return a new promise rejected with that exception.
-    auto reader_or_exception = acquire_readable_stream_default_reader(*stream);
+    auto reader_or_exception = stream->get_a_reader();
     if (reader_or_exception.is_exception())
         return WebIDL::create_rejected_promise_from_exception(realm, reader_or_exception.release_error());
     auto reader = reader_or_exception.release_value();
@@ -432,7 +432,7 @@ GC::Ref<WebIDL::Promise> Blob::bytes()
     auto stream = get_stream();
 
     // 2. Let reader be the result of getting a reader from stream. If that threw an exception, return a new promise rejected with that exception.
-    auto reader_or_exception = acquire_readable_stream_default_reader(*stream);
+    auto reader_or_exception = stream->get_a_reader();
     if (reader_or_exception.is_exception())
         return WebIDL::create_rejected_promise_from_exception(realm, reader_or_exception.release_error());
     auto reader = reader_or_exception.release_value();

--- a/Libraries/LibWeb/FileAPI/FileReader.cpp
+++ b/Libraries/LibWeb/FileAPI/FileReader.cpp
@@ -134,7 +134,7 @@ WebIDL::ExceptionOr<void> FileReader::read_operation(Blob& blob, Type type, Opti
     auto stream = blob.get_stream();
 
     // 6. Let reader be the result of getting a reader from stream.
-    auto reader = TRY(acquire_readable_stream_default_reader(*stream));
+    auto reader = TRY(stream->get_a_reader());
 
     // 7. Let bytes be an empty byte sequence.
     ByteBuffer bytes;

--- a/Libraries/LibWeb/Streams/AbstractOperations.cpp
+++ b/Libraries/LibWeb/Streams/AbstractOperations.cpp
@@ -290,7 +290,7 @@ bool readable_stream_has_default_reader(ReadableStream const& stream)
 }
 
 // https://streams.spec.whatwg.org/#readable-stream-pipe-to
-GC::Ref<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source, WritableStream& dest, bool, bool, bool, Optional<JS::Value> signal)
+GC::Ref<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source, WritableStream& dest, bool, bool, bool, JS::Value signal)
 {
     auto& realm = source.realm();
 
@@ -299,11 +299,10 @@ GC::Ref<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source, Writabl
     // 3. Assert: preventClose, preventAbort, and preventCancel are all booleans.
 
     // 4. If signal was not given, let signal be undefined.
-    if (!signal.has_value())
-        signal = JS::js_undefined();
+    // NOTE: Done by default argument
 
     // 5. Assert: either signal is undefined, or signal implements AbortSignal.
-    VERIFY(signal->is_undefined() || (signal->is_object() && is<DOM::AbortSignal>(signal->as_object())));
+    VERIFY(signal.is_undefined() || (signal.is_object() && is<DOM::AbortSignal>(signal.as_object())));
 
     // 6. Assert: ! IsReadableStreamLocked(source) is false.
     VERIFY(!is_readable_stream_locked(source));

--- a/Libraries/LibWeb/Streams/AbstractOperations.h
+++ b/Libraries/LibWeb/Streams/AbstractOperations.h
@@ -40,7 +40,7 @@ size_t readable_stream_get_num_read_requests(ReadableStream const&);
 bool readable_stream_has_byob_reader(ReadableStream const&);
 bool readable_stream_has_default_reader(ReadableStream const&);
 
-GC::Ref<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source, WritableStream& dest, bool prevent_close, bool prevent_abort, bool prevent_cancel, Optional<JS::Value> signal);
+GC::Ref<WebIDL::Promise> readable_stream_pipe_to(ReadableStream& source, WritableStream& dest, bool prevent_close, bool prevent_abort, bool prevent_cancel, JS::Value signal = JS::js_undefined());
 
 WebIDL::ExceptionOr<ReadableStreamPair> readable_stream_tee(JS::Realm&, ReadableStream&, bool clone_for_branch2);
 WebIDL::ExceptionOr<ReadableStreamPair> readable_stream_default_tee(JS::Realm& realm, ReadableStream& stream, bool clone_for_branch2);

--- a/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -383,4 +383,20 @@ void ReadableStream::set_up_with_byte_reading_support(GC::Ptr<PullAlgorithm> pul
     MUST(set_up_readable_byte_stream_controller(*this, controller, start_algorithm, pull_algorithm_wrapper, cancel_algorithm_wrapper, high_water_mark, JS::js_undefined()));
 }
 
+// https://streams.spec.whatwg.org/#readablestream-pipe-through
+GC::Ref<WebIDL::Promise> ReadableStream::piped_through(GC::Ref<WritableStream> writable, bool prevent_close, bool prevent_abort, bool prevent_cancel, JS::Value signal)
+{
+    // 1. Assert: ! IsReadableStreamLocked(readable) is false.
+    VERIFY(!is_readable_stream_locked(*this));
+
+    // 2. Assert: ! IsWritableStreamLocked(writable) is false.
+    VERIFY(!is_writable_stream_locked(writable));
+
+    // 3. Let signalArg be signal if signal was given, or undefined otherwise.
+    // NOTE: Done by default arguments.
+
+    // 4. Return ! ReadableStreamPipeTo(readable, writable, preventClose, preventAbort, preventCancel, signalArg).
+    return readable_stream_pipe_to(*this, writable, prevent_close, prevent_abort, prevent_cancel, signal);
+}
+
 }

--- a/Libraries/LibWeb/Streams/ReadableStream.cpp
+++ b/Libraries/LibWeb/Streams/ReadableStream.cpp
@@ -259,6 +259,13 @@ bool ReadableStream::is_disturbed() const
     return m_disturbed;
 }
 
+// https://streams.spec.whatwg.org/#readablestream-get-a-reader
+WebIDL::ExceptionOr<GC::Ref<ReadableStreamDefaultReader>> ReadableStream::get_a_reader()
+{
+    // To get a reader for a ReadableStream stream, return ? AcquireReadableStreamDefaultReader(stream). The result will be a ReadableStreamDefaultReader.
+    return TRY(acquire_readable_stream_default_reader(*this));
+}
+
 // https://streams.spec.whatwg.org/#readablestream-pull-from-bytes
 WebIDL::ExceptionOr<void> ReadableStream::pull_from_bytes(ByteBuffer bytes)
 {

--- a/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Libraries/LibWeb/Streams/ReadableStream.h
@@ -108,6 +108,7 @@ public:
     WebIDL::ExceptionOr<void> pull_from_bytes(ByteBuffer);
     WebIDL::ExceptionOr<void> enqueue(JS::Value chunk);
     void set_up_with_byte_reading_support(GC::Ptr<PullAlgorithm> = {}, GC::Ptr<CancelAlgorithm> = {}, double high_water_mark = 0);
+    GC::Ref<WebIDL::Promise> piped_through(GC::Ref<WritableStream>, bool prevent_close = false, bool prevent_abort = false, bool prevent_cancel = false, JS::Value signal = JS::js_undefined());
 
 private:
     explicit ReadableStream(JS::Realm&);

--- a/Libraries/LibWeb/Streams/ReadableStream.h
+++ b/Libraries/LibWeb/Streams/ReadableStream.h
@@ -105,6 +105,7 @@ public:
     State state() const { return m_state; }
     void set_state(State value) { m_state = value; }
 
+    WebIDL::ExceptionOr<GC::Ref<ReadableStreamDefaultReader>> get_a_reader();
     WebIDL::ExceptionOr<void> pull_from_bytes(ByteBuffer);
     WebIDL::ExceptionOr<void> enqueue(JS::Value chunk);
     void set_up_with_byte_reading_support(GC::Ptr<PullAlgorithm> = {}, GC::Ptr<CancelAlgorithm> = {}, double high_water_mark = 0);

--- a/Libraries/LibWeb/Streams/TransformStream.cpp
+++ b/Libraries/LibWeb/Streams/TransformStream.cpp
@@ -74,6 +74,13 @@ WebIDL::ExceptionOr<GC::Ref<TransformStream>> TransformStream::construct_impl(JS
     return stream;
 }
 
+// https://streams.spec.whatwg.org/#transformstream-enqueue
+void TransformStream::enqueue(JS::Value chunk)
+{
+    // To enqueue the JavaScript value chunk into a TransformStream stream, perform ! TransformStreamDefaultControllerEnqueue(stream.[[controller]], chunk).
+    MUST(Streams::transform_stream_default_controller_enqueue(*controller(), chunk));
+}
+
 // https://streams.spec.whatwg.org/#transformstream-set-up
 void TransformStream::set_up(GC::Ref<TransformAlgorithm> transform_algorithm, GC::Ptr<FlushAlgorithm> flush_algorithm, GC::Ptr<CancelAlgorithm> cancel_algorithm)
 {

--- a/Libraries/LibWeb/Streams/TransformStream.h
+++ b/Libraries/LibWeb/Streams/TransformStream.h
@@ -42,6 +42,7 @@ public:
     void set_controller(GC::Ptr<TransformStreamDefaultController> value) { m_controller = value; }
 
     void set_up(GC::Ref<TransformAlgorithm>, GC::Ptr<FlushAlgorithm> = {}, GC::Ptr<CancelAlgorithm> = {});
+    void enqueue(JS::Value chunk);
 
 private:
     explicit TransformStream(JS::Realm& realm);


### PR DESCRIPTION
This reads a bit nicer, and follows the streams spec pattern on
performing operations on a stream outside of the streams spec.

Noticed as part of investigating improving the implementation of ReadableStreamPipeTo to make it less crashy and correct (notably, started out of making signal a `JS::Value` instead of `Optional<JS::Value>` in that AO)