### PR TITLE
LibURL+LibWeb: Add a stub for URLPattern.exec, along with some corresponding IDL generator fixes

### DIFF
--- a/Libraries/LibURL/Pattern/Pattern.h
+++ b/Libraries/LibURL/Pattern/Pattern.h
@@ -6,7 +6,10 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
+#include <AK/String.h>
 #include <AK/Variant.h>
+#include <AK/Vector.h>
 #include <LibURL/Pattern/Init.h>
 
 namespace URL::Pattern {
@@ -17,6 +20,26 @@ using Input = Variant<String, Init>;
 // https://urlpattern.spec.whatwg.org/#dictdef-urlpatternoptions
 struct Options {
     bool ignore_case { false };
+};
+
+// https://urlpattern.spec.whatwg.org/#dictdef-urlpatterncomponentresult
+struct ComponentResult {
+    String input;
+    OrderedHashMap<String, Variant<String, Empty>> groups;
+};
+
+// https://urlpattern.spec.whatwg.org/#dictdef-urlpatternresult
+struct Result {
+    Vector<Input> inputs;
+
+    ComponentResult protocol;
+    ComponentResult username;
+    ComponentResult password;
+    ComponentResult hostname;
+    ComponentResult port;
+    ComponentResult pathname;
+    ComponentResult search;
+    ComponentResult hash;
 };
 
 }

--- a/Libraries/LibWeb/Animations/AnimationEffect.idl
+++ b/Libraries/LibWeb/Animations/AnimationEffect.idl
@@ -30,8 +30,8 @@ enum PlaybackDirection { "normal", "reverse", "alternate", "alternate-reverse" }
 
 // https://www.w3.org/TR/web-animations-1/#the-computedeffecttiming-dictionary
 dictionary ComputedEffectTiming : EffectTiming {
-    unrestricted double endTime;
-    unrestricted double activeDuration;
+    [GenerateAsRequired] unrestricted double endTime;
+    [GenerateAsRequired] unrestricted double activeDuration;
     double? localTime;
     double? progress;
     unrestricted double? currentIteration;

--- a/Libraries/LibWeb/Encoding/TextEncoder.idl
+++ b/Libraries/LibWeb/Encoding/TextEncoder.idl
@@ -5,8 +5,8 @@ interface mixin TextEncoderCommon {
 
 // https://encoding.spec.whatwg.org/#dictdef-textencoderencodeintoresult
 dictionary TextEncoderEncodeIntoResult {
-    unsigned long long read;
-    unsigned long long written;
+    [GenerateAsRequired] unsigned long long read;
+    [GenerateAsRequired] unsigned long long written;
 };
 
 // https://encoding.spec.whatwg.org/#textencoder

--- a/Libraries/LibWeb/HTML/Navigation.idl
+++ b/Libraries/LibWeb/HTML/Navigation.idl
@@ -45,8 +45,8 @@ dictionary NavigationReloadOptions : NavigationOptions {
 };
 
 dictionary NavigationResult {
-    Promise<NavigationHistoryEntry> committed;
-    Promise<NavigationHistoryEntry> finished;
+    [GenerateAsRequired] Promise<NavigationHistoryEntry> committed;
+    [GenerateAsRequired] Promise<NavigationHistoryEntry> finished;
 };
 
 enum NavigationHistoryBehavior {

--- a/Libraries/LibWeb/URLPattern/URLPattern.cpp
+++ b/Libraries/LibWeb/URLPattern/URLPattern.cpp
@@ -36,4 +36,11 @@ WebIDL::ExceptionOr<GC::Ref<URLPattern>> URLPattern::construct_impl(JS::Realm& r
     return realm.create<URLPattern>(realm);
 }
 
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-exec
+Optional<URLPatternResult> URLPattern::exec(URLPatternInput const&, Optional<String> const&) const
+{
+    dbgln("FIXME: Implement URLPattern::match");
+    return {};
+}
+
 }

--- a/Libraries/LibWeb/URLPattern/URLPattern.h
+++ b/Libraries/LibWeb/URLPattern/URLPattern.h
@@ -16,6 +16,7 @@ namespace Web::URLPattern {
 using URLPatternInit = URL::Pattern::Init;
 using URLPatternInput = URL::Pattern::Input;
 using URLPatternOptions = URL::Pattern::Options;
+using URLPatternResult = URL::Pattern::Result;
 
 // https://urlpattern.spec.whatwg.org/#urlpattern
 class URLPattern : public Bindings::PlatformObject {
@@ -25,6 +26,8 @@ class URLPattern : public Bindings::PlatformObject {
 public:
     static WebIDL::ExceptionOr<GC::Ref<URLPattern>> construct_impl(JS::Realm&, URLPatternInput const&, String const& base_url, URLPatternOptions const& = {});
     static WebIDL::ExceptionOr<GC::Ref<URLPattern>> construct_impl(JS::Realm&, URLPatternInput const&, URLPatternOptions const& = {});
+
+    Optional<URLPatternResult> exec(URLPatternInput const&, Optional<String> const&) const;
 
     virtual ~URLPattern() override;
 

--- a/Libraries/LibWeb/URLPattern/URLPattern.idl
+++ b/Libraries/LibWeb/URLPattern/URLPattern.idl
@@ -42,20 +42,20 @@ dictionary URLPatternOptions {
 
 // https://urlpattern.spec.whatwg.org/#dictdef-urlpatternresult
 dictionary URLPatternResult {
-    sequence<URLPatternInput> inputs;
+    [GenerateAsRequired] sequence<URLPatternInput> inputs;
 
-    URLPatternComponentResult protocol;
-    URLPatternComponentResult username;
-    URLPatternComponentResult password;
-    URLPatternComponentResult hostname;
-    URLPatternComponentResult port;
-    URLPatternComponentResult pathname;
-    URLPatternComponentResult search;
-    URLPatternComponentResult hash;
+    [GenerateAsRequired] URLPatternComponentResult protocol;
+    [GenerateAsRequired] URLPatternComponentResult username;
+    [GenerateAsRequired] URLPatternComponentResult password;
+    [GenerateAsRequired] URLPatternComponentResult hostname;
+    [GenerateAsRequired] URLPatternComponentResult port;
+    [GenerateAsRequired] URLPatternComponentResult pathname;
+    [GenerateAsRequired] URLPatternComponentResult search;
+    [GenerateAsRequired] URLPatternComponentResult hash;
 };
 
 // https://urlpattern.spec.whatwg.org/#dictdef-urlpatterncomponentresult
 dictionary URLPatternComponentResult {
-    USVString input;
-    record<USVString, (USVString or undefined)> groups;
+    [GenerateAsRequired] USVString input;
+    [GenerateAsRequired] record<USVString, (USVString or undefined)> groups;
 };

--- a/Libraries/LibWeb/URLPattern/URLPattern.idl
+++ b/Libraries/LibWeb/URLPattern/URLPattern.idl
@@ -8,7 +8,7 @@ interface URLPattern {
 
     [FIXME] boolean test(optional URLPatternInput input = {}, optional USVString baseURL);
 
-    [FIXME] URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
+    URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
 
     [FIXME] readonly attribute USVString protocol;
     [FIXME] readonly attribute USVString username;

--- a/Libraries/LibWeb/WebAudio/AudioContext.idl
+++ b/Libraries/LibWeb/WebAudio/AudioContext.idl
@@ -25,7 +25,7 @@ dictionary AudioContextOptions {
 };
 
 dictionary AudioTimestamp {
-    double contextTime;
+    [GenerateAsRequired] double contextTime;
     // FIXME: Should be DOMHighResTimeStamp, but DOMHighResTimeStamp doesn't get parsed as a double during codegen
-    double performanceTime;
+    [GenerateAsRequired] double performanceTime;
 };

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1801,8 +1801,11 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
 
     if (type.is_string()) {
         if (type.is_nullable() || is_optional) {
+            // FIXME: Ideally we would not need to do this const_cast, but we currently rely on temporary
+            //        lifetime extension to allow Variants to compile and handle an interface returning a
+            //        GC::Ref while the generated code will visit it as a GC::Root.
             scoped_generator.append(R"~~~(
-    @result_expression@ JS::PrimitiveString::create(vm, @value@.release_value());
+    @result_expression@ JS::PrimitiveString::create(vm, const_cast<decltype(@value@)&>(@value@).release_value());
 )~~~");
         } else {
             scoped_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1848,6 +1848,39 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
 
     @result_expression@ new_array@recursion_depth@;
 )~~~");
+    } else if (type.name() == "record") {
+        // https://webidl.spec.whatwg.org/#es-record
+
+        auto& parameterized_type = as<IDL::ParameterizedType>(type);
+        VERIFY(parameterized_type.parameters().size() == 2);
+        VERIFY(parameterized_type.parameters()[0]->is_string());
+
+        scoped_generator.append(R"~~~(
+    {
+        // An IDL record<…> value D is converted to a JavaScript value as follows:
+        // 1. Let result be OrdinaryObjectCreate(%Object.prototype%).
+        auto result = JS::Object::create(realm, realm.intrinsics().object_prototype());
+
+        // 2. For each key → value of D:
+        for (auto const& [key, value] : @value@) {
+            // 1. Let jsKey be key converted to a JavaScript value.
+            auto js_key = JS::PropertyKey { key.to_byte_string() };
+
+            // 2. Let jsValue be value converted to a JavaScript value.
+)~~~");
+        generate_wrap_statement(scoped_generator, "value"sv, parameterized_type.parameters()[1], interface, "auto js_value ="sv, WrappingReference::Yes, recursion_depth + 1);
+        scoped_generator.append(R"~~~(
+
+            // 3. Let created be ! CreateDataProperty(result, jsKey, jsValue).
+            bool created = MUST(result->create_data_property(js_key, js_value));
+
+            // 4. Assert: created is true.
+            VERIFY(created);
+        }
+
+        @result_expression@ result;
+    }
+)~~~");
     } else if (type.name() == "boolean" || type.is_floating_point()) {
         if (type.is_nullable()) {
             scoped_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1985,7 +1985,8 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
         auto dictionary_generator = scoped_generator.fork();
 
         dictionary_generator.append(R"~~~(
-    auto dictionary_object@recursion_depth@ = JS::Object::create(realm, realm.intrinsics().object_prototype());
+    {
+        auto dictionary_object@recursion_depth@ = JS::Object::create(realm, realm.intrinsics().object_prototype());
 )~~~");
 
         auto* current_dictionary = &interface.dictionaries.find(type.name())->value;
@@ -2001,12 +2002,12 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
                 dictionary_generator.set("wrapped_value_name", wrapped_value_name);
 
                 dictionary_generator.append(R"~~~(
-    JS::Value @wrapped_value_name@;
+        JS::Value @wrapped_value_name@;
 )~~~");
                 generate_wrap_statement(dictionary_generator, ByteString::formatted("{}{}{}", value, type.is_nullable() ? "->" : ".", member.name.to_snakecase()), member.type, interface, ByteString::formatted("{} =", wrapped_value_name), WrappingReference::No, recursion_depth + 1);
 
                 dictionary_generator.append(R"~~~(
-    MUST(dictionary_object@recursion_depth@->create_data_property("@member_key@", @wrapped_value_name@));
+        MUST(dictionary_object@recursion_depth@->create_data_property("@member_key@", @wrapped_value_name@));
 )~~~");
             }
 
@@ -2017,7 +2018,8 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
         }
 
         dictionary_generator.append(R"~~~(
-    @result_expression@ dictionary_object@recursion_depth@;
+        @result_expression@ dictionary_object@recursion_depth@;
+    }
 )~~~");
     } else if (type.name() == "object") {
         scoped_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1744,7 +1744,7 @@ enum class WrappingReference {
     Yes,
 };
 
-static void generate_wrap_statement(SourceGenerator& generator, ByteString const& value, IDL::Type const& type, IDL::Interface const& interface, StringView result_expression, WrappingReference wrapping_reference = WrappingReference::No, size_t recursion_depth = 0)
+static void generate_wrap_statement(SourceGenerator& generator, ByteString const& value, IDL::Type const& type, IDL::Interface const& interface, StringView result_expression, WrappingReference wrapping_reference = WrappingReference::No, size_t recursion_depth = 0, bool is_optional = false)
 {
     auto scoped_generator = generator.fork();
     scoped_generator.set("value", value);
@@ -1771,7 +1771,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
         return;
     }
 
-    if (type.is_nullable() && !is<UnionType>(type)) {
+    if ((is_optional || type.is_nullable()) && !is<UnionType>(type)) {
         if (type.is_string()) {
             scoped_generator.append(R"~~~(
     if (!@value@.has_value()) {
@@ -1800,7 +1800,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
     }
 
     if (type.is_string()) {
-        if (type.is_nullable()) {
+        if (type.is_nullable() || is_optional) {
             scoped_generator.append(R"~~~(
     @result_expression@ JS::PrimitiveString::create(vm, @value@.release_value());
 )~~~");
@@ -1817,16 +1817,16 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
     auto new_array@recursion_depth@ = MUST(JS::Array::create(realm, 0));
 )~~~");
 
-        if (!type.is_nullable()) {
-            scoped_generator.append(R"~~~(
-    for (size_t i@recursion_depth@ = 0; i@recursion_depth@ < @value@.size(); ++i@recursion_depth@) {
-        auto& element@recursion_depth@ = @value@.at(i@recursion_depth@);
-)~~~");
-        } else {
+        if (type.is_nullable() || is_optional) {
             scoped_generator.append(R"~~~(
     auto& @value@_non_optional = @value@.value();
     for (size_t i@recursion_depth@ = 0; i@recursion_depth@ < @value@_non_optional.size(); ++i@recursion_depth@) {
         auto& element@recursion_depth@ = @value@_non_optional.at(i@recursion_depth@);
+)~~~");
+        } else {
+            scoped_generator.append(R"~~~(
+    for (size_t i@recursion_depth@ = 0; i@recursion_depth@ < @value@.size(); ++i@recursion_depth@) {
+        auto& element@recursion_depth@ = @value@.at(i@recursion_depth@);
 )~~~");
         }
 
@@ -2004,7 +2004,14 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
                 dictionary_generator.append(R"~~~(
         JS::Value @wrapped_value_name@;
 )~~~");
-                generate_wrap_statement(dictionary_generator, ByteString::formatted("{}{}{}", value, type.is_nullable() ? "->" : ".", member.name.to_snakecase()), member.type, interface, ByteString::formatted("{} =", wrapped_value_name), WrappingReference::No, recursion_depth + 1);
+                // NOTE: This has similar semantics as 'required' in WebIDL. However, the spec does not put 'required' on
+                //       _returned_ dictionary members since with the way the spec is worded it has no normative effect to
+                //      do so. We could implement this without the 'GenerateAsRequired' extended attribute, but it would require
+                //      the generated code to do some metaprogramming to inspect the type of the member in the C++ struct to
+                //      determine whether the type is present or not (e.g through a has_value() on an Optional<T>, or a null
+                //      check on a GC::Ptr<T>). So to save some complexity in the generator, give ourselves a hint of what to do.
+                bool is_optional = !member.extended_attributes.contains("GenerateAsRequired") && !member.default_value.has_value();
+                generate_wrap_statement(dictionary_generator, ByteString::formatted("{}{}{}", value, type.is_nullable() ? "->" : ".", member.name.to_snakecase()), member.type, interface, ByteString::formatted("{} =", wrapped_value_name), WrappingReference::No, recursion_depth + 1, is_optional);
 
                 dictionary_generator.append(R"~~~(
         MUST(dictionary_object@recursion_depth@->create_data_property("@member_key@", @wrapped_value_name@));
@@ -2037,7 +2044,7 @@ static void generate_wrap_statement(SourceGenerator& generator, ByteString const
         }
     }
 
-    if (type.is_nullable() && !is<UnionType>(type)) {
+    if ((type.is_nullable() || is_optional) && !is<UnionType>(type)) {
         scoped_generator.append(R"~~~(
     }
 )~~~");


### PR DESCRIPTION
This fixes enough in the IDL generator to get the IDL for URLPattern.exec compiling, which is the bulky part of the interface.