### PR TITLE
LibWeb: Make SVGSVGElement.getElementById() return Element? (nullable)

### DIFF
--- a/Libraries/LibWeb/SVG/SVGSVGElement.idl
+++ b/Libraries/LibWeb/SVG/SVGSVGElement.idl
@@ -29,7 +29,8 @@ interface SVGSVGElement : SVGGraphicsElement {
     SVGTransform createSVGTransform();
     [FIXME] SVGTransform createSVGTransformFromMatrix(optional DOMMatrix2DInit matrix = {});
 
-    Element getElementById(DOMString elementId);
+    // NOTE: The spec says this returns `Element` but that's a bug: https://github.com/w3c/svgwg/issues/923
+    Element? getElementById(DOMString elementId);
 
     // Deprecated methods that have no effect when called,
     // but which are kept for compatibility reasons.

--- a/Tests/LibWeb/Text/expected/SVG/svg-svg-getElementById.txt
+++ b/Tests/LibWeb/Text/expected/SVG/svg-svg-getElementById.txt
@@ -1,0 +1,1 @@
+PASS: true

--- a/Tests/LibWeb/Text/input/SVG/svg-svg-getElementById.html
+++ b/Tests/LibWeb/Text/input/SVG/svg-svg-getElementById.html
@@ -1,0 +1,8 @@
+<script src="../include.js"></script>
+<svg id="svgRoot"></svg>
+<script>
+    test(() => {
+        const x = svgRoot.getElementById("x");
+        println(`PASS: ${x === null}`);
+    });
+</script>


### PR DESCRIPTION
This is wrong in the spec, and there's already a bug open.