### PR TITLE
LibJS: A small `import` goodie bag

### DIFF
--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -51,9 +51,26 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>& verify_cast(InputType& input)
     return static_cast<CopyConst<InputType, OutputType>&>(input);
 }
 
+template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>* as_if(InputType& input)
+{
+    if (!is<OutputType>(input))
+        return nullptr;
+    return static_cast<CopyConst<InputType, OutputType>*>(&input);
+}
+
+template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>* as_if(InputType* input)
+{
+    if (!input)
+        return nullptr;
+    return as_if<OutputType>(*input);
+}
+
 }
 
 #if USING_AK_GLOBALLY
+using AK::as_if;
 using AK::is;
 using AK::verify_cast;
 #endif

--- a/Libraries/LibJS/CyclicModule.h
+++ b/Libraries/LibJS/CyclicModule.h
@@ -36,7 +36,9 @@ public:
     virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override final;
 
     virtual PromiseCapability& load_requested_modules(GC::Ptr<GraphLoadingState::HostDefined>) override;
-    virtual void inner_module_loading(GraphLoadingState& state);
+
+    ModuleStatus status() const { return m_status; }
+    void set_status(ModuleStatus status) { m_status = status; }
 
     Vector<ModuleRequest> const& requested_modules() const { return m_requested_modules; }
     Vector<ModuleWithSpecifier> const& loaded_modules() const { return m_loaded_modules; }
@@ -74,6 +76,7 @@ protected:
     Optional<u32> m_pending_async_dependencies;           // [[PendingAsyncDependencies]]
 };
 
+void inner_module_loading(VM&, GraphLoadingState& state, GC::Ref<Module>);
 void continue_module_loading(GraphLoadingState&, ThrowCompletionOr<GC::Ref<Module>> const&);
 void continue_dynamic_import(GC::Ref<PromiseCapability>, ThrowCompletionOr<GC::Ref<Module>> const& module_completion);
 

--- a/Libraries/LibJS/Module.cpp
+++ b/Libraries/LibJS/Module.cpp
@@ -106,11 +106,12 @@ void finish_loading_imported_module(ImportedModuleReferrer referrer, ModuleReque
         }
     }
 
+    // 2. If payload is a GraphLoadingState Record, then
     if (payload.has<GC::Ref<GraphLoadingState>>()) {
         // a. Perform ContinueModuleLoading(payload, result)
         continue_module_loading(payload.get<GC::Ref<GraphLoadingState>>(), result);
     }
-    // Else,
+    // 3. Else,
     else {
         // a. Perform ContinueDynamicImport(payload, result).
         continue_dynamic_import(payload.get<GC::Ref<PromiseCapability>>(), result);

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -4544,13 +4544,6 @@ void Parser::check_identifier_name_for_assignment_validity(DeprecatedFlyString c
     }
 }
 
-bool Parser::match_with_clause() const
-{
-    if (m_state.current_token.original_value() == "with"sv)
-        return true;
-    return !m_state.current_token.trivia_contains_line_terminator() && m_state.current_token.original_value() == "assert"sv;
-}
-
 DeprecatedFlyString Parser::consume_string_value()
 {
     VERIFY(match(TokenType::StringLiteral));
@@ -4585,11 +4578,10 @@ ModuleRequest Parser::parse_module_request()
 
     ModuleRequest request { consume_string_value() };
 
-    if (!match_with_clause())
+    if (!match(TokenType::With))
         return request;
 
-    VERIFY(m_state.current_token.original_value().is_one_of("with"sv, "assert"sv));
-    consume();
+    consume(TokenType::With);
     consume(TokenType::CurlyOpen);
 
     while (!done() && !match(TokenType::CurlyClose)) {

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -4589,7 +4589,7 @@ ModuleRequest Parser::parse_module_request()
         return request;
 
     VERIFY(m_state.current_token.original_value().is_one_of("with"sv, "assert"sv));
-    consume(TokenType::Identifier);
+    consume();
     consume(TokenType::CurlyOpen);
 
     while (!done() && !match(TokenType::CurlyClose)) {

--- a/Libraries/LibJS/Parser.cpp
+++ b/Libraries/LibJS/Parser.cpp
@@ -4631,10 +4631,10 @@ static DeprecatedFlyString default_string_value = "default";
 NonnullRefPtr<ImportStatement const> Parser::parse_import_statement(Program& program)
 {
     // We use the extended syntax which adds:
-    //  ImportDeclaration:
-    //      import ImportClause FromClause [no LineTerminator here] WithClause;
-    //      import ModuleSpecifier [no LineTerminator here] WithClause;
-    // From:  https://tc39.es/proposal-import-attributes/#prod-ImportDeclaration
+    //     ImportDeclaration:
+    //         import ImportClause FromClause WithClause[opt] ;
+    //         import ModuleSpecifier WithClause[opt] ;
+    // From: https://tc39.es/proposal-import-attributes/#prod-ImportDeclaration
 
     auto rule_start = push_start();
     if (program.type() != Program::Type::Module)

--- a/Libraries/LibJS/Parser.h
+++ b/Libraries/LibJS/Parser.h
@@ -225,7 +225,6 @@ private:
     bool match_secondary_expression(ForbiddenTokens forbidden = {}) const;
     bool match_statement() const;
     bool match_export_or_import() const;
-    bool match_with_clause() const;
 
     enum class AllowUsingDeclaration {
         No,

--- a/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -1699,11 +1699,11 @@ static bool all_import_attributes_supported(VM& vm, Vector<ImportAttribute> cons
     return true;
 }
 
+// 13.3.10.2 EvaluateImportCall ( specifierExpression [ , optionsExpression ] ), https://tc39.es/proposal-import-attributes/#sec-evaluate-import-call
 ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value options_value)
 {
     auto& realm = *vm.current_realm();
 
-    // 13.3.10.2 EvaluateImportCall ( specifierExpression [ , optionsExpression ] ), https://tc39.es/proposal-import-attributes/#sec-evaluate-import-call
     // 1. Let referrer be GetActiveScriptOrModule().
     auto referrer = [&]() -> ImportedModuleReferrer {
         auto active_script_or_module = vm.get_active_script_or_module();
@@ -1744,17 +1744,9 @@ ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value opti
         // c. IfAbruptRejectPromise(attributesObj, promiseCapability).
         auto attributes_obj = TRY_OR_REJECT_WITH_VALUE(vm, promise_capability, options_value.get(vm, vm.names.with));
 
-        // d. Normative Optional, Deprecated
-        // 11. If the host supports the deprecated assert keyword for import attributes and attributesObj is undefined, then
-        if (attributes_obj.is_undefined()) {
-            // i. Set attributesObj to Completion(Get(options, "assert")).
-            // ii. IfAbruptRejectPromise(attributesObj, promiseCapability).
-            attributes_obj = TRY_OR_REJECT_WITH_VALUE(vm, promise_capability, options_value.get(vm, vm.names.assert));
-        }
-
-        // e. If attributesObj is not undefined,
+        // d. If attributesObj is not undefined, then
         if (!attributes_obj.is_undefined()) {
-            // i. If Type(attributesObj) is not Object,
+            // i. If Type(attributesObj) is not Object, then
             if (!attributes_obj.is_object()) {
                 auto error = TypeError::create(realm, TRY_OR_THROW_OOM(vm, String::formatted(ErrorType::NotAnObject.message(), "ImportOptionsAssertions")));
                 // 1. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
@@ -1791,7 +1783,7 @@ ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value opti
             }
         }
 
-        // f. If AllImportAttributesSupported(attributes) is false, then
+        // e. If AllImportAttributesSupported(attributes) is false, then
         if (!all_import_attributes_supported(vm, attributes)) {
             auto error = TypeError::create(realm, TRY_OR_THROW_OOM(vm, String::formatted(ErrorType::NotAnObject.message(), "ImportOptionsAssertions")));
             // i. Perform ! Call(promiseCapability.[[Reject]], undefined, « a newly created TypeError object »).
@@ -1801,7 +1793,7 @@ ThrowCompletionOr<Value> perform_import_call(VM& vm, Value specifier, Value opti
             return Value { promise_capability->promise() };
         }
 
-        // g. Sort attributes according to the lexicographic order of their [[Key]] fields,
+        // f. Sort attributes according to the lexicographic order of their [[Key]] fields,
         //    treating the value of each such field as a sequence of UTF-16 code unit values.
         //    NOTE: This sorting is observable only in that hosts are prohibited from
         //    distinguishing among attributes by the order they occur in.

--- a/Libraries/LibJS/Tests/modules/basic-modules.js
+++ b/Libraries/LibJS/Tests/modules/basic-modules.js
@@ -179,8 +179,8 @@ describe("in- and exports", () => {
         );
     });
 
-    test("can import with (useless) assertions", () => {
-        expectModulePassed("./import-with-assertions.mjs");
+    test("can import with (useless) attributes", () => {
+        expectModulePassed("./import-with-attributes.mjs");
     });
 
     test("namespace has expected ordering", () => {

--- a/Libraries/LibJS/Tests/modules/basic-modules.js
+++ b/Libraries/LibJS/Tests/modules/basic-modules.js
@@ -219,6 +219,10 @@ describe("in- and exports", () => {
         expect(result.default).toBeInstanceOf(RegExp);
         expect(result.default.toString()).toBe(/foo/.toString());
     });
+
+    test("importing a non-existent file results in a SyntaxError", () => {
+        expectedModuleToThrowSyntaxError("./i-do-no-exist.mjs", "Cannot find/open module");
+    });
 });
 
 describe("loops", () => {

--- a/Libraries/LibJS/Tests/modules/import-with-assertions.mjs
+++ b/Libraries/LibJS/Tests/modules/import-with-assertions.mjs
@@ -1,4 +1,0 @@
-import * as self from "./import-with-assertions.mjs" assert { key: "value", key2: "value2", default: "shouldwork" };
-import "./import-with-assertions.mjs" assert { key: "value", key2: "value2", default: "shouldwork" };
-
-export { passed } from "./module-with-default.mjs" assert { key: "value", key2: "value2", default: "shouldwork" };

--- a/Libraries/LibJS/Tests/modules/import-with-attributes.mjs
+++ b/Libraries/LibJS/Tests/modules/import-with-attributes.mjs
@@ -1,0 +1,4 @@
+import * as self from "./import-with-attributes.mjs" with { key: "value", key2: "value2", default: "shouldwork" };
+import "./import-with-attributes.mjs" with { key: "value", key2: "value2", default: "shouldwork" };
+
+export { passed } from "./module-with-default.mjs" with { key: "value", key2: "value2", default: "shouldwork" };

--- a/Libraries/LibJS/Tests/modules/json-module.mjs
+++ b/Libraries/LibJS/Tests/modules/json-module.mjs
@@ -1,0 +1,2 @@
+import json from "./json-module.json" with { type: "json" };
+export default json;

--- a/Libraries/LibJS/Tests/modules/json-modules.js
+++ b/Libraries/LibJS/Tests/modules/json-modules.js
@@ -4,7 +4,7 @@ describe("basic behavior", () => {
         let error = null;
         let result = null;
 
-        import("./json-module.json", { assert: { type: "json" } })
+        import("./json-module.json", { with: { type: "json" } })
             .then(jsonObj => {
                 passed = true;
                 result = jsonObj;

--- a/Libraries/LibJS/Tests/modules/json-modules.js
+++ b/Libraries/LibJS/Tests/modules/json-modules.js
@@ -1,10 +1,43 @@
 describe("basic behavior", () => {
-    test("can import json modules", () => {
+    test("can import json modules (with import function)", () => {
         let passed = false;
         let error = null;
         let result = null;
 
         import("./json-module.json", { assert: { type: "json" } })
+            .then(jsonObj => {
+                passed = true;
+                result = jsonObj;
+            })
+            .catch(err => {
+                error = err;
+            });
+
+        runQueuedPromiseJobs();
+
+        if (error) throw error;
+
+        console.log(JSON.stringify(result));
+        expect(passed).toBeTrue();
+
+        expect(result).not.toBeNull();
+        expect(result).not.toBeUndefined();
+
+        const jsonResult = result.default;
+        expect(jsonResult).not.toBeNull();
+        expect(jsonResult).not.toBeUndefined();
+
+        expect(jsonResult).toHaveProperty("value", "value");
+        expect(jsonResult).toHaveProperty("array", [1, 2, 3]);
+        expect(jsonResult).toHaveProperty("map", { innerValue: "innerValue" });
+    });
+
+    test("can import json modules (with import statement)", () => {
+        let passed = false;
+        let error = null;
+        let result = null;
+
+        import("./json-module.mjs")
             .then(jsonObj => {
                 passed = true;
                 result = jsonObj;


### PR DESCRIPTION
A few fixes for import assertions and JSON modules.

test262 diff:
```
+17 ✅    -6 ❌    -11 💥

test/language/import/import-attributes/json-extensibility-array.js                    ❌ -> ✅
test/language/import/import-attributes/json-extensibility-object.js                   ❌ -> ✅
test/language/import/import-attributes/json-value-array.js                            ❌ -> ✅
test/language/import/import-attributes/json-value-boolean.js                          ❌ -> ✅
test/language/import/import-attributes/json-value-null.js                             ❌ -> ✅
test/language/import/import-attributes/json-value-number.js                           ❌ -> ✅
test/language/import/import-attributes/json-value-object.js                           ❌ -> ✅
test/language/import/import-attributes/json-value-string.js                           ❌ -> ✅
test/language/import/import-attributes/json-via-namespace.js                          ❌ -> ✅
test/language/import/import-defer/errors/get-other-while-dep-evaluating-async/main.js 💥 -> ❌
test/language/import/import-defer/errors/get-other-while-dep-evaluating/main.js       💥 -> ❌
test/language/import/import-defer/errors/get-other-while-evaluating-async/main.js     💥 -> ❌
test/language/import/import-defer/errors/get-other-while-evaluating/main.js           💥 -> ❌
test/language/module-code/import-attributes/import-attribute-empty.js                 ❌ -> ✅
test/language/module-code/instn-resolve-empty-export.js                               💥 -> ✅
test/language/module-code/instn-resolve-empty-import.js                               💥 -> ✅
test/language/module-code/instn-resolve-err-syntax-1.js                               💥 -> ✅
test/language/module-code/instn-resolve-err-syntax-2.js                               💥 -> ✅
test/language/module-code/instn-resolve-order-depth.js                                💥 -> ✅
test/language/module-code/instn-resolve-order-src.js                                  💥 -> ✅
test/language/module-code/source-phase-import/import-source-binding-name.js           💥 -> ✅
```