### PR TITLE
LibWeb: Do not run microtasks when the event loop is paused

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -503,6 +503,9 @@ void perform_a_microtask_checkpoint()
 // https://html.spec.whatwg.org/#perform-a-microtask-checkpoint
 void EventLoop::perform_a_microtask_checkpoint()
 {
+    if (execution_paused())
+        return;
+
     // NOTE: This assertion is per requirement 9.5 of the ECMA-262 spec, see: https://tc39.es/ecma262/#sec-jobs
     // > At some future point in time, when there is no running context in the agent for which the job is scheduled and that agent's execution context stack is empty...
     VERIFY(vm().execution_context_stack().is_empty());
@@ -653,6 +656,8 @@ EventLoop::PauseHandle::~PauseHandle()
 // https://html.spec.whatwg.org/multipage/webappapis.html#pause
 EventLoop::PauseHandle EventLoop::pause()
 {
+    m_execution_paused = true;
+
     // 1. Let global be the current global object.
     auto& global = current_principal_global_object();
 
@@ -667,7 +672,6 @@ EventLoop::PauseHandle EventLoop::pause()
     //    not run further tasks, and any script in the currently running task must block. User agents should remain
     //    responsive to user input while paused, however, albeit in a reduced capacity since the event loop will not be
     //    doing anything.
-    m_execution_paused = true;
 
     return PauseHandle { *this, global, time_before_pause };
 }

--- a/Tests/LibWeb/Text/expected/alert.txt
+++ b/Tests/LibWeb/Text/expected/alert.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/alert.html
+++ b/Tests/LibWeb/Text/input/alert.html
@@ -1,0 +1,7 @@
+<script src="include.js"></script>
+<script>
+    test(() => {
+        alert("Well hello friends!");
+        println("PASS (didn't crash)");
+    });
+</script>


### PR DESCRIPTION
For example, running `alert(1)` will pause the event loop, during which time no JavaScript should execute. This patch extends this disruption to microtasks. This avoids a crash inside the microtask executor, which asserts the JS execution context stack is empty.

This makes us behave the same as Firefox in the following page:

```html
<script>
    queueMicrotask(() => {
        console.log("inside microtask");
    });

    alert("hi");
</script>
```
Before the aforementioned assertion was added, we would execute that microtask before showing the alert. Firefox does not do this, and now we don't either.

WPT of `/webdriver/tests/classic` before:
```
web-platform-test
~~~~~~~~~~~~~~~~~
Ran 3617 checks (3423 subtests, 194 tests)
Expected results: 2253
Unexpected results: 1364
  subtest: 1364 (996 error, 368 fail)
```

After:
```  
web-platform-test
~~~~~~~~~~~~~~~~~
Ran 3607 checks (3413 subtests, 194 tests)
Expected results: 3122
Unexpected results: 485
  test: 1 (1 timeout)
  subtest: 484 (60 error, 424 fail)
```