### PR TITLE
LibCore: Consistently treat file descriptors as handles on Windows

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2023, Liav A. <liavalb@hotmail.co.il>
  * Copyright (c) 2023, Cameron Youell <cameronyouell@gmail.com>
- * Copyright (c) 2024, stasoid <stasoid@yahoo.com>
+ * Copyright (c) 2024-2025, stasoid <stasoid@yahoo.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,6 +11,8 @@
 #    include <AK/ByteString.h>
 #    include <AK/HashMap.h>
 #    include <windows.h>
+// Comment to prevent clang-format from including windows.h too late
+#    include <winbase.h>
 #endif
 
 namespace AK {
@@ -21,31 +23,39 @@ Error Error::from_string_view_or_print_error_and_return_errno(StringView string_
 }
 
 #ifdef AK_OS_WINDOWS
-Error Error::from_windows_error(DWORD code)
+Error Error::from_windows_error(u64 code)
 {
-    static HashMap<DWORD, ByteString> windows_errors;
+    thread_local HashMap<u64, ByteString> s_windows_errors;
 
-    auto string = windows_errors.get(code);
-    if (string.has_value()) {
+    auto string = s_windows_errors.get(code);
+    if (string.has_value())
         return Error::from_string_view(string->view());
-    } else {
-        char* message = nullptr;
-        auto size = FormatMessageA(
-            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
-            nullptr,
-            code,
-            MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-            (LPSTR)&message,
-            0,
-            nullptr);
 
-        if (size == 0)
-            return Error::from_string_view_or_print_error_and_return_errno("Unknown error"sv, code);
+    char* message = nullptr;
+    auto size = FormatMessage(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr,
+        static_cast<DWORD>(code),
+        MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+        reinterpret_cast<LPSTR>(&message),
+        0,
+        nullptr);
 
-        windows_errors.set(code, { message, size });
-        LocalFree(message);
-        return from_windows_error(code);
+    if (size == 0) {
+        static char buffer[128];
+        (void)snprintf(buffer, _countof(buffer), "Error 0x%08lX while getting text of error 0x%08llX", GetLastError(), code);
+        return Error::from_string_view({ buffer, _countof(buffer) });
     }
+
+    auto& string_in_map = s_windows_errors.ensure(code, [message, size] { return ByteString { message, size }; });
+    LocalFree(message);
+    return Error::from_string_view(string_in_map.view());
+}
+
+// This can be used both for generic Windows errors and for winsock errors because WSAGetLastError is forwarded to GetLastError.
+Error Error::from_windows_error()
+{
+    return from_windows_error(GetLastError());
 }
 #endif
 

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -7,13 +7,8 @@
 #pragma once
 
 #include <AK/StringView.h>
-#include <AK/Try.h>
 #include <AK/Variant.h>
 #include <errno.h>
-#include <string.h>
-#ifdef AK_OS_WINDOWS
-typedef unsigned long DWORD;
-#endif
 
 namespace AK {
 
@@ -29,7 +24,8 @@ public:
     }
 
 #ifdef AK_OS_WINDOWS
-    static Error from_windows_error(DWORD code);
+    static Error from_windows_error(u64 code);
+    static Error from_windows_error();
 #endif
 
     // NOTE: For calling this method from within kernel code, we will simply print

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -207,6 +207,17 @@ enum MemoryOrder {
     memory_order_seq_cst = __ATOMIC_SEQ_CST
 };
 
+#ifdef AK_OS_WINDOWS
+inline void* to_handle(int fd)
+{
+    return reinterpret_cast<void*>(static_cast<intptr_t>(fd));
+}
+inline int to_fd(void* handle)
+{
+    return reinterpret_cast<intptr_t>(handle);
+}
+#endif
+
 }
 
 #if USING_AK_GLOBALLY
@@ -216,4 +227,8 @@ using AK::explode_byte;
 using AK::MemoryOrder;
 using AK::nullptr_t;
 using AK::TriState;
+#    ifdef AK_OS_WINDOWS
+using AK::to_fd;
+using AK::to_handle;
+#    endif
 #endif

--- a/Libraries/LibCore/AnonymousBufferWindows.cpp
+++ b/Libraries/LibCore/AnonymousBufferWindows.cpp
@@ -30,7 +30,7 @@ ErrorOr<NonnullRefPtr<AnonymousBufferImpl>> AnonymousBufferImpl::create(size_t s
 {
     HANDLE map_handle = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, size >> 31 >> 1, size & 0xFFFFFFFF, NULL);
     if (!map_handle)
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
 
     return create((int)(intptr_t)map_handle, size);
 }
@@ -39,7 +39,7 @@ ErrorOr<NonnullRefPtr<AnonymousBufferImpl>> AnonymousBufferImpl::create(int fd, 
 {
     void* ptr = MapViewOfFile((HANDLE)(intptr_t)fd, FILE_MAP_ALL_ACCESS, 0, 0, size);
     if (!ptr)
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
 
     return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousBufferImpl(fd, size, ptr));
 }

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2023, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2024, stasoid <stasoid@yahoo.com>
+ * Copyright (c) 2024-2025, stasoid <stasoid@yahoo.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -163,10 +163,8 @@ void EventLoopManagerWindows::register_notifier(Notifier& notifier)
 {
     HANDLE event = CreateEvent(NULL, FALSE, FALSE, NULL);
     VERIFY(event);
-    SOCKET socket = _get_osfhandle(notifier.fd());
-    VERIFY(socket != INVALID_SOCKET);
-    int rc = WSAEventSelect(socket, event, notifier_type_to_network_event(notifier.type()));
-    VERIFY(rc == 0);
+    int rc = WSAEventSelect(notifier.fd(), event, notifier_type_to_network_event(notifier.type()));
+    VERIFY(!rc);
 
     auto& notifiers = ThreadData::the().notifiers;
     VERIFY(!notifiers.get(event).has_value());

--- a/Libraries/LibCore/ProcessWindows.cpp
+++ b/Libraries/LibCore/ProcessWindows.cpp
@@ -71,7 +71,7 @@ ErrorOr<Process> Process::spawn(ProcessSpawnOptions const& options)
         &process_info);
 
     if (!result)
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
 
     CloseHandle(process_info.hThread);
 
@@ -108,7 +108,7 @@ ErrorOr<String> Process::get_name()
 
     DWORD length = GetModuleFileNameW(NULL, path, MAX_PATH);
     if (!length)
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
 
     return String::from_utf16(Utf16View { { (u16*)path, length } });
 }
@@ -150,11 +150,11 @@ ErrorOr<int> Process::wait_for_termination()
 {
     auto result = WaitForSingleObject(m_handle, INFINITE);
     if (result == WAIT_FAILED)
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
 
     DWORD exit_code = 0;
     if (!GetExitCodeProcess(m_handle, &exit_code))
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
 
     return exit_code;
 }

--- a/Libraries/LibCore/System.cpp
+++ b/Libraries/LibCore/System.cpp
@@ -1004,4 +1004,10 @@ int getpid()
     return ::getpid();
 }
 
+bool is_socket(int fd)
+{
+    auto result = fstat(fd);
+    return !result.is_error() && S_ISSOCK(result.value().st_mode);
+}
+
 }

--- a/Libraries/LibCore/System.h
+++ b/Libraries/LibCore/System.h
@@ -180,5 +180,6 @@ ErrorOr<void> set_resource_limits(int resource, rlim_t limit);
 #endif
 
 int getpid();
+bool is_socket(int fd);
 
 }

--- a/Libraries/LibCore/SystemWindows.cpp
+++ b/Libraries/LibCore/SystemWindows.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> open(StringView path, int options, mode_t mode)
         if (::stat(sz_path, &st) == 0 && (st.st_mode & S_IFDIR)) {
             HANDLE dir_handle = CreateFile(sz_path, GENERIC_ALL, 0, NULL, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, NULL);
             if (dir_handle == INVALID_HANDLE_VALUE)
-                return Error::from_windows_error(GetLastError());
+                return Error::from_windows_error();
             int dir_fd = _open_osfhandle((intptr_t)dir_handle, 0);
             if (dir_fd != -1)
                 return dir_fd;
@@ -84,7 +84,7 @@ ErrorOr<void> ftruncate(int fd, off_t length)
         return result.release_error();
 
     if (SetEndOfFile((HANDLE)_get_osfhandle(fd)) == 0)
-        return Error::from_windows_error(GetLastError());
+        return Error::from_windows_error();
     return {};
 }
 


### PR DESCRIPTION
This PR replaces #2946. It is a prerequisite for [LibIPC](https://github.com/LadybirdBrowser/ladybird/pull/2643).

Before porting LibIPC we used CRT file descriptors for files/directories/sockets and file mapping handle (cast to int) for AnonymousBuffer.
When porting LibIPC it became apparent that System::dup and System::close need to be able to work with all types of objects mentioned above.
To address this problem I created #2946 which took a safe route: it allowed to coexist CRT fds and handles by using sign bit to distinguish between them.
Also I realized that [CRT fds are better not be used for sockets](https://github.com/LadybirdBrowser/ladybird/pull/2643#issuecomment-2547541084).
I was already on edge about #2946 when I wrote it. The solution seemed a bit too convoluted for the problem it tried to solve.

These two thing pushed me over the edge:
* All validity checks of the form `fd < 0` should be changed to `fd == -1`. Seems like not much, but it is one more thing to remember.
* SOCKET_TAKEOVER "just works" if fd == handle, otherwise we need some ugly-ass code like
```cpp
// LibWebView/Process.cpp

#ifndef AK_OS_WINDOWS
    auto takeover_string = MUST(String::formatted("{}:{}", options.name, socket_fds[1]));
#else
    auto takeover_string = MUST(String::formatted("{}:{}", options.name, (intptr_t)Core::System::fd_to_handle(socket_fds[1])));
#endif

// LibCore/SystemServerTakeover.cpp

#ifndef AK_OS_WINDOWS
        s_overtaken_sockets.set(params[0].to_byte_string(), params[1].to_number<int>().value());
#else
        s_overtaken_sockets.set(params[0].to_byte_string(), handle_to_fd(params[1].to_number<intptr_t>().value(), System::SocketHandle));
#endif
```
The problem with CRT fds is that they are fake fds, they only work for some objects (files, folders) and certain circumstances (they cannot be inherited like handles).
So in the end they are too cumbersome to work with in our case.

So I decided to bite the bullet and consistently treat file descriptors as handles on Windows. Now, if you see an fd somewhere in the code outside of SystemWindows.cpp, it is always simply holds a handle on Windows. 
Note: Windows handle is [not an actual pointer](https://stackoverflow.com/a/30428340), so it can safely be cast to int.

I was afraid that it will uglify SystemWindows.cpp, but this implementation turned out to be even shorter (by 40 lines). I am very pleased with the result.

There are only 3 places left in SystemWindows.cpp that use CRT fds: open, fstat and mmap. mmap requires fd, and with open/fstat I just wanted to use existing functions instead of implementing them manually using WIN32 APIs.
I use `dup` in these functions as advised [here](https://stackoverflow.com/a/37549324) because there is no way of closing fd without closing underlying handle and handles that are associated with fds should not be closed with `CloseHandle` ([link](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-osfhandle)).
I renamed all fd arguments in SystemWindows.cpp to `handle` to distinguish them from CRT fds used in those 3 functions.
