### PR TITLE
Headless ignore wpt support files

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -41,15 +41,8 @@ Text/input/wpt-import/html/syntax/parsing/html5lib_tests5.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_webkit01.html
 Text/input/wpt-import/html/syntax/parsing/named-character-references.html
 
-; Support files (not tests themselves)
-Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-frame.html
-Text/input/wpt-import/html/webappapis/dynamic-markup-insertion/opening-the-input-stream/resources/aborted-parser-async-frame.html
-
 ; Unknown, imported as skipped in #2148
 Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/structuredclone_0.html
-Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/resources/echo-iframe.html
-Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/resources/iframe-resizable-arraybuffer-helper.html
-Text/input/wpt-import/html/infrastructure/safe-passing-of-structured-data/resources/post-parent-type-error.html
 
 ; Flaky, apparently due to font loading
 Text/input/wpt-import/css/css-flexbox/flex-item-compressible-001.html

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -428,7 +428,12 @@ ErrorOr<void> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePixelSize
 #endif
 
     tests.remove_all_matching([&](auto const& test) {
-        bool is_support_file = test.input_path.matches("*/wpt-import/*/support/*"sv);
+        static constexpr Array support_file_patterns {
+            "*/wpt-import/*/support/*"sv,
+            "*/wpt-import/*/resources/*"sv,
+            "*/wpt-import/common/*"sv,
+        };
+        bool is_support_file = any_of(support_file_patterns, [&](auto pattern) { return test.input_path.matches(pattern); });
         bool match_glob = test.input_path.matches(test_glob, CaseSensitivity::CaseSensitive);
         return is_support_file || !match_glob;
     });


### PR DESCRIPTION
With this change, we now ignore files imported from WPT if they are in the root `common` directory, or any directory named `resources`. This matches the behavior of the WPT test harness.