### PR TITLE
LibWeb/XHR: Isomorphic decode accessing XMLHttpRequest response headers

### DIFF
--- a/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -61,8 +61,8 @@ public:
     WebIDL::ExceptionOr<void> set_request_header(String const& header, String const& value);
     WebIDL::ExceptionOr<void> set_response_type(Bindings::XMLHttpRequestResponseType);
 
-    WebIDL::ExceptionOr<Optional<String>> get_response_header(String const& name) const;
-    WebIDL::ExceptionOr<String> get_all_response_headers() const;
+    Optional<String> get_response_header(String const& name) const;
+    String get_all_response_headers() const;
 
     WebIDL::CallbackType* onreadystatechange();
     void set_onreadystatechange(WebIDL::CallbackType*);

--- a/Tests/LibWeb/Text/expected/XHR/XMLHttpRequest-response-header-decoding.txt
+++ b/Tests/LibWeb/Text/expected/XHR/XMLHttpRequest-response-header-decoding.txt
@@ -1,0 +1,4 @@
+getAllResponseHeaders()
+refresh: 0;./refreshed.txt?ÿ
+
+getResponseHeader("Refresh") => '0;./refreshed.txt?ÿ'

--- a/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-response-header-decoding.html
+++ b/Tests/LibWeb/Text/input/XHR/XMLHttpRequest-response-header-decoding.html
@@ -1,0 +1,29 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        try {
+            const httpServer = httpTestServer();
+            const url = await httpServer.createEcho("GET", "/xml-http-request-response-header-decoding", {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Origin": "*",
+                    "Access-Control-Expose-Headers": "Refresh",
+                    "Refresh": "0;./refreshed.txt?\u0080\u00FF",
+                },
+                body: "",
+            });
+
+            const xhr = new XMLHttpRequest();
+            xhr.open("GET", url);
+
+            xhr.addEventListener("load", () => {
+                println(`getAllResponseHeaders()\n${xhr.getAllResponseHeaders().replace('\r','')}`);
+                println(`getResponseHeader("Refresh") => '${xhr.getResponseHeader("Refresh")}'`);
+                done();
+            });
+            xhr.send();
+        } catch (err) {
+            console.log("FAIL - " + err);
+        }
+    });
+</script>


### PR DESCRIPTION
Fixes a crash on:

https://wpt.live/html/browsers/browsing-the-web/navigating-across-documents/refresh/subresource.any.html