### PR TITLE
LibWeb: Fix CSS tag seletor case sensitivity for SVG elements

### DIFF
--- a/Tests/LibWeb/Ref/expected/css-tag-selector-case-sensitivity-html.html
+++ b/Tests/LibWeb/Ref/expected/css-tag-selector-case-sensitivity-html.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<div style="color:green;">
+    This should be green.
+</div>

--- a/Tests/LibWeb/Ref/expected/css-tag-selector-case-sensitivity-svg.html
+++ b/Tests/LibWeb/Ref/expected/css-tag-selector-case-sensitivity-svg.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<svg viewBox="0 0 200 200">
+    <foreignObject width="200" height="200">
+        <span style="color:green;">This should be green.</span>
+    </foreignObject>
+</svg>

--- a/Tests/LibWeb/Ref/expected/css-tag-selector-case-sensitivity-xhtml.xhtml
+++ b/Tests/LibWeb/Ref/expected/css-tag-selector-case-sensitivity-xhtml.xhtml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <div>
+        This should not be red.
+    </div>
+</html>

--- a/Tests/LibWeb/Ref/input/css-tag-selector-case-sensitivity-html.html
+++ b/Tests/LibWeb/Ref/input/css-tag-selector-case-sensitivity-html.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/css-tag-selector-case-sensitivity-html.html" />
+<style>
+    DIV {
+        color: green;
+    }
+</style>
+
+<div>
+    This should be green.
+</div>

--- a/Tests/LibWeb/Ref/input/css-tag-selector-case-sensitivity-svg.html
+++ b/Tests/LibWeb/Ref/input/css-tag-selector-case-sensitivity-svg.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/css-tag-selector-case-sensitivity-svg.html" />
+<style>
+    foreignObject * {
+        color: green;
+    }
+    foreignobject * {
+        color: red;
+    }
+</style>
+
+<svg viewBox="0 0 200 200">
+    <foreignObject width="200" height="200">
+        <span>This should be green.</span>
+    </foreignObject>
+</svg>

--- a/Tests/LibWeb/Ref/input/css-tag-selector-case-sensitivity-xhtml.xhtml
+++ b/Tests/LibWeb/Ref/input/css-tag-selector-case-sensitivity-xhtml.xhtml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml">
+    <link rel="match" href="../expected/css-tag-selector-case-sensitivity-xhtml.xhtml" />
+    <style>
+        DIV {
+            color: red;
+        }
+    </style>
+
+    <div>
+        This should not be red.
+    </div>
+</html>


### PR DESCRIPTION
For things like tag names, the [CSS spec](https://drafts.csswg.org/selectors-4/#case-sensitive) defers whether or not they are case-sensitive to the specifications these names come from.
In HTML, tag names are case-insensitive, but in SVG they are case-sensitive.
I'm not sure which of the two MathML falls under, but I also don't think we currently support that.

The test uses foreignObject, cause selecting those by tag name was impossible before this fix.