### PR TITLE
LibWeb: Emit comment token for unterminated bogus comments on EOF

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -487,8 +487,8 @@ _StartOfFunction:
                 }
                 ON_EOF
                 {
-                    m_queued_tokens.enqueue(move(m_current_token));
-                    EMIT_EOF;
+                    m_current_token.set_comment(consume_current_builder());
+                    EMIT_CURRENT_TOKEN_FOLLOWED_BY_EOF;
                 }
                 ON(0)
                 {

--- a/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/html5lib_comments01.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/syntax/parsing/html5lib_comments01.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 16 tests
 
-15 Pass
-1 Fail
+16 Pass
 Pass	html5lib_comments01.html 3dbda8330033c3fbf3185a55e963075328099578
 Pass	html5lib_comments01.html 7476098e9823b3deee1857739daf719ff18e37b4
 Pass	html5lib_comments01.html eca7f97a4659eab6da4127c225420f1664b6c0c4
@@ -17,6 +16,6 @@ Pass	html5lib_comments01.html 8b36d140a4a223b083a8d41af7c98a1c20377856
 Pass	html5lib_comments01.html 1894e23c5ee89d6f4b5f1dbe9b681b42863b4d1f
 Pass	html5lib_comments01.html 2cefeae994b6b0be0accbfff4757fef40ed914eb
 Pass	html5lib_comments01.html ac9fd94008255e73cba953dbd374cb41703f5446
-Fail	html5lib_comments01.html 617815b6a683613fcb6b9cd5841b2ea7428d838d
+Pass	html5lib_comments01.html 617815b6a683613fcb6b9cd5841b2ea7428d838d
 Pass	html5lib_comments01.html bb8faf75d2e28aee13ec4a0d8eab00b4d7475763
 Pass	html5lib_comments01.html 89c4ae1ae34df9dff0e516afdef87cd169c3e6a5


### PR DESCRIPTION
This fixes the 1 remaining failing subtest in http://wpt.live/html/syntax/parsing/html5lib_comments01.html