### PR TITLE
LibWeb/SVG: Fix crash when SVG use element is used on an external SVG

### DIFF
--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -13,6 +13,8 @@
 #include <LibWeb/HTML/NavigationParams.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
+#include <LibWeb/HTML/Window.h>
+#include <LibWeb/HTML/WindowProxy.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
@@ -44,10 +46,12 @@ ErrorOr<GC::Ref<SVGDecodedImageData>> SVGDecodedImageData::create(JS::Realm& rea
     navigation_params->opener_policy = HTML::OpenerPolicy {};
 
     // FIXME: Use Navigable::navigate() instead of manually replacing the navigable's document.
-    auto document = DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params).release_value_but_fixme_should_propagate_errors();
+    auto document = MUST(DOM::Document::create_and_initialize(DOM::Document::Type::HTML, "text/html"_string, navigation_params));
     navigable->set_ongoing_navigation({});
     navigable->active_document()->destroy();
     navigable->active_session_history_entry()->document_state()->set_document(document);
+    auto& window = verify_cast<HTML::Window>(HTML::relevant_global_object(document));
+    document->browsing_context()->window_proxy()->set_window(window);
 
     auto parser = HTML::HTMLParser::create_with_uncertain_encoding(document, data);
     parser->run(document->url());

--- a/Tests/LibWeb/Layout/data/svg-with-id.svg
+++ b/Tests/LibWeb/Layout/data/svg-with-id.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <symbol id="myid"></symbol>
+</svg>

--- a/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
@@ -1,0 +1,17 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x150 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+      SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
+        TextNode <#text>
+        SVGGraphicsBox <use> at (8,8) content-size 300x150 children: not-inline
+          SVGGraphicsBox <symbol#myid> at (8,8) content-size 300x150 [BFC] children: not-inline
+        TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x150]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
+        SVGGraphicsPaintable (SVGGraphicsBox<use>) [8,8 300x150]
+          SVGGraphicsPaintable (SVGGraphicsBox<symbol>#myid) [8,8 300x150]

--- a/Tests/LibWeb/Layout/input/svg/svg-use-element-crashtest.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-use-element-crashtest.html
@@ -1,0 +1,3 @@
+<svg>
+  <use href="../../data/svg-with-id.svg#myid"></use>
+</svg>


### PR DESCRIPTION
We were previously crashing when invoking 'scroll to the fragment' on such documents as it was unable to find the active document. This is as a result of our AD-HOC implementation not setting up the document fully to mark it is active before running the parser.

Fixes a crash on https://tweakers.net.