### PR TITLE
LibCore: Simplify ThreadEventQueue::current

### DIFF
--- a/Libraries/LibCore/ThreadEventQueue.h
+++ b/Libraries/LibCore/ThreadEventQueue.h
@@ -36,7 +36,6 @@ public:
 
 private:
     ThreadEventQueue();
-    ~ThreadEventQueue();
 
     struct Private;
     OwnPtr<Private> m_private;


### PR DESCRIPTION
This also fixes error on Windows when ~WebContentClient (which is called from ~ThreadEventQueue) loops forever in HashTable::lookup_with_hash.
