### PR TITLE
LibWeb: Check if input is disabled before submit event to form

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -6,6 +6,7 @@
  * Copyright (c) 2023, Bastiaan van der Plaat <bastiaan.v.d.plaat@gmail.com>
  * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
  * Copyright (c) 2024, Fernando Kiotheka <fer@k6a.dev>
+ * Copyright (c) 2025, Felipe Muñoz Mazur <felipe.munoz.mazur@protonmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -376,8 +377,15 @@ WebIDL::ExceptionOr<void> HTMLInputElement::run_input_activation_behavior(DOM::E
         auto change_event = DOM::Event::create(realm(), HTML::EventNames::change);
         change_event->set_bubbles(true);
         dispatch_event(*change_event);
-    } else if (type_state() == TypeAttributeState::SubmitButton) {
+    }
+    // https://html.spec.whatwg.org/multipage/input.html#submit-button-state-(type=submit)
+    else if (type_state() == TypeAttributeState::SubmitButton) {
         GC::Ptr<HTMLFormElement> form;
+
+        // The input element represents a button that, when activated, submits the form.
+        if (is_actually_disabled())
+            return {};
+
         // 1. If the element does not have a form owner, then return.
         if (!(form = this->form()))
             return {};
@@ -418,6 +426,10 @@ WebIDL::ExceptionOr<void> HTMLInputElement::run_input_activation_behavior(DOM::E
     }
     // https://html.spec.whatwg.org/multipage/input.html#reset-button-state-(type=reset)
     else if (type_state() == TypeAttributeState::ResetButton) {
+        // The input element represents a button that, when activated, resets the form.
+        if (is_actually_disabled())
+            return {};
+
         // 1. If the element does not have a form owner, then return.
         auto* form = this->form();
         if (!form)

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/events/Event-dispatch-click.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/events/Event-dispatch-click.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 33 tests
 
-30 Pass
-3 Fail
+33 Pass
 Pass	basic with click()
 Pass	basic with dispatchEvent()
 Pass	basic with wrong event class
@@ -34,6 +33,6 @@ Pass	disabling checkbox in onclick listener shouldn't suppress onchange
 Pass	disabling radio in onclick listener shouldn't suppress oninput
 Pass	disabling radio in onclick listener shouldn't suppress onchange
 Pass	disconnected form should not submit
-Fail	disabled submit button should not activate
-Fail	submit button should not activate if the event listener disables it
-Fail	submit button that morphed from checkbox should not activate
+Pass	disabled submit button should not activate
+Pass	submit button should not activate if the event listener disables it
+Pass	submit button that morphed from checkbox should not activate


### PR DESCRIPTION
This PR checks if input is disabled before sending event.

WPT result when running: ` ./Meta/WPT.sh run dom/events/Event-dispatch-click.html`

Before
```sh
Ran 1 tests finished in 1.5 seconds.
  • 0 ran as expected. 0 tests skipped.
  • 1 tests had unexpected subtest results
```

After
```sh
Ran 1 tests finished in 1.3 seconds.
  • 1 ran as expected. 0 tests skipped.
```