### PR TITLE
LibURL+LibWeb: Make URL::basic_parse return an Optional<URL>

### DIFF
--- a/Libraries/LibURL/Parser.cpp
+++ b/Libraries/LibURL/Parser.cpp
@@ -708,7 +708,7 @@ String Parser::percent_encode_after_encoding(TextCodec::Encoder& encoder, String
 }
 
 // https://url.spec.whatwg.org/#concept-basic-url-parser
-URL Parser::basic_parse(StringView raw_input, Optional<URL const&> base_url, URL* url, Optional<State> state_override, Optional<StringView> encoding)
+Optional<URL> Parser::basic_parse(StringView raw_input, Optional<URL const&> base_url, URL* url, Optional<State> state_override, Optional<StringView> encoding)
 {
     dbgln_if(URL_PARSER_DEBUG, "URL::Parser::basic_parse: Parsing '{}'", raw_input);
 

--- a/Libraries/LibURL/Parser.h
+++ b/Libraries/LibURL/Parser.h
@@ -58,7 +58,7 @@ public:
     }
 
     // https://url.spec.whatwg.org/#concept-basic-url-parser
-    static URL basic_parse(StringView input, Optional<URL const&> base_url = {}, URL* url = nullptr, Optional<State> state_override = {}, Optional<StringView> encoding = {});
+    static Optional<URL> basic_parse(StringView input, Optional<URL const&> base_url = {}, URL* url = nullptr, Optional<State> state_override = {}, Optional<StringView> encoding = {});
 
     // https://url.spec.whatwg.org/#string-percent-encode-after-encoding
     static String percent_encode_after_encoding(TextCodec::Encoder&, StringView input, PercentEncodeSet percent_encode_set, bool space_as_plus = false);

--- a/Libraries/LibWeb/CSS/Fetch.cpp
+++ b/Libraries/LibWeb/CSS/Fetch.cpp
@@ -24,14 +24,14 @@ void fetch_a_style_resource(String const& url_value, CSSStyleSheet const& sheet,
 
     // 3. Let parsedUrl be the result of the URL parser steps with urlValue’s url and base. If the algorithm returns an error, return.
     auto parsed_url = URL::Parser::basic_parse(url_value, base);
-    if (!parsed_url.is_valid())
+    if (!parsed_url.has_value())
         return;
 
     // 4. Let req be a new request whose url is parsedUrl, whose destination is destination, mode is corsMode,
     //    origin is environmentSettings’s origin, credentials mode is "same-origin", use-url-credentials flag is set,
     //    client is environmentSettings, and whose referrer is environmentSettings’s API base URL.
     auto request = Fetch::Infrastructure::Request::create(vm);
-    request->set_url(parsed_url);
+    request->set_url(parsed_url.release_value());
     request->set_destination(destination);
     request->set_mode(cors_mode == CorsMode::Cors ? Fetch::Infrastructure::Request::Mode::CORS : Fetch::Infrastructure::Request::Mode::NoCORS);
     request->set_origin(environment_settings.origin());

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -196,7 +196,7 @@ WebIDL::ExceptionOr<void> Location::set_protocol(String const& value)
     auto possible_failure = URL::Parser::basic_parse(value, {}, &copy_url, URL::Parser::State::SchemeStart);
 
     // 5. If possibleFailure is failure, then throw a "SyntaxError" DOMException.
-    if (!possible_failure.is_valid())
+    if (!possible_failure.has_value())
         return WebIDL::SyntaxError::create(realm(), MUST(String::formatted("Failed to set protocol. '{}' is an invalid protocol", value)));
 
     // 6. if copyURL's scheme is not an HTTP(S) scheme, then terminate these steps.

--- a/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
+++ b/Libraries/LibWeb/HTML/NavigatorBeacon.cpp
@@ -32,9 +32,9 @@ WebIDL::ExceptionOr<bool> NavigatorBeaconMixin::send_beacon(String const& url, O
 
     // 3. Set parsedUrl to the result of the URL parser steps with url and base. If the algorithm returns an error, or if parsedUrl's scheme is not "http" or "https", throw a "TypeError" exception and terminate these steps.
     auto parsed_url = URL::Parser::basic_parse(url, base_url);
-    if (!parsed_url.is_valid())
+    if (!parsed_url.has_value())
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("Beacon URL {} is invalid.", url)) };
-    if (parsed_url.scheme() != "http" && parsed_url.scheme() != "https")
+    if (parsed_url->scheme() != "http" && parsed_url->scheme() != "https")
         return WebIDL::SimpleException { WebIDL::SimpleExceptionType::TypeError, MUST(String::formatted("Beacon URL {} must be either http:// or https://.", url)) };
 
     // 4. Let headerList be an empty list.
@@ -76,7 +76,7 @@ WebIDL::ExceptionOr<bool> NavigatorBeaconMixin::send_beacon(String const& url, O
     auto req = Fetch::Infrastructure::Request::create(vm);
     req->set_method(MUST(ByteBuffer::copy("POST"sv.bytes()))); // method: POST
     req->set_client(&relevant_settings_object);                // client: this's relevant settings object
-    req->set_url_list({ parsed_url });                         // url: parsedUrl
+    req->set_url_list({ parsed_url.release_value() });         // url: parsedUrl
     req->set_header_list(header_list);                         // header list: headerList
     req->set_origin(origin);                                   // origin: origin
     req->set_keepalive(true);                                  // keepalive: true

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -342,36 +342,36 @@ TEST_CASE(unicode)
 TEST_CASE(query_with_non_ascii)
 {
     {
-        URL::URL url = URL::Parser::basic_parse("http://example.com/?utf8=✓"sv);
-        EXPECT(url.is_valid());
-        EXPECT_EQ(url.serialize_path(), "/"sv);
-        EXPECT_EQ(url.query(), "utf8=%E2%9C%93");
-        EXPECT(!url.fragment().has_value());
+        Optional<URL::URL> url = URL::Parser::basic_parse("http://example.com/?utf8=✓"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->serialize_path(), "/"sv);
+        EXPECT_EQ(url->query(), "utf8=%E2%9C%93");
+        EXPECT(!url->fragment().has_value());
     }
     {
-        URL::URL url = URL::Parser::basic_parse("http://example.com/?shift_jis=✓"sv, {}, nullptr, {}, "shift_jis"sv);
-        EXPECT(url.is_valid());
-        EXPECT_EQ(url.serialize_path(), "/"sv);
-        EXPECT_EQ(url.query(), "shift_jis=%26%2310003%3B");
-        EXPECT(!url.fragment().has_value());
+        Optional<URL::URL> url = URL::Parser::basic_parse("http://example.com/?shift_jis=✓"sv, {}, nullptr, {}, "shift_jis"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->serialize_path(), "/"sv);
+        EXPECT_EQ(url->query(), "shift_jis=%26%2310003%3B");
+        EXPECT(!url->fragment().has_value());
     }
 }
 
 TEST_CASE(fragment_with_non_ascii)
 {
     {
-        URL::URL url = URL::Parser::basic_parse("http://example.com/#✓"sv);
-        EXPECT(url.is_valid());
-        EXPECT_EQ(url.serialize_path(), "/"sv);
-        EXPECT(!url.query().has_value());
-        EXPECT_EQ(url.fragment(), "%E2%9C%93");
+        Optional<URL::URL> url = URL::Parser::basic_parse("http://example.com/#✓"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->serialize_path(), "/"sv);
+        EXPECT(!url->query().has_value());
+        EXPECT_EQ(url->fragment(), "%E2%9C%93");
     }
     {
-        URL::URL url = URL::Parser::basic_parse("http://example.com/#✓"sv, {}, nullptr, {}, "shift_jis"sv);
-        EXPECT(url.is_valid());
-        EXPECT_EQ(url.serialize_path(), "/"sv);
-        EXPECT(!url.query().has_value());
-        EXPECT_EQ(url.fragment(), "%E2%9C%93");
+        Optional<URL::URL> url = URL::Parser::basic_parse("http://example.com/#✓"sv, {}, nullptr, {}, "shift_jis"sv);
+        EXPECT(url.has_value());
+        EXPECT_EQ(url->serialize_path(), "/"sv);
+        EXPECT(!url->query().has_value());
+        EXPECT_EQ(url->fragment(), "%E2%9C%93");
     }
 }
 
@@ -392,9 +392,9 @@ TEST_CASE(complete_file_url_with_base)
 TEST_CASE(empty_url_with_base_url)
 {
     URL::URL base_url { "https://foo.com/"sv };
-    URL::URL parsed_url = URL::Parser::basic_parse(""sv, base_url);
-    EXPECT_EQ(parsed_url.is_valid(), true);
-    EXPECT(base_url.equals(parsed_url));
+    Optional<URL::URL> parsed_url = URL::Parser::basic_parse(""sv, base_url);
+    EXPECT_EQ(parsed_url.has_value(), true);
+    EXPECT(base_url.equals(*parsed_url));
 }
 
 TEST_CASE(google_street_view)

--- a/Utilities/xml.cpp
+++ b/Utilities/xml.cpp
@@ -365,13 +365,13 @@ static auto parse(StringView contents)
             .resolve_external_resource = [&](XML::SystemID const& system_id, Optional<XML::PublicID> const&) -> ErrorOr<Variant<ByteString, Vector<XML::MarkupDeclaration>>> {
                 auto base = URL::create_with_file_scheme(s_path);
                 auto url = URL::Parser::basic_parse(system_id.system_literal, base);
-                if (!url.is_valid())
+                if (!url.has_value())
                     return Error::from_string_literal("Invalid URL");
 
-                if (url.scheme() != "file")
+                if (url->scheme() != "file")
                     return Error::from_string_literal("NYI: Nonlocal entity");
 
-                auto file = TRY(Core::File::open(URL::percent_decode(url.serialize_path()), Core::File::OpenMode::Read));
+                auto file = TRY(Core::File::open(URL::percent_decode(url->serialize_path()), Core::File::OpenMode::Read));
                 return ByteString::copy(TRY(file->read_until_eof()));
             },
         },


### PR DESCRIPTION
URL::basic_parse has a subtle bug where the resulting URL is not set to valid when StateOveride is provided and the URL parser early returns a valid URL.

This has not surfaced as a problem so far, as the only users of the state override API provide an already valid URL buffer and also ignore the result of basic parsing with a state override.

However, this bug surfaces implementing the URL pattern spec, which as part of URL canonicalization:
 * Provides a dummy (invalid!) URL record
 * Basic URL parses that URL with state override
 * Checks the result of the URL parser to validate the URL

While we could set URL validity on every early return of the URL parser during state override, it has been a long standing FIXME around the code to try and remove the awkward validity state of the URL class. So this commit makes the first stage of this change by migrating the basic parser API to return Optional, which also happens to make this subtle issue not a problem any more.