### PR TITLE
LibWeb/HTML: Fix URL fragment comparison triggering unwanted events

### DIFF
--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -413,7 +413,10 @@ WebIDL::ExceptionOr<void> Location::set_hash(String const& value)
     (void)URL::Parser::basic_parse(input, {}, &copy_url, URL::Parser::State::Fragment);
 
     // 7. If copyURL's fragment is this's url's fragment, then return.
-    if (copy_url.fragment() == this->url().fragment())
+    // NOTE: Ignore null values when comparing fragments. This behavior is not explicitly mentioned in the specs, potential bug?
+    auto copy_url_fragment = copy_url.fragment().has_value() ? copy_url.fragment() : String {};
+    auto this_url_fragment = this->url().fragment().has_value() ? this->url().fragment() : String {};
+    if (copy_url_fragment == this_url_fragment)
         return {};
 
     // 8. Location-object navigate this to copyURL.

--- a/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/history-traversal/hash-empty-string.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/browsers/browsing-the-web/history-traversal/hash-empty-string.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	URL has no hash
+Pass	changing the hash from an empty string to an empty string does not trigger a popstate event
+Pass	changing the hash from an empty string to an empty string does not trigger a hashchange event

--- a/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/history-traversal/hash-empty-string.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/browsers/browsing-the-web/history-traversal/hash-empty-string.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<meta charset="utf8">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<link rel="help"
+      href="https://html.spec.whatwg.org/multipage/nav-history-apis.html#the-location-interface:concept-url-fragment-4">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=1544428">
+<link rel="author" title="Zach Hoffman" href="mailto:zach@zrhoffman.net">
+<script>
+let popstateTriggered = false;
+window.addEventListener("popstate", () => popstateTriggered = true);
+
+let hashchangeTriggered = false;
+window.addEventListener("hashchange", () => hashchangeTriggered = true);
+
+test(() => {
+  assert_equals(location.href.indexOf("#"), -1)
+}, "URL has no hash")
+
+location.hash = "";
+
+test(() => {
+  assert_false(popstateTriggered);
+}, "changing the hash from an empty string to an empty string does not trigger a popstate event")
+
+promise_test(async () => {
+  // hashchange is fired async
+  await new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+  assert_false(hashchangeTriggered);
+}, "changing the hash from an empty string to an empty string does not trigger a hashchange event")
+</script>


### PR DESCRIPTION
This update fixes all tests in https://wpt.live/html/browsers/browsing-the-web/history-traversal/hash-empty-string.html

Note: I was unable to import the test using the WPT import script due to an issue that resulted in an empty expected text file.