### PR TITLE
LibWebView: Fix capitalization in devtools

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1544,6 +1544,9 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
         MUST(object.add("type"sv, "element"));
 
         auto const* element = static_cast<DOM::Element const*>(this);
+        if (element->namespace_uri().has_value())
+            MUST(object.add("namespace"sv, element->namespace_uri().value()));
+
         if (element->has_attributes()) {
             auto attributes = MUST(object.add_object("attributes"sv));
             element->for_each_attribute([&attributes](auto& name, auto& value) {

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -633,7 +633,9 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
             if (name.equals_ignoring_ascii_case("BODY"sv) || name.equals_ignoring_ascii_case("FRAMESET"sv))
                 m_body_or_frameset_node_id = node_id;
 
-            auto tag = name.to_lowercase();
+            auto tag = name;
+            if (node.get_byte_string("namespace"sv) == "http://www.w3.org/1999/xhtml")
+                tag = tag.to_lowercase();
 
             builder.appendff("<span class=\"hoverable\" {}>", data_attributes.string_view());
             builder.append("<span>&lt;</span>"sv);


### PR DESCRIPTION
Only HTML elements are case-insensitive.
This fixes things like SVG's `<foreignObject>` being displayed as "&lt;foreignobject&gt;":
![grafik](https://github.com/user-attachments/assets/29827d68-ad4e-4441-8d01-43cf5fbfa3f4)
