### PR TITLE
LibWeb: Implement dialog.requestClose()

### DIFF
--- a/Libraries/LibWeb/HTML/CloseWatcher.h
+++ b/Libraries/LibWeb/HTML/CloseWatcher.h
@@ -25,9 +25,14 @@ public:
     static WebIDL::ExceptionOr<GC::Ref<CloseWatcher>> construct_impl(JS::Realm&, CloseWatcherOptions const& = {});
     [[nodiscard]] static GC::Ref<CloseWatcher> establish(HTML::Window&);
 
-    bool request_close();
+    void request_close_for_bindings();
     void close();
     void destroy();
+
+    bool request_close(bool require_history_action_activation);
+
+    bool get_enabled_state() const { return m_is_enabled; }
+    void set_enabled(bool enabled) { m_is_enabled = enabled; }
 
     virtual ~CloseWatcher() override = default;
 
@@ -44,6 +49,7 @@ private:
 
     bool m_is_running_cancel_action { false };
     bool m_is_active { true };
+    bool m_is_enabled { true };
 };
 
 }

--- a/Libraries/LibWeb/HTML/CloseWatcher.idl
+++ b/Libraries/LibWeb/HTML/CloseWatcher.idl
@@ -6,7 +6,7 @@
 interface CloseWatcher : EventTarget {
     constructor(optional CloseWatcherOptions options = {});
 
-    undefined requestClose();
+    [ImplementedAs=request_close_for_bindings] undefined requestClose();
     undefined close();
     undefined destroy();
 

--- a/Libraries/LibWeb/HTML/CloseWatcherManager.cpp
+++ b/Libraries/LibWeb/HTML/CloseWatcherManager.cpp
@@ -75,10 +75,11 @@ bool CloseWatcherManager::process_close_watchers()
         }
         // 2.2 For each closeWatcher of group, in reverse order:
         for (auto it = group_copy.rbegin(); it != group_copy.rend(); ++it) {
-            // FIXME: 2.2.1 If the result of running closeWatcher's get enabled state is true, set processedACloseWatcher to true.
-            processed_a_close_watcher = true;
+            // 2.2.1 If the result of running closeWatcher's get enabled state is true, set processedACloseWatcher to true.
+            if ((*it)->get_enabled_state())
+                processed_a_close_watcher = true;
             // 2.2.2 Let shouldProceed be the result of requesting to close closeWatcher with true.
-            bool should_proceed = (*it)->request_close();
+            bool should_proceed = (*it)->request_close(true);
             // 2.2.3 If shouldProceed is false, then break;
             if (!should_proceed)
                 break;

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/ToggleTaskTracker.h>
@@ -28,6 +29,7 @@ public:
     WebIDL::ExceptionOr<void> show();
     WebIDL::ExceptionOr<void> show_modal();
     void close(Optional<String> return_value);
+    void request_close(Optional<String> return_value);
 
     // https://www.w3.org/TR/html-aria/#el-dialog
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::dialog; }
@@ -50,6 +52,7 @@ private:
 
     String m_return_value;
     bool m_is_modal { false };
+    Optional<String> m_request_close_return_value;
     GC::Ptr<CloseWatcher> m_close_watcher;
 
     // https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-toggle-task-tracker

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.idl
@@ -12,6 +12,6 @@ interface HTMLDialogElement : HTMLElement {
     [CEReactions] undefined show();
     [CEReactions] undefined showModal();
     [CEReactions] undefined close(optional DOMString returnValue);
-    [FIXME, CEReactions] undefined requestClose(optional DOMString returnValue);
+    [CEReactions] undefined requestClose(optional DOMString returnValue);
 
 };

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1146,7 +1146,8 @@ WebIDL::ExceptionOr<void> HTMLElement::show_popover(ThrowExceptions throw_except
             0, "", &realm());
         auto close_callback = realm().heap().allocate<WebIDL::CallbackType>(*close_callback_function, realm());
         m_popover_close_watcher->add_event_listener_without_options(HTML::EventNames::close, DOM::IDLEventListener::create(realm(), close_callback));
-        // FIXME: - getEnabledState being to return true.
+        // - getEnabledState being to return true.
+        m_popover_close_watcher->set_enabled(true);
     }
     // FIXME: 19. Set element's previously focused element to null.
     // FIXME: 20. Let originallyFocusedElement be document's focused area of the document's DOM anchor.


### PR DESCRIPTION
Depends on #3354 

See https://html.spec.whatwg.org/multipage/interaction.html#dom-closewatcher-requestclose

Can manually test using https://wpt.live/html/semantics/interactive-elements/the-dialog-element/dialog-requestclose.html where it passes all tests.

If I import the test it's flaky and sometimes fails on test runner.