### PR TITLE
LibWeb: Make CustomElementDefinition relationship with GC more sane

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2181,7 +2181,7 @@ JS::ThrowCompletionOr<void> Element::upgrade_element(GC::Ref<HTML::CustomElement
     }
 
     // 6. Add element to the end of definition's construction stack.
-    custom_element_definition->construction_stack().append(GC::make_root(this));
+    custom_element_definition->construction_stack().append(GC::Ref { *this });
 
     // 7. Let C be definition's constructor.
     auto& constructor = custom_element_definition->constructor();

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementDefinition.cpp
@@ -13,6 +13,11 @@ void CustomElementDefinition::visit_edges(Visitor& visitor)
     Base::visit_edges(visitor);
     visitor.visit(m_constructor);
     visitor.visit(m_lifecycle_callbacks);
+    for (auto& entry : m_construction_stack) {
+        entry.visit(
+            [&](GC::Ref<DOM::Element>& element) { visitor.visit(element); },
+            [&](AlreadyConstructedCustomElementMarker&) {});
+    }
 }
 
 }

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementRegistry.cpp
@@ -185,7 +185,7 @@ JS::ThrowCompletionOr<void> CustomElementRegistry::define(String const& name, We
 
     // NOTE: This is not in the spec, but is required because of how we catch the exception by using a lambda, meaning we need to define this
     //       variable outside of it to use it later.
-    CustomElementDefinition::LifecycleCallbacksStorage lifecycle_callbacks;
+    OrderedHashMap<FlyString, GC::Root<WebIDL::CallbackType>> lifecycle_callbacks;
 
     // 14. Run the following steps while catching any exceptions:
     auto get_definition_attributes_from_constructor = [&]() -> JS::ThrowCompletionOr<void> {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -2635,7 +2635,7 @@ static void generate_html_constructor(SourceGenerator& generator, IDL::Construct
         return JS::throw_completion(WebIDL::InvalidStateError::create(realm, "Custom element has already been constructed"_string));
 
     // 12. Perform ? element.[[SetPrototypeOf]](prototype).
-    auto actual_element = element.get<GC::Root<DOM::Element>>();
+    auto actual_element = element.get<GC::Ref<DOM::Element>>();
     TRY(actual_element->internal_set_prototype_of(&prototype.as_object()));
 
     // 13. Replace the last entry in definition's construction stack with an already constructed marker.


### PR DESCRIPTION
1. Stop using `GC::Root` in member variables, since that usually creates a realm leak.

2. Stop putting `OrderedHashMap<FlyString, GC::Ptr>` on the stack while setting these up, since that won't protect the objects from GC.