### PR TITLE
LibWeb/CSS: Preparation for calc() contexts

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -446,14 +446,6 @@ bool CSSNumericType::matches_number() const
     return true;
 }
 
-// https://drafts.css-houdini.org/css-typed-om-1/#cssnumericvalue-match
-bool CSSNumericType::matches_number_percentage() const
-{
-    // FIXME: This is incorrect. <number-percentage> is not a legal type. Instead we should check separately if this
-    //        matches a number, or if it matches a percentage.
-    return matches_number() || matches_percentage();
-}
-
 bool CSSNumericType::matches_dimension() const
 {
     // This isn't a spec algorithm.

--- a/Libraries/LibWeb/CSS/CSSNumericType.h
+++ b/Libraries/LibWeb/CSS/CSSNumericType.h
@@ -76,7 +76,6 @@ public:
     bool matches_length() const { return matches_dimension(BaseType::Length); }
     bool matches_length_percentage() const { return matches_dimension_percentage(BaseType::Length); }
     bool matches_number() const;
-    bool matches_number_percentage() const;
     bool matches_percentage() const;
     bool matches_resolution() const { return matches_dimension(BaseType::Resolution); }
     bool matches_resolution_percentage() const { return matches_dimension_percentage(BaseType::Resolution); }

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3879,29 +3879,16 @@ RefPtr<CSSStyleValue> Parser::parse_paint_value(TokenStream<ComponentValue>& tok
 // https://www.w3.org/TR/css-values-4/#position
 RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentValue>& tokens, PositionParsingMode position_parsing_mode)
 {
-    auto parse_position_edge = [](ComponentValue const& token) -> Optional<PositionEdge> {
+    auto parse_position_edge = [](TokenStream<ComponentValue>& tokens) -> Optional<PositionEdge> {
+        auto transaction = tokens.begin_transaction();
+        auto& token = tokens.consume_a_token();
         if (!token.is(Token::Type::Ident))
             return {};
         auto keyword = keyword_from_string(token.token().ident());
         if (!keyword.has_value())
             return {};
+        transaction.commit();
         return keyword_to_position_edge(*keyword);
-    };
-
-    auto parse_length_percentage = [&](ComponentValue const& token) -> Optional<LengthPercentage> {
-        if (token.is(Token::Type::EndOfFile))
-            return {};
-
-        if (auto dimension = parse_dimension(token); dimension.has_value()) {
-            if (dimension->is_length_percentage())
-                return dimension->length_percentage();
-            return {};
-        }
-
-        if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_length_percentage())
-            return LengthPercentage { calc.release_nonnull() };
-
-        return {};
     };
 
     auto is_horizontal = [](PositionEdge edge, bool accept_center) -> bool {
@@ -3945,10 +3932,9 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
         auto transaction = tokens.begin_transaction();
 
         tokens.discard_whitespace();
-        auto const& token = tokens.consume_a_token();
 
         // [ left | center | right | top | bottom ]
-        if (auto maybe_edge = parse_position_edge(token); maybe_edge.has_value()) {
+        if (auto maybe_edge = parse_position_edge(tokens); maybe_edge.has_value()) {
             auto edge = maybe_edge.release_value();
             transaction.commit();
 
@@ -3966,7 +3952,7 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
         }
 
         // [ <length-percentage> ]
-        if (auto maybe_percentage = parse_length_percentage(token); maybe_percentage.has_value()) {
+        if (auto maybe_percentage = parse_length_percentage(tokens); maybe_percentage.has_value()) {
             transaction.commit();
             return PositionStyleValue::create(EdgeStyleValue::create({}, *maybe_percentage), EdgeStyleValue::create(PositionEdge::Center, {}));
         }
@@ -3981,14 +3967,14 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
         tokens.discard_whitespace();
 
         // Parse out two position edges
-        auto maybe_first_edge = parse_position_edge(tokens.consume_a_token());
+        auto maybe_first_edge = parse_position_edge(tokens);
         if (!maybe_first_edge.has_value())
             return nullptr;
 
         auto first_edge = maybe_first_edge.release_value();
         tokens.discard_whitespace();
 
-        auto maybe_second_edge = parse_position_edge(tokens.consume_a_token());
+        auto maybe_second_edge = parse_position_edge(tokens);
         if (!maybe_second_edge.has_value())
             return nullptr;
 
@@ -4016,9 +4002,8 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
 
         auto parse_position_or_length = [&](bool as_horizontal) -> RefPtr<EdgeStyleValue> {
             tokens.discard_whitespace();
-            auto const& token = tokens.consume_a_token();
 
-            if (auto maybe_position = parse_position_edge(token); maybe_position.has_value()) {
+            if (auto maybe_position = parse_position_edge(tokens); maybe_position.has_value()) {
                 auto position = maybe_position.release_value();
                 bool valid = as_horizontal ? is_horizontal(position, true) : is_vertical(position, true);
                 if (!valid)
@@ -4026,7 +4011,7 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
                 return EdgeStyleValue::create(position, {});
             }
 
-            auto maybe_length = parse_length_percentage(token);
+            auto maybe_length = parse_length_percentage(tokens);
             if (!maybe_length.has_value())
                 return nullptr;
 
@@ -4058,13 +4043,13 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
         auto parse_position_and_length = [&]() -> Optional<PositionAndLength> {
             tokens.discard_whitespace();
 
-            auto maybe_position = parse_position_edge(tokens.consume_a_token());
+            auto maybe_position = parse_position_edge(tokens);
             if (!maybe_position.has_value())
                 return {};
 
             tokens.discard_whitespace();
 
-            auto maybe_length = parse_length_percentage(tokens.consume_a_token());
+            auto maybe_length = parse_length_percentage(tokens);
             if (!maybe_length.has_value())
                 return {};
 
@@ -4115,22 +4100,23 @@ RefPtr<PositionStyleValue> Parser::parse_position_value(TokenStream<ComponentVal
 
         // [ <position> <length-percentage>? ]
         auto parse_position_and_maybe_length = [&]() -> Optional<PositionAndMaybeLength> {
+            auto inner_transaction = tokens.begin_transaction();
             tokens.discard_whitespace();
 
-            auto maybe_position = parse_position_edge(tokens.consume_a_token());
+            auto maybe_position = parse_position_edge(tokens);
             if (!maybe_position.has_value())
                 return {};
 
             tokens.discard_whitespace();
 
-            auto maybe_length = parse_length_percentage(tokens.next_token());
+            auto maybe_length = parse_length_percentage(tokens);
             if (maybe_length.has_value()) {
                 // 'center' cannot be followed by a <length-percentage>
                 if (maybe_position.value() == PositionEdge::Center && maybe_length.has_value())
                     return {};
-                tokens.discard_a_token();
             }
 
+            inner_transaction.commit();
             return PositionAndMaybeLength {
                 .position = maybe_position.release_value(),
                 .length = move(maybe_length),

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1988,270 +1988,154 @@ Optional<Dimension> Parser::parse_dimension(ComponentValue const& component_valu
 
 Optional<AngleOrCalculated> Parser::parse_angle(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_angle()) {
-            transaction.commit();
-            return dimension->angle();
-        }
-        return {};
+    if (auto value = parse_angle_value(tokens)) {
+        if (value->is_angle())
+            return value->as_angle().angle();
+        if (value->is_calculated())
+            return AngleOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_angle()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<AnglePercentage> Parser::parse_angle_percentage(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_angle_percentage()) {
-            transaction.commit();
-            return dimension->angle_percentage();
-        }
-        return {};
+    if (auto value = parse_angle_percentage_value(tokens)) {
+        if (value->is_angle())
+            return value->as_angle().angle();
+        if (value->is_percentage())
+            return value->as_percentage().percentage();
+        if (value->is_calculated())
+            return AnglePercentage { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_angle_percentage()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<FlexOrCalculated> Parser::parse_flex(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_flex()) {
-            transaction.commit();
-            return dimension->flex();
-        }
-        return {};
+    if (auto value = parse_flex_value(tokens)) {
+        if (value->is_flex())
+            return value->as_flex().flex();
+        if (value->is_calculated())
+            return FlexOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_flex()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<FrequencyOrCalculated> Parser::parse_frequency(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_frequency()) {
-            transaction.commit();
-            return dimension->frequency();
-        }
-        return {};
+    if (auto value = parse_frequency_value(tokens)) {
+        if (value->is_frequency())
+            return value->as_frequency().frequency();
+        if (value->is_calculated())
+            return FrequencyOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_frequency()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<FrequencyPercentage> Parser::parse_frequency_percentage(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_frequency_percentage()) {
-            transaction.commit();
-            return dimension->frequency_percentage();
-        }
-        return {};
+    if (auto value = parse_frequency_percentage_value(tokens)) {
+        if (value->is_frequency())
+            return value->as_frequency().frequency();
+        if (value->is_percentage())
+            return value->as_percentage().percentage();
+        if (value->is_calculated())
+            return FrequencyPercentage { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_frequency_percentage()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<IntegerOrCalculated> Parser::parse_integer(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (token.is(Token::Type::Number) && token.token().number().is_integer()) {
-        transaction.commit();
-        return token.token().to_integer();
+    if (auto value = parse_integer_value(tokens)) {
+        if (value->is_integer())
+            return value->as_integer().integer();
+        if (value->is_calculated())
+            return IntegerOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_number()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<LengthOrCalculated> Parser::parse_length(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_length()) {
-            transaction.commit();
-            return dimension->length();
-        }
-        return {};
+    if (auto value = parse_length_value(tokens)) {
+        if (value->is_length())
+            return value->as_length().length();
+        if (value->is_calculated())
+            return LengthOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_length()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<LengthPercentage> Parser::parse_length_percentage(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_length_percentage()) {
-            transaction.commit();
-            return dimension->length_percentage();
-        }
-        return {};
+    if (auto value = parse_length_percentage_value(tokens)) {
+        if (value->is_length())
+            return value->as_length().length();
+        if (value->is_percentage())
+            return value->as_percentage().percentage();
+        if (value->is_calculated())
+            return LengthPercentage { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_length_percentage()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<NumberOrCalculated> Parser::parse_number(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (token.is(Token::Type::Number)) {
-        transaction.commit();
-        return token.token().number_value();
+    if (auto value = parse_number_value(tokens)) {
+        if (value->is_number())
+            return value->as_number().number();
+        if (value->is_calculated())
+            return NumberOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_number()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<NumberPercentage> Parser::parse_number_percentage(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (token.is(Token::Type::Number)) {
-        transaction.commit();
-        return token.token().number();
+    if (auto value = parse_number_percentage_value(tokens)) {
+        if (value->is_number())
+            return Number { Number::Type::Number, value->as_number().number() };
+        if (value->is_percentage())
+            return value->as_percentage().percentage();
+        if (value->is_calculated())
+            return NumberPercentage { value->as_calculated() };
     }
-
-    if (token.is(Token::Type::Percentage)) {
-        transaction.commit();
-        return Percentage(token.token().percentage());
-    }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_number_percentage()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<ResolutionOrCalculated> Parser::parse_resolution(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_resolution()) {
-            transaction.commit();
-            return dimension->resolution();
-        }
-        return {};
+    if (auto value = parse_resolution_value(tokens)) {
+        if (value->is_resolution())
+            return value->as_resolution().resolution();
+        if (value->is_calculated())
+            return ResolutionOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_resolution()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<TimeOrCalculated> Parser::parse_time(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_time()) {
-            transaction.commit();
-            return dimension->time();
-        }
-        return {};
+    if (auto value = parse_time_value(tokens)) {
+        if (value->is_time())
+            return value->as_time().time();
+        if (value->is_calculated())
+            return TimeOrCalculated { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_time()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 
 Optional<TimePercentage> Parser::parse_time_percentage(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    auto& token = tokens.consume_a_token();
-
-    if (auto dimension = parse_dimension(token); dimension.has_value()) {
-        if (dimension->is_time_percentage()) {
-            transaction.commit();
-            return dimension->time_percentage();
-        }
-        return {};
+    if (auto value = parse_time_percentage_value(tokens)) {
+        if (value->is_time())
+            return value->as_time().time();
+        if (value->is_percentage())
+            return value->as_percentage().percentage();
+        if (value->is_calculated())
+            return TimePercentage { value->as_calculated() };
     }
-
-    if (auto calc = parse_calculated_value(token); calc && calc->resolves_to_time_percentage()) {
-        transaction.commit();
-        return calc.release_nonnull();
-    }
-
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -8727,13 +8727,6 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
         }
         return {};
     };
-    auto any_property_accepts_type_percentage = [](ReadonlySpan<PropertyID> property_ids, ValueType value_type) -> Optional<PropertyID> {
-        for (auto const& property : property_ids) {
-            if (property_accepts_type(property, value_type) && property_accepts_type(property, ValueType::Percentage))
-                return property;
-        }
-        return {};
-    };
     auto any_property_accepts_keyword = [](ReadonlySpan<PropertyID> property_ids, Keyword keyword) -> Optional<PropertyID> {
         for (auto const& property : property_ids) {
             if (property_accepts_keyword(property, keyword))
@@ -8802,38 +8795,9 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
             return PropertyAndValue { *property, maybe_ratio };
     }
 
-    auto property_accepting_integer = any_property_accepts_type(property_ids, ValueType::Integer);
-    auto property_accepting_number = any_property_accepts_type(property_ids, ValueType::Number);
-    bool property_accepts_numeric = property_accepting_integer.has_value() || property_accepting_number.has_value();
-
-    if (peek_token.is(Token::Type::Number) && property_accepts_numeric) {
-        if (peek_token.token().number().is_integer() && property_accepting_integer.has_value()) {
-            auto integer = IntegerStyleValue::create(peek_token.token().number().integer_value());
-            if (property_accepts_integer(*property_accepting_integer, integer->as_integer().integer())) {
-                tokens.discard_a_token(); // integer
-                return PropertyAndValue { *property_accepting_integer, integer };
-            }
-        }
-        if (property_accepting_number.has_value()) {
-            auto number = NumberStyleValue::create(peek_token.token().number().value());
-            if (property_accepts_number(*property_accepting_number, number->as_number().number())) {
-                tokens.discard_a_token(); // number
-                return PropertyAndValue { *property_accepting_number, number };
-            }
-        }
-    }
-
     if (auto property = any_property_accepts_type(property_ids, ValueType::OpenTypeTag); property.has_value()) {
         if (auto maybe_rect = parse_opentype_tag_value(tokens))
             return PropertyAndValue { *property, maybe_rect };
-    }
-
-    if (peek_token.is(Token::Type::Percentage)) {
-        auto percentage = Percentage(peek_token.token().percentage());
-        if (auto property = any_property_accepts_type(property_ids, ValueType::Percentage); property.has_value() && property_accepts_percentage(*property, percentage)) {
-            tokens.discard_a_token();
-            return PropertyAndValue { *property, PercentageStyleValue::create(percentage) };
-        }
     }
 
     if (auto property = any_property_accepts_type(property_ids, ValueType::Rect); property.has_value()) {
@@ -8851,132 +8815,126 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
             return PropertyAndValue { *property, url };
     }
 
-    bool property_accepts_dimension = any_property_accepts_type(property_ids, ValueType::Angle).has_value()
-        || any_property_accepts_type(property_ids, ValueType::Flex).has_value()
-        || any_property_accepts_type(property_ids, ValueType::Frequency).has_value()
-        || any_property_accepts_type(property_ids, ValueType::Length).has_value()
-        || any_property_accepts_type(property_ids, ValueType::Percentage).has_value()
-        || any_property_accepts_type(property_ids, ValueType::Resolution).has_value()
-        || any_property_accepts_type(property_ids, ValueType::Time).has_value();
-
-    if (property_accepts_dimension) {
-        if (peek_token.is(Token::Type::Number) && m_context.is_parsing_svg_presentation_attribute()) {
-            auto transaction = tokens.begin_transaction();
-            auto const& token = tokens.consume_a_token();
-            // https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value
-            // We need to allow <number> in any place that expects a <length> or <angle>.
-            // FIXME: How should these numbers be interpreted? https://github.com/w3c/svgwg/issues/792
-            //        For now: Convert them to px lengths, or deg angles.
-            auto angle = Angle::make_degrees(token.token().number_value());
-            if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value() && property_accepts_angle(*property, angle)) {
-                transaction.commit();
-                return PropertyAndValue { *property, AngleStyleValue::create(angle) };
-            }
-            auto length = Length::make_px(CSSPixels::nearest_value_for(token.token().number_value()));
-            if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value() && property_accepts_length(*property, length)) {
-                transaction.commit();
-                return PropertyAndValue { *property, LengthStyleValue::create(length) };
-            }
-        }
-
-        auto transaction = tokens.begin_transaction();
-        if (auto maybe_dimension = parse_dimension(peek_token); maybe_dimension.has_value()) {
-            tokens.discard_a_token();
-            auto dimension = maybe_dimension.release_value();
-            if (dimension.is_angle()) {
-                auto angle = dimension.angle();
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value() && property_accepts_angle(*property, angle)) {
-                    transaction.commit();
-                    return PropertyAndValue { *property, AngleStyleValue::create(angle) };
-                }
-            }
-            if (dimension.is_flex()) {
-                auto flex = dimension.flex();
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Flex); property.has_value() && property_accepts_flex(*property, flex)) {
-                    transaction.commit();
-                    return PropertyAndValue { *property, FlexStyleValue::create(flex) };
-                }
-            }
-            if (dimension.is_frequency()) {
-                auto frequency = dimension.frequency();
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Frequency); property.has_value() && property_accepts_frequency(*property, frequency)) {
-                    transaction.commit();
-                    return PropertyAndValue { *property, FrequencyStyleValue::create(frequency) };
-                }
-            }
-            if (dimension.is_length()) {
-                auto length = dimension.length();
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value() && property_accepts_length(*property, length)) {
-                    transaction.commit();
-                    return PropertyAndValue { *property, LengthStyleValue::create(length) };
-                }
-            }
-            if (dimension.is_resolution()) {
-                auto resolution = dimension.resolution();
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Resolution); property.has_value() && property_accepts_resolution(*property, resolution)) {
-                    transaction.commit();
-                    return PropertyAndValue { *property, ResolutionStyleValue::create(resolution) };
-                }
-            }
-            if (dimension.is_time()) {
-                auto time = dimension.time();
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Time); property.has_value() && property_accepts_time(*property, time)) {
-                    transaction.commit();
-                    return PropertyAndValue { *property, TimeStyleValue::create(time) };
-                }
-            }
+    // <integer>/<number> come before <length>, so that 0 is not interpreted as a <length> in case both are allowed.
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Integer); property.has_value()) {
+        if (auto value = parse_integer_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_integer() && property_accepts_integer(*property, value->as_integer().integer()))
+                return PropertyAndValue { *property, value };
         }
     }
 
-    // In order to not end up parsing `calc()` and other math expressions multiple times,
-    // we parse it once, and then see if its resolved type matches what the property accepts.
-    if (peek_token.is_function() && (property_accepts_dimension || property_accepts_numeric)) {
-        if (auto maybe_calculated = parse_calculated_value(peek_token); maybe_calculated) {
-            tokens.discard_a_token();
-            auto& calculated = *maybe_calculated;
-            // This is a bit sensitive to ordering: `<foo>` and `<percentage>` have to be checked before `<foo-percentage>`.
-            // FIXME: When parsing SVG presentation attributes, <number> is permitted wherever <length>, <length-percentage>, or <angle> are.
-            //        The specifics are unclear, so I'm ignoring this for calculated values for now.
-            //        See https://github.com/w3c/svgwg/issues/792
-            if (calculated.resolves_to_percentage()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Percentage); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_angle()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_angle_percentage()) {
-                if (auto property = any_property_accepts_type_percentage(property_ids, ValueType::Angle); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_flex()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Flex); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_frequency()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Frequency); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_frequency_percentage()) {
-                if (auto property = any_property_accepts_type_percentage(property_ids, ValueType::Frequency); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_number()) {
-                if (property_accepts_numeric) {
-                    auto property_or_resolved = property_accepting_integer.value_or_lazy_evaluated([property_accepting_number]() { return property_accepting_number.value(); });
-                    return PropertyAndValue { property_or_resolved, calculated };
-                }
-            } else if (calculated.resolves_to_number_percentage()) {
-                if (auto property = any_property_accepts_type_percentage(property_ids, ValueType::Number); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_length()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_length_percentage()) {
-                if (auto property = any_property_accepts_type_percentage(property_ids, ValueType::Length); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_time()) {
-                if (auto property = any_property_accepts_type(property_ids, ValueType::Time); property.has_value())
-                    return PropertyAndValue { *property, calculated };
-            } else if (calculated.resolves_to_time_percentage()) {
-                if (auto property = any_property_accepts_type_percentage(property_ids, ValueType::Time); property.has_value())
-                    return PropertyAndValue { *property, calculated };
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Number); property.has_value()) {
+        if (auto value = parse_number_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_number() && property_accepts_number(*property, value->as_number().number()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Angle); property.has_value()) {
+        if (property_accepts_type(*property, ValueType::Percentage)) {
+            if (auto value = parse_angle_percentage_value(tokens)) {
+                if (value->is_calculated())
+                    return PropertyAndValue { *property, value };
+                if (value->is_angle() && property_accepts_angle(*property, value->as_angle().angle()))
+                    return PropertyAndValue { *property, value };
+                if (value->is_percentage() && property_accepts_percentage(*property, value->as_percentage().percentage()))
+                    return PropertyAndValue { *property, value };
             }
+        }
+        if (auto value = parse_angle_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_angle() && property_accepts_angle(*property, value->as_angle().angle()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Flex); property.has_value()) {
+        if (auto value = parse_flex_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_flex() && property_accepts_flex(*property, value->as_flex().flex()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Frequency); property.has_value()) {
+        if (property_accepts_type(*property, ValueType::Percentage)) {
+            if (auto value = parse_frequency_percentage_value(tokens)) {
+                if (value->is_calculated())
+                    return PropertyAndValue { *property, value };
+                if (value->is_frequency() && property_accepts_frequency(*property, value->as_frequency().frequency()))
+                    return PropertyAndValue { *property, value };
+                if (value->is_percentage() && property_accepts_percentage(*property, value->as_percentage().percentage()))
+                    return PropertyAndValue { *property, value };
+            }
+        }
+        if (auto value = parse_frequency_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_frequency() && property_accepts_frequency(*property, value->as_frequency().frequency()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value()) {
+        if (property_accepts_type(*property, ValueType::Percentage)) {
+            if (auto value = parse_length_percentage_value(tokens)) {
+                if (value->is_calculated())
+                    return PropertyAndValue { *property, value };
+                if (value->is_length() && property_accepts_length(*property, value->as_length().length()))
+                    return PropertyAndValue { *property, value };
+                if (value->is_percentage() && property_accepts_percentage(*property, value->as_percentage().percentage()))
+                    return PropertyAndValue { *property, value };
+            }
+        }
+        if (auto value = parse_length_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_length() && property_accepts_length(*property, value->as_length().length()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Resolution); property.has_value()) {
+        if (auto value = parse_resolution_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_resolution() && property_accepts_resolution(*property, value->as_resolution().resolution()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Time); property.has_value()) {
+        if (property_accepts_type(*property, ValueType::Percentage)) {
+            if (auto value = parse_time_percentage_value(tokens)) {
+                if (value->is_calculated())
+                    return PropertyAndValue { *property, value };
+                if (value->is_time() && property_accepts_time(*property, value->as_time().time()))
+                    return PropertyAndValue { *property, value };
+                if (value->is_percentage() && property_accepts_percentage(*property, value->as_percentage().percentage()))
+                    return PropertyAndValue { *property, value };
+            }
+        }
+        if (auto value = parse_time_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_time() && property_accepts_time(*property, value->as_time().time()))
+                return PropertyAndValue { *property, value };
+        }
+    }
+
+    // <percentage> is checked after the <foo-percentage> types.
+    if (auto property = any_property_accepts_type(property_ids, ValueType::Percentage); property.has_value()) {
+        if (auto value = parse_percentage_value(tokens)) {
+            if (value->is_calculated())
+                return PropertyAndValue { *property, value };
+            if (value->is_percentage() && property_accepts_percentage(*property, value->as_percentage().percentage()))
+                return PropertyAndValue { *property, value };
         }
     }
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2572,34 +2572,6 @@ Vector<Gfx::UnicodeRange> Parser::parse_unicode_ranges(TokenStream<ComponentValu
     return unicode_ranges;
 }
 
-RefPtr<CSSStyleValue> Parser::parse_dimension_value(TokenStream<ComponentValue>& tokens)
-{
-    if (auto dimension = parse_dimension(tokens.next_token()); dimension.has_value()) {
-        tokens.discard_a_token(); // dimension
-
-        if (dimension->is_angle())
-            return AngleStyleValue::create(dimension->angle());
-        if (dimension->is_frequency())
-            return FrequencyStyleValue::create(dimension->frequency());
-        if (dimension->is_length())
-            return LengthStyleValue::create(dimension->length());
-        if (dimension->is_percentage())
-            return PercentageStyleValue::create(dimension->percentage());
-        if (dimension->is_resolution())
-            return ResolutionStyleValue::create(dimension->resolution());
-        if (dimension->is_time())
-            return TimeStyleValue::create(dimension->time());
-        VERIFY_NOT_REACHED();
-    }
-
-    if (auto calc = parse_calculated_value(tokens.next_token()); calc && calc->resolves_to_dimension()) {
-        tokens.discard_a_token(); // calc
-        return calc;
-    }
-
-    return nullptr;
-}
-
 RefPtr<CSSStyleValue> Parser::parse_integer_value(TokenStream<ComponentValue>& tokens)
 {
     auto const& peek_token = tokens.next_token();
@@ -2694,130 +2666,302 @@ RefPtr<CSSStyleValue> Parser::parse_percentage_value(TokenStream<ComponentValue>
 
 RefPtr<CSSStyleValue> Parser::parse_angle_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_angle()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_angle())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto angle_type = Angle::unit_from_name(dimension_token.dimension_unit()); angle_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return AngleStyleValue::create(Angle { (dimension_token.dimension_value()), angle_type.release_value() });
         }
+        return nullptr;
+    }
+
+    // https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value
+    // When parsing an SVG attribute, an angle is allowed without a unit.
+    // FIXME: How should these numbers be interpreted? https://github.com/w3c/svgwg/issues/792
+    //        For now: Convert to an angle in degrees.
+    if (tokens.next_token().is(Token::Type::Number) && m_context.is_parsing_svg_presentation_attribute()) {
+        auto numeric_value = tokens.consume_a_token().token().number_value();
+        return AngleStyleValue::create(Angle::make_degrees(numeric_value));
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_angle()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_angle_percentage_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_angle() || dimension_value->is_percentage()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_angle_percentage())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto angle_type = Angle::unit_from_name(dimension_token.dimension_unit()); angle_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return AngleStyleValue::create(Angle { (dimension_token.dimension_value()), angle_type.release_value() });
         }
+        return nullptr;
+    }
+
+    if (tokens.next_token().is(Token::Type::Percentage))
+        return PercentageStyleValue::create(Percentage { tokens.consume_a_token().token().percentage() });
+
+    // https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value
+    // When parsing an SVG attribute, an angle is allowed without a unit.
+    // FIXME: How should these numbers be interpreted? https://github.com/w3c/svgwg/issues/792
+    //        For now: Convert to an angle in degrees.
+    if (tokens.next_token().is(Token::Type::Number) && m_context.is_parsing_svg_presentation_attribute()) {
+        auto numeric_value = tokens.consume_a_token().token().number_value();
+        return AngleStyleValue::create(Angle::make_degrees(numeric_value));
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_angle_percentage()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_flex_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_flex()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_flex())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto flex_type = Flex::unit_from_name(dimension_token.dimension_unit()); flex_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return FlexStyleValue::create(Flex { (dimension_token.dimension_value()), flex_type.release_value() });
         }
+        return nullptr;
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_flex()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_frequency_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_frequency()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_frequency())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto frequency_type = Frequency::unit_from_name(dimension_token.dimension_unit()); frequency_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return FrequencyStyleValue::create(Frequency { (dimension_token.dimension_value()), frequency_type.release_value() });
         }
+        return nullptr;
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_frequency()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_frequency_percentage_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_frequency() || dimension_value->is_percentage()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_frequency_percentage())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto frequency_type = Frequency::unit_from_name(dimension_token.dimension_unit()); frequency_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return FrequencyStyleValue::create(Frequency { (dimension_token.dimension_value()), frequency_type.release_value() });
         }
+        return nullptr;
+    }
+
+    if (tokens.next_token().is(Token::Type::Percentage))
+        return PercentageStyleValue::create(Percentage { tokens.consume_a_token().token().percentage() });
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_frequency_percentage()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_length_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_length()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_length())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto length_type = Length::unit_from_name(dimension_token.dimension_unit()); length_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return LengthStyleValue::create(Length { (dimension_token.dimension_value()), length_type.release_value() });
         }
+        return nullptr;
+    }
+
+    if (tokens.next_token().is(Token::Type::Number)) {
+        auto transaction = tokens.begin_transaction();
+        auto numeric_value = tokens.consume_a_token().token().number_value();
+        if (numeric_value == 0) {
+            transaction.commit();
+            return LengthStyleValue::create(Length::make_px(0));
+        }
+        if (m_context.in_quirks_mode() && property_has_quirk(m_context.current_property_id(), Quirk::UnitlessLength)) {
+            // https://quirks.spec.whatwg.org/#quirky-length-value
+            // FIXME: Disallow quirk when inside a CSS sub-expression (like `calc()`)
+            // "The <quirky-length> value must not be supported in arguments to CSS expressions other than the rect()
+            // expression, and must not be supported in the supports() static method of the CSS interface."
+            transaction.commit();
+            return LengthStyleValue::create(Length::make_px(CSSPixels::nearest_value_for(numeric_value)));
+        }
+
+        // https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value
+        // When parsing an SVG attribute, a length is allowed without a unit.
+        // FIXME: How should these numbers be interpreted? https://github.com/w3c/svgwg/issues/792
+        //        For now: Convert to a length in pixels.
+        if (m_context.is_parsing_svg_presentation_attribute()) {
+            transaction.commit();
+            return LengthStyleValue::create(Length::make_px(CSSPixels::nearest_value_for(numeric_value)));
+        }
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_length()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_length_percentage_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_length() || dimension_value->is_percentage()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_length_percentage())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto length_type = Length::unit_from_name(dimension_token.dimension_unit()); length_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return LengthStyleValue::create(Length { (dimension_token.dimension_value()), length_type.release_value() });
         }
+        return nullptr;
+    }
+
+    if (tokens.next_token().is(Token::Type::Percentage))
+        return PercentageStyleValue::create(Percentage { tokens.consume_a_token().token().percentage() });
+
+    if (tokens.next_token().is(Token::Type::Number)) {
+        auto transaction = tokens.begin_transaction();
+        auto numeric_value = tokens.consume_a_token().token().number_value();
+        if (numeric_value == 0) {
+            transaction.commit();
+            return LengthStyleValue::create(Length::make_px(0));
+        }
+        if (m_context.in_quirks_mode() && property_has_quirk(m_context.current_property_id(), Quirk::UnitlessLength)) {
+            // https://quirks.spec.whatwg.org/#quirky-length-value
+            // FIXME: Disallow quirk when inside a CSS sub-expression (like `calc()`)
+            // "The <quirky-length> value must not be supported in arguments to CSS expressions other than the rect()
+            // expression, and must not be supported in the supports() static method of the CSS interface."
+            transaction.commit();
+            return LengthStyleValue::create(Length::make_px(CSSPixels::nearest_value_for(numeric_value)));
+        }
+
+        // https://svgwg.org/svg2-draft/types.html#presentation-attribute-css-value
+        // When parsing an SVG attribute, a length is allowed without a unit.
+        // FIXME: How should these numbers be interpreted? https://github.com/w3c/svgwg/issues/792
+        //        For now: Convert to a length in pixels.
+        if (m_context.is_parsing_svg_presentation_attribute()) {
+            transaction.commit();
+            return LengthStyleValue::create(Length::make_px(CSSPixels::nearest_value_for(numeric_value)));
+        }
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_length_percentage()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_resolution_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_resolution()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_resolution())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto resolution_type = Resolution::unit_from_name(dimension_token.dimension_unit()); resolution_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return ResolutionStyleValue::create(Resolution { (dimension_token.dimension_value()), resolution_type.release_value() });
         }
+        return nullptr;
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_resolution()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_time_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_time()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_time())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto time_type = Time::unit_from_name(dimension_token.dimension_unit()); time_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return TimeStyleValue::create(Time { (dimension_token.dimension_value()), time_type.release_value() });
         }
+        return nullptr;
+    }
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_time()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_time_percentage_value(TokenStream<ComponentValue>& tokens)
 {
-    auto transaction = tokens.begin_transaction();
-    if (auto dimension_value = parse_dimension_value(tokens)) {
-        if (dimension_value->is_time() || dimension_value->is_percentage()
-            || (dimension_value->is_calculated() && dimension_value->as_calculated().resolves_to_time_percentage())) {
+    if (tokens.next_token().is(Token::Type::Dimension)) {
+        auto transaction = tokens.begin_transaction();
+        auto& dimension_token = tokens.consume_a_token().token();
+        if (auto time_type = Time::unit_from_name(dimension_token.dimension_unit()); time_type.has_value()) {
             transaction.commit();
-            return dimension_value;
+            return TimeStyleValue::create(Time { (dimension_token.dimension_value()), time_type.release_value() });
         }
+        return nullptr;
+    }
+
+    if (tokens.next_token().is(Token::Type::Percentage))
+        return PercentageStyleValue::create(Percentage { tokens.consume_a_token().token().percentage() });
+
+    auto transaction = tokens.begin_transaction();
+    if (auto calculated_value = parse_calculated_value(tokens.consume_a_token());
+        calculated_value && calculated_value->resolves_to_time_percentage()) {
+
+        transaction.commit();
+        return calculated_value;
     }
     return nullptr;
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3067,25 +3067,13 @@ RefPtr<CSSStyleValue> Parser::parse_hue_none_value(TokenStream<ComponentValue>& 
     // Parses [<hue> | none]
     //   <hue> = <number> | <angle>
 
-    auto peek_token = tokens.next_token();
-    if (peek_token.is(Token::Type::Number)) {
-        tokens.discard_a_token(); // number
-        return NumberStyleValue::create(peek_token.token().number().value());
-    }
-    if (auto calc = parse_calculated_value(peek_token); calc && (calc->resolves_to_number() || calc->resolves_to_angle())) {
-        tokens.discard_a_token(); // calc number/angle
-        return calc;
-    }
-    if (auto dimension = parse_dimension(peek_token); dimension.has_value() && dimension->is_angle()) {
-        tokens.discard_a_token(); // angle
-        return AngleStyleValue::create(dimension->angle());
-    }
-    if (peek_token.is(Token::Type::Ident)) {
-        auto keyword = keyword_from_string(peek_token.token().ident());
-        if (keyword.has_value() && keyword.value() == Keyword::None) {
-            tokens.discard_a_token(); // keyword none
-            return CSSKeywordValue::create(keyword.value());
-        }
+    if (auto angle = parse_angle_value(tokens))
+        return angle;
+    if (auto number = parse_number_value(tokens))
+        return number;
+    if (tokens.next_token().is_ident("none"sv)) {
+        tokens.discard_a_token(); // keyword none
+        return CSSKeywordValue::create(Keyword::None);
     }
 
     return nullptr;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2489,45 +2489,24 @@ RefPtr<CSSStyleValue> Parser::parse_number_value(TokenStream<ComponentValue>& to
 RefPtr<CSSStyleValue> Parser::parse_number_percentage_value(TokenStream<ComponentValue>& tokens)
 {
     // Parses [<percentage> | <number>] (which is equivalent to [<alpha-value>])
-    auto const& peek_token = tokens.next_token();
-    if (peek_token.is(Token::Type::Number)) {
-        tokens.discard_a_token(); // number
-        return NumberStyleValue::create(peek_token.token().number().value());
-    }
-    if (peek_token.is(Token::Type::Percentage)) {
-        tokens.discard_a_token(); // percentage
-        return PercentageStyleValue::create(Percentage(peek_token.token().percentage()));
-    }
-    if (auto calc = parse_calculated_value(peek_token); calc && calc->resolves_to_number_percentage()) {
-        tokens.discard_a_token(); // calc
-        return calc;
-    }
-
+    if (auto value = parse_number_value(tokens))
+        return value;
+    if (auto value = parse_percentage_value(tokens))
+        return value;
     return nullptr;
 }
 
 RefPtr<CSSStyleValue> Parser::parse_number_percentage_none_value(TokenStream<ComponentValue>& tokens)
 {
     // Parses [<percentage> | <number> | none] (which is equivalent to [<alpha-value> | none])
-    auto peek_token = tokens.next_token();
-    if (peek_token.is(Token::Type::Number)) {
-        tokens.discard_a_token(); // number
-        return NumberStyleValue::create(peek_token.token().number().value());
-    }
-    if (peek_token.is(Token::Type::Percentage)) {
-        tokens.discard_a_token(); // percentage
-        return PercentageStyleValue::create(Percentage(peek_token.token().percentage()));
-    }
-    if (auto calc = parse_calculated_value(peek_token); calc && calc->resolves_to_number_percentage()) {
-        tokens.discard_a_token(); // calc
-        return calc;
-    }
-    if (peek_token.is(Token::Type::Ident)) {
-        auto keyword = keyword_from_string(peek_token.token().ident());
-        if (keyword.has_value() && keyword.value() == Keyword::None) {
-            tokens.discard_a_token(); // keyword none
-            return CSSKeywordValue::create(keyword.value());
-        }
+    if (auto value = parse_number_value(tokens))
+        return value;
+    if (auto value = parse_percentage_value(tokens))
+        return value;
+
+    if (tokens.next_token().is_ident("none"sv)) {
+        tokens.discard_a_token(); // keyword none
+        return CSSKeywordValue::create(Keyword::None);
     }
 
     return nullptr;

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -9068,39 +9068,6 @@ OwnPtr<CalculationNode> Parser::convert_to_calculation_node(CalcParsing::Node co
                 return NegateCalculationNode::create(child_as_node.release_nonnull());
             return nullptr;
         },
-        [](Number const& number) -> OwnPtr<CalculationNode> {
-            return NumericCalculationNode::create(number);
-        },
-        [this](Dimension const& dimension) -> OwnPtr<CalculationNode> {
-            if (dimension.is_angle())
-                return NumericCalculationNode::create(dimension.angle());
-            if (dimension.is_frequency())
-                return NumericCalculationNode::create(dimension.frequency());
-            if (dimension.is_length())
-                return NumericCalculationNode::create(dimension.length());
-            if (dimension.is_percentage()) {
-                // FIXME: Figure this out in non-property contexts
-                auto percentage_resolved_type = property_resolves_percentages_relative_to(m_context.current_property_id());
-                return NumericCalculationNode::create(dimension.percentage(), percentage_resolved_type);
-            }
-            if (dimension.is_resolution())
-                return NumericCalculationNode::create(dimension.resolution());
-            if (dimension.is_time())
-                return NumericCalculationNode::create(dimension.time());
-            if (dimension.is_flex()) {
-                // https://www.w3.org/TR/css3-grid-layout/#fr-unit
-                // NOTE: <flex> values are not <length>s (nor are they compatible with <length>s, like some <percentage> values),
-                //       so they cannot be represented in or combined with other unit types in calc() expressions.
-                // FIXME: Flex is allowed in calc(), so figure out what this spec text means and how to implement it.
-                dbgln_if(CSS_PARSER_DEBUG, "Rejecting <flex> in calc()");
-                return nullptr;
-            }
-            dbgln_if(CSS_PARSER_DEBUG, "Unrecognized dimension type in calc() expression: {}", dimension.to_string());
-            return nullptr;
-        },
-        [](CalculationNode::ConstantType const& constant_type) -> OwnPtr<CalculationNode> {
-            return ConstantCalculationNode::create(constant_type);
-        },
         [this](NonnullRawPtr<ComponentValue const> const& component_value) -> OwnPtr<CalculationNode> {
             // NOTE: This is the "process the leaf nodes" part of step 5 of https://drafts.csswg.org/css-values-4/#parse-a-calculation
             //       We divert a little from the spec: Rather than modify an existing tree of values, we construct a new one from that source tree.
@@ -9124,6 +9091,56 @@ OwnPtr<CalculationNode> Parser::convert_to_calculation_node(CalcParsing::Node co
                     return nullptr;
 
                 return leaf_calculation.release_nonnull();
+            }
+
+            // AD-HOC: We also need to convert tokens into their numeric types.
+
+            if (component_value->is(Token::Type::Ident)) {
+                auto maybe_constant = CalculationNode::constant_type_from_string(component_value->token().ident());
+                if (!maybe_constant.has_value())
+                    return nullptr;
+                return ConstantCalculationNode::create(*maybe_constant);
+            }
+
+            if (component_value->is(Token::Type::Number))
+                return NumericCalculationNode::create(component_value->token().number());
+
+            if (component_value->is(Token::Type::Dimension)) {
+                auto numeric_value = component_value->token().dimension_value();
+                auto unit_string = component_value->token().dimension_unit();
+
+                if (auto length_type = Length::unit_from_name(unit_string); length_type.has_value())
+                    return NumericCalculationNode::create(Length { numeric_value, length_type.release_value() });
+
+                if (auto angle_type = Angle::unit_from_name(unit_string); angle_type.has_value())
+                    return NumericCalculationNode::create(Angle { numeric_value, angle_type.release_value() });
+
+                if (auto flex_type = Flex::unit_from_name(unit_string); flex_type.has_value()) {
+                    // https://www.w3.org/TR/css3-grid-layout/#fr-unit
+                    // NOTE: <flex> values are not <length>s (nor are they compatible with <length>s, like some <percentage> values),
+                    //       so they cannot be represented in or combined with other unit types in calc() expressions.
+                    // FIXME: Flex is allowed in calc(), so figure out what this spec text means and how to implement it.
+                    dbgln_if(CSS_PARSER_DEBUG, "Rejecting <flex> in calc()");
+                    return nullptr;
+                }
+
+                if (auto frequency_type = Frequency::unit_from_name(unit_string); frequency_type.has_value())
+                    return NumericCalculationNode::create(Frequency { numeric_value, frequency_type.release_value() });
+
+                if (auto resolution_type = Resolution::unit_from_name(unit_string); resolution_type.has_value())
+                    return NumericCalculationNode::create(Resolution { numeric_value, resolution_type.release_value() });
+
+                if (auto time_type = Time::unit_from_name(unit_string); time_type.has_value())
+                    return NumericCalculationNode::create(Time { numeric_value, time_type.release_value() });
+
+                dbgln_if(CSS_PARSER_DEBUG, "Unrecognized dimension type in calc() expression: {}", component_value->to_string());
+                return nullptr;
+            }
+
+            if (component_value->is(Token::Type::Percentage)) {
+                // FIXME: Figure this out in non-property contexts
+                auto percentage_resolved_type = property_resolves_percentages_relative_to(m_context.current_property_id());
+                return NumericCalculationNode::create(Percentage { component_value->token().percentage() }, percentage_resolved_type);
             }
 
             // NOTE: If we get here, then we have a ComponentValue that didn't get replaced with something else,
@@ -9156,24 +9173,6 @@ OwnPtr<CalculationNode> Parser::parse_a_calculation(Vector<ComponentValue> const
                 values.append(CalcParsing::Operator { static_cast<char>(value.token().delim()) });
                 continue;
             }
-        }
-
-        if (value.is(Token::Type::Ident)) {
-            auto maybe_constant = CalculationNode::constant_type_from_string(value.token().ident());
-            if (maybe_constant.has_value()) {
-                values.append(maybe_constant.value());
-                continue;
-            }
-        }
-
-        if (value.is(Token::Type::Number)) {
-            values.append(value.token().number());
-            continue;
-        }
-
-        if (auto dimension = parse_dimension(value); dimension.has_value()) {
-            values.append(dimension.release_value());
-            continue;
         }
 
         values.append(NonnullRawPtr { value });

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -7192,95 +7192,55 @@ RefPtr<CSSStyleValue> Parser::parse_transform_value(TokenStream<ComponentValue>&
             TokenStream argument_tokens { arguments[argument_index] };
             argument_tokens.discard_whitespace();
 
-            auto const& value = argument_tokens.consume_a_token();
-            RefPtr<CalculatedStyleValue> maybe_calc_value = parse_calculated_value(value);
-
             switch (function_metadata.parameters[argument_index].type) {
             case TransformFunctionParameterType::Angle: {
                 // These are `<angle> | <zero>` in the spec, so we have to check for both kinds.
-                if (maybe_calc_value && maybe_calc_value->resolves_to_angle()) {
-                    values.append(maybe_calc_value.release_nonnull());
-                } else if (value.is(Token::Type::Number) && value.token().number_value() == 0) {
-                    values.append(AngleStyleValue::create(Angle::make_degrees(0)));
-                } else {
-                    // FIXME: Remove this reconsume once all parsing functions are TokenStream-based.
-                    argument_tokens.reconsume_current_input_token();
-                    auto dimension_value = parse_dimension_value(argument_tokens);
-                    if (!dimension_value || !dimension_value->is_angle())
-                        return nullptr;
-                    values.append(dimension_value.release_nonnull());
+                if (auto angle_value = parse_angle_value(argument_tokens)) {
+                    values.append(angle_value.release_nonnull());
+                    break;
                 }
-                break;
+                if (argument_tokens.next_token().is(Token::Type::Number) && argument_tokens.next_token().token().number_value() == 0) {
+                    argument_tokens.discard_a_token(); // 0
+                    values.append(AngleStyleValue::create(Angle::make_degrees(0)));
+                    break;
+                }
+                return nullptr;
             }
             case TransformFunctionParameterType::Length:
             case TransformFunctionParameterType::LengthNone: {
-                if (maybe_calc_value && maybe_calc_value->resolves_to_length()) {
-                    argument_tokens.discard_a_token(); // calc()
-                    values.append(maybe_calc_value.release_nonnull());
-                } else {
-                    // FIXME: Remove this reconsume once all parsing functions are TokenStream-based.
-                    argument_tokens.reconsume_current_input_token();
-
-                    if (function_metadata.parameters[argument_index].type == TransformFunctionParameterType::LengthNone) {
-                        auto keyword_transaction = argument_tokens.begin_transaction();
-                        auto keyword_value = parse_keyword_value(argument_tokens);
-                        if (keyword_value && keyword_value->to_keyword() == Keyword::None) {
-                            values.append(keyword_value.release_nonnull());
-                            keyword_transaction.commit();
-                            break;
-                        }
-                    }
-
-                    auto dimension_value = parse_dimension_value(argument_tokens);
-                    if (!dimension_value || !dimension_value->is_length())
-                        return nullptr;
-
-                    values.append(dimension_value.release_nonnull());
+                if (auto length_value = parse_length_value(argument_tokens)) {
+                    values.append(length_value.release_nonnull());
+                    break;
                 }
-                break;
+                if (function_metadata.parameters[argument_index].type == TransformFunctionParameterType::LengthNone
+                    && argument_tokens.next_token().is_ident("none"sv)) {
+
+                    argument_tokens.discard_a_token(); // none
+                    values.append(CSSKeywordValue::create(Keyword::None));
+                    break;
+                }
+                return nullptr;
             }
             case TransformFunctionParameterType::LengthPercentage: {
-                if (maybe_calc_value && maybe_calc_value->resolves_to_length_percentage()) {
-                    values.append(maybe_calc_value.release_nonnull());
-                } else {
-                    // FIXME: Remove this reconsume once all parsing functions are TokenStream-based.
-                    argument_tokens.reconsume_current_input_token();
-                    auto dimension_value = parse_dimension_value(argument_tokens);
-                    if (!dimension_value)
-                        return nullptr;
-
-                    if (dimension_value->is_percentage() || dimension_value->is_length())
-                        values.append(dimension_value.release_nonnull());
-                    else
-                        return nullptr;
+                if (auto length_percentage_value = parse_length_percentage_value(argument_tokens)) {
+                    values.append(length_percentage_value.release_nonnull());
+                    break;
                 }
-                break;
+                return nullptr;
             }
             case TransformFunctionParameterType::Number: {
-                if (maybe_calc_value && maybe_calc_value->resolves_to_number()) {
-                    values.append(maybe_calc_value.release_nonnull());
-                } else {
-                    // FIXME: Remove this reconsume once all parsing functions are TokenStream-based.
-                    argument_tokens.reconsume_current_input_token();
-                    auto number = parse_number_value(argument_tokens);
-                    if (!number)
-                        return nullptr;
-                    values.append(number.release_nonnull());
+                if (auto number_value = parse_number_value(argument_tokens)) {
+                    values.append(number_value.release_nonnull());
+                    break;
                 }
-                break;
+                return nullptr;
             }
             case TransformFunctionParameterType::NumberPercentage: {
-                if (maybe_calc_value && maybe_calc_value->resolves_to_number()) {
-                    values.append(maybe_calc_value.release_nonnull());
-                } else {
-                    // FIXME: Remove this reconsume once all parsing functions are TokenStream-based.
-                    argument_tokens.reconsume_current_input_token();
-                    auto number_or_percentage = parse_number_percentage_value(argument_tokens);
-                    if (!number_or_percentage)
-                        return nullptr;
-                    values.append(number_or_percentage.release_nonnull());
+                if (auto number_percentage_value = parse_number_percentage_value(argument_tokens)) {
+                    values.append(number_percentage_value.release_nonnull());
+                    break;
                 }
-                break;
+                return nullptr;
             }
             }
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -43,7 +43,7 @@ struct ProductNode;
 struct SumNode;
 struct InvertNode;
 struct NegateNode;
-using Node = Variant<Operator, Number, Dimension, CalculationNode::ConstantType, NonnullOwnPtr<ProductNode>, NonnullOwnPtr<SumNode>, NonnullOwnPtr<InvertNode>, NonnullOwnPtr<NegateNode>, NonnullRawPtr<ComponentValue const>>;
+using Node = Variant<Operator, NonnullOwnPtr<ProductNode>, NonnullOwnPtr<SumNode>, NonnullOwnPtr<InvertNode>, NonnullOwnPtr<NegateNode>, NonnullRawPtr<ComponentValue const>>;
 struct ProductNode {
     Vector<Node> children;
 };

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -257,7 +257,7 @@ private:
     RefPtr<CSSStyleValue> parse_basic_shape_value(TokenStream<ComponentValue>&);
 
     template<typename TElement>
-    Optional<Vector<TElement>> parse_color_stop_list(TokenStream<ComponentValue>& tokens, auto is_position, auto get_position);
+    Optional<Vector<TElement>> parse_color_stop_list(TokenStream<ComponentValue>& tokens, auto parse_position);
     Optional<Vector<LinearColorStopListElement>> parse_linear_color_stop_list(TokenStream<ComponentValue>&);
     Optional<Vector<AngularColorStopListElement>> parse_angular_color_stop_list(TokenStream<ComponentValue>&);
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -311,7 +311,6 @@ private:
     RefPtr<CSSStyleValue> parse_filter_value_list_value(TokenStream<ComponentValue>&);
     RefPtr<StringStyleValue> parse_opentype_tag_value(TokenStream<ComponentValue>&);
 
-    RefPtr<CSSStyleValue> parse_dimension_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_angle_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_angle_percentage_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_flex_value(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -99,7 +99,6 @@ public:
     Optional<Time> resolve_time_percentage(Time const& percentage_basis) const;
 
     bool resolves_to_number() const { return m_resolved_type.matches_number(); }
-    bool resolves_to_number_percentage() const { return m_resolved_type.matches_number_percentage(); }
     Optional<double> resolve_number() const;
     Optional<double> resolve_number(Length::ResolutionContext const&) const;
     Optional<double> resolve_number(Layout::Node const& layout_node) const;


### PR DESCRIPTION
The main purpose of this is to split apart how we parse `calc()` and dimensions, so that we determine which property we're parsing for *before* parsing the value, instead of after. This is necessary for knowing what type percentages in `calc()` should resolve to, when in a shorthand property - because it depends which longhand we're parsing the `calc()` for.

`parse_dimension[_value]()` is the main culprit there, and I generally think it was a mistake. It made sense back before we started parsing types intentionally (as in, "I want a length, so try parsing a length") but now that we do that, it's unnecessary to try parsing a dimension token as a `<resolution>` when we only care about `<angle>`s, for example. I've removed its use from everywhere except for `parse_grid_size()` which needs a bit more work.