### PR TITLE
LibWeb/CSS: Let calc() know its context

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNumericType.h
+++ b/Libraries/LibWeb/CSS/CSSNumericType.h
@@ -78,7 +78,6 @@ public:
     bool matches_number() const;
     bool matches_percentage() const;
     bool matches_resolution() const { return matches_dimension(BaseType::Resolution); }
-    bool matches_resolution_percentage() const { return matches_dimension_percentage(BaseType::Resolution); }
     bool matches_time() const { return matches_dimension(BaseType::Time); }
     bool matches_time_percentage() const { return matches_dimension_percentage(BaseType::Time); }
 

--- a/Libraries/LibWeb/CSS/CSSNumericType.h
+++ b/Libraries/LibWeb/CSS/CSSNumericType.h
@@ -68,18 +68,18 @@ public:
     Optional<CSSNumericType> consistent_type(CSSNumericType const& other) const;
     Optional<CSSNumericType> made_consistent_with(CSSNumericType const& other) const;
 
-    bool matches_angle() const { return matches_dimension(BaseType::Angle); }
-    bool matches_angle_percentage() const { return matches_dimension_percentage(BaseType::Angle); }
-    bool matches_flex() const { return matches_dimension(BaseType::Flex); }
-    bool matches_frequency() const { return matches_dimension(BaseType::Frequency); }
-    bool matches_frequency_percentage() const { return matches_dimension_percentage(BaseType::Frequency); }
-    bool matches_length() const { return matches_dimension(BaseType::Length); }
-    bool matches_length_percentage() const { return matches_dimension_percentage(BaseType::Length); }
-    bool matches_number() const;
+    bool matches_angle(Optional<ValueType> percentages_resolve_as) const { return matches_dimension(BaseType::Angle, percentages_resolve_as); }
+    bool matches_angle_percentage(Optional<ValueType> percentages_resolve_as) const { return matches_dimension_percentage(BaseType::Angle, percentages_resolve_as); }
+    bool matches_flex(Optional<ValueType> percentages_resolve_as) const { return matches_dimension(BaseType::Flex, percentages_resolve_as); }
+    bool matches_frequency(Optional<ValueType> percentages_resolve_as) const { return matches_dimension(BaseType::Frequency, percentages_resolve_as); }
+    bool matches_frequency_percentage(Optional<ValueType> percentages_resolve_as) const { return matches_dimension_percentage(BaseType::Frequency, percentages_resolve_as); }
+    bool matches_length(Optional<ValueType> percentages_resolve_as) const { return matches_dimension(BaseType::Length, percentages_resolve_as); }
+    bool matches_length_percentage(Optional<ValueType> percentages_resolve_as) const { return matches_dimension_percentage(BaseType::Length, percentages_resolve_as); }
+    bool matches_number(Optional<ValueType> percentages_resolve_as) const;
     bool matches_percentage() const;
-    bool matches_resolution() const { return matches_dimension(BaseType::Resolution); }
-    bool matches_time() const { return matches_dimension(BaseType::Time); }
-    bool matches_time_percentage() const { return matches_dimension_percentage(BaseType::Time); }
+    bool matches_resolution(Optional<ValueType> percentages_resolve_as) const { return matches_dimension(BaseType::Resolution, percentages_resolve_as); }
+    bool matches_time(Optional<ValueType> percentages_resolve_as) const { return matches_dimension(BaseType::Time, percentages_resolve_as); }
+    bool matches_time_percentage(Optional<ValueType> percentages_resolve_as) const { return matches_dimension_percentage(BaseType::Time, percentages_resolve_as); }
 
     bool matches_dimension() const;
 
@@ -104,8 +104,8 @@ private:
     void copy_all_entries_from(CSSNumericType const& other, SkipIfAlreadyPresent);
 
     Optional<BaseType> entry_with_value_1_while_all_others_are_0() const;
-    bool matches_dimension(BaseType) const;
-    bool matches_dimension_percentage(BaseType) const;
+    bool matches_dimension(BaseType, Optional<ValueType> percentages_resolve_as) const;
+    bool matches_dimension_percentage(BaseType, Optional<ValueType> percentages_resolve_as) const;
 
     Array<Optional<i32>, to_underlying(BaseType::__Count)> m_type_exponents;
     Optional<BaseType> m_percent_hint;

--- a/Libraries/LibWeb/CSS/Interpolation.h
+++ b/Libraries/LibWeb/CSS/Interpolation.h
@@ -11,13 +11,15 @@
 
 namespace Web::CSS {
 
+struct CalculationContext;
+
 ValueComparingRefPtr<CSSStyleValue const> interpolate_property(DOM::Element&, PropertyID, CSSStyleValue const& from, CSSStyleValue const& to, float delta);
 
 // https://drafts.csswg.org/css-transitions/#transitionable
 bool property_values_are_transitionable(PropertyID, CSSStyleValue const& old_value, CSSStyleValue const& new_value);
 
-NonnullRefPtr<CSSStyleValue const> interpolate_value(DOM::Element&, CSSStyleValue const& from, CSSStyleValue const& to, float delta);
-NonnullRefPtr<CSSStyleValue const> interpolate_box_shadow(DOM::Element&, CSSStyleValue const& from, CSSStyleValue const& to, float delta);
+NonnullRefPtr<CSSStyleValue const> interpolate_value(DOM::Element&, CalculationContext const&, CSSStyleValue const& from, CSSStyleValue const& to, float delta);
+NonnullRefPtr<CSSStyleValue const> interpolate_box_shadow(DOM::Element&, CalculationContext const&, CSSStyleValue const& from, CSSStyleValue const& to, float delta);
 RefPtr<CSSStyleValue const> interpolate_transform(DOM::Element&, CSSStyleValue const& from, CSSStyleValue const& to, float delta);
 
 Color interpolate_color(Color from, Color to, float delta);

--- a/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/GradientParsing.cpp
@@ -150,6 +150,8 @@ RefPtr<CSSStyleValue> Parser::parse_linear_gradient_function(TokenStream<Compone
         gradient_type = GradientType::WebKit;
     });
 
+    auto context_guard = push_temporary_value_parsing_context(FunctionContext { function_name });
+
     function_name = consume_if_starts_with(function_name, "repeating-"sv, [&] {
         repeating_gradient = GradientRepeating::Yes;
     });
@@ -274,6 +276,7 @@ RefPtr<CSSStyleValue> Parser::parse_conic_gradient_function(TokenStream<Componen
     GradientRepeating repeating_gradient = GradientRepeating::No;
 
     auto function_name = component_value.function().name.bytes_as_string_view();
+    auto context_guard = push_temporary_value_parsing_context(FunctionContext { function_name });
 
     function_name = consume_if_starts_with(function_name, "repeating-"sv, [&] {
         repeating_gradient = GradientRepeating::Yes;
@@ -384,6 +387,7 @@ RefPtr<CSSStyleValue> Parser::parse_radial_gradient_function(TokenStream<Compone
     auto repeating_gradient = GradientRepeating::No;
 
     auto function_name = component_value.function().name.bytes_as_string_view();
+    auto context_guard = push_temporary_value_parsing_context(FunctionContext { function_name });
 
     function_name = consume_if_starts_with(function_name, "repeating-"sv, [&] {
         repeating_gradient = GradientRepeating::Yes;

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -443,6 +443,18 @@ private:
     Vector<Token> m_tokens;
     TokenStream<Token> m_token_stream;
 
+    struct FunctionContext {
+        StringView name;
+    };
+    using ValueParsingContext = Variant<PropertyID, FunctionContext>;
+    Vector<ValueParsingContext> m_value_context;
+    auto push_temporary_value_parsing_context(ValueParsingContext&& context)
+    {
+        m_value_context.append(context);
+        return ScopeGuard { [&] { m_value_context.take_last(); } };
+    }
+    bool context_allows_quirky_length() const;
+
     enum class ContextType {
         Unknown,
         Style,

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -276,8 +276,8 @@ private:
     RefPtr<CalculatedStyleValue> parse_calculated_value(ComponentValue const&);
     RefPtr<CustomIdentStyleValue> parse_custom_ident_value(TokenStream<ComponentValue>&, std::initializer_list<StringView> blacklist);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
-    OwnPtr<CalculationNode> parse_math_function(Function const&);
-    OwnPtr<CalculationNode> parse_a_calc_function_node(Function const&);
+    OwnPtr<CalculationNode> parse_math_function(Function const&, CalculationContext const&);
+    OwnPtr<CalculationNode> parse_a_calc_function_node(Function const&, CalculationContext const&);
     RefPtr<CSSStyleValue> parse_keyword_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_hue_none_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_solidus_and_alpha_value(TokenStream<ComponentValue>&);
@@ -396,8 +396,8 @@ private:
     RefPtr<CSSStyleValue> parse_grid_area_shorthand_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_grid_shorthand_value(TokenStream<ComponentValue>&);
 
-    OwnPtr<CalculationNode> convert_to_calculation_node(CalcParsing::Node const&);
-    OwnPtr<CalculationNode> parse_a_calculation(Vector<ComponentValue> const&);
+    OwnPtr<CalculationNode> convert_to_calculation_node(CalcParsing::Node const&, CalculationContext const&);
+    OwnPtr<CalculationNode> parse_a_calculation(Vector<ComponentValue> const&, CalculationContext const&);
 
     ParseErrorOr<NonnullRefPtr<Selector>> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
     ParseErrorOr<Optional<Selector::CompoundSelector>> parse_compound_selector(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/ParsingContext.h
+++ b/Libraries/LibWeb/CSS/Parser/ParsingContext.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021-2023, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,9 +34,6 @@ public:
     HTML::Window const* window() const;
     URL::URL complete_url(StringView) const;
 
-    PropertyID current_property_id() const { return m_current_property_id; }
-    void set_current_property_id(PropertyID property_id) { m_current_property_id = property_id; }
-
     JS::Realm& realm() const
     {
         VERIFY(m_realm);
@@ -46,7 +43,6 @@ public:
 private:
     GC::Ptr<JS::Realm> m_realm;
     GC::Ptr<DOM::Document const> m_document;
-    PropertyID m_current_property_id { PropertyID::Invalid };
     URL::URL m_url;
     Mode m_mode { Mode::Normal };
 };

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -2723,7 +2723,8 @@
     "inherited": false,
     "initial": "none",
     "affects-layout": false,
-    "affects-stacking-context": true
+    "affects-stacking-context": true,
+    "percentages-resolve-to": "length"
   },
   "transform-box": {
     "animation-type": "discrete",

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.cpp
@@ -1825,7 +1825,7 @@ bool CalculatedStyleValue::equals(CSSStyleValue const& other) const
 Optional<Angle> CalculatedStyleValue::resolve_angle() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_angle())
+    if (result.type().has_value() && result.type()->matches_angle(m_context.percentages_resolve_as))
         return Angle::make_degrees(result.value());
     return {};
 }
@@ -1838,7 +1838,7 @@ Optional<Angle> CalculatedStyleValue::resolve_angle(Layout::Node const& layout_n
 Optional<Angle> CalculatedStyleValue::resolve_angle(Length::ResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context, {});
-    if (result.type().has_value() && result.type()->matches_angle())
+    if (result.type().has_value() && result.type()->matches_angle(m_context.percentages_resolve_as))
         return Angle::make_degrees(result.value());
     return {};
 }
@@ -1846,7 +1846,7 @@ Optional<Angle> CalculatedStyleValue::resolve_angle(Length::ResolutionContext co
 Optional<Angle> CalculatedStyleValue::resolve_angle_percentage(Angle const& percentage_basis) const
 {
     auto result = m_calculation->resolve({}, percentage_basis);
-    if (result.type().has_value() && result.type()->matches_angle())
+    if (result.type().has_value() && result.type()->matches_angle(m_context.percentages_resolve_as))
         return Angle::make_degrees(result.value());
     return {};
 }
@@ -1854,7 +1854,7 @@ Optional<Angle> CalculatedStyleValue::resolve_angle_percentage(Angle const& perc
 Optional<Flex> CalculatedStyleValue::resolve_flex() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_flex())
+    if (result.type().has_value() && result.type()->matches_flex(m_context.percentages_resolve_as))
         return Flex::make_fr(result.value());
     return {};
 }
@@ -1862,7 +1862,7 @@ Optional<Flex> CalculatedStyleValue::resolve_flex() const
 Optional<Frequency> CalculatedStyleValue::resolve_frequency() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_frequency())
+    if (result.type().has_value() && result.type()->matches_frequency(m_context.percentages_resolve_as))
         return Frequency::make_hertz(result.value());
     return {};
 }
@@ -1870,7 +1870,7 @@ Optional<Frequency> CalculatedStyleValue::resolve_frequency() const
 Optional<Frequency> CalculatedStyleValue::resolve_frequency_percentage(Frequency const& percentage_basis) const
 {
     auto result = m_calculation->resolve({}, percentage_basis);
-    if (result.type().has_value() && result.type()->matches_frequency())
+    if (result.type().has_value() && result.type()->matches_frequency(m_context.percentages_resolve_as))
         return Frequency::make_hertz(result.value());
     return {};
 }
@@ -1878,7 +1878,7 @@ Optional<Frequency> CalculatedStyleValue::resolve_frequency_percentage(Frequency
 Optional<Length> CalculatedStyleValue::resolve_length(Length::ResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context, {});
-    if (result.type().has_value() && result.type()->matches_length())
+    if (result.type().has_value() && result.type()->matches_length(m_context.percentages_resolve_as))
         return Length::make_px(CSSPixels { result.value() });
     return {};
 }
@@ -1901,7 +1901,7 @@ Optional<Length> CalculatedStyleValue::resolve_length_percentage(Layout::Node co
 Optional<Length> CalculatedStyleValue::resolve_length_percentage(Length::ResolutionContext const& resolution_context, Length const& percentage_basis) const
 {
     auto result = m_calculation->resolve(resolution_context, percentage_basis);
-    if (result.type().has_value() && result.type()->matches_length())
+    if (result.type().has_value() && result.type()->matches_length(m_context.percentages_resolve_as))
         return Length::make_px(CSSPixels { result.value() });
     return {};
 }
@@ -1917,7 +1917,7 @@ Optional<Percentage> CalculatedStyleValue::resolve_percentage() const
 Optional<Resolution> CalculatedStyleValue::resolve_resolution() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_resolution())
+    if (result.type().has_value() && result.type()->matches_resolution(m_context.percentages_resolve_as))
         return Resolution::make_dots_per_pixel(result.value());
     return {};
 }
@@ -1925,7 +1925,7 @@ Optional<Resolution> CalculatedStyleValue::resolve_resolution() const
 Optional<Time> CalculatedStyleValue::resolve_time() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_time())
+    if (result.type().has_value() && result.type()->matches_time(m_context.percentages_resolve_as))
         return Time::make_seconds(result.value());
     return {};
 }
@@ -1933,7 +1933,7 @@ Optional<Time> CalculatedStyleValue::resolve_time() const
 Optional<Time> CalculatedStyleValue::resolve_time_percentage(Time const& percentage_basis) const
 {
     auto result = m_calculation->resolve({}, percentage_basis);
-    if (result.type().has_value() && result.type()->matches_time())
+    if (result.type().has_value() && result.type()->matches_time(m_context.percentages_resolve_as))
         return Time::make_seconds(result.value());
     return {};
 }
@@ -1941,7 +1941,7 @@ Optional<Time> CalculatedStyleValue::resolve_time_percentage(Time const& percent
 Optional<double> CalculatedStyleValue::resolve_number() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_number())
+    if (result.type().has_value() && result.type()->matches_number(m_context.percentages_resolve_as))
         return result.value();
     return {};
 }
@@ -1949,7 +1949,7 @@ Optional<double> CalculatedStyleValue::resolve_number() const
 Optional<double> CalculatedStyleValue::resolve_number(Length::ResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context, {});
-    if (result.type().has_value() && result.type()->matches_number())
+    if (result.type().has_value() && result.type()->matches_number(m_context.percentages_resolve_as))
         return result.value();
     return {};
 }
@@ -1962,7 +1962,7 @@ Optional<double> CalculatedStyleValue::resolve_number(Layout::Node const& layout
 Optional<i64> CalculatedStyleValue::resolve_integer() const
 {
     auto result = m_calculation->resolve({}, {});
-    if (result.type().has_value() && result.type()->matches_number())
+    if (result.type().has_value() && result.type()->matches_number(m_context.percentages_resolve_as))
         return llround(result.value());
     return {};
 }
@@ -1970,7 +1970,7 @@ Optional<i64> CalculatedStyleValue::resolve_integer() const
 Optional<i64> CalculatedStyleValue::resolve_integer(Length::ResolutionContext const& context) const
 {
     auto result = m_calculation->resolve(context, {});
-    if (result.type().has_value() && result.type()->matches_number())
+    if (result.type().has_value() && result.type()->matches_number(m_context.percentages_resolve_as))
         return llround(result.value());
     return {};
 }

--- a/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CalculatedStyleValue.h
@@ -69,23 +69,23 @@ public:
     virtual String to_string(SerializationMode) const override;
     virtual bool equals(CSSStyleValue const& other) const override;
 
-    bool resolves_to_angle() const { return m_resolved_type.matches_angle(); }
-    bool resolves_to_angle_percentage() const { return m_resolved_type.matches_angle_percentage(); }
+    bool resolves_to_angle() const { return m_resolved_type.matches_angle(m_context.percentages_resolve_as); }
+    bool resolves_to_angle_percentage() const { return m_resolved_type.matches_angle_percentage(m_context.percentages_resolve_as); }
     Optional<Angle> resolve_angle() const;
     Optional<Angle> resolve_angle(Layout::Node const& layout_node) const;
     Optional<Angle> resolve_angle(Length::ResolutionContext const& context) const;
     Optional<Angle> resolve_angle_percentage(Angle const& percentage_basis) const;
 
-    bool resolves_to_flex() const { return m_resolved_type.matches_flex(); }
+    bool resolves_to_flex() const { return m_resolved_type.matches_flex(m_context.percentages_resolve_as); }
     Optional<Flex> resolve_flex() const;
 
-    bool resolves_to_frequency() const { return m_resolved_type.matches_frequency(); }
-    bool resolves_to_frequency_percentage() const { return m_resolved_type.matches_frequency_percentage(); }
+    bool resolves_to_frequency() const { return m_resolved_type.matches_frequency(m_context.percentages_resolve_as); }
+    bool resolves_to_frequency_percentage() const { return m_resolved_type.matches_frequency_percentage(m_context.percentages_resolve_as); }
     Optional<Frequency> resolve_frequency() const;
     Optional<Frequency> resolve_frequency_percentage(Frequency const& percentage_basis) const;
 
-    bool resolves_to_length() const { return m_resolved_type.matches_length(); }
-    bool resolves_to_length_percentage() const { return m_resolved_type.matches_length_percentage(); }
+    bool resolves_to_length() const { return m_resolved_type.matches_length(m_context.percentages_resolve_as); }
+    bool resolves_to_length_percentage() const { return m_resolved_type.matches_length_percentage(m_context.percentages_resolve_as); }
     Optional<Length> resolve_length(Length::ResolutionContext const&) const;
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
     Optional<Length> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
@@ -95,15 +95,15 @@ public:
     bool resolves_to_percentage() const { return m_resolved_type.matches_percentage(); }
     Optional<Percentage> resolve_percentage() const;
 
-    bool resolves_to_resolution() const { return m_resolved_type.matches_resolution(); }
+    bool resolves_to_resolution() const { return m_resolved_type.matches_resolution(m_context.percentages_resolve_as); }
     Optional<Resolution> resolve_resolution() const;
 
-    bool resolves_to_time() const { return m_resolved_type.matches_time(); }
-    bool resolves_to_time_percentage() const { return m_resolved_type.matches_time_percentage(); }
+    bool resolves_to_time() const { return m_resolved_type.matches_time(m_context.percentages_resolve_as); }
+    bool resolves_to_time_percentage() const { return m_resolved_type.matches_time_percentage(m_context.percentages_resolve_as); }
     Optional<Time> resolve_time() const;
     Optional<Time> resolve_time_percentage(Time const& percentage_basis) const;
 
-    bool resolves_to_number() const { return m_resolved_type.matches_number(); }
+    bool resolves_to_number() const { return m_resolved_type.matches_number(m_context.percentages_resolve_as); }
     Optional<double> resolve_number() const;
     Optional<double> resolve_number(Length::ResolutionContext const&) const;
     Optional<double> resolve_number(Layout::Node const& layout_node) const;
@@ -125,6 +125,8 @@ private:
         , m_context(move(context))
     {
     }
+
+    Optional<ValueType> percentage_resolved_type() const;
 
     CSSNumericType m_resolved_type;
     NonnullOwnPtr<CalculationNode> m_calculation;

--- a/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/EdgeStyleValue.cpp
@@ -16,15 +16,19 @@ String EdgeStyleValue::to_string(SerializationMode mode) const
                 auto flipped_percentage = 100 - offset().percentage().value();
                 return Percentage(flipped_percentage).to_string();
             }
+
+            // FIXME: Figure out how to get the proper calculation context here
+            CalculationContext context = {};
+
             Vector<NonnullOwnPtr<CalculationNode>> sum_parts;
-            sum_parts.append(NumericCalculationNode::create(Percentage(100)));
+            sum_parts.append(NumericCalculationNode::create(Percentage(100), context));
             if (offset().is_length()) {
-                sum_parts.append(NegateCalculationNode::create(NumericCalculationNode::create(offset().length())));
+                sum_parts.append(NegateCalculationNode::create(NumericCalculationNode::create(offset().length(), context)));
             } else {
                 // FIXME: Flip calculated offsets (convert CalculatedStyleValue to CalculationNode, then negate and append)
                 return to_string(CSSStyleValue::SerializationMode::Normal);
             }
-            auto flipped_absolute = CalculatedStyleValue::create(SumCalculationNode::create(move(sum_parts)), CSSNumericType(CSSNumericType::BaseType::Length, 1));
+            auto flipped_absolute = CalculatedStyleValue::create(SumCalculationNode::create(move(sum_parts)), CSSNumericType(CSSNumericType::BaseType::Length, 1), context);
             return flipped_absolute->to_string(mode);
         }
         return offset().to_string();

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
@@ -116,7 +116,7 @@ static Optional<RoundingStrategy> parse_rounding_strategy(Vector<ComponentValue>
     return keyword_to_rounding_strategy(maybe_keyword.value());
 }
 
-OwnPtr<CalculationNode> Parser::parse_math_function(Function const& function)
+OwnPtr<CalculationNode> Parser::parse_math_function(Function const& function, CalculationContext const& context)
 {
     TokenStream stream { function.value };
     auto arguments = parse_a_comma_separated_list_of_component_values(stream);
@@ -140,7 +140,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(Function const& function)
         parsed_arguments.ensure_capacity(arguments.size());
 
         for (auto& argument : arguments) {
-            auto calculation_node = parse_a_calculation(argument);
+            auto calculation_node = parse_a_calculation(argument, context);
             if (!calculation_node) {
                 dbgln_if(CSS_PARSER_DEBUG, "@name:lowercase@() argument #{} is not a valid calculation", parsed_arguments.size());
                 return nullptr;
@@ -243,7 +243,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(Function const& function)
                     // NOTE: This assumes everything not handled above is a calculation node of some kind.
                     parameter_is_calculation = true;
                     parameter_generator.set("parameter_type", "OwnPtr<CalculationNode>"_string);
-                    parameter_generator.set("parse_function", "parse_a_calculation(arguments[argument_index])"_string);
+                    parameter_generator.set("parse_function", "parse_a_calculation(arguments[argument_index], context)"_string);
                     parameter_generator.set("check_function", " != nullptr"_string);
                     parameter_generator.set("release_function", ".release_nonnull()"_string);
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
@@ -53,23 +53,23 @@ String generate_calculation_type_check(StringView calculation_variable_name, Str
         first_type_check = false;
 
         if (allowed_type_name == "<angle>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_angle()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_angle(percentages_resolve_as)"sv);
         } else if (allowed_type_name == "<dimension>"sv) {
             builder.appendff("{}.{}", calculation_variable_name, "matches_dimension()"sv);
         } else if (allowed_type_name == "<flex>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_flex()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_flex(percentages_resolve_as)"sv);
         } else if (allowed_type_name == "<frequency>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_frequency()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_frequency(percentages_resolve_as)"sv);
         } else if (allowed_type_name == "<length>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_length()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_length(percentages_resolve_as)"sv);
         } else if (allowed_type_name == "<number>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_number()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_number(percentages_resolve_as)"sv);
         } else if (allowed_type_name == "<percentage>"sv) {
             builder.appendff("{}.{}", calculation_variable_name, "matches_percentage()"sv);
         } else if (allowed_type_name == "<resolution>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_resolution()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_resolution(percentages_resolve_as)"sv);
         } else if (allowed_type_name == "<time>"sv) {
-            builder.appendff("{}.{}", calculation_variable_name, "matches_time()"sv);
+            builder.appendff("{}.{}", calculation_variable_name, "matches_time(percentages_resolve_as)"sv);
         } else {
             dbgln("I don't know what '{}' is!", allowed_type_name);
             VERIFY_NOT_REACHED();
@@ -120,6 +120,7 @@ OwnPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
 {
     TokenStream stream { function.value };
     auto arguments = parse_a_comma_separated_list_of_component_values(stream);
+    auto const& percentages_resolve_as = context.percentages_resolve_as;
 )~~~");
 
     functions_data.for_each_member([&](auto& name, JsonValue const& value) -> void {


### PR DESCRIPTION
The old way, where we had a single variable storing what property we're currently parsing, was not enough for what we actually need. It ignored longhands, as well as CSS functions, which can affect things like whether quirks are allowed or what a percentage should resolve as.

So this PR replaces that with a stack of `ValueParsingContext`s, which we push and pop as parsing progresses. This means handling quirks more correctly, being more accurate with what type percentages resolve as inside a calculation, and resolving some FIXMEs in `CSSNumericType` to do with checking what types it matches.

There are very likely some properties and functions that still need marking with what they resolve percentages as. `transform` and the `*-gradient()` functions showed up when my changes broke tests, but I'll take a more thorough look through `Properties.json` soon to make sure.

We do now have too many "context" types in the `Parser`. I'm going to rename `ParsingContext` soon as it's really just a set of arguments for constructing a `Parser`.