### PR TITLE
LibWeb: Skip unneeded style invalidation on custom element state change

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2520,6 +2520,9 @@ void StyleComputer::collect_selector_insights(Selector const& selector, Selector
                 if (simple_selector.pseudo_class().type == PseudoClass::Has) {
                     insights.has_has_selectors = true;
                 }
+                if (simple_selector.pseudo_class().type == PseudoClass::Defined) {
+                    insights.has_defined_selectors = true;
+                }
                 for (auto const& argument_selector : simple_selector.pseudo_class().argument_selector_list) {
                     collect_selector_insights(*argument_selector, insights);
                 }
@@ -3010,6 +3013,12 @@ bool StyleComputer::has_has_selectors() const
 {
     build_rule_cache_if_needed();
     return m_selector_insights->has_has_selectors;
+}
+
+bool StyleComputer::has_defined_selectors() const
+{
+    build_rule_cache_if_needed();
+    return m_selector_insights->has_defined_selectors;
 }
 
 bool StyleComputer::has_attribute_selector(FlyString const& attribute_name) const

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -170,6 +170,7 @@ public:
     void collect_animation_into(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, GC::Ref<Animations::KeyframeEffect> animation, ComputedProperties&, AnimationRefresh = AnimationRefresh::No) const;
 
     [[nodiscard]] bool has_has_selectors() const;
+    [[nodiscard]] bool has_defined_selectors() const;
     [[nodiscard]] bool has_attribute_selector(FlyString const& attribute_name) const;
 
     size_t number_of_css_font_faces_with_loading_in_progress() const;
@@ -250,6 +251,7 @@ private:
 
     struct SelectorInsights {
         bool has_has_selectors { false };
+        bool has_defined_selectors { false };
         HashTable<FlyString> all_names_used_in_attribute_selectors;
     };
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2266,7 +2266,9 @@ void Element::set_custom_element_state(CustomElementState state)
     if (m_custom_element_state == state)
         return;
     m_custom_element_state = state;
-    invalidate_style(StyleInvalidationReason::CustomElementStateChange);
+
+    if (document().style_computer().has_defined_selectors())
+        invalidate_style(StyleInvalidationReason::CustomElementStateChange);
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -63,7 +63,7 @@ void HTMLIFrameElement::attribute_changed(FlyString const& name, Optional<String
 
     if (name == HTML::AttributeNames::width || name == HTML::AttributeNames::height) {
         // FIXME: This should only invalidate the layout, not the style.
-        invalidate_style(DOM::StyleInvalidationReason::ElementAttributeChange);
+        invalidate_style(DOM::StyleInvalidationReason::HTMLIFrameElementGeometryChange);
     }
 }
 


### PR DESCRIPTION
If there are no :defined pseudo-class selectors anywhere in the
document, we don't have to invalidate style at all when an element's
custom element state changes.