### PR TITLE
LibWeb: Remove unused pointer from DOM::Text to its "owner" element

### DIFF
--- a/Libraries/LibWeb/DOM/Text.cpp
+++ b/Libraries/LibWeb/DOM/Text.cpp
@@ -37,7 +37,6 @@ void Text::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);
     SlottableMixin::visit_edges(visitor);
-    visitor.visit(m_owner);
 }
 
 // https://dom.spec.whatwg.org/#dom-text-text

--- a/Libraries/LibWeb/DOM/Text.h
+++ b/Libraries/LibWeb/DOM/Text.h
@@ -46,8 +46,6 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
 private:
-    GC::Ptr<Element> m_owner;
-
     Optional<size_t> m_max_length {};
     bool m_is_password_input { false };
 };


### PR DESCRIPTION
This is a leftover from an earlier implementation of text input.