### PR TITLE
LibWeb: Add support for ARIA Graphics roles, and compute roles for SVG graphics-symbol elements and foreignObject

### DIFF
--- a/Libraries/LibWeb/ARIA/AriaRoles.json
+++ b/Libraries/LibWeb/ARIA/AriaRoles.json
@@ -4606,5 +4606,141 @@
     "implicitValueForRole": {
       "aria-orientation": "AriaOrientation::Horizontal"
     }
+  },
+  "GraphicsDocument": {
+    "specLink": "https://w3c.github.io/graphics-aria/#graphics-document",
+    "description": "A type of document in which the visual appearance or layout of content conveys meaning.",
+    "superClassRoles": [
+      "Document"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-braillelabel",
+      "aria-brailleroledescription",
+      "aria-controls",
+      "aria-describedby",
+      "aria-description",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "GraphicsObject": {
+    "specLink": "https://w3c.github.io/graphics-aria/#graphics-object",
+    "description": "A section of a graphics-document that represents a distinct object or sub-component with semantic meaning.",
+    "superClassRoles": [
+      "Group"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-activedescendant",
+      "aria-atomic",
+      "aria-braillelabel",
+      "aria-brailleroledescription",
+      "aria-controls",
+      "aria-describedby",
+      "aria-description",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": false,
+    "childrenArePresentational": false,
+    "implicitValueForRole": {}
+  },
+  "GraphicsSymbol": {
+    "specLink": "https://w3c.github.io/graphics-aria/#graphics-symbol",
+    "description": "A graphical object used to convey a simple meaning or category, where the meaning is more important than the particular visual appearance.",
+    "superClassRoles": [
+      "Img"
+    ],
+    "supportedStates": [
+      "aria-busy",
+      "aria-current",
+      "aria-disabled",
+      "aria-grabbed",
+      "aria-hidden",
+      "aria-invalid"
+    ],
+    "supportedProperties": [
+      "aria-atomic",
+      "aria-braillelabel",
+      "aria-brailleroledescription",
+      "aria-controls",
+      "aria-describedby",
+      "aria-description",
+      "aria-details",
+      "aria-dropeffect",
+      "aria-errormessage",
+      "aria-flowto",
+      "aria-haspopup",
+      "aria-keyshortcuts",
+      "aria-label",
+      "aria-labelledby",
+      "aria-live",
+      "aria-owns",
+      "aria-relevant",
+      "aria-roledescription"
+    ],
+    "requiredStates": [],
+    "requiredProperties": [],
+    "prohibitedStates": [],
+    "prohibitedProperties": [],
+    "requiredContextRoles": [],
+    "requiredOwnedElements": [],
+    "nameFromSource": "Author",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
+    "implicitValueForRole": {}
   }
 }

--- a/Libraries/LibWeb/ARIA/RoleType.cpp
+++ b/Libraries/LibWeb/ARIA/RoleType.cpp
@@ -202,6 +202,12 @@ ErrorOr<NonnullOwnPtr<RoleType>> RoleType::build_role_object(Role role, bool foc
         return adopt_nonnull_own_or_enomem(new (nothrow) Form(data));
     case Role::generic:
         return adopt_nonnull_own_or_enomem(new (nothrow) Generic(data));
+    case Role::graphicsdocument:
+        return adopt_nonnull_own_or_enomem(new (nothrow) GraphicsDocument(data));
+    case Role::graphicsobject:
+        return adopt_nonnull_own_or_enomem(new (nothrow) GraphicsObject(data));
+    case Role::graphicssymbol:
+        return adopt_nonnull_own_or_enomem(new (nothrow) GraphicsSymbol(data));
     case Role::grid:
         return adopt_nonnull_own_or_enomem(static_cast<Composite*>(new (nothrow) Grid(data)));
     case Role::gridcell:

--- a/Libraries/LibWeb/ARIA/Roles.cpp
+++ b/Libraries/LibWeb/ARIA/Roles.cpp
@@ -13,11 +13,11 @@ StringView role_name(Role role)
 {
     // Note: Role::switch_ is mapped to "switch" (due to C++ keyword clash)
     switch (role) {
-#define __ENUMERATE_ARIA_ROLE(name)                \
+#define __ENUMERATE_ARIA_ROLE(name, attribute)     \
     case Role::name:                               \
         if constexpr (Role::name == Role::switch_) \
             return "switch"sv;                     \
-        return #name##sv;
+        return attribute##sv;
         ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE
     default:
@@ -28,13 +28,13 @@ StringView role_name(Role role)
 Optional<Role> role_from_string(StringView role_name)
 {
     // Note: "switch" is mapped to Role::switch_ (due to C++ keyword clash)
-#define __ENUMERATE_ARIA_ROLE(name)                           \
-    if constexpr (Role::name == Role::switch_) {              \
-        if (role_name.equals_ignoring_ascii_case("switch"sv)) \
-            return Role::switch_;                             \
-    } else {                                                  \
-        if (role_name.equals_ignoring_ascii_case(#name##sv))  \
-            return Role::name;                                \
+#define __ENUMERATE_ARIA_ROLE(name, attribute)                   \
+    if constexpr (Role::name == Role::switch_) {                 \
+        if (role_name.equals_ignoring_ascii_case("switch"sv))    \
+            return Role::switch_;                                \
+    } else {                                                     \
+        if (role_name.equals_ignoring_ascii_case(attribute##sv)) \
+            return Role::name;                                   \
     }
     ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE

--- a/Libraries/LibWeb/ARIA/Roles.h
+++ b/Libraries/LibWeb/ARIA/Roles.h
@@ -11,109 +11,112 @@
 
 namespace Web::ARIA {
 
-#define ENUMERATE_ARIA_ROLES                \
-    __ENUMERATE_ARIA_ROLE(alert)            \
-    __ENUMERATE_ARIA_ROLE(alertdialog)      \
-    __ENUMERATE_ARIA_ROLE(application)      \
-    __ENUMERATE_ARIA_ROLE(article)          \
-    __ENUMERATE_ARIA_ROLE(banner)           \
-    __ENUMERATE_ARIA_ROLE(blockquote)       \
-    __ENUMERATE_ARIA_ROLE(button)           \
-    __ENUMERATE_ARIA_ROLE(caption)          \
-    __ENUMERATE_ARIA_ROLE(cell)             \
-    __ENUMERATE_ARIA_ROLE(checkbox)         \
-    __ENUMERATE_ARIA_ROLE(code)             \
-    __ENUMERATE_ARIA_ROLE(columnheader)     \
-    __ENUMERATE_ARIA_ROLE(combobox)         \
-    __ENUMERATE_ARIA_ROLE(command)          \
-    __ENUMERATE_ARIA_ROLE(complementary)    \
-    __ENUMERATE_ARIA_ROLE(composite)        \
-    __ENUMERATE_ARIA_ROLE(contentinfo)      \
-    __ENUMERATE_ARIA_ROLE(definition)       \
-    __ENUMERATE_ARIA_ROLE(deletion)         \
-    __ENUMERATE_ARIA_ROLE(dialog)           \
-    __ENUMERATE_ARIA_ROLE(directory)        \
-    __ENUMERATE_ARIA_ROLE(document)         \
-    __ENUMERATE_ARIA_ROLE(emphasis)         \
-    __ENUMERATE_ARIA_ROLE(feed)             \
-    __ENUMERATE_ARIA_ROLE(figure)           \
-    __ENUMERATE_ARIA_ROLE(form)             \
-    __ENUMERATE_ARIA_ROLE(generic)          \
-    __ENUMERATE_ARIA_ROLE(grid)             \
-    __ENUMERATE_ARIA_ROLE(gridcell)         \
-    __ENUMERATE_ARIA_ROLE(group)            \
-    __ENUMERATE_ARIA_ROLE(heading)          \
-    __ENUMERATE_ARIA_ROLE(image)            \
-    __ENUMERATE_ARIA_ROLE(img)              \
-    __ENUMERATE_ARIA_ROLE(input)            \
-    __ENUMERATE_ARIA_ROLE(insertion)        \
-    __ENUMERATE_ARIA_ROLE(landmark)         \
-    __ENUMERATE_ARIA_ROLE(link)             \
-    __ENUMERATE_ARIA_ROLE(list)             \
-    __ENUMERATE_ARIA_ROLE(listbox)          \
-    __ENUMERATE_ARIA_ROLE(listitem)         \
-    __ENUMERATE_ARIA_ROLE(log)              \
-    __ENUMERATE_ARIA_ROLE(main)             \
-    __ENUMERATE_ARIA_ROLE(mark)             \
-    __ENUMERATE_ARIA_ROLE(marquee)          \
-    __ENUMERATE_ARIA_ROLE(math)             \
-    __ENUMERATE_ARIA_ROLE(meter)            \
-    __ENUMERATE_ARIA_ROLE(menu)             \
-    __ENUMERATE_ARIA_ROLE(menubar)          \
-    __ENUMERATE_ARIA_ROLE(menuitem)         \
-    __ENUMERATE_ARIA_ROLE(menuitemcheckbox) \
-    __ENUMERATE_ARIA_ROLE(menuitemradio)    \
-    __ENUMERATE_ARIA_ROLE(navigation)       \
-    __ENUMERATE_ARIA_ROLE(none)             \
-    __ENUMERATE_ARIA_ROLE(note)             \
-    __ENUMERATE_ARIA_ROLE(option)           \
-    __ENUMERATE_ARIA_ROLE(paragraph)        \
-    __ENUMERATE_ARIA_ROLE(presentation)     \
-    __ENUMERATE_ARIA_ROLE(progressbar)      \
-    __ENUMERATE_ARIA_ROLE(radio)            \
-    __ENUMERATE_ARIA_ROLE(radiogroup)       \
-    __ENUMERATE_ARIA_ROLE(range)            \
-    __ENUMERATE_ARIA_ROLE(region)           \
-    __ENUMERATE_ARIA_ROLE(roletype)         \
-    __ENUMERATE_ARIA_ROLE(row)              \
-    __ENUMERATE_ARIA_ROLE(rowgroup)         \
-    __ENUMERATE_ARIA_ROLE(rowheader)        \
-    __ENUMERATE_ARIA_ROLE(scrollbar)        \
-    __ENUMERATE_ARIA_ROLE(search)           \
-    __ENUMERATE_ARIA_ROLE(searchbox)        \
-    __ENUMERATE_ARIA_ROLE(section)          \
-    __ENUMERATE_ARIA_ROLE(sectionfooter)    \
-    __ENUMERATE_ARIA_ROLE(sectionhead)      \
-    __ENUMERATE_ARIA_ROLE(sectionheader)    \
-    __ENUMERATE_ARIA_ROLE(select)           \
-    __ENUMERATE_ARIA_ROLE(separator)        \
-    __ENUMERATE_ARIA_ROLE(slider)           \
-    __ENUMERATE_ARIA_ROLE(spinbutton)       \
-    __ENUMERATE_ARIA_ROLE(status)           \
-    __ENUMERATE_ARIA_ROLE(strong)           \
-    __ENUMERATE_ARIA_ROLE(structure)        \
-    __ENUMERATE_ARIA_ROLE(subscript)        \
-    __ENUMERATE_ARIA_ROLE(suggestion)       \
-    __ENUMERATE_ARIA_ROLE(superscript)      \
-    __ENUMERATE_ARIA_ROLE(switch_)          \
-    __ENUMERATE_ARIA_ROLE(tab)              \
-    __ENUMERATE_ARIA_ROLE(table)            \
-    __ENUMERATE_ARIA_ROLE(tablist)          \
-    __ENUMERATE_ARIA_ROLE(tabpanel)         \
-    __ENUMERATE_ARIA_ROLE(term)             \
-    __ENUMERATE_ARIA_ROLE(textbox)          \
-    __ENUMERATE_ARIA_ROLE(time)             \
-    __ENUMERATE_ARIA_ROLE(timer)            \
-    __ENUMERATE_ARIA_ROLE(toolbar)          \
-    __ENUMERATE_ARIA_ROLE(tooltip)          \
-    __ENUMERATE_ARIA_ROLE(tree)             \
-    __ENUMERATE_ARIA_ROLE(treegrid)         \
-    __ENUMERATE_ARIA_ROLE(treeitem)         \
-    __ENUMERATE_ARIA_ROLE(widget)           \
-    __ENUMERATE_ARIA_ROLE(window)
+#define ENUMERATE_ARIA_ROLES                                     \
+    __ENUMERATE_ARIA_ROLE(alert, "alert")                        \
+    __ENUMERATE_ARIA_ROLE(alertdialog, "alertdialog")            \
+    __ENUMERATE_ARIA_ROLE(application, "application")            \
+    __ENUMERATE_ARIA_ROLE(article, "article")                    \
+    __ENUMERATE_ARIA_ROLE(banner, "banner")                      \
+    __ENUMERATE_ARIA_ROLE(blockquote, "blockquote")              \
+    __ENUMERATE_ARIA_ROLE(button, "button")                      \
+    __ENUMERATE_ARIA_ROLE(caption, "caption")                    \
+    __ENUMERATE_ARIA_ROLE(cell, "cell")                          \
+    __ENUMERATE_ARIA_ROLE(checkbox, "checkbox")                  \
+    __ENUMERATE_ARIA_ROLE(code, "code")                          \
+    __ENUMERATE_ARIA_ROLE(columnheader, "columnheader")          \
+    __ENUMERATE_ARIA_ROLE(combobox, "combobox")                  \
+    __ENUMERATE_ARIA_ROLE(command, "command")                    \
+    __ENUMERATE_ARIA_ROLE(complementary, "complementary")        \
+    __ENUMERATE_ARIA_ROLE(composite, "composite")                \
+    __ENUMERATE_ARIA_ROLE(contentinfo, "contentinfo")            \
+    __ENUMERATE_ARIA_ROLE(definition, "definition")              \
+    __ENUMERATE_ARIA_ROLE(deletion, "deletion")                  \
+    __ENUMERATE_ARIA_ROLE(dialog, "dialog")                      \
+    __ENUMERATE_ARIA_ROLE(directory, "directory")                \
+    __ENUMERATE_ARIA_ROLE(document, "document")                  \
+    __ENUMERATE_ARIA_ROLE(emphasis, "emphasis")                  \
+    __ENUMERATE_ARIA_ROLE(feed, "feed")                          \
+    __ENUMERATE_ARIA_ROLE(figure, "figure")                      \
+    __ENUMERATE_ARIA_ROLE(form, "form")                          \
+    __ENUMERATE_ARIA_ROLE(generic, "generic")                    \
+    __ENUMERATE_ARIA_ROLE(graphicsdocument, "graphics-document") \
+    __ENUMERATE_ARIA_ROLE(graphicsobject, "graphics-object")     \
+    __ENUMERATE_ARIA_ROLE(graphicssymbol, "graphics-symbol")     \
+    __ENUMERATE_ARIA_ROLE(grid, "grid")                          \
+    __ENUMERATE_ARIA_ROLE(gridcell, "gridcell")                  \
+    __ENUMERATE_ARIA_ROLE(group, "group")                        \
+    __ENUMERATE_ARIA_ROLE(heading, "heading")                    \
+    __ENUMERATE_ARIA_ROLE(image, "image")                        \
+    __ENUMERATE_ARIA_ROLE(img, "img")                            \
+    __ENUMERATE_ARIA_ROLE(input, "input")                        \
+    __ENUMERATE_ARIA_ROLE(insertion, "insertion")                \
+    __ENUMERATE_ARIA_ROLE(landmark, "landmark")                  \
+    __ENUMERATE_ARIA_ROLE(link, "link")                          \
+    __ENUMERATE_ARIA_ROLE(list, "list")                          \
+    __ENUMERATE_ARIA_ROLE(listbox, "listbox")                    \
+    __ENUMERATE_ARIA_ROLE(listitem, "listitem")                  \
+    __ENUMERATE_ARIA_ROLE(log, "log")                            \
+    __ENUMERATE_ARIA_ROLE(main, "main")                          \
+    __ENUMERATE_ARIA_ROLE(mark, "mark")                          \
+    __ENUMERATE_ARIA_ROLE(marquee, "marquee")                    \
+    __ENUMERATE_ARIA_ROLE(math, "math")                          \
+    __ENUMERATE_ARIA_ROLE(meter, "meter")                        \
+    __ENUMERATE_ARIA_ROLE(menu, "menu")                          \
+    __ENUMERATE_ARIA_ROLE(menubar, "menubar")                    \
+    __ENUMERATE_ARIA_ROLE(menuitem, "menuitem")                  \
+    __ENUMERATE_ARIA_ROLE(menuitemcheckbox, "menuitemcheckbox")  \
+    __ENUMERATE_ARIA_ROLE(menuitemradio, "menuitemradio")        \
+    __ENUMERATE_ARIA_ROLE(navigation, "navigation")              \
+    __ENUMERATE_ARIA_ROLE(none, "none")                          \
+    __ENUMERATE_ARIA_ROLE(note, "note")                          \
+    __ENUMERATE_ARIA_ROLE(option, "option")                      \
+    __ENUMERATE_ARIA_ROLE(paragraph, "paragraph")                \
+    __ENUMERATE_ARIA_ROLE(presentation, "presentation")          \
+    __ENUMERATE_ARIA_ROLE(progressbar, "progressbar")            \
+    __ENUMERATE_ARIA_ROLE(radio, "radio")                        \
+    __ENUMERATE_ARIA_ROLE(radiogroup, "radiogroup")              \
+    __ENUMERATE_ARIA_ROLE(range, "range")                        \
+    __ENUMERATE_ARIA_ROLE(region, "region")                      \
+    __ENUMERATE_ARIA_ROLE(roletype, "roletype")                  \
+    __ENUMERATE_ARIA_ROLE(row, "row")                            \
+    __ENUMERATE_ARIA_ROLE(rowgroup, "rowgroup")                  \
+    __ENUMERATE_ARIA_ROLE(rowheader, "rowheader")                \
+    __ENUMERATE_ARIA_ROLE(scrollbar, "scrollbar")                \
+    __ENUMERATE_ARIA_ROLE(search, "search")                      \
+    __ENUMERATE_ARIA_ROLE(searchbox, "searchbox")                \
+    __ENUMERATE_ARIA_ROLE(section, "section")                    \
+    __ENUMERATE_ARIA_ROLE(sectionfooter, "sectionfooter")        \
+    __ENUMERATE_ARIA_ROLE(sectionhead, "sectionhead")            \
+    __ENUMERATE_ARIA_ROLE(sectionheader, "sectionheader")        \
+    __ENUMERATE_ARIA_ROLE(select, "select")                      \
+    __ENUMERATE_ARIA_ROLE(separator, "separator")                \
+    __ENUMERATE_ARIA_ROLE(slider, "slider")                      \
+    __ENUMERATE_ARIA_ROLE(spinbutton, "spinbutton")              \
+    __ENUMERATE_ARIA_ROLE(status, "status")                      \
+    __ENUMERATE_ARIA_ROLE(strong, "strong")                      \
+    __ENUMERATE_ARIA_ROLE(structure, "structure")                \
+    __ENUMERATE_ARIA_ROLE(subscript, "subscript")                \
+    __ENUMERATE_ARIA_ROLE(suggestion, "suggestion")              \
+    __ENUMERATE_ARIA_ROLE(superscript, "superscript")            \
+    __ENUMERATE_ARIA_ROLE(switch_, "switch_")                    \
+    __ENUMERATE_ARIA_ROLE(tab, "tab")                            \
+    __ENUMERATE_ARIA_ROLE(table, "table")                        \
+    __ENUMERATE_ARIA_ROLE(tablist, "tablist")                    \
+    __ENUMERATE_ARIA_ROLE(tabpanel, "tabpanel")                  \
+    __ENUMERATE_ARIA_ROLE(term, "term")                          \
+    __ENUMERATE_ARIA_ROLE(textbox, "textbox")                    \
+    __ENUMERATE_ARIA_ROLE(time, "time")                          \
+    __ENUMERATE_ARIA_ROLE(timer, "timer")                        \
+    __ENUMERATE_ARIA_ROLE(toolbar, "toolbar")                    \
+    __ENUMERATE_ARIA_ROLE(tooltip, "tooltip")                    \
+    __ENUMERATE_ARIA_ROLE(tree, "tree")                          \
+    __ENUMERATE_ARIA_ROLE(treegrid, "treegrid")                  \
+    __ENUMERATE_ARIA_ROLE(treeitem, "treeitem")                  \
+    __ENUMERATE_ARIA_ROLE(widget, "widget")                      \
+    __ENUMERATE_ARIA_ROLE(window, "window")
 
 enum class Role {
-#define __ENUMERATE_ARIA_ROLE(name) name,
+#define __ENUMERATE_ARIA_ROLE(name, attribute) name,
     ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE
 };

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -55,11 +55,17 @@ Optional<ARIA::Role> SVGElement::default_role() const
     // https://w3c.github.io/svg-aam/#mapping_role_table
     if (local_name() == TagNames::a && (has_attribute(SVG::AttributeNames::href) || has_attribute(AttributeNames::xlink_href)))
         return ARIA::Role::link;
-    if (local_name() == TagNames::g && should_include_in_accessibility_tree())
+    if (local_name().is_one_of(TagNames::foreignObject, TagNames::g)
+        && should_include_in_accessibility_tree())
         return ARIA::Role::group;
     if (local_name() == TagNames::image && should_include_in_accessibility_tree())
         return ARIA::Role::image;
-    return {};
+    if (local_name() == TagNames::circle && should_include_in_accessibility_tree())
+        return ARIA::Role::graphicssymbol;
+    if (local_name().is_one_of(TagNames::ellipse, TagNames::path, TagNames::polygon, TagNames::polyline)
+        && should_include_in_accessibility_tree())
+        return ARIA::Role::graphicssymbol;
+    return ARIA::Role::generic;
 }
 
 void SVGElement::visit_edges(Cell::Visitor& visitor)

--- a/Tests/LibWeb/Text/expected/wpt-import/graphics-aria/graphics-roles.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/graphics-aria/graphics-roles.txt
@@ -1,0 +1,8 @@
+Harness status: OK
+
+Found 3 tests
+
+3 Pass
+Pass	graphics-document
+Pass	graphics-object
+Pass	graphics-symbol

--- a/Tests/LibWeb/Text/expected/wpt-import/svg-aam/role/roles-generic.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/svg-aam/role/roles-generic.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Pass
+Pass	el-circle
+Pass	el-ellipse
+Pass	el-foreignObject
+Pass	el-g
+Pass	el-line
+Pass	el-path
+Pass	el-polygon
+Pass	el-polyline
+Pass	el-rect

--- a/Tests/LibWeb/Text/input/wpt-import/graphics-aria/graphics-roles.html
+++ b/Tests/LibWeb/Text/input/wpt-import/graphics-aria/graphics-roles.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<head>
+  <script src="../resources/testharness.js"></script>
+  <script src="../resources/testharnessreport.js"></script>
+  <script src="../resources/testdriver.js"></script>
+  <script src="../resources/testdriver-vendor.js"></script>
+  <script src="../resources/testdriver-actions.js"></script>
+  <script src="../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+<p>Tests the concrete roles defined in the <a href="https://www.w3.org/TR/graphics-aria-1.0/#role_definitions">ARIA Graphics Module</a> role definitions.</p>
+
+<div role="graphics-document" data-expectedrole="graphics-document" class="ex">x</div>
+<div role="graphics-object" data-expectedrole="graphics-object" class="ex">x</div>
+<div role="graphics-symbol" data-expectedrole="graphics-symbol" class="ex">x</div>
+
+<script>
+AriaUtils.verifyRolesBySelector(".ex");
+</script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/svg-aam/role/roles-generic.html
+++ b/Tests/LibWeb/Text/input/wpt-import/svg-aam/role/roles-generic.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html>
+<head>
+  <title>SVG-AAM Generic Role Verification Tests</title>
+  <script src="../../resources/testharness.js"></script>
+  <script src="../../resources/testharnessreport.js"></script>
+  <script src="../../resources/testdriver.js"></script>
+  <script src="../../resources/testdriver-vendor.js"></script>
+  <script src="../../resources/testdriver-actions.js"></script>
+  <script src="../../wai-aria/scripts/aria-utils.js"></script>
+</head>
+<body>
+
+
+<p>Tests ONLY the default <code>generic</code> mappings defined in <a href="https://w3c.github.io/svg-aam/#include_elements">SVG-AAM: 5.1.2 Including Elements in the Accessibility Tree</a>.</p>
+
+<h2>Simple Elements</h2>
+<!-- Note: adding an inoccuous label, tabindex, or some other accessible marker may cause the computedrole result to change. -->
+<svg>
+  <!-- Some elements skipped: never-rendered elements can return unpredicable/undefined/unspecified values for computedrole. -->
+  <circle data-testname="el-circle" class="ex-generic"></circle>
+  <ellipse data-testname="el-ellipse" class="ex-generic"></ellipse>
+  <foreignObject data-testname="el-foreignObject" class="ex-generic"></foreignObject>
+  <g data-testname="el-g" class="ex-generic"></g>
+  <!-- image -> in ./role-img.tentative.html -->
+  <line data-testname="el-line" class="ex-generic"></line>
+  <!-- skipped: mesh -->
+  <path data-testname="el-path" class="ex-generic"></path>
+  <polygon data-testname="el-polygon" class="ex-generic"></polygon>
+  <polyline data-testname="el-polyline" class="ex-generic"></polyline>
+  <rect data-testname="el-rect" class="ex-generic"></rect>
+  <!-- blocked: textPath -> https://w3c.github.io/svg-aam/#textpath-tspan-mappings-issue-->
+  <!-- blocked: tspan -> https://w3c.github.io/svg-aam/#textpath-tspan-mappings-issue -->
+  <!-- skipped: use -->
+</svg>
+
+<script>
+AriaUtils.verifyGenericRolesBySelector(".ex-generic");
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This change includes two commits:

- 86c439fb478dfbf23c545d8c60f5864548b6df88 Add support for the `graphics-document`, `graphics-object`, and `graphics-symbol` roles from the WAI-ARIA Graphics Module spec at https://w3c.github.io/graphics-aria/#role_definitions.
- 6d810196608a8dc42a2b6df0702b4a7d82c1052e Compute roles for SVG elements that default to the `graphics-symbol` role, and compute the role for the SVG `foreignObject` element.