### PR TITLE
LibWeb: Mark a few calls to set_attribute as infallible

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLIElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.h
@@ -38,7 +38,7 @@ public:
     WebIDL::Long value();
     void set_value(WebIDL::Long value)
     {
-        set_attribute(AttributeNames::value, String::number(value)).release_value_but_fixme_should_propagate_errors();
+        MUST(set_attribute(AttributeNames::value, String::number(value)));
     }
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLOListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.h
@@ -25,7 +25,7 @@ public:
     WebIDL::Long start();
     void set_start(WebIDL::Long start)
     {
-        set_attribute(AttributeNames::start, String::number(start)).release_value_but_fixme_should_propagate_errors();
+        MUST(set_attribute(AttributeNames::start, String::number(start)));
     }
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSummaryElement.cpp
@@ -37,7 +37,7 @@ void HTMLSummaryElement::activation_behavior(DOM::Event const&)
     if (parent->has_attribute(HTML::AttributeNames::open))
         parent->remove_attribute(HTML::AttributeNames::open);
     else
-        parent->set_attribute(HTML::AttributeNames::open, String {}).release_value_but_fixme_should_propagate_errors();
+        MUST(parent->set_attribute(HTML::AttributeNames::open, String {}));
 }
 
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#summary-for-its-parent-details


### PR DESCRIPTION
These cannot possibly throw an exception because the attribute names are already known to be valid.

Just a very, very minor thing I came across while working in related area.