### PR TITLE
LibWeb/HTML: Update some navigables code to current spec

### DIFF
--- a/Libraries/LibURL/Host.cpp
+++ b/Libraries/LibURL/Host.cpp
@@ -191,14 +191,13 @@ Optional<String> Host::public_suffix() const
     auto trailing_dot = host_string.ends_with('.') ? "."sv : ""sv;
 
     // 3. Let publicSuffix be the public suffix determined by running the Public Suffix List algorithm with host as domain. [PSL]
-    auto public_suffix = get_public_suffix(host_string.bytes_as_string_view());
-
-    // NOTE: get_public_suffix() returns Optional, but this algorithm assumes a value. Is that OK?
-    VERIFY(public_suffix.has_value());
+    // NOTE: The spec algorithm for the public suffix returns "*" by default, but get_public_suffix() returns an empty Optional.
+    //       Remove the `value_or()` if and when we update it.
+    auto public_suffix = get_public_suffix(host_string.bytes_as_string_view()).value_or("*"_string);
 
     // 4. Assert: publicSuffix is an ASCII string that does not end with ".".
-    VERIFY(all_of(public_suffix->code_points(), is_ascii));
-    VERIFY(!public_suffix->ends_with('.'));
+    VERIFY(all_of(public_suffix.code_points(), is_ascii));
+    VERIFY(!public_suffix.ends_with('.'));
 
     // 5. Return publicSuffix and trailingDot concatenated.
     return MUST(String::formatted("{}{}", public_suffix, trailing_dot));
@@ -219,14 +218,13 @@ Optional<String> Host::registrable_domain() const
     auto trailing_dot = host_string.ends_with('.') ? "."sv : ""sv;
 
     // 3. Let registrableDomain be the registrable domain determined by running the Public Suffix List algorithm with host as domain. [PSL]
-    auto registrable_domain = get_public_suffix(host_string);
-
-    // NOTE: get_public_suffix() returns Optional, but this algorithm assumes a value. Is that OK?
-    VERIFY(registrable_domain.has_value());
+    // NOTE: The spec algorithm for the public suffix returns "*" by default, but get_public_suffix() returns an empty Optional.
+    //       Remove the `value_or()` if and when we update it.
+    auto registrable_domain = get_public_suffix(host_string).value_or("*"_string);
 
     // 4. Assert: registrableDomain is an ASCII string that does not end with ".".
-    VERIFY(all_of(registrable_domain->code_points(), is_ascii));
-    VERIFY(!registrable_domain->ends_with('.'));
+    VERIFY(all_of(registrable_domain.code_points(), is_ascii));
+    VERIFY(!registrable_domain.ends_with('.'));
 
     // 5. Return registrableDomain and trailingDot concatenated.
     return MUST(String::formatted("{}{}", registrable_domain, trailing_dot));

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -763,7 +763,7 @@ GC::Ptr<HTML::WindowProxy const> Document::default_view() const
     return const_cast<Document*>(this)->default_view();
 }
 
-URL::Origin Document::origin() const
+URL::Origin const& Document::origin() const
 {
     return m_origin;
 }

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -151,7 +151,7 @@ public:
     String url_string() const { return m_url.to_string(); }
     String document_uri() const { return url_string(); }
 
-    URL::Origin origin() const;
+    URL::Origin const& origin() const;
     void set_origin(URL::Origin const& origin);
 
     HTML::OpenerPolicy const& opener_policy() const { return m_opener_policy; }

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -113,6 +113,8 @@ public:
 
     ChosenNavigable choose_a_navigable(StringView name, TokenizedFeature::NoOpener no_opener, ActivateTab = ActivateTab::Yes, Optional<TokenizedFeature::Map const&> window_features = {});
 
+    GC::Ptr<Navigable> find_a_navigable_by_target_name(StringView name);
+
     static GC::Ptr<Navigable> navigable_with_active_document(GC::Ref<DOM::Document>);
 
     enum class Traversal {


### PR DESCRIPTION
This is a partial implementation of the changes in https://github.com/whatwg/html/pull/10818

I don't know if the ad-hoc change in Host is because of a spec bug, or just our implementation being wrong. (I suspect the latter.) Maybe `localhost` should fail the `Host::is_domain()` call, but the spec is pretty vague.