### PR TITLE
LibWeb: Space-separate parts of multi-label accessible names

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2425,6 +2425,8 @@ ErrorOr<String> Node::name_or_description(NameOrDescription target, Document con
         if (labels != nullptr && labels->length() > 0) {
             StringBuilder builder;
             for (u32 i = 0; i < labels->length(); i++) {
+                if (!builder.is_empty())
+                    builder.append(" "sv);
                 auto nodes = labels->item(i)->children_as_vector();
                 for (auto const& node : nodes) {
                     // AD-HOC: https://wpt.fyi/results/accname/name/comp_host_language_label.html has “encapsulation”

--- a/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_host_language_label.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/accname/name/comp_host_language_label.txt
@@ -1,8 +1,8 @@
 Harness status: OK
 
-Found 78 tests
+Found 79 tests
 
-78 Pass
+79 Pass
 Pass	html: input[type=button]
 Pass	html: input[type=image]
 Pass	html: input[type=reset]
@@ -81,3 +81,4 @@ Pass	html: img[alt] (non-empty)
 Pass	html: picture > img[alt] (non-empty)
 Pass	html: fieldset > legend
 Pass	html: table > caption
+Pass	html: multiple label elements[for]

--- a/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_host_language_label.html
+++ b/Tests/LibWeb/Text/input/wpt-import/accname/name/comp_host_language_label.html
@@ -155,6 +155,11 @@
 <tr><th>a</th><th>b</th><th>c</th></tr>
 <tr><th>1</th><td>2</td><td>3</td></tr>
 </table>
+<!-- HTML-AAM: https://www.w3.org/TR/html-aam-1.0/#input-type-text-input-type-password-input-type-number-input-type-search-input-type-tel-input-type-email-input-type-url-and-textarea-element-accessible-name-computation -->
+<h2>HTML input with multiple label/for</h2>
+<label for="multi-label">textfield label 1</label>
+<label for="multi-label">textfield label 2</label>
+<input id="multi-label" type="text" data-expectedlabel="textfield label 1 textfield label 2" data-testname="html: multiple label elements[for]" class="ex">
 <!-- SVG: -> /svg-aam/name/ -->
 <!-- todo: Ruby? -->
 <!-- todo: MathML? -->


### PR DESCRIPTION
This change ensures that when an accessible name is computed from multiple labels, the parts computed from each label are separated by spaces. Otherwise, without this change, the parts are run together in the accessible name, with no space in between.