### PR TITLE
LibWeb: Require existing Selection for `.execCommand("selectAll")`

### DIFF
--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -112,17 +112,17 @@ bool Document::query_command_enabled(FlyString const& command)
     if (command.is_one_of(
             Editing::CommandNames::defaultParagraphSeparator,
             Editing::CommandNames::redo,
-            Editing::CommandNames::selectAll,
             Editing::CommandNames::styleWithCSS,
             Editing::CommandNames::undo,
             Editing::CommandNames::useCSS))
         return true;
 
+    // AD-HOC: selectAll requires a selection object to exist.
+    if (command == Editing::CommandNames::selectAll)
+        return get_selection();
+
     // The other commands defined here are enabled if the active range is not null,
-    auto selection = get_selection();
-    if (!selection)
-        return false;
-    auto active_range = selection->range();
+    auto active_range = Editing::active_range(*this);
     if (!active_range)
         return false;
 

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-selectAll.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-selectAll.txt
@@ -1,3 +1,7 @@
 No range.
 DIV 0 - DIV 0
 BODY 0 - BODY 5
+true
+false
+false
+Did not crash!

--- a/Tests/LibWeb/Text/input/Editing/execCommand-selectAll.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-selectAll.html
@@ -33,5 +33,17 @@
         // Perform selectAll
         document.execCommand('selectAll');
         reportSelection();
+
+        // Report whether command is enabled and make sure it does not crash
+        const documents = [
+            document,
+            new Document(),
+            document.implementation.createHTMLDocument(),
+        ];
+        for (const doc of documents) {
+            println(doc.queryCommandEnabled('selectAll'));
+            doc.execCommand('selectAll');
+        }
+        println('Did not crash!');
     });
 </script>


### PR DESCRIPTION
Disable the command if no selection is available. This is a spec bug:

https://github.com/w3c/editing/issues/475

Fixes #3325