### PR TITLE
LibWeb: Update implementation of Range::partially_contains_node()

### DIFF
--- a/Libraries/LibWeb/DOM/Range.cpp
+++ b/Libraries/LibWeb/DOM/Range.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2020, the SerenityOS developers.
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022-2023, Andreas Kling <andreas@ladybird.org>
- * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ * Copyright (c) 2024-2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -807,12 +807,9 @@ bool Range::contains_node(GC::Ref<Node> node) const
 // https://dom.spec.whatwg.org/#partially-contained
 bool Range::partially_contains_node(GC::Ref<Node> node) const
 {
-    // A node is partially contained in a live range if it’s an inclusive ancestor of the live range’s start node but not its end node, or vice versa.
-    if (node->is_inclusive_ancestor_of(m_start_container) && node != m_end_container)
-        return true;
-    if (node->is_inclusive_ancestor_of(m_end_container) && node != m_start_container)
-        return true;
-    return false;
+    // A node is partially contained in a live range if it’s an inclusive ancestor of the live range’s start node but
+    // not its end node, or vice versa.
+    return node->is_inclusive_ancestor_of(m_start_container) != node->is_inclusive_ancestor_of(m_end_container);
 }
 
 // https://dom.spec.whatwg.org/#dom-range-insertnode


### PR DESCRIPTION
This accurately reflects the spec it's implementing. This algorithm is used in 5 spots in the spec but the old buggy behavior was never triggered:

  * In both ::extract() and ::clone_the_contents(), invocations to this method are guarded by a check to see if the start node is the inclusive ancestor of the end node, or vice versa - effectively resulting in the inequality checks to be accidentally correct.

  * In ::surround_contents(), we forego the usage of this algorithm as stated in the spec, and instead use a correct and more optimized version that simply compares the start and end nodes.

A lot of words to say: no functional changes :^)