### PR TITLE
LibJS: A couple of parser fixes related to `async` functions as object properties

### DIFF
--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -2019,7 +2019,6 @@ NonnullRefPtr<ObjectExpression const> Parser::parse_object_expression()
 
             if (lookahead_token.type() != TokenType::ParenOpen && lookahead_token.type() != TokenType::Colon
                 && lookahead_token.type() != TokenType::Comma && lookahead_token.type() != TokenType::CurlyClose
-                && lookahead_token.type() != TokenType::Async
                 && !lookahead_token.trivia_contains_line_terminator()) {
                 consume(TokenType::Async);
                 function_kind = FunctionKind::Async;

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -2025,6 +2025,7 @@ NonnullRefPtr<ObjectExpression const> Parser::parse_object_expression()
                 function_kind = FunctionKind::Async;
             }
         }
+
         if (match(TokenType::Asterisk)) {
             consume();
             property_type = ObjectProperty::Type::KeyValue;
@@ -2058,6 +2059,7 @@ NonnullRefPtr<ObjectExpression const> Parser::parse_object_expression()
                 continue;
             }
         }
+
         if (match(TokenType::Equals)) {
             // Not a valid object literal, but a valid assignment target
             consume();
@@ -2078,6 +2080,11 @@ NonnullRefPtr<ObjectExpression const> Parser::parse_object_expression()
                 parse_options |= FunctionNodeParseOptions::IsAsyncFunction;
             auto function = parse_function_node<FunctionExpression>(parse_options, function_start);
             properties.append(create_ast_node<ObjectProperty>({ m_source_code, rule_start.position(), position() }, *property_key, function, property_type, true));
+        } else if (function_kind == FunctionKind::Async) {
+            // If we previously parsed an `async` keyword, then a function must follow.
+            syntax_error("Expected function after async keyword");
+            skip_to_next_property();
+            continue;
         } else if (match(TokenType::Colon)) {
             if (!property_key) {
                 expected("a property name");

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -207,6 +207,15 @@ describe("shorthanded properties with special names", () => {
     });
 
     test("async functions as properties", () => {
+        expect("({ async async() {} });").toEval();
+        expect('"use strict"; ({ async async() {} });').toEval();
+
+        expect("({ async async });").not.toEval();
+        expect("({ async async, });").not.toEval();
+        expect("({ async async() });").not.toEval();
+        expect("({ async async: 0 });").not.toEval();
+        expect("({ async async = 0 });").not.toEval();
+
         expect("({ async foo });").not.toEval();
         expect("({ async foo, });").not.toEval();
         expect("({ async foo() });").not.toEval();

--- a/Libraries/LibJS/Tests/object-basic.js
+++ b/Libraries/LibJS/Tests/object-basic.js
@@ -205,6 +205,14 @@ describe("shorthanded properties with special names", () => {
         expect('"use strict"; var await = 8; ({ await, })').toEval();
         expect('"use strict"; var async = 7; ({ async, })').toEval();
     });
+
+    test("async functions as properties", () => {
+        expect("({ async foo });").not.toEval();
+        expect("({ async foo, });").not.toEval();
+        expect("({ async foo() });").not.toEval();
+        expect("({ async foo: 0 });").not.toEval();
+        expect("({ async foo = 0 });").not.toEval();
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
This fixes JS exceptions thrown on https://locals.com/site/discover and allows the page to load.

No test262 or test262-parser-tests diff.

Before:
<img width="1495" alt="Screenshot 2024-12-26 at 9 18 46 AM" src="https://github.com/user-attachments/assets/df63e55e-d4e5-4658-a915-7796f84fdc1c" />

After:
<img width="1495" alt="Screenshot 2024-12-26 at 9 18 31 AM" src="https://github.com/user-attachments/assets/10f51e11-8d0f-470f-8639-24867ca6ae5e" />
