### PR TITLE
LibWeb+LibThreading: Make MutexLocker and TemporaryExecutionContext [[nodiscard]]

### DIFF
--- a/Libraries/LibThreading/Mutex.h
+++ b/Libraries/LibThreading/Mutex.h
@@ -42,7 +42,7 @@ private:
     unsigned m_lock_count { 0 };
 };
 
-class MutexLocker {
+class [[nodiscard]] MutexLocker {
     AK_MAKE_NONCOPYABLE(MutexLocker);
     AK_MAKE_NONMOVABLE(MutexLocker);
 

--- a/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
+++ b/Libraries/LibWeb/HTML/Scripting/TemporaryExecutionContext.h
@@ -14,7 +14,7 @@ namespace Web::HTML {
 // When JS is run from outside the context of any user script, we currently do not have a running execution context.
 // This results in a crash when we access VM::running_execution_context(). This is a spec issue. Until it is resolved,
 // this is a workaround to temporarily push an execution context.
-class TemporaryExecutionContext {
+class [[nodiscard]] TemporaryExecutionContext {
 public:
     enum class CallbacksEnabled {
         No,


### PR DESCRIPTION
Inspired by #3197. 

Adding `[[nodiscard]]` makes not naming these objects a compile error.