### PR TITLE
LibWeb/HTML: Fix UTF-16BE/LE not converting to UTF-8

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
@@ -311,7 +311,8 @@ Optional<ByteString> run_prescan_byte_stream_algorithm(DOM::Document& document, 
 
             if (!need_pragma.has_value() || (need_pragma.value() && !got_pragma) || !charset.has_value())
                 continue;
-            if (charset.value() == "UTF-16BE/LE")
+            // https://encoding.spec.whatwg.org/#common-infrastructure-for-utf-16be-and-utf-16le
+            if (charset.value() == "UTF-16BE" || charset.value() == "UTF-16LE")
                 return "UTF-8";
             else if (charset.value() == "x-user-defined")
                 return "windows-1252";

--- a/Tests/LibWeb/Text/expected/document-computed-mimetype.txt
+++ b/Tests/LibWeb/Text/expected/document-computed-mimetype.txt
@@ -1,1 +1,4 @@
-PASS: UTF-8
+Encoding: utf-16be mapped to characterSet: UTF-8
+Encoding: utf-16le mapped to characterSet: UTF-8
+Encoding: utf-8 mapped to characterSet: UTF-8
+Encoding: x-user-defined mapped to characterSet: windows-1252

--- a/Tests/LibWeb/Text/input/document-computed-mimetype.html
+++ b/Tests/LibWeb/Text/input/document-computed-mimetype.html
@@ -2,23 +2,37 @@
 <script src="include.js"></script>
 <script>
     asyncTest(async (done) => {
-        const httpServer = httpTestServer();
-        const url = await httpServer.createEcho("GET", "/document-computed-mimetype-test", {
-            status: 200,
-            headers: {
-                "Access-Control-Allow-Origin": "*",
-            },
-            body: `<!doctype html><meta charset="UTF-8"><script>parent.postMessage(document.characterSet, "*")<\/script>`,
-        });
+        const encodings = ['utf-8', 'utf-16be', 'utf-16le', 'x-user-defined'];
 
-        const frame = document.createElement('iframe');
-        frame.src = url;
+        let receivedMessages = [];
+        const dumpMessages = () => {
+            receivedMessages.sort((a, b) => a.encoding.localeCompare(b.encoding));
+            for (const receivedMessage of receivedMessages) {
+                println(`Encoding: ${receivedMessage.encoding} mapped to characterSet: ${receivedMessage.characterSet}`);
+            }
+        };
 
         addEventListener("message", (event) => {
-            println("PASS: " + event.data);
-            done();
+            receivedMessages.push(event.data);
+            if (receivedMessages.length == encodings.length) {
+                dumpMessages();
+                done();
+            }
         }, false);
 
-        document.body.appendChild(frame);
+        const httpServer = httpTestServer();
+        for (let encoding of encodings) {
+            const url = await httpServer.createEcho("GET", `/document-computed-mimetype-test-${encoding}`, {
+                status: 200,
+                headers: {
+                    "Access-Control-Allow-Origin": "*",
+                },
+                body: `<!doctype html><meta charset="${encoding}"><script>parent.postMessage({"encoding": "${encoding}", "characterSet": document.characterSet}, "*")<\/script>`,
+            });
+
+            const frame = document.createElement("iframe");
+            frame.src = url;
+            document.body.appendChild(frame);
+        }
     });
 </script>


### PR DESCRIPTION
The correct behavior is specified in the standard [here](https://encoding.spec.whatwg.org/#common-infrastructure-for-utf-16be-and-utf-16le). I believe the mistake was made when reading "If charset is UTF-16BE/LE, then set charset to UTF-8" in the standard document [here](https://html.spec.whatwg.org/multipage/parsing.html#documentEncoding).

Fixes 9 [WPT tests](https://wpt.fyi/results/dom/nodes/Document-characterSet-normalization-1.html?product=ladybird).

I had wanted to import the WPT test, but as the entire test takes >30s to run (on my machine), I don't think that's really wanted. I can, however, create a small test just for this case if you'd like, but feel like it's quite niche.
