### PR TITLE
LibCore: Make EventReceiver ref counting use atomics

### DIFF
--- a/Libraries/LibCore/EventReceiver.h
+++ b/Libraries/LibCore/EventReceiver.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2021, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/AtomicRefCounted.h>
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
 #include <AK/Function.h>
@@ -50,7 +51,7 @@ public:                                            \
     }
 
 class EventReceiver
-    : public RefCounted<EventReceiver>
+    : public AtomicRefCounted<EventReceiver>
     , public Weakable<EventReceiver> {
     // NOTE: No C_OBJECT macro for Core::EventReceiver itself.
 


### PR DESCRIPTION
This removes a race in ImageDecoder's `make_decode_image_job()`, where the ref count of `this` is mutated from separate threads in the callbacks.

ASAN tipped me off about this:

```
/Users/kling/src/ladybird/AK/RefCounted.h:59:37: runtime error: downcast of address 0x613000000740 which does not point to an object of type 'const Core::EventReceiver'
0x613000000740: note: object has invalid vptr
 00 00 00 00  77 04 00 00 00 00 00 00  00 00 00 00 be be be be  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              invalid vptr
    #0 0x10010376c in AK::RefCounted<Core::EventReceiver>::unref() const RefCounted.h:59
    #1 0x100133a6c in AK::ErrorOr<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>::~ErrorOr() Error.h:129
    #2 0x100133800 in Core::Promise<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>::~Promise() Forward.h:40
    #3 0x1001336b0 in Core::Promise<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>::~Promise() Forward.h:40
    #4 0x1013eb220 in AK::RefCounted<Core::EventReceiver>::unref() const RefCounted.h:65
    #5 0x10144a058 in AK::Vector<AK::NonnullRefPtr<Core::Promise<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>>, 16ul>::remove(unsigned long) Vector.h:399
    #6 0x101444c20 in Core::ThreadEventQueue::process() ThreadEventQueue.cpp:100
    #7 0x10145cc24 in Core::EventLoopImplementationUnix::exec() EventLoopImplementationUnix.cpp:316
    #8 0x1013ec908 in Core::EventLoop::exec() EventLoop.cpp:88
    #9 0x10010076c in serenity_main(Main::Arguments) main.cpp:44
    #10 0x10015c814 in main Main.cpp:39
    #11 0x193b87150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /Users/kling/src/ladybird/AK/RefCounted.h:59:37 in 
=================================================================
==36947==ERROR: AddressSanitizer: heap-use-after-free on address 0x613000000748 at pc 0x000100103968 bp 0x00016fd068b0 sp 0x00016fd068a8
READ of size 4 at 0x613000000748 thread T0
    #0 0x100103964 in AK::RefCounted<Core::EventReceiver>::unref() const RefCounted.h:61
    #1 0x100133a6c in AK::ErrorOr<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>::~ErrorOr() Error.h:129
    #2 0x100133800 in Core::Promise<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>::~Promise() Forward.h:40
    #3 0x1001336b0 in Core::Promise<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>::~Promise() Forward.h:40
    #4 0x1013eb220 in AK::RefCounted<Core::EventReceiver>::unref() const RefCounted.h:65
    #5 0x10144a058 in AK::Vector<AK::NonnullRefPtr<Core::Promise<AK::NonnullRefPtr<Core::EventReceiver>, AK::Error>>, 16ul>::remove(unsigned long) Vector.h:399
    #6 0x101444c20 in Core::ThreadEventQueue::process() ThreadEventQueue.cpp:100
    #7 0x10145cc24 in Core::EventLoopImplementationUnix::exec() EventLoopImplementationUnix.cpp:316
    #8 0x1013ec908 in Core::EventLoop::exec() EventLoop.cpp:88
    #9 0x10010076c in serenity_main(Main::Arguments) main.cpp:44
    #10 0x10015c814 in main Main.cpp:39
    #11 0x193b87150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)

0x613000000748 is located 8 bytes inside of 360-byte region [0x613000000740,0x6130000008a8)
freed by thread T0 here:
    #0 0x10201c2d4 in _ZdlPv+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x642d4)
    #1 0x1001036c4 in AK::RefCounted<Core::EventReceiver>::unref() const RefCounted.h:65
    #2 0x10013efdc in Threading::BackgroundAction<ImageDecoder::ConnectionFromClient::DecodeResult>::BackgroundAction(AK::Function<AK::ErrorOr<ImageDecoder::ConnectionFromClient::DecodeResult, AK::Error> (Threading::BackgroundAction<ImageDecoder::ConnectionFromClient::DecodeResult>&)>, AK::Function<AK::ErrorOr<void, AK::Error> (ImageDecoder::ConnectionFromClient::DecodeResult)>, AK::Optional<AK::Function<void (AK::Error)>>)::'lambda'()::operator()() const::'lambda'()::~() BackgroundAction.h:87
    #3 0x10013c970 in AK::Function<void ()>::CallableWrapper<Threading::BackgroundAction<ImageDecoder::ConnectionFromClient::DecodeResult>::BackgroundAction(AK::Function<AK::ErrorOr<ImageDecoder::ConnectionFromClient::DecodeResult, AK::Error> (Threading::BackgroundAction<ImageDecoder::ConnectionFromClient::DecodeResult>&)>, AK::Function<AK::ErrorOr<void, AK::Error> (ImageDecoder::ConnectionFromClient::DecodeResult)>, AK::Optional<AK::Function<void (AK::Error)>>)::'lambda'()::operator()() const::'lambda'()>::~CallableWrapper() Function.h:175
    #4 0x1013f010c in AK::Function<void ()>::clear(bool) Function.h:239
    #5 0x1013f26a8 in Core::DeferredInvocationEvent::~DeferredInvocationEvent() Event.h:50
    #6 0x1013f2614 in Core::DeferredInvocationEvent::~DeferredInvocationEvent() Event.h:50
    #7 0x101447668 in Core::ThreadEventQueue::Private::QueuedEvent::~QueuedEvent() ThreadEventQueue.cpp:31
    #8 0x101449e6c in AK::Vector<Core::ThreadEventQueue::Private::QueuedEvent, 0ul>::clear_with_capacity() Vector.h:388
    #9 0x101449d10 in AK::Vector<Core::ThreadEventQueue::Private::QueuedEvent, 0ul>::clear() Vector.h:377
    #10 0x10144571c in Core::ThreadEventQueue::process() ThreadEventQueue.cpp:134
    #11 0x10145cc24 in Core::EventLoopImplementationUnix::exec() EventLoopImplementationUnix.cpp:316
    #12 0x1013ec908 in Core::EventLoop::exec() EventLoop.cpp:88
    #13 0x10010076c in serenity_main(Main::Arguments) main.cpp:44
    #14 0x10015c814 in main Main.cpp:39
    #15 0x193b87150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)

previously allocated by thread T0 here:
    #0 0x10201be94 in _Znwm+0x74 (libclang_rt.asan_osx_dynamic.dylib:arm64e+0x63e94)
    #1 0x1001076f0 in ImageDecoder::ConnectionFromClient::make_decode_image_job(long long, Core::AnonymousBuffer, AK::Optional<Gfx::Size<int>>, AK::Optional<AK::ByteString>) ConnectionFromClient.cpp:136
    #2 0x100108bac in ImageDecoder::ConnectionFromClient::decode_image(Core::AnonymousBuffer const&, AK::Optional<Gfx::Size<int>> const&, AK::Optional<AK::ByteString> const&) ConnectionFromClient.cpp:162
    #3 0x10010ae98 in ImageDecoderServerStub::handle(IPC::Message const&) ImageDecoderServerEndpoint.h:461
    #4 0x1008720cc in IPC::ConnectionBase::handle_messages() Connection.cpp:110
    #5 0x1013fca7c in AK::Function<void ()>::operator()() const Function.h:120
    #6 0x1013fca7c in AK::Function<void ()>::operator()() const Function.h:120
    #7 0x1014450e8 in Core::ThreadEventQueue::process() ThreadEventQueue.cpp:118
    #8 0x10145cc24 in Core::EventLoopImplementationUnix::exec() EventLoopImplementationUnix.cpp:316
    #9 0x1013ec908 in Core::EventLoop::exec() EventLoop.cpp:88
    #10 0x10010076c in serenity_main(Main::Arguments) main.cpp:44
    #11 0x10015c814 in main Main.cpp:39
    #12 0x193b87150 in start+0x9a8 (dyld:arm64e+0xfffffffffff4d150)

SUMMARY: AddressSanitizer: heap-use-after-free RefCounted.h:61 in AK::RefCounted<Core::EventReceiver>::unref() const
Shadow bytes around the buggy address:
  0x613000000480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x613000000500: 00 00 fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x613000000580: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x613000000600: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x613000000680: 00 00 00 00 00 00 00 00 00 00 fa fa fa fa fa fa
=>0x613000000700: fa fa fa fa fa fa fa fa fd[fd]fd fd fd fd fd fd
  0x613000000780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x613000000800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x613000000880: fd fd fd fd fd fa fa fa fa fa fa fa fa fa fa fa
  0x613000000900: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x613000000980: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==36947==ABORTING
```