### PR TITLE
LibWeb: Implement user-select

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1395,6 +1395,12 @@ Optional<CSS::WritingMode> ComputedProperties::writing_mode() const
     return keyword_to_writing_mode(value.to_keyword());
 }
 
+Optional<CSS::UserSelect> ComputedProperties::user_select() const
+{
+    auto const& value = property(CSS::PropertyID::UserSelect);
+    return keyword_to_user_select(value.to_keyword());
+}
+
 Optional<CSS::MaskType> ComputedProperties::mask_type() const
 {
     auto const& value = property(CSS::PropertyID::MaskType);

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -158,6 +158,7 @@ public:
     Optional<CSS::Direction> direction() const;
     Optional<CSS::UnicodeBidi> unicode_bidi() const;
     Optional<CSS::WritingMode> writing_mode() const;
+    Optional<CSS::UserSelect> user_select() const;
 
     static Vector<CSS::Transformation> transformations_for_style_value(CSSStyleValue const& value);
     Vector<CSS::Transformation> transformations() const;

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -168,6 +168,7 @@ public:
     static CSS::Direction direction() { return CSS::Direction::Ltr; }
     static CSS::UnicodeBidi unicode_bidi() { return CSS::UnicodeBidi::Normal; }
     static CSS::WritingMode writing_mode() { return CSS::WritingMode::HorizontalTb; }
+    static CSS::UserSelect user_select() { return CSS::UserSelect::Auto; }
 
     // https://www.w3.org/TR/SVG/geometry.html
     static LengthPercentage cx() { return CSS::Length::make_px(0); }
@@ -421,6 +422,7 @@ public:
     CSS::Direction direction() const { return m_inherited.direction; }
     CSS::UnicodeBidi unicode_bidi() const { return m_noninherited.unicode_bidi; }
     CSS::WritingMode writing_mode() const { return m_inherited.writing_mode; }
+    CSS::UserSelect user_select() const { return m_noninherited.user_select; }
 
     CSS::LengthBox const& inset() const { return m_noninherited.inset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -671,6 +673,8 @@ protected:
         CSS::ObjectFit object_fit { InitialValues::object_fit() };
         CSS::ObjectPosition object_position { InitialValues::object_position() };
         CSS::UnicodeBidi unicode_bidi { InitialValues::unicode_bidi() };
+        CSS::UserSelect user_select { InitialValues::user_select() };
+
         Optional<CSS::Transformation> rotate;
         Optional<CSS::Transformation> translate;
         Optional<CSS::Transformation> scale;
@@ -841,6 +845,7 @@ public:
     void set_direction(CSS::Direction value) { m_inherited.direction = value; }
     void set_unicode_bidi(CSS::UnicodeBidi value) { m_noninherited.unicode_bidi = value; }
     void set_writing_mode(CSS::WritingMode value) { m_inherited.writing_mode = value; }
+    void set_user_select(CSS::UserSelect value) { m_noninherited.user_select = value; }
 
     void set_fill(SVGPaint value) { m_inherited.fill = move(value); }
     void set_stroke(SVGPaint value) { m_inherited.stroke = move(value); }

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -538,6 +538,13 @@
     "normal",
     "plaintext"
   ],
+  "user-select": [
+    "all",
+    "auto",
+    "contain",
+    "none",
+    "text"
+  ],
   "vertical-align": [
     "baseline",
     "bottom",

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -2819,12 +2819,8 @@
     "animation-type": "discrete",
     "inherited": false,
     "initial": "auto",
-    "valid-identifiers": [
-      "all",
-      "auto",
-      "contain",
-      "none",
-      "text"
+    "valid-types": [
+      "user-select"
     ]
   },
   "vertical-align": {

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -22,6 +22,7 @@
 #include <LibWeb/CSS/StyleValues/URLStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Dump.h>
+#include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/FormattingContext.h>
@@ -996,6 +997,9 @@ void NodeWithStyle::apply_style(const CSS::ComputedProperties& computed_style)
     if (auto writing_mode = computed_style.writing_mode(); writing_mode.has_value())
         computed_values.set_writing_mode(writing_mode.value());
 
+    if (auto user_select = computed_style.user_select(); user_select.has_value())
+        computed_values.set_user_select(user_select.value());
+
     propagate_style_to_anonymous_wrappers();
 }
 
@@ -1204,6 +1208,55 @@ DOM::Document& Node::document()
 DOM::Document const& Node::document() const
 {
     return m_dom_node->document();
+}
+
+// https://drafts.csswg.org/css-ui/#propdef-user-select
+CSS::UserSelect Node::user_select_used_value() const
+{
+    // The used value is the same as the computed value, except:
+    auto computed_value = computed_values().user_select();
+
+    // 1. on editable elements where the used value is always 'contain' regardless of the computed value
+
+    // 2. when the computed value is 'auto', in which case the used value is one of the other values as defined below
+
+    // For the purpose of this specification, an editable element is either an editing host or a mutable form control with
+    // textual content, such as textarea.
+    auto* form_control = dynamic_cast<HTML::FormAssociatedTextControlElement const*>(dom_node());
+    // FIXME: Check if this needs to exclude input elements with types such as color or range, and if so, which ones exactly.
+    if ((dom_node() && dom_node()->is_editing_host()) || (form_control && form_control->is_mutable())) {
+        return CSS::UserSelect::Contain;
+    } else if (computed_value == CSS::UserSelect::Auto) {
+        // The used value of 'auto' is determined as follows:
+        // - On the '::before' and '::after' pseudo-elements, the used value is 'none'
+        if (is_generated_for_before_pseudo_element() || is_generated_for_after_pseudo_element()) {
+            return CSS::UserSelect::None;
+        }
+
+        // - If the element is an editable element, the used value is 'contain'
+        // NOTE: We already handled this above.
+
+        auto parent_element = parent();
+        if (parent_element) {
+            auto parent_used_value = parent_element->user_select_used_value();
+
+            // - Otherwise, if the used value of user-select on the parent of this element is 'all', the used value is 'all'
+            if (parent_used_value == CSS::UserSelect::All) {
+                return CSS::UserSelect::All;
+            }
+
+            // - Otherwise, if the used value of user-select on the parent of this element is 'none', the used value is
+            //   'none'
+            if (parent_used_value == CSS::UserSelect::None) {
+                return CSS::UserSelect::None;
+            }
+        }
+
+        // - Otherwise, the used value is 'text'
+        return CSS::UserSelect::Text;
+    }
+
+    return computed_value;
 }
 
 }

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -188,6 +188,9 @@ public:
         return false;
     }
 
+    // https://drafts.csswg.org/css-ui/#propdef-user-select
+    CSS::UserSelect user_select_used_value() const;
+
 protected:
     Node(DOM::Document&, DOM::Node*);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-ui/parsing/user-select-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-ui/parsing/user-select-valid.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	e.style['user-select'] = "auto" should set the property value
+Pass	e.style['user-select'] = "text" should set the property value
+Pass	e.style['user-select'] = "none" should set the property value
+Pass	e.style['user-select'] = "contain" should set the property value
+Pass	e.style['user-select'] = "all" should set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-ui/parsing/user-select-valid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-ui/parsing/user-select-valid.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS UI Level 4: parsing user-select with valid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-ui-4/#content-selection">
+<meta name="assert" content="user-select supports the full grammar 'auto | text | none | contain | all'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_valid_value("user-select", "auto");
+test_valid_value("user-select", "text");
+test_valid_value("user-select", "none");
+test_valid_value("user-select", "contain");
+test_valid_value("user-select", "all");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This implements all values of user-select.

Some things to note:
1. There is no tests yet. It is 2am and I'm just opening this PR for now so that the code can at least be looked at. I will add tests tomorrow.
2. I've modified the steps in `ViewportPaintable::recompute_selection_states()` to support cases where the end container of the range includes the start container, as this is now a possibility due to how `user-select: all` and `user-select: contain` have been implemented. (Example for `contain`: If the user's selection overshoots the end of the `contain` element, it is clamped back into said element by making that element the end container of the selection and setting the end index to its length.)
3. Elements with `user-select: none` are included in a selection if it spans across the entire element, starting before it and ending after it. This is spec-compliant for browsers which do not support multi-range selections, which, currently, is any conforming browser, according to [the Selection API](https://w3c.github.io/selection-api/).