### PR TITLE
LibWeb: Optimize inherited style update caused by animation

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -939,7 +939,10 @@ void KeyframeEffect::update_computed_properties()
 
     // Traversal of the subtree is necessary to update the animated properties inherited from the target element.
     target->for_each_in_subtree_of_type<DOM::Element>([&](auto& element) {
-        invalidation |= element.recompute_inherited_style();
+        auto element_invalidation = element.recompute_inherited_style();
+        if (element_invalidation.is_none())
+            return TraversalDecision::SkipChildrenAndContinue;
+        invalidation |= element_invalidation;
         return TraversalDecision::Continue;
     });
 


### PR DESCRIPTION
It is possible to skip inherited style recalculation for children if parent's recalculation does not cause any changes.

Improves performance on Github where we could avoid dozens of inherited style calculations that do not produce any visible changes.