### PR TITLE
LibCore: Several bug fixes for EventLoopImplementationWindows

### DIFF
--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -9,6 +9,7 @@
 #include <LibCore/EventLoopImplementationWindows.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/ThreadEventQueue.h>
+#include <LibCore/Timer.h>
 
 #include <AK/Windows.h>
 
@@ -196,7 +197,9 @@ void EventLoopManagerWindows::unregister_notifier(Notifier& notifier)
 intptr_t EventLoopManagerWindows::register_timer(EventReceiver& object, int milliseconds, bool should_reload, TimerShouldFireWhenNotVisible fire_when_not_visible)
 {
     VERIFY(milliseconds >= 0);
-    HANDLE timer = CreateWaitableTimer(NULL, FALSE, NULL);
+    // FIXME: This is a temporary fix for issue #3641
+    bool manual_reset = static_cast<Timer&>(object).is_single_shot();
+    HANDLE timer = CreateWaitableTimer(NULL, manual_reset, NULL);
     VERIFY(timer);
 
     LARGE_INTEGER first_time = {};

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -112,7 +112,9 @@ size_t EventLoopImplementationWindows::pump(PumpMode)
     for (auto& entry : timers)
         event_handles.append(entry.key.handle);
 
-    DWORD result = WaitForMultipleObjects(event_count, event_handles.data(), FALSE, INFINITE);
+    bool has_pending_events = ThreadEventQueue::current().has_pending_events();
+    int timeout = has_pending_events ? 0 : INFINITE;
+    DWORD result = WaitForMultipleObjects(event_count, event_handles.data(), FALSE, timeout);
     size_t index = result - WAIT_OBJECT_0;
     VERIFY(index < event_count);
 


### PR DESCRIPTION
Picture for commit "LibCore: Make single-shot timer objects manually reset on Windows":
![image](https://github.com/user-attachments/assets/acc2e1b3-a083-446e-abb1-3b73f535fbc8)

<details>
<summary>Some useful logging capabilities</summary>

```cpp
// AK/Format.h

#define RED(str)     "\33[91m" str "\33[0m"
#define GREEN(str)   "\33[92m" str "\33[0m"
#define BLUE(str)    "\33[94m" str "\33[0m"
#define MAGENTA(str) "\33[95m" str "\33[0m"
#define CYAN(str)    "\33[96m" str "\33[0m"
#define DCYAN(str)   "\33[36m" str "\33[0m"

namespace AK { StringView process_name_for_logging(); }

template<typename... Parameters>
void pdbgln(const char* proc_name, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
{
    if (proc_name == AK::process_name_for_logging())
        dbgln(move(fmtstr), parameters...);
}
```
</details>