### PR TITLE
LibWeb: Optimize :hover style invalidation

### DIFF
--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -362,6 +362,17 @@ public:
 
     static constexpr size_t max_size = 0xffffffff;
 
+    [[nodiscard]] bool operator==(BitmapView const& other) const
+    {
+        if (size() != other.size())
+            return false;
+        for (size_t i = 0; i < size_in_bytes(); ++i) {
+            if (m_data[i] != other.m_data[i])
+                return false;
+        }
+        return true;
+    }
+
 protected:
     u8* m_data { nullptr };
     size_t m_size { 0 };

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -213,6 +213,9 @@ public:
 
     static float resolve_opacity_value(CSSStyleValue const& value);
 
+    bool did_match_any_hover_rules() const { return m_did_match_any_hover_rules; }
+    void set_did_match_any_hover_rules() { m_did_match_any_hover_rules = true; }
+
 private:
     friend class StyleComputer;
 
@@ -236,6 +239,8 @@ private:
     mutable RefPtr<Gfx::FontCascadeList> m_font_list;
 
     Optional<CSSPixels> m_line_height;
+
+    bool m_did_match_any_hover_rules { false };
 };
 
 }

--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -57,10 +57,15 @@ Selector::Selector(Vector<CompoundSelector>&& compound_selectors)
                 break;
             }
             if (simple_selector.type == SimpleSelector::Type::PseudoClass) {
+                if (simple_selector.pseudo_class().type == PseudoClass::Hover) {
+                    m_contains_hover_pseudo_class = true;
+                }
                 for (auto const& child_selector : simple_selector.pseudo_class().argument_selector_list) {
                     if (child_selector->contains_the_nesting_selector()) {
                         m_contains_the_nesting_selector = true;
-                        break;
+                    }
+                    if (child_selector->contains_hover_pseudo_class()) {
+                        m_contains_hover_pseudo_class = true;
                     }
                 }
                 if (m_contains_the_nesting_selector)

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -261,6 +261,7 @@ public:
     Optional<PseudoElement> const& pseudo_element() const { return m_pseudo_element; }
     NonnullRefPtr<Selector> relative_to(SimpleSelector const&) const;
     bool contains_the_nesting_selector() const { return m_contains_the_nesting_selector; }
+    bool contains_hover_pseudo_class() const { return m_contains_hover_pseudo_class; }
     RefPtr<Selector> absolutized(SimpleSelector const& selector_for_nesting) const;
     u32 specificity() const;
     String serialize() const;
@@ -274,6 +275,7 @@ private:
     mutable Optional<u32> m_specificity;
     Optional<Selector::PseudoElement> m_pseudo_element;
     bool m_contains_the_nesting_selector { false };
+    bool m_contains_hover_pseudo_class { false };
 
     void collect_ancestor_hashes();
 

--- a/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -16,9 +16,14 @@ enum class SelectorKind {
     Relative,
 };
 
-bool matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host, Optional<CSS::Selector::PseudoElement::Type> = {}, GC::Ptr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal, GC::Ptr<DOM::Element const> anchor = nullptr);
+struct MatchContext {
+    GC::Ptr<CSS::CSSStyleSheet const> style_sheet_for_rule {};
+    bool did_match_any_hover_rules { false };
+};
 
-[[nodiscard]] bool fast_matches(CSS::Selector const&, Optional<CSS::CSSStyleSheet const&> style_sheet_for_rule, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host);
+bool matches(CSS::Selector const&, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, Optional<CSS::Selector::PseudoElement::Type> = {}, GC::Ptr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal, GC::Ptr<DOM::Element const> anchor = nullptr);
+
+[[nodiscard]] bool fast_matches(CSS::Selector const&, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context);
 [[nodiscard]] bool can_use_fast_matches(CSS::Selector const&);
 
 [[nodiscard]] bool matches_hover_pseudo_class(DOM::Element const&);

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -146,6 +146,7 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
 
+    Vector<MatchingRule> const& get_hover_rules() const;
     Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_hover_rules, FlyString const& qualified_layer_name = {}) const;
 
     void invalidate_rule_cache();
@@ -267,13 +268,14 @@ private:
         HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
     };
 
-    NonnullOwnPtr<RuleCache> make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&);
+    NonnullOwnPtr<RuleCache> make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&, Vector<MatchingRule>& hover_rules);
 
     RuleCache const& rule_cache_for_cascade_origin(CascadeOrigin) const;
 
     static void collect_selector_insights(Selector const&, SelectorInsights&);
 
     OwnPtr<SelectorInsights> m_selector_insights;
+    Vector<MatchingRule> m_hover_rules;
     OwnPtr<RuleCache> m_author_rule_cache;
     OwnPtr<RuleCache> m_user_rule_cache;
     OwnPtr<RuleCache> m_user_agent_rule_cache;

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -146,7 +146,7 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
 
-    Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, FlyString const& qualified_layer_name = {}) const;
+    Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_hover_rules, FlyString const& qualified_layer_name = {}) const;
 
     void invalidate_rule_cache();
 
@@ -191,7 +191,7 @@ private:
     [[nodiscard]] bool should_reject_with_ancestor_filter(Selector const&) const;
 
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_style_impl(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, ComputeStyleMode) const;
-    [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_pseudo_element_rules, ComputeStyleMode) const;
+    [[nodiscard]] GC::Ref<CascadedProperties> compute_cascaded_values(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_pseudo_element_rules, bool& did_match_any_hover_rules, ComputeStyleMode) const;
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_ascending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     static RefPtr<Gfx::FontCascadeList const> find_matching_font_weight_descending(Vector<MatchingFontCandidate> const& candidates, int target_weight, float font_size_in_pt, bool inclusive);
     RefPtr<Gfx::FontCascadeList const> font_matching_algorithm(FlyString const& family_name, int weight, int slope, float font_size_in_pt) const;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -174,6 +174,7 @@ public:
 
     virtual FlyString node_name() const override { return "#document"_fly_string; }
 
+    void invalidate_style_for_elements_affected_by_hover_change(GC::Ptr<Node> old_new_hovered_common_ancestor, GC::Ptr<Node> hovered_node);
     void set_hovered_node(Node*);
     Node* hovered_node() { return m_hovered_node.ptr(); }
     Node const* hovered_node() const { return m_hovered_node.ptr(); }

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -734,7 +734,8 @@ WebIDL::ExceptionOr<bool> Element::matches(StringView selectors) const
     // 3. If the result of match a selector against an element, using s, this, and scoping root this, returns success, then return true; otherwise, return false.
     auto sel = maybe_selectors.value();
     for (auto& s : sel) {
-        if (SelectorEngine::matches(s, {}, *this, nullptr, {}, static_cast<ParentNode const*>(this)))
+        SelectorEngine::MatchContext context;
+        if (SelectorEngine::matches(s, *this, nullptr, context, {}, static_cast<ParentNode const*>(this)))
             return true;
     }
     return false;
@@ -753,7 +754,8 @@ WebIDL::ExceptionOr<DOM::Element const*> Element::closest(StringView selectors) 
     auto matches_selectors = [this](CSS::SelectorList const& selector_list, Element const* element) {
         // 4. For each element in elements, if match a selector against an element, using s, element, and scoping root this, returns success, return element.
         for (auto const& selector : selector_list) {
-            if (SelectorEngine::matches(selector, {}, *element, nullptr, {}, this))
+            SelectorEngine::MatchContext context;
+            if (SelectorEngine::matches(selector, *element, nullptr, context, {}, this))
                 return true;
         }
         return false;
@@ -1113,6 +1115,22 @@ GC::Ptr<Layout::NodeWithStyle> Element::get_pseudo_element_node(CSS::Selector::P
     if (auto element_data = get_pseudo_element(pseudo_element); element_data.has_value())
         return element_data->layout_node;
     return nullptr;
+}
+
+bool Element::affected_by_hover() const
+{
+    if (m_computed_properties && m_computed_properties->did_match_any_hover_rules()) {
+        return true;
+    }
+    if (m_pseudo_element_data) {
+        for (auto& pseudo_element : *m_pseudo_element_data) {
+            if (!pseudo_element.computed_properties)
+                continue;
+            if (pseudo_element.computed_properties->did_match_any_hover_rules())
+                return true;
+        }
+    }
+    return false;
 }
 
 bool Element::has_pseudo_elements() const

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -261,6 +261,8 @@ public:
 
     static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
 
+    bool affected_by_hover() const;
+
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, GC::Ptr<Layout::NodeWithStyle>);
     GC::Ptr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
     bool has_pseudo_elements() const;

--- a/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -70,7 +70,8 @@ static WebIDL::ExceptionOr<Variant<GC::Ptr<Element>, GC::Ref<NodeList>>> scope_m
     // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
     node.for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
-            if (SelectorEngine::matches(selector, {}, element, nullptr, {}, node)) {
+            SelectorEngine::MatchContext context;
+            if (SelectorEngine::matches(selector, element, nullptr, context, {}, node)) {
                 if (return_matches == ReturnMatches::First) {
                     single_result = &element;
                     return TraversalDecision::Break;


### PR DESCRIPTION
Instead of recalculating styles for all nodes in the common ancestor of the new and old hovered nodes' subtrees, this change introduces the following approach:
- While calculating ComputedProperties, a flag is saved if any rule applied to an element is affected by the hover state during the execution of SelectorEngine::matches().
- When the hovered element changes, styles are marked for recalculation only if the flag saved in ComputedProperties indicates that the element could be affected by the hover state.