### PR TITLE
Meta: Check for compatible Python version in `WPT.sh`

### DIFF
--- a/Meta/WPT.sh
+++ b/Meta/WPT.sh
@@ -98,6 +98,11 @@ if [ "$CMD" = "--help" ] || [ "$CMD" = "help" ]; then
     exit 0
 fi
 
+# As of 2025-01-02 the WPT repository is not compatible with Python 3.13,
+# and it looks like this is going to stay that way for a while.
+# https://github.com/web-platform-tests/wpt/issues/48585
+check_program_version_is_compatible Python python 3.8 3.13 || exit 1
+
 set_logging_flags()
 {
     [ -n "${1}" ] || usage;

--- a/Meta/ladybird.sh
+++ b/Meta/ladybird.sh
@@ -84,7 +84,7 @@ EOF
 fi
 
 create_build_dir() {
-    check_program_version_at_least CMake cmake 3.25 || exit 1
+    check_program_version_is_compatible CMake cmake 3.25 || exit 1
     cmake --preset "$BUILD_PRESET" "${CMAKE_ARGS[@]}" -S "$LADYBIRD_SOURCE_DIR" -B "$BUILD_DIR"
 }
 

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -17,21 +17,24 @@ exit_if_running_as_root() {
     fi
 }
 
-# Usage: check_program_version_at_least <Display Name> <Program Name> <Version String>
-check_program_version_at_least()
+# Usage: check_program_version_is_compatible <display name> <program name> <minimum version> <optional: first version that is too high>
+check_program_version_is_compatible()
 {
-    echo -n "Checking for $1 version at least $3... "
+    echo -n "Checking for compatible $1 version... "
     if ! command -v "$2" > /dev/null 2>&1; then
         echo "ERROR: Cannot find $2 ($1)"
         return 1
     fi
     v=$("$2" --version 2>&1 | grep -E -o '[0-9]+\.[0-9\.]+[a-z]*' | head -n1)
-    if printf '%s\n' "$3" "$v" | sort --version-sort --check &>/dev/null; then
+    if ! printf '%s\n' "$3" "$v" | sort --version-sort --check &>/dev/null; then
+        echo "ERROR: found version $v, which is too old! At least $3 is required."
+        return 1;
+    elif [ -n "$4" ] && printf '%s\n' "$4" "$v" | sort --version-sort --check &>/dev/null; then
+        echo "ERROR: found version $v, which is too new! A version below $4 is required."
+        return 1;
+    else
         echo "ok, found $v"
         return 0;
-    else
-        echo "ERROR: found version $v, too old!"
-        return 1;
     fi
 }
 


### PR DESCRIPTION
Running `WPT.sh` with Python 3.13 results in multiple non-obvious error messages due to compatibility problems between the Python code in the WPT repository and Python 3.13. To make the root cause more obvious, `WPT.sh` checks for a compatible Python version now.