### PR TITLE
Tests: Check internals object is exposed before use

### DIFF
--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -121,7 +121,15 @@ class HTTPTestServer {
     }
 }
 
-const __httpTestServer = new HTTPTestServer(`http://localhost:${internals.getEchoServerPort()}`);
+const __httpTestServer = (function () {
+    if (globalThis.internals && globalThis.internals.getEchoServerPort)
+        return new HTTPTestServer(`http://localhost:${internals.getEchoServerPort()}`);
+
+    return null;
+})();
+
 function httpTestServer() {
+    if (!__httpTestServer)
+        throw new Error("window.internals must be exposed to use HTTPTestServer");
     return __httpTestServer;
 }

--- a/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
+++ b/Tests/LibWeb/Text/input/wpt-import/resources/testharness.js
@@ -559,7 +559,7 @@
     // Tell the ladybird test runner what our preferred timeout is
     {
         let timeout = test_environment.test_timeout();
-        if (timeout)
+        if (timeout && window.internals)
             window.internals.setTestTimeout(timeout);
     }
 


### PR DESCRIPTION
Previously, some tests would fail to display any output if the internals object was not exposed, which can hinder the ability to view tests in browsers other than Ladybird.

Tests which make use of the HTTP echo server will now complain with a descriptive error message if the internals object is not exposed.