### PR TITLE
LibWeb: Fix selector matching for non-HTML mixed-case element names

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -799,7 +799,7 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, Optio
         // Reject if the tag name doesn't match
         if (component.type == CSS::Selector::SimpleSelector::Type::TagName) {
             // See https://html.spec.whatwg.org/multipage/semantics-other.html#case-sensitivity-of-selectors
-            if (element.document().document_type() == DOM::Document::Type::HTML) {
+            if (element.document().document_type() == DOM::Document::Type::HTML && element.namespace_uri() == Namespace::HTML) {
                 if (qualified_name.name.lowercase_name != element.local_name())
                     return false;
             } else if (!Infra::is_ascii_case_insensitive_match(qualified_name.name.name, element.local_name())) {

--- a/Tests/LibWeb/Text/expected/non-html-mixed-case-element-name-selector-matching.txt
+++ b/Tests/LibWeb/Text/expected/non-html-mixed-case-element-name-selector-matching.txt
@@ -1,0 +1,4 @@
+✅ Pass: Selector match for SVG element textPath.
+✅ Pass: Selector match for SVG element clipPath.
+✅ Pass: Selector match for SVG element foreignObject.
+✅ Pass: Selector match for SVG element radialGradient.

--- a/Tests/LibWeb/Text/input/non-html-mixed-case-element-name-selector-matching.html
+++ b/Tests/LibWeb/Text/input/non-html-mixed-case-element-name-selector-matching.html
@@ -1,0 +1,28 @@
+<script src="include.js"></script>
+<svg>
+    <textPath></textPath>
+    <clipPath></clipPath>
+    <foreignObject></foreignObject>
+    <linearGradient></linearGradient>
+    <radialGradient></radialGradient>
+</svg>
+<script>
+    test(() => {
+        if (document.querySelector("textPath"))
+            println("✅ Pass: Selector match for SVG element textPath.");
+        else
+            println("❌ Fail: No selector match for SVG element textPath.");
+        if (document.querySelector("clipPath"))
+            println("✅ Pass: Selector match for SVG element clipPath.");
+        else
+            println("❌ Fail: No selector match for SVG element clipPath.");
+        if (document.querySelector("foreignObject"))
+            println("✅ Pass: Selector match for SVG element foreignObject.");
+        else
+            println("❌ Fail: No selector match for SVG element foreignObject.");
+        if (document.querySelector("radialGradient"))
+            println("✅ Pass: Selector match for SVG element radialGradient.");
+        else
+            println("❌ Fail: No selector match for SVG element radialGradient.");
+    });
+</script>


### PR DESCRIPTION
This change fixes selector matching for non-HTML elements that have mixed-case names — such as the SVG `foreignObject` element.

Otherwise, without this change, attempting to use a selector to match such an element — e.g., `document.querySelector("foreignObject")` — fails.