### PR TITLE
LibWeb: Return early if insets are missing

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -249,6 +249,7 @@ public:
         Optional<CSSPixels> left;
     };
     StickyInsets const& sticky_insets() const { return *m_sticky_insets; }
+    StickyInsets const* sticky_insets_ptr() const { return m_sticky_insets.ptr(); }
     void set_sticky_insets(OwnPtr<StickyInsets> sticky_insets) { m_sticky_insets = move(sticky_insets); }
 
     [[nodiscard]] bool is_scrollable() const;

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -181,6 +181,10 @@ void ViewportPaintable::refresh_scroll_state()
 
     m_scroll_state.for_each_sticky_frame([&](auto& scroll_frame) {
         auto const& sticky_box = scroll_frame->paintable_box();
+
+        if (!sticky_box.sticky_insets_ptr())
+            return;
+
         auto const& sticky_insets = sticky_box.sticky_insets();
 
         auto const* nearest_scrollable_ancestor = sticky_box.nearest_scrollable_ancestor();


### PR DESCRIPTION
Fixed #3133 

We aren't returning early enough to load the page.