### PR TITLE
Meta: Switch to clang-19 and clang-format-19

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
         "./features/ladybird": {
-            "llvm_version": 18
+            "llvm_version": 19
         },
         "./features/vcpkg-cache": {
             "release_triplet": true,
@@ -70,7 +70,7 @@
                 "git.inputValidationSubjectLength": 72,
                 // If clangd was obtained from a package manager, its path can be set here.
                 // Note: This has to be adjusted manually, to the "llvm_version" from above
-                "clangd.path": "clangd-18",
+                "clangd.path": "clangd-19",
                 "clangd.arguments": [
                     "--header-insertion=never" // See https://github.com/clangd/clangd/issues/1247
                 ]

--- a/.devcontainer/features/ladybird/devcontainer-feature.json
+++ b/.devcontainer/features/ladybird/devcontainer-feature.json
@@ -12,7 +12,7 @@
                 19,
                 "trunk"
             ],
-            "default": 18,
+            "default": 19,
             "description": "Select LLVM compiler version to use"
         }
     }

--- a/.devcontainer/features/ladybird/install.sh
+++ b/.devcontainer/features/ladybird/install.sh
@@ -3,7 +3,7 @@ set -e
 
 # Feature options
 
-LLVM_VERSION=${LLVM_VERSION:-18}
+LLVM_VERSION=${LLVM_VERSION:-19}
 ### Check distro
 
 if [ ! -f /etc/lsb-release ]; then

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -28,15 +28,15 @@ runs:
         set -e
 
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-18 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/noble/ llvm-toolchain-noble-19 main'
 
         sudo apt-get update -y
-        sudo apt-get install -y autoconf autoconf-archive automake build-essential ccache clang-18 clang++-18 cmake curl fonts-liberation2 \
+        sudo apt-get install -y autoconf autoconf-archive automake build-essential ccache clang-19 clang++-19 cmake curl fonts-liberation2 \
             gcc-13 g++-13 libegl1-mesa-dev libgl1-mesa-dev libpulse-dev libssl-dev \
-            libstdc++-13-dev lld-18 nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
+            libstdc++-13-dev lld-19 nasm ninja-build qt6-base-dev qt6-tools-dev-tools tar unzip zip
 
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
@@ -57,7 +57,7 @@ runs:
       run: |
         set -e
         brew update
-        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@18 nasm ninja qt unzip wabt
+        brew install autoconf autoconf-archive automake bash ccache coreutils llvm@19 nasm ninja qt unzip wabt
 
     - name: 'Install vcpkg'
       shell: bash

--- a/.github/workflows/ladybird-js-artifacts.yml
+++ b/.github/workflows/ladybird-js-artifacts.yml
@@ -52,8 +52,8 @@ jobs:
       - name: Create build directory Ubuntu
         run: |
           cmake --preset Distribution_CI \
-            -DCMAKE_C_COMPILER=clang-18 \
-            -DCMAKE_CXX_COMPILER=clang++-18 \
+            -DCMAKE_C_COMPILER=clang-19 \
+            -DCMAKE_CXX_COMPILER=clang++-19 \
             -DENABLE_GUI_TARGETS=OFF
         if: ${{ matrix.os_name == 'Linux' }}
 

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           if ${{ inputs.os_name == 'Linux' }} ; then
             if ${{ inputs.toolchain == 'Clang' }} ; then
-              echo "host_cc=clang-18" >> "$GITHUB_OUTPUT"
-              echo "host_cxx=clang++-18" >> "$GITHUB_OUTPUT"
+              echo "host_cc=clang-19" >> "$GITHUB_OUTPUT"
+              echo "host_cxx=clang++-19" >> "$GITHUB_OUTPUT"
             elif ${{ inputs.toolchain == 'GNU' }} ; then
               echo "host_cc=gcc-13" >> "$GITHUB_OUTPUT"
               echo "host_cxx=g++-13" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           set -e
 
-          brew install curl flake8 llvm@18 ninja shellcheck swift-format unzip
+          brew install curl flake8 llvm@19 ninja shellcheck swift-format unzip
 
           # Note: gn isn't available in homebrew :(
           # Corresponds to https://gn.googlesource.com/gn/+/225e90c5025bf74f41dbee60d9cde4512c846fe7

--- a/AK/DistinctNumeric.h
+++ b/AK/DistinctNumeric.h
@@ -46,13 +46,13 @@ namespace AK {
  */
 
 namespace DistinctNumericFeature {
-enum Arithmetic {};
-enum CastToBool {};
-enum CastToUnderlying {};
-enum Comparison {};
-enum Flags {};
-enum Increment {};
-enum Shift {};
+enum Arithmetic { };
+enum CastToBool { };
+enum CastToUnderlying { };
+enum Comparison { };
+enum Flags { };
+enum Increment { };
+enum Shift { };
 };
 
 template<typename T, typename X, typename... Opts>

--- a/AK/IntrusiveList.h
+++ b/AK/IntrusiveList.h
@@ -20,9 +20,9 @@ class IntrusiveListNode;
 
 struct ExtractIntrusiveListTypes {
     template<typename V, typename Container, typename T>
-    static V value(IntrusiveListNode<V, Container> T::*x);
+    static V value(IntrusiveListNode<V, Container> T::* x);
     template<typename V, typename Container, typename T>
-    static Container container(IntrusiveListNode<V, Container> T::*x);
+    static Container container(IntrusiveListNode<V, Container> T::* x);
 };
 
 template<typename T, typename Container = RawPtr<T>>
@@ -33,14 +33,14 @@ class IntrusiveListStorage {
 private:
     friend class IntrusiveListNode<T, Container>;
 
-    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
+    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::* member>
     friend class IntrusiveList;
 
     SubstitutedIntrusiveListNode<T, Container>* m_first { nullptr };
     SubstitutedIntrusiveListNode<T, Container>* m_last { nullptr };
 };
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 class IntrusiveList {
     AK_MAKE_NONCOPYABLE(IntrusiveList);
     AK_MAKE_NONMOVABLE(IntrusiveList);
@@ -162,7 +162,7 @@ public:
     //       to be of equal types. so for now, just make the members public on clang.
 #if !defined(AK_COMPILER_CLANG)
 private:
-    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::*member>
+    template<class T_, typename Container_, SubstitutedIntrusiveListNode<T_, Container_> T_::* member>
     friend class ::AK::Detail::IntrusiveList;
 #endif
 
@@ -172,7 +172,7 @@ private:
     [[no_unique_address]] SelfReferenceIfNeeded<Container, IsRaw> m_self;
 };
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, Container, member>::Iterator::erase()
 {
     auto old = m_value;
@@ -181,26 +181,26 @@ inline typename IntrusiveList<T, Container, member>::Iterator& IntrusiveList<T, 
     return *this;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline IntrusiveList<T, Container, member>::~IntrusiveList()
 {
     clear();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::clear()
 {
     while (m_storage.m_first)
         m_storage.m_first->remove();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline bool IntrusiveList<T, Container, member>::is_empty() const
 {
     return m_storage.m_first == nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline size_t IntrusiveList<T, Container, member>::size_slow() const
 {
     size_t size = 0;
@@ -211,7 +211,7 @@ inline size_t IntrusiveList<T, Container, member>::size_slow() const
     return size;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::append(T& n)
 {
     remove(n);
@@ -230,7 +230,7 @@ inline void IntrusiveList<T, Container, member>::append(T& n)
         m_storage.m_first = &nnode;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::prepend(T& n)
 {
     remove(n);
@@ -249,7 +249,7 @@ inline void IntrusiveList<T, Container, member>::prepend(T& n)
         m_storage.m_last = &nnode;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::insert_before(T& bn, T& n)
 {
     remove(n);
@@ -271,7 +271,7 @@ inline void IntrusiveList<T, Container, member>::insert_before(T& bn, T& n)
         new_node.m_self.reference = &n;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline void IntrusiveList<T, Container, member>::remove(T& n)
 {
     auto& nnode = n.*member;
@@ -279,20 +279,20 @@ inline void IntrusiveList<T, Container, member>::remove(T& n)
         nnode.remove();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline bool IntrusiveList<T, Container, member>::contains(T const& n) const
 {
     auto& nnode = n.*member;
     return nnode.m_storage == &m_storage;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::first() const
 {
     return m_storage.m_first ? node_to_value(*m_storage.m_first) : nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::take_first()
 {
     if (Container ptr = first()) {
@@ -302,7 +302,7 @@ inline Container IntrusiveList<T, Container, member>::take_first()
     return nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::take_last()
 {
     if (Container ptr = last()) {
@@ -312,13 +312,13 @@ inline Container IntrusiveList<T, Container, member>::take_last()
     return nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline Container IntrusiveList<T, Container, member>::last() const
 {
     return m_storage.m_last ? node_to_value(*m_storage.m_last) : nullptr;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T const* IntrusiveList<T, Container, member>::next(T const* current)
 {
     auto& nextnode = (current->*member).m_next;
@@ -326,7 +326,7 @@ inline T const* IntrusiveList<T, Container, member>::next(T const* current)
     return nextstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T const* IntrusiveList<T, Container, member>::prev(T const* current)
 {
     auto& prevnode = (current->*member).m_prev;
@@ -334,7 +334,7 @@ inline T const* IntrusiveList<T, Container, member>::prev(T const* current)
     return prevstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T* IntrusiveList<T, Container, member>::next(T* current)
 {
     auto& nextnode = (current->*member).m_next;
@@ -342,7 +342,7 @@ inline T* IntrusiveList<T, Container, member>::next(T* current)
     return nextstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T* IntrusiveList<T, Container, member>::prev(T* current)
 {
     auto& prevnode = (current->*member).m_prev;
@@ -350,25 +350,25 @@ inline T* IntrusiveList<T, Container, member>::prev(T* current)
     return prevstruct;
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::Iterator IntrusiveList<T, Container, member>::begin()
 {
     return m_storage.m_first ? Iterator(node_to_value(*m_storage.m_first)) : Iterator();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::ReverseIterator IntrusiveList<T, Container, member>::rbegin()
 {
     return m_storage.m_last ? ReverseIterator(node_to_value(*m_storage.m_last)) : ReverseIterator();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline typename IntrusiveList<T, Container, member>::ConstIterator IntrusiveList<T, Container, member>::begin() const
 {
     return m_storage.m_first ? ConstIterator(node_to_value(*m_storage.m_first)) : ConstIterator();
 }
 
-template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, SubstitutedIntrusiveListNode<T, Container> T::* member>
 inline T* IntrusiveList<T, Container, member>::node_to_value(SubstitutedIntrusiveListNode<T, Container>& node)
 {
     // Note: A data member pointer is a 32-bit offset in the Windows ABI (both x86 and x86_64),
@@ -422,7 +422,7 @@ inline bool IntrusiveListNode<T, Container>::is_in_list() const
 // By default, intrusive lists cannot contain null entries anyway, so switch to RefPtr
 // and just make the user-facing functions deref the pointers.
 
-template<class T, SubstitutedIntrusiveListNode<T, NonnullRefPtr<T>> T::*member>
+template<class T, SubstitutedIntrusiveListNode<T, NonnullRefPtr<T>> T::* member>
 class IntrusiveList<T, NonnullRefPtr<T>, member> : public IntrusiveList<T, RefPtr<T>, member> {
 public:
     [[nodiscard]] NonnullRefPtr<T> first() const { return *IntrusiveList<T, RefPtr<T>, member>::first(); }

--- a/AK/IntrusiveListRelaxedConst.h
+++ b/AK/IntrusiveListRelaxedConst.h
@@ -11,7 +11,7 @@
 namespace AK {
 namespace Detail {
 
-template<class T, typename Container, IntrusiveListNode<T, Container> T::*member>
+template<class T, typename Container, IntrusiveListNode<T, Container> T::* member>
 class IntrusiveListRelaxedConst : public IntrusiveList<T, Container, member> {
     AK_MAKE_NONCOPYABLE(IntrusiveListRelaxedConst);
     AK_MAKE_NONMOVABLE(IntrusiveListRelaxedConst);

--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -16,17 +16,17 @@ class IntrusiveRedBlackTreeNode;
 
 struct ExtractIntrusiveRedBlackTreeTypes {
     template<typename K, typename V, typename Container, typename T>
-    static K key(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    static K key(IntrusiveRedBlackTreeNode<K, V, Container> T::* x);
     template<typename K, typename V, typename Container, typename T>
-    static V value(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    static V value(IntrusiveRedBlackTreeNode<K, V, Container> T::* x);
     template<typename K, typename V, typename Container, typename T>
-    static Container container(IntrusiveRedBlackTreeNode<K, V, Container> T::*x);
+    static Container container(IntrusiveRedBlackTreeNode<K, V, Container> T::* x);
 };
 
 template<Integral K, typename V, typename Container = RawPtr<V>>
 using SubstitutedIntrusiveRedBlackTreeNode = IntrusiveRedBlackTreeNode<K, V, typename SubstituteIntrusiveContainerType<V, Container>::Type>;
 
-template<Integral K, typename V, typename Container, SubstitutedIntrusiveRedBlackTreeNode<K, V, Container> V::*member>
+template<Integral K, typename V, typename Container, SubstitutedIntrusiveRedBlackTreeNode<K, V, Container> V::* member>
 class IntrusiveRedBlackTree : public BaseRedBlackTree<K> {
 
 public:
@@ -200,7 +200,7 @@ public:
 
 #if !defined(AK_COMPILER_CLANG)
 private:
-    template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::*member>
+    template<Integral TK, typename TV, typename TContainer, SubstitutedIntrusiveRedBlackTreeNode<TK, TV, TContainer> TV::* member>
     friend class ::AK::Detail::IntrusiveRedBlackTree;
 #endif
 
@@ -211,7 +211,7 @@ private:
 // Specialise IntrusiveRedBlackTree for NonnullRefPtr
 // By default, red black trees cannot contain null entries anyway, so switch to RefPtr
 // and just make the user-facing functions deref the pointers.
-template<Integral K, typename V, SubstitutedIntrusiveRedBlackTreeNode<K, V, NonnullRefPtr<V>> V::*member>
+template<Integral K, typename V, SubstitutedIntrusiveRedBlackTreeNode<K, V, NonnullRefPtr<V>> V::* member>
 class IntrusiveRedBlackTree<K, V, NonnullRefPtr<V>, member> : public IntrusiveRedBlackTree<K, V, RefPtr<V>, member> {
 public:
     [[nodiscard]] NonnullRefPtr<V> find(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find(key).release_nonnull(); }

--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -44,7 +44,7 @@ inline void secure_zero(void* ptr, size_t size)
     // The memory barrier is here to avoid the compiler optimizing
     // away the memset when we rely on it for wiping secrets.
     asm volatile("" ::
-                     : "memory");
+            : "memory");
 }
 
 // Naive implementation of a constant time buffer comparison function.

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -42,7 +42,7 @@ public:
         Node()
         {
         }
-        virtual ~Node() {};
+        virtual ~Node() { }
     };
 
 protected:

--- a/AK/Result.h
+++ b/AK/Result.h
@@ -94,8 +94,8 @@ public:
     ~Result() = default;
 
     // For compatibility with TRY().
-    void value() {};
-    void release_value() {};
+    void value() { }
+    void release_value() { }
 
     ErrorType& error()
     {

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -132,7 +132,7 @@ requires(IsIntegral<T>)
 {
     if (!is_constant_evaluated()) {
         asm volatile(""
-                     : "+r"(value));
+            : "+r"(value));
     }
 }
 
@@ -142,9 +142,9 @@ requires(!IsIntegral<T>)
 {
     if (!is_constant_evaluated()) {
         asm volatile(""
-                     :
-                     : "m"(value)
-                     : "memory");
+            :
+            : "m"(value)
+            : "memory");
     }
 }
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 **Do:**
 
 * Write in idiomatic project-style C++23, using the `AK` containers in all code.
-* Conform to the project coding style found in [CodingStyle.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 18) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-18.
+* Conform to the project coding style found in [CodingStyle.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/CodingStyle.md). Use `clang-format` (version 19) to automatically format C++ files. See [AdvancedBuildInstructions.md](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/AdvancedBuildInstructions.md#clang-format-updates) for instructions on how to get an up-to-date version if your OS distribution does not ship clang-format-19.
 * Choose expressive variable, function and class names. Make it as obvious as possible what the code is doing.
 * Split your changes into separate, atomic commits (i.e. A commit per feature or fix, where the build, tests and the system are all functioning).
 * Make sure your commits are rebased on the master branch.

--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -49,10 +49,10 @@ sudo wget -O /usr/share/keyrings/llvm-snapshot.gpg.key https://apt.llvm.org/llvm
 # Optional: Verify the GPG key manually
 
 # Use the key to authorize an entry for apt.llvm.org in apt sources list
-echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] https://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-18 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
+echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot.gpg.key] https://apt.llvm.org/$(lsb_release -sc)/ llvm-toolchain-$(lsb_release -sc)-19 main" | sudo tee -a /etc/apt/sources.list.d/llvm.list
 
 # Update apt package list and install clang and associated packages
-sudo apt update -y && sudo apt install clang-18 clangd-18 clang-format-18 clang-tidy-18 lld-18 -y
+sudo apt update -y && sudo apt install clang-19 clangd-19 clang-format-19 clang-tidy-19 lld-19 -y
 ```
 
 - Alternative: Install gcc-13 or newer from [Ubuntu Toolchain PPA](https://launchpad.net/~ubuntu-toolchain-r/+archive/ubuntu/test):
@@ -102,7 +102,7 @@ sudo xbps-install -S git bash gcc python3 curl cmake zip unzip linux-headers mak
 ### NixOS or with Nix:
 
 > [!NOTE]
-> Ladybird's build system uses vcpkg to vendor third-party dependencies, which proves undesirable to use with Nix for [several reasons](https://github.com/LadybirdBrowser/ladybird/issues/371).  
+> Ladybird's build system uses vcpkg to vendor third-party dependencies, which proves undesirable to use with Nix for [several reasons](https://github.com/LadybirdBrowser/ladybird/issues/371).
 > As a result, using `ladybird.sh` to compile and run Ladybird will fail. Therefore, it is necessary to use system packages provided by the dev-shell.
 
 To build the project, first enter the shell:
@@ -145,7 +145,7 @@ brew install autoconf autoconf-archive automake ccache cmake nasm ninja pkg-conf
 
 If you wish to use clang from homebrew instead:
 ```
-brew install llvm@18
+brew install llvm@19
 ```
 
 If you also plan to use the Qt chrome on macOS:

--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -2,7 +2,7 @@
 
 For low-level styling (spaces, parentheses, brace placement, etc), all code should follow the format specified in `.clang-format` in the project root.
 
-**Important: Make sure you use `clang-format` version 18!**
+**Important: Make sure you use `clang-format` version 19!**
 
 This document describes the coding style used for C++ code in the Ladybird Browser project. All new code should conform to this style.
 
@@ -505,7 +505,7 @@ wrapping or to insert necessary punctuation such as adding `**` when a number is
 done using elements like `<sup>` which do not appear in the copied text.
 
 Please wrap long comments onto multiple lines so that they are easier to read. Generally, 120 characters is a good width
-to aim for. 
+to aim for.
 
 Use FIXME: (without attribution) to denote items that need to be addressed in the future.
 TODO: (without attribution) is also permitted.

--- a/Documentation/EditorConfiguration/QtCreatorConfiguration.md
+++ b/Documentation/EditorConfiguration/QtCreatorConfiguration.md
@@ -36,7 +36,7 @@ Qt Creator should be set up correctly now, go ahead and explore the project and 
 
 ## Auto-Formatting
 
-You can use `clang-format` to help you with the [style guide](../CodingStyle.md). Before you proceed, check that you're actually using clang-format version 18, as some OSes will ship other clang-format versions by default.
+You can use `clang-format` to help you with the [style guide](../CodingStyle.md). Before you proceed, check that you're actually using the clang-format version specified in the style guide, as some OSes will ship other clang-format versions by default.
 
 - In QtCreator, go to "Help > About Plugins…"
 - Find the `Beautifier (experimental)` row (for example, by typing `beau` into the search)

--- a/Libraries/LibCompress/Brotli.h
+++ b/Libraries/LibCompress/Brotli.h
@@ -20,7 +20,9 @@ public:
     CanonicalCode() = default;
     CanonicalCode(Vector<size_t> codes, Vector<size_t> values)
         : m_symbol_codes(move(codes))
-        , m_symbol_values(move(values)) {};
+        , m_symbol_values(move(values))
+    {
+    }
 
     static ErrorOr<CanonicalCode> read_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size);
     static ErrorOr<CanonicalCode> read_simple_prefix_code(LittleEndianInputBitStream&, size_t alphabet_size);

--- a/Libraries/LibCore/Command.cpp
+++ b/Libraries/LibCore/Command.cpp
@@ -69,7 +69,7 @@ ErrorOr<void> Command::write_lines(Span<ByteString> lines)
     // It's possible the process dies before we can write everything to the
     // stdin. So make sure that we don't crash but just stop writing.
 
-    struct sigaction action_handler { };
+    struct sigaction action_handler {};
     action_handler.sa_handler = SIG_IGN;
 
     struct sigaction old_action_handler;

--- a/Libraries/LibCore/Process.cpp
+++ b/Libraries/LibCore/Process.cpp
@@ -286,7 +286,7 @@ ErrorOr<bool> Process::is_being_debugged()
     if (sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0) < 0)
         return Error::from_syscall("sysctl"sv, -errno);
 
-        // We're being debugged if the P_TRACED flag is set.
+    // We're being debugged if the P_TRACED flag is set.
 #    if defined(AK_OS_MACOS)
     return ((info.kp_proc.p_flag & P_TRACED) != 0);
 #    elif defined(AK_OS_FREEBSD)

--- a/Libraries/LibCore/ThreadedPromise.h
+++ b/Libraries/LibCore/ThreadedPromise.h
@@ -111,7 +111,7 @@ public:
     // Set the callback to be called when the promise is rejected. Setting this callback
     // will cause the promise fulfillment to be ready to be handled.
     template<CallableAs<void, ErrorType&&> RejectedHandler>
-    ThreadedPromise& when_rejected(RejectedHandler when_rejected = [](ErrorType&) {})
+    ThreadedPromise& when_rejected(RejectedHandler when_rejected = [](ErrorType&) { })
     {
         Threading::MutexLocker locker { m_mutex };
         VERIFY(!m_rejection_handler);

--- a/Libraries/LibCrypto/BigFraction/BigFraction.cpp
+++ b/Libraries/LibCrypto/BigFraction/BigFraction.cpp
@@ -199,8 +199,8 @@ String BigFraction::to_string(unsigned rounding_threshold) const
     auto const number_of_digits = [](auto integer) {
         unsigned size = 1;
         for (auto division_result = integer.divided_by(UnsignedBigInteger { 10 });
-             division_result.remainder == UnsignedBigInteger { 0 } && division_result.quotient != UnsignedBigInteger { 0 };
-             division_result = division_result.quotient.divided_by(UnsignedBigInteger { 10 })) {
+            division_result.remainder == UnsignedBigInteger { 0 } && division_result.quotient != UnsignedBigInteger { 0 };
+            division_result = division_result.quotient.divided_by(UnsignedBigInteger { 10 })) {
             ++size;
         }
         return size;

--- a/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Libraries/LibFileSystem/FileSystem.cpp
@@ -316,7 +316,7 @@ bool can_delete_or_move(StringView path)
     auto stat_or_empty = [](StringView path) {
         auto stat_or_error = Core::System::stat(path);
         if (stat_or_error.is_error()) {
-            struct stat stat { };
+            struct stat stat {};
             return stat;
         }
         return stat_or_error.release_value();

--- a/Libraries/LibGfx/Font/Typeface.cpp
+++ b/Libraries/LibGfx/Font/Typeface.cpp
@@ -60,7 +60,7 @@ NonnullRefPtr<ScaledFont> Typeface::scaled_font(float point_size) const
 hb_face_t* Typeface::harfbuzz_typeface() const
 {
     if (!m_harfbuzz_blob)
-        m_harfbuzz_blob = hb_blob_create(reinterpret_cast<char const*>(buffer().data()), buffer().size(), HB_MEMORY_MODE_READONLY, nullptr, [](void*) {});
+        m_harfbuzz_blob = hb_blob_create(reinterpret_cast<char const*>(buffer().data()), buffer().size(), HB_MEMORY_MODE_READONLY, nullptr, [](void*) { });
     if (!m_harfbuzz_face)
         m_harfbuzz_face = hb_face_create(m_harfbuzz_blob, ttc_index());
     return m_harfbuzz_face;

--- a/Libraries/LibGfx/Font/TypefaceSkia.cpp
+++ b/Libraries/LibGfx/Font/TypefaceSkia.cpp
@@ -64,9 +64,9 @@ SkTypeface const* TypefaceSkia::sk_typeface() const
 TypefaceSkia::TypefaceSkia(NonnullOwnPtr<Impl> impl, ReadonlyBytes buffer, int ttc_index)
     : m_impl(move(impl))
     , m_buffer(buffer)
-    , m_ttc_index(ttc_index) {
-
-    };
+    , m_ttc_index(ttc_index)
+{
+}
 
 u32 TypefaceSkia::glyph_count() const
 {

--- a/Libraries/LibGfx/ImageFormats/ImageDecoder.h
+++ b/Libraries/LibGfx/ImageFormats/ImageDecoder.h
@@ -48,7 +48,7 @@ public:
     }
 
 protected:
-    virtual void fill_main_tags() const {};
+    virtual void fill_main_tags() const { }
 
     mutable HashMap<StringView, String> m_main_tags;
 };

--- a/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/JPEGLoader.cpp
@@ -62,7 +62,7 @@ ErrorOr<void> JPEGLoadingContext::decode()
 
     source_manager.next_input_byte = data.data();
     source_manager.bytes_in_buffer = data.size();
-    source_manager.init_source = [](j_decompress_ptr) {};
+    source_manager.init_source = [](j_decompress_ptr) { };
     source_manager.fill_input_buffer = [](j_decompress_ptr) -> boolean { return false; };
     source_manager.skip_input_data = [](j_decompress_ptr context, long num_bytes) {
         if (num_bytes > static_cast<long>(context->src->bytes_in_buffer)) {
@@ -73,7 +73,7 @@ ErrorOr<void> JPEGLoadingContext::decode()
         context->src->bytes_in_buffer -= num_bytes;
     };
     source_manager.resync_to_restart = jpeg_resync_to_restart;
-    source_manager.term_source = [](j_decompress_ptr) {};
+    source_manager.term_source = [](j_decompress_ptr) { };
 
     cinfo.src = &source_manager;
 

--- a/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
+++ b/Libraries/LibGfx/ImageFormats/JPEGWriter.cpp
@@ -48,8 +48,8 @@ struct MemoryDestinationManager : public jpeg_destination_mgr {
 
 ErrorOr<void> JPEGWriter::encode_impl(Stream& stream, auto const& bitmap, Options const& options, ColorSpace color_space)
 {
-    struct jpeg_compress_struct cinfo { };
-    struct jpeg_error_mgr jerr { };
+    struct jpeg_compress_struct cinfo {};
+    struct jpeg_error_mgr jerr {};
 
     cinfo.err = jpeg_std_error(&jerr);
 

--- a/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
+++ b/Libraries/LibGfx/ImageFormats/WebPSharedLossless.h
@@ -41,7 +41,7 @@ private:
 ALWAYS_INLINE ErrorOr<void> CanonicalCode::write_symbol(LittleEndianOutputBitStream& bit_stream, u32 symbol) const
 {
     TRY(m_code.visit(
-        [&](u32 single_code) __attribute__((always_inline))->ErrorOr<void> { VERIFY(symbol == single_code); return {}; },
+        [&](u32 single_code) __attribute__((always_inline)) -> ErrorOr<void> { VERIFY(symbol == single_code); return {}; },
         [&](Compress::CanonicalCode const& code) __attribute__((always_inline)) { return code.write_symbol(bit_stream, symbol); }));
     return {};
 }

--- a/Libraries/LibGfx/MetalContext.h
+++ b/Libraries/LibGfx/MetalContext.h
@@ -23,7 +23,7 @@ public:
     virtual size_t width() const = 0;
     virtual size_t height() const = 0;
 
-    virtual ~MetalTexture() {};
+    virtual ~MetalTexture() { }
 };
 
 class MetalContext : public RefCounted<MetalContext> {
@@ -33,7 +33,7 @@ public:
 
     virtual OwnPtr<MetalTexture> create_texture_from_iosurface(Core::IOSurfaceHandle const&) = 0;
 
-    virtual ~MetalContext() {};
+    virtual ~MetalContext() { }
 };
 
 RefPtr<MetalContext> get_metal_context();

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -37,10 +37,10 @@ public:
     static RefPtr<Gfx::SkiaBackendContext> create_metal_context(MetalContext&);
 #endif
 
-    SkiaBackendContext() {};
-    virtual ~SkiaBackendContext() {};
+    SkiaBackendContext() { }
+    virtual ~SkiaBackendContext() { }
 
-    virtual void flush_and_submit(SkSurface*) {};
+    virtual void flush_and_submit(SkSurface*) { }
     virtual GrDirectContext* sk_context() const = 0;
 
     virtual MetalContext& metal_context() = 0;

--- a/Libraries/LibJS/AST.h
+++ b/Libraries/LibJS/AST.h
@@ -719,7 +719,7 @@ public:
     virtual bool has_name() const = 0;
     virtual Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString given_name) const = 0;
 
-    virtual ~FunctionNode() {};
+    virtual ~FunctionNode() { }
 
 protected:
     FunctionNode(RefPtr<Identifier const> name, ByteString source_text, NonnullRefPtr<Statement const> body, Vector<FunctionParameter> parameters, i32 function_length, FunctionKind kind, bool is_strict_mode, FunctionParsingInsights parsing_insights, bool is_arrow_function, Vector<DeprecatedFlyString> local_variables_names)
@@ -779,7 +779,7 @@ public:
     bool has_name() const override { return true; }
     Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString) const override { VERIFY_NOT_REACHED(); }
 
-    virtual ~FunctionDeclaration() {};
+    virtual ~FunctionDeclaration() { }
 
 private:
     bool m_is_hoisted { false };
@@ -806,7 +806,7 @@ public:
 
     Value instantiate_ordinary_function_expression(VM&, DeprecatedFlyString given_name) const override;
 
-    virtual ~FunctionExpression() {};
+    virtual ~FunctionExpression() { }
 
 private:
     virtual bool is_function_expression() const override { return true; }

--- a/Libraries/LibJS/Runtime/ErrorConstructor.cpp
+++ b/Libraries/LibJS/Runtime/ErrorConstructor.cpp
@@ -101,7 +101,7 @@ ThrowCompletionOr<GC::Ref<Object>> ErrorConstructor::construct(FunctionObject& n
         auto message = vm.argument(0);                                                                                      \
         auto options = vm.argument(1);                                                                                      \
                                                                                                                             \
-        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */       \
+        /* 2. Let O be ? OrdinaryCreateFromConstructor(newTarget, "%NativeError.prototype%", « [[ErrorData]] »). */         \
         auto error = TRY(ordinary_create_from_constructor<ClassName>(vm, new_target, &Intrinsics::snake_name##_prototype)); \
                                                                                                                             \
         /* 3. If message is not undefined, then */                                                                          \

--- a/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -48,7 +48,9 @@ public:
 
 protected:
     explicit IndexedPropertyStorage(IsSimpleStorage is_simple_storage)
-        : m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes) {};
+        : m_is_simple_storage(is_simple_storage == IsSimpleStorage::Yes)
+    {
+    }
 
 private:
     bool m_is_simple_storage { false };
@@ -57,7 +59,9 @@ private:
 class SimpleIndexedPropertyStorage final : public IndexedPropertyStorage {
 public:
     SimpleIndexedPropertyStorage()
-        : IndexedPropertyStorage(IsSimpleStorage::Yes) {};
+        : IndexedPropertyStorage(IsSimpleStorage::Yes)
+    {
+    }
     explicit SimpleIndexedPropertyStorage(Vector<Value>&& initial_values);
 
     virtual bool has_index(u32 index) const override;
@@ -99,7 +103,9 @@ class GenericIndexedPropertyStorage final : public IndexedPropertyStorage {
 public:
     explicit GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&&);
     explicit GenericIndexedPropertyStorage()
-        : IndexedPropertyStorage(IsSimpleStorage::No) {};
+        : IndexedPropertyStorage(IsSimpleStorage::No)
+    {
+    }
 
     virtual bool has_index(u32 index) const override;
     virtual Optional<ValueAndAttributes> get(u32 index) const override;

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -221,7 +221,7 @@ struct DurationRecord {
 };
 
 struct DurationInstanceComponent {
-    double DurationRecord::*value_slot;
+    double DurationRecord::* value_slot;
     DurationFormat::ValueStyle (DurationFormat::*get_style_slot)() const;
     void (DurationFormat::*set_style_slot)(DurationFormat::ValueStyle);
     DurationFormat::Display (DurationFormat::*get_display_slot)() const;

--- a/Libraries/LibJS/Runtime/PromiseCapability.h
+++ b/Libraries/LibJS/Runtime/PromiseCapability.h
@@ -44,7 +44,7 @@ private:
         auto&& _temporary_try_or_reject_result = (expression);                                                                           \
         /* 1. If value is an abrupt completion, then */                                                                                  \
         if (_temporary_try_or_reject_result.is_error()) {                                                                                \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                            \
+            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                              \
             CALL_CHECK(JS::call(vm, *(capability)->reject(), js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
                                                                                                                                          \
             /* b. Return capability.[[Promise]]. */                                                                                      \
@@ -70,7 +70,7 @@ private:
         auto&& _temporary_try_or_reject_result = (expression);                                                                    \
         /* 1. If value is an abrupt completion, then */                                                                           \
         if (_temporary_try_or_reject_result.is_error()) {                                                                         \
-            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                     \
+            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                       \
             TRY(JS::call(vm, *(capability)->reject(), js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
                                                                                                                                   \
             /* b. Return capability.[[Promise]]. */                                                                               \

--- a/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -71,7 +71,7 @@ void DurationPrototype::initialize(Realm& realm)
         /* 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]). */ \
         auto duration = TRY(typed_this_object(vm));                                        \
                                                                                            \
-        /* 3. Return 𝔽(duration.[[<unit>]]). */                                         \
+        /* 3. Return 𝔽(duration.[[<unit>]]). */                                            \
         return duration->unit();                                                           \
     }
 JS_ENUMERATE_DURATION_UNITS

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -145,15 +145,15 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::era_year_getter)
     __JS_ENUMERATE(months_in_year)                      \
     __JS_ENUMERATE(in_leap_year)
 
-#define __JS_ENUMERATE(field)                                                                                             \
-    JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::field##_getter)                                                     \
-    {                                                                                                                     \
-        /* 1. Let dateTime be the this value. */                                                                          \
-        /* 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]). */                                \
-        auto date_time = TRY(typed_this_object(vm));                                                                      \
-                                                                                                                          \
+#define __JS_ENUMERATE(field)                                                                                          \
+    JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::field##_getter)                                                  \
+    {                                                                                                                  \
+        /* 1. Let dateTime be the this value. */                                                                       \
+        /* 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]). */                             \
+        auto date_time = TRY(typed_this_object(vm));                                                                   \
+                                                                                                                       \
         /* 3. Return 𝔽(CalendarISOToDate(dateTime.[[Calendar]], dateTime.[[ISODateTime]].[[ISODate]]).[[<field>]]). */ \
-        return calendar_iso_to_date(date_time->calendar(), date_time->iso_date_time().iso_date).field;                    \
+        return calendar_iso_to_date(date_time->calendar(), date_time->iso_date_time().iso_date).field;                 \
     }
 JS_ENUMERATE_PLAIN_DATE_TIME_SIMPLE_DATE_FIELDS
 #undef __JS_ENUMERATE
@@ -191,7 +191,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::month_code_getter)
         /* 2. Perform ? RequireInternalSlot(dateTime, [[InitializedTemporalDateTime]]). */ \
         auto date_time = TRY(typed_this_object(vm));                                       \
                                                                                            \
-        /* 3. Return 𝔽(dateTime.[[ISODateTime]].[[Time]].[[<field>]]). */               \
+        /* 3. Return 𝔽(dateTime.[[ISODateTime]].[[Time]].[[<field>]]). */                  \
         return date_time->iso_date_time().time.field;                                      \
     }
 JS_ENUMERATE_PLAIN_DATE_TIME_TIME_FIELDS

--- a/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainTimePrototype.cpp
@@ -72,7 +72,7 @@ void PlainTimePrototype::initialize(Realm& realm)
         /* 2. Perform ? RequireInternalSlot(temporalTime, [[InitializedTemporalTime]]). */ \
         auto temporal_time = TRY(typed_this_object(vm));                                   \
                                                                                            \
-        /* 3. Return 𝔽(temporalTime.[[Time]].[[<field>]]). */                           \
+        /* 3. Return 𝔽(temporalTime.[[Time]].[[<field>]]). */                              \
         return temporal_time->time().field;                                                \
     }
 JS_ENUMERATE_PLAIN_TIME_FIELDS

--- a/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ZonedDateTimePrototype.cpp
@@ -186,7 +186,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::era_year_getter)
         /* Let isoDateTime be GetISODateTimeFor(zonedDateTime.[[TimeZone]], zonedDateTime.[[EpochNanoseconds]]). */                    \
         auto iso_date_time = get_iso_date_time_for(zoned_date_time->time_zone(), zoned_date_time->epoch_nanoseconds()->big_integer()); \
                                                                                                                                        \
-        /* 3. Return 𝔽(CalendarISOToDate(zonedDateTime.[[Calendar]], isoDateTime.[[ISODate]]).[[<field>]]). */                      \
+        /* 3. Return 𝔽(CalendarISOToDate(zonedDateTime.[[Calendar]], isoDateTime.[[ISODate]]).[[<field>]]). */                         \
         return calendar_iso_to_date(zoned_date_time->calendar(), iso_date_time.iso_date).field;                                        \
     }
 JS_ENUMERATE_ZONED_DATE_TIME_SIMPLE_DATE_FIELDS
@@ -231,7 +231,7 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimePrototype::month_code_getter)
         /* Let isoDateTime be GetISODateTimeFor(zonedDateTime.[[TimeZone]], zonedDateTime.[[EpochNanoseconds]]). */                    \
         auto iso_date_time = get_iso_date_time_for(zoned_date_time->time_zone(), zoned_date_time->epoch_nanoseconds()->big_integer()); \
                                                                                                                                        \
-        /* 3. Return 𝔽(isoDateTime.[[Time]].[[<field>]]). */                                                                        \
+        /* 3. Return 𝔽(isoDateTime.[[Time]].[[<field>]]). */                                                                           \
         return iso_date_time.time.field;                                                                                               \
     }
 JS_ENUMERATE_PLAIN_DATE_TIME_TIME_FIELDS

--- a/Libraries/LibJS/Runtime/Value.cpp
+++ b/Libraries/LibJS/Runtime/Value.cpp
@@ -2380,8 +2380,8 @@ ThrowCompletionOr<TriState> is_less_than(VM& vm, Value lhs, Value rhs, bool left
         // b. Let ly be the length of py.
         // c. For each integer i such that 0 ≤ i < min(lx, ly), in ascending order, do
         for (auto k = x_code_points.begin(), l = y_code_points.begin();
-             k != x_code_points.end() && l != y_code_points.end();
-             ++k, ++l) {
+            k != x_code_points.end() && l != y_code_points.end();
+            ++k, ++l) {
             // i. Let cx be the integer that is the numeric value of the code unit at index i within px.
             // ii. Let cy be the integer that is the numeric value of the code unit at index i within py.
             if (*k != *l) {

--- a/Libraries/LibJS/SourceTextModule.cpp
+++ b/Libraries/LibJS/SourceTextModule.cpp
@@ -176,7 +176,7 @@ Result<GC::Ref<SourceTextModule>, Vector<ParserError>> SourceTextModule::parse(S
                                      [&](ImportEntry const& import_entry) {
                                          return import_entry.local_name == entry.local_or_import_name;
                                      })
-                       .is_end());
+                    .is_end());
             default_export = export_statement;
         }
 

--- a/Libraries/LibLine/Editor.h
+++ b/Libraries/LibLine/Editor.h
@@ -468,10 +468,8 @@ private:
 
     KeyCallbackMachine m_callback_machine;
 
-    struct termios m_termios {
-    };
-    struct termios m_default_termios {
-    };
+    struct termios m_termios {};
+    struct termios m_default_termios {};
     bool m_was_interrupted { false };
     bool m_previous_interrupt_was_handled_as_interrupt { true };
     bool m_was_resized { false };

--- a/Libraries/LibLine/KeyCallbackMachine.h
+++ b/Libraries/LibLine/KeyCallbackMachine.h
@@ -25,7 +25,9 @@ struct Key {
 
     Key(unsigned c)
         : modifiers(None)
-        , key(c) {};
+        , key(c)
+    {
+    }
 
     Key(unsigned c, int modifiers)
         : modifiers(modifiers)

--- a/Libraries/LibMedia/VideoDecoder.h
+++ b/Libraries/LibMedia/VideoDecoder.h
@@ -16,7 +16,7 @@ namespace Media {
 
 class VideoDecoder {
 public:
-    virtual ~VideoDecoder() {};
+    virtual ~VideoDecoder() { }
 
     virtual DecoderErrorOr<void> receive_sample(AK::Duration timestamp, ReadonlyBytes sample) = 0;
     DecoderErrorOr<void> receive_sample(AK::Duration timestamp, ByteBuffer const& sample) { return receive_sample(timestamp, sample.span()); }

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -194,8 +194,8 @@ struct Options {
     OPTION_WITH_DEFAULTS(bool, validate_certificates, true)
     OPTION_WITH_DEFAULTS(bool, allow_self_signed_certificates, false)
     OPTION_WITH_DEFAULTS(Optional<Vector<Certificate>>, root_certificates, )
-    OPTION_WITH_DEFAULTS(Function<void(AlertDescription)>, alert_handler, [](auto) {})
-    OPTION_WITH_DEFAULTS(Function<void()>, finish_callback, [] {})
+    OPTION_WITH_DEFAULTS(Function<void(AlertDescription)>, alert_handler, [](auto) { })
+    OPTION_WITH_DEFAULTS(Function<void()>, finish_callback, [] { })
     OPTION_WITH_DEFAULTS(Function<Vector<Certificate>()>, certificate_provider, [] { return Vector<Certificate> {}; })
     OPTION_WITH_DEFAULTS(bool, enable_extended_master_secret, true)
 

--- a/Libraries/LibWeb/CSS/ColumnCount.h
+++ b/Libraries/LibWeb/CSS/ColumnCount.h
@@ -34,7 +34,7 @@ private:
         , m_value(value)
     {
     }
-    ColumnCount() {};
+    ColumnCount() { }
 
     Type m_type { Type::Auto };
     Optional<int> m_value;

--- a/Libraries/LibWeb/CSS/Filter.h
+++ b/Libraries/LibWeb/CSS/Filter.h
@@ -16,7 +16,9 @@ class Filter {
 public:
     Filter() = default;
     Filter(FilterValueListStyleValue const& filter_value_list)
-        : m_filter_value_list { filter_value_list } {};
+        : m_filter_value_list { filter_value_list }
+    {
+    }
 
     static Filter make_none()
     {

--- a/Libraries/LibWeb/CSS/GridTrackPlacement.h
+++ b/Libraries/LibWeb/CSS/GridTrackPlacement.h
@@ -71,11 +71,17 @@ private:
     };
 
     GridTrackPlacement()
-        : m_value(Auto {}) {};
+        : m_value(Auto {})
+    {
+    }
     GridTrackPlacement(AreaOrLine value)
-        : m_value(value) {};
+        : m_value(value)
+    {
+    }
     GridTrackPlacement(Span value)
-        : m_value(value) {};
+        : m_value(value)
+    {
+    }
 
     Variant<Auto, AreaOrLine, Span> m_value;
 };

--- a/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -263,10 +263,10 @@ bool is_unknown_html_element(FlyString const& tag_name)
     if (tag_name.is_one_of(HTML::TagNames::applet, HTML::TagNames::bgsound, HTML::TagNames::blink, HTML::TagNames::isindex, HTML::TagNames::keygen, HTML::TagNames::multicol, HTML::TagNames::nextid, HTML::TagNames::spacer))
         return true;
 
-        // 2. If name is acronym, basefont, big, center, nobr, noembed, noframes, plaintext, rb, rtc, strike, or tt, then return HTMLElement.
-        // 3. If name is listing or xmp, then return HTMLPreElement.
-        // 4. Otherwise, if this specification defines an interface appropriate for the element type corresponding to the local name name, then return that interface.
-        // 5. If other applicable specifications define an appropriate interface for name, then return the interface they define.
+    // 2. If name is acronym, basefont, big, center, nobr, noembed, noframes, plaintext, rb, rtc, strike, or tt, then return HTMLElement.
+    // 3. If name is listing or xmp, then return HTMLPreElement.
+    // 4. Otherwise, if this specification defines an interface appropriate for the element type corresponding to the local name name, then return that interface.
+    // 5. If other applicable specifications define an appropriate interface for name, then return the interface they define.
 #define __ENUMERATE_HTML_TAG(name)        \
     if (tag_name == HTML::TagNames::name) \
         return false;

--- a/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
+++ b/Libraries/LibWeb/DOMURL/URLSearchParams.cpp
@@ -286,7 +286,7 @@ bool URLSearchParams::has(String const& name, Optional<String> const& value)
         if (!m_list.find_if([&name, &value](auto& entry) {
                        return entry.name == name && entry.value == value.value();
                    })
-                 .is_end()) {
+                .is_end()) {
             return true;
         }
     }
@@ -295,7 +295,7 @@ bool URLSearchParams::has(String const& name, Optional<String> const& value)
         if (!m_list.find_if([&name](auto& entry) {
                        return entry.name == name;
                    })
-                 .is_end()) {
+                .is_end()) {
             return true;
         }
     }

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -600,8 +600,8 @@ bool command_insert_paragraph_action(DOM::Document& document, String const&)
     // 12. If container's local name is "address", "listing", or "pre":
     if (is<DOM::Element>(*container)
         && static_cast<DOM::Element&>(*container)
-               .local_name()
-               .is_one_of(HTML::TagNames::address, HTML::TagNames::listing, HTML::TagNames::pre)) {
+            .local_name()
+            .is_one_of(HTML::TagNames::address, HTML::TagNames::listing, HTML::TagNames::pre)) {
         // 1. Let br be the result of calling createElement("br") on the context object.
         auto br = MUST(DOM::create_element(document, HTML::TagNames::br, Namespace::HTML));
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -1042,7 +1042,7 @@ WebIDL::ExceptionOr<void> HTMLMediaElement::fetch_resource(URL::URL const& url_r
             // 5. Otherwise, incrementally read response's body given updateMedia, processEndOfMedia, an empty algorithm, and global.
 
             VERIFY(response->body());
-            auto empty_algorithm = GC::create_function(heap(), [](JS::Value) {});
+            auto empty_algorithm = GC::create_function(heap(), [](JS::Value) { });
 
             // FIXME: We are "fully" reading the response here, rather than "incrementally". Memory concerns aside, this should be okay for now as we are
             //        always setting byteRange to "entire resource". However, we should switch to incremental reads when that is implemented, and then

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -211,7 +211,7 @@ WebIDL::ExceptionOr<void> HTMLVideoElement::determine_element_poster_frame(Optio
         });
 
         VERIFY(response->body());
-        auto empty_algorithm = GC::create_function(heap(), [](JS::Value) {});
+        auto empty_algorithm = GC::create_function(heap(), [](JS::Value) { });
 
         response->body()->fully_read(realm, on_image_data_read, empty_algorithm, GC::Ref { global });
     };

--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -174,14 +174,11 @@ namespace Web::HTML {
 #define SWITCH_TO_AND_EMIT_CURRENT_CHARACTER(new_state) \
     SWITCH_TO_AND_EMIT_CHARACTER(current_input_character.value(), new_state)
 
-// clang-format-18 handles the `state:` label rather badly.
-// clang-format off
 #define BEGIN_STATE(state) \
     state:                 \
     case State::state: {   \
         {                  \
             {
-// clang-format on
 
 #define END_STATE         \
     VERIFY_NOT_REACHED(); \

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -688,8 +688,8 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
             //    that is synchronous navigation steps with a target navigable not contained in navigablesThatMustWaitBeforeHandlingSyncNavigation.
             //   2. Remove steps from traversable's session history traversal queue's algorithm set.
             for (auto entry = m_session_history_traversal_queue->first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation);
-                 entry;
-                 entry = m_session_history_traversal_queue->first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation)) {
+                entry;
+                entry = m_session_history_traversal_queue->first_synchronous_navigation_steps_with_target_navigable_not_contained_in(navigables_that_must_wait_before_handling_sync_navigation)) {
 
                 // 3. Set traversable's running nested apply history step to true.
                 m_running_nested_apply_history_step = true;

--- a/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -226,9 +226,9 @@ void SVGFormattingContext::run(AvailableSpace const& available_space)
 
         CSSPixelPoint offset = viewbox_offset_and_scale.offset;
         m_current_viewbox_transform = Gfx::AffineTransform { m_current_viewbox_transform }.multiply(Gfx::AffineTransform {}
-                                                                                                        .translate(offset.to_type<float>())
-                                                                                                        .scale(viewbox_offset_and_scale.scale_factor_x, viewbox_offset_and_scale.scale_factor_y)
-                                                                                                        .translate({ -viewbox->min_x, -viewbox->min_y }));
+                .translate(offset.to_type<float>())
+                .scale(viewbox_offset_and_scale.scale_factor_x, viewbox_offset_and_scale.scale_factor_y)
+                .translate({ -viewbox->min_x, -viewbox->min_y }));
     }
 
     if (svg_box_state.has_definite_width() && svg_box_state.has_definite_height()) {

--- a/Libraries/LibWeb/Painting/BackingStore.h
+++ b/Libraries/LibWeb/Painting/BackingStore.h
@@ -23,8 +23,8 @@ public:
     virtual Gfx::IntSize size() const = 0;
     virtual Gfx::Bitmap& bitmap() const = 0;
 
-    BackingStore() {};
-    virtual ~BackingStore() {};
+    BackingStore() { }
+    virtual ~BackingStore() { }
 };
 
 class BitmapBackingStore final : public BackingStore {

--- a/Libraries/LibWeb/Painting/PaintStyle.h
+++ b/Libraries/LibWeb/Painting/PaintStyle.h
@@ -47,7 +47,7 @@ public:
     ReadonlySpan<ColorStop> color_stops() const { return m_color_stops; }
     Optional<float> repeat_length() const { return m_repeat_length; }
 
-    virtual ~SVGGradientPaintStyle() {};
+    virtual ~SVGGradientPaintStyle() { }
 
 protected:
     Vector<ColorStop, 4> m_color_stops;

--- a/Libraries/LibWeb/SVG/SVGAnimatedTransformList.cpp
+++ b/Libraries/LibWeb/SVG/SVGAnimatedTransformList.cpp
@@ -20,7 +20,9 @@ GC::Ref<SVGAnimatedTransformList> SVGAnimatedTransformList::create(JS::Realm& re
 SVGAnimatedTransformList::SVGAnimatedTransformList(JS::Realm& realm, GC::Ref<SVGTransformList> base_val, GC::Ref<SVGTransformList> anim_val)
     : PlatformObject(realm)
     , m_base_val(base_val)
-    , m_anim_val(anim_val) {};
+    , m_anim_val(anim_val)
+{
+}
 
 SVGAnimatedTransformList::~SVGAnimatedTransformList() = default;
 

--- a/Libraries/LibWeb/SVG/SVGTransform.cpp
+++ b/Libraries/LibWeb/SVG/SVGTransform.cpp
@@ -19,7 +19,9 @@ GC::Ref<SVGTransform> SVGTransform::create(JS::Realm& realm)
 }
 
 SVGTransform::SVGTransform(JS::Realm& realm)
-    : PlatformObject(realm) {};
+    : PlatformObject(realm)
+{
+}
 
 SVGTransform::~SVGTransform() = default;
 

--- a/Libraries/LibWeb/XHR/XMLHttpRequestEventTarget.h
+++ b/Libraries/LibWeb/XHR/XMLHttpRequestEventTarget.h
@@ -24,7 +24,7 @@ class XMLHttpRequestEventTarget : public DOM::EventTarget {
     WEB_PLATFORM_OBJECT(XMLHttpRequestEventTarget, DOM::EventTarget);
 
 public:
-    virtual ~XMLHttpRequestEventTarget() override {};
+    virtual ~XMLHttpRequestEventTarget() override { }
 
 #undef __ENUMERATE
 #define __ENUMERATE(attribute_name, event_name)       \

--- a/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.mm
+++ b/Libraries/LibWebView/EventLoop/EventLoopImplementationMacOS.mm
@@ -92,7 +92,7 @@ public:
 
 SignalHandlers::SignalHandlers(int signal_number, CFFileDescriptorCallBack handle_signal)
     : m_signal_number(signal_number)
-    , m_original_handler(signal(signal_number, [](int) {}))
+    , m_original_handler(signal(signal_number, [](int) { }))
 {
     m_kevent_fd = kqueue();
     if (m_kevent_fd < 0) {
@@ -320,7 +320,7 @@ static void handle_signal(CFFileDescriptorRef f, CFOptionFlags callback_types, v
     VERIFY(callback_types & kCFFileDescriptorReadCallBack);
     auto* signal_handlers = static_cast<SignalHandlers*>(info);
 
-    struct kevent event { };
+    struct kevent event {};
 
     // returns number of events that have occurred since last call
     (void)::kevent(CFFileDescriptorGetNativeDescriptor(f), nullptr, 0, &event, 1, nullptr);

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -47,7 +47,7 @@ StringView process_name_from_type(ProcessType type)
 }
 
 ProcessManager::ProcessManager()
-    : on_process_exited([](Process&&) {})
+    : on_process_exited([](Process&&) { })
 {
     m_signal_handle = Core::EventLoop::register_signal(SIGCHLD, [this](int) {
         auto result = Core::System::waitpid(-1, WNOHANG);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -488,8 +488,8 @@ void ViewImplementation::did_allocate_iosurface_backing_stores(i32 front_id, Cor
 
     auto bytes_per_row = front_iosurface.bytes_per_row();
 
-    auto front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, front_size, bytes_per_row, front_iosurface.data(), [handle = move(front_iosurface)] {});
-    auto back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, back_size, bytes_per_row, back_iosurface.data(), [handle = move(back_iosurface)] {});
+    auto front_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, front_size, bytes_per_row, front_iosurface.data(), [handle = move(front_iosurface)] { });
+    auto back_bitmap = Gfx::Bitmap::create_wrapper(Gfx::BitmapFormat::BGRA8888, Gfx::AlphaType::Premultiplied, back_size, bytes_per_row, back_iosurface.data(), [handle = move(back_iosurface)] { });
 
     m_client_state.front_bitmap.bitmap = front_bitmap.release_value_but_fixme_should_propagate_errors();
     m_client_state.front_bitmap.id = front_id;

--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -14,7 +14,7 @@ die() {
 
 pick_clang() {
     local BEST_VERSION=0
-    for CLANG_CANDIDATE in clang clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang ; do
+    for CLANG_CANDIDATE in clang clang-17 clang-18 clang-19 /opt/homebrew/opt/llvm/bin/clang ; do
         if ! command -v $CLANG_CANDIDATE >/dev/null 2>&1; then
             continue
         fi

--- a/Meta/find_compiler.sh
+++ b/Meta/find_compiler.sh
@@ -56,7 +56,7 @@ pick_host_compiler() {
         return
     fi
 
-    find_newest_compiler clang clang-17 clang-18 /opt/homebrew/opt/llvm/bin/clang
+    find_newest_compiler clang clang-17 clang-18 clang-19 /opt/homebrew/opt/llvm/bin/clang
     if is_supported_compiler "$HOST_COMPILER"; then
         export CC="${HOST_COMPILER}"
         export CXX="${HOST_COMPILER/clang/clang++}"

--- a/Meta/lint-clang-format.sh
+++ b/Meta/lint-clang-format.sh
@@ -28,21 +28,21 @@ fi
 if (( ${#files[@]} )); then
     TOOLCHAIN_DIR=Toolchain/Local/clang/bin
     CLANG_FORMAT=false
-    if command -v clang-format-18 >/dev/null 2>&1 ; then
-        CLANG_FORMAT=clang-format-18
-    elif command -v brew >/dev/null 2>&1 && command -v "$(brew --prefix llvm@18)"/bin/clang-format >/dev/null 2>&1 ; then
-        CLANG_FORMAT="$(brew --prefix llvm@18)"/bin/clang-format
-    elif command -v $TOOLCHAIN_DIR/clang-format >/dev/null 2>&1 && $TOOLCHAIN_DIR/clang-format --version | grep -qF ' 18.' ; then
+    if command -v clang-format-19 >/dev/null 2>&1 ; then
+        CLANG_FORMAT=clang-format-19
+    elif command -v brew >/dev/null 2>&1 && command -v "$(brew --prefix llvm@19)"/bin/clang-format >/dev/null 2>&1 ; then
+        CLANG_FORMAT="$(brew --prefix llvm@19)"/bin/clang-format
+    elif command -v $TOOLCHAIN_DIR/clang-format >/dev/null 2>&1 && $TOOLCHAIN_DIR/clang-format --version | grep -qF ' 19.' ; then
         CLANG_FORMAT=$TOOLCHAIN_DIR/clang-format
     elif command -v clang-format >/dev/null 2>&1 ; then
         CLANG_FORMAT=clang-format
-        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) != 18) exit 1; }'; then
-            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 18."
+        if ! "${CLANG_FORMAT}" --version | awk '{ if (substr($NF, 1, index($NF, ".") - 1) != 19) exit 1; }'; then
+            echo "You are using '$("${CLANG_FORMAT}" --version)', which appears to not be clang-format 19."
             echo "It is very likely that the resulting changes are not what you wanted."
         fi
     else
-        echo "clang-format-18 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-18."
-        echo "(If you install a package 'clang-format', please make sure it's version 18.)"
+        echo "clang-format-19 is not available, but C or C++ files need linting! Either skip this script, or install clang-format-19."
+        echo "(If you install a package 'clang-format', please make sure it's version 19.)"
         exit 1
     fi
 

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -31,8 +31,8 @@ public:
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override;
     virtual Web::CSS::PreferredContrast preferred_contrast() const override;
     virtual Web::CSS::PreferredMotion preferred_motion() const override;
-    virtual void paint_next_frame() override {};
-    virtual void process_screenshot_requests() override {};
+    virtual void paint_next_frame() override { }
+    virtual void process_screenshot_requests() override { }
     virtual void paint(Web::DevicePixelRect const&, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
     virtual void request_file(Web::FileRequest) override;
     virtual bool is_ready_to_paint() const override { return true; }

--- a/Tests/LibGC/TestHeap.cpp
+++ b/Tests/LibGC/TestHeap.cpp
@@ -10,6 +10,6 @@
 GC::Heap& test_gc_heap()
 {
     // FIXME: The GC heap should become thread aware!
-    thread_local GC::Heap heap(nullptr, [](auto&) {});
+    thread_local GC::Heap heap(nullptr, [](auto&) { });
     return heap;
 }


### PR DESCRIPTION
clang 19 has been out for some time, and it's becoming increasingly difficult to keep clang-format-18 on updated distros.