### PR TITLE
LibWeb/HTML: Upstream some changes from transferable streams branch

### DIFF
--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -438,17 +438,28 @@ void MessagePort::close()
         disentangle();
 }
 
-#undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)                         \
-    void MessagePort::set_##attribute_name(WebIDL::CallbackType* value) \
-    {                                                                   \
-        set_event_handler_attribute(event_name, value);                 \
-    }                                                                   \
-    WebIDL::CallbackType* MessagePort::attribute_name()                 \
-    {                                                                   \
-        return event_handler_attribute(event_name);                     \
-    }
-ENUMERATE_MESSAGE_PORT_EVENT_HANDLERS(__ENUMERATE)
-#undef __ENUMERATE
+// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessageerror
+void MessagePort::set_onmessageerror(GC::Ptr<WebIDL::CallbackType> value)
+{
+    set_event_handler_attribute(EventNames::messageerror, value);
+}
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessageerror
+GC::Ptr<WebIDL::CallbackType> MessagePort::onmessageerror()
+{
+    return event_handler_attribute(EventNames::messageerror);
+}
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessage
+void MessagePort::set_onmessage(GC::Ptr<WebIDL::CallbackType> value)
+{
+    set_event_handler_attribute(EventNames::message, value);
+}
+
+// https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessage
+GC::Ptr<WebIDL::CallbackType> MessagePort::onmessage()
+{
+    return event_handler_attribute(EventNames::message);
+}
 
 }

--- a/Libraries/LibWeb/HTML/MessagePort.cpp
+++ b/Libraries/LibWeb/HTML/MessagePort.cpp
@@ -454,6 +454,11 @@ GC::Ptr<WebIDL::CallbackType> MessagePort::onmessageerror()
 void MessagePort::set_onmessage(GC::Ptr<WebIDL::CallbackType> value)
 {
     set_event_handler_attribute(EventNames::message, value);
+
+    // https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports:handler-messageeventtarget-onmessage
+    // The first time a MessagePort object's onmessage IDL attribute is set, the port's port message queue must be enabled,
+    // as if the start() method had been called.
+    start();
 }
 
 // https://html.spec.whatwg.org/multipage/web-messaging.html#handler-messageeventtarget-onmessage

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -36,6 +36,9 @@ public:
 
     void disentangle();
 
+    GC::Ptr<MessagePort> entangled_port() { return m_remote_port; }
+    GC::Ptr<MessagePort const> entangled_port() const { return m_remote_port; }
+
     // https://html.spec.whatwg.org/multipage/web-messaging.html#dom-messageport-postmessage
     WebIDL::ExceptionOr<void> post_message(JS::Value message, Vector<GC::Root<JS::Object>> const& transfer);
 
@@ -59,6 +62,8 @@ public:
 
     void set_worker_event_target(GC::Ref<DOM::EventTarget>);
 
+    WebIDL::ExceptionOr<void> message_port_post_message_steps(GC::Ptr<MessagePort> target_port, JS::Value message, StructuredSerializeOptions const& options);
+
 private:
     explicit MessagePort(JS::Realm&);
 
@@ -68,7 +73,6 @@ private:
 
     bool is_entangled() const;
 
-    WebIDL::ExceptionOr<void> message_port_post_message_steps(GC::Ptr<MessagePort> target_port, JS::Value message, StructuredSerializeOptions const& options);
     void post_message_task_steps(SerializedTransferRecord&);
     void post_port_message(SerializedTransferRecord);
     ErrorOr<void> send_message_on_transport(SerializedTransferRecord const&);

--- a/Libraries/LibWeb/HTML/MessagePort.h
+++ b/Libraries/LibWeb/HTML/MessagePort.h
@@ -18,10 +18,6 @@
 
 namespace Web::HTML {
 
-#define ENUMERATE_MESSAGE_PORT_EVENT_HANDLERS(E) \
-    E(onmessage, HTML::EventNames::message)      \
-    E(onmessageerror, HTML::EventNames::messageerror)
-
 // https://html.spec.whatwg.org/multipage/web-messaging.html#message-ports
 class MessagePort final : public DOM::EventTarget
     , public Bindings::Transferable {
@@ -50,12 +46,11 @@ public:
 
     void close();
 
-#undef __ENUMERATE
-#define __ENUMERATE(attribute_name, event_name)       \
-    void set_##attribute_name(WebIDL::CallbackType*); \
-    WebIDL::CallbackType* attribute_name();
-    ENUMERATE_MESSAGE_PORT_EVENT_HANDLERS(__ENUMERATE)
-#undef __ENUMERATE
+    void set_onmessageerror(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onmessageerror();
+
+    void set_onmessage(GC::Ptr<WebIDL::CallbackType>);
+    GC::Ptr<WebIDL::CallbackType> onmessage();
 
     // ^Transferable
     virtual WebIDL::ExceptionOr<void> transfer_steps(HTML::TransferDataHolder&) override;

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -1136,7 +1136,7 @@ WebIDL::ExceptionOr<void> Window::window_post_message_steps(JS::Value message, W
         auto& source = verify_cast<WindowProxy>(incumbent_settings.realm().global_environment().global_this_value());
 
         // 4. Let deserializeRecord be StructuredDeserializeWithTransfer(serializeWithTransferResult, targetRealm).
-        auto temporary_execution_context = TemporaryExecutionContext { target_realm };
+        auto temporary_execution_context = TemporaryExecutionContext { target_realm, TemporaryExecutionContext::CallbacksEnabled::Yes };
         auto deserialize_record_or_error = structured_deserialize_with_transfer(vm(), serialize_with_transfer_result);
 
         // If this throws an exception, catch it, fire an event named messageerror at targetWindow, using MessageEvent,


### PR DESCRIPTION
I've been trying to implement transferable streams for a bit, and have half working implementation with the additional changes of:

Implementing the transferable streams AOs:  https://github.com/shannonbooth/ladybird/commit/77c937a498743d018a30d6c0e225f180796546f7

And using those AOs to make ReadableStream transferable: https://github.com/shannonbooth/ladybird/commit/5c5f2503661f240521724c92e7c022700b3583ff (very similar diff needed for WritableStream)

I've been debugging some issues in MessagePort / Pipe implementation which are causing some issues with that implementation causing timeouts / messages to not be received on the other end of the message port. In the meantime, this upstreams a portion of the changes from that branch.