### PR TITLE
LibWeb/HTML: Include better information in 'report an exception' event

### DIFF
--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -72,7 +72,12 @@ public:
     GC::Ref<IndexedDB::IDBFactory> indexed_db();
 
     void report_error(JS::Value e);
-    void report_an_exception(JS::Value const& e);
+
+    enum class OmitError {
+        Yes,
+        No,
+    };
+    void report_an_exception(JS::Value exception, OmitError = OmitError::No);
 
     [[nodiscard]] GC::Ref<Crypto::Crypto> crypto();
 

--- a/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
+++ b/Tests/LibWeb/Text/expected/HTML/WindowOrWorkerGlobalScope-reportError.txt
@@ -1,6 +1,6 @@
 message = Reporting an Error!
-lineno = 0
-colno = 0
+lineno = 17
+colno = 28
 error = Error: Reporting an Error!
 filename URL scheme = file:
 filename URL final path segment = WindowOrWorkerGlobalScope-reportError.html

--- a/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/reporterror.any.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/webappapis/scripting/reporterror.any.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	self.reportError(1)
+Pass	self.reportError(TypeError)
+Pass	self.reportError(undefined)
+Pass	self.reportError() (without arguments) throws
+Pass	self.reportError() doesn't invoke getters

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/reporterror.any.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/reporterror.any.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<meta charset=utf-8>
+
+<script>
+self.GLOBAL = {
+  isWindow: function() { return true; },
+  isWorker: function() { return false; },
+  isShadowRealm: function() { return false; },
+};
+</script>
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+
+<div id=log></div>
+<script src="../../../html/webappapis/scripting/reporterror.any.js"></script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/reporterror.any.js
+++ b/Tests/LibWeb/Text/input/wpt-import/html/webappapis/scripting/reporterror.any.js
@@ -1,0 +1,49 @@
+setup({ allow_uncaught_exception:true });
+
+[
+  1,
+  new TypeError(),
+  undefined
+].forEach(throwable => {
+  test(t => {
+    let happened = false;
+    self.addEventListener("error", t.step_func(e => {
+      assert_true(e.message !== "");
+      assert_equals(e.filename, new URL("reporterror.any.js", location.href).href);
+      assert_greater_than(e.lineno, 0);
+      assert_greater_than(e.colno, 0);
+      assert_equals(e.error, throwable);
+      happened = true;
+    }), { once:true });
+    self.reportError(throwable);
+    assert_true(happened);
+  }, `self.reportError(${throwable})`);
+});
+
+test(() => {
+  assert_throws_js(TypeError, () => self.reportError());
+}, `self.reportError() (without arguments) throws`);
+
+test(() => {
+  // Workaround for https://github.com/web-platform-tests/wpt/issues/32105
+  let invoked = false;
+  self.reportError({
+    get name() {
+      invoked = true;
+      assert_unreached('get name')
+    },
+    get message() {
+      invoked = true;
+      assert_unreached('get message');
+    },
+    get fileName() {
+      invoked = true;
+      assert_unreached('get fileName');
+    },
+    get lineNumber() {
+      invoked = true;
+      assert_unreached('get lineNumber');
+    }
+  });
+  assert_false(invoked);
+}, `self.reportError() doesn't invoke getters`);


### PR DESCRIPTION
Instead of always reporting a colno and lineno of zero try and use the values from the Error object that may be provided, falling back to the source location of the invocation if not provided. We can definitely improve the reporting even more, but this is a start!

Also update this function to latest spec while we're in the area.