### PR TITLE
AK: Add optional `message` argument to VERIFY and friends

### DIFF
--- a/AK/Assertions.cpp
+++ b/AK/Assertions.cpp
@@ -100,22 +100,28 @@ void ak_trap(void)
     __builtin_trap();
 }
 
-void ak_verification_failed(char const* message)
+void ak_verification_failed(char const* message, char const* user_message)
 {
     if (ak_colorize_output())
         ERRORLN("\033[31;1mVERIFICATION FAILED\033[0m: {}", message);
     else
         ERRORLN("VERIFICATION FAILED: {}", message);
 
+    if (user_message)
+        ERRORLN("{}", user_message);
+
     ak_trap();
 }
 
-void ak_assertion_failed(char const* message)
+void ak_assertion_failed(char const* message, char const* user_message)
 {
     if (ak_colorize_output())
         ERRORLN("\033[31;1mASSERTION FAILED\033[0m: {}", message);
     else
         ERRORLN("ASSERTION FAILED: {}", message);
+
+    if (user_message)
+        ERRORLN("{}", user_message);
 
     ak_trap();
 }

--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -9,29 +9,29 @@
 extern "C" bool ak_colorize_output(void);
 extern "C" __attribute__((noreturn)) void ak_trap(void);
 
-extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*);
+extern "C" __attribute__((noreturn)) void ak_verification_failed(char const*, char const* = 0);
 #define __stringify_helper(x) #x
 #define __stringify(x) __stringify_helper(x)
-#define VERIFY(...)                                                                          \
-    (__builtin_expect(/* NOLINT(readability-simplify-boolean-expr) */ !(__VA_ARGS__), 0)     \
-            ? ak_verification_failed(#__VA_ARGS__ " at " __FILE__ ":" __stringify(__LINE__)) \
+#define VERIFY(expr, ...)                                                                                        \
+    (__builtin_expect(/* NOLINT(readability-simplify-boolean-expr) */ !(expr), 0)                                \
+            ? ak_verification_failed(#expr " at " __FILE__ ":" __stringify(__LINE__) __VA_OPT__(, ) __VA_ARGS__) \
             : (void)0)
-#define VERIFY_NOT_REACHED() VERIFY(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define VERIFY_NOT_REACHED(...) VERIFY(false __VA_OPT__(, ) __VA_ARGS__) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 static constexpr bool TODO = false;
-#define TODO() VERIFY(TODO)         /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#define TODO_AARCH64() VERIFY(TODO) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#define TODO_RISCV64() VERIFY(TODO) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#define TODO_PPC64() VERIFY(TODO)   /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-#define TODO_PPC() VERIFY(TODO)     /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO(...) VERIFY(TODO __VA_OPT__(, ) __VA_ARGS__) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO_AARCH64() VERIFY(TODO)                       /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO_RISCV64() VERIFY(TODO)                       /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO_PPC64() VERIFY(TODO)                         /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#define TODO_PPC() VERIFY(TODO)                           /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 
-extern "C" __attribute__((noreturn)) void ak_assertion_failed(char const*);
+extern "C" __attribute__((noreturn)) void ak_assertion_failed(char const*, char const* = 0);
 #ifndef NDEBUG
-#    define ASSERT(...)                                                                       \
-        (__builtin_expect(/* NOLINT(readability-simplify-boolean-expr) */ !(__VA_ARGS__), 0)  \
-                ? ak_assertion_failed(#__VA_ARGS__ " at " __FILE__ ":" __stringify(__LINE__)) \
+#    define ASSERT(expr, ...)                                                                                     \
+        (__builtin_expect(/* NOLINT(readability-simplify-boolean-expr) */ !(expr), 0)                             \
+                ? ak_assertion_failed(#expr " at " __FILE__ ":" __stringify(__LINE__) __VA_OPT__(, ) __VA_ARGS__) \
                 : (void)0)
-#    define ASSERT_NOT_REACHED() ASSERT(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
+#    define ASSERT_NOT_REACHED(...) ASSERT(false __VA_OPT__(, ) __VA_ARGS__) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #else
-#    define ASSERT(...)
-#    define ASSERT_NOT_REACHED() __builtin_unreachable()
+#    define ASSERT(expr, ...)
+#    define ASSERT_NOT_REACHED(...) __builtin_unreachable()
 #endif


### PR DESCRIPTION
This PR effectively reverts [079edff](https://github.com/LadybirdBrowser/ladybird/pull/2454/commits/079edffd478d6e1acd871d4faf51de2d49a31ce5).

[Discord discussion.](https://discord.com/channels/1247070541085671459/1256703242679746560/1347550062154223637)

-----

This works only in clang-cl, doesn't work in clang/gcc by default:
```cpp
#define VERIFY(expr, msg...) func(#expr, msg)
```
This works in 2 CIs, fails in other two with [expected primary-expression before ‘)’ token](https://github.com/LadybirdBrowser/ladybird/actions/runs/12607986659/job/35139964682?pr=3132):
```
#define VERIFY(expr, msg...) func(#expr ,##msg)
```
This produces `warning: __VA_OPT__ can only appear in the expansion of a C++2a variadic macro`:
```cpp
#define VERIFY(expr, msg...) func(#expr __VA_OPT__(,) msg)
```
That's how I arrived at this abomination:
```cpp
#define VERIFY(expr, ...) func(#expr __VA_OPT__(,) __VA_ARGS__)
```