### PR TITLE
LibWeb: Fix CSS clip-path ignoring scroll position

### DIFF
--- a/Libraries/LibWeb/Painting/Command.h
+++ b/Libraries/LibWeb/Painting/Command.h
@@ -128,6 +128,9 @@ struct PushStackingContext {
     {
         source_paintable_rect.translate_by(offset);
         transform.origin.translate_by(offset.to_type<float>());
+        if (clip_path.has_value()) {
+            clip_path.value().transform(Gfx::AffineTransform().translate(offset.to_type<float>()));
+        }
     }
 };
 

--- a/Tests/LibWeb/Ref/expected/clip-path-scrolling.html
+++ b/Tests/LibWeb/Ref/expected/clip-path-scrolling.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<style>
+  body {
+    height: 200vh;
+    position: relative;
+  }
+  div {
+    position: absolute;
+    top: 100px;
+    background-color: green;
+    width: 100px;
+    height: 100px;
+  }
+</style>
+<div></div>
+<script>
+  window.scrollTo(0, 100);
+</script>

--- a/Tests/LibWeb/Ref/input/clip-path-scrolling.html
+++ b/Tests/LibWeb/Ref/input/clip-path-scrolling.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/clip-path-scrolling.html" />
+<style>
+  body {
+    height: 200vh;
+    position: relative;
+  }
+  div {
+    position: absolute;
+    top: 100px;
+    background-color: green;
+    width: 100px;
+    height: 100px;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+  }
+</style>
+<div></div>
+<script>
+  window.scrollTo(0, 100);
+</script>


### PR DESCRIPTION
This fixes all the previews on https://www.newgrounds.com/games getting cut off once you start scrolling.