### PR TITLE
Tests/LibWeb: Finish async test when an error is caught

### DIFF
--- a/Tests/LibWeb/Text/input/include.js
+++ b/Tests/LibWeb/Text/input/include.js
@@ -86,7 +86,10 @@ function asyncTest(f) {
         __finishTest();
     };
     document.addEventListener("DOMContentLoaded", () => {
-        f(done);
+        Promise.resolve(f(done)).catch(error => {
+            println(`Caught error while running async test: ${error}`);
+            done();
+        });
     });
 }
 


### PR DESCRIPTION
This catches errors that occur within async tests so that we fail faster
rather than timing out due to `done()` not being called.

We use `Promise.resolve()` because `f` isn't guaranteed to be an async
function.