### PR TITLE
LibWeb/HTML: Skip layout for a an empty label that controls nothing

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLabelElement.cpp
@@ -29,6 +29,12 @@ void HTMLLabelElement::initialize(JS::Realm& realm)
 
 GC::Ptr<Layout::Node> HTMLLabelElement::create_layout_node(GC::Ref<CSS::ComputedProperties> style)
 {
+    bool const has_control = (control() != nullptr);
+    bool const is_child_text_empty = this->child_text_content().is_empty();
+
+    if (!has_control && is_child_text_empty) // Skip layout for an empty label that controls nothing.
+        return nullptr;
+
     return heap().allocate<Layout::Label>(document(), this, move(style));
 }
 

--- a/Tests/LibWeb/Layout/expected/misc/label-empty-embedded-control.txt
+++ b/Tests/LibWeb/Layout/expected/misc/label-empty-embedded-control.txt
@@ -1,0 +1,22 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from Label start: 0, length: 0, rect: [8,8 200x21] baseline: 21
+      Label <label> at (8,8) content-size 200x21 inline-block [BFC] children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 198x19] baseline: 21
+        TextNode <#text>
+        BlockContainer <input#hello> at (9,9) content-size 198x19 inline-block [BFC] children: not-inline
+          Box <div> at (11,10) content-size 194x17 flex-container(row) [FFC] children: not-inline
+            BlockContainer <div> at (11,10) content-size 194x17 flex-item [BFC] children: inline
+              TextNode <#text>
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (Label<LABEL>) [8,8 200x21]
+        PaintableWithLines (BlockContainer<INPUT>#hello) [8,8 200x21]
+          PaintableBox (Box<DIV>) [9,9 198x19]
+            PaintableWithLines (BlockContainer<DIV>) [11,10 194x17]
+

--- a/Tests/LibWeb/Layout/expected/misc/label-empty-forcontrol.txt
+++ b/Tests/LibWeb/Layout/expected/misc/label-empty-forcontrol.txt
@@ -1,0 +1,24 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x24 children: inline
+      frag 0 from Label start: 0, length: 0, rect: [8,29 0x0] baseline: 0
+      frag 1 from TextNode start: 0, length: 1, rect: [8,15 8x17] baseline: 13.296875
+          " "
+      frag 2 from BlockContainer start: 0, length: 0, rect: [17,9 198x19] baseline: 21
+      Label <label> at (8,29) content-size 0x0 inline-block [BFC] children: not-inline
+      TextNode <#text>
+      BlockContainer <input#hello> at (17,9) content-size 198x19 inline-block [BFC] children: not-inline
+        Box <div> at (19,10) content-size 194x17 flex-container(row) [FFC] children: not-inline
+          BlockContainer <div> at (19,10) content-size 194x17 flex-item [BFC] children: inline
+            TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x24]
+      PaintableWithLines (Label<LABEL>) [8,29 0x0]
+      TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<INPUT>#hello) [16,8 200x21]
+        PaintableBox (Box<DIV>) [17,9 198x19]
+          PaintableWithLines (BlockContainer<DIV>) [19,10 194x17]
+

--- a/Tests/LibWeb/Layout/expected/misc/label-empty-nocontrol.txt
+++ b/Tests/LibWeb/Layout/expected/misc/label-empty-nocontrol.txt
@@ -1,0 +1,19 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (8,8) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]

--- a/Tests/LibWeb/Layout/expected/misc/label-notempty-nocontrol.txt
+++ b/Tests/LibWeb/Layout/expected/misc/label-notempty-nocontrol.txt
@@ -1,0 +1,26 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
+        frag 0 from Label start: 0, length: 0, rect: [8,8 45.90625x17] baseline: 13.296875
+        Label <label> at (8,8) content-size 45.90625x17 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 5, rect: [8,8 45.90625x17] baseline: 13.296875
+              "howdy"
+          TextNode <#text>
+        TextNode <#text>
+      BlockContainer <div> at (8,25) content-size 784x17 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,25 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
+        PaintableWithLines (Label<LABEL>) [8,8 45.90625x17]
+          TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,25 784x17]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]

--- a/Tests/LibWeb/Layout/input/misc/label-empty-embedded-control.html
+++ b/Tests/LibWeb/Layout/input/misc/label-empty-embedded-control.html
@@ -1,0 +1,3 @@
+<label>
+<input id="hello" />
+</label>

--- a/Tests/LibWeb/Layout/input/misc/label-empty-forcontrol.html
+++ b/Tests/LibWeb/Layout/input/misc/label-empty-forcontrol.html
@@ -1,0 +1,2 @@
+<label for="hello"></label>
+<input id="hello" />

--- a/Tests/LibWeb/Layout/input/misc/label-empty-nocontrol.html
+++ b/Tests/LibWeb/Layout/input/misc/label-empty-nocontrol.html
@@ -1,0 +1,2 @@
+<label></label>
+<div>hello</div>

--- a/Tests/LibWeb/Layout/input/misc/label-notempty-nocontrol.html
+++ b/Tests/LibWeb/Layout/input/misc/label-notempty-nocontrol.html
@@ -1,0 +1,2 @@
+<label>howdy</label>
+<div>hello</div>


### PR DESCRIPTION
Fixes #2864 