### PR TITLE
LibWeb: Avoid crash from zero-duration transitions

### DIFF
--- a/Libraries/LibWeb/CSS/CSSTransition.cpp
+++ b/Libraries/LibWeb/CSS/CSSTransition.cpp
@@ -140,6 +140,11 @@ void CSSTransition::visit_edges(Cell::Visitor& visitor)
 double CSSTransition::timing_function_output_at_time(double t) const
 {
     auto progress = (t - transition_start_time()) / (transition_end_time() - transition_start_time());
+    // AD-HOC: If the transition has an empty duration then we get NaN here,
+    // setting progress to 1 because an instant transition may be considered "finished".
+    if (transition_start_time() < transition_end_time())
+        progress = 1;
+
     // FIXME: Is this before_flag value correct?
     bool before_flag = t < transition_start_time();
     return m_keyframe_effect->timing_function().evaluate_at(progress, before_flag);

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/CSSTransition-effect.tentative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/CSSTransition-effect.tentative.txt
@@ -2,11 +2,11 @@ Harness status: OK
 
 Found 10 tests
 
-5 Pass
-5 Fail
+6 Pass
+4 Fail
 Pass	After setting a transition's effect to null, it still reports the original transition property
 Pass	After setting a transition's effect to null, it becomes finished
-Fail	After setting a transition's effect to null, style is updated
+Pass	After setting a transition's effect to null, style is updated
 Fail	After setting a transition's effect to null, a new transition can be started
 Fail	After setting a transition's effect to null, it should be possible to interrupt that transition
 Pass	After setting a new keyframe effect with a shorter duration, the transition becomes finished


### PR DESCRIPTION
Fixes a crash on https://neal.fun/ (and another website I forgot (and a single WPT subtest ??)).

It's difficult to consistently reproduce the crash in a test since it seems to depend on precise timing when interrupting a transition.