### PR TITLE
LibJS: Parse dates like "2025-01-02 14:00:00+0000"

### DIFF
--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -189,7 +189,8 @@ static double parse_date_string(VM& vm, StringView date_string)
         "%d%t%b%t%Y%t%R"sv,                    // "01 Jan 2000 08:00"
         "%A,%t%B%t%e,%t%Y,%t%R%t%Z"sv,         // "Tuesday, October 29, 2024, 18:00 UTC"
         "%B%t%d%t%Y%t%T%t%z"sv,                // "November 19 2024 00:00:00 +0900"
-        "%a%t%b%t%e%t%Y"sv                     // "Wed Nov 20 2024"
+        "%a%t%b%t%e%t%Y"sv,                    // "Wed Nov 20 2024"
+        "%Y-%m-%d%t%H:%M:%S%z"sv,              // "2024-12-30 03:00:00+0000"
     };
 
     for (auto const& format : extra_formats) {

--- a/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -42,6 +42,7 @@ test("basic functionality", () => {
     expect(Date.parse("Tuesday, October 29, 2024, 18:00 UTC")).toBe(1730224800000);
     expect(Date.parse("November 19 2024 00:00:00 +0900")).toBe(1731942000000);
     expect(Date.parse("Wed Nov 20 2024")).toBe(1732082400000);
+    expect(Date.parse("2025-01-02 14:00:00+0000")).toBe(1735826400000);
 
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
     setTimeZone(originalTimeZone);


### PR DESCRIPTION
This was getting spammed in the console by a website in the wild.

![image](https://github.com/user-attachments/assets/1aae8a99-1e50-40f4-ab0d-e221e60bd991)

Unfortunately I've forgotten what website I was browsing at the time😅 