### PR TITLE
LibWeb: Remove special handling for the ARIA "switch" role

### DIFF
--- a/Libraries/LibWeb/ARIA/Roles.cpp
+++ b/Libraries/LibWeb/ARIA/Roles.cpp
@@ -11,12 +11,9 @@ namespace Web::ARIA {
 
 StringView role_name(Role role)
 {
-    // Note: Role::switch_ is mapped to "switch" (due to C++ keyword clash)
     switch (role) {
-#define __ENUMERATE_ARIA_ROLE(name, attribute)     \
-    case Role::name:                               \
-        if constexpr (Role::name == Role::switch_) \
-            return "switch"sv;                     \
+#define __ENUMERATE_ARIA_ROLE(name, attribute) \
+    case Role::name:                           \
         return attribute##sv;
         ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE
@@ -27,15 +24,9 @@ StringView role_name(Role role)
 
 Optional<Role> role_from_string(StringView role_name)
 {
-    // Note: "switch" is mapped to Role::switch_ (due to C++ keyword clash)
-#define __ENUMERATE_ARIA_ROLE(name, attribute)                   \
-    if constexpr (Role::name == Role::switch_) {                 \
-        if (role_name.equals_ignoring_ascii_case("switch"sv))    \
-            return Role::switch_;                                \
-    } else {                                                     \
-        if (role_name.equals_ignoring_ascii_case(attribute##sv)) \
-            return Role::name;                                   \
-    }
+#define __ENUMERATE_ARIA_ROLE(name, attribute)               \
+    if (role_name.equals_ignoring_ascii_case(attribute##sv)) \
+        return Role::name;
     ENUMERATE_ARIA_ROLES
 #undef __ENUMERATE_ARIA_ROLE
     return {};

--- a/Libraries/LibWeb/ARIA/Roles.h
+++ b/Libraries/LibWeb/ARIA/Roles.h
@@ -98,7 +98,7 @@ namespace Web::ARIA {
     __ENUMERATE_ARIA_ROLE(subscript, "subscript")                \
     __ENUMERATE_ARIA_ROLE(suggestion, "suggestion")              \
     __ENUMERATE_ARIA_ROLE(superscript, "superscript")            \
-    __ENUMERATE_ARIA_ROLE(switch_, "switch_")                    \
+    __ENUMERATE_ARIA_ROLE(switch_, "switch")                     \
     __ENUMERATE_ARIA_ROLE(tab, "tab")                            \
     __ENUMERATE_ARIA_ROLE(table, "table")                        \
     __ENUMERATE_ARIA_ROLE(tablist, "tablist")                    \


### PR DESCRIPTION
If we use the correct string for "switch", the special handling is not necessary after 8961d5d2ce32876c42449256964e742df582a889.