### PR TITLE
LibWeb: Cache the margin box rect for floating boxes

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -99,6 +99,8 @@ private:
 
         // Bottom margin edge of `box`.
         CSSPixels bottom_margin_edge { 0 };
+
+        CSSPixelRect margin_box_rect_in_root_coordinate_space;
     };
 
     struct FloatSideData {


### PR DESCRIPTION
Fixes #3318 (or at least helps a lot)

Here's a performance comparison measured using
`hyperfine "Build/release/bin/headless-browser --dump-layout-tree /tmp/test.html"` with the example in #3318.
![Mean time to compute layout](https://github.com/user-attachments/assets/486ba6ca-a0f6-4ea1-8dcb-7fa4816314d3)

I'm not 100% confident about when (and how) the cached value is invalidated, the invalidation in `place_block_level_element_in_normal_flow_vertically` was done to fix the only regression I could find after running every single WPT test containing the string `float:`.