### PR TITLE
AK: Remove no longer valid FIXME comment in SourceGenerator

### DIFF
--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -131,7 +131,6 @@ public:
         appendln(StringView { pattern, N - 1 });
     }
 
-    // FIXME: These are deprecated.
     void set(StringView key, ByteString value)
     {
         set(key, MUST(String::from_byte_string(value)));


### PR DESCRIPTION
In 5e1499d, we un-deprecated DeprecatedString and repurposed it as a byte string. That commit was auto-generated and it missed this FIXME comment. This commit cleans up the comment so that it doesn't cause confusion.

EDIT 1: seems like CI is failing on an unrelated LibWeb timeout. Unsure what to do about that, if anything. 🤷

EDIT 2: trying a force push to re-trigger CI and see if it passed this time.