### PR TITLE
LibWeb: Use finalize for cleaning up all navigables

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3787,8 +3787,8 @@ void Document::destroy()
 
     // Not in the spec:
     for (auto& navigable_container : HTML::NavigableContainer::all_instances()) {
-        if (&navigable_container->document() == this)
-            HTML::all_navigables().remove(navigable_container->content_navigable());
+        if (&navigable_container->document() == this && navigable_container->content_navigable())
+            HTML::all_navigables().remove(*navigable_container->content_navigable());
     }
 
     // 9. Set document's node navigable's active session history entry's document state's document to null.

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -192,6 +192,7 @@ protected:
     explicit Navigable(GC::Ref<Page>);
 
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual void finalize() override;
 
     // https://html.spec.whatwg.org/multipage/browsing-the-web.html#ongoing-navigation
     Variant<Empty, Traversal, String> m_ongoing_navigation;
@@ -236,7 +237,7 @@ private:
     Web::EventHandler m_event_handler;
 };
 
-HashTable<Navigable*>& all_navigables();
+HashTable<GC::RawRef<Navigable>>& all_navigables();
 
 bool navigation_must_be_a_replace(URL::URL const& url, DOM::Document const& document);
 void finalize_a_cross_document_navigation(GC::Ref<Navigable>, HistoryHandlingBehavior, UserNavigationInvolvement, GC::Ref<SessionHistoryEntry>);

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -283,7 +283,7 @@ void NavigableContainer::destroy_the_child_navigable()
         m_content_navigable = nullptr;
 
         // Not in the spec:
-        HTML::all_navigables().remove(navigable);
+        HTML::all_navigables().remove(*navigable);
 
         // 6. Let parentDocState be container's node navigable's active session history entry's document state.
         auto parent_doc_state = this->navigable()->active_session_history_entry()->document_state();

--- a/Libraries/LibWeb/HTML/Navigation.cpp
+++ b/Libraries/LibWeb/HTML/Navigation.cpp
@@ -245,9 +245,8 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::navigate(String url, Navigatio
 
     // 5. Let serializedState be StructuredSerializeForStorage(state).
     //    If this throws an exception, then return an early error result for that exception.
-    // FIXME: Fix this spec grammaro in the note
-    // NOTE: It is importantly to perform this step early, since serialization can invoke web developer code,
-    //       which in turn might change various things we check in later steps.
+    // Spec-Note: It is important to perform this step early, since serialization can invoke web developer code,
+    //            which in turn might change various things we check in later steps.
     auto serialized_state_or_error = structured_serialize_for_storage(vm, state);
     if (serialized_state_or_error.is_error()) {
         return early_error_result(serialized_state_or_error.release_error());
@@ -309,8 +308,8 @@ WebIDL::ExceptionOr<NavigationResult> Navigation::reload(NavigationReloadOptions
 
     // 3. If options["state"] exists, then set serializedState to StructuredSerializeForStorage(options["state"]).
     //    If this throws an exception, then return an early error result for that exception.
-    // NOTE: It is importantly to perform this step early, since serialization can invoke web developer
-    //       code, which in turn might change various things we check in later steps.
+    // Spec-Note: It is important to perform this step early, since serialization can invoke web developer
+    //            code, which in turn might change various things we check in later steps.
     if (options.state.has_value()) {
         auto serialized_state_or_error = structured_serialize_for_storage(vm, options.state.value());
         if (serialized_state_or_error.is_error())

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -1268,7 +1268,7 @@ void TraversableNavigable::destroy_top_level_traversable()
     // FIXME: Figure out why we need to do this... we shouldn't be leaking Navigables for all time.
     //        However, without this, we can keep stale destroyed traversables around.
     set_has_been_destroyed();
-    all_navigables().remove(this);
+    all_navigables().remove(*this);
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#finalize-a-same-document-navigation

--- a/Libraries/LibWeb/WebDriver/Contexts.cpp
+++ b/Libraries/LibWeb/WebDriver/Contexts.cpp
@@ -46,7 +46,7 @@ JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)
 
 static GC::Ptr<HTML::Navigable> find_navigable_with_handle(StringView handle, bool should_be_top_level)
 {
-    for (auto* navigable : Web::HTML::all_navigables()) {
+    for (auto navigable : Web::HTML::all_navigables()) {
         if (navigable->is_top_level_traversable() != should_be_top_level)
             continue;
 

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -581,7 +581,7 @@ Messages::WebDriverClient::SwitchToWindowResponse WebDriverConnection::switch_to
     //    Otherwise, return error with error code no such window.
     bool found_matching_context = false;
 
-    for (auto* navigable : Web::HTML::all_navigables()) {
+    for (auto navigable : Web::HTML::all_navigables()) {
         auto traversable = navigable->top_level_traversable();
         if (!traversable || !traversable->active_browsing_context())
             continue;


### PR DESCRIPTION
The use of this HashMap looks very spooky, but let's at least use finalize when cleaning them up on destruction to make things slightly less dangerous looking.