### PR TITLE
LibGC: Rename remaining occurrence of marked vector

### DIFF
--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -267,7 +267,7 @@ void Heap::gather_roots(HashMap<Cell*, HeapRoot>& roots)
     for (auto& root : m_roots)
         roots.set(root.cell(), HeapRoot { .type = HeapRoot::Type::Root, .location = &root.source_location() });
 
-    for (auto& vector : m_marked_vectors)
+    for (auto& vector : m_root_vectors)
         vector.gather_roots(roots);
 
     if constexpr (HEAP_DEBUG) {

--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -61,8 +61,8 @@ public:
     void did_create_root(Badge<RootImpl>, RootImpl&);
     void did_destroy_root(Badge<RootImpl>, RootImpl&);
 
-    void did_create_marked_vector(Badge<RootVectorBase>, RootVectorBase&);
-    void did_destroy_marked_vector(Badge<RootVectorBase>, RootVectorBase&);
+    void did_create_root_vector(Badge<RootVectorBase>, RootVectorBase&);
+    void did_destroy_root_vector(Badge<RootVectorBase>, RootVectorBase&);
 
     void did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
     void did_destroy_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase&);
@@ -139,7 +139,7 @@ private:
     CellAllocator::List m_all_cell_allocators;
 
     RootImpl::List m_roots;
-    RootVectorBase::List m_marked_vectors;
+    RootVectorBase::List m_root_vectors;
     ConservativeVectorBase::List m_conservative_vectors;
     WeakContainer::List m_weak_containers;
 
@@ -165,16 +165,16 @@ inline void Heap::did_destroy_root(Badge<RootImpl>, RootImpl& impl)
     m_roots.remove(impl);
 }
 
-inline void Heap::did_create_marked_vector(Badge<RootVectorBase>, RootVectorBase& vector)
+inline void Heap::did_create_root_vector(Badge<RootVectorBase>, RootVectorBase& vector)
 {
-    VERIFY(!m_marked_vectors.contains(vector));
-    m_marked_vectors.append(vector);
+    VERIFY(!m_root_vectors.contains(vector));
+    m_root_vectors.append(vector);
 }
 
-inline void Heap::did_destroy_marked_vector(Badge<RootVectorBase>, RootVectorBase& vector)
+inline void Heap::did_destroy_root_vector(Badge<RootVectorBase>, RootVectorBase& vector)
 {
-    VERIFY(m_marked_vectors.contains(vector));
-    m_marked_vectors.remove(vector);
+    VERIFY(m_root_vectors.contains(vector));
+    m_root_vectors.remove(vector);
 }
 
 inline void Heap::did_create_conservative_vector(Badge<ConservativeVectorBase>, ConservativeVectorBase& vector)

--- a/Libraries/LibGC/RootVector.cpp
+++ b/Libraries/LibGC/RootVector.cpp
@@ -13,12 +13,12 @@ namespace GC {
 RootVectorBase::RootVectorBase(Heap& heap)
     : m_heap(&heap)
 {
-    m_heap->did_create_marked_vector({}, *this);
+    m_heap->did_create_root_vector({}, *this);
 }
 
 RootVectorBase::~RootVectorBase()
 {
-    m_heap->did_destroy_marked_vector({}, *this);
+    m_heap->did_destroy_root_vector({}, *this);
 }
 
 RootVectorBase& RootVectorBase::operator=(RootVectorBase const& other)
@@ -27,7 +27,7 @@ RootVectorBase& RootVectorBase::operator=(RootVectorBase const& other)
         m_heap = other.m_heap;
 
         // NOTE: IntrusiveList will remove this RootVectorBase from the old heap it was part of.
-        m_heap->did_create_marked_vector({}, *this);
+        m_heap->did_create_root_vector({}, *this);
     }
 
     return *this;


### PR DESCRIPTION
In #3048 `MarkedVector` was renamed to `RootVector`, but some related symbols were missed. This commit corrects this.