### PR TITLE
LibJS: Temporal editorials and bug fixes

### DIFF
--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2021-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -389,8 +389,8 @@ Optional<Unicode::CalendarPattern> get_date_time_format(Unicode::CalendarPattern
             return IterationDecision::Continue;
         });
 
-        // c. If defaults is ZONED-DATE-TIME, then
-        if (defaults == OptionDefaults::ZonedDateTime) {
+        // c. If defaults is ZONED-DATE-TIME and formatOptions.[[timeZoneName]] is undefined, then
+        if (defaults == OptionDefaults::ZonedDateTime && !format_options.time_zone_name.has_value()) {
             // i. Set formatOptions.[[timeZoneName]] to "short".
             format_options.time_zone_name = Unicode::CalendarPatternStyle::Short;
         }

--- a/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -71,7 +71,7 @@ static bool is_valid_date(ParseResult const& result)
     return true;
 }
 
-// 13.30 ISO 8601 grammar, https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar
+// 13.30 RFC 9557 / ISO 8601 grammar, https://tc39.es/proposal-temporal/#sec-temporal-iso8601grammar
 class ISO8601Parser {
 public:
     explicit ISO8601Parser(StringView input)

--- a/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -2,12 +2,13 @@
  * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2024, Shannon Booth <shannon@serenityos.org>
- * Copyright (c) 2024, Tim Flynn <trflynn89@ladybird.org>
+ * Copyright (c) 2024-2025, Tim Flynn <trflynn89@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/Checked.h>
+#include <AK/NumericLimits.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
 #include <LibJS/Runtime/Temporal/DateEquations.h>
@@ -202,9 +203,10 @@ ThrowCompletionOr<ISODate> regulate_iso_date(VM& vm, double year, double month, 
         // c. Set day to the result of clamping day between 1 and daysInMonth.
         day = clamp(day, 1, iso_days_in_month(year, month));
 
-        // AD-HOC: We further clamp the year to the range allowed by ISOYearMonthWithinLimits, to ensure we do not
-        //         overflow when we store the year as an integer.
-        year = clamp(year, -271821, 275760);
+        // AD-HOC: We further clamp the year to the range allowed by ISODate.year, to ensure we do not overflow when we
+        //         store the year as an integer.
+        using YearType = decltype(declval<ISODate>().year);
+        year = clamp(year, static_cast<double>(NumericLimits<YearType>::min()), static_cast<double>(NumericLimits<YearType>::max()));
 
         break;
 

--- a/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
+++ b/Libraries/LibJS/Runtime/Temporal/PlainDateTimePrototype.cpp
@@ -289,7 +289,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimePrototype::with)
     auto result = TRY(interpret_temporal_date_time_fields(vm, calendar, fields, overflow));
 
     // 17. Return ? CreateTemporalDateTime(result, calendar).
-    return MUST(create_temporal_date_time(vm, result, calendar));
+    return TRY(create_temporal_date_time(vm, result, calendar));
 }
 
 // 5.3.26 Temporal.PlainDateTime.prototype.withPlainTime ( [ plainTimeLike ] ), https://tc39.es/proposal-temporal/#sec-temporal.plaindatetime.prototype.withplaintime

--- a/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/Duration/Duration.prototype.total.js
@@ -87,10 +87,15 @@ describe("errors", () => {
     });
 
     test("relativeTo with invalid date", () => {
-        const duration = new Temporal.Duration(0, 0, 0, 31);
-
         expect(() => {
+            const duration = new Temporal.Duration(0, 0, 0, 31);
             duration.total({ unit: "minute", relativeTo: "-271821-04-19" });
         }).toThrowWithMessage(RangeError, "Invalid ISO date time");
+
+        expect(() => {
+            const duration = new Temporal.Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 1);
+            const relativeTo = new Temporal.ZonedDateTime(864n * 10n ** 19n - 1n, "UTC");
+            duration.total({ unit: "years", relativeTo: relativeTo });
+        }).toThrowWithMessage(RangeError, "Invalid ISO date");
     });
 });

--- a/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.with.js
+++ b/Libraries/LibJS/Tests/builtins/Temporal/PlainDateTime/PlainDateTime.prototype.with.js
@@ -80,4 +80,12 @@ describe("errors", () => {
             new Temporal.PlainDateTime(1970, 1, 1).with({ timeZone: {} });
         }).toThrowWithMessage(TypeError, "Object must be a partial Temporal object");
     });
+
+    test("invalid ISO date range", () => {
+        const plainDateTime = new Temporal.PlainDateTime(-271821, 4, 19, 0, 0, 0, 0, 0, 1);
+
+        expect(() => {
+            plainDateTime.with({ nanosecond: 0 });
+        }).toThrowWithMessage(RangeError, "Invalid plain date time");
+    });
 });


### PR DESCRIPTION
The first 2 commits are recent editorial changes to the spec. The last 2 commits fix errors caught by recently added test262 tests.

test262 diff:
```
+16 ✅    -13 ❌    -3 💥

test/built-ins/Temporal/Duration/prototype/total/throws-if-date-time-invalid-with-plaindate-relative.js         💥 -> ✅
test/built-ins/Temporal/Duration/prototype/total/throws-if-date-time-invalid-with-zoneddatetime-relative.js     💥 -> ✅
test/built-ins/Temporal/PlainDate/prototype/since/throws-if-rounded-date-outside-valid-iso-range.js             ❌ -> ✅
test/built-ins/Temporal/PlainDate/prototype/until/throws-if-rounded-date-outside-valid-iso-range.js             ❌ -> ✅
test/built-ins/Temporal/PlainDateTime/prototype/since/throws-if-rounded-date-outside-valid-iso-range.js         ❌ -> ✅
test/built-ins/Temporal/PlainDateTime/prototype/until/throws-if-rounded-date-outside-valid-iso-range.js         ❌ -> ✅
test/built-ins/Temporal/PlainDateTime/prototype/with/throws-if-combined-date-time-outside-valid-iso-range.js    💥 -> ✅
test/built-ins/Temporal/PlainYearMonth/compare/argument-string-invalid.js                                       ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/from/argument-string-invalid.js                                          ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/equals/argument-string-invalid.js                              ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/since/argument-string-invalid.js                               ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/since/throws-if-rounded-date-outside-valid-iso-range.js        ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/until/argument-string-invalid.js                               ❌ -> ✅
test/built-ins/Temporal/PlainYearMonth/prototype/until/throws-if-rounded-date-outside-valid-iso-range.js        ❌ -> ✅
test/intl402/Temporal/ZonedDateTime/prototype/toLocaleString/options-timeZoneName-affects-instance-time-zone.js ❌ -> ✅
```