### PR TITLE
LibWeb: Revert addition of VERIFY call to isomorphic-decode

### DIFF
--- a/Libraries/LibWeb/Infra/Strings.cpp
+++ b/Libraries/LibWeb/Infra/Strings.cpp
@@ -152,7 +152,9 @@ ByteBuffer isomorphic_encode(StringView input)
     // NOTE: This is essentially spec-speak for "Encode as ISO-8859-1 / Latin-1".
     ByteBuffer buf = {};
     for (auto code_point : Utf8View { input }) {
-        VERIFY(code_point <= 0xFF);
+        // VERIFY(code_point <= 0xFF);
+        if (code_point > 0xFF)
+            dbgln("FIXME: Trying to isomorphic encode a string with code points > U+00FF.");
         buf.append((u8)code_point);
     }
     return buf;


### PR DESCRIPTION
I pre-emptively [suggested](https://github.com/LadybirdBrowser/ladybird/pull/2890#issuecomment-2540606951) this VERIFY could be uncommented in #2890.

We're still doing something wrong to let non-latin-1 codepoints through, causing this check to fail when loading an article on https://cnn.com/ (as showcased in the December update video, oops!). 