### PR TITLE
LibWeb/HTML: Assert microtasks invoked on empty execution context stack

### DIFF
--- a/Libraries/LibWeb/FileAPI/FileReader.cpp
+++ b/Libraries/LibWeb/FileAPI/FileReader.cpp
@@ -157,7 +157,7 @@ WebIDL::ExceptionOr<void> FileReader::read_operation(Blob& blob, Type type, Opti
 
             // 1. Wait for chunkPromise to be fulfilled or rejected.
             // FIXME: Create spec issue to use WebIDL react to promise steps here instead of this custom logic
-            Platform::EventLoopPlugin::the().spin_until(GC::create_function(heap(), [promise]() {
+            HTML::main_thread_event_loop().spin_until(GC::create_function(heap(), [promise]() {
                 return promise->state() == JS::Promise::State::Fulfilled || promise->state() == JS::Promise::State::Rejected;
             }));
 

--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -473,6 +473,10 @@ void perform_a_microtask_checkpoint()
 // https://html.spec.whatwg.org/#perform-a-microtask-checkpoint
 void EventLoop::perform_a_microtask_checkpoint()
 {
+    // NOTE: This assertion is per requirement 9.5 of the ECMA-262 spec, see: https://tc39.es/ecma262/#sec-jobs
+    // > At some future point in time, when there is no running context in the agent for which the job is scheduled and that agent's execution context stack is empty...
+    VERIFY(vm().execution_context_stack().is_empty());
+
     // 1. If the event loop's performing a microtask checkpoint is true, then return.
     if (m_performing_a_microtask_checkpoint)
         return;

--- a/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -942,7 +942,7 @@ WebIDL::ExceptionOr<void> XMLHttpRequest::send(Optional<DocumentOrXMLHttpRequest
         }
 
         // FIXME: This is not exactly correct, as it allows the HTML event loop to continue executing tasks.
-        Platform::EventLoopPlugin::the().spin_until(GC::create_function(heap(), [&]() {
+        HTML::main_thread_event_loop().spin_until(GC::create_function(heap(), [&]() {
             return processed_response || did_time_out;
         }));
 


### PR DESCRIPTION
This a requirement from the ECMA-262 spec.