### PR TITLE
LibWeb/CSS: Implement hint type check before apply percent

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -164,11 +164,19 @@ Optional<CSSNumericType> CSSNumericType::added_to(CSSNumericType const& other) c
 
             // 1. Provisionally apply the percent hint hint to both type1 and type2.
             auto provisional_type1 = type1;
-            provisional_type1.apply_percent_hint(hint);
             auto provisional_type2 = type2;
-            provisional_type2.apply_percent_hint(hint);
 
-            // 2. If, afterwards, all the entries of type1 with non-zero values are contained in type2
+            // 2. If type1 does not have percent hint hint, apply the percent hint hint to type1.
+            if (!type1.percent_hint().has_value()) {
+                provisional_type1.apply_percent_hint(hint);
+            }
+            
+            //    Vice versa for type2.
+            if (!type2.percent_hint().has_value()) {
+                provisional_type2.apply_percent_hint(hint);
+            }
+
+            // 3. If, afterwards, all the entries of type1 with non-zero values are contained in type2
             //    with the same value, and vice versa, then copy all of type1’s entries to finalType,
             //    and then copy all of type2’s entries to finalType that finalType doesn’t already contain.
             //    Set finalType’s percent hint to hint. Return finalType.
@@ -181,7 +189,7 @@ Optional<CSSNumericType> CSSNumericType::added_to(CSSNumericType const& other) c
                 return final_type;
             }
 
-            // 3. Otherwise, revert type1 and type2 to their state at the start of this loop.
+            // 4. Otherwise, revert type1 and type2 to their state at the start of this loop.
             // NOTE: We did the modifications to provisional_type1/2 so this is a no-op.
         }
 

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-values/reference/all-green.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-values/reference/all-green.html
@@ -1,0 +1,1 @@
+<html style="background: green"></html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-values/max-unitless-zero-invalid.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-values/max-unitless-zero-invalid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>CSS Values and Units Test: min() with unitless 0</title>
+
+	<meta name="assert" content="Unitless 0 isn't supported in math functions.">
+	<link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
+	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+	<link rel="match" href="../../../../expected/wpt-import/css/css-values/reference/all-green.html">
+
+	<style>
+			html, body { margin: 0px; padding: 0px; }
+
+			html { background: red; overflow: hidden; }
+			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
+
+			#outer {
+				/* Assert that min() is supported */
+				height: min(100%);
+
+	 			/* The min() expression (thus the declaration) should be invalid */
+				height: min(0, 100%);
+			}
+	</style>
+
+</head>
+<body>
+
+	<div id="outer"></div>
+
+</body>
+</html>


### PR DESCRIPTION
Match logic done earlier in the "added_to" and "multiplied_by" functions that only sent non percent hint types to "apply_percent_hint". Alternatively "apply_percent_hint" could early return on percent hint type check instead of VERIFY since return values are not used. This allows at least one WPT test in css-values to finish instead of crashing.