### PR TITLE
LibWeb: Avoid invalidation on .textContent setter no-op

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -202,6 +202,10 @@ void Node::set_text_content(Optional<String> const& maybe_content)
 
     // If DocumentFragment or Element, string replace all with the given value within this.
     if (is<DocumentFragment>(this) || is<Element>(this)) {
+        // OPTIMIZATION: Replacing nothing with nothing is a no-op. Avoid all invalidation in this case.
+        if (!first_child() && content.is_empty()) {
+            return;
+        }
         string_replace_all(content);
     }
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -74,6 +74,7 @@ enum class IsDescendant {
     X(HTMLIFrameElementGeometryChange)              \
     X(HTMLInputElementSetChecked)                   \
     X(HTMLObjectElementUpdateLayoutAndChildObjects) \
+    X(HTMLOptionElementSelectedChange)              \
     X(HTMLSelectElementSetIsOpen)                   \
     X(Hover)                                        \
     X(MediaQueryChangedMatchState)                  \

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -68,6 +68,9 @@ void HTMLOptionElement::set_selected(bool selected)
 
 void HTMLOptionElement::set_selected_internal(bool selected)
 {
+    if (m_selected != selected)
+        invalidate_style(DOM::StyleInvalidationReason::HTMLOptionElementSelectedChange);
+
     m_selected = selected;
     if (selected)
         m_selectedness_update_index = m_next_selectedness_update_index++;


### PR DESCRIPTION
When setting the textContent of an element with no children to null or the empty string, nothing happens. Even so, we were still invalidating style, layout and collections, causing pointless churn.

Skipping invalidation in this case also revealed that we were missing invalidation when changing the selected state of HTMLOptionElement. This was all caught by existing tests already in-tree. :^)