### PR TITLE
LibWeb: Improve <select> dropdown position

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -431,7 +431,7 @@ void HTMLSelectElement::show_the_picker_if_applicable()
     // Request select dropdown
     auto weak_element = make_weak_ptr<HTMLSelectElement>();
     auto rect = get_bounding_client_rect();
-    auto position = document().navigable()->to_top_level_position(Web::CSSPixelPoint { rect->x(), rect->y() });
+    auto position = document().navigable()->to_top_level_position(Web::CSSPixelPoint { rect->x(), rect->y() + rect->height() });
     document().page().did_request_select_dropdown(weak_element, position, CSSPixels(rect->width()), m_select_items);
     set_is_open(true);
 }


### PR DESCRIPTION
This makes it go right below the select element, so it does not cover it up anymore:
![image](https://github.com/user-attachments/assets/bc105d92-cb01-4aa1-9142-a553b331563f)
