### PR TITLE
LibWeb: Allow keyboard input to alter email inputs

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -143,12 +143,14 @@ public:
     WebIDL::ExceptionOr<void> select();
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart
-    Optional<WebIDL::UnsignedLong> selection_start() const;
-    WebIDL::ExceptionOr<void> set_selection_start(Optional<WebIDL::UnsignedLong> const&);
+    Optional<WebIDL::UnsignedLong> selection_start_binding() const;
+    WebIDL::ExceptionOr<void> set_selection_start_binding(Optional<WebIDL::UnsignedLong> const&);
+    WebIDL::UnsignedLong selection_start() const;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionend
-    Optional<WebIDL::UnsignedLong> selection_end() const;
-    WebIDL::ExceptionOr<void> set_selection_end(Optional<WebIDL::UnsignedLong> const&);
+    Optional<WebIDL::UnsignedLong> selection_end_binding() const;
+    WebIDL::ExceptionOr<void> set_selection_end_binding(Optional<WebIDL::UnsignedLong> const&);
+    WebIDL::UnsignedLong selection_end() const;
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectiondirection
     Optional<String> selection_direction() const;
@@ -157,7 +159,8 @@ public:
     SelectionDirection selection_direction_state() const { return m_selection_direction; }
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setrangetext
-    WebIDL::ExceptionOr<void> set_range_text(String const& replacement);
+    WebIDL::ExceptionOr<void> set_range_text_binding(String const& replacement);
+    WebIDL::ExceptionOr<void> set_range_text_binding(String const& replacement, WebIDL::UnsignedLong start, WebIDL::UnsignedLong end, Bindings::SelectionMode = Bindings::SelectionMode::Preserve);
     WebIDL::ExceptionOr<void> set_range_text(String const& replacement, WebIDL::UnsignedLong start, WebIDL::UnsignedLong end, Bindings::SelectionMode = Bindings::SelectionMode::Preserve);
 
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-setselectionrange

--- a/Libraries/LibWeb/HTML/HTMLInputElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.idl
@@ -60,11 +60,11 @@ interface HTMLInputElement : HTMLElement {
     readonly attribute NodeList? labels;
 
     undefined select();
-    attribute unsigned long? selectionStart;
-    attribute unsigned long? selectionEnd;
+    [ImplementedAs=selection_start_binding] attribute unsigned long? selectionStart;
+    [ImplementedAs=selection_end_binding] attribute unsigned long? selectionEnd;
     [ImplementedAs=selection_direction_binding] attribute DOMString? selectionDirection;
-    undefined setRangeText(DOMString replacement);
-    undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
+    [ImplementedAs=set_range_text_binding] undefined setRangeText(DOMString replacement);
+    [ImplementedAs=set_range_text_binding] undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
     undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 
     undefined showPicker();

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -328,22 +328,22 @@ WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_rows(WebIDL::UnsignedLong row
 
 WebIDL::UnsignedLong HTMLTextAreaElement::selection_start_binding() const
 {
-    return selection_start().value();
+    return FormAssociatedTextControlElement::selection_start_binding().value();
 }
 
 WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_start_binding(WebIDL::UnsignedLong const& value)
 {
-    return set_selection_start(value);
+    return FormAssociatedTextControlElement::set_selection_start_binding(value);
 }
 
 WebIDL::UnsignedLong HTMLTextAreaElement::selection_end_binding() const
 {
-    return selection_end().value();
+    return FormAssociatedTextControlElement::selection_end_binding().value();
 }
 
 WebIDL::ExceptionOr<void> HTMLTextAreaElement::set_selection_end_binding(WebIDL::UnsignedLong const& value)
 {
-    return set_selection_end(value);
+    return FormAssociatedTextControlElement::set_selection_end_binding(value);
 }
 
 String HTMLTextAreaElement::selection_direction_binding() const

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.idl
@@ -38,7 +38,7 @@ interface HTMLTextAreaElement : HTMLElement {
     [ImplementedAs=selection_start_binding] attribute unsigned long selectionStart;
     [ImplementedAs=selection_end_binding] attribute unsigned long selectionEnd;
     [ImplementedAs=selection_direction_binding] attribute DOMString selectionDirection;
-    undefined setRangeText(DOMString replacement);
-    undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
+    [ImplementedAs=set_range_text_binding] undefined setRangeText(DOMString replacement);
+    [ImplementedAs=set_range_text_binding] undefined setRangeText(DOMString replacement, unsigned long start, unsigned long end, optional SelectionMode selectionMode = "preserve");
     undefined setSelectionRange(unsigned long start, unsigned long end, optional DOMString direction);
 };

--- a/Libraries/LibWeb/Painting/PaintableFragment.cpp
+++ b/Libraries/LibWeb/Painting/PaintableFragment.cpp
@@ -200,9 +200,7 @@ CSSPixelRect PaintableFragment::selection_rect() const
         }
         auto selection_start = text_control_element->selection_start();
         auto selection_end = text_control_element->selection_end();
-        if (!selection_start.has_value() || !selection_end.has_value())
-            return {};
-        return range_rect(selection_start.value(), selection_end.value());
+        return range_rect(selection_start, selection_end);
     }
     auto selection = paintable().document().get_selection();
     if (!selection)

--- a/Tests/LibWeb/Text/expected/HTMLInputElement-edit-value.txt
+++ b/Tests/LibWeb/Text/expected/HTMLInputElement-edit-value.txt
@@ -1,0 +1,6 @@
+input[type=text] value: PASS
+input[type=search] value: PASS
+input[type=tel] value: PASS
+input[type=url] value: PASS
+input[type=email] value: PASS
+input[type=password] value: PASS

--- a/Tests/LibWeb/Text/input/HTMLInputElement-edit-value.html
+++ b/Tests/LibWeb/Text/input/HTMLInputElement-edit-value.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        const inputTypes = [
+            "text",
+            "search",
+            "tel",
+            "url",
+            "email",
+            "password",
+        ];
+
+        inputTypes.forEach(type => {
+            const input = document.createElement("input");
+            input.type = type;
+            document.body.appendChild(input);
+            internals.sendText(input, "PASS");
+            println(`input[type=${type}] value: ${input.value}`);
+            input.remove();
+        });
+    });
+</script>


### PR DESCRIPTION
Previously, the`HTMLInputElement.selectinStart` and `HTMLInputElement.selectionEnd` IDL setters, and the `setRangeText()` IDL method were used when updating an input's value on keyboard input. These methods can't be used for this purpose, since selection doesn't apply to email type inputs. Therefore, this change introduces internal-use only methods that don't check whether selection applies to the given input.

Fixes #3054