### PR TITLE
LibWeb: Check if types have a present and nonzero percentage value

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -154,7 +154,7 @@ Optional<CSSNumericType> CSSNumericType::added_to(CSSNumericType const& other) c
     }
     //    If type1 and/or type2 contain "percent" with a non-zero value,
     //    and type1 and/or type2 contain a key other than "percent" with a non-zero value
-    if ((type1.exponent(BaseType::Percent) != 0 || type2.exponent(BaseType::Percent) != 0)
+    if (((type1.exponent(BaseType::Percent).has_value() && type1.exponent(BaseType::Percent) != 0) || (type2.exponent(BaseType::Percent).has_value() && type2.exponent(BaseType::Percent) != 0))
         && (type1.contains_a_key_other_than_percent_with_a_non_zero_value() || type2.contains_a_key_other_than_percent_with_a_non_zero_value())) {
         // For each base type other than "percent" hint:
         for (auto hint_int = 0; hint_int < to_underlying(BaseType::__Count); ++hint_int) {

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-values/reference/all-green.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-values/reference/all-green.html
@@ -1,0 +1,1 @@
+<html style="background: green"></html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-values/max-unitless-zero-invalid.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-values/max-unitless-zero-invalid.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<meta charset="utf-8">
+	<title>CSS Values and Units Test: min() with unitless 0</title>
+
+	<meta name="assert" content="Unitless 0 isn't supported in math functions.">
+	<link rel="author" title="Fuqiao Xue" href="mailto:xfq@w3.org">
+	<link rel="help" href="https://drafts.csswg.org/css-values/#calc-type-checking">
+	<link rel="match" href="../../../../expected/wpt-import/css/css-values/reference/all-green.html">
+
+	<style>
+			html, body { margin: 0px; padding: 0px; }
+
+			html { background: red; overflow: hidden; }
+			#outer { position: absolute; top: 0px; left: 0px; background: green; width: 100%; }
+
+			#outer {
+				/* Assert that min() is supported */
+				height: min(100%);
+
+	 			/* The min() expression (thus the declaration) should be invalid */
+				height: min(0, 100%);
+			}
+	</style>
+
+</head>
+<body>
+
+	<div id="outer"></div>
+
+</body>
+</html>


### PR DESCRIPTION
This is a third attempt at fixing #3050 (see also #3069 and #3080).

Our code was incorrectly counting null "percentage" values as non-zero, fixing this is sufficient to prevent the crash in all cases without needing to introduce ad-hoc behaviour. This is sufficient because a present-and-non-zero "percentage" exponent and a non-null percent hint are mutually exclusive.

Turns out this wasn't a spec bug, just a boring ladybug.