### PR TITLE
RequestServer: Clean up the CURLM "multi handle" when client drops

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -270,6 +270,10 @@ ConnectionFromClient::ConnectionFromClient(IPC::Transport transport)
 
 ConnectionFromClient::~ConnectionFromClient()
 {
+    m_active_requests.clear();
+
+    curl_multi_cleanup(m_curl_multi);
+    m_curl_multi = nullptr;
 }
 
 void ConnectionFromClient::die()


### PR DESCRIPTION
Otherwise we may leak all kinds of things inside CURL.