### PR TITLE
LibWebView+ImageDecoder+RequestServer+WebContent: Add init_transport

### DIFF
--- a/Libraries/LibImageDecoderClient/Client.h
+++ b/Libraries/LibImageDecoderClient/Client.h
@@ -34,6 +34,8 @@ class Client final
     C_OBJECT_ABSTRACT(Client);
 
 public:
+    using InitTransport = Messages::ImageDecoderServer::InitTransport;
+
     Client(IPC::Transport);
 
     NonnullRefPtr<Core::Promise<DecodedImage>> decode_image(ReadonlyBytes, Function<ErrorOr<void>(DecodedImage&)> on_resolved, Function<void(Error&)> on_rejected, Optional<Gfx::IntSize> ideal_size = {}, Optional<ByteString> mime_type = {});

--- a/Libraries/LibRequests/RequestClient.h
+++ b/Libraries/LibRequests/RequestClient.h
@@ -24,6 +24,8 @@ class RequestClient final
     C_OBJECT_ABSTRACT(RequestClient)
 
 public:
+    using InitTransport = Messages::RequestServer::InitTransport;
+
     explicit RequestClient(IPC::Transport);
     virtual ~RequestClient() override;
 

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -53,6 +53,11 @@ static ErrorOr<NonnullRefPtr<ClientType>> launch_server_process(
             if constexpr (requires { client->set_pid(pid_t {}); })
                 client->set_pid(process.pid());
 
+            if constexpr (requires { client->transport().set_peer_pid(0); } && !IsSame<ClientType, Web::HTML::WebWorkerClient>) {
+                auto response = client->template send_sync<typename ClientType::InitTransport>(Core::System::getpid());
+                client->transport().set_peer_pid(response->peer_pid());
+            }
+
             WebView::Application::the().add_child_process(move(process));
 
             if (chrome_options.profile_helper_process == process_type) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -29,6 +29,8 @@ class WebContentClient final
     C_OBJECT_ABSTRACT(WebContentClient);
 
 public:
+    using InitTransport = Messages::WebContentServer::InitTransport;
+
     static Optional<ViewImplementation&> view_for_pid_and_page_id(pid_t pid, u64 page_id);
 
     template<CallableAs<IterationDecision, WebContentClient&> Callback>

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -40,6 +40,15 @@ void ConnectionFromClient::die()
     }
 }
 
+Messages::ImageDecoderServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    m_transport.set_peer_pid(peer_pid);
+    return Core::System::getpid();
+#endif
+    VERIFY_NOT_REACHED();
+}
+
 ErrorOr<IPC::File> ConnectionFromClient::connect_new_client()
 {
     int socket_fds[2] {};

--- a/Services/ImageDecoder/ConnectionFromClient.h
+++ b/Services/ImageDecoder/ConnectionFromClient.h
@@ -43,6 +43,7 @@ private:
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&, Optional<Gfx::IntSize> const& ideal_size, Optional<ByteString> const& mime_type) override;
     virtual void cancel_decoding(i64 image_id) override;
     virtual Messages::ImageDecoderServer::ConnectNewClientsResponse connect_new_clients(size_t count) override;
+    virtual Messages::ImageDecoderServer::InitTransportResponse init_transport(int peer_pid) override;
 
     ErrorOr<IPC::File> connect_new_client();
 

--- a/Services/ImageDecoder/ImageDecoderServer.ipc
+++ b/Services/ImageDecoder/ImageDecoderServer.ipc
@@ -2,6 +2,7 @@
 
 endpoint ImageDecoderServer
 {
+    init_transport(int peer_pid) => (int peer_pid)
     decode_image(Core::AnonymousBuffer data, Optional<Gfx::IntSize> ideal_size, Optional<ByteString> mime_type) => (i64 image_id)
     cancel_decoding(i64 image_id) =|
 

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -286,6 +286,15 @@ void ConnectionFromClient::die()
         Core::EventLoop::current().quit(0);
 }
 
+Messages::RequestServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    m_transport.set_peer_pid(peer_pid);
+    return Core::System::getpid();
+#endif
+    VERIFY_NOT_REACHED();
+}
+
 Messages::RequestServer::ConnectNewClientResponse ConnectionFromClient::connect_new_client()
 {
     static_assert(IsSame<IPC::Transport, IPC::TransportSocket>, "Need to handle other IPC transports here");

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -43,6 +43,7 @@ public:
 private:
     explicit ConnectionFromClient(IPC::Transport);
 
+    virtual Messages::RequestServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual Messages::RequestServer::ConnectNewClientResponse connect_new_client() override;
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(ByteString const&) override;
     virtual void set_dns_server(ByteString const& host_or_address, u16 port, bool use_tls) override;

--- a/Services/RequestServer/RequestServer.ipc
+++ b/Services/RequestServer/RequestServer.ipc
@@ -5,6 +5,7 @@
 
 endpoint RequestServer
 {
+    init_transport(int peer_pid) => (int peer_pid)
     connect_new_client() => (IPC::File client_socket)
 
     // use_tls: enable DNS over TLS

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -70,6 +70,15 @@ void ConnectionFromClient::die()
     Web::Platform::EventLoopPlugin::the().quit();
 }
 
+Messages::WebContentServer::InitTransportResponse ConnectionFromClient::init_transport([[maybe_unused]] int peer_pid)
+{
+#ifdef AK_OS_WINDOWS
+    m_transport.set_peer_pid(peer_pid);
+    return Core::System::getpid();
+#endif
+    VERIFY_NOT_REACHED();
+}
+
 Optional<PageClient&> ConnectionFromClient::page(u64 index, SourceLocation location)
 {
     if (auto page = m_page_host->page(index); page.has_value())

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -53,6 +53,7 @@ private:
     Optional<PageClient&> page(u64 index, SourceLocation = SourceLocation::current());
     Optional<PageClient const&> page(u64 index, SourceLocation = SourceLocation::current()) const;
 
+    virtual Messages::WebContentServer::InitTransportResponse init_transport(int peer_pid) override;
     virtual void close_server() override;
     virtual Messages::WebContentServer::GetWindowHandleResponse get_window_handle(u64 page_id) override;
     virtual void set_window_handle(u64 page_id, String const& handle) override;

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -16,6 +16,7 @@
 
 endpoint WebContentServer
 {
+    init_transport(int peer_pid) => (int peer_pid)
     close_server() =|
 
     get_window_handle(u64 page_id) => (String handle)

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -275,6 +275,10 @@ ErrorOr<void> initialize_resource_loader(GC::Heap& heap, int request_server_sock
     TRY(socket->set_blocking(true));
 
     auto request_client = TRY(try_make_ref_counted<Requests::RequestClient>(IPC::Transport(move(socket))));
+#ifdef AK_OS_WINDOWS
+    auto response = request_client->send_sync<Messages::RequestServer::InitTransport>(Core::System::getpid());
+    request_client->transport().set_peer_pid(response->peer_pid());
+#endif
     Web::ResourceLoader::initialize(heap, move(request_client));
 
     return {};
@@ -287,6 +291,10 @@ ErrorOr<void> initialize_image_decoder(int image_decoder_socket)
     TRY(socket->set_blocking(true));
 
     auto new_client = TRY(try_make_ref_counted<ImageDecoderClient::Client>(IPC::Transport(move(socket))));
+#ifdef AK_OS_WINDOWS
+    auto response = new_client->send_sync<Messages::ImageDecoderServer::InitTransport>(Core::System::getpid());
+    new_client->transport().set_peer_pid(response->peer_pid());
+#endif
 
     Web::Platform::ImageCodecPlugin::install(*new WebView::ImageCodecPlugin(move(new_client)));
 


### PR DESCRIPTION
This is logically part of #2643. That PR is already big, so I decided to split this part of functionality into a separate PR.

Transport socket needs to know the pid of the process holding the other end of a socket pair to pass handles between processes. Both DuplicateHandle and WSADuplicateSocket require target process pid.

This PR implements only the minimal code required to run headless browser. It doesn't initialize WebDriver connection or connections in LibWeb.

IPC compiler doesn't support conditional compilation, so init_transport message is present on Linux too.

Note: [This method](https://stackoverflow.com/a/25431340) doesn't work because `dwOwningPid` is "The PID of the process that issued a context bind for this TCP connection" ([link](https://learn.microsoft.com/en-us/windows/win32/api/tcpmib/ns-tcpmib-mib_tcprow2)), so both ends will have the pid of the process that called `socketpair`.




