### PR TITLE
LibWeb: Invalidate entire layout tree on SVG <use> clone instantiation

### DIFF
--- a/Libraries/LibWeb/SVG/SVGUseElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGUseElement.cpp
@@ -183,6 +183,9 @@ void SVGUseElement::clone_element_tree_as_our_shadow_tree(Element* to_clone)
         auto cloned_reference_node = MUST(to_clone->clone_node(nullptr, true));
         shadow_root()->append_child(cloned_reference_node).release_value_but_fixme_should_propagate_errors();
     }
+
+    // FIXME: Only invalidate the part of the layout tree that is affected by this change.
+    document().invalidate_layout_tree();
 }
 
 bool SVGUseElement::is_valid_reference_element(Element const& reference_element) const

--- a/Tests/LibWeb/Text/expected/layout-tree-update/svg-use-invalidation-1.txt
+++ b/Tests/LibWeb/Text/expected/layout-tree-update/svg-use-invalidation-1.txt
@@ -1,0 +1,1 @@
+PASS (didn't fall apart)

--- a/Tests/LibWeb/Text/input/layout-tree-update/svg-use-invalidation-1.html
+++ b/Tests/LibWeb/Text/input/layout-tree-update/svg-use-invalidation-1.html
@@ -1,0 +1,10 @@
+<script src="../include.js"></script>
+<svg><symbol id="foo"></symbol><use href="#foo"></use></svg>
+<script>
+    test(() => {
+        document.body.offsetWidth; // force layout
+        foo.setAttribute("id", "bar");
+        document.body.offsetWidth; // force layout
+        println("PASS (didn't fall apart)");
+    });
+</script>


### PR DESCRIPTION
This is sub-optimal but let's rebuild the whole tree for now, since this case gets quite complicated and there are more valuable things to chase after first.