### PR TITLE
LibWeb/HTML: Update/add "cloning steps" algorithms

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1660,9 +1660,11 @@ void HTMLInputElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropertie
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#the-input-element%3Aconcept-node-clone-ext
-WebIDL::ExceptionOr<void> HTMLInputElement::cloned(DOM::Node& copy, bool)
+WebIDL::ExceptionOr<void> HTMLInputElement::cloned(DOM::Node& copy, bool subtree)
 {
-    // The cloning steps for input elements must propagate the value, dirty value flag, checkedness, and dirty checkedness flag from the node being cloned to the copy.
+    TRY(Base::cloned(copy, subtree));
+
+    // The cloning steps for input elements given node, copy, and subtree are to propagate the value, dirty value flag, checkedness, and dirty checkedness flag from node to copy.
     auto& input_clone = verify_cast<HTMLInputElement>(copy);
     input_clone.m_value = m_value;
     input_clone.m_dirty_value = m_dirty_value;

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
@@ -56,7 +56,7 @@ void HTMLOrSVGElement<ElementBase>::blur()
     // User agents may selectively or uniformly ignore calls to this method for usability reasons.
 }
 
-// https://html.spec.whatwg.org/#dom-noncedelement-nonce
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce
 template<typename ElementBase>
 void HTMLOrSVGElement<ElementBase>::attribute_changed(FlyString const& local_name, Optional<String> const&, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
@@ -76,17 +76,17 @@ void HTMLOrSVGElement<ElementBase>::attribute_changed(FlyString const& local_nam
     }
 }
 
-// https://html.spec.whatwg.org/#dom-noncedelement-nonce
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce
 template<typename ElementBase>
 WebIDL::ExceptionOr<void> HTMLOrSVGElement<ElementBase>::cloned(DOM::Node& copy, bool)
 {
-    // The cloning steps for elements that include HTMLOrSVGElement must set the
-    // [[CryptographicNonce]] slot on the copy to the value of the slot on the element being cloned.
+    // The cloning steps for elements that include HTMLOrSVGElement given node, copy, and subtree
+    // are to set copy's [[CryptographicNonce]] to node's [[CryptographicNonce]].
     static_cast<ElementBase&>(copy).m_cryptographic_nonce = m_cryptographic_nonce;
     return {};
 }
 
-// https://html.spec.whatwg.org/#dom-noncedelement-nonce
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce
 template<typename ElementBase>
 void HTMLOrSVGElement<ElementBase>::inserted()
 {

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -650,4 +650,16 @@ void HTMLScriptElement::set_async(bool async)
     }
 }
 
+// https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model:concept-node-clone-ext
+WebIDL::ExceptionOr<void> HTMLScriptElement::cloned(Node& copy, bool subtree)
+{
+    TRY(Base::cloned(copy, subtree));
+
+    // The cloning steps for script elements given node, copy, and subtree are to set copy's already started to node's already started.
+    auto& script_copy = verify_cast<HTMLScriptElement>(copy);
+    script_copy.m_already_started = m_already_started;
+
+    return {};
+}
+
 }

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -63,6 +63,8 @@ public:
     [[nodiscard]] bool async() const;
     void set_async(bool);
 
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
+
 private:
     HTMLScriptElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -136,9 +136,11 @@ void HTMLTextAreaElement::clear_algorithm()
 }
 
 // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-node-clone-ext
-WebIDL::ExceptionOr<void> HTMLTextAreaElement::cloned(DOM::Node& copy, bool)
+WebIDL::ExceptionOr<void> HTMLTextAreaElement::cloned(DOM::Node& copy, bool subtree)
 {
-    // The cloning steps for textarea elements must propagate the raw value and dirty value flag from the node being cloned to the copy.
+    TRY(Base::cloned(copy, subtree));
+
+    // The cloning steps for textarea elements given node, copy, and subtree are to propagate the raw value and dirty value flag from node to copy.
     auto& textarea_copy = verify_cast<HTMLTextAreaElement>(copy);
     textarea_copy.m_raw_value = m_raw_value;
     textarea_copy.m_dirty_value = m_dirty_value;


### PR DESCRIPTION
The spec changed for these, but I also noticed we weren't calling the base method, and that HTMLScriptElement didn't have one at all. So that's all sorted.