### PR TITLE
LibWeb: Bring navigables code closer to spec

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -4452,15 +4452,10 @@ void Document::start_intersection_observing_a_lazy_loading_element(Element& elem
                 }
 
                 // 4. Stop intersection-observing a lazy loading element for entry.target.
-                // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#stop-intersection-observing-a-lazy-loading-element
-                // 1. Let doc be element's node document.
-                // NOTE: It's `this`.
+                stop_intersection_observing_a_lazy_loading_element(entry.target());
 
-                // 2. Assert: doc's lazy load intersection observer is not null.
-                VERIFY(m_lazy_load_intersection_observer);
-
-                // 3. Call doc's lazy load intersection observer unobserve method with element as the argument.
-                m_lazy_load_intersection_observer->unobserve(entry.target());
+                // 5. Set entry.target's lazy load resumption steps to null.
+                entry.target()->take_lazy_load_resumption_steps({});
 
                 // 6. Invoke resumptionSteps.
                 resumption_steps->function()();
@@ -4480,6 +4475,19 @@ void Document::start_intersection_observing_a_lazy_loading_element(Element& elem
     // 3. Call doc's lazy load intersection observer's observe method with element as the argument.
     VERIFY(m_lazy_load_intersection_observer);
     m_lazy_load_intersection_observer->observe(element);
+}
+
+// https://html.spec.whatwg.org/multipage/urls-and-fetching.html#stop-intersection-observing-a-lazy-loading-element
+void Document::stop_intersection_observing_a_lazy_loading_element(Element& element)
+{
+    // 1. Let doc be element's node document.
+    // NOTE: It's `this`.
+
+    // 2. Assert: doc's lazy load intersection observer is not null.
+    VERIFY(m_lazy_load_intersection_observer);
+
+    // 3. Call doc's lazy load intersection observer unobserve method with element as the argument.
+    m_lazy_load_intersection_observer->unobserve(element);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#shared-declarative-refresh-steps

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -606,6 +606,7 @@ public:
     void run_the_update_intersection_observations_steps(HighResolutionTime::DOMHighResTimeStamp time);
 
     void start_intersection_observing_a_lazy_loading_element(Element&);
+    void stop_intersection_observing_a_lazy_loading_element(Element&);
 
     void shared_declarative_refresh_steps(StringView input, GC::Ptr<HTML::HTMLMetaElement const> meta_element = nullptr);
 

--- a/Libraries/LibWeb/DOM/DocumentLoading.cpp
+++ b/Libraries/LibWeb/DOM/DocumentLoading.cpp
@@ -460,15 +460,16 @@ GC::Ptr<DOM::Document> load_document(HTML::NavigationParams const& navigation_pa
     if (type.essence() == "application/pdf"_string
         || type.essence() == "text/pdf"_string) {
         // FIXME: If the user agent's PDF viewer supported is true, return the result of creating a document for inline
-        //        content that doesn't have a DOM given navigationParams's navigable.
+        //        content that doesn't have a DOM given navigationParams's navigable, navigationParams's id,
+        //        navigationParams's navigation timing type, and navigationParams's user involvement.
     }
 
     // Otherwise, proceed onward.
 
-    // 3. If, given type, the new resource is to be handled by displaying some sort of inline content, e.g., a
+    // FIXME: 3. If, given type, the new resource is to be handled by displaying some sort of inline content, e.g., a
     //    native rendering of the content or an error message because the specified type is not supported, then
     //    return the result of creating a document for inline content that doesn't have a DOM given navigationParams's
-    //    navigable, navigationParams's id, and navigationParams's navigation timing type.
+    //    navigable, navigationParams's id, navigationParams's navigation timing type, and navigationParams's user involvement.
 
     // FIXME: 4. Otherwise, the document's type is such that the resource will not affect navigationParams's navigable,
     //        e.g., because the resource is to be handed to an external application or because it is an unknown type

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -18,7 +18,7 @@ bool can_load_document_with_type(MimeSniff::MimeType const&);
 
 // https://html.spec.whatwg.org/multipage/document-lifecycle.html#read-ua-inline
 template<typename MutateDocument>
-GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigable> navigable, Optional<String> navigation_id, MutateDocument mutate_document)
+GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigable> navigable, Optional<String> navigation_id, HTML::UserNavigationInvolvement user_involvement, MutateDocument mutate_document)
 {
     auto& vm = navigable->vm();
 
@@ -53,6 +53,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     //    opener policy: coop
     //    FIXME: navigation timing type: navTimingType
     //    about base URL: null
+    //    user involvement: userInvolvement
     auto response = Fetch::Infrastructure::Response::create(vm);
     response->url_list().append(URL::URL("about:error")); // AD-HOC: https://github.com/whatwg/html/issues/9122
     auto navigation_params = vm.heap().allocate<HTML::NavigationParams>();
@@ -69,6 +70,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     navigation_params->final_sandboxing_flag_set = HTML::SandboxingFlagSet {};
     navigation_params->opener_policy = move(coop);
     navigation_params->about_base_url = {};
+    navigation_params->user_involvement = user_involvement;
 
     // 5. Let document be the result of creating and initializing a Document object given "html", "text/html", and navigationParams.
     auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params).release_value_but_fixme_should_propagate_errors();

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -166,6 +166,7 @@ public:
     virtual bool is_html_object_element() const { return false; }
     virtual bool is_html_form_element() const { return false; }
     virtual bool is_html_image_element() const { return false; }
+    virtual bool is_html_iframe_element() const { return false; }
     virtual bool is_navigable_container() const { return false; }
     virtual bool is_lazy_loading() const { return false; }
 

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -40,6 +40,9 @@ private:
 
     virtual void initialize(JS::Realm&) override;
 
+    // ^DOM::Node
+    virtual bool is_html_iframe_element() const override { return true; }
+
     // ^DOM::Element
     virtual void post_connection() override;
     virtual void removed_from(Node*) override;

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1325,11 +1325,18 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
         return {};
     }
 
-    // FIXME: 9. Let container be navigable's container.
-    // 10. If container is an iframe element and will lazy load element steps given container returns true,
+    // 9. Let container be navigable's container.
+    auto& container = m_container;
 
-    // FIXME: 10. If container is an iframe element and will lazy load element steps given container returns true,
+    // 10. If container is an iframe element and will lazy load element steps given container returns true,
     //     then stop intersection-observing a lazy loading element container and set container's lazy load resumption steps to null.
+    if (container && container->is_html_iframe_element()) {
+        auto& iframe_element = static_cast<HTMLIFrameElement&>(*container);
+        if (iframe_element.will_lazy_load_element()) {
+            iframe_element.document().stop_intersection_observing_a_lazy_loading_element(iframe_element);
+            iframe_element.set_lazy_load_resumption_steps(nullptr);
+        }
+    }
 
     // 11. If historyHandling is "auto", then:
     if (history_handling == Bindings::NavigationHistoryBehavior::Auto) {

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -34,13 +34,6 @@ enum class CSPNavigationType {
     FormSubmission,
 };
 
-// https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement
-enum class UserNavigationInvolvement {
-    BrowserUI,
-    Activation,
-    None,
-};
-
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#target-snapshot-params
 struct TargetSnapshotParams {
     SandboxingFlagSet sandboxing_flags {};
@@ -133,6 +126,7 @@ public:
         GC::Ptr<SessionHistoryEntry> entry,
         SourceSnapshotParams const& source_snapshot_params,
         TargetSnapshotParams const& target_snapshot_params,
+        UserNavigationInvolvement user_involvement,
         Optional<String> navigation_id = {},
         NavigationParamsVariant navigation_params = Navigable::NullOrError {},
         CSPNavigationType csp_navigation_type = CSPNavigationType::Other,
@@ -156,12 +150,12 @@ public:
 
     WebIDL::ExceptionOr<void> navigate_to_a_fragment(URL::URL const&, HistoryHandlingBehavior, UserNavigationInvolvement, Optional<SerializationRecord> navigation_api_state, String navigation_id);
 
-    GC::Ptr<DOM::Document> evaluate_javascript_url(URL::URL const&, URL::Origin const& new_document_origin, String navigation_id);
-    void navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, URL::Origin const& initiator_origin, CSPNavigationType csp_navigation_type, String navigation_id);
+    GC::Ptr<DOM::Document> evaluate_javascript_url(URL::URL const&, URL::Origin const& new_document_origin, UserNavigationInvolvement, String navigation_id);
+    void navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, URL::Origin const& initiator_origin, UserNavigationInvolvement, CSPNavigationType csp_navigation_type, String navigation_id);
 
     bool allowed_by_sandboxing_to_navigate(Navigable const& target, SourceSnapshotParams const&);
 
-    void reload();
+    void reload(UserNavigationInvolvement = UserNavigationInvolvement::None);
 
     // https://github.com/whatwg/html/issues/9690
     [[nodiscard]] bool has_been_destroyed() const { return m_has_been_destroyed; }
@@ -245,7 +239,7 @@ private:
 HashTable<Navigable*>& all_navigables();
 
 bool navigation_must_be_a_replace(URL::URL const& url, DOM::Document const& document);
-void finalize_a_cross_document_navigation(GC::Ref<Navigable>, HistoryHandlingBehavior, GC::Ref<SessionHistoryEntry>);
+void finalize_a_cross_document_navigation(GC::Ref<Navigable>, HistoryHandlingBehavior, UserNavigationInvolvement, GC::Ref<SessionHistoryEntry>);
 void perform_url_and_history_update_steps(DOM::Document& document, URL::URL new_url, Optional<SerializationRecord> = {}, HistoryHandlingBehavior history_handling = HistoryHandlingBehavior::Replace);
 UserNavigationInvolvement user_navigation_involvement(DOM::Event const&);
 

--- a/Libraries/LibWeb/HTML/NavigationParams.h
+++ b/Libraries/LibWeb/HTML/NavigationParams.h
@@ -20,6 +20,13 @@
 
 namespace Web::HTML {
 
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#user-navigation-involvement
+enum class UserNavigationInvolvement {
+    BrowserUI,
+    Activation,
+    None,
+};
+
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigation-params
 struct NavigationParams : JS::Cell {
     GC_CELL(NavigationParams, JS::Cell);
@@ -66,6 +73,9 @@ struct NavigationParams : JS::Cell {
     // a URL or null used to populate the new Document's about base URL
     Optional<URL::URL> about_base_url;
 
+    // a user navigation involvement used when obtaining a browsing context for the new Document
+    UserNavigationInvolvement user_involvement;
+
     void visit_edges(Visitor& visitor) override;
 };
 
@@ -93,6 +103,9 @@ struct NonFetchSchemeNavigationParams : JS::Cell {
     URL::Origin initiator_origin;
 
     // FIXME: a NavigationTimingType used for creating the navigation timing entry for the new Document
+
+    // a user navigation involvement used when obtaining a browsing context for the new Document (if one is created)
+    UserNavigationInvolvement user_involvement;
 
     void visit_edges(Visitor& visitor) override;
 };

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -429,7 +429,7 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     bool check_for_cancelation,
     IGNORE_USE_IN_ESCAPING_LAMBDA Optional<SourceSnapshotParams> source_snapshot_params,
     GC::Ptr<Navigable> initiator_to_check,
-    IGNORE_USE_IN_ESCAPING_LAMBDA Optional<UserNavigationInvolvement> user_involvement_for_navigate_events,
+    IGNORE_USE_IN_ESCAPING_LAMBDA UserNavigationInvolvement user_involvement,
     IGNORE_USE_IN_ESCAPING_LAMBDA Optional<Bindings::NavigationType> navigation_type,
     IGNORE_USE_IN_ESCAPING_LAMBDA SynchronousNavigation synchronous_navigation)
 {
@@ -459,9 +459,9 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
     auto navigables_crossing_documents = get_all_navigables_that_might_experience_a_cross_document_traversal(target_step);
 
     // 5. If checkForCancelation is true, and the result of checking if unloading is canceled given navigablesCrossingDocuments, traversable, targetStep,
-    //    and userInvolvementForNavigateEvents is not "continue", then return that result.
+    //    and userInvolvement is not "continue", then return that result.
     if (check_for_cancelation) {
-        auto result = check_if_unloading_is_canceled(navigables_crossing_documents, *this, target_step, user_involvement_for_navigate_events);
+        auto result = check_if_unloading_is_canceled(navigables_crossing_documents, *this, target_step, user_involvement);
         if (result == CheckIfUnloadingIsCanceledResult::CanceledByBeforeUnload)
             return HistoryStepResult::CanceledByBeforeUnload;
         if (result == CheckIfUnloadingIsCanceledResult::CanceledByNavigate)
@@ -570,14 +570,11 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
                 && target_entry != navigable->current_session_history_entry()
                 && old_origin == navigable->current_session_history_entry()->document_state()->origin()) {
 
-                // 1. Assert: userInvolvementForNavigateEvents is not null.
-                VERIFY(user_involvement_for_navigate_events.has_value());
-
-                // 2. Let navigation be navigable's active window's navigation API.
+                // 1. Let navigation be navigable's active window's navigation API.
                 auto navigation = active_window()->navigation();
 
-                // 3. Fire a traverse navigate event at navigation given targetEntry and userInvolvementForNavigateEvents.
-                navigation->fire_a_traverse_navigate_event(*target_entry, *user_involvement_for_navigate_events);
+                // 2. Fire a traverse navigate event at navigation given targetEntry and userInvolvement.
+                navigation->fire_a_traverse_navigate_event(*target_entry, user_involvement);
             }
 
             auto after_document_populated = [old_origin, changing_navigable_continuation, &changing_navigable_continuations, &vm, &navigable](bool populated_cloned_target_she, GC::Ref<SessionHistoryEntry> target_entry) mutable {
@@ -641,10 +638,11 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
                 auto populated_target_entry = target_entry->clone();
 
                 // 7. In parallel, attempt to populate the history entry's document for targetEntry, given navigable, potentiallyTargetSpecificSourceSnapshotParams,
-                //    targetSnapshotParams, with allowPOST set to allowPOST and completionSteps set to queue a global task on the navigation and traversal task source given
-                //    navigable's active window to run afterDocumentPopulated.
-                Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(this->heap(), [populated_target_entry, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated = GC::create_function(this->heap(), move(after_document_populated))] {
-                    navigable->populate_session_history_entry_document(populated_target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, {}, Navigable::NullOrError {}, CSPNavigationType::Other, allow_POST, GC::create_function(this->heap(), [this, after_document_populated, populated_target_entry]() mutable {
+                //    targetSnapshotParams, userInvolvement, with allowPOST set to allowPOST and completionSteps set to
+                //    queue a global task on the navigation and traversal task source given navigable's active window to
+                //    run afterDocumentPopulated.
+                Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(this->heap(), [populated_target_entry, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated = GC::create_function(this->heap(), move(after_document_populated)), user_involvement] {
+                    navigable->populate_session_history_entry_document(populated_target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, user_involvement, {}, Navigable::NullOrError {}, CSPNavigationType::Other, allow_POST, GC::create_function(this->heap(), [this, after_document_populated, populated_target_entry]() mutable {
                                  VERIFY(active_window());
                                  queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(this->heap(), [after_document_populated, populated_target_entry]() mutable {
                                      after_document_populated->function()(true, populated_target_entry);
@@ -789,8 +787,8 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
             // 1. Assert: navigationType is not null.
             VERIFY(navigation_type.has_value());
 
-            // 2. Deactivate displayedDocument, given userNavigationInvolvement, targetEntry, navigationType, and afterPotentialUnloads.
-            deactivate_a_document_for_cross_document_navigation(*displayed_document, user_involvement_for_navigate_events, *populated_target_entry, after_potential_unload);
+            // 2. Deactivate displayedDocument, given userInvolvement, targetEntry, navigationType, and afterPotentialUnloads.
+            deactivate_a_document_for_cross_document_navigation(*displayed_document, user_involvement, *populated_target_entry, after_potential_unload);
         }
     }
 
@@ -896,26 +894,23 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
         // 3. If targetEntry is not traversable's current session history entry, and targetEntry's document state's origin is the same as
         //    traversable's current session history entry's document state's origin, then:
         if (target_entry != traversable->current_session_history_entry() && target_entry->document_state()->origin() != traversable->current_session_history_entry()->document_state()->origin()) {
-            // 1. Assert: userInvolvementForNavigateEvent is not null.
-            VERIFY(user_involvement_for_navigate_events.has_value());
-
-            // 2. Let eventsFired be false.
+            // 1. Let eventsFired be false.
             IGNORE_USE_IN_ESCAPING_LAMBDA auto events_fired = false;
 
-            // 3. Let needsBeforeunload be true if navigablesThatNeedBeforeUnload contains traversable; otherwise false.
+            // 2. Let needsBeforeunload be true if navigablesThatNeedBeforeUnload contains traversable; otherwise false.
             auto it = navigables_that_need_before_unload.find_if([&traversable](GC::Root<Navigable> navigable) {
                 return navigable.ptr() == traversable.ptr();
             });
             auto needs_beforeunload = it != navigables_that_need_before_unload.end();
 
-            // 4. If needsBeforeunload is true, then remove traversable's active document from documentsToFireBeforeunload.
+            // 3. If needsBeforeunload is true, then remove traversable's active document from documentsToFireBeforeunload.
             if (needs_beforeunload) {
                 documents_to_fire_beforeunload.remove_first_matching([&](auto& document) {
                     return document.ptr() == traversable->active_document().ptr();
                 });
             }
 
-            // 5. Queue a global task on the navigation and traversal task source given traversable's active window to perform the following steps:
+            // 4. Queue a global task on the navigation and traversal task source given traversable's active window to perform the following steps:
             VERIFY(traversable->active_window());
             queue_global_task(Task::Source::NavigationAndTraversal, *traversable->active_window(), GC::create_function(heap(), [needs_beforeunload, user_involvement_for_navigate_events, traversable, target_entry, &final_status, &unload_prompt_shown, &events_fired] {
                 // 1. if needsBeforeunload is true, then:
@@ -952,12 +947,12 @@ TraversableNavigable::CheckIfUnloadingIsCanceledResult TraversableNavigable::che
                 events_fired = true;
             }));
 
-            // 6. Wait for eventsFired to be true.
+            // 5. Wait for eventsFired to be true.
             main_thread_event_loop().spin_until(GC::create_function(heap(), [&] {
                 return events_fired;
             }));
 
-            // 7. If finalStatus is not "continue", then return finalStatus.
+            // 6. If finalStatus is not "continue", then return finalStatus.
             if (final_status != CheckIfUnloadingIsCanceledResult::Continue)
                 return final_status;
         }
@@ -1177,24 +1172,25 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::update_for_navigab
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step to traversable given false, null, null, null, and null.
-    return apply_the_history_step(step, false, {}, {}, {}, {}, SynchronousNavigation::No);
+    return apply_the_history_step(step, false, {}, {}, UserNavigationInvolvement::None, {}, SynchronousNavigation::No);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-reload-history-step
-TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_reload_history_step()
+TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_reload_history_step(UserNavigationInvolvement user_involvement)
 {
     // 1. Let step be traversable's current session history step.
     auto step = current_session_history_step();
 
     // 2. Return the result of applying the history step step to traversable given true, null, null, null, and "reload".
-    return apply_the_history_step(step, true, {}, {}, {}, Bindings::NavigationType::Reload, SynchronousNavigation::No);
+    return apply_the_history_step(step, true, {}, {}, user_involvement, Bindings::NavigationType::Reload, SynchronousNavigation::No);
 }
 
-TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, SynchronousNavigation synchronous_navigation)
+// https://html.spec.whatwg.org/multipage/browsing-the-web.html#apply-the-push/replace-history-step
+TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement, SynchronousNavigation synchronous_navigation)
 {
-    // 1. Return the result of applying the history step step to traversable given false, null, null, null, and historyHandling.
+    // 1. Return the result of applying the history step step to traversable given false, null, null, userInvolvement, and historyHandling.
     auto navigation_type = history_handling == HistoryHandlingBehavior::Replace ? Bindings::NavigationType::Replace : Bindings::NavigationType::Push;
-    return apply_the_history_step(step, false, {}, {}, {}, navigation_type, synchronous_navigation);
+    return apply_the_history_step(step, false, {}, {}, user_involvement, navigation_type, synchronous_navigation);
 }
 
 TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_traverse_history_step(int step, Optional<SourceSnapshotParams> source_snapshot_params, GC::Ptr<Navigable> initiator_to_check, UserNavigationInvolvement user_involvement)
@@ -1276,7 +1272,7 @@ void TraversableNavigable::destroy_top_level_traversable()
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation
-void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversable, GC::Ref<Navigable> target_navigable, GC::Ref<SessionHistoryEntry> target_entry, GC::Ptr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior history_handling)
+void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversable, GC::Ref<Navigable> target_navigable, GC::Ref<SessionHistoryEntry> target_entry, GC::Ptr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior history_handling, UserNavigationInvolvement user_involvement)
 {
     // NOTE: This is not in the spec but we should not navigate destroyed navigable.
     if (target_navigable->has_been_destroyed())
@@ -1321,8 +1317,8 @@ void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversab
         target_step = traversable->current_session_history_step();
     }
 
-    // 6. Apply the push/replace history step targetStep to traversable given historyHandling.
-    traversable->apply_the_push_or_replace_history_step(*target_step, history_handling, TraversableNavigable::SynchronousNavigation::Yes);
+    // 6. Apply the push/replace history step targetStep to traversable given historyHandling and userInvolvement.
+    traversable->apply_the_push_or_replace_history_step(*target_step, history_handling, user_involvement, TraversableNavigable::SynchronousNavigation::Yes);
 }
 
 // https://html.spec.whatwg.org/multipage/interaction.html#system-visibility-state

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -61,12 +61,12 @@ public:
     };
 
     HistoryStepResult apply_the_traverse_history_step(int, Optional<SourceSnapshotParams>, GC::Ptr<Navigable>, UserNavigationInvolvement);
-    HistoryStepResult apply_the_reload_history_step();
+    HistoryStepResult apply_the_reload_history_step(UserNavigationInvolvement);
     enum class SynchronousNavigation : bool {
         Yes,
         No,
     };
-    HistoryStepResult apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, SynchronousNavigation);
+    HistoryStepResult apply_the_push_or_replace_history_step(int step, HistoryHandlingBehavior history_handling, UserNavigationInvolvement, SynchronousNavigation);
     HistoryStepResult update_for_navigable_creation_or_destruction();
 
     int get_the_used_step(int step) const;
@@ -122,7 +122,7 @@ private:
         bool check_for_cancelation,
         Optional<SourceSnapshotParams>,
         GC::Ptr<Navigable> initiator_to_check,
-        Optional<UserNavigationInvolvement> user_involvement_for_navigate_events,
+        UserNavigationInvolvement user_involvement,
         Optional<Bindings::NavigationType> navigation_type,
         SynchronousNavigation);
 
@@ -167,6 +167,6 @@ struct BrowsingContextAndDocument {
 };
 
 WebIDL::ExceptionOr<BrowsingContextAndDocument> create_a_new_top_level_browsing_context_and_document(GC::Ref<Page> page);
-void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversable, GC::Ref<Navigable> target_navigable, GC::Ref<SessionHistoryEntry> target_entry, GC::Ptr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior);
+void finalize_a_same_document_navigation(GC::Ref<TraversableNavigable> traversable, GC::Ref<Navigable> target_navigable, GC::Ref<SessionHistoryEntry> target_entry, GC::Ptr<SessionHistoryEntry> entry_to_replace, HistoryHandlingBehavior, UserNavigationInvolvement);
 
 }


### PR DESCRIPTION
This is the second part of implementing the changes in https://github.com/whatwg/html/pull/10818

I noticed while doing that, that the spec numbers weren't lining up. So I then updated the spec steps, and filled in a couple of FIXMEs we had there.

For the first time in over a month, I have zero spec changes in my GitHub notifications. :tada: 