### PR TITLE
LibWeb/HTML: Make disabled items immutable & fix disabled activations

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -173,7 +173,7 @@ public:
     bool has_scheduled_selectionchange_event() const { return m_has_scheduled_selectionchange_event; }
     void set_scheduled_selectionchange_event(bool value) { m_has_scheduled_selectionchange_event = value; }
 
-    bool is_mutable() const { return m_is_mutable; }
+    bool is_mutable() const { return m_is_mutable && enabled(); }
     void set_is_mutable(bool is_mutable) { m_is_mutable = is_mutable; }
 
     virtual void did_edit_text_node() = 0;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2467,14 +2467,19 @@ bool HTMLInputElement::has_activation_behavior() const
     return true;
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#the-input-element:activation-behaviour
 void HTMLInputElement::activation_behavior(DOM::Event const& event)
 {
     // The activation behavior for input elements are these steps:
 
-    // FIXME: 1. If this element is not mutable and is not in the Checkbox state and is not in the Radio state, then return.
+    // 1. If this element is not mutable and is not in the Checkbox state and is not in the Radio state, then return.
+    if (!is_mutable() && type_state() != TypeAttributeState::Checkbox && type_state() != TypeAttributeState::RadioButton)
+        return;
 
     // 2. Run this element's input activation behavior, if any, and do nothing otherwise.
     run_input_activation_behavior(event).release_value_but_fixme_should_propagate_errors();
+
+    // FIXME: 3. Run the popover target attribute activation behavior given element and event's target.
 }
 
 bool HTMLInputElement::has_input_activation_behavior() const

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/events/Event-dispatch-click.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/events/Event-dispatch-click.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 33 tests
 
-30 Pass
-3 Fail
+33 Pass
 Pass	basic with click()
 Pass	basic with dispatchEvent()
 Pass	basic with wrong event class
@@ -34,6 +33,6 @@ Pass	disabling checkbox in onclick listener shouldn't suppress onchange
 Pass	disabling radio in onclick listener shouldn't suppress oninput
 Pass	disabling radio in onclick listener shouldn't suppress onchange
 Pass	disconnected form should not submit
-Fail	disabled submit button should not activate
-Fail	submit button should not activate if the event listener disables it
-Fail	submit button that morphed from checkbox should not activate
+Pass	disabled submit button should not activate
+Pass	submit button should not activate if the event listener disables it
+Pass	submit button that morphed from checkbox should not activate


### PR DESCRIPTION
Follows `HTMLInputElement::activation_behavior` closer to specifications.

Previously, these disabled form input elements wouldn't be able to be activated via user interaction, but they would be able to be activated via JavaScript (at least in some conditions).

As for the changes in `FormAssociatedTextControlElement::is_mutable`, it seems to me that it makes sense for disabled input items to also not be mutable, though I didn't personally find the [spec](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-mutable) **entirely** clear in that regard. Afterwards, as a sanity check, I looked at what [Firefox](https://github.com/mozilla/gecko-dev/blob/822ad254f71224ef6758c3531184a3524cace381/dom/html/input/InputType.cpp#L112) and [WebKit](https://github.com/WebKit/WebKit/blob/82d81077a049566638c9bb6a3022e2621d69934a/Source/WebCore/html/ValidatedFormListedElement.h#L73) do, and they seem to also register a form input element as immutable if it is disabled, I believe for all form input types, thus I believe this change is correct.

Fixes 3 WPT tests.