### PR TITLE
LibWeb: Normalize getter name for reflected “Element?” IDL types

### DIFF
--- a/Libraries/LibWeb/HTML/PopoverInvokerElement.h
+++ b/Libraries/LibWeb/HTML/PopoverInvokerElement.h
@@ -17,7 +17,7 @@ class PopoverInvokerElement {
 public:
     PopoverInvokerElement() { }
 
-    GC::Ptr<DOM::Element> get_popover_target_element() { return m_popover_target_element; }
+    GC::Ptr<DOM::Element> popover_target_element() { return m_popover_target_element; }
 
     void set_popover_target_element(GC::Ptr<DOM::Element> value) { m_popover_target_element = value; }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -3821,7 +3821,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@attribute.getter_callback@)
                 //      1. If reflectedTarget's explicitly set attr-element is a descendant of any of element's shadow-including ancestors, then return reflectedTarget's explicitly set attr-element.
                 //      2. Return null.
                 attribute_generator.append(R"~~~(
-    auto const explicitly_set_attr = TRY(throw_dom_exception_if_needed(vm, [&] { return impl->get_@attribute.cpp_name@(); }));
+    auto const explicitly_set_attr = TRY(throw_dom_exception_if_needed(vm, [&] { return impl->@attribute.cpp_name@(); }));
     if (explicitly_set_attr) {
         if (&impl->shadow_including_root() == &explicitly_set_attr->shadow_including_root()) {
             retval = explicitly_set_attr;


### PR DESCRIPTION
This change updates the bindings generator for the case defined at https://html.spec.whatwg.org/#reflecting-content-attributes-in-idl-attributes:element; that is, the case _“If a reflected IDL attribute has the type T?, where T is either Element or an interface that inherits from Element”_.

The change “normalizes” the generator behavior for that case — such that the generated code expects a getter with a name of the form used in other cases; e.g., `popover_target_element()`.

Otherwise, without this change, the generator expects a name of the form `get_popover_target_element()` for that case.