### PR TITLE
LibWeb/XML: Set attributes using Element::set_attribute_ns

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.cpp
@@ -142,12 +142,13 @@ void XMLDocumentBuilder::element_start(const XML::Name& name, HashMap<XML::Name,
             } else {
                 m_has_error = true;
             }
-        } else if (attribute.key.contains(":"sv)) {
-            if (!attribute.key.starts_with("xml:"sv)) {
+        } else if (attribute.key.contains(':')) {
+            auto result = node->set_attribute_ns(m_namespace, MUST(FlyString::from_deprecated_fly_string(attribute.key)), MUST(String::from_byte_string(attribute.value)));
+            if (result.is_error())
                 m_has_error = true;
-            }
+        } else {
+            MUST(node->set_attribute(MUST(FlyString::from_deprecated_fly_string(attribute.key)), MUST(String::from_byte_string(attribute.value))));
         }
-        MUST(node->set_attribute(MUST(FlyString::from_deprecated_fly_string(attribute.key)), MUST(String::from_byte_string(attribute.value))));
     }
 
     m_current_node = node.ptr();


### PR DESCRIPTION
Otherwise we'd end up ignoring attr prefixes and treating them as part of the attribute's local name.
Fixes #3137.