### PR TITLE
AK: Optimize performance in GenericShorthands by using forwarding references

### DIFF
--- a/AK/GenericShorthands.h
+++ b/AK/GenericShorthands.h
@@ -7,61 +7,62 @@
 #pragma once
 
 #include <AK/Platform.h>
+#include <AK/StdLibExtras.h>
 
 namespace AK {
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_one_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_one_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... || (to_compare == valid_values));
+    return (... || (forward<T>(to_compare) == forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_smaller_than_one_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_smaller_than_one_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... || (to_compare < valid_values));
+    return (... || (forward<T>(to_compare) < forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_smaller_or_equal_than_one_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_smaller_or_equal_than_one_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... || (to_compare <= valid_values));
+    return (... || (forward<T>(to_compare) <= forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_larger_than_one_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_larger_than_one_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... || (to_compare > valid_values));
+    return (... || (forward<T>(to_compare) > forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_larger_or_equal_than_one_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_larger_or_equal_than_one_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... || (to_compare >= valid_values));
+    return (... || (forward<T>(to_compare) >= forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_smaller_than_all_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_smaller_than_all_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... && (to_compare < valid_values));
+    return (... && (forward<T>(to_compare) < forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_smaller_or_equal_than_all_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_smaller_or_equal_than_all_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... && (to_compare <= valid_values));
+    return (... && (forward<T>(to_compare) <= forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_larger_than_all_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_larger_than_all_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... && (to_compare > valid_values));
+    return (... && (forward<T>(to_compare) > forward<Ts>(valid_values)));
 }
 
 template<typename T, typename... Ts>
-[[nodiscard]] constexpr bool first_is_larger_or_equal_than_all_of(T const to_compare, Ts const... valid_values)
+[[nodiscard]] constexpr bool first_is_larger_or_equal_than_all_of(T&& to_compare, Ts&&... valid_values)
 {
-    return (... && (to_compare >= valid_values));
+    return (... && (forward<T>(to_compare) >= forward<Ts>(valid_values)));
 }
 }
 

--- a/Meta/gn/secondary/Tests/AK/BUILD.gn
+++ b/Meta/gn/secondary/Tests/AK/BUILD.gn
@@ -32,6 +32,7 @@ tests = [
   "TestFlyString",
   "TestFormat",
   "TestGenericLexer",
+  "TestGenericShorthands",
   "TestHashFunctions",
   "TestHashMap",
   "TestHashTable",

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -30,6 +30,7 @@ set(AK_TEST_SOURCES
     TestFlyString.cpp
     TestFormat.cpp
     TestGenericLexer.cpp
+    TestGenericShorthands.cpp
     TestHashFunctions.cpp
     TestHashMap.cpp
     TestHashTable.cpp

--- a/Tests/AK/TestGenericShorthands.cpp
+++ b/Tests/AK/TestGenericShorthands.cpp
@@ -1,0 +1,256 @@
+/*
+ * Copyright (c) 2025, the Ladybird developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/GenericShorthands.h>
+
+TEST_CASE(first_is_one_of)
+{
+    // Finds item if in list of arguments
+    static_assert(first_is_one_of(3, 1, 2, 3, 4, 5));
+    EXPECT(first_is_one_of(3, 1, 2, 3, 4, 5));
+
+    // Finds item when single value in list
+    static_assert(first_is_one_of(42, 42));
+    EXPECT(first_is_one_of(42, 42));
+
+    // Finds item when duplicate values in list
+    static_assert(first_is_one_of(42, 42, 42));
+    EXPECT(first_is_one_of(42, 42, 42));
+
+    // Doesn't find items not in list
+    static_assert(!first_is_one_of(10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_one_of(10, 1, 2, 3, 4, 5));
+
+    // Doesn't find item when single value in list
+    static_assert(!first_is_one_of(10, 1));
+    EXPECT(!first_is_one_of(10, 1));
+
+    // Doesn't find items when duplicate values in list
+    static_assert(!first_is_one_of(10, 1, 1));
+    EXPECT(!first_is_one_of(10, 1, 1));
+
+    // Doesn't find item when empty list
+    static_assert(!first_is_one_of(10));
+    EXPECT(!first_is_one_of(10));
+}
+
+TEST_CASE(first_is_smaller_or_equal_than_one_of)
+{
+    // Finds smaller items
+    static_assert(first_is_smaller_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_or_equal_than_one_of(-10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_or_equal_than_one_of(-10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_or_equal_than_one_of(42, 43));
+    EXPECT(first_is_smaller_or_equal_than_one_of(42, 43));
+
+    // Find equal items
+    static_assert(first_is_smaller_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_or_equal_than_one_of(-2, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_or_equal_than_one_of(-2, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_or_equal_than_one_of(42, 42));
+    EXPECT(first_is_smaller_or_equal_than_one_of(42, 42));
+
+    // Doesn't find larger items
+    static_assert(!first_is_smaller_or_equal_than_one_of(10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_smaller_or_equal_than_one_of(10, 1, 2, 3, 4, 5));
+
+    // Doesn't find item when empty list
+    static_assert(!first_is_smaller_or_equal_than_one_of(10));
+    EXPECT(!first_is_smaller_or_equal_than_one_of(10));
+}
+
+TEST_CASE(first_is_smaller_than_one_of)
+{
+    // Finds smaller items
+    static_assert(first_is_smaller_than_one_of(1, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_than_one_of(1, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_than_one_of(-10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_than_one_of(-10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_than_one_of(42, 43));
+    EXPECT(first_is_smaller_than_one_of(42, 43));
+
+    // Doesn't find equal items
+    static_assert(!first_is_smaller_than_one_of(5, 1, -2, 3, -4, 5));
+    EXPECT(!first_is_smaller_than_one_of(5, 1, -2, 3, -4, 5));
+
+    // Doesn't find larger items
+    static_assert(!first_is_smaller_than_one_of(10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_smaller_than_one_of(10, 1, 2, 3, 4, 5));
+
+    // Doesn't find item when empty list
+    static_assert(!first_is_smaller_than_one_of(10));
+    EXPECT(!first_is_smaller_than_one_of(10));
+}
+
+TEST_CASE(first_is_smaller_or_equal_than_all_of)
+{
+    // Finds smaller than all items
+    static_assert(first_is_smaller_or_equal_than_all_of(-10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_or_equal_than_all_of(-10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_or_equal_than_all_of(42, 43));
+    EXPECT(first_is_smaller_or_equal_than_all_of(42, 43));
+
+    // Find equal items
+    static_assert(first_is_smaller_or_equal_than_all_of(42, 42));
+    EXPECT(first_is_smaller_or_equal_than_all_of(42, 42));
+
+    // Match on empty list
+    static_assert(first_is_smaller_or_equal_than_all_of(10));
+    EXPECT(first_is_smaller_or_equal_than_all_of(10));
+
+    // Doesn't find smaller than some items
+    static_assert(!first_is_smaller_or_equal_than_all_of(1, 1, -2, 3, -4, 5));
+    EXPECT(!first_is_smaller_or_equal_than_all_of(1, 1, -2, 3, -4, 5));
+
+    // Doesn't find larger items
+    static_assert(!first_is_smaller_or_equal_than_all_of(10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_smaller_or_equal_than_all_of(10, 1, 2, 3, 4, 5));
+}
+
+TEST_CASE(first_is_smaller_than_all_of)
+{
+    // Finds smaller than all items
+    static_assert(first_is_smaller_than_all_of(-10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_smaller_than_all_of(-10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_smaller_than_all_of(42, 43));
+    EXPECT(first_is_smaller_than_all_of(42, 43));
+
+    // Match on empty list
+    static_assert(first_is_smaller_than_all_of(10));
+    EXPECT(first_is_smaller_than_all_of(10));
+
+    // Doesn't find equal items
+    static_assert(!first_is_smaller_than_all_of(42, 42));
+    EXPECT(!first_is_smaller_than_all_of(42, 42));
+
+    // Doesn't find smaller than some items
+    static_assert(!first_is_smaller_than_all_of(1, 1, -2, 3, -4, 5));
+    EXPECT(!first_is_smaller_than_all_of(1, 1, -2, 3, -4, 5));
+
+    // Doesn't find larger items
+    static_assert(!first_is_smaller_than_all_of(10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_smaller_than_all_of(10, 1, 2, 3, 4, 5));
+}
+
+TEST_CASE(first_is_larger_or_equal_than_one_of)
+{
+    // Finds larger items
+    static_assert(first_is_larger_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_or_equal_than_one_of(10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_or_equal_than_one_of(10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_or_equal_than_one_of(44, 43));
+    EXPECT(first_is_larger_or_equal_than_one_of(44, 43));
+
+    // Finds equal items
+    static_assert(first_is_larger_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_or_equal_than_one_of(1, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_or_equal_than_one_of(-2, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_or_equal_than_one_of(-2, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_or_equal_than_one_of(42, 42));
+    EXPECT(first_is_larger_or_equal_than_one_of(42, 42));
+
+    // Doesn't find smaller items
+    static_assert(!first_is_larger_or_equal_than_one_of(-10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_larger_or_equal_than_one_of(-10, 1, 2, 3, 4, 5));
+
+    // Doesn't find item when empty list
+    static_assert(!first_is_larger_or_equal_than_one_of(10));
+    EXPECT(!first_is_larger_or_equal_than_one_of(10));
+}
+
+TEST_CASE(first_is_larger_than_one_of)
+{
+    // Finds larger items
+    static_assert(first_is_larger_than_one_of(1, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_than_one_of(1, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_than_one_of(10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_than_one_of(10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_than_one_of(44, 43));
+    EXPECT(first_is_larger_than_one_of(44, 43));
+
+    // Doesn't find equal items
+    static_assert(!first_is_larger_than_one_of(-4, 1, -2, 3, -4, 5));
+    EXPECT(!first_is_larger_than_one_of(-4, 1, -2, 3, -4, 5));
+
+    // Doesn't find smaller items
+    static_assert(!first_is_larger_than_one_of(-10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_larger_than_one_of(-10, 1, 2, 3, 4, 5));
+
+    // Doesn't find item when empty list
+    static_assert(!first_is_larger_than_one_of(10));
+    EXPECT(!first_is_larger_than_one_of(10));
+}
+
+TEST_CASE(first_is_larger_or_equal_than_all_of)
+{
+    // Finds larger than all items
+    static_assert(first_is_larger_or_equal_than_all_of(10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_or_equal_than_all_of(10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_or_equal_than_all_of(44, 43));
+    EXPECT(first_is_larger_or_equal_than_all_of(44, 43));
+
+    // Find equal items
+    static_assert(first_is_larger_or_equal_than_all_of(42, 42));
+    EXPECT(first_is_larger_or_equal_than_all_of(42, 42));
+
+    // Match on empty list
+    static_assert(first_is_larger_or_equal_than_all_of(10));
+    EXPECT(first_is_larger_or_equal_than_all_of(10));
+
+    // Doesn't find larger than some items
+    static_assert(!first_is_larger_or_equal_than_all_of(1, 1, -2, 3, -4, 5));
+    EXPECT(!first_is_larger_or_equal_than_all_of(1, 1, -2, 3, -4, 5));
+
+    // Doesn't find smaller items
+    static_assert(!first_is_larger_or_equal_than_all_of(-10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_larger_or_equal_than_all_of(-10, 1, 2, 3, 4, 5));
+}
+
+TEST_CASE(first_is_larger_than_all_of)
+{
+    // Finds larger than all items
+    static_assert(first_is_larger_than_all_of(10, 1, -2, 3, -4, 5));
+    EXPECT(first_is_larger_than_all_of(10, 1, -2, 3, -4, 5));
+
+    static_assert(first_is_larger_than_all_of(44, 43));
+    EXPECT(first_is_larger_than_all_of(44, 43));
+
+    // Match on empty list
+    static_assert(first_is_larger_than_all_of(10));
+    EXPECT(first_is_larger_than_all_of(10));
+
+    // Doesn't find equal items
+    static_assert(!first_is_larger_than_all_of(42, 42));
+    EXPECT(!first_is_larger_than_all_of(42, 42));
+
+    // Doesn't find larger than some items
+    static_assert(!first_is_larger_than_all_of(1, 1, -2, 3, -4, 5));
+    EXPECT(!first_is_larger_than_all_of(1, 1, -2, 3, -4, 5));
+
+    // Doesn't find smaller items
+    static_assert(!first_is_larger_than_all_of(-10, 1, 2, 3, 4, 5));
+    EXPECT(!first_is_larger_than_all_of(-10, 1, 2, 3, 4, 5));
+}


### PR DESCRIPTION
This was mentioned [in Discord](https://discord.com/channels/1247070541085671459/1247090154141646871/1319698940001648650):

> here's an observation: I think first_is_one_of() will copy all the arguments. that doesn't seem optimal! (same for that entire family of helpers)

With that in mind, this PR:
1. adds tests for AK/GenericShorthands which had none so far
2. optimizes the functions in AK/GenericShorthands by switching from pass-by-value to forwarding references
