### PR TITLE
LibWeb: Skip keyframe animation update if target element isn't connected

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -918,7 +918,7 @@ static CSS::RequiredInvalidationAfterStyleChange compute_required_invalidation(H
 void KeyframeEffect::update_computed_properties()
 {
     auto target = this->target();
-    if (!target)
+    if (!target || !target->is_connected())
         return;
 
     GC::Ptr<CSS::ComputedProperties> style = {};


### PR DESCRIPTION
Makes some pages on Github faster as previously we had to update animation for elements in not connected shadow trees.