### PR TITLE
LibWeb: Insert default font in font list before emoji font

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -228,7 +228,7 @@ Color ComputedProperties::color_or_fallback(CSS::PropertyID id, Layout::NodeWith
     return value.to_color(node);
 }
 
-NonnullRefPtr<Gfx::Font const> ComputedProperties::font_fallback(bool monospace, bool bold)
+NonnullRefPtr<Gfx::Font const> ComputedProperties::font_fallback(bool monospace, bool bold, float point_size)
 {
     if (monospace && bold)
         return Platform::FontPlugin::the().default_fixed_width_font().bold_variant();
@@ -237,9 +237,9 @@ NonnullRefPtr<Gfx::Font const> ComputedProperties::font_fallback(bool monospace,
         return Platform::FontPlugin::the().default_fixed_width_font();
 
     if (bold)
-        return Platform::FontPlugin::the().default_font().bold_variant();
+        return Platform::FontPlugin::the().default_font(point_size)->bold_variant();
 
-    return Platform::FontPlugin::the().default_font();
+    return *Platform::FontPlugin::the().default_font(point_size);
 }
 
 CSSPixels ComputedProperties::compute_line_height(CSSPixelRect const& viewport_rect, Length::FontMetrics const& font_metrics, Length::FontMetrics const& root_font_metrics) const

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -209,7 +209,7 @@ public:
 
     Optional<CSS::ScrollbarWidth> scrollbar_width() const;
 
-    static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold);
+    static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold, float point_size);
 
     static float resolve_opacity_value(CSSStyleValue const& value);
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -173,7 +173,7 @@ static DOM::Element const* element_to_inherit_style_from(DOM::Element const*, Op
 
 StyleComputer::StyleComputer(DOM::Document& document)
     : m_document(document)
-    , m_default_font_metrics(16, Platform::FontPlugin::the().default_font().pixel_metrics())
+    , m_default_font_metrics(16, Platform::FontPlugin::the().default_font(16)->pixel_metrics())
     , m_root_element_font_metrics(m_default_font_metrics)
 {
     m_qualified_layer_names_in_order.append({});
@@ -1786,7 +1786,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
     if (parent_element && parent_element->computed_properties())
         font_pixel_metrics = parent_element->computed_properties()->first_available_computed_font().pixel_metrics();
     else
-        font_pixel_metrics = Platform::FontPlugin::the().default_font().pixel_metrics();
+        font_pixel_metrics = Platform::FontPlugin::the().default_font(font_size_in_px.to_float())->pixel_metrics();
     auto parent_font_size = [&]() -> CSSPixels {
         if (!parent_element || !parent_element->computed_properties())
             return font_size_in_px;
@@ -2013,7 +2013,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
         font_list->add(*emoji_font);
     }
 
-    auto found_font = ComputedProperties::font_fallback(monospace, bold);
+    auto found_font = ComputedProperties::font_fallback(monospace, bold, 12);
     font_list->set_last_resort_font(found_font->with_size(font_size_in_pt));
 
     return font_list;
@@ -2069,7 +2069,7 @@ void StyleComputer::compute_font(ComputedProperties& style, DOM::Element const* 
 Gfx::Font const& StyleComputer::initial_font() const
 {
     // FIXME: This is not correct.
-    return ComputedProperties::font_fallback(false, false);
+    return ComputedProperties::font_fallback(false, false, 12);
 }
 
 void StyleComputer::absolutize_values(ComputedProperties& style) const

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2013,7 +2013,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
         font_list->add(*emoji_font);
     }
 
-    auto found_font = ComputedProperties::font_fallback(monospace, bold, 12);
+    auto found_font = ComputedProperties::font_fallback(monospace, bold, font_size_in_pt);
     font_list->set_last_resort_font(found_font->with_size(font_size_in_pt));
 
     return font_list;

--- a/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -43,14 +43,14 @@ void ImageBox::prepare_for_replaced_layout()
             set_natural_width(0);
             set_natural_height(0);
         } else {
-            auto const& font = Platform::FontPlugin::the().default_font();
+            auto font = Platform::FontPlugin::the().default_font(12);
             CSSPixels alt_text_width = 0;
             if (!m_cached_alt_text_width.has_value())
-                m_cached_alt_text_width = CSSPixels::nearest_value_for(font.width(alt));
+                m_cached_alt_text_width = CSSPixels::nearest_value_for(font->width(alt));
             alt_text_width = m_cached_alt_text_width.value();
 
             set_natural_width(alt_text_width + 16);
-            set_natural_height(CSSPixels::nearest_value_for(font.pixel_size()) + 16);
+            set_natural_height(CSSPixels::nearest_value_for(font->pixel_size()) + 16);
         }
     }
 

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -66,7 +66,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
         if (m_renders_as_alt_text) {
             auto enclosing_rect = context.enclosing_device_rect(absolute_rect()).to_type<int>();
             context.display_list_recorder().draw_rect(enclosing_rect, Gfx::Color::Black);
-            context.display_list_recorder().draw_text(enclosing_rect, m_alt_text, Platform::FontPlugin::the().default_font(), Gfx::TextAlignment::Center, computed_values().color());
+            context.display_list_recorder().draw_text(enclosing_rect, m_alt_text, *Platform::FontPlugin::the().default_font(12), Gfx::TextAlignment::Center, computed_values().color());
         } else if (auto bitmap = m_image_provider.current_image_bitmap(image_rect.size().to_type<int>())) {
             ScopedCornerRadiusClip corner_clip { context, image_rect, normalized_border_radii_data(ShrinkRadiiForBorders::Yes) };
             auto image_int_rect = image_rect.to_type<int>();

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -415,7 +415,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         paint_inspector_rect(border_rect, Color::Green);
         paint_inspector_rect(content_rect, Color::Magenta);
 
-        auto& font = Platform::FontPlugin::the().default_font();
+        auto font = Platform::FontPlugin::the().default_font(12);
 
         StringBuilder builder;
         if (layout_node_with_style_and_box_metrics().dom_node())
@@ -427,12 +427,12 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         auto size_text_rect = border_rect;
         size_text_rect.set_y(border_rect.y() + border_rect.height());
         size_text_rect.set_top(size_text_rect.top());
-        size_text_rect.set_width(CSSPixels::nearest_value_for(font.width(size_text)) + 4);
-        size_text_rect.set_height(CSSPixels::nearest_value_for(font.pixel_size()) + 4);
+        size_text_rect.set_width(CSSPixels::nearest_value_for(font->width(size_text)) + 4);
+        size_text_rect.set_height(CSSPixels::nearest_value_for(font->pixel_size()) + 4);
         auto size_text_device_rect = context.enclosing_device_rect(size_text_rect).to_type<int>();
         context.display_list_recorder().fill_rect(size_text_device_rect, context.palette().color(Gfx::ColorRole::Tooltip));
         context.display_list_recorder().draw_rect(size_text_device_rect, context.palette().threed_shadow1());
-        context.display_list_recorder().draw_text(size_text_device_rect, size_text, font.with_size(font.point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
+        context.display_list_recorder().draw_text(size_text_device_rect, size_text, font->with_size(font->point_size() * context.device_pixels_per_css_pixel()), Gfx::TextAlignment::Center, context.palette().color(Gfx::ColorRole::TooltipText));
     }
 }
 

--- a/Libraries/LibWeb/Platform/FontPlugin.h
+++ b/Libraries/LibWeb/Platform/FontPlugin.h
@@ -31,7 +31,7 @@ public:
 
     virtual ~FontPlugin();
 
-    virtual Gfx::Font& default_font() = 0;
+    virtual RefPtr<Gfx::Font> default_font(float point_size) = 0;
     virtual Gfx::Font& default_fixed_width_font() = 0;
     virtual RefPtr<Gfx::Font> default_emoji_font(float point_size) = 0;
 

--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -42,9 +42,7 @@ FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_p
 
     update_generic_fonts();
 
-    auto default_font_name = generic_font_name(Web::Platform::GenericFont::UiSansSerif);
-    m_default_font = Gfx::FontDatabase::the().get(default_font_name, 12.0, 400, Gfx::FontWidth::Normal, 0);
-    VERIFY(m_default_font);
+    m_default_font_name = generic_font_name(Web::Platform::GenericFont::UiSansSerif);
 
     auto default_fixed_width_font_name = generic_font_name(Web::Platform::GenericFont::UiMonospace);
     m_default_fixed_width_font = Gfx::FontDatabase::the().get(default_fixed_width_font_name, 12.0, 400, Gfx::FontWidth::Normal, 0);
@@ -53,9 +51,9 @@ FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_p
 
 FontPlugin::~FontPlugin() = default;
 
-Gfx::Font& FontPlugin::default_font()
+RefPtr<Gfx::Font> FontPlugin::default_font(float point_size)
 {
-    return *m_default_font;
+    return Gfx::FontDatabase::the().get(m_default_font_name, point_size, 400, Gfx::FontWidth::Normal, 0);
 }
 
 Gfx::Font& FontPlugin::default_fixed_width_font()

--- a/Libraries/LibWebView/Plugins/FontPlugin.h
+++ b/Libraries/LibWebView/Plugins/FontPlugin.h
@@ -18,7 +18,7 @@ public:
     FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* = nullptr);
     virtual ~FontPlugin();
 
-    virtual Gfx::Font& default_font() override;
+    virtual RefPtr<Gfx::Font> default_font(float point_size) override;
     virtual Gfx::Font& default_fixed_width_font() override;
     virtual RefPtr<Gfx::Font> default_emoji_font(float point_size) override;
     virtual FlyString generic_font_name(Web::Platform::GenericFont) override;
@@ -27,7 +27,7 @@ public:
 
 private:
     Vector<FlyString> m_generic_font_names;
-    RefPtr<Gfx::Font> m_default_font;
+    FlyString m_default_font_name;
     RefPtr<Gfx::Font> m_default_fixed_width_font;
     bool m_is_layout_test_mode { false };
 };

--- a/Tests/LibWeb/Layout/expected/non-existing-font-family.txt
+++ b/Tests/LibWeb/Layout/expected/non-existing-font-family.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x17 children: inline
+      frag 0 from TextNode start: 0, length: 77, rect: [8,8 647.140625x17] baseline: 13.296875
+          "the same font is supposed to be used for all characters including whitespaces"
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
+      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/non-existing-font-family.html
+++ b/Tests/LibWeb/Layout/input/non-existing-font-family.html
@@ -1,0 +1,5 @@
+<style>
+* {
+    font-family: "some fake font name";
+}
+</style>the same font is supposed to be used for all characters including whitespaces


### PR DESCRIPTION
This change fixes a bug where, if a non-existent font family is specified in
CSS, whitespaces would be rendered using the emoji font, while letters
would use the default font. This issue occurred because the font was
resolved separately for each code point. Since the emoji font was listed
before the default font, it was chosen for whitespace characters due to
its inclusion of whitespace glyphs (at least in the Apple Color Emoji
font on macOS). This change resolves the issue by placing the default
font before the emoji font in the list.

This change fixes the same issue as https://github.com/LadybirdBrowser/ladybird/pull/2955 but I also made default font respect specified size and added a comment to clarify why default font has to be both inserted in font list and used as a last resort font.