### PR TITLE
LibWeb: Implement the exclusive `<details>` accordion

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -53,19 +53,39 @@ void HTMLDetailsElement::removed_from(DOM::Node*)
     set_shadow_root(nullptr);
 }
 
-void HTMLDetailsElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element:concept-element-attributes-change-ext
+void HTMLDetailsElement::attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
 {
-    Base::attribute_changed(name, old_value, value, namespace_);
+    Base::attribute_changed(local_name, old_value, value, namespace_);
 
-    // https://html.spec.whatwg.org/multipage/interactive-elements.html#details-notification-task-steps
-    if (name == HTML::AttributeNames::open) {
-        // 1. If the open attribute is added, queue a details toggle event task given the details element, "closed", and "open".
-        if (value.has_value()) {
-            queue_a_details_toggle_event_task("closed"_string, "open"_string);
+    // 1. If namespace is not null, then return.
+    if (namespace_.has_value())
+        return;
+
+    // 2. If localName is name, then ensure details exclusivity by closing the given element if needed given element.
+    if (local_name == HTML::AttributeNames::name) {
+        // FIXME: Implement the exclusivity steps.
+    }
+
+    // 3. If localName is open, then:
+    else if (local_name == HTML::AttributeNames::open) {
+        // 1. If one of oldValue or value is null and the other is not null, run the following steps, which are known as
+        //    the details notification task steps, for this details element:
+        {
+            // 1. If oldValue is null, queue a details toggle event task given the details element, "closed", and "open".
+            if (!old_value.has_value()) {
+                queue_a_details_toggle_event_task("closed"_string, "open"_string);
+            }
+            // 2. Otherwise, queue a details toggle event task given the details element, "open", and "closed".
+            else {
+                queue_a_details_toggle_event_task("open"_string, "closed"_string);
+            }
         }
-        // 2. Otherwise, queue a details toggle event task given the details element, "open", and "closed".
-        else {
-            queue_a_details_toggle_event_task("open"_string, "closed"_string);
+
+        // 2. If oldValue is null and value is not null, then ensure details exclusivity by closing other elements if
+        //    needed given element.
+        if (!old_value.has_value() && value.has_value()) {
+            // FIXME: Implement the exclusivity steps.
         }
 
         update_shadow_tree_style();

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
- * Copyright (c) 2023, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2023-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,6 +37,8 @@ private:
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);
+    void ensure_details_exclusivity_by_closing_other_elements_if_needed();
+    void ensure_details_exclusivity_by_closing_the_given_element_if_needed();
 
     WebIDL::ExceptionOr<void> create_shadow_tree_if_needed();
     void update_shadow_tree_slots();

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -34,7 +34,7 @@ private:
     virtual void inserted() override;
     virtual void removed_from(DOM::Node*) override;
     virtual void children_changed() override;
-    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
+    virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);
 

--- a/Tests/LibWeb/Text/expected/HTML/details-name.txt
+++ b/Tests/LibWeb/Text/expected/HTML/details-name.txt
@@ -1,0 +1,7 @@
+details0=✗ details1=✗ details2=✗ details3=✗ details4=✗
+details0=✓ details1=✗ details2=✗ details3=✗ details4=✗
+details0=✗ details1=✓ details2=✗ details3=✗ details4=✗
+details0=✗ details1=✗ details2=✓ details3=✗ details4=✗
+details0=✗ details1=✗ details2=✓ details3=✓ details4=✗
+details0=✗ details1=✗ details2=✓ details3=✓ details4=✓
+details0=✓ details1=✗ details2=✗ details3=✓ details4=✓

--- a/Tests/LibWeb/Text/input/HTML/details-name.html
+++ b/Tests/LibWeb/Text/input/HTML/details-name.html
@@ -1,0 +1,56 @@
+<details id="details0" name="group1">
+    <summary>Summary 0</summary>
+    <span>Contents 0</span>
+</details>
+<details id="details1" name="group1">
+    <summary>Summary 1</summary>
+    <span>Contents 1</span>
+</details>
+<details id="details2" name="group1">
+    <summary>Summary 2</summary>
+    <span>Contents 2</span>
+</details>
+<details id="details3" name="group2">
+    <summary>Summary 3</summary>
+    <span>Contents 3</span>
+</details>
+<details id="details4">
+    <summary>Summary 4</summary>
+    <span>Contents 4</span>
+</details>
+<script src="../include.js"></script>
+<script>
+    test(done => {
+        const elements = document.getElementsByTagName("details");
+
+        const logState = () => {
+            let result = "";
+
+            for (const element of elements) {
+                result += `${element.id}=${element.open ? "✓" : "✗"} `;
+            }
+
+            println(result.trimEnd());
+        };
+
+        logState();
+
+        elements[0].toggleAttribute("open");
+        logState();
+
+        elements[1].toggleAttribute("open");
+        logState();
+
+        elements[2].toggleAttribute("open");
+        logState();
+
+        elements[3].toggleAttribute("open");
+        logState();
+
+        elements[4].toggleAttribute("open");
+        logState();
+
+        elements[0].toggleAttribute("open");
+        logState();
+    });
+</script>


### PR DESCRIPTION
This is a relatively new feature which allows naming `<details>` groups to ensure only one `<details>` element in that group is opened at a time.

The test imported here is manually written - the WPT test doesn't work because it depends on the `DOMSubtreeModified` mutation event, which we don't support yet.

Demo from https://frontendmasters.com/blog/bone-up-html-2025/

https://github.com/user-attachments/assets/88c52744-3f3c-4c4a-a2e4-748cc2b41d8b

