### PR TITLE
LibWeb: Use invalidation sets to reduce style recalculation

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SOURCES
     CSS/GridTrackPlacement.cpp
     CSS/GridTrackSize.cpp
     CSS/Interpolation.cpp
+    CSS/InvalidationSet.cpp
     CSS/Length.cpp
     CSS/LengthBox.cpp
     CSS/MediaList.cpp
@@ -116,6 +117,7 @@ set(SOURCES
     CSS/Sizing.cpp
     CSS/StyleComputer.cpp
     CSS/StyleInvalidation.cpp
+    CSS/StyleInvalidationData.cpp
     CSS/StyleProperty.cpp
     CSS/StyleSheet.cpp
     CSS/StyleSheetIdentifier.cpp

--- a/Libraries/LibWeb/CSS/InvalidationSet.cpp
+++ b/Libraries/LibWeb/CSS/InvalidationSet.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/InvalidationSet.h>
+
+namespace Web::CSS {
+
+void InvalidationSet::include_all_from(InvalidationSet const& other)
+{
+    m_needs_invalidate_self |= other.m_needs_invalidate_self;
+    m_needs_invalidate_whole_subtree |= other.m_needs_invalidate_whole_subtree;
+    for (auto const& property : other.m_properties)
+        m_properties.set(property);
+}
+
+bool InvalidationSet::is_empty() const
+{
+    return !m_needs_invalidate_self && !m_needs_invalidate_whole_subtree && m_properties.is_empty();
+}
+
+void InvalidationSet::for_each_property(Function<void(Property const&)> const& callback) const
+{
+    if (m_needs_invalidate_self)
+        callback({ Property::Type::InvalidateSelf });
+    if (m_needs_invalidate_whole_subtree)
+        callback({ Property::Type::InvalidateWholeSubtree });
+    for (auto const& property : m_properties)
+        callback(property);
+}
+
+}
+
+namespace AK {
+
+unsigned Traits<Web::CSS::InvalidationSet::Property>::hash(Web::CSS::InvalidationSet::Property const& invalidation_set_property)
+{
+    return pair_int_hash(to_underlying(invalidation_set_property.type), invalidation_set_property.name.hash());
+}
+
+ErrorOr<void> Formatter<Web::CSS::InvalidationSet::Property>::format(FormatBuilder& builder, Web::CSS::InvalidationSet::Property const& invalidation_set_property)
+{
+    switch (invalidation_set_property.type) {
+    case Web::CSS::InvalidationSet::Property::Type::InvalidateSelf: {
+        TRY(builder.put_string("$"sv));
+        return {};
+    }
+    case Web::CSS::InvalidationSet::Property::Type::Class: {
+        TRY(builder.put_string("."sv));
+        TRY(builder.put_string(invalidation_set_property.name));
+        return {};
+    }
+    case Web::CSS::InvalidationSet::Property::Type::Id: {
+        TRY(builder.put_string("#"sv));
+        TRY(builder.put_string(invalidation_set_property.name));
+        return {};
+    }
+    case Web::CSS::InvalidationSet::Property::Type::TagName: {
+        TRY(builder.put_string(invalidation_set_property.name));
+        return {};
+    }
+    case Web::CSS::InvalidationSet::Property::Type::Attribute: {
+        TRY(builder.put_string("["sv));
+        TRY(builder.put_string(invalidation_set_property.name));
+        TRY(builder.put_string("]"sv));
+        return {};
+    }
+    case Web::CSS::InvalidationSet::Property::Type::InvalidateWholeSubtree: {
+        TRY(builder.put_string("*"sv));
+        return {};
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+ErrorOr<void> Formatter<Web::CSS::InvalidationSet>::format(FormatBuilder& builder, Web::CSS::InvalidationSet const& invalidation_set)
+{
+    bool first = true;
+    invalidation_set.for_each_property([&](auto const& property) {
+        if (!first)
+            builder.builder().append(", "sv);
+        builder.builder().appendff("{}", property);
+    });
+    return {};
+}
+
+}

--- a/Libraries/LibWeb/CSS/InvalidationSet.h
+++ b/Libraries/LibWeb/CSS/InvalidationSet.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/FlyString.h>
+#include <AK/Format.h>
+#include <AK/Forward.h>
+#include <AK/HashTable.h>
+#include <AK/Traits.h>
+
+namespace Web::CSS {
+
+class InvalidationSet {
+public:
+    struct Property {
+        enum class Type : u8 {
+            InvalidateSelf,
+            InvalidateWholeSubtree,
+            Class,
+            Id,
+            TagName,
+            Attribute,
+        };
+
+        Type type;
+        FlyString name {};
+
+        bool operator==(Property const& other) const = default;
+    };
+
+    void include_all_from(InvalidationSet const& other);
+
+    bool needs_invalidate_self() const { return m_needs_invalidate_self; }
+    void set_needs_invalidate_self() { m_needs_invalidate_self = true; }
+
+    bool needs_invalidate_whole_subtree() const { return m_needs_invalidate_whole_subtree; }
+    void set_needs_invalidate_whole_subtree() { m_needs_invalidate_whole_subtree = true; }
+
+    void set_needs_invalidate_class(FlyString const& name) { m_properties.set({ Property::Type::Class, name }); }
+    void set_needs_invalidate_id(FlyString const& name) { m_properties.set({ Property::Type::Id, name }); }
+    void set_needs_invalidate_tag_name(FlyString const& name) { m_properties.set({ Property::Type::TagName, name }); }
+    void set_needs_invalidate_attribute(FlyString const& name) { m_properties.set({ Property::Type::Attribute, name }); }
+
+    bool is_empty() const;
+    void for_each_property(Function<void(Property const&)> const& callback) const;
+
+private:
+    bool m_needs_invalidate_self { false };
+    bool m_needs_invalidate_whole_subtree { false };
+    HashTable<Property> m_properties;
+};
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<Web::CSS::InvalidationSet::Property> : DefaultTraits<String> {
+    static unsigned hash(Web::CSS::InvalidationSet::Property const&);
+    static bool equals(Web::CSS::InvalidationSet::Property const& a, Web::CSS::InvalidationSet::Property const& b) { return a == b; }
+};
+
+template<>
+struct Formatter<Web::CSS::InvalidationSet::Property> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder&, Web::CSS::InvalidationSet::Property const&);
+};
+
+template<>
+struct Formatter<Web::CSS::InvalidationSet> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder&, Web::CSS::InvalidationSet const&);
+};
+
+}

--- a/Libraries/LibWeb/CSS/InvalidationSet.h
+++ b/Libraries/LibWeb/CSS/InvalidationSet.h
@@ -11,6 +11,7 @@
 #include <AK/Forward.h>
 #include <AK/HashTable.h>
 #include <AK/Traits.h>
+#include <LibWeb/CSS/PseudoClass.h>
 
 namespace Web::CSS {
 
@@ -24,10 +25,13 @@ public:
             Id,
             TagName,
             Attribute,
+            PseudoClass,
         };
 
         Type type;
-        FlyString name {};
+        Variant<FlyString, PseudoClass, Empty> value { Empty {} };
+
+        FlyString const& name() const { return value.get<FlyString>(); }
 
         bool operator==(Property const& other) const = default;
     };
@@ -44,6 +48,7 @@ public:
     void set_needs_invalidate_id(FlyString const& name) { m_properties.set({ Property::Type::Id, name }); }
     void set_needs_invalidate_tag_name(FlyString const& name) { m_properties.set({ Property::Type::TagName, name }); }
     void set_needs_invalidate_attribute(FlyString const& name) { m_properties.set({ Property::Type::Attribute, name }); }
+    void set_needs_invalidate_pseudo_class(PseudoClass pseudo_class) { m_properties.set({ Property::Type::PseudoClass, pseudo_class }); }
 
     bool is_empty() const;
     void for_each_property(Function<void(Property const&)> const& callback) const;

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -447,19 +447,23 @@ bool StyleComputer::invalidation_property_used_in_has_selector(InvalidationSet::
         return true;
     switch (property.type) {
     case InvalidationSet::Property::Type::Id:
-        if (m_style_invalidation_data->ids_used_in_has_selectors.contains(property.name))
+        if (m_style_invalidation_data->ids_used_in_has_selectors.contains(property.name()))
             return true;
         break;
     case InvalidationSet::Property::Type::Class:
-        if (m_style_invalidation_data->class_names_used_in_has_selectors.contains(property.name))
+        if (m_style_invalidation_data->class_names_used_in_has_selectors.contains(property.name()))
             return true;
         break;
     case InvalidationSet::Property::Type::Attribute:
-        if (m_style_invalidation_data->attribute_names_used_in_has_selectors.contains(property.name))
+        if (m_style_invalidation_data->attribute_names_used_in_has_selectors.contains(property.name()))
             return true;
         break;
     case InvalidationSet::Property::Type::TagName:
-        if (m_style_invalidation_data->tag_names_used_in_has_selectors.contains(property.name))
+        if (m_style_invalidation_data->tag_names_used_in_has_selectors.contains(property.name()))
+            return true;
+        break;
+    case InvalidationSet::Property::Type::PseudoClass:
+        if (m_style_invalidation_data->pseudo_classes_used_in_has_selectors.contains(property.value.get<PseudoClass>()))
             return true;
         break;
     default:

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -19,6 +19,7 @@
 #include <LibWeb/CSS/CascadedProperties.h>
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleInvalidationData.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 
@@ -149,6 +150,9 @@ public:
     Vector<MatchingRule> const& get_hover_rules() const;
     Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_hover_rules, FlyString const& qualified_layer_name = {}) const;
 
+    InvalidationSet invalidation_set_for_properties(Vector<InvalidationSet::Property> const&) const;
+    bool invalidation_property_used_in_has_selector(InvalidationSet::Property const&) const;
+
     void invalidate_rule_cache();
 
     Gfx::Font const& initial_font() const;
@@ -278,6 +282,7 @@ private:
 
     OwnPtr<SelectorInsights> m_selector_insights;
     Vector<MatchingRule> m_hover_rules;
+    OwnPtr<StyleInvalidationData> m_style_invalidation_data;
     OwnPtr<RuleCache> m_author_rule_cache;
     OwnPtr<RuleCache> m_user_rule_cache;
     OwnPtr<RuleCache> m_user_agent_rule_cache;

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -66,6 +66,16 @@ static void collect_properties_used_in_has(Selector::SimpleSelector const& selec
     }
     case Selector::SimpleSelector::Type::PseudoClass: {
         auto const& pseudo_class = selector.pseudo_class();
+        switch (pseudo_class.type) {
+        case PseudoClass::Enabled:
+        case PseudoClass::Disabled:
+        case PseudoClass::PlaceholderShown:
+        case PseudoClass::Checked:
+            style_invalidation_data.pseudo_classes_used_in_has_selectors.set(pseudo_class.type);
+            break;
+        default:
+            break;
+        }
         for (auto const& child_selector : pseudo_class.argument_selector_list) {
             for (auto const& compound_selector : child_selector->compound_selectors()) {
                 for (auto const& simple_selector : compound_selector.simple_selectors) {
@@ -102,6 +112,16 @@ static void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector
         break;
     case Selector::SimpleSelector::Type::PseudoClass: {
         auto const& pseudo_class = selector.pseudo_class();
+        switch (pseudo_class.type) {
+        case PseudoClass::Enabled:
+        case PseudoClass::Disabled:
+        case PseudoClass::PlaceholderShown:
+        case PseudoClass::Checked:
+            invalidation_set.set_needs_invalidate_pseudo_class(pseudo_class.type);
+            break;
+        default:
+            break;
+        }
         if (pseudo_class.type == PseudoClass::Has)
             break;
         if (exclude_properties_nested_in_not_pseudo_class == ExcludePropertiesNestedInNotPseudoClass::Yes && pseudo_class.type == PseudoClass::Not)

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/GenericShorthands.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/CSS/StyleInvalidationData.h>
+
+namespace Web::CSS {
+
+// Iterates over the given selector, grouping consecutive simple selectors that have no combinator (Combinator::None).
+// For example, given "div:not(.a) + .b[foo]", the callback is invoked twice:
+// once for "div:not(.a)" and once for ".b[foo]".
+template<typename Callback>
+static void for_each_consecutive_simple_selector_group(Selector const& selector, Callback callback)
+{
+    auto const& compound_selectors = selector.compound_selectors();
+    int compound_selector_index = compound_selectors.size() - 1;
+    Vector<Selector::SimpleSelector const&> simple_selectors;
+    Selector::Combinator combinator = Selector::Combinator::None;
+    bool is_rightmost = true;
+    while (compound_selector_index >= 0) {
+        if (!simple_selectors.is_empty()) {
+            callback(simple_selectors, combinator, is_rightmost);
+            simple_selectors.clear();
+            is_rightmost = false;
+        }
+
+        auto const& compound_selector = compound_selectors[compound_selector_index];
+        for (auto const& simple_selector : compound_selector.simple_selectors) {
+            simple_selectors.append(simple_selector);
+        }
+        combinator = compound_selector.combinator;
+
+        --compound_selector_index;
+    }
+    if (!simple_selectors.is_empty()) {
+        callback(simple_selectors, combinator, is_rightmost);
+    }
+}
+
+static void collect_properties_used_in_has(Selector::SimpleSelector const& selector, StyleInvalidationData& style_invalidation_data, bool in_has)
+{
+    switch (selector.type) {
+    case Selector::SimpleSelector::Type::Id: {
+        if (in_has)
+            style_invalidation_data.ids_used_in_has_selectors.set(selector.name());
+        break;
+    }
+    case Selector::SimpleSelector::Type::Class: {
+        if (in_has)
+            style_invalidation_data.class_names_used_in_has_selectors.set(selector.name());
+        break;
+    }
+    case Selector::SimpleSelector::Type::Attribute: {
+        if (in_has)
+            style_invalidation_data.attribute_names_used_in_has_selectors.set(selector.attribute().qualified_name.name.lowercase_name);
+        break;
+    }
+    case Selector::SimpleSelector::Type::TagName: {
+        if (in_has)
+            style_invalidation_data.tag_names_used_in_has_selectors.set(selector.qualified_name().name.lowercase_name);
+        break;
+    }
+    case Selector::SimpleSelector::Type::PseudoClass: {
+        auto const& pseudo_class = selector.pseudo_class();
+        for (auto const& child_selector : pseudo_class.argument_selector_list) {
+            for (auto const& compound_selector : child_selector->compound_selectors()) {
+                for (auto const& simple_selector : compound_selector.simple_selectors) {
+                    collect_properties_used_in_has(simple_selector, style_invalidation_data, in_has || pseudo_class.type == PseudoClass::Has);
+                }
+            }
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+enum class ExcludePropertiesNestedInNotPseudoClass : bool {
+    No,
+    Yes,
+};
+
+static void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector const& selector, InvalidationSet& invalidation_set, ExcludePropertiesNestedInNotPseudoClass exclude_properties_nested_in_not_pseudo_class, StyleInvalidationData& rule_invalidation_data)
+{
+    switch (selector.type) {
+    case Selector::SimpleSelector::Type::Class:
+        invalidation_set.set_needs_invalidate_class(selector.name());
+        break;
+    case Selector::SimpleSelector::Type::Id:
+        invalidation_set.set_needs_invalidate_id(selector.name());
+        break;
+    case Selector::SimpleSelector::Type::TagName:
+        invalidation_set.set_needs_invalidate_tag_name(selector.qualified_name().name.lowercase_name);
+        break;
+    case Selector::SimpleSelector::Type::Attribute:
+        invalidation_set.set_needs_invalidate_attribute(selector.attribute().qualified_name.name.lowercase_name);
+        break;
+    case Selector::SimpleSelector::Type::PseudoClass: {
+        auto const& pseudo_class = selector.pseudo_class();
+        if (pseudo_class.type == PseudoClass::Has)
+            break;
+        if (exclude_properties_nested_in_not_pseudo_class == ExcludePropertiesNestedInNotPseudoClass::Yes && pseudo_class.type == PseudoClass::Not)
+            break;
+        for (auto const& nested_selector : pseudo_class.argument_selector_list) {
+            auto rightmost_invalidation_set_for_selector = rule_invalidation_data.build_invalidation_sets_for_selector(*nested_selector);
+            invalidation_set.include_all_from(rightmost_invalidation_set_for_selector);
+        }
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+InvalidationSet StyleInvalidationData::build_invalidation_sets_for_selector(Selector const& selector)
+{
+    auto const& compound_selectors = selector.compound_selectors();
+    int compound_selector_index = compound_selectors.size() - 1;
+    VERIFY(compound_selector_index >= 0);
+
+    InvalidationSet invalidation_set_for_rightmost_selector;
+    Selector::Combinator previous_compound_combinator = Selector::Combinator::None;
+    for_each_consecutive_simple_selector_group(selector, [&](Vector<Selector::SimpleSelector const&> const& simple_selectors, Selector::Combinator combinator, bool is_rightmost) {
+        // Collect properties used in :has() so we can decide if only specific properties
+        // trigger descendant invalidation or if the entire document must be invalidated.
+        for (auto const& simple_selector : simple_selectors) {
+            bool in_has = false;
+            if (simple_selector.type == Selector::SimpleSelector::Type::PseudoClass) {
+                auto const& pseudo_class = simple_selector.pseudo_class();
+                if (pseudo_class.type == PseudoClass::Has)
+                    in_has = true;
+            }
+            collect_properties_used_in_has(simple_selector, *this, in_has);
+        }
+
+        if (is_rightmost) {
+            // The rightmost selector is handled twice:
+            //  1) Include properties nested in :not()
+            //  2) Exclude properties nested in :not()
+            //
+            // This ensures we handle cases like:
+            //   :not(.foo) => produce invalidation set .foo { $ } ($ = invalidate self)
+            //   .bar :not(.foo) => produce invalidation sets .foo { $ } and .bar { * } (* = invalidate subtree)
+            //                      which means invalidation_set_for_rightmost_selector should be empty
+            for (auto const& simple_selector : simple_selectors) {
+                InvalidationSet s;
+                build_invalidation_sets_for_simple_selector(simple_selector, s, ExcludePropertiesNestedInNotPseudoClass::No, *this);
+                s.for_each_property([&](auto const& invalidation_property) {
+                    auto& descendant_invalidation_set = descendant_invalidation_sets.ensure(invalidation_property, [] { return InvalidationSet {}; });
+                    descendant_invalidation_set.set_needs_invalidate_self();
+                });
+            }
+
+            for (auto const& simple_selector : simple_selectors) {
+                build_invalidation_sets_for_simple_selector(simple_selector, invalidation_set_for_rightmost_selector, ExcludePropertiesNestedInNotPseudoClass::Yes, *this);
+            }
+        } else {
+            VERIFY(previous_compound_combinator != Selector::Combinator::None);
+            for (auto const& simple_selector : simple_selectors) {
+                InvalidationSet s;
+                build_invalidation_sets_for_simple_selector(simple_selector, s, ExcludePropertiesNestedInNotPseudoClass::No, *this);
+                s.for_each_property([&](auto const& invalidation_property) {
+                    auto& descendant_invalidation_set = descendant_invalidation_sets.ensure(invalidation_property, [] {
+                        return InvalidationSet {};
+                    });
+                    // If the rightmost selector's invalidation set is empty, it means there's no
+                    // specific property-based invalidation, so we fall back to invalidating the whole subtree.
+                    // If combinator to the right of current compound selector is NextSibling or SubsequentSibling,
+                    // we also need to invalidate the whole subtree, because we don't support sibling invalidation sets.
+                    if (AK::first_is_one_of(previous_compound_combinator, Selector::Combinator::NextSibling, Selector::Combinator::SubsequentSibling)) {
+                        descendant_invalidation_set.set_needs_invalidate_whole_subtree();
+                    } else if (invalidation_set_for_rightmost_selector.is_empty()) {
+                        descendant_invalidation_set.set_needs_invalidate_whole_subtree();
+                    } else {
+                        descendant_invalidation_set.include_all_from(invalidation_set_for_rightmost_selector);
+                    }
+                });
+            }
+        }
+
+        previous_compound_combinator = combinator;
+    });
+
+    return invalidation_set_for_rightmost_selector;
+}
+
+}

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.h
@@ -18,6 +18,7 @@ struct StyleInvalidationData {
     HashTable<FlyString> class_names_used_in_has_selectors;
     HashTable<FlyString> attribute_names_used_in_has_selectors;
     HashTable<FlyString> tag_names_used_in_has_selectors;
+    HashTable<PseudoClass> pseudo_classes_used_in_has_selectors;
 
     InvalidationSet build_invalidation_sets_for_selector(Selector const& selector);
 };

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.h
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2025, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <LibWeb/CSS/InvalidationSet.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::CSS {
+
+struct StyleInvalidationData {
+    HashMap<InvalidationSet::Property, InvalidationSet> descendant_invalidation_sets;
+    HashTable<FlyString> ids_used_in_has_selectors;
+    HashTable<FlyString> class_names_used_in_has_selectors;
+    HashTable<FlyString> attribute_names_used_in_has_selectors;
+    HashTable<FlyString> tag_names_used_in_has_selectors;
+
+    InvalidationSet build_invalidation_sets_for_selector(Selector const& selector);
+};
+
+}

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -2016,6 +2016,17 @@ void Element::invalidate_style_after_attribute_change(FlyString const& attribute
         return;
     }
 
+    if (attribute_name == HTML::AttributeNames::id) {
+        Vector<CSS::InvalidationSet::Property> changed_properties;
+        if (old_value.has_value())
+            changed_properties.append({ .type = CSS::InvalidationSet::Property::Type::Id, .name = old_value.value() });
+        if (new_value.has_value())
+            changed_properties.append({ .type = CSS::InvalidationSet::Property::Type::Id, .name = new_value.value() });
+        changed_properties.append({ .type = CSS::InvalidationSet::Property::Type::Attribute, .name = HTML::AttributeNames::id });
+        invalidate_style(StyleInvalidationReason::ElementAttributeChange, changed_properties);
+        return;
+    }
+
     if (is_presentational_hint(attribute_name)
         || attribute_name_may_affect_selectors(*this, attribute_name)) {
         invalidate_style(StyleInvalidationReason::ElementAttributeChange);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -263,6 +263,7 @@ public:
     static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
 
     bool affected_by_hover() const;
+    bool affected_by_invalidation_property(CSS::InvalidationSet::Property const&) const;
 
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, GC::Ptr<Layout::NodeWithStyle>);
     GC::Ptr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
@@ -420,7 +421,7 @@ protected:
 private:
     void make_html_uppercased_qualified_name();
 
-    void invalidate_style_after_attribute_change(FlyString const& attribute_name);
+    void invalidate_style_after_attribute_change(FlyString const& attribute_name, Optional<String> const& old_value, Optional<String> const& new_value);
 
     WebIDL::ExceptionOr<GC::Ptr<Node>> insert_adjacent(StringView where, GC::Ref<Node> node);
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -14,6 +14,7 @@
 #include <AK/RefPtr.h>
 #include <AK/TypeCasts.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/InvalidationSet.h>
 #include <LibWeb/DOM/AccessibilityTreeNode.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOM/Slottable.h>
@@ -297,6 +298,7 @@ public:
     void set_child_needs_style_update(bool b) { m_child_needs_style_update = b; }
 
     void invalidate_style(StyleInvalidationReason);
+    void invalidate_style(StyleInvalidationReason, Vector<CSS::InvalidationSet::Property> const&);
 
     void set_document(Badge<Document>, Document&);
 


### PR DESCRIPTION
Implements idea described in
https://docs.google.com/document/d/1vEW86DaeVs4uQzNFI5R-_xS9TcS1Cs_EUsHRSgCHGu8

Invalidation sets are used to reduce the number of elements marked for style recalculation by collecting metadata from style rules about the dependencies between properties that could affect an element’s style.

Currently, this optimization is only applied to style invalidation triggered by class list mutations on an element.