### PR TITLE
LibWeb: Remove the initialize_strings methods

### DIFF
--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -26,11 +26,7 @@
 #include <LibWeb/Bindings/SyntheticHostDefined.h>
 #include <LibWeb/Bindings/WindowExposedInterfaces.h>
 #include <LibWeb/DOM/Document.h>
-#include <LibWeb/DOM/MutationType.h>
-#include <LibWeb/Editing/CommandNames.h>
-#include <LibWeb/HTML/AttributeNames.h>
 #include <LibWeb/HTML/CustomElements/CustomElementDefinition.h>
-#include <LibWeb/HTML/CustomElements/CustomElementReactionNames.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/HTML/Location.h>
 #include <LibWeb/HTML/PromiseRejectionEvent.h>
@@ -44,25 +40,12 @@
 #include <LibWeb/HTML/Scripting/SyntheticRealmSettings.h>
 #include <LibWeb/HTML/Scripting/TemporaryExecutionContext.h>
 #include <LibWeb/HTML/ShadowRealmGlobalScope.h>
-#include <LibWeb/HTML/TagNames.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/HTML/WorkletGlobalScope.h>
-#include <LibWeb/MathML/TagNames.h>
-#include <LibWeb/MediaSourceExtensions/EventNames.h>
-#include <LibWeb/Namespace.h>
-#include <LibWeb/NavigationTiming/EntryNames.h>
-#include <LibWeb/PerformanceTimeline/EntryTypes.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
-#include <LibWeb/SVG/AttributeNames.h>
-#include <LibWeb/SVG/TagNames.h>
 #include <LibWeb/ServiceWorker/ServiceWorkerGlobalScope.h>
-#include <LibWeb/UIEvents/EventNames.h>
-#include <LibWeb/UIEvents/InputTypes.h>
-#include <LibWeb/WebGL/EventNames.h>
 #include <LibWeb/WebIDL/AbstractOperations.h>
-#include <LibWeb/XHR/EventNames.h>
-#include <LibWeb/XLink/AttributeNames.h>
 
 namespace Web::Bindings {
 
@@ -104,26 +87,6 @@ ErrorOr<void> initialize_main_thread_vm(HTML::EventLoop::Type type)
     // NOTE: We intentionally leak the main thread JavaScript VM.
     //       This avoids doing an exhaustive garbage collection on process exit.
     s_main_thread_vm->ref();
-
-    // These strings could potentially live on the VM similar to CommonPropertyNames.
-    DOM::MutationType::initialize_strings();
-    Editing::CommandNames::initialize_strings();
-    HTML::AttributeNames::initialize_strings();
-    HTML::CustomElementReactionNames::initialize_strings();
-    HTML::EventNames::initialize_strings();
-    HTML::TagNames::initialize_strings();
-    MathML::TagNames::initialize_strings();
-    MediaSourceExtensions::EventNames::initialize_strings();
-    Namespace::initialize_strings();
-    NavigationTiming::EntryNames::initialize_strings();
-    PerformanceTimeline::EntryTypes::initialize_strings();
-    SVG::AttributeNames::initialize_strings();
-    SVG::TagNames::initialize_strings();
-    UIEvents::EventNames::initialize_strings();
-    UIEvents::InputTypes::initialize_strings();
-    WebGL::EventNames::initialize_strings();
-    XHR::EventNames::initialize_strings();
-    XLink::AttributeNames::initialize_strings();
 
     // 8.1.5.1 HostEnsureCanAddPrivateElement(O), https://html.spec.whatwg.org/multipage/webappapis.html#the-hostensurecanaddprivateelement-implementation
     s_main_thread_vm->host_ensure_can_add_private_element = [](JS::Object const& object) -> JS::ThrowCompletionOr<void> {

--- a/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -267,7 +267,7 @@ bool is_unknown_html_element(FlyString const& tag_name)
     // 3. If name is listing or xmp, then return HTMLPreElement.
     // 4. Otherwise, if this specification defines an interface appropriate for the element type corresponding to the local name name, then return that interface.
     // 5. If other applicable specifications define an appropriate interface for name, then return the interface they define.
-#define __ENUMERATE_HTML_TAG(name)        \
+#define __ENUMERATE_HTML_TAG(name, tag)   \
     if (tag_name == HTML::TagNames::name) \
         return false;
     ENUMERATE_HTML_TAGS

--- a/Libraries/LibWeb/DOM/MutationType.cpp
+++ b/Libraries/LibWeb/DOM/MutationType.cpp
@@ -8,20 +8,9 @@
 
 namespace Web::DOM::MutationType {
 
-#define __ENUMERATE_MUTATION_TYPE(name) FlyString name;
+#define __ENUMERATE_MUTATION_TYPE(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_MUTATION_TYPES
 #undef __ENUMERATE_MUTATION_TYPE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_MUTATION_TYPE(name) name = #name##_fly_string;
-    ENUMERATE_MUTATION_TYPES
-#undef __ENUMERATE_MUTATION_TYPE
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/DOM/MutationType.h
+++ b/Libraries/LibWeb/DOM/MutationType.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::DOM::MutationType {
@@ -19,7 +18,5 @@ namespace Web::DOM::MutationType {
 #define __ENUMERATE_MUTATION_TYPE(name) extern FlyString name;
 ENUMERATE_MUTATION_TYPES
 #undef __ENUMERATE_MUTATION_TYPE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/Editing/CommandNames.cpp
+++ b/Libraries/LibWeb/Editing/CommandNames.cpp
@@ -8,22 +8,9 @@
 
 namespace Web::Editing::CommandNames {
 
-#define __ENUMERATE_COMMAND_NAME(name) FlyString name;
+#define __ENUMERATE_COMMAND_NAME(name, command) \
+    FlyString name = command##_fly_string;
 ENUMERATE_COMMAND_NAMES
 #undef __ENUMERATE_COMMAND_NAME
-FlyString delete_;
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_COMMAND_NAME(name) name = #name##_fly_string;
-    ENUMERATE_COMMAND_NAMES
-#undef __ENUMERATE_COMMAND_NAME
-    delete_ = "delete"_fly_string;
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/Editing/CommandNames.h
+++ b/Libraries/LibWeb/Editing/CommandNames.h
@@ -10,53 +10,50 @@
 
 namespace Web::Editing::CommandNames {
 
-#define ENUMERATE_COMMAND_NAMES                         \
-    __ENUMERATE_COMMAND_NAME(backColor)                 \
-    __ENUMERATE_COMMAND_NAME(bold)                      \
-    __ENUMERATE_COMMAND_NAME(copy)                      \
-    __ENUMERATE_COMMAND_NAME(createLink)                \
-    __ENUMERATE_COMMAND_NAME(cut)                       \
-    __ENUMERATE_COMMAND_NAME(defaultParagraphSeparator) \
-    __ENUMERATE_COMMAND_NAME(fontName)                  \
-    __ENUMERATE_COMMAND_NAME(fontSize)                  \
-    __ENUMERATE_COMMAND_NAME(foreColor)                 \
-    __ENUMERATE_COMMAND_NAME(formatBlock)               \
-    __ENUMERATE_COMMAND_NAME(forwardDelete)             \
-    __ENUMERATE_COMMAND_NAME(hiliteColor)               \
-    __ENUMERATE_COMMAND_NAME(indent)                    \
-    __ENUMERATE_COMMAND_NAME(insertHTML)                \
-    __ENUMERATE_COMMAND_NAME(insertHorizontalRule)      \
-    __ENUMERATE_COMMAND_NAME(insertImage)               \
-    __ENUMERATE_COMMAND_NAME(insertLineBreak)           \
-    __ENUMERATE_COMMAND_NAME(insertOrderedList)         \
-    __ENUMERATE_COMMAND_NAME(insertParagraph)           \
-    __ENUMERATE_COMMAND_NAME(insertText)                \
-    __ENUMERATE_COMMAND_NAME(insertUnorderedList)       \
-    __ENUMERATE_COMMAND_NAME(italic)                    \
-    __ENUMERATE_COMMAND_NAME(justifyCenter)             \
-    __ENUMERATE_COMMAND_NAME(justifyFull)               \
-    __ENUMERATE_COMMAND_NAME(justifyLeft)               \
-    __ENUMERATE_COMMAND_NAME(justifyRight)              \
-    __ENUMERATE_COMMAND_NAME(outdent)                   \
-    __ENUMERATE_COMMAND_NAME(paste)                     \
-    __ENUMERATE_COMMAND_NAME(redo)                      \
-    __ENUMERATE_COMMAND_NAME(removeFormat)              \
-    __ENUMERATE_COMMAND_NAME(selectAll)                 \
-    __ENUMERATE_COMMAND_NAME(strikethrough)             \
-    __ENUMERATE_COMMAND_NAME(styleWithCSS)              \
-    __ENUMERATE_COMMAND_NAME(subscript)                 \
-    __ENUMERATE_COMMAND_NAME(superscript)               \
-    __ENUMERATE_COMMAND_NAME(underline)                 \
-    __ENUMERATE_COMMAND_NAME(undo)                      \
-    __ENUMERATE_COMMAND_NAME(unlink)                    \
-    __ENUMERATE_COMMAND_NAME(useCSS)
+#define ENUMERATE_COMMAND_NAMES                                                      \
+    __ENUMERATE_COMMAND_NAME(backColor, "backColor")                                 \
+    __ENUMERATE_COMMAND_NAME(bold, "bold")                                           \
+    __ENUMERATE_COMMAND_NAME(copy, "copy")                                           \
+    __ENUMERATE_COMMAND_NAME(createLink, "createLink")                               \
+    __ENUMERATE_COMMAND_NAME(cut, "cut")                                             \
+    __ENUMERATE_COMMAND_NAME(defaultParagraphSeparator, "defaultParagraphSeparator") \
+    __ENUMERATE_COMMAND_NAME(delete_, "delete")                                      \
+    __ENUMERATE_COMMAND_NAME(fontName, "fontName")                                   \
+    __ENUMERATE_COMMAND_NAME(fontSize, "fontSize")                                   \
+    __ENUMERATE_COMMAND_NAME(foreColor, "foreColor")                                 \
+    __ENUMERATE_COMMAND_NAME(formatBlock, "formatBlock")                             \
+    __ENUMERATE_COMMAND_NAME(forwardDelete, "forwardDelete")                         \
+    __ENUMERATE_COMMAND_NAME(hiliteColor, "hiliteColor")                             \
+    __ENUMERATE_COMMAND_NAME(indent, "indent")                                       \
+    __ENUMERATE_COMMAND_NAME(insertHorizontalRule, "insertHorizontalRule")           \
+    __ENUMERATE_COMMAND_NAME(insertHTML, "insertHTML")                               \
+    __ENUMERATE_COMMAND_NAME(insertImage, "insertImage")                             \
+    __ENUMERATE_COMMAND_NAME(insertLineBreak, "insertLineBreak")                     \
+    __ENUMERATE_COMMAND_NAME(insertOrderedList, "insertOrderedList")                 \
+    __ENUMERATE_COMMAND_NAME(insertParagraph, "insertParagraph")                     \
+    __ENUMERATE_COMMAND_NAME(insertText, "insertText")                               \
+    __ENUMERATE_COMMAND_NAME(insertUnorderedList, "insertUnorderedList")             \
+    __ENUMERATE_COMMAND_NAME(italic, "italic")                                       \
+    __ENUMERATE_COMMAND_NAME(justifyCenter, "justifyCenter")                         \
+    __ENUMERATE_COMMAND_NAME(justifyFull, "justifyFull")                             \
+    __ENUMERATE_COMMAND_NAME(justifyLeft, "justifyLeft")                             \
+    __ENUMERATE_COMMAND_NAME(justifyRight, "justifyRight")                           \
+    __ENUMERATE_COMMAND_NAME(outdent, "outdent")                                     \
+    __ENUMERATE_COMMAND_NAME(paste, "paste")                                         \
+    __ENUMERATE_COMMAND_NAME(redo, "redo")                                           \
+    __ENUMERATE_COMMAND_NAME(removeFormat, "removeFormat")                           \
+    __ENUMERATE_COMMAND_NAME(selectAll, "selectAll")                                 \
+    __ENUMERATE_COMMAND_NAME(strikethrough, "strikethrough")                         \
+    __ENUMERATE_COMMAND_NAME(styleWithCSS, "styleWithCSS")                           \
+    __ENUMERATE_COMMAND_NAME(subscript, "subscript")                                 \
+    __ENUMERATE_COMMAND_NAME(superscript, "superscript")                             \
+    __ENUMERATE_COMMAND_NAME(underline, "underline")                                 \
+    __ENUMERATE_COMMAND_NAME(undo, "undo")                                           \
+    __ENUMERATE_COMMAND_NAME(unlink, "unlink")                                       \
+    __ENUMERATE_COMMAND_NAME(useCSS, "useCSS")
 
-#define __ENUMERATE_COMMAND_NAME(name) extern FlyString name;
+#define __ENUMERATE_COMMAND_NAME(name, command) extern FlyString name;
 ENUMERATE_COMMAND_NAMES
 #undef __ENUMERATE_COMMAND_NAME
-
-extern FlyString delete_;
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/HTML/AttributeNames.cpp
+++ b/Libraries/LibWeb/HTML/AttributeNames.cpp
@@ -9,33 +9,10 @@
 namespace Web::HTML {
 namespace AttributeNames {
 
-#define __ENUMERATE_HTML_ATTRIBUTE(name) FlyString name;
+#define __ENUMERATE_HTML_ATTRIBUTE(name, attribute) \
+    FlyString name = attribute##_fly_string;
 ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_HTML_ATTRIBUTE(name) \
-    name = #name##_fly_string;
-    ENUMERATE_HTML_ATTRIBUTES
-#undef __ENUMERATE_HTML_ATTRIBUTE
-
-    // NOTE: Special cases for C++ keywords.
-    class_ = "class"_fly_string;
-    for_ = "for"_fly_string;
-    default_ = "default"_fly_string;
-    char_ = "char"_fly_string;
-    switch_ = "switch"_fly_string;
-
-    // NOTE: Special cases for attributes with dashes in them.
-    accept_charset = "accept-charset"_fly_string;
-    http_equiv = "http-equiv"_fly_string;
-
-    s_initialized = true;
-}
 
 }
 

--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -6,313 +6,310 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::HTML {
 namespace AttributeNames {
 
-#define ENUMERATE_HTML_ATTRIBUTES                          \
-    __ENUMERATE_HTML_ATTRIBUTE(abbr)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(accept)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(accept_charset)             \
-    __ENUMERATE_HTML_ATTRIBUTE(accesskey)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(action)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(align)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(alink)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(allow)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(allowfullscreen)            \
-    __ENUMERATE_HTML_ATTRIBUTE(alt)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(archive)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(as)                         \
-    __ENUMERATE_HTML_ATTRIBUTE(async)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(autocomplete)               \
-    __ENUMERATE_HTML_ATTRIBUTE(autofocus)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(autoplay)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(axis)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(background)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(behavior)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(bgcolor)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(border)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(bottommargin)               \
-    __ENUMERATE_HTML_ATTRIBUTE(cellpadding)                \
-    __ENUMERATE_HTML_ATTRIBUTE(cellspacing)                \
-    __ENUMERATE_HTML_ATTRIBUTE(char_)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(charoff)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(charset)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(checked)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(cite)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(class_)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(classid)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(clear)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(code)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(codebase)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(codetype)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(color)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(cols)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(colspan)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(compact)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(content)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(contenteditable)            \
-    __ENUMERATE_HTML_ATTRIBUTE(controls)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(coords)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(crossorigin)                \
-    __ENUMERATE_HTML_ATTRIBUTE(data)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(datetime)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(declare)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(decoding)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(default_)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(defaultchecked)             \
-    __ENUMERATE_HTML_ATTRIBUTE(defaultselected)            \
-    __ENUMERATE_HTML_ATTRIBUTE(defer)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(dir)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(direction)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(dirname)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(disabled)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(download)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(enctype)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(ended)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(enterkeyhint)               \
-    __ENUMERATE_HTML_ATTRIBUTE(event)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(face)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(fetchpriority)              \
-    __ENUMERATE_HTML_ATTRIBUTE(for_)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(form)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(formaction)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(formenctype)                \
-    __ENUMERATE_HTML_ATTRIBUTE(formmethod)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(formnovalidate)             \
-    __ENUMERATE_HTML_ATTRIBUTE(formtarget)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(frame)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(frameborder)                \
-    __ENUMERATE_HTML_ATTRIBUTE(headers)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(height)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(hidden)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(high)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(href)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(hreflang)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(hspace)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(http_equiv)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(id)                         \
-    __ENUMERATE_HTML_ATTRIBUTE(imagesizes)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(imagesrcset)                \
-    __ENUMERATE_HTML_ATTRIBUTE(indeterminate)              \
-    __ENUMERATE_HTML_ATTRIBUTE(inert)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(inputmode)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(integrity)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(is)                         \
-    __ENUMERATE_HTML_ATTRIBUTE(iscontenteditable)          \
-    __ENUMERATE_HTML_ATTRIBUTE(ismap)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(itemscope)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(kind)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(label)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(lang)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(language)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(leftmargin)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(link)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(list)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(loading)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(longdesc)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(loop)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(low)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(lowsrc)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(marginheight)               \
-    __ENUMERATE_HTML_ATTRIBUTE(marginwidth)                \
-    __ENUMERATE_HTML_ATTRIBUTE(max)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(maxlength)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(media)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(method)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(min)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(minlength)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(multiple)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(muted)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(name)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(nohref)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(nomodule)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(nonce)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(noresize)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(noshade)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(novalidate)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(nowrap)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(onabort)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onafterprint)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onauxclick)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onbeforeinput)              \
-    __ENUMERATE_HTML_ATTRIBUTE(onbeforematch)              \
-    __ENUMERATE_HTML_ATTRIBUTE(onbeforeprint)              \
-    __ENUMERATE_HTML_ATTRIBUTE(onbeforetoggle)             \
-    __ENUMERATE_HTML_ATTRIBUTE(onbeforeunload)             \
-    __ENUMERATE_HTML_ATTRIBUTE(onblur)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(oncancel)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(oncanplay)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(oncanplaythrough)           \
-    __ENUMERATE_HTML_ATTRIBUTE(onchange)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onclick)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onclose)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(oncontextlost)              \
-    __ENUMERATE_HTML_ATTRIBUTE(oncontextmenu)              \
-    __ENUMERATE_HTML_ATTRIBUTE(oncontextrestored)          \
-    __ENUMERATE_HTML_ATTRIBUTE(oncopy)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(oncuechange)                \
-    __ENUMERATE_HTML_ATTRIBUTE(oncut)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(ondblclick)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(ondrag)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(ondragend)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(ondragenter)                \
-    __ENUMERATE_HTML_ATTRIBUTE(ondragleave)                \
-    __ENUMERATE_HTML_ATTRIBUTE(ondragover)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(ondragstart)                \
-    __ENUMERATE_HTML_ATTRIBUTE(ondrop)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(ondurationchange)           \
-    __ENUMERATE_HTML_ATTRIBUTE(onemptied)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onended)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onerror)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onfocus)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onfocusin)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onfocusout)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onformdata)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(ongotpointercapture)        \
-    __ENUMERATE_HTML_ATTRIBUTE(onhashchange)               \
-    __ENUMERATE_HTML_ATTRIBUTE(oninput)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(oninvalid)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onkeydown)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onkeypress)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onkeyup)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onlanguagechange)           \
-    __ENUMERATE_HTML_ATTRIBUTE(onload)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(onloadeddata)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onloadedmetadata)           \
-    __ENUMERATE_HTML_ATTRIBUTE(onloadstart)                \
-    __ENUMERATE_HTML_ATTRIBUTE(onlostpointercapture)       \
-    __ENUMERATE_HTML_ATTRIBUTE(onmessage)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onmessageerror)             \
-    __ENUMERATE_HTML_ATTRIBUTE(onmousedown)                \
-    __ENUMERATE_HTML_ATTRIBUTE(onmouseenter)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onmouseleave)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onmousemove)                \
-    __ENUMERATE_HTML_ATTRIBUTE(onmouseout)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onmouseover)                \
-    __ENUMERATE_HTML_ATTRIBUTE(onmouseup)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onoffline)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(ononline)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onpagehide)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onpagereveal)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onpageshow)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onpageswap)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onpaste)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onpause)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onplay)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(onplaying)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointercancel)            \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerdown)              \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerenter)             \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerleave)             \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointermove)              \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerout)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerover)              \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerrawupdate)         \
-    __ENUMERATE_HTML_ATTRIBUTE(onpointerup)                \
-    __ENUMERATE_HTML_ATTRIBUTE(onpopstate)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onprogress)                 \
-    __ENUMERATE_HTML_ATTRIBUTE(onratechange)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onrejectionhandled)         \
-    __ENUMERATE_HTML_ATTRIBUTE(onreset)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(onresize)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onscroll)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onscrollend)                \
-    __ENUMERATE_HTML_ATTRIBUTE(onsecuritypolicyviolation)  \
-    __ENUMERATE_HTML_ATTRIBUTE(onseeked)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onseeking)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onselect)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onselectionchange)          \
-    __ENUMERATE_HTML_ATTRIBUTE(onslotchange)               \
-    __ENUMERATE_HTML_ATTRIBUTE(onstalled)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onstorage)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onsubmit)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onsuspend)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(ontimeupdate)               \
-    __ENUMERATE_HTML_ATTRIBUTE(ontoggle)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onunhandledrejection)       \
-    __ENUMERATE_HTML_ATTRIBUTE(onunload)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(onvolumechange)             \
-    __ENUMERATE_HTML_ATTRIBUTE(onwaiting)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationend)       \
-    __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationiteration) \
-    __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationstart)     \
-    __ENUMERATE_HTML_ATTRIBUTE(onwebkittransitionend)      \
-    __ENUMERATE_HTML_ATTRIBUTE(onwheel)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(open)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(optimum)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(pattern)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(paused)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(ping)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(placeholder)                \
-    __ENUMERATE_HTML_ATTRIBUTE(playsinline)                \
-    __ENUMERATE_HTML_ATTRIBUTE(popover)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(popovertarget)              \
-    __ENUMERATE_HTML_ATTRIBUTE(popovertargetaction)        \
-    __ENUMERATE_HTML_ATTRIBUTE(poster)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(preload)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(readonly)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(referrerpolicy)             \
-    __ENUMERATE_HTML_ATTRIBUTE(rel)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(required)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(rev)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(reversed)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(rightmargin)                \
-    __ENUMERATE_HTML_ATTRIBUTE(rows)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(rowspan)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(rules)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(sandbox)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(scheme)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(scope)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(scrollamount)               \
-    __ENUMERATE_HTML_ATTRIBUTE(scrolldelay)                \
-    __ENUMERATE_HTML_ATTRIBUTE(scrolling)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(seeking)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(selected)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(shadowrootclonable)         \
-    __ENUMERATE_HTML_ATTRIBUTE(shadowrootdelegatesfocus)   \
-    __ENUMERATE_HTML_ATTRIBUTE(shadowrootmode)             \
-    __ENUMERATE_HTML_ATTRIBUTE(shadowrootserializable)     \
-    __ENUMERATE_HTML_ATTRIBUTE(shape)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(size)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(sizes)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(slot)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(span)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(src)                        \
-    __ENUMERATE_HTML_ATTRIBUTE(srcdoc)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(srclang)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(srcset)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(standby)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(start)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(step)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(style)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(summary)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(switch_)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(tabindex)                   \
-    __ENUMERATE_HTML_ATTRIBUTE(target)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(text)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(title)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(topmargin)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(truespeed)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(type)                       \
-    __ENUMERATE_HTML_ATTRIBUTE(usemap)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(valign)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(value)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(valuetype)                  \
-    __ENUMERATE_HTML_ATTRIBUTE(version)                    \
-    __ENUMERATE_HTML_ATTRIBUTE(vlink)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(vspace)                     \
-    __ENUMERATE_HTML_ATTRIBUTE(width)                      \
-    __ENUMERATE_HTML_ATTRIBUTE(willvalidate)               \
-    __ENUMERATE_HTML_ATTRIBUTE(wrap)
+#define ENUMERATE_HTML_ATTRIBUTES                                                        \
+    __ENUMERATE_HTML_ATTRIBUTE(abbr, "abbr")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(accept, "accept")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(accept_charset, "accept-charset")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(accesskey, "accesskey")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(action, "action")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(align, "align")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(alink, "alink")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(allow, "allow")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(allowfullscreen, "allowfullscreen")                       \
+    __ENUMERATE_HTML_ATTRIBUTE(alt, "alt")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(archive, "archive")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(as, "as")                                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(async, "async")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(autocomplete, "autocomplete")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(autofocus, "autofocus")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(autoplay, "autoplay")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(axis, "axis")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(background, "background")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(behavior, "behavior")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(bgcolor, "bgcolor")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(border, "border")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(bottommargin, "bottommargin")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(cellpadding, "cellpadding")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(cellspacing, "cellspacing")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(char_, "char")                                            \
+    __ENUMERATE_HTML_ATTRIBUTE(charoff, "charoff")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(charset, "charset")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(checked, "checked")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(cite, "cite")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(class_, "class")                                          \
+    __ENUMERATE_HTML_ATTRIBUTE(classid, "classid")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(clear, "clear")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(code, "code")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(codebase, "codebase")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(codetype, "codetype")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(color, "color")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(cols, "cols")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(colspan, "colspan")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(compact, "compact")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(content, "content")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(contenteditable, "contenteditable")                       \
+    __ENUMERATE_HTML_ATTRIBUTE(controls, "controls")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(coords, "coords")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(crossorigin, "crossorigin")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(data, "data")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(datetime, "datetime")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(declare, "declare")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(decoding, "decoding")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(default_, "default")                                      \
+    __ENUMERATE_HTML_ATTRIBUTE(defaultchecked, "defaultchecked")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(defaultselected, "defaultselected")                       \
+    __ENUMERATE_HTML_ATTRIBUTE(defer, "defer")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(dir, "dir")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(direction, "direction")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(dirname, "dirname")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(disabled, "disabled")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(download, "download")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(enctype, "enctype")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(ended, "ended")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(enterkeyhint, "enterkeyhint")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(event, "event")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(face, "face")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(fetchpriority, "fetchpriority")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(for_, "for")                                              \
+    __ENUMERATE_HTML_ATTRIBUTE(form, "form")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(formaction, "formaction")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(formenctype, "formenctype")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(formmethod, "formmethod")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(formnovalidate, "formnovalidate")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(formtarget, "formtarget")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(frame, "frame")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(frameborder, "frameborder")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(headers, "headers")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(height, "height")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(hidden, "hidden")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(high, "high")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(href, "href")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(hreflang, "hreflang")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(hspace, "hspace")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(http_equiv, "http-equiv")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(id, "id")                                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(imagesizes, "imagesizes")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(imagesrcset, "imagesrcset")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(indeterminate, "indeterminate")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(inert, "inert")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(inputmode, "inputmode")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(integrity, "integrity")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(is, "is")                                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(iscontenteditable, "iscontenteditable")                   \
+    __ENUMERATE_HTML_ATTRIBUTE(ismap, "ismap")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(itemscope, "itemscope")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(kind, "kind")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(label, "label")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(lang, "lang")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(language, "language")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(leftmargin, "leftmargin")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(link, "link")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(list, "list")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(loading, "loading")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(longdesc, "longdesc")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(loop, "loop")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(low, "low")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(lowsrc, "lowsrc")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(marginheight, "marginheight")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(marginwidth, "marginwidth")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(max, "max")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(maxlength, "maxlength")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(media, "media")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(method, "method")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(min, "min")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(minlength, "minlength")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(multiple, "multiple")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(muted, "muted")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(name, "name")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(nohref, "nohref")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(nomodule, "nomodule")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(nonce, "nonce")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(noresize, "noresize")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(noshade, "noshade")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(novalidate, "novalidate")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(nowrap, "nowrap")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onabort, "onabort")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onafterprint, "onafterprint")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onauxclick, "onauxclick")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforeinput, "onbeforeinput")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforematch, "onbeforematch")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforeprint, "onbeforeprint")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforetoggle, "onbeforetoggle")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onbeforeunload, "onbeforeunload")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onblur, "onblur")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(oncancel, "oncancel")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(oncanplay, "oncanplay")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(oncanplaythrough, "oncanplaythrough")                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onchange, "onchange")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onclick, "onclick")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onclose, "onclose")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(oncontextlost, "oncontextlost")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(oncontextmenu, "oncontextmenu")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(oncontextrestored, "oncontextrestored")                   \
+    __ENUMERATE_HTML_ATTRIBUTE(oncopy, "oncopy")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(oncuechange, "oncuechange")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(oncut, "oncut")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(ondblclick, "ondblclick")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(ondrag, "ondrag")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(ondragend, "ondragend")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(ondragenter, "ondragenter")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(ondragleave, "ondragleave")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(ondragover, "ondragover")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(ondragstart, "ondragstart")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(ondrop, "ondrop")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(ondurationchange, "ondurationchange")                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onemptied, "onemptied")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onended, "onended")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onerror, "onerror")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onfocus, "onfocus")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onfocusin, "onfocusin")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onfocusout, "onfocusout")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onformdata, "onformdata")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(ongotpointercapture, "ongotpointercapture")               \
+    __ENUMERATE_HTML_ATTRIBUTE(onhashchange, "onhashchange")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(oninput, "oninput")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(oninvalid, "oninvalid")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onkeydown, "onkeydown")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onkeypress, "onkeypress")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onkeyup, "onkeyup")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onlanguagechange, "onlanguagechange")                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onload, "onload")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onloadeddata, "onloadeddata")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onloadedmetadata, "onloadedmetadata")                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onloadstart, "onloadstart")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(onlostpointercapture, "onlostpointercapture")             \
+    __ENUMERATE_HTML_ATTRIBUTE(onmessage, "onmessage")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onmessageerror, "onmessageerror")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onmousedown, "onmousedown")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(onmouseenter, "onmouseenter")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onmouseleave, "onmouseleave")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onmousemove, "onmousemove")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(onmouseout, "onmouseout")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onmouseover, "onmouseover")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(onmouseup, "onmouseup")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onoffline, "onoffline")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(ononline, "ononline")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onpagehide, "onpagehide")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpagereveal, "onpagereveal")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onpageshow, "onpageshow")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpageswap, "onpageswap")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpaste, "onpaste")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onpause, "onpause")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onplay, "onplay")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onplaying, "onplaying")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointercancel, "onpointercancel")                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerdown, "onpointerdown")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerenter, "onpointerenter")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerleave, "onpointerleave")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointermove, "onpointermove")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerout, "onpointerout")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerover, "onpointerover")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerrawupdate, "onpointerrawupdate")                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onpointerup, "onpointerup")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(onpopstate, "onpopstate")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onprogress, "onprogress")                                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onratechange, "onratechange")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onrejectionhandled, "onrejectionhandled")                 \
+    __ENUMERATE_HTML_ATTRIBUTE(onreset, "onreset")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(onresize, "onresize")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onscroll, "onscroll")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onscrollend, "onscrollend")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(onsecuritypolicyviolation, "onsecuritypolicyviolation")   \
+    __ENUMERATE_HTML_ATTRIBUTE(onseeked, "onseeked")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onseeking, "onseeking")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onselect, "onselect")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onselectionchange, "onselectionchange")                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onslotchange, "onslotchange")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(onstalled, "onstalled")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onstorage, "onstorage")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onsubmit, "onsubmit")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onsuspend, "onsuspend")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(ontimeupdate, "ontimeupdate")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(ontoggle, "ontoggle")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onunhandledrejection, "onunhandledrejection")             \
+    __ENUMERATE_HTML_ATTRIBUTE(onunload, "onunload")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(onvolumechange, "onvolumechange")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(onwaiting, "onwaiting")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationend, "onwebkitanimationend")             \
+    __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationiteration, "onwebkitanimationiteration") \
+    __ENUMERATE_HTML_ATTRIBUTE(onwebkitanimationstart, "onwebkitanimationstart")         \
+    __ENUMERATE_HTML_ATTRIBUTE(onwebkittransitionend, "onwebkittransitionend")           \
+    __ENUMERATE_HTML_ATTRIBUTE(onwheel, "onwheel")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(open, "open")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(optimum, "optimum")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(pattern, "pattern")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(paused, "paused")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(ping, "ping")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(placeholder, "placeholder")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(playsinline, "playsinline")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(popover, "popover")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(popovertarget, "popovertarget")                           \
+    __ENUMERATE_HTML_ATTRIBUTE(popovertargetaction, "popovertargetaction")               \
+    __ENUMERATE_HTML_ATTRIBUTE(poster, "poster")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(preload, "preload")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(readonly, "readonly")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(referrerpolicy, "referrerpolicy")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(rel, "rel")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(required, "required")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(rev, "rev")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(reversed, "reversed")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(rightmargin, "rightmargin")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(rows, "rows")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(rowspan, "rowspan")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(rules, "rules")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(sandbox, "sandbox")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(scheme, "scheme")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(scope, "scope")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(scrollamount, "scrollamount")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(scrolldelay, "scrolldelay")                               \
+    __ENUMERATE_HTML_ATTRIBUTE(scrolling, "scrolling")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(seeking, "seeking")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(selected, "selected")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootclonable, "shadowrootclonable")                 \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootdelegatesfocus, "shadowrootdelegatesfocus")     \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootmode, "shadowrootmode")                         \
+    __ENUMERATE_HTML_ATTRIBUTE(shadowrootserializable, "shadowrootserializable")         \
+    __ENUMERATE_HTML_ATTRIBUTE(shape, "shape")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(size, "size")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(sizes, "sizes")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(slot, "slot")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(span, "span")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(src, "src")                                               \
+    __ENUMERATE_HTML_ATTRIBUTE(srcdoc, "srcdoc")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(srclang, "srclang")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(srcset, "srcset")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(standby, "standby")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(start, "start")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(step, "step")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(style, "style")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(summary, "summary")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(switch_, "switch")                                        \
+    __ENUMERATE_HTML_ATTRIBUTE(tabindex, "tabindex")                                     \
+    __ENUMERATE_HTML_ATTRIBUTE(target, "target")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(text, "text")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(title, "title")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(topmargin, "topmargin")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(truespeed, "truespeed")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(type, "type")                                             \
+    __ENUMERATE_HTML_ATTRIBUTE(usemap, "usemap")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(valign, "valign")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(value, "value")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(valuetype, "valuetype")                                   \
+    __ENUMERATE_HTML_ATTRIBUTE(version, "version")                                       \
+    __ENUMERATE_HTML_ATTRIBUTE(vlink, "vlink")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(vspace, "vspace")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(width, "width")                                           \
+    __ENUMERATE_HTML_ATTRIBUTE(willvalidate, "willvalidate")                             \
+    __ENUMERATE_HTML_ATTRIBUTE(wrap, "wrap")
 
-#define __ENUMERATE_HTML_ATTRIBUTE(name) extern FlyString name;
+#define __ENUMERATE_HTML_ATTRIBUTE(name, attribute) extern FlyString name;
 ENUMERATE_HTML_ATTRIBUTES
 #undef __ENUMERATE_HTML_ATTRIBUTE
-
-void initialize_strings();
 
 }
 

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementReactionNames.cpp
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementReactionNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::HTML::CustomElementReactionNames {
 
-#define __ENUMERATE_CUSTOM_ELEMENT_REACTION_NAME(name) FlyString name;
+#define __ENUMERATE_CUSTOM_ELEMENT_REACTION_NAME(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_CUSTOM_ELEMENT_REACTION_NAMES
 #undef __ENUMERATE_CUSTOM_ELEMENT_REACTION_NAME
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_CUSTOM_ELEMENT_REACTION_NAME(name) \
-    name = #name##_fly_string;
-    ENUMERATE_CUSTOM_ELEMENT_REACTION_NAMES
-#undef __ENUMERATE_CUSTOM_ELEMENT_REACTION_NAME
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/HTML/CustomElements/CustomElementReactionNames.h
+++ b/Libraries/LibWeb/HTML/CustomElements/CustomElementReactionNames.h
@@ -25,6 +25,4 @@ namespace Web::HTML::CustomElementReactionNames {
 ENUMERATE_CUSTOM_ELEMENT_REACTION_NAMES
 #undef __ENUMERATE_CUSTOM_ELEMENT_REACTION_NAME
 
-void initialize_strings();
-
 }

--- a/Libraries/LibWeb/HTML/EventNames.cpp
+++ b/Libraries/LibWeb/HTML/EventNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::HTML::EventNames {
 
-#define __ENUMERATE_HTML_EVENT(name) FlyString name;
+#define __ENUMERATE_HTML_EVENT(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_HTML_EVENTS
 #undef __ENUMERATE_HTML_EVENT
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_HTML_EVENT(name) \
-    name = #name##_fly_string;
-    ENUMERATE_HTML_EVENTS
-#undef __ENUMERATE_HTML_EVENT
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/HTML/EventNames.h
+++ b/Libraries/LibWeb/HTML/EventNames.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::HTML::EventNames {
@@ -85,8 +84,8 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(open)                     \
     __ENUMERATE_HTML_EVENT(pagehide)                 \
     __ENUMERATE_HTML_EVENT(pagereveal)               \
-    __ENUMERATE_HTML_EVENT(pageswap)                 \
     __ENUMERATE_HTML_EVENT(pageshow)                 \
+    __ENUMERATE_HTML_EVENT(pageswap)                 \
     __ENUMERATE_HTML_EVENT(paste)                    \
     __ENUMERATE_HTML_EVENT(pause)                    \
     __ENUMERATE_HTML_EVENT(play)                     \
@@ -117,9 +116,9 @@ namespace Web::HTML::EventNames {
     __ENUMERATE_HTML_EVENT(timeupdate)               \
     __ENUMERATE_HTML_EVENT(toggle)                   \
     __ENUMERATE_HTML_EVENT(transitioncancel)         \
+    __ENUMERATE_HTML_EVENT(transitionend)            \
     __ENUMERATE_HTML_EVENT(transitionrun)            \
     __ENUMERATE_HTML_EVENT(transitionstart)          \
-    __ENUMERATE_HTML_EVENT(transitionend)            \
     __ENUMERATE_HTML_EVENT(unhandledrejection)       \
     __ENUMERATE_HTML_EVENT(unload)                   \
     __ENUMERATE_HTML_EVENT(upgradeneeded)            \
@@ -135,7 +134,5 @@ namespace Web::HTML::EventNames {
 #define __ENUMERATE_HTML_EVENT(name) extern FlyString name;
 ENUMERATE_HTML_EVENTS
 #undef __ENUMERATE_HTML_EVENT
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/HTML/EventNames.h
+++ b/Libraries/LibWeb/HTML/EventNames.h
@@ -11,9 +11,6 @@
 
 namespace Web::HTML::EventNames {
 
-// FIXME: Add app cache events https://html.spec.whatwg.org/multipage/offline.html#appcacheevents
-// FIXME: Add drag and drop events https://html.spec.whatwg.org/multipage/dnd.html#dndevents
-
 #define ENUMERATE_HTML_EVENTS                        \
     __ENUMERATE_HTML_EVENT(abort)                    \
     __ENUMERATE_HTML_EVENT(addtrack)                 \

--- a/Libraries/LibWeb/HTML/TagNames.cpp
+++ b/Libraries/LibWeb/HTML/TagNames.cpp
@@ -8,23 +8,9 @@
 
 namespace Web::HTML::TagNames {
 
-#define __ENUMERATE_HTML_TAG(name) FlyString name;
+#define __ENUMERATE_HTML_TAG(name, tag) \
+    FlyString name = tag##_fly_string;
 ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_HTML_TAG(name) \
-    name = #name##_fly_string;
-    ENUMERATE_HTML_TAGS
-#undef __ENUMERATE_HTML_TAG
-
-    template_ = "template"_fly_string;
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/HTML/TagNames.h
+++ b/Libraries/LibWeb/HTML/TagNames.h
@@ -6,162 +6,159 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::HTML::TagNames {
 
-#define ENUMERATE_HTML_TAGS          \
-    __ENUMERATE_HTML_TAG(a)          \
-    __ENUMERATE_HTML_TAG(abbr)       \
-    __ENUMERATE_HTML_TAG(acronym)    \
-    __ENUMERATE_HTML_TAG(address)    \
-    __ENUMERATE_HTML_TAG(applet)     \
-    __ENUMERATE_HTML_TAG(area)       \
-    __ENUMERATE_HTML_TAG(article)    \
-    __ENUMERATE_HTML_TAG(aside)      \
-    __ENUMERATE_HTML_TAG(audio)      \
-    __ENUMERATE_HTML_TAG(b)          \
-    __ENUMERATE_HTML_TAG(base)       \
-    __ENUMERATE_HTML_TAG(basefont)   \
-    __ENUMERATE_HTML_TAG(bdi)        \
-    __ENUMERATE_HTML_TAG(bdo)        \
-    __ENUMERATE_HTML_TAG(bgsound)    \
-    __ENUMERATE_HTML_TAG(big)        \
-    __ENUMERATE_HTML_TAG(blink)      \
-    __ENUMERATE_HTML_TAG(blockquote) \
-    __ENUMERATE_HTML_TAG(body)       \
-    __ENUMERATE_HTML_TAG(br)         \
-    __ENUMERATE_HTML_TAG(button)     \
-    __ENUMERATE_HTML_TAG(canvas)     \
-    __ENUMERATE_HTML_TAG(caption)    \
-    __ENUMERATE_HTML_TAG(center)     \
-    __ENUMERATE_HTML_TAG(cite)       \
-    __ENUMERATE_HTML_TAG(code)       \
-    __ENUMERATE_HTML_TAG(col)        \
-    __ENUMERATE_HTML_TAG(colgroup)   \
-    __ENUMERATE_HTML_TAG(data)       \
-    __ENUMERATE_HTML_TAG(datalist)   \
-    __ENUMERATE_HTML_TAG(dd)         \
-    __ENUMERATE_HTML_TAG(del)        \
-    __ENUMERATE_HTML_TAG(details)    \
-    __ENUMERATE_HTML_TAG(dfn)        \
-    __ENUMERATE_HTML_TAG(dialog)     \
-    __ENUMERATE_HTML_TAG(dir)        \
-    __ENUMERATE_HTML_TAG(div)        \
-    __ENUMERATE_HTML_TAG(dl)         \
-    __ENUMERATE_HTML_TAG(dt)         \
-    __ENUMERATE_HTML_TAG(em)         \
-    __ENUMERATE_HTML_TAG(embed)      \
-    __ENUMERATE_HTML_TAG(fieldset)   \
-    __ENUMERATE_HTML_TAG(figcaption) \
-    __ENUMERATE_HTML_TAG(figure)     \
-    __ENUMERATE_HTML_TAG(font)       \
-    __ENUMERATE_HTML_TAG(footer)     \
-    __ENUMERATE_HTML_TAG(form)       \
-    __ENUMERATE_HTML_TAG(frame)      \
-    __ENUMERATE_HTML_TAG(frameset)   \
-    __ENUMERATE_HTML_TAG(h1)         \
-    __ENUMERATE_HTML_TAG(h2)         \
-    __ENUMERATE_HTML_TAG(h3)         \
-    __ENUMERATE_HTML_TAG(h4)         \
-    __ENUMERATE_HTML_TAG(h5)         \
-    __ENUMERATE_HTML_TAG(h6)         \
-    __ENUMERATE_HTML_TAG(head)       \
-    __ENUMERATE_HTML_TAG(header)     \
-    __ENUMERATE_HTML_TAG(hgroup)     \
-    __ENUMERATE_HTML_TAG(hr)         \
-    __ENUMERATE_HTML_TAG(html)       \
-    __ENUMERATE_HTML_TAG(i)          \
-    __ENUMERATE_HTML_TAG(iframe)     \
-    __ENUMERATE_HTML_TAG(image)      \
-    __ENUMERATE_HTML_TAG(img)        \
-    __ENUMERATE_HTML_TAG(input)      \
-    __ENUMERATE_HTML_TAG(ins)        \
-    __ENUMERATE_HTML_TAG(isindex)    \
-    __ENUMERATE_HTML_TAG(kbd)        \
-    __ENUMERATE_HTML_TAG(keygen)     \
-    __ENUMERATE_HTML_TAG(label)      \
-    __ENUMERATE_HTML_TAG(legend)     \
-    __ENUMERATE_HTML_TAG(li)         \
-    __ENUMERATE_HTML_TAG(link)       \
-    __ENUMERATE_HTML_TAG(listing)    \
-    __ENUMERATE_HTML_TAG(main)       \
-    __ENUMERATE_HTML_TAG(map)        \
-    __ENUMERATE_HTML_TAG(mark)       \
-    __ENUMERATE_HTML_TAG(marquee)    \
-    __ENUMERATE_HTML_TAG(math)       \
-    __ENUMERATE_HTML_TAG(menu)       \
-    __ENUMERATE_HTML_TAG(menuitem)   \
-    __ENUMERATE_HTML_TAG(meta)       \
-    __ENUMERATE_HTML_TAG(meter)      \
-    __ENUMERATE_HTML_TAG(multicol)   \
-    __ENUMERATE_HTML_TAG(nav)        \
-    __ENUMERATE_HTML_TAG(nextid)     \
-    __ENUMERATE_HTML_TAG(nobr)       \
-    __ENUMERATE_HTML_TAG(noembed)    \
-    __ENUMERATE_HTML_TAG(noframes)   \
-    __ENUMERATE_HTML_TAG(noscript)   \
-    __ENUMERATE_HTML_TAG(object)     \
-    __ENUMERATE_HTML_TAG(ol)         \
-    __ENUMERATE_HTML_TAG(optgroup)   \
-    __ENUMERATE_HTML_TAG(option)     \
-    __ENUMERATE_HTML_TAG(output)     \
-    __ENUMERATE_HTML_TAG(p)          \
-    __ENUMERATE_HTML_TAG(param)      \
-    __ENUMERATE_HTML_TAG(picture)    \
-    __ENUMERATE_HTML_TAG(path)       \
-    __ENUMERATE_HTML_TAG(plaintext)  \
-    __ENUMERATE_HTML_TAG(pre)        \
-    __ENUMERATE_HTML_TAG(progress)   \
-    __ENUMERATE_HTML_TAG(q)          \
-    __ENUMERATE_HTML_TAG(ruby)       \
-    __ENUMERATE_HTML_TAG(rb)         \
-    __ENUMERATE_HTML_TAG(rp)         \
-    __ENUMERATE_HTML_TAG(rt)         \
-    __ENUMERATE_HTML_TAG(rtc)        \
-    __ENUMERATE_HTML_TAG(s)          \
-    __ENUMERATE_HTML_TAG(samp)       \
-    __ENUMERATE_HTML_TAG(script)     \
-    __ENUMERATE_HTML_TAG(search)     \
-    __ENUMERATE_HTML_TAG(section)    \
-    __ENUMERATE_HTML_TAG(select)     \
-    __ENUMERATE_HTML_TAG(slot)       \
-    __ENUMERATE_HTML_TAG(small)      \
-    __ENUMERATE_HTML_TAG(source)     \
-    __ENUMERATE_HTML_TAG(span)       \
-    __ENUMERATE_HTML_TAG(spacer)     \
-    __ENUMERATE_HTML_TAG(strike)     \
-    __ENUMERATE_HTML_TAG(strong)     \
-    __ENUMERATE_HTML_TAG(style)      \
-    __ENUMERATE_HTML_TAG(sub)        \
-    __ENUMERATE_HTML_TAG(sup)        \
-    __ENUMERATE_HTML_TAG(summary)    \
-    __ENUMERATE_HTML_TAG(svg)        \
-    __ENUMERATE_HTML_TAG(table)      \
-    __ENUMERATE_HTML_TAG(tbody)      \
-    __ENUMERATE_HTML_TAG(td)         \
-    __ENUMERATE_HTML_TAG(template_)  \
-    __ENUMERATE_HTML_TAG(textarea)   \
-    __ENUMERATE_HTML_TAG(tfoot)      \
-    __ENUMERATE_HTML_TAG(th)         \
-    __ENUMERATE_HTML_TAG(thead)      \
-    __ENUMERATE_HTML_TAG(time)       \
-    __ENUMERATE_HTML_TAG(title)      \
-    __ENUMERATE_HTML_TAG(tr)         \
-    __ENUMERATE_HTML_TAG(track)      \
-    __ENUMERATE_HTML_TAG(tt)         \
-    __ENUMERATE_HTML_TAG(u)          \
-    __ENUMERATE_HTML_TAG(ul)         \
-    __ENUMERATE_HTML_TAG(var)        \
-    __ENUMERATE_HTML_TAG(video)      \
-    __ENUMERATE_HTML_TAG(wbr)        \
-    __ENUMERATE_HTML_TAG(xmp)
+#define ENUMERATE_HTML_TAGS                        \
+    __ENUMERATE_HTML_TAG(a, "a")                   \
+    __ENUMERATE_HTML_TAG(abbr, "abbr")             \
+    __ENUMERATE_HTML_TAG(acronym, "acronym")       \
+    __ENUMERATE_HTML_TAG(address, "address")       \
+    __ENUMERATE_HTML_TAG(applet, "applet")         \
+    __ENUMERATE_HTML_TAG(area, "area")             \
+    __ENUMERATE_HTML_TAG(article, "article")       \
+    __ENUMERATE_HTML_TAG(aside, "aside")           \
+    __ENUMERATE_HTML_TAG(audio, "audio")           \
+    __ENUMERATE_HTML_TAG(b, "b")                   \
+    __ENUMERATE_HTML_TAG(base, "base")             \
+    __ENUMERATE_HTML_TAG(basefont, "basefont")     \
+    __ENUMERATE_HTML_TAG(bdi, "bdi")               \
+    __ENUMERATE_HTML_TAG(bdo, "bdo")               \
+    __ENUMERATE_HTML_TAG(bgsound, "bgsound")       \
+    __ENUMERATE_HTML_TAG(big, "big")               \
+    __ENUMERATE_HTML_TAG(blink, "blink")           \
+    __ENUMERATE_HTML_TAG(blockquote, "blockquote") \
+    __ENUMERATE_HTML_TAG(body, "body")             \
+    __ENUMERATE_HTML_TAG(br, "br")                 \
+    __ENUMERATE_HTML_TAG(button, "button")         \
+    __ENUMERATE_HTML_TAG(canvas, "canvas")         \
+    __ENUMERATE_HTML_TAG(caption, "caption")       \
+    __ENUMERATE_HTML_TAG(center, "center")         \
+    __ENUMERATE_HTML_TAG(cite, "cite")             \
+    __ENUMERATE_HTML_TAG(code, "code")             \
+    __ENUMERATE_HTML_TAG(col, "col")               \
+    __ENUMERATE_HTML_TAG(colgroup, "colgroup")     \
+    __ENUMERATE_HTML_TAG(data, "data")             \
+    __ENUMERATE_HTML_TAG(datalist, "datalist")     \
+    __ENUMERATE_HTML_TAG(dd, "dd")                 \
+    __ENUMERATE_HTML_TAG(del, "del")               \
+    __ENUMERATE_HTML_TAG(details, "details")       \
+    __ENUMERATE_HTML_TAG(dfn, "dfn")               \
+    __ENUMERATE_HTML_TAG(dialog, "dialog")         \
+    __ENUMERATE_HTML_TAG(dir, "dir")               \
+    __ENUMERATE_HTML_TAG(div, "div")               \
+    __ENUMERATE_HTML_TAG(dl, "dl")                 \
+    __ENUMERATE_HTML_TAG(dt, "dt")                 \
+    __ENUMERATE_HTML_TAG(em, "em")                 \
+    __ENUMERATE_HTML_TAG(embed, "embed")           \
+    __ENUMERATE_HTML_TAG(fieldset, "fieldset")     \
+    __ENUMERATE_HTML_TAG(figcaption, "figcaption") \
+    __ENUMERATE_HTML_TAG(figure, "figure")         \
+    __ENUMERATE_HTML_TAG(font, "font")             \
+    __ENUMERATE_HTML_TAG(footer, "footer")         \
+    __ENUMERATE_HTML_TAG(form, "form")             \
+    __ENUMERATE_HTML_TAG(frame, "frame")           \
+    __ENUMERATE_HTML_TAG(frameset, "frameset")     \
+    __ENUMERATE_HTML_TAG(h1, "h1")                 \
+    __ENUMERATE_HTML_TAG(h2, "h2")                 \
+    __ENUMERATE_HTML_TAG(h3, "h3")                 \
+    __ENUMERATE_HTML_TAG(h4, "h4")                 \
+    __ENUMERATE_HTML_TAG(h5, "h5")                 \
+    __ENUMERATE_HTML_TAG(h6, "h6")                 \
+    __ENUMERATE_HTML_TAG(head, "head")             \
+    __ENUMERATE_HTML_TAG(header, "header")         \
+    __ENUMERATE_HTML_TAG(hgroup, "hgroup")         \
+    __ENUMERATE_HTML_TAG(hr, "hr")                 \
+    __ENUMERATE_HTML_TAG(html, "html")             \
+    __ENUMERATE_HTML_TAG(i, "i")                   \
+    __ENUMERATE_HTML_TAG(iframe, "iframe")         \
+    __ENUMERATE_HTML_TAG(image, "image")           \
+    __ENUMERATE_HTML_TAG(img, "img")               \
+    __ENUMERATE_HTML_TAG(input, "input")           \
+    __ENUMERATE_HTML_TAG(ins, "ins")               \
+    __ENUMERATE_HTML_TAG(isindex, "isindex")       \
+    __ENUMERATE_HTML_TAG(kbd, "kbd")               \
+    __ENUMERATE_HTML_TAG(keygen, "keygen")         \
+    __ENUMERATE_HTML_TAG(label, "label")           \
+    __ENUMERATE_HTML_TAG(legend, "legend")         \
+    __ENUMERATE_HTML_TAG(li, "li")                 \
+    __ENUMERATE_HTML_TAG(link, "link")             \
+    __ENUMERATE_HTML_TAG(listing, "listing")       \
+    __ENUMERATE_HTML_TAG(main, "main")             \
+    __ENUMERATE_HTML_TAG(map, "map")               \
+    __ENUMERATE_HTML_TAG(mark, "mark")             \
+    __ENUMERATE_HTML_TAG(marquee, "marquee")       \
+    __ENUMERATE_HTML_TAG(math, "math")             \
+    __ENUMERATE_HTML_TAG(menu, "menu")             \
+    __ENUMERATE_HTML_TAG(menuitem, "menuitem")     \
+    __ENUMERATE_HTML_TAG(meta, "meta")             \
+    __ENUMERATE_HTML_TAG(meter, "meter")           \
+    __ENUMERATE_HTML_TAG(multicol, "multicol")     \
+    __ENUMERATE_HTML_TAG(nav, "nav")               \
+    __ENUMERATE_HTML_TAG(nextid, "nextid")         \
+    __ENUMERATE_HTML_TAG(nobr, "nobr")             \
+    __ENUMERATE_HTML_TAG(noembed, "noembed")       \
+    __ENUMERATE_HTML_TAG(noframes, "noframes")     \
+    __ENUMERATE_HTML_TAG(noscript, "noscript")     \
+    __ENUMERATE_HTML_TAG(object, "object")         \
+    __ENUMERATE_HTML_TAG(ol, "ol")                 \
+    __ENUMERATE_HTML_TAG(optgroup, "optgroup")     \
+    __ENUMERATE_HTML_TAG(option, "option")         \
+    __ENUMERATE_HTML_TAG(output, "output")         \
+    __ENUMERATE_HTML_TAG(p, "p")                   \
+    __ENUMERATE_HTML_TAG(param, "param")           \
+    __ENUMERATE_HTML_TAG(path, "path")             \
+    __ENUMERATE_HTML_TAG(picture, "picture")       \
+    __ENUMERATE_HTML_TAG(plaintext, "plaintext")   \
+    __ENUMERATE_HTML_TAG(pre, "pre")               \
+    __ENUMERATE_HTML_TAG(progress, "progress")     \
+    __ENUMERATE_HTML_TAG(q, "q")                   \
+    __ENUMERATE_HTML_TAG(rb, "rb")                 \
+    __ENUMERATE_HTML_TAG(rp, "rp")                 \
+    __ENUMERATE_HTML_TAG(rt, "rt")                 \
+    __ENUMERATE_HTML_TAG(rtc, "rtc")               \
+    __ENUMERATE_HTML_TAG(ruby, "ruby")             \
+    __ENUMERATE_HTML_TAG(s, "s")                   \
+    __ENUMERATE_HTML_TAG(samp, "samp")             \
+    __ENUMERATE_HTML_TAG(script, "script")         \
+    __ENUMERATE_HTML_TAG(search, "search")         \
+    __ENUMERATE_HTML_TAG(section, "section")       \
+    __ENUMERATE_HTML_TAG(select, "select")         \
+    __ENUMERATE_HTML_TAG(slot, "slot")             \
+    __ENUMERATE_HTML_TAG(small, "small")           \
+    __ENUMERATE_HTML_TAG(source, "source")         \
+    __ENUMERATE_HTML_TAG(spacer, "spacer")         \
+    __ENUMERATE_HTML_TAG(span, "span")             \
+    __ENUMERATE_HTML_TAG(strike, "strike")         \
+    __ENUMERATE_HTML_TAG(strong, "strong")         \
+    __ENUMERATE_HTML_TAG(style, "style")           \
+    __ENUMERATE_HTML_TAG(sub, "sub")               \
+    __ENUMERATE_HTML_TAG(summary, "summary")       \
+    __ENUMERATE_HTML_TAG(sup, "sup")               \
+    __ENUMERATE_HTML_TAG(svg, "svg")               \
+    __ENUMERATE_HTML_TAG(table, "table")           \
+    __ENUMERATE_HTML_TAG(tbody, "tbody")           \
+    __ENUMERATE_HTML_TAG(td, "td")                 \
+    __ENUMERATE_HTML_TAG(template_, "template")    \
+    __ENUMERATE_HTML_TAG(textarea, "textarea")     \
+    __ENUMERATE_HTML_TAG(tfoot, "tfoot")           \
+    __ENUMERATE_HTML_TAG(th, "th")                 \
+    __ENUMERATE_HTML_TAG(thead, "thead")           \
+    __ENUMERATE_HTML_TAG(time, "time")             \
+    __ENUMERATE_HTML_TAG(title, "title")           \
+    __ENUMERATE_HTML_TAG(tr, "tr")                 \
+    __ENUMERATE_HTML_TAG(track, "track")           \
+    __ENUMERATE_HTML_TAG(tt, "tt")                 \
+    __ENUMERATE_HTML_TAG(u, "u")                   \
+    __ENUMERATE_HTML_TAG(ul, "ul")                 \
+    __ENUMERATE_HTML_TAG(var, "var")               \
+    __ENUMERATE_HTML_TAG(video, "video")           \
+    __ENUMERATE_HTML_TAG(wbr, "wbr")               \
+    __ENUMERATE_HTML_TAG(xmp, "xmp")
 
-#define __ENUMERATE_HTML_TAG(name) extern FlyString name;
+#define __ENUMERATE_HTML_TAG(name, tag) extern FlyString name;
 ENUMERATE_HTML_TAGS
 #undef __ENUMERATE_HTML_TAG
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/MathML/TagNames.cpp
+++ b/Libraries/LibWeb/MathML/TagNames.cpp
@@ -4,27 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/String.h>
 #include <LibWeb/MathML/TagNames.h>
 
 namespace Web::MathML::TagNames {
 
-#define __ENUMERATE_MATHML_TAG(name) FlyString name;
+#define __ENUMERATE_MATHML_TAG(name, tag) \
+    FlyString name = tag##_fly_string;
 ENUMERATE_MATHML_TAGS
 #undef __ENUMERATE_MATHML_TAG
-FlyString annotation_xml;
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_MATHML_TAG(name) name = #name##_fly_string;
-    ENUMERATE_MATHML_TAGS
-#undef __ENUMERATE_MATHML_TAG
-    annotation_xml = "annotation-xml"_fly_string;
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/MathML/TagNames.h
+++ b/Libraries/LibWeb/MathML/TagNames.h
@@ -10,45 +10,42 @@
 
 namespace Web::MathML::TagNames {
 
-#define ENUMERATE_MATHML_TAGS             \
-    __ENUMERATE_MATHML_TAG(annotation)    \
-    __ENUMERATE_MATHML_TAG(maction)       \
-    __ENUMERATE_MATHML_TAG(malignmark)    \
-    __ENUMERATE_MATHML_TAG(math)          \
-    __ENUMERATE_MATHML_TAG(merror)        \
-    __ENUMERATE_MATHML_TAG(mglyph)        \
-    __ENUMERATE_MATHML_TAG(mfrac)         \
-    __ENUMERATE_MATHML_TAG(mi)            \
-    __ENUMERATE_MATHML_TAG(mmultiscripts) \
-    __ENUMERATE_MATHML_TAG(mn)            \
-    __ENUMERATE_MATHML_TAG(mo)            \
-    __ENUMERATE_MATHML_TAG(mover)         \
-    __ENUMERATE_MATHML_TAG(mpadded)       \
-    __ENUMERATE_MATHML_TAG(mphantom)      \
-    __ENUMERATE_MATHML_TAG(mprescripts)   \
-    __ENUMERATE_MATHML_TAG(mroot)         \
-    __ENUMERATE_MATHML_TAG(mrow)          \
-    __ENUMERATE_MATHML_TAG(ms)            \
-    __ENUMERATE_MATHML_TAG(mspace)        \
-    __ENUMERATE_MATHML_TAG(msqrt)         \
-    __ENUMERATE_MATHML_TAG(mstyle)        \
-    __ENUMERATE_MATHML_TAG(msub)          \
-    __ENUMERATE_MATHML_TAG(msubsup)       \
-    __ENUMERATE_MATHML_TAG(msup)          \
-    __ENUMERATE_MATHML_TAG(mtable)        \
-    __ENUMERATE_MATHML_TAG(mtd)           \
-    __ENUMERATE_MATHML_TAG(mtext)         \
-    __ENUMERATE_MATHML_TAG(mtr)           \
-    __ENUMERATE_MATHML_TAG(munder)        \
-    __ENUMERATE_MATHML_TAG(munderover)    \
-    __ENUMERATE_MATHML_TAG(semantics)
+#define ENUMERATE_MATHML_TAGS                                \
+    __ENUMERATE_MATHML_TAG(annotation, "annotation")         \
+    __ENUMERATE_MATHML_TAG(annotation_xml, "annotation-xml") \
+    __ENUMERATE_MATHML_TAG(maction, "maction")               \
+    __ENUMERATE_MATHML_TAG(malignmark, "malignmark")         \
+    __ENUMERATE_MATHML_TAG(math, "math")                     \
+    __ENUMERATE_MATHML_TAG(merror, "merror")                 \
+    __ENUMERATE_MATHML_TAG(mfrac, "mfrac")                   \
+    __ENUMERATE_MATHML_TAG(mglyph, "mglyph")                 \
+    __ENUMERATE_MATHML_TAG(mi, "mi")                         \
+    __ENUMERATE_MATHML_TAG(mmultiscripts, "mmultiscripts")   \
+    __ENUMERATE_MATHML_TAG(mn, "mn")                         \
+    __ENUMERATE_MATHML_TAG(mo, "mo")                         \
+    __ENUMERATE_MATHML_TAG(mover, "mover")                   \
+    __ENUMERATE_MATHML_TAG(mpadded, "mpadded")               \
+    __ENUMERATE_MATHML_TAG(mphantom, "mphantom")             \
+    __ENUMERATE_MATHML_TAG(mprescripts, "mprescripts")       \
+    __ENUMERATE_MATHML_TAG(mroot, "mroot")                   \
+    __ENUMERATE_MATHML_TAG(mrow, "mrow")                     \
+    __ENUMERATE_MATHML_TAG(ms, "ms")                         \
+    __ENUMERATE_MATHML_TAG(mspace, "mspace")                 \
+    __ENUMERATE_MATHML_TAG(msqrt, "msqrt")                   \
+    __ENUMERATE_MATHML_TAG(mstyle, "mstyle")                 \
+    __ENUMERATE_MATHML_TAG(msub, "msub")                     \
+    __ENUMERATE_MATHML_TAG(msubsup, "msubsup")               \
+    __ENUMERATE_MATHML_TAG(msup, "msup")                     \
+    __ENUMERATE_MATHML_TAG(mtable, "mtable")                 \
+    __ENUMERATE_MATHML_TAG(mtd, "mtd")                       \
+    __ENUMERATE_MATHML_TAG(mtext, "mtext")                   \
+    __ENUMERATE_MATHML_TAG(mtr, "mtr")                       \
+    __ENUMERATE_MATHML_TAG(munder, "munder")                 \
+    __ENUMERATE_MATHML_TAG(munderover, "munderover")         \
+    __ENUMERATE_MATHML_TAG(semantics, "semantics")
 
-#define __ENUMERATE_MATHML_TAG(name) extern FlyString name;
+#define __ENUMERATE_MATHML_TAG(name, tag) extern FlyString name;
 ENUMERATE_MATHML_TAGS
 #undef __ENUMERATE_MATHML_TAG
-
-extern FlyString annotation_xml;
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/EventNames.cpp
+++ b/Libraries/LibWeb/MediaSourceExtensions/EventNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::MediaSourceExtensions::EventNames {
 
-#define __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(name) FlyString name;
-ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(__ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE)
-#undef __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
 #define __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(name) \
-    name = #name##_fly_string;
-    ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(__ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE)
+    FlyString name = #name##_fly_string;
+ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES
 #undef __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/MediaSourceExtensions/EventNames.h
+++ b/Libraries/LibWeb/MediaSourceExtensions/EventNames.h
@@ -10,25 +10,23 @@
 
 namespace Web::MediaSourceExtensions::EventNames {
 
-#define ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(E) \
-    E(abort)                                            \
-    E(addsourcebuffer)                                  \
-    E(bufferedchange)                                   \
-    E(endstreaming)                                     \
-    E(error)                                            \
-    E(removesourcebuffer)                               \
-    E(sourceclose)                                      \
-    E(sourceended)                                      \
-    E(sourceopen)                                       \
-    E(startstreaming)                                   \
-    E(update)                                           \
-    E(updateend)                                        \
-    E(updatestart)
+#define ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES                  \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(abort)              \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(addsourcebuffer)    \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(bufferedchange)     \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(endstreaming)       \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(error)              \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(removesourcebuffer) \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(sourceclose)        \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(sourceended)        \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(sourceopen)         \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(startstreaming)     \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(update)             \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(updateend)          \
+    __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(updatestart)
 
 #define __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE(name) extern FlyString name;
-ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES(__ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE)
+ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTES
 #undef __ENUMERATE_MEDIA_SOURCE_EXTENSIONS_ATTRIBUTE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/Namespace.cpp
+++ b/Libraries/LibWeb/Namespace.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::Namespace {
 
-#define __ENUMERATE_NAMESPACE(name, namespace_) FlyString name;
+#define __ENUMERATE_NAMESPACE(name, namespace_) \
+    FlyString name = namespace_##_fly_string;
 ENUMERATE_NAMESPACES
 #undef __ENUMERATE_NAMESPACE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_NAMESPACE(name, namespace_) \
-    name = namespace_##_fly_string;
-    ENUMERATE_NAMESPACES
-#undef __ENUMERATE_NAMESPACE
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/Namespace.h
+++ b/Libraries/LibWeb/Namespace.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::Namespace {
@@ -22,7 +21,5 @@ namespace Web::Namespace {
 #define __ENUMERATE_NAMESPACE(name, namespace_) extern FlyString name;
 ENUMERATE_NAMESPACES
 #undef __ENUMERATE_NAMESPACE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/NavigationTiming/EntryNames.cpp
+++ b/Libraries/LibWeb/NavigationTiming/EntryNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::NavigationTiming::EntryNames {
 
-#define __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(name, _) FlyString name;
+#define __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(name, _) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_NAVIGATION_TIMING_ENTRY_NAMES
 #undef __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(name, _) \
-    name = #name##_fly_string;
-    ENUMERATE_NAVIGATION_TIMING_ENTRY_NAMES
-#undef __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/NavigationTiming/EntryNames.h
+++ b/Libraries/LibWeb/NavigationTiming/EntryNames.h
@@ -11,32 +11,30 @@
 namespace Web::NavigationTiming::EntryNames {
 
 #define ENUMERATE_NAVIGATION_TIMING_ENTRY_NAMES                                                          \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(navigationStart, navigation_start)                          \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(unloadEventStart, unload_event_start)                       \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(unloadEventEnd, unload_event_end)                           \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(redirectStart, redirect_start)                              \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(redirectEnd, redirect_end)                                  \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(fetchStart, fetch_start)                                    \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domainLookupStart, domain_lookup_start)                     \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domainLookupEnd, domain_lookup_end)                         \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(connectStart, connect_start)                                \
     __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(connectEnd, connect_end)                                    \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(secureConnectionStart, secure_connection_start)             \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(requestStart, request_start)                                \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(responseStart, response_start)                              \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(responseEnd, response_end)                                  \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domLoading, dom_loading)                                    \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domInteractive, dom_interactive)                            \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domContentLoadedEventStart, dom_content_loaded_event_start) \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domContentLoadedEventEnd, dom_content_loaded_event_end)     \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(connectStart, connect_start)                                \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domainLookupEnd, domain_lookup_end)                         \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domainLookupStart, domain_lookup_start)                     \
     __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domComplete, dom_complete)                                  \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domContentLoadedEventEnd, dom_content_loaded_event_end)     \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domContentLoadedEventStart, dom_content_loaded_event_start) \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domInteractive, dom_interactive)                            \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(domLoading, dom_loading)                                    \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(fetchStart, fetch_start)                                    \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(loadEventEnd, load_event_end)                               \
     __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(loadEventStart, load_event_start)                           \
-    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(loadEventEnd, load_event_end)
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(navigationStart, navigation_start)                          \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(redirectEnd, redirect_end)                                  \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(redirectStart, redirect_start)                              \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(requestStart, request_start)                                \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(responseEnd, response_end)                                  \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(responseStart, response_start)                              \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(secureConnectionStart, secure_connection_start)             \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(unloadEventEnd, unload_event_end)                           \
+    __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(unloadEventStart, unload_event_start)
 
 #define __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME(name, _) extern FlyString name;
 ENUMERATE_NAVIGATION_TIMING_ENTRY_NAMES
 #undef __ENUMERATE_NAVIGATION_TIMING_ENTRY_NAME
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/PerformanceTimeline/EntryTypes.cpp
+++ b/Libraries/LibWeb/PerformanceTimeline/EntryTypes.cpp
@@ -8,26 +8,9 @@
 
 namespace Web::PerformanceTimeline::EntryTypes {
 
-#define __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(name) FlyString name;
+#define __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(name, type) \
+    FlyString name = type##_fly_string;
 ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPES
 #undef __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(name) \
-    name = #name##_fly_string;
-    ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPES
-#undef __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE
-
-    // NOTE: Special cases for attributes with dashes in them.
-    first_input = "first-input"_fly_string;
-    largest_contentful_paint = "largest-contentful-paint"_fly_string;
-    layout_shift = "layout-shift"_fly_string;
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/PerformanceTimeline/EntryTypes.h
+++ b/Libraries/LibWeb/PerformanceTimeline/EntryTypes.h
@@ -11,23 +11,21 @@
 namespace Web::PerformanceTimeline::EntryTypes {
 
 // https://w3c.github.io/timing-entrytypes-registry/#registry
-#define ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPES                        \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(element)                  \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(event)                    \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(first_input)              \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(largest_contentful_paint) \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(layout_shift)             \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(longtask)                 \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(mark)                     \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(measure)                  \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(navigation)               \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(resource)                 \
-    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(paint)
+#define ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPES                                                    \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(element, "element")                                   \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(event, "event")                                       \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(first_input, "first-input")                           \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(largest_contentful_paint, "largest-contentful-paint") \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(layout_shift, "layout-shift")                         \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(longtask, "longtask")                                 \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(mark, "mark")                                         \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(measure, "measure")                                   \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(navigation, "navigation")                             \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(paint, "paint")                                       \
+    __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(resource, "resource")
 
-#define __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(name) extern FlyString name;
+#define __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE(name, type) extern FlyString name;
 ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPES
 #undef __ENUMERATE_PERFORMANCE_TIMELINE_ENTRY_TYPE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/SVG/AttributeNames.cpp
+++ b/Libraries/LibWeb/SVG/AttributeNames.cpp
@@ -8,27 +8,9 @@
 
 namespace Web::SVG::AttributeNames {
 
-#define __ENUMERATE_SVG_ATTRIBUTE(name) FlyString name;
-ENUMERATE_SVG_ATTRIBUTES(__ENUMERATE_SVG_ATTRIBUTE)
+#define __ENUMERATE_SVG_ATTRIBUTE(name, attribute) \
+    FlyString name = attribute##_fly_string;
+ENUMERATE_SVG_ATTRIBUTES
 #undef __ENUMERATE_SVG_ATTRIBUTE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_SVG_ATTRIBUTE(name) \
-    name = #name##_fly_string;
-    ENUMERATE_SVG_ATTRIBUTES(__ENUMERATE_SVG_ATTRIBUTE)
-#undef __ENUMERATE_SVG_ATTRIBUTE
-
-    // NOTE: Special cases for C++ keywords.
-    class_ = "class"_fly_string;
-
-    // NOTE: Special case for attributes with ':' in them.
-    xlink_href = "xlink:href"_fly_string;
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/SVG/AttributeNames.h
+++ b/Libraries/LibWeb/SVG/AttributeNames.h
@@ -6,102 +6,99 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::SVG::AttributeNames {
 
-#define ENUMERATE_SVG_ATTRIBUTES(E) \
-    E(attributeName)                \
-    E(attributeType)                \
-    E(baseFrequency)                \
-    E(baseProfile)                  \
-    E(calcMode)                     \
-    E(class_)                       \
-    E(clipPathUnits)                \
-    E(contentScriptType)            \
-    E(contentStyleType)             \
-    E(cx)                           \
-    E(cy)                           \
-    E(dx)                           \
-    E(dy)                           \
-    E(diffuseConstant)              \
-    E(edgeMode)                     \
-    E(filterUnits)                  \
-    E(fr)                           \
-    E(fx)                           \
-    E(fy)                           \
-    E(glyphRef)                     \
-    E(gradientTransform)            \
-    E(gradientUnits)                \
-    E(height)                       \
-    E(href)                         \
-    E(kernelMatrix)                 \
-    E(kernelUnitLength)             \
-    E(keyPoints)                    \
-    E(keySplines)                   \
-    E(keyTimes)                     \
-    E(lengthAdjust)                 \
-    E(limitingConeAngle)            \
-    E(markerHeight)                 \
-    E(markerUnits)                  \
-    E(markerWidth)                  \
-    E(maskContentUnits)             \
-    E(maskUnits)                    \
-    E(numOctaves)                   \
-    E(offset)                       \
-    E(opacity)                      \
-    E(pathLength)                   \
-    E(patternContentUnits)          \
-    E(patternTransform)             \
-    E(patternUnits)                 \
-    E(points)                       \
-    E(pointsAtX)                    \
-    E(pointsAtY)                    \
-    E(pointsAtZ)                    \
-    E(preserveAlpha)                \
-    E(preserveAspectRatio)          \
-    E(primitiveUnits)               \
-    E(r)                            \
-    E(refX)                         \
-    E(refY)                         \
-    E(repeatCount)                  \
-    E(repeatDur)                    \
-    E(requiredExtensions)           \
-    E(requiredFeatures)             \
-    E(rx)                           \
-    E(ry)                           \
-    E(specularConstant)             \
-    E(specularExponent)             \
-    E(spreadMethod)                 \
-    E(startOffset)                  \
-    E(stdDeviation)                 \
-    E(stitchTiles)                  \
-    E(surfaceScale)                 \
-    E(systemLanguage)               \
-    E(tableValues)                  \
-    E(targetX)                      \
-    E(targetY)                      \
-    E(textLength)                   \
-    E(version)                      \
-    E(viewBox)                      \
-    E(viewTarget)                   \
-    E(width)                        \
-    E(x)                            \
-    E(x1)                           \
-    E(x2)                           \
-    E(xChannelSelector)             \
-    E(xlink_href)                   \
-    E(y)                            \
-    E(y1)                           \
-    E(y2)                           \
-    E(yChannelSelector)             \
-    E(zoomAndPan)
+#define ENUMERATE_SVG_ATTRIBUTES                                          \
+    __ENUMERATE_SVG_ATTRIBUTE(attributeName, "attributeName")             \
+    __ENUMERATE_SVG_ATTRIBUTE(attributeType, "attributeType")             \
+    __ENUMERATE_SVG_ATTRIBUTE(baseFrequency, "baseFrequency")             \
+    __ENUMERATE_SVG_ATTRIBUTE(baseProfile, "baseProfile")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(calcMode, "calcMode")                       \
+    __ENUMERATE_SVG_ATTRIBUTE(class_, "class")                            \
+    __ENUMERATE_SVG_ATTRIBUTE(clipPathUnits, "clipPathUnits")             \
+    __ENUMERATE_SVG_ATTRIBUTE(contentScriptType, "contentScriptType")     \
+    __ENUMERATE_SVG_ATTRIBUTE(contentStyleType, "contentStyleType")       \
+    __ENUMERATE_SVG_ATTRIBUTE(cx, "cx")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(cy, "cy")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(diffuseConstant, "diffuseConstant")         \
+    __ENUMERATE_SVG_ATTRIBUTE(dx, "dx")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(dy, "dy")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(edgeMode, "edgeMode")                       \
+    __ENUMERATE_SVG_ATTRIBUTE(filterUnits, "filterUnits")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(fr, "fr")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(fx, "fx")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(fy, "fy")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(glyphRef, "glyphRef")                       \
+    __ENUMERATE_SVG_ATTRIBUTE(gradientTransform, "gradientTransform")     \
+    __ENUMERATE_SVG_ATTRIBUTE(gradientUnits, "gradientUnits")             \
+    __ENUMERATE_SVG_ATTRIBUTE(height, "height")                           \
+    __ENUMERATE_SVG_ATTRIBUTE(href, "href")                               \
+    __ENUMERATE_SVG_ATTRIBUTE(kernelMatrix, "kernelMatrix")               \
+    __ENUMERATE_SVG_ATTRIBUTE(kernelUnitLength, "kernelUnitLength")       \
+    __ENUMERATE_SVG_ATTRIBUTE(keyPoints, "keyPoints")                     \
+    __ENUMERATE_SVG_ATTRIBUTE(keySplines, "keySplines")                   \
+    __ENUMERATE_SVG_ATTRIBUTE(keyTimes, "keyTimes")                       \
+    __ENUMERATE_SVG_ATTRIBUTE(lengthAdjust, "lengthAdjust")               \
+    __ENUMERATE_SVG_ATTRIBUTE(limitingConeAngle, "limitingConeAngle")     \
+    __ENUMERATE_SVG_ATTRIBUTE(markerHeight, "markerHeight")               \
+    __ENUMERATE_SVG_ATTRIBUTE(markerUnits, "markerUnits")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(markerWidth, "markerWidth")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(maskContentUnits, "maskContentUnits")       \
+    __ENUMERATE_SVG_ATTRIBUTE(maskUnits, "maskUnits")                     \
+    __ENUMERATE_SVG_ATTRIBUTE(numOctaves, "numOctaves")                   \
+    __ENUMERATE_SVG_ATTRIBUTE(offset, "offset")                           \
+    __ENUMERATE_SVG_ATTRIBUTE(opacity, "opacity")                         \
+    __ENUMERATE_SVG_ATTRIBUTE(pathLength, "pathLength")                   \
+    __ENUMERATE_SVG_ATTRIBUTE(patternContentUnits, "patternContentUnits") \
+    __ENUMERATE_SVG_ATTRIBUTE(patternTransform, "patternTransform")       \
+    __ENUMERATE_SVG_ATTRIBUTE(patternUnits, "patternUnits")               \
+    __ENUMERATE_SVG_ATTRIBUTE(points, "points")                           \
+    __ENUMERATE_SVG_ATTRIBUTE(pointsAtX, "pointsAtX")                     \
+    __ENUMERATE_SVG_ATTRIBUTE(pointsAtY, "pointsAtY")                     \
+    __ENUMERATE_SVG_ATTRIBUTE(pointsAtZ, "pointsAtZ")                     \
+    __ENUMERATE_SVG_ATTRIBUTE(preserveAlpha, "preserveAlpha")             \
+    __ENUMERATE_SVG_ATTRIBUTE(preserveAspectRatio, "preserveAspectRatio") \
+    __ENUMERATE_SVG_ATTRIBUTE(primitiveUnits, "primitiveUnits")           \
+    __ENUMERATE_SVG_ATTRIBUTE(r, "r")                                     \
+    __ENUMERATE_SVG_ATTRIBUTE(refX, "refX")                               \
+    __ENUMERATE_SVG_ATTRIBUTE(refY, "refY")                               \
+    __ENUMERATE_SVG_ATTRIBUTE(repeatCount, "repeatCount")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(repeatDur, "repeatDur")                     \
+    __ENUMERATE_SVG_ATTRIBUTE(requiredExtensions, "requiredExtensions")   \
+    __ENUMERATE_SVG_ATTRIBUTE(requiredFeatures, "requiredFeatures")       \
+    __ENUMERATE_SVG_ATTRIBUTE(rx, "rx")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(ry, "ry")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(specularConstant, "specularConstant")       \
+    __ENUMERATE_SVG_ATTRIBUTE(specularExponent, "specularExponent")       \
+    __ENUMERATE_SVG_ATTRIBUTE(spreadMethod, "spreadMethod")               \
+    __ENUMERATE_SVG_ATTRIBUTE(startOffset, "startOffset")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(stdDeviation, "stdDeviation")               \
+    __ENUMERATE_SVG_ATTRIBUTE(stitchTiles, "stitchTiles")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(surfaceScale, "surfaceScale")               \
+    __ENUMERATE_SVG_ATTRIBUTE(systemLanguage, "systemLanguage")           \
+    __ENUMERATE_SVG_ATTRIBUTE(tableValues, "tableValues")                 \
+    __ENUMERATE_SVG_ATTRIBUTE(targetX, "targetX")                         \
+    __ENUMERATE_SVG_ATTRIBUTE(targetY, "targetY")                         \
+    __ENUMERATE_SVG_ATTRIBUTE(textLength, "textLength")                   \
+    __ENUMERATE_SVG_ATTRIBUTE(version, "version")                         \
+    __ENUMERATE_SVG_ATTRIBUTE(viewBox, "viewBox")                         \
+    __ENUMERATE_SVG_ATTRIBUTE(viewTarget, "viewTarget")                   \
+    __ENUMERATE_SVG_ATTRIBUTE(width, "width")                             \
+    __ENUMERATE_SVG_ATTRIBUTE(x, "x")                                     \
+    __ENUMERATE_SVG_ATTRIBUTE(x1, "x1")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(x2, "x2")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(xChannelSelector, "xChannelSelector")       \
+    __ENUMERATE_SVG_ATTRIBUTE(xlink_href, "xlink:href")                   \
+    __ENUMERATE_SVG_ATTRIBUTE(y, "y")                                     \
+    __ENUMERATE_SVG_ATTRIBUTE(y1, "y1")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(y2, "y2")                                   \
+    __ENUMERATE_SVG_ATTRIBUTE(yChannelSelector, "yChannelSelector")       \
+    __ENUMERATE_SVG_ATTRIBUTE(zoomAndPan, "zoomAndPan")
 
-#define __ENUMERATE_SVG_ATTRIBUTE(name) extern FlyString name;
-ENUMERATE_SVG_ATTRIBUTES(__ENUMERATE_SVG_ATTRIBUTE)
+#define __ENUMERATE_SVG_ATTRIBUTE(name, attribute) extern FlyString name;
+ENUMERATE_SVG_ATTRIBUTES
 #undef __ENUMERATE_SVG_ATTRIBUTE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/SVG/TagNames.cpp
+++ b/Libraries/LibWeb/SVG/TagNames.cpp
@@ -8,20 +8,9 @@
 
 namespace Web::SVG::TagNames {
 
-#define __ENUMERATE_SVG_TAG(name) FlyString name;
+#define __ENUMERATE_SVG_TAG(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_SVG_TAGS
 #undef __ENUMERATE_SVG_TAG
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_SVG_TAG(name) name = #name##_fly_string;
-    ENUMERATE_SVG_TAGS
-#undef __ENUMERATE_SVG_TAG
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/SVG/TagNames.h
+++ b/Libraries/LibWeb/SVG/TagNames.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::SVG::TagNames {
@@ -47,7 +46,5 @@ namespace Web::SVG::TagNames {
 #define __ENUMERATE_SVG_TAG(name) extern FlyString name;
 ENUMERATE_SVG_TAGS
 #undef __ENUMERATE_SVG_TAG
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/UIEvents/EventNames.cpp
+++ b/Libraries/LibWeb/UIEvents/EventNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::UIEvents::EventNames {
 
-#define __ENUMERATE_UI_EVENT(name) FlyString name;
+#define __ENUMERATE_UI_EVENT(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_UI_EVENTS
 #undef __ENUMERATE_UI_EVENT
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_UI_EVENT(name) \
-    name = #name##_fly_string;
-    ENUMERATE_UI_EVENTS
-#undef __ENUMERATE_UI_EVENT
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/UIEvents/EventNames.h
+++ b/Libraries/LibWeb/UIEvents/EventNames.h
@@ -47,6 +47,4 @@ namespace Web::UIEvents::EventNames {
 ENUMERATE_UI_EVENTS
 #undef __ENUMERATE_UI_EVENT
 
-void initialize_strings();
-
 }

--- a/Libraries/LibWeb/UIEvents/InputTypes.cpp
+++ b/Libraries/LibWeb/UIEvents/InputTypes.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::UIEvents::InputTypes {
 
-#define __ENUMERATE_INPUT_TYPE(name) FlyString name;
+#define __ENUMERATE_INPUT_TYPE(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_INPUT_TYPES
 #undef __ENUMERATE_INPUT_TYPE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_INPUT_TYPE(name) \
-    name = #name##_fly_string;
-    ENUMERATE_INPUT_TYPES
-#undef __ENUMERATE_INPUT_TYPE
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/UIEvents/InputTypes.h
+++ b/Libraries/LibWeb/UIEvents/InputTypes.h
@@ -6,13 +6,11 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::UIEvents::InputTypes {
 
 // https://w3c.github.io/input-events/#interface-InputEvent-Attributes
-
 #define ENUMERATE_INPUT_TYPES                     \
     __ENUMERATE_INPUT_TYPE(insertText)            \
     __ENUMERATE_INPUT_TYPE(insertParagraph)       \
@@ -22,7 +20,5 @@ namespace Web::UIEvents::InputTypes {
 #define __ENUMERATE_INPUT_TYPE(name) extern FlyString name;
 ENUMERATE_INPUT_TYPES
 #undef __ENUMERATE_INPUT_TYPE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/WebGL/EventNames.cpp
+++ b/Libraries/LibWeb/WebGL/EventNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::WebGL::EventNames {
 
-#define __ENUMERATE_GL_EVENT(name) FlyString name;
+#define __ENUMERATE_GL_EVENT(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_GL_EVENTS
 #undef __ENUMERATE_GL_EVENT
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_GL_EVENT(name) \
-    name = #name##_fly_string;
-    ENUMERATE_GL_EVENTS
-#undef __ENUMERATE_GL_EVENT
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/WebGL/EventNames.h
+++ b/Libraries/LibWeb/WebGL/EventNames.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::WebGL::EventNames {
@@ -19,7 +18,5 @@ namespace Web::WebGL::EventNames {
 #define __ENUMERATE_GL_EVENT(name) extern FlyString name;
 ENUMERATE_GL_EVENTS
 #undef __ENUMERATE_GL_EVENT
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/XHR/EventNames.cpp
+++ b/Libraries/LibWeb/XHR/EventNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::XHR::EventNames {
 
-#define __ENUMERATE_XHR_EVENT(name) FlyString name;
+#define __ENUMERATE_XHR_EVENT(name) \
+    FlyString name = #name##_fly_string;
 ENUMERATE_XHR_EVENTS
 #undef __ENUMERATE_XHR_EVENT
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
-#define __ENUMERATE_XHR_EVENT(name) \
-    name = #name##_fly_string;
-    ENUMERATE_XHR_EVENTS
-#undef __ENUMERATE_XHR_EVENT
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/XHR/EventNames.h
+++ b/Libraries/LibWeb/XHR/EventNames.h
@@ -6,25 +6,22 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::XHR::EventNames {
 
 #define ENUMERATE_XHR_EVENTS                \
-    __ENUMERATE_XHR_EVENT(readystatechange) \
-    __ENUMERATE_XHR_EVENT(loadstart)        \
-    __ENUMERATE_XHR_EVENT(progress)         \
     __ENUMERATE_XHR_EVENT(abort)            \
     __ENUMERATE_XHR_EVENT(error)            \
     __ENUMERATE_XHR_EVENT(load)             \
-    __ENUMERATE_XHR_EVENT(timeout)          \
-    __ENUMERATE_XHR_EVENT(loadend)
+    __ENUMERATE_XHR_EVENT(loadend)          \
+    __ENUMERATE_XHR_EVENT(loadstart)        \
+    __ENUMERATE_XHR_EVENT(progress)         \
+    __ENUMERATE_XHR_EVENT(readystatechange) \
+    __ENUMERATE_XHR_EVENT(timeout)
 
 #define __ENUMERATE_XHR_EVENT(name) extern FlyString name;
 ENUMERATE_XHR_EVENTS
 #undef __ENUMERATE_XHR_EVENT
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWeb/XLink/AttributeNames.cpp
+++ b/Libraries/LibWeb/XLink/AttributeNames.cpp
@@ -8,21 +8,9 @@
 
 namespace Web::XLink::AttributeNames {
 
-#define __ENUMERATE_XLINK_ATTRIBUTE(name) FlyString name;
-ENUMERATE_XLINK_ATTRIBUTES(__ENUMERATE_XLINK_ATTRIBUTE)
-#undef __ENUMERATE_XLINK_ATTRIBUTE
-
-void initialize_strings()
-{
-    static bool s_initialized = false;
-    VERIFY(!s_initialized);
-
 #define __ENUMERATE_XLINK_ATTRIBUTE(name) \
-    name = #name##_fly_string;
-    ENUMERATE_XLINK_ATTRIBUTES(__ENUMERATE_XLINK_ATTRIBUTE)
+    FlyString name = #name##_fly_string;
+ENUMERATE_XLINK_ATTRIBUTES
 #undef __ENUMERATE_XLINK_ATTRIBUTE
-
-    s_initialized = true;
-}
 
 }

--- a/Libraries/LibWeb/XLink/AttributeNames.h
+++ b/Libraries/LibWeb/XLink/AttributeNames.h
@@ -6,27 +6,24 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace Web::XLink::AttributeNames {
 
-#define ENUMERATE_XLINK_ATTRIBUTES(E) \
-    E(type)                           \
-    E(href)                           \
-    E(role)                           \
-    E(arcrole)                        \
-    E(title)                          \
-    E(show)                           \
-    E(actuate)                        \
-    E(label)                          \
-    E(from)                           \
-    E(to)
+#define ENUMERATE_XLINK_ATTRIBUTES       \
+    __ENUMERATE_XLINK_ATTRIBUTE(actuate) \
+    __ENUMERATE_XLINK_ATTRIBUTE(arcrole) \
+    __ENUMERATE_XLINK_ATTRIBUTE(from)    \
+    __ENUMERATE_XLINK_ATTRIBUTE(href)    \
+    __ENUMERATE_XLINK_ATTRIBUTE(label)   \
+    __ENUMERATE_XLINK_ATTRIBUTE(role)    \
+    __ENUMERATE_XLINK_ATTRIBUTE(show)    \
+    __ENUMERATE_XLINK_ATTRIBUTE(title)   \
+    __ENUMERATE_XLINK_ATTRIBUTE(to)      \
+    __ENUMERATE_XLINK_ATTRIBUTE(type)
 
 #define __ENUMERATE_XLINK_ATTRIBUTE(name) extern FlyString name;
-ENUMERATE_XLINK_ATTRIBUTES(__ENUMERATE_XLINK_ATTRIBUTE)
+ENUMERATE_XLINK_ATTRIBUTES
 #undef __ENUMERATE_XLINK_ATTRIBUTE
-
-void initialize_strings();
 
 }

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -16,6 +16,7 @@
 #include <LibCore/Resource.h>
 #include <LibJS/MarkupGenerator.h>
 #include <LibWeb/Infra/Strings.h>
+#include <LibWeb/Namespace.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/CookieJar.h>
 #include <LibWebView/InspectorClient.h>
@@ -634,7 +635,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
                 m_body_or_frameset_node_id = node_id;
 
             auto tag = name;
-            if (node.get_byte_string("namespace"sv) == "http://www.w3.org/1999/xhtml")
+            if (node.get_byte_string("namespace"sv) == Web::Namespace::HTML.bytes_as_string_view())
                 tag = tag.to_lowercase();
 
             builder.appendff("<span class=\"hoverable\" {}>", data_attributes.string_view());


### PR DESCRIPTION
We added these methods to propagate OOM errors at process startup, but
we longer fret about these tiny OOM failures. Requiring that these init
methods be called prohibits using these strings in processes that have
not set up a MainThreadVM. So let's just remove them and initialize the
strings in a sane manner.

In doing so, this also standardizes how we initialize strings whose C++
variable name differs from their string value. Instead of special-casing
these strings, we just include their string value in the x-macro list.