### PR TITLE
LibXml: Notify listener as soon as doctype is parsed

### DIFF
--- a/Libraries/LibXML/Parser/Parser.cpp
+++ b/Libraries/LibXML/Parser/Parser.cpp
@@ -182,9 +182,6 @@ ErrorOr<void, ParseError> Parser::parse_with_listener(Listener& listener)
     if (result.is_error())
         m_listener->error(result.error());
     m_listener->document_end();
-    if (m_doctype.has_value()) {
-        m_listener->set_doctype(m_doctype.release_value());
-    }
     m_root_node.clear();
     return result;
 }
@@ -622,6 +619,10 @@ ErrorOr<void, ParseError> Parser::parse_doctype_decl()
 
     rollback.disarm();
     m_doctype = move(doctype);
+    if (m_doctype.has_value() && m_listener) {
+        m_listener->set_doctype(m_doctype.value());
+    }
+
     return {};
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/DocumentType-literal-xhtml.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/DocumentType-literal-xhtml.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	DocumentType literals

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/DocumentType-literal-xhtml.xhtml
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/DocumentType-literal-xhtml.xhtml
@@ -1,0 +1,23 @@
+<!DOCTYPE html PUBLIC "STAFF" "staffNS.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>DocumentType literals</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-documenttype-name"/>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-documenttype-publicid"/>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-documenttype-systemid"/>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+</head>
+<body>
+<div id="log"/>
+<script>
+test(function() {
+  var doctype = document.firstChild;
+  assert_true(doctype instanceof DocumentType)
+  assert_equals(doctype.name, "html")
+  assert_equals(doctype.publicId, 'STAFF')
+  assert_equals(doctype.systemId, 'staffNS.dtd')
+})
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes Wtp Test dom/nodes/DocumentType-literal-xhtml.xhtml using value() instead of release_value() avoid regression on html/the-xhtml-syntax/parsing-xhtml-documents