### PR TITLE
CI: Add Nightly arm64 Linux job, and nightly distribution jobs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -40,6 +40,8 @@ runs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-13 100
 
+        # FIXME: https://github.com/WebAssembly/wabt/issues/2533
+        #        wabt doesn't have binary releases for arm64 Linux
         wget https://github.com/WebAssembly/wabt/releases/download/1.0.35/wabt-1.0.35-ubuntu-20.04.tar.gz
         tar -xzf ./wabt-1.0.35-ubuntu-20.04.tar.gz
         rm ./wabt-1.0.35-ubuntu-20.04.tar.gz
@@ -58,6 +60,13 @@ runs:
         set -e
         brew update
         brew install autoconf autoconf-archive automake bash ccache coreutils llvm@19 nasm ninja qt unzip wabt
+
+    - name: 'Set required environment variables'
+      if: ${{ inputs.os == 'Linux' && inputs.arch == 'arm64' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.exportVariable('VCPKG_FORCE_SYSTEM_BINARIES', '1')
 
     - name: 'Install vcpkg'
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         os_name: ['Linux']
         os: [ubuntu-24.04]
         arch: ['x86_64']
-        fuzzer: ['NO_FUZZ']
+        build_preset: ['Sanitizer_CI']
         toolchain: ['GNU']
         clang_plugins: [false]
 
@@ -25,21 +25,21 @@ jobs:
           - os_name: 'Linux'
             os: ubuntu-24.04
             arch: 'x86_64'
-            fuzzer: 'NO_FUZZ'
+            build_preset: 'Sanitizer_CI'
             toolchain: 'Clang'
             clang_plugins: true
 
           - os_name: 'macOS'
             os: macos-15
             arch: 'arm64'
-            fuzzer: 'NO_FUZZ'
+            build_preset: 'Sanitizer_CI'
             toolchain: 'Clang'
             clang_plugins: false
 
           - os_name: 'Linux'
             os: ubuntu-24.04
             arch: 'x86_64'
-            fuzzer: 'FUZZ'
+            build_preset: 'Fuzzers_CI'
             toolchain: 'Clang'
             clang_plugins: false
 
@@ -49,5 +49,5 @@ jobs:
       os_name: ${{ matrix.os_name }}
       os: ${{ matrix.os }}
       arch: ${{ matrix.arch }}
-      fuzzer: ${{ matrix.fuzzer }}
+      build_preset: ${{ matrix.build_preset }}
       clang_plugins: ${{ matrix.clang_plugins }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
       matrix:
         os_name: ['Linux']
         os: [ubuntu-24.04]
+        arch: ['x86_64']
         fuzzer: ['NO_FUZZ']
         toolchain: ['GNU']
         clang_plugins: [false]
@@ -23,18 +24,21 @@ jobs:
         include:
           - os_name: 'Linux'
             os: ubuntu-24.04
+            arch: 'x86_64'
             fuzzer: 'NO_FUZZ'
             toolchain: 'Clang'
             clang_plugins: true
 
           - os_name: 'macOS'
             os: macos-15
+            arch: 'arm64'
             fuzzer: 'NO_FUZZ'
             toolchain: 'Clang'
             clang_plugins: false
 
           - os_name: 'Linux'
             os: ubuntu-24.04
+            arch: 'x86_64'
             fuzzer: 'FUZZ'
             toolchain: 'Clang'
             clang_plugins: false
@@ -44,5 +48,6 @@ jobs:
       toolchain: ${{ matrix.toolchain }}
       os_name: ${{ matrix.os_name }}
       os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
       fuzzer: ${{ matrix.fuzzer }}
       clang_plugins: ${{ matrix.clang_plugins }}

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -15,10 +15,9 @@ on:
         arch:
           required: true
           type: string
-        fuzzer:
-          required: false
+        build_preset:
+          required: true
           type: string
-          default: 'NO_FUZZ'
         clang_plugins:
           required: false
           type: boolean
@@ -79,10 +78,10 @@ jobs:
           fi
 
           if ${{ inputs.clang_plugins }} ; then
-            echo "ccache_key=${{ inputs.fuzzer }}-CLANG_PLUGINS" >> "$GITHUB_OUTPUT"
+            echo "ccache_key=${{ inputs.build_preset }}-CLANG_PLUGINS" >> "$GITHUB_OUTPUT"
             echo "cmake_options=-DENABLE_CLANG_PLUGINS=ON" >> "$GITHUB_OUTPUT"
           else
-            echo "ccache_key=${{ inputs.fuzzer }}" >> "$GITHUB_OUTPUT"
+            echo "ccache_key=${{ inputs.build_preset }}" >> "$GITHUB_OUTPUT"
             echo "cmake_options=" >> "$GITHUB_OUTPUT"
           fi
 
@@ -109,10 +108,10 @@ jobs:
         run: sqlite3 $HOME/Library/Application\ Support/com.apple.TCC/TCC.db "INSERT OR IGNORE INTO access VALUES ('kTCCServiceMicrophone','/usr/local/opt/runner/provisioner/provisioner',1,2,4,1,NULL,NULL,0,'UNUSED',NULL,0,1687786159,NULL,NULL,'UNUSED',1687786159);"
 
       - name: Create Build Environment
-        if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.build_preset != 'Fuzzers_CI' }}
         working-directory: ${{ github.workspace }}
         run: |
-          cmake --preset Sanitizer_CI -B Build \
+          cmake --preset ${{ inputs.build_preset }} -B Build \
             -DINCLUDE_WASM_SPEC_TESTS=ON \
             -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \
             ${{ steps.build-parameters.outputs.cmake_options }} \
@@ -121,7 +120,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }}
 
       - name: Create Build Environment
-        if: ${{ inputs.fuzzer == 'FUZZ' }}
+        if: ${{ inputs.build_preset == 'Fuzzers_CI' }}
         working-directory: ${{ github.workspace }}
         run: |
           set -e
@@ -137,7 +136,7 @@ jobs:
 
           ninja -C ${{ github.workspace }}/Build/tools-build install
 
-          cmake --preset Fuzzers_CI -B Build \
+          cmake --preset ${{ inputs.build_preset }} -B Build \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \
             -DCMAKE_CXX_COMPILER=${{ steps.build-parameters.outputs.host_cxx }} \
@@ -153,23 +152,23 @@ jobs:
           cmake --install . --strip --prefix ${{ github.workspace }}/Install
 
       - name: Enable the Ladybird Qt chrome
-        if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}
         run: cmake -B Build -DENABLE_QT=ON
 
       - name: Build the Ladybird Qt chrome
-        if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}/Build
         run: cmake --build .
 
       - name: Enable the AppKit chrome with Swift files
-        if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}
         # FIXME: Don't force release build after https://github.com/LadybirdBrowser/ladybird/issues/1101 is fixed
         run: cmake -B Build -DENABLE_QT=OFF -DENABLE_SWIFT=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 
       - name: Build the AppKit chrome with Swift files
-        if: ${{ inputs.os_name == 'macOS' && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.os_name == 'macOS' && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}/Build
         run: cmake --build .
 
@@ -183,7 +182,7 @@ jobs:
       # === TEST ===
 
       - name: Test
-        if: ${{ inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}
         run: ctest --preset Sanitizer --output-on-failure --test-dir Build --timeout 1800
         env:
@@ -192,17 +191,24 @@ jobs:
           ASAN_OPTIONS: 'log_path=${{ github.workspace }}/asan.log'
           UBSAN_OPTIONS: 'log_path=${{ github.workspace }}/ubsan.log'
 
+      - name: Test
+        if: ${{ inputs.build_preset != 'Fuzzers_CI' && inputs.build_preset != 'Sanitizer_CI' }}
+        working-directory: ${{ github.workspace }}
+        run: ctest --output-on-failure --test-dir Build --timeout 1800
+        env:
+          TESTS_ONLY: 1
+
       - name: Upload LibWeb Test Artifacts
-        if: ${{ always() && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ always() && inputs.build_preset != 'Fuzzers_CI' }}
         uses: actions/upload-artifact@v4
         with:
-          name: libweb-test-artifacts-${{ inputs.os_name }}-${{inputs.fuzzer}}-${{inputs.toolchain}}-${{inputs.clang-plugins}}
+          name: libweb-test-artifacts-${{ inputs.os_name }}-${{inputs.build_preset}}-${{inputs.toolchain}}-${{inputs.clang-plugins}}
           path: ${{ github.workspace }}/Build/UI/Headless/test-dumps
           retention-days: 0
           if-no-files-found: ignore
 
       - name: Sanitizer Output
-        if: ${{ !cancelled() && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ !cancelled() && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}
         run: |
           log_output=$(find . -maxdepth 1 \( -name 'asan.log.*' -o -name 'ubsan.log.*' \) -exec cat {} \; )
@@ -214,7 +220,7 @@ jobs:
           fi
 
       - name: Lints
-        if: ${{ inputs.os_name == 'Linux' && inputs.fuzzer == 'NO_FUZZ' }}
+        if: ${{ inputs.os_name == 'Linux' && inputs.build_preset == 'Sanitizer_CI' }}
         working-directory: ${{ github.workspace }}
         run: |
           set -e

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -12,6 +12,9 @@ on:
         os:
           required: true
           type: string
+        arch:
+          required: true
+          type: string
         fuzzer:
           required: false
           type: string
@@ -55,7 +58,7 @@ jobs:
         uses: ./.github/actions/setup
         with:
           os: ${{ inputs.os_name }}
-          arch: 'Lagom'
+          arch: ${{ inputs.arch }}
 
       # === PREPARE FOR BUILDING ===
 
@@ -88,7 +91,7 @@ jobs:
         id: 'cache-restore'
         with:
           os: ${{ inputs.os_name }}
-          arch: 'Lagom'
+          arch: ${{ inputs.arch }}
           toolchain: ${{ inputs.toolchain }}
           cache_key_extra: ${{ steps.build-parameters.outputs.ccache_key }}
           ccache_path: ${{ env.CCACHE_DIR }}
@@ -173,7 +176,7 @@ jobs:
       - name: Save Caches
         uses: ./.github/actions/cache-save
         with:
-          arch: 'Lagom'
+          arch: ${{ inputs.arch }}
           ccache_path: ${{ env.CCACHE_DIR }}
           ccache_primary_key: ${{ steps.cache-restore.outputs.ccache_primary_key }}
 

--- a/.github/workflows/lagom-template.yml
+++ b/.github/workflows/lagom-template.yml
@@ -82,7 +82,14 @@ jobs:
             echo "cmake_options=-DENABLE_CLANG_PLUGINS=ON" >> "$GITHUB_OUTPUT"
           else
             echo "ccache_key=${{ inputs.build_preset }}" >> "$GITHUB_OUTPUT"
-            echo "cmake_options=" >> "$GITHUB_OUTPUT"
+            if ${{ inputs.os_name == 'Linux' && inputs.arch == 'arm64' }} ; then
+                # FIXME: https://github.com/WebAssembly/wabt/issues/2533
+                #        wabt doesn't have binary releases for arm64 Linux
+                PKGCONFIG=$(which pkg-config)
+                echo "cmake_options=-DPKG_CONFIG_EXECUTABLE=$PKGCONFIG" >> "$GITHUB_OUTPUT"
+            else
+              echo "cmake_options=-DINCLUDE_WASM_SPEC_TESTS=ON -DWASM_SPEC_TEST_SKIP_FORMATTING=ON" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
       - name: Restore Caches
@@ -112,8 +119,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: |
           cmake --preset ${{ inputs.build_preset }} -B Build \
-            -DINCLUDE_WASM_SPEC_TESTS=ON \
-            -DWASM_SPEC_TEST_SKIP_FORMATTING=ON \
             ${{ steps.build-parameters.outputs.cmake_options }} \
             -DPython3_EXECUTABLE=${{ env.pythonLocation }}/bin/python \
             -DCMAKE_C_COMPILER=${{ steps.build-parameters.outputs.host_cc }} \

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -1,0 +1,34 @@
+name: Nightly Lagom
+
+on:
+  # Automatically run at the end of every day.
+  schedule:
+    - cron: '0 0 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # CI matrix - runs the job in lagom-template.yml with different configurations.
+  Lagom:
+    if: github.repository == 'LadybirdBrowser/ladybird'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os_name: ['Linux']
+        os: [ubuntu-24.04-arm]
+        arch: ['arm64']
+        build_preset: ['Sanitizer_CI']
+        toolchain: ['Clang']
+        clang_plugins: [false]
+
+    uses: ./.github/workflows/lagom-template.yml
+    with:
+      toolchain: ${{ matrix.toolchain }}
+      os_name: ${{ matrix.os_name }}
+      os: ${{ matrix.os }}
+      arch: ${{ matrix.arch }}
+      build_preset: ${{ matrix.build_preset }}
+      clang_plugins: ${{ matrix.clang_plugins }}

--- a/.github/workflows/nightly-lagom.yml
+++ b/.github/workflows/nightly-lagom.yml
@@ -24,6 +24,28 @@ jobs:
         toolchain: ['Clang']
         clang_plugins: [false]
 
+        include:
+          - os_name: 'Linux'
+            os: ubuntu-24.04
+            arch: 'x86_64'
+            build_preset: 'Distribution_CI'
+            toolchain: 'GNU'
+            clang_plugins: false
+
+          - os_name: 'macOS'
+            os: macos-15
+            arch: 'arm64'
+            build_preset: 'Distribution_CI'
+            toolchain: 'Clang'
+            clang_plugins: false
+
+          - os_name: 'Linux'
+            os: ubuntu-24.04-arm
+            arch: 'arm64'
+            build_preset: 'Distribution_CI'
+            toolchain: 'Clang'
+            clang_plugins: false
+
     uses: ./.github/workflows/lagom-template.yml
     with:
       toolchain: ${{ matrix.toolchain }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -212,6 +212,24 @@
       ]
     },
     {
+      "name": "Distribution",
+      "configurePreset": "Distribution",
+      "displayName": "Build",
+      "description": "Build the project for distribution",
+      "targets": [
+        "all"
+      ]
+    },
+    {
+      "name": "Debug",
+      "configurePreset": "Debug",
+      "displayName": "Build",
+      "description": "Build the project in debug",
+      "targets": [
+          "all"
+      ]
+    },
+    {
       "name": "Sanitizer",
       "configurePreset": "Sanitizer",
       "displayName": "Build with Sanitizers",
@@ -249,6 +267,11 @@
       "name": "Debug",
       "inherits": "default",
       "configurePreset": "Debug"
+    },
+    {
+      "name": "Distribution",
+      "inherits": "default",
+      "configurePreset": "Distribution"
     }
   ]
 }

--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -6,7 +6,6 @@ endif()
 
 set(SOURCES
     Audio/Loader.cpp
-    Audio/PlaybackStream.cpp
     Audio/SampleFormats.cpp
     Color/ColorConverter.cpp
     Color/ColorPrimaries.cpp
@@ -47,4 +46,6 @@ elseif (LADYBIRD_AUDIO_BACKEND STREQUAL "OBOE")
     target_link_libraries(LibMedia PRIVATE log oboe::oboe)
 elseif (DEFINED LADYBIRD_AUDIO_BACKEND)
     message(FATAL_ERROR "Please update ${CMAKE_CURRENT_LIST_FILE} for audio backend ${LADYBIRD_AUDIO_BACKEND}")
+else ()
+    target_sources(LibMedia PRIVATE Audio/PlaybackStream.cpp)
 endif()

--- a/Meta/shell_include.sh
+++ b/Meta/shell_include.sh
@@ -75,6 +75,9 @@ get_build_dir() {
         "Sanitizer")
             BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/sanitizers"
             ;;
+        "Distribution")
+            BUILD_DIR="${LADYBIRD_SOURCE_DIR}/Build/distribution"
+            ;;
         *)
             echo "Unknown BUILD_PRESET: '$1'" >&2
             exit 1


### PR DESCRIPTION
Refactor the Lagom CI template a bit:
- Actually use the arch parameter again
- Pass build_preset from top level matrix instead of FUZZ/NO_FUZZ

Add a nightly job using the newly widely available ubuntu-24.04-arm runners (https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/)
- Disable wasm spec tests on this job, because wabt doesn't have an arm64 release
- Manually pass PKG_CONFIG_EXECUTABLE, otherwise we don't detect system libpulse-dev binaries.
- Set VCPKG_FORCE_SYSTEM_BINARIES=1 as explained in vcpkg docs, and so the vcpkg binary doesn't yell at us

Add 3 nightly jobs for Distribution_CI preset: macOS, x86_64 linux, arm64 linux.

Draft until the new jobs pass on my fork. Expected-to-pass run :tm: : https://github.com/ADKaster/ladybird-browser/actions/runs/13394961544