### PR TITLE
LibWeb: Clone all attribute properties when cloning a single node

### DIFF
--- a/Libraries/LibWeb/DOM/Attr.cpp
+++ b/Libraries/LibWeb/DOM/Attr.cpp
@@ -28,7 +28,7 @@ GC::Ref<Attr> Attr::create(Document& document, QualifiedName qualified_name, Str
     return document.realm().create<Attr>(document, move(qualified_name), move(value), owner_element);
 }
 
-GC::Ref<Attr> Attr::clone(Document& document)
+GC::Ref<Attr> Attr::clone(Document& document) const
 {
     return realm().create<Attr>(document, m_qualified_name, m_value, nullptr);
 }

--- a/Libraries/LibWeb/DOM/Attr.h
+++ b/Libraries/LibWeb/DOM/Attr.h
@@ -20,7 +20,7 @@ class Attr final : public Node {
 public:
     [[nodiscard]] static GC::Ref<Attr> create(Document&, QualifiedName, String value = {}, Element* = nullptr);
     [[nodiscard]] static GC::Ref<Attr> create(Document&, FlyString local_name, String value = {}, Element* = nullptr);
-    GC::Ref<Attr> clone(Document&);
+    GC::Ref<Attr> clone(Document&) const;
 
     virtual ~Attr() override = default;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1030,7 +1030,7 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Node::replace_child(GC::Ref<Node> node, GC::R
 }
 
 // https://dom.spec.whatwg.org/#concept-node-clone
-WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_node(Document* document, bool subtree, Node* parent)
+WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_node(Document* document, bool subtree, Node* parent) const
 {
     // To clone a node given a node node and an optional document document (default node’s node document),
     // boolean subtree (default false), and node-or-null parent (default null):
@@ -1085,7 +1085,7 @@ WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_node(Document* document, bool sub
 }
 
 // https://dom.spec.whatwg.org/#clone-a-single-node
-WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_single_node(Document& document)
+WebIDL::ExceptionOr<GC::Ref<Node>> Node::clone_single_node(Document& document) const
 {
     // To clone a single node given a node node and document document:
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -199,8 +199,8 @@ public:
 
     WebIDL::ExceptionOr<GC::Ref<Node>> replace_child(GC::Ref<Node> node, GC::Ref<Node> child);
 
-    WebIDL::ExceptionOr<GC::Ref<Node>> clone_node(Document* document = nullptr, bool subtree = false, Node* parent = nullptr);
-    WebIDL::ExceptionOr<GC::Ref<Node>> clone_single_node(Document&);
+    WebIDL::ExceptionOr<GC::Ref<Node>> clone_node(Document* document = nullptr, bool subtree = false, Node* parent = nullptr) const;
+    WebIDL::ExceptionOr<GC::Ref<Node>> clone_single_node(Document&) const;
     WebIDL::ExceptionOr<GC::Ref<Node>> clone_node_binding(bool subtree);
 
     // NOTE: This is intended for the JS bindings.
@@ -263,7 +263,7 @@ public:
     virtual void removed_from(Node*);
     virtual void children_changed() { }
     virtual void adopted_from(Document&) { }
-    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) { return {}; }
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const { return {}; }
 
     Layout::Node const* layout_node() const { return m_layout_node; }
     Layout::Node* layout_node() { return m_layout_node; }

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -612,7 +612,7 @@ void HTMLElement::attribute_changed(FlyString const& name, Optional<String> cons
 #undef __ENUMERATE
 }
 
-WebIDL::ExceptionOr<void> HTMLElement::cloned(Web::DOM::Node& copy, bool clone_children)
+WebIDL::ExceptionOr<void> HTMLElement::cloned(Web::DOM::Node& copy, bool clone_children) const
 {
     TRY(Base::cloned(copy, clone_children));
     TRY(HTMLOrSVGElement::cloned(copy, clone_children));

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -137,7 +137,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
-    virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) override;
+    virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
     virtual void inserted() override;
 
     virtual void visit_edges(Cell::Visitor&) override;

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1706,7 +1706,7 @@ void HTMLInputElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropertie
 }
 
 // https://html.spec.whatwg.org/multipage/input.html#the-input-element%3Aconcept-node-clone-ext
-WebIDL::ExceptionOr<void> HTMLInputElement::cloned(DOM::Node& copy, bool subtree)
+WebIDL::ExceptionOr<void> HTMLInputElement::cloned(DOM::Node& copy, bool subtree) const
 {
     TRY(Base::cloned(copy, subtree));
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -183,7 +183,7 @@ public:
     virtual void form_associated_element_was_removed(DOM::Node*) override;
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
-    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
 
     GC::Ref<ValidityState const> validity() const;
 

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
@@ -78,7 +78,7 @@ void HTMLOrSVGElement<ElementBase>::attribute_changed(FlyString const& local_nam
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#dom-noncedelement-nonce
 template<typename ElementBase>
-WebIDL::ExceptionOr<void> HTMLOrSVGElement<ElementBase>::cloned(DOM::Node& copy, bool)
+WebIDL::ExceptionOr<void> HTMLOrSVGElement<ElementBase>::cloned(DOM::Node& copy, bool) const
 {
     // The cloning steps for elements that include HTMLOrSVGElement given node, copy, and subtree
     // are to set copy's [[CryptographicNonce]] to node's [[CryptographicNonce]].

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.h
@@ -26,7 +26,7 @@ public:
 
 protected:
     void attribute_changed(FlyString const&, Optional<String> const&, Optional<String> const&, Optional<FlyString> const&);
-    WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool);
+    WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const;
     void inserted();
     void visit_edges(JS::Cell::Visitor&);
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -651,7 +651,7 @@ void HTMLScriptElement::set_async(bool async)
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model:concept-node-clone-ext
-WebIDL::ExceptionOr<void> HTMLScriptElement::cloned(Node& copy, bool subtree)
+WebIDL::ExceptionOr<void> HTMLScriptElement::cloned(Node& copy, bool subtree) const
 {
     TRY(Base::cloned(copy, subtree));
 

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -63,7 +63,7 @@ public:
     [[nodiscard]] bool async() const;
     void set_async(bool);
 
-    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
 
 private:
     HTMLScriptElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTemplateElement.cpp
@@ -46,7 +46,7 @@ void HTMLTemplateElement::adopted_from(DOM::Document&)
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#the-template-element:concept-node-clone-ext
-WebIDL::ExceptionOr<void> HTMLTemplateElement::cloned(Node& copy, bool subtree)
+WebIDL::ExceptionOr<void> HTMLTemplateElement::cloned(Node& copy, bool subtree) const
 {
     TRY(Base::cloned(copy, subtree));
 

--- a/Libraries/LibWeb/HTML/HTMLTemplateElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTemplateElement.h
@@ -24,7 +24,7 @@ public:
     void set_template_contents(GC::Ref<DOM::DocumentFragment>);
 
     virtual void adopted_from(DOM::Document&) override;
-    virtual WebIDL::ExceptionOr<void> cloned(Node& copy, bool clone_children) override;
+    virtual WebIDL::ExceptionOr<void> cloned(Node& copy, bool clone_children) const override;
 
 private:
     HTMLTemplateElement(DOM::Document&, DOM::QualifiedName);

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -136,7 +136,7 @@ void HTMLTextAreaElement::clear_algorithm()
 }
 
 // https://html.spec.whatwg.org/multipage/forms.html#the-textarea-element:concept-node-clone-ext
-WebIDL::ExceptionOr<void> HTMLTextAreaElement::cloned(DOM::Node& copy, bool subtree)
+WebIDL::ExceptionOr<void> HTMLTextAreaElement::cloned(DOM::Node& copy, bool subtree) const
 {
     TRY(Base::cloned(copy, subtree));
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -64,7 +64,7 @@ public:
     virtual void reset_algorithm() override;
     virtual void clear_algorithm() override;
 
-    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) override;
+    virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const override;
 
     virtual void form_associated_element_was_inserted() override;
     virtual void form_associated_element_was_removed(DOM::Node*) override;

--- a/Libraries/LibWeb/MathML/MathMLElement.cpp
+++ b/Libraries/LibWeb/MathML/MathMLElement.cpp
@@ -26,7 +26,7 @@ void MathMLElement::attribute_changed(FlyString const& local_name, Optional<Stri
     HTMLOrSVGElement::attribute_changed(local_name, old_value, value, namespace_);
 }
 
-WebIDL::ExceptionOr<void> MathMLElement::cloned(DOM::Node& node, bool clone_children)
+WebIDL::ExceptionOr<void> MathMLElement::cloned(DOM::Node& node, bool clone_children) const
 {
     TRY(Base::cloned(node, clone_children));
     TRY(HTMLOrSVGElement::cloned(node, clone_children));

--- a/Libraries/LibWeb/MathML/MathMLElement.h
+++ b/Libraries/LibWeb/MathML/MathMLElement.h
@@ -25,7 +25,7 @@ public:
 
 protected:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
-    virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) override;
+    virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
     virtual void inserted() override;
     virtual GC::Ptr<DOM::EventTarget> global_event_handlers_to_event_target(FlyString const&) override { return *this; }
 

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -83,7 +83,7 @@ void SVGElement::attribute_changed(FlyString const& local_name, Optional<String>
     update_use_elements_that_reference_this();
 }
 
-WebIDL::ExceptionOr<void> SVGElement::cloned(DOM::Node& copy, bool clone_children)
+WebIDL::ExceptionOr<void> SVGElement::cloned(DOM::Node& copy, bool clone_children) const
 {
     TRY(Base::cloned(copy, clone_children));
     TRY(HTMLOrSVGElement::cloned(copy, clone_children));

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -35,7 +35,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
-    virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) override;
+    virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
     virtual void children_changed() override;
     virtual void inserted() override;
     virtual void removed_from(Node*) override;

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Node-cloneNode-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Node-cloneNode-svg.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	cloned <svg> should have the right properties
+Pass	cloned <svg>'s xmlns:xlink attribute should have the right properties
+Pass	cloned <use> should have the right properties
+Pass	cloned <use>'s xlink:href attribute should have the right properties

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Node-cloneNode-svg.html
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Node-cloneNode-svg.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Cloning of SVG elements and attributes</title>
+<link rel="help" href="https://dom.spec.whatwg.org/#dom-node-clonenode">
+<link rel="help" href="https://dom.spec.whatwg.org/#concept-node-clone">
+<!-- regression test for https://github.com/jsdom/jsdom/issues/1601 -->
+
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+
+<svg xmlns:xlink='http://www.w3.org/1999/xlink'><use xlink:href='#test'></use></svg>
+
+<script>
+"use strict";
+
+const svg = document.querySelector("svg");
+const clone = svg.cloneNode(true);
+
+test(() => {
+
+  assert_equals(clone.namespaceURI, "http://www.w3.org/2000/svg");
+  assert_equals(clone.prefix, null);
+  assert_equals(clone.localName, "svg");
+  assert_equals(clone.tagName, "svg");
+
+}, "cloned <svg> should have the right properties");
+
+test(() => {
+
+  const attr = clone.attributes[0];
+
+  assert_equals(attr.namespaceURI, "http://www.w3.org/2000/xmlns/");
+  assert_equals(attr.prefix, "xmlns");
+  assert_equals(attr.localName, "xlink");
+  assert_equals(attr.name, "xmlns:xlink");
+  assert_equals(attr.value, "http://www.w3.org/1999/xlink");
+
+}, "cloned <svg>'s xmlns:xlink attribute should have the right properties");
+
+test(() => {
+
+  const use = clone.firstElementChild;
+  assert_equals(use.namespaceURI, "http://www.w3.org/2000/svg");
+  assert_equals(use.prefix, null);
+  assert_equals(use.localName, "use");
+  assert_equals(use.tagName, "use");
+
+}, "cloned <use> should have the right properties");
+
+test(() => {
+
+  const use = clone.firstElementChild;
+  const attr = use.attributes[0];
+
+  assert_equals(attr.namespaceURI, "http://www.w3.org/1999/xlink");
+  assert_equals(attr.prefix, "xlink");
+  assert_equals(attr.localName, "href");
+  assert_equals(attr.name, "xlink:href");
+  assert_equals(attr.value, "#test");
+
+}, "cloned <use>'s xlink:href attribute should have the right properties");
+
+</script>


### PR DESCRIPTION
Previously, the namespace of the attributes on the cloned element was not being set.

Fixes: http://wpt.live/dom/nodes/Node-cloneNode-svg.html