### PR TITLE
LibWeb: Resolve `SVGImageElement` source URL correctly

### DIFF
--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Tim Ledbetter <tim.ledbetter@ladybird.org>
+ * Copyright (c) 2024-2025, Tim Ledbetter <tim.ledbetter@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -140,7 +140,13 @@ Gfx::Rect<CSSPixels> SVGImageElement::bounding_box() const
 // https://www.w3.org/TR/SVG2/linking.html#processingURL
 void SVGImageElement::process_the_url(Optional<String> const& href)
 {
-    m_href = document().url().complete_url(href.value_or(String {}));
+    if (!href.has_value()) {
+        m_href = {};
+        return;
+    }
+
+    m_href = document().parse_url(*href);
+
     if (!m_href.is_valid())
         return;
 

--- a/Tests/LibWeb/Ref/expected/svg-image-in-iframe-ref.html
+++ b/Tests/LibWeb/Ref/expected/svg-image-in-iframe-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<iframe srcdoc="<svg xmlns='http://www.w3.org/2000/svg'><rect width='150' height='100' fill='green' /></svg>"></iframe>

--- a/Tests/LibWeb/Ref/input/svg-image-in-iframe.html
+++ b/Tests/LibWeb/Ref/input/svg-image-in-iframe.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<link rel="match" href="../expected/svg-image-in-iframe-ref.html" />
+<iframe srcdoc="<svg xmlns='http://www.w3.org/2000/svg'><image href='../data/rectangle.png' width='150' height='100' /></svg>"></iframe>


### PR DESCRIPTION
This fixes an issue where an SVGImageElement, whose source was a relative URL would not load inside an iframe.