### PR TITLE
CI: Do not insinuate PRs can be reopened in stalebot's close message

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,8 +30,8 @@ jobs:
             This pull request has been automatically marked as stale because it has not had recent activity. It will be
             closed in 7 days if no further activity occurs. Thank you for your contributions!
 
-          # PRs get closed after 30 days (21 + 7) of inactivity (currently disabled)
+          # PRs get closed after 30 days (21 + 7) of inactivity
           days-before-pr-close: 7
           close-pr-message: >
-              This pull request has been closed because it has not had recent activity. Feel free to re-open if you
-              wish to still contribute these changes. Thank you for your contributions!
+            This pull request has been closed because it has not had recent activity. Feel free to open a new pull
+            request if you wish to still contribute these changes. Thank you for your contributions!


### PR DESCRIPTION
Elevated permissions are required to do so. Contributors can create a new pull request based on their branch instead. There has been some confusion around the wording of this message lately, so let's change it.