### PR TITLE
LibWeb: Unload fonts when adopted style sheet is removed

### DIFF
--- a/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
+++ b/Libraries/LibWeb/DOM/AdoptedStyleSheets.cpp
@@ -35,7 +35,13 @@ GC::Ref<WebIDL::ObservableArray> create_adopted_style_sheets_list(Document& docu
         document.invalidate_style(DOM::StyleInvalidationReason::AdoptedStyleSheetsList);
         return {};
     });
-    adopted_style_sheets->set_on_delete_an_indexed_value_callback([&document]() -> WebIDL::ExceptionOr<void> {
+    adopted_style_sheets->set_on_delete_an_indexed_value_callback([&document](JS::Value value) -> WebIDL::ExceptionOr<void> {
+        VERIFY(value.is_object());
+        auto& object = value.as_object();
+        VERIFY(is<CSS::CSSStyleSheet>(object));
+        auto& style_sheet = static_cast<CSS::CSSStyleSheet&>(object);
+
+        document.style_computer().unload_fonts_from_sheet(style_sheet);
         document.style_computer().invalidate_rule_cache();
         document.invalidate_style(DOM::StyleInvalidationReason::AdoptedStyleSheetsList);
         return {};

--- a/Libraries/LibWeb/WebIDL/ObservableArray.h
+++ b/Libraries/LibWeb/WebIDL/ObservableArray.h
@@ -23,7 +23,7 @@ public:
     virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const& property_key) override;
 
     using SetAnIndexedValueCallbackFunction = Function<ExceptionOr<void>(JS::Value&)>;
-    using DeleteAnIndexedValueCallbackFunction = Function<ExceptionOr<void>()>;
+    using DeleteAnIndexedValueCallbackFunction = Function<ExceptionOr<void>(JS::Value)>;
 
     void set_on_set_an_indexed_value_callback(SetAnIndexedValueCallbackFunction&& callback);
     void set_on_delete_an_indexed_value_callback(DeleteAnIndexedValueCallbackFunction&& callback);


### PR DESCRIPTION
Add missing unloading step that we do for regular style sheets but mistakenly missed for adopted style sheets.