### PR TITLE
LibWeb: Align AudioContext constructors with current specification steps

### DIFF
--- a/Libraries/LibWeb/WebAudio/AudioContext.h
+++ b/Libraries/LibWeb/WebAudio/AudioContext.h
@@ -28,7 +28,7 @@ class AudioContext final : public BaseAudioContext {
     GC_DECLARE_ALLOCATOR(AudioContext);
 
 public:
-    static WebIDL::ExceptionOr<GC::Ref<AudioContext>> construct_impl(JS::Realm&, AudioContextOptions const& context_options = {});
+    static WebIDL::ExceptionOr<GC::Ref<AudioContext>> construct_impl(JS::Realm&, Optional<AudioContextOptions> const& context_options = {});
 
     virtual ~AudioContext() override;
 
@@ -40,7 +40,10 @@ public:
     WebIDL::ExceptionOr<GC::Ref<WebIDL::Promise>> close();
 
 private:
-    explicit AudioContext(JS::Realm&, AudioContextOptions const& context_options);
+    explicit AudioContext(JS::Realm& realm)
+        : BaseAudioContext(realm)
+    {
+    }
 
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
+++ b/Libraries/LibWeb/WebAudio/BaseAudioContext.cpp
@@ -153,6 +153,14 @@ WebIDL::ExceptionOr<GC::Ref<PeriodicWave>> BaseAudioContext::create_periodic_wav
     return PeriodicWave::construct_impl(realm(), *this, options);
 }
 
+WebIDL::ExceptionOr<void> BaseAudioContext::verify_audio_options_inside_nominal_range(JS::Realm& realm, float sample_rate)
+{
+    if (sample_rate < MIN_SAMPLE_RATE || sample_rate > MAX_SAMPLE_RATE)
+        return WebIDL::NotSupportedError::create(realm, "Sample rate is outside of allowed range"_string);
+
+    return {};
+}
+
 // https://webaudio.github.io/web-audio-api/#dom-baseaudiocontext-createbuffer
 WebIDL::ExceptionOr<void> BaseAudioContext::verify_audio_options_inside_nominal_range(JS::Realm& realm, WebIDL::UnsignedLong number_of_channels, WebIDL::UnsignedLong length, float sample_rate)
 {
@@ -167,8 +175,7 @@ WebIDL::ExceptionOr<void> BaseAudioContext::verify_audio_options_inside_nominal_
     if (length == 0)
         return WebIDL::NotSupportedError::create(realm, "Length of buffer must be at least 1"_string);
 
-    if (sample_rate < MIN_SAMPLE_RATE || sample_rate > MAX_SAMPLE_RATE)
-        return WebIDL::NotSupportedError::create(realm, "Sample rate is outside of allowed range"_string);
+    TRY(verify_audio_options_inside_nominal_range(realm, sample_rate));
 
     return {};
 }

--- a/Libraries/LibWeb/WebAudio/BaseAudioContext.h
+++ b/Libraries/LibWeb/WebAudio/BaseAudioContext.h
@@ -57,6 +57,7 @@ public:
     void set_control_state(Bindings::AudioContextState state) { m_control_thread_state = state; }
     void set_rendering_state(Bindings::AudioContextState state) { m_rendering_thread_state = state; }
 
+    static WebIDL::ExceptionOr<void> verify_audio_options_inside_nominal_range(JS::Realm&, float sample_rate);
     static WebIDL::ExceptionOr<void> verify_audio_options_inside_nominal_range(JS::Realm&, WebIDL::UnsignedLong number_of_channels, WebIDL::UnsignedLong length, float sample_rate);
 
     WebIDL::ExceptionOr<GC::Ref<BiquadFilterNode>> create_biquad_filter();

--- a/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.txt
@@ -1,0 +1,38 @@
+Harness status: Error
+
+Found 32 tests
+
+27 Pass
+5 Fail
+Pass	# AUDIT TASK RUNNER STARTED.
+Pass	Executing "test-audiocontextoptions-latencyHint-basic"
+Fail	Executing "test-audiocontextoptions-latencyHint-double"
+Pass	Executing "test-audiocontextoptions-sampleRate"
+Pass	Audit report
+Pass	> [test-audiocontextoptions-latencyHint-basic] Test creating contexts with basic latencyHint types.
+Pass	  context = new AudioContext() did not throw an exception.
+Pass	  context.sampleRate (44100 Hz) is greater than 0.
+Pass	  default baseLatency is greater than or equal to 0.
+Pass	  context = new AudioContext({'latencyHint': 'interactive'}) did not throw an exception.
+Pass	  interactive baseLatency is equal to 0.
+Pass	  context = new AudioContext({'latencyHint': 'balanced'}) did not throw an exception.
+Pass	  balanced baseLatency is greater than or equal to 0.
+Pass	  context = new AudioContext({'latencyHint': 'playback'}) did not throw an exception.
+Pass	  playback baseLatency is greater than or equal to 0.
+Pass	< [test-audiocontextoptions-latencyHint-basic] All assertions passed. (total 9 assertions)
+Pass	> [test-audiocontextoptions-latencyHint-double] Test creating contexts with explicit latencyHint values.
+Fail	X context = new AudioContext({'latencyHint': interactiveLatency/2}) incorrectly threw TypeError: "Invalid value '0' for enumeration type 'AudioContextLatencyCategory'".
+Pass	  double-constructor baseLatency small is less than or equal to 0.
+Fail	X context = new AudioContext({'latencyHint': validLatency}) incorrectly threw TypeError: "Invalid value '0' for enumeration type 'AudioContextLatencyCategory'".
+Pass	  double-constructor baseLatency inrange 1 is greater than or equal to 0.
+Pass	  double-constructor baseLatency inrange 2 is less than or equal to 0.
+Fail	X creating two high latency contexts incorrectly threw TypeError: "Invalid value '0' for enumeration type 'AudioContextLatencyCategory'".
+Pass	> [test-audiocontextoptions-sampleRate] Test creating contexts with non-default sampleRate values.
+Pass	  context = new AudioContext({sampleRate: 1}) threw NotSupportedError: "Sample rate is outside of allowed range".
+Pass	  context = new AudioContext({sampleRate: 1000000}) threw NotSupportedError: "Sample rate is outside of allowed range".
+Pass	  context = new AudioContext({sampleRate: -1}) threw NotSupportedError: "Sample rate is outside of allowed range".
+Pass	  context = new AudioContext({sampleRate: 0}) threw NotSupportedError: "Sample rate is outside of allowed range".
+Pass	  context = new AudioContext({sampleRate: 24000}) did not throw an exception.
+Pass	  sampleRate inrange is equal to 24000.
+Pass	< [test-audiocontextoptions-sampleRate] All assertions passed. (total 6 assertions)
+Fail	# AUDIT TASK RUNNER FINISHED: 1 out of 3 tasks were failed.

--- a/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html
+++ b/Tests/LibWeb/Text/input/wpt-import/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html
@@ -1,0 +1,215 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>
+      Test AudioContextOptions
+    </title>
+    <script src="../../../resources/testharness.js"></script>
+    <script src="../../../resources/testharnessreport.js"></script>
+    <script src="../../../webaudio/resources/audit.js"></script>
+  </head>
+  <body>
+    <script id="layout-test-code">
+      let context;
+      let defaultLatency;
+      let interactiveLatency;
+      let balancedLatency;
+      let playbackLatency;
+
+      let audit = Audit.createTaskRunner();
+
+      audit.define(
+          {
+            label: 'test-audiocontextoptions-latencyHint-basic',
+            description: 'Test creating contexts with basic latencyHint types.'
+          },
+          function(task, should) {
+            let closingPromises = [];
+
+            // Verify that an AudioContext can be created with default options.
+            should(function() {
+              context = new AudioContext()
+            }, 'context = new AudioContext()').notThrow();
+
+            should(context.sampleRate,
+              `context.sampleRate (${context.sampleRate} Hz)`).beGreaterThan(0);
+
+            defaultLatency = context.baseLatency;
+            should(defaultLatency, 'default baseLatency').beGreaterThanOrEqualTo(0);
+
+            // Verify that an AudioContext can be created with the expected
+            // latency types.
+            should(
+                function() {
+                  context = new AudioContext({'latencyHint': 'interactive'})
+                },
+                'context = new AudioContext({\'latencyHint\': \'interactive\'})')
+                .notThrow();
+
+            interactiveLatency = context.baseLatency;
+            should(interactiveLatency, 'interactive baseLatency')
+                .beEqualTo(defaultLatency);
+            closingPromises.push(context.close());
+
+            should(
+                function() {
+                  context = new AudioContext({'latencyHint': 'balanced'})
+                },
+                'context = new AudioContext({\'latencyHint\': \'balanced\'})')
+                .notThrow();
+
+            balancedLatency = context.baseLatency;
+            should(balancedLatency, 'balanced baseLatency')
+                .beGreaterThanOrEqualTo(interactiveLatency);
+            closingPromises.push(context.close());
+
+            should(
+                function() {
+                  context = new AudioContext({'latencyHint': 'playback'})
+                },
+                'context = new AudioContext({\'latencyHint\': \'playback\'})')
+                .notThrow();
+
+            playbackLatency = context.baseLatency;
+            should(playbackLatency, 'playback baseLatency')
+                .beGreaterThanOrEqualTo(balancedLatency);
+            closingPromises.push(context.close());
+
+            Promise.all(closingPromises).then(function() {
+              task.done();
+            });
+          });
+
+      audit.define(
+          {
+            label: 'test-audiocontextoptions-latencyHint-double',
+            description:
+                'Test creating contexts with explicit latencyHint values.'
+          },
+          function(task, should) {
+            let closingPromises = [];
+
+            // Verify too small exact latency clamped to 'interactive'
+            should(
+                function() {
+                  context =
+                      new AudioContext({'latencyHint': interactiveLatency / 2})
+                },
+                'context = new AudioContext({\'latencyHint\': ' +
+                    'interactiveLatency/2})')
+                .notThrow();
+            should(context.baseLatency, 'double-constructor baseLatency small')
+                .beLessThanOrEqualTo(interactiveLatency);
+            closingPromises.push(context.close());
+
+            // Verify that exact latency in range works as expected
+            let validLatency = (interactiveLatency + playbackLatency) / 2;
+            should(
+                function() {
+                  context = new AudioContext({'latencyHint': validLatency})
+                },
+                'context = new AudioContext({\'latencyHint\': validLatency})')
+                .notThrow();
+            should(
+                context.baseLatency, 'double-constructor baseLatency inrange 1')
+                .beGreaterThanOrEqualTo(interactiveLatency);
+            should(
+                context.baseLatency, 'double-constructor baseLatency inrange 2')
+                .beLessThanOrEqualTo(playbackLatency);
+            closingPromises.push(context.close());
+
+            // Verify too big exact latency clamped to some value
+            let context1;
+            let context2;
+            should(function() {
+              context1 =
+                  new AudioContext({'latencyHint': playbackLatency * 10});
+              context2 =
+                  new AudioContext({'latencyHint': playbackLatency * 20});
+            }, 'creating two high latency contexts').notThrow();
+            should(context1.baseLatency, 'high latency context baseLatency')
+                .beEqualTo(context2.baseLatency);
+            should(context1.baseLatency, 'high latency context baseLatency')
+                .beGreaterThanOrEqualTo(interactiveLatency);
+            closingPromises.push(context1.close());
+            closingPromises.push(context2.close());
+
+            // Verify that invalid latencyHint values are rejected.
+            should(
+                function() {
+                  context = new AudioContext({'latencyHint': 'foo'})
+                },
+                'context = new AudioContext({\'latencyHint\': \'foo\'})')
+                .throw(TypeError);
+
+            // Verify that no extra options can be passed into the
+            // AudioContextOptions.
+            should(
+                function() {
+                  context = new AudioContext('latencyHint')
+                },
+                'context = new AudioContext(\'latencyHint\')')
+                .throw(TypeError);
+
+            Promise.all(closingPromises).then(function() {
+              task.done();
+            });
+          });
+
+      audit.define(
+          {
+            label: 'test-audiocontextoptions-sampleRate',
+            description:
+                'Test creating contexts with non-default sampleRate values.'
+          },
+          function(task, should) {
+            // A sampleRate of 1 is unlikely to be supported on any browser,
+            // test that this rate is rejected.
+            should(
+                () => {
+                  context = new AudioContext({sampleRate: 1})
+                },
+                'context = new AudioContext({sampleRate: 1})')
+                .throw(DOMException, 'NotSupportedError');
+
+            // A sampleRate of 1,000,000 is unlikely to be supported on any
+            // browser, test that this rate is also rejected.
+            should(
+                () => {
+                  context = new AudioContext({sampleRate: 1000000})
+                },
+                'context = new AudioContext({sampleRate: 1000000})')
+                .throw(DOMException, 'NotSupportedError');
+            // A negative sample rate should not be accepted
+            should(
+                () => {
+                  context = new AudioContext({sampleRate: -1})
+                },
+                'context = new AudioContext({sampleRate: -1})')
+                .throw(DOMException, 'NotSupportedError');
+            // A null sample rate should not be accepted
+            should(
+                () => {
+                  context = new AudioContext({sampleRate: 0})
+                },
+                'context = new AudioContext({sampleRate: 0})')
+                .throw(DOMException, 'NotSupportedError');
+
+            should(
+                () => {
+                  context = new AudioContext({sampleRate: 24000})
+                },
+                'context = new AudioContext({sampleRate: 24000})')
+                .notThrow();
+            should(
+                context.sampleRate, 'sampleRate inrange')
+                .beEqualTo(24000);
+
+            context.close();
+            task.done();
+          });
+
+      audit.run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This PR updates the spec steps for the `AudioContext` and `OfflineAudioContext` constructors.

While working on this I found a few minor inconsistencies, which I believe are (minor) spec issues:
* The `AudioContext` spec steps don't mention validating the given sample rate. The `/webaudio/the-audio-api/the-audiocontext-interface/audiocontextoptions.html` test expects this parameter to be validated.
* The spec only mentions validating `OfflineAudioContext` parameters for the constructor that takes individual arguments - not the constructor that takes an `OfflineAudioContextOptions` object.
* The `AudioContext` steps don't include a step to "Determine the `[[render quantum size]]`". We don't currently implement this, so it's not currently a problem for us.
* The `OfflineAudioContext` constructor steps should probably end with a `Return c` step. This would match the `AudioContext` constructor steps.