### PR TITLE
LibWeb: Handle non-shorthand background position when serializing

### DIFF
--- a/Tests/LibWeb/Text/expected/background-style-declaration-cssText-crash.txt
+++ b/Tests/LibWeb/Text/expected/background-style-declaration-cssText-crash.txt
@@ -1,0 +1,2 @@
+:root { background: transparent none 1px 1px auto auto repeat scroll padding-box border-box; }
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/background-style-declaration-cssText-crash.html
+++ b/Tests/LibWeb/Text/input/background-style-declaration-cssText-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<style>
+    :root {
+        background: 1px 1px;
+    }
+</style>
+<script>
+    test(() => {
+        println(document.styleSheets[0].cssRules[0].cssText);
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
Fixes a crash when loading https://www.lottielab.com/.

My assumption in `ShorthandStyleValue::to_string` that `background-position` would always be a shorthand was false, because the parser outputs a `PositionStyleValue` which is exposed by `document.styleSheets[0].cssRules[0].cssText`.

An alternative solution would be to change the parser to output a `ShorthandStyleValue` for `background-position`, but I'm not convinced it's any cleaner.