### PR TITLE
LibJS: Only run queued promise jobs if there is no embedder

### DIFF
--- a/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -19,17 +19,12 @@ class AsyncFunctionDriverWrapper final : public Promise {
     GC_DECLARE_ALLOCATOR(AsyncFunctionDriverWrapper);
 
 public:
-    enum class IsInitialExecution {
-        No,
-        Yes,
-    };
-
     [[nodiscard]] static GC::Ref<Promise> create(Realm&, GeneratorObject*);
 
     virtual ~AsyncFunctionDriverWrapper() override = default;
     void visit_edges(Cell::Visitor&) override;
 
-    void continue_async_execution(VM&, Value, bool is_successful, IsInitialExecution is_initial_execution = IsInitialExecution::No);
+    void continue_async_execution(VM&, Value, bool is_successful);
 
 private:
     AsyncFunctionDriverWrapper(Realm&, GC::Ref<GeneratorObject>, GC::Ref<Promise> top_level_promise);


### PR DESCRIPTION
This has no functional difference as run_queued_promise jobs does nothing when LibWeb is used as it has a different implementation of enqueuing and running promise jobs. But this change makes it more obvious that run_queued_promise jobs does nothing when there is an embedder, and adjusts the comment to reflect what the code is actually achieving.