### PR TITLE
LibWeb: Fix insert/delete rule invalidation for adopted style sheets

### DIFF
--- a/Libraries/LibWeb/CSS/CSSStyleRule.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleRule.cpp
@@ -139,10 +139,7 @@ void CSSStyleRule::set_selector_text(StringView selector_text)
 
         m_selectors = parsed_selectors.release_value();
         if (auto* sheet = parent_style_sheet()) {
-            if (auto style_sheet_list = sheet->style_sheet_list()) {
-                style_sheet_list->document().style_computer().invalidate_rule_cache();
-                style_sheet_list->document_or_shadow_root().invalidate_style(DOM::StyleInvalidationReason::SetSelectorText);
-            }
+            sheet->invalidate_owners(DOM::StyleInvalidationReason::SetSelectorText);
         }
     }
 

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/CSSRuleList.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/StyleSheet.h>
+#include <LibWeb/DOM/Node.h>
 #include <LibWeb/WebIDL/Types.h>
 
 namespace Web::CSS {
@@ -62,8 +63,9 @@ public:
     bool evaluate_media_queries(HTML::Window const&);
     void for_each_effective_keyframes_at_rule(Function<void(CSSKeyframesRule const&)> const& callback) const;
 
-    GC::Ptr<StyleSheetList> style_sheet_list() const { return m_style_sheet_list; }
-    void set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList*);
+    void add_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root);
+    void remove_owning_document_or_shadow_root(DOM::Node& document_or_shadow_root);
+    void invalidate_owners(DOM::StyleInvalidationReason);
 
     Optional<FlyString> default_namespace() const;
     GC::Ptr<CSSNamespaceRule> default_namespace_rule() const { return m_default_namespace_rule; }
@@ -109,11 +111,11 @@ private:
     HashMap<FlyString, GC::Ptr<CSSNamespaceRule>> m_namespace_rules;
     Vector<GC::Ref<CSSImportRule>> m_import_rules;
 
-    GC::Ptr<StyleSheetList> m_style_sheet_list;
     GC::Ptr<CSSRule> m_owner_css_rule;
 
     Optional<URL::URL> m_base_url;
     GC::Ptr<DOM::Document const> m_constructor_document;
+    HashTable<GC::Ptr<DOM::Node>> m_owning_documents_or_shadow_roots;
     bool m_constructed { false };
     bool m_disallow_modification { false };
     Optional<bool> m_did_match;

--- a/Libraries/LibWeb/CSS/StyleSheetList.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheetList.cpp
@@ -81,7 +81,7 @@ void StyleSheetList::create_a_css_style_sheet(String type, DOM::Element* owner_n
 
 void StyleSheetList::add_sheet(CSSStyleSheet& sheet)
 {
-    sheet.set_style_sheet_list({}, this);
+    sheet.add_owning_document_or_shadow_root(document_or_shadow_root());
 
     if (m_sheets.is_empty()) {
         // This is the first sheet, append it to the list.
@@ -114,7 +114,7 @@ void StyleSheetList::add_sheet(CSSStyleSheet& sheet)
 
 void StyleSheetList::remove_sheet(CSSStyleSheet& sheet)
 {
-    sheet.set_style_sheet_list({}, nullptr);
+    sheet.remove_owning_document_or_shadow_root(document_or_shadow_root());
     bool did_remove = m_sheets.remove_first_matching([&](auto& entry) { return entry.ptr() == &sheet; });
     VERIFY(did_remove);
 

--- a/Libraries/LibWeb/DOM/AdoptedStyleSheets.h
+++ b/Libraries/LibWeb/DOM/AdoptedStyleSheets.h
@@ -11,6 +11,6 @@
 
 namespace Web::DOM {
 
-GC::Ref<WebIDL::ObservableArray> create_adopted_style_sheets_list(Document& document);
+GC::Ref<WebIDL::ObservableArray> create_adopted_style_sheets_list(Node& document_or_shadow_root);
 
 }

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -141,14 +141,14 @@ void ShadowRoot::visit_edges(Visitor& visitor)
 GC::Ref<WebIDL::ObservableArray> ShadowRoot::adopted_style_sheets() const
 {
     if (!m_adopted_style_sheets)
-        m_adopted_style_sheets = create_adopted_style_sheets_list(const_cast<Document&>(document()));
+        m_adopted_style_sheets = create_adopted_style_sheets_list(const_cast<ShadowRoot&>(*this));
     return *m_adopted_style_sheets;
 }
 
 WebIDL::ExceptionOr<void> ShadowRoot::set_adopted_style_sheets(JS::Value new_value)
 {
     if (!m_adopted_style_sheets)
-        m_adopted_style_sheets = create_adopted_style_sheets_list(const_cast<Document&>(document()));
+        m_adopted_style_sheets = create_adopted_style_sheets_list(*this);
 
     m_adopted_style_sheets->clear();
     auto iterator_record = TRY(get_iterator(vm(), new_value, JS::IteratorHint::Sync));

--- a/Tests/LibWeb/Text/expected/css/insert-rule-in-adopted-style-sheet.txt
+++ b/Tests/LibWeb/Text/expected/css/insert-rule-in-adopted-style-sheet.txt
@@ -1,0 +1,4 @@
+color of box 1 before rule insertion: rgb(255, 0, 0)
+color of box 2 before rule insertion: rgb(255, 0, 0)
+color of box 1 after rule insertion: rgb(0, 128, 0)
+color of box 2 after rule insertion: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/css/insert-rule-in-adopted-style-sheet.html
+++ b/Tests/LibWeb/Text/input/css/insert-rule-in-adopted-style-sheet.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<my-shadow-box id="box1"></my-shadow-box>
+<my-shadow-box id="box2"></my-shadow-box>
+<script>
+    const myStyleSheet = new CSSStyleSheet();
+
+    myStyleSheet.replaceSync(`
+      .box {
+        width: 100px;
+        height: 100px;
+        background-color: red;
+      }
+    `);
+
+    class MyShadowBox extends HTMLElement {
+        constructor() {
+            super();
+
+            const shadowRoot = this.attachShadow({ mode: 'open' });
+            shadowRoot.adoptedStyleSheets = [myStyleSheet];
+
+            this.box = document.createElement('div');
+            this.box.classList.add('box');
+
+            shadowRoot.appendChild(this.box);
+        }
+
+        getBoxColor() {
+            return getComputedStyle(this.box).backgroundColor;
+        }
+    }
+
+
+    test(() => {
+        customElements.define('my-shadow-box', MyShadowBox);
+
+        println("color of box 1 before rule insertion: " + box1.getBoxColor());
+        println("color of box 2 before rule insertion: " + box2.getBoxColor());
+        myStyleSheet.insertRule(
+            '.box { background-color: green; }',
+            myStyleSheet.cssRules.length
+        );
+        println("color of box 1 after rule insertion: " + box1.getBoxColor());
+        println("color of box 2 after rule insertion: " + box2.getBoxColor());
+    });
+</script>


### PR DESCRIPTION
Invalidaiton for adopted style sheets was broken because we had an assumption that "active" style sheet is always attached to StyleSheetList which is not true for adopted style sheets. This change addresses that by keeping track of all documents/shadow roots that own a style sheet and notifying them about invalidation instead of going through the StyleSheetList.