### PR TITLE
LibWeb: Disallow Editing API calls on non-HTML documents

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -581,12 +581,12 @@ public:
     void set_previous_document_unload_timing(DocumentUnloadTimingInfo const& previous_document_unload_timing) { m_previous_document_unload_timing = previous_document_unload_timing; }
 
     // https://w3c.github.io/editing/docs/execCommand/
-    bool exec_command(FlyString const& command, bool show_ui, String const& value);
-    bool query_command_enabled(FlyString const& command);
-    bool query_command_indeterm(FlyString const& command);
-    bool query_command_state(FlyString const& command);
-    bool query_command_supported(FlyString const& command);
-    String query_command_value(FlyString const& command);
+    WebIDL::ExceptionOr<bool> exec_command(FlyString const& command, bool show_ui, String const& value);
+    WebIDL::ExceptionOr<bool> query_command_enabled(FlyString const& command);
+    WebIDL::ExceptionOr<bool> query_command_indeterm(FlyString const& command);
+    WebIDL::ExceptionOr<bool> query_command_state(FlyString const& command);
+    WebIDL::ExceptionOr<bool> query_command_supported(FlyString const& command);
+    WebIDL::ExceptionOr<String> query_command_value(FlyString const& command);
 
     // https://w3c.github.io/selection-api/#dfn-has-scheduled-selectionchange-event
     bool has_scheduled_selectionchange_event() const { return m_has_scheduled_selectionchange_event; }

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -52,7 +52,7 @@ bool command_back_color_action(DOM::Document& document, String const& value)
 bool command_bold_action(DOM::Document& document, String const&)
 {
     // If queryCommandState("bold") returns true, set the selection's value to "normal".
-    if (document.query_command_state(CommandNames::bold)) {
+    if (MUST(document.query_command_state(CommandNames::bold))) {
         set_the_selections_value(document, CommandNames::bold, "normal"_string);
     }
 
@@ -1867,7 +1867,7 @@ bool command_insert_unordered_list_state(DOM::Document const& document)
 bool command_italic_action(DOM::Document& document, String const&)
 {
     // If queryCommandState("italic") returns true, set the selection's value to "normal".
-    if (document.query_command_state(CommandNames::italic)) {
+    if (MUST(document.query_command_state(CommandNames::italic))) {
         set_the_selections_value(document, CommandNames::italic, "normal"_string);
     }
 
@@ -2259,7 +2259,7 @@ bool command_select_all_action(DOM::Document& document, String const&)
 bool command_strikethrough_action(DOM::Document& document, String const&)
 {
     // If queryCommandState("strikethrough") returns true, set the selection's value to null.
-    if (document.query_command_state(CommandNames::strikethrough)) {
+    if (MUST(document.query_command_state(CommandNames::strikethrough))) {
         set_the_selections_value(document, CommandNames::strikethrough, {});
     }
 
@@ -2294,7 +2294,7 @@ bool command_style_with_css_state(DOM::Document const& document)
 bool command_subscript_action(DOM::Document& document, String const&)
 {
     // 1. Call queryCommandState("subscript"), and let state be the result.
-    auto state = document.query_command_state(CommandNames::subscript);
+    auto state = MUST(document.query_command_state(CommandNames::subscript));
 
     // 2. Set the selection's value to null.
     set_the_selections_value(document, CommandNames::subscript, {});
@@ -2347,7 +2347,7 @@ bool command_subscript_indeterminate(DOM::Document const& document)
 bool command_superscript_action(DOM::Document& document, String const&)
 {
     // 1. Call queryCommandState("superscript"), and let state be the result.
-    auto state = document.query_command_state(CommandNames::superscript);
+    auto state = MUST(document.query_command_state(CommandNames::superscript));
 
     // 2. Set the selection's value to null.
     set_the_selections_value(document, CommandNames::superscript, {});
@@ -2400,7 +2400,7 @@ bool command_superscript_indeterminate(DOM::Document const& document)
 bool command_underline_action(DOM::Document& document, String const&)
 {
     // If queryCommandState("underline") returns true, set the selection's value to null.
-    if (document.query_command_state(CommandNames::underline)) {
+    if (MUST(document.query_command_state(CommandNames::underline))) {
         set_the_selections_value(document, CommandNames::underline, {});
     }
 

--- a/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
+++ b/Libraries/LibWeb/Editing/Internal/Algorithms.cpp
@@ -3323,7 +3323,7 @@ Vector<RecordedOverride> record_current_states_and_values(DOM::Document const& d
     // 6. For each command in the list "fontName", "foreColor", "hiliteColor", in order: add (command, command's value)
     //    to overrides.
     for (auto const& command : { CommandNames::fontName, CommandNames::foreColor, CommandNames::hiliteColor })
-        overrides.empend(command, node->document().query_command_value(command));
+        overrides.empend(command, MUST(node->document().query_command_value(command)));
 
     // 7. Add ("fontSize", node's effective command value for "fontSize") to overrides.
     effective_value = effective_command_value(node, CommandNames::fontSize);
@@ -3506,7 +3506,7 @@ void restore_states_and_values(DOM::Document& document, Vector<RecordedOverride>
         for (auto override : overrides) {
             // 1. If override is a boolean, and queryCommandState(command) returns something different from override,
             //    take the action for command, with value equal to the empty string.
-            if (override.value.has<bool>() && document.query_command_state(override.command) != override.value.get<bool>()) {
+            if (override.value.has<bool>() && MUST(document.query_command_state(override.command)) != override.value.get<bool>()) {
                 take_the_action_for_command(document, override.command, {});
             }
 
@@ -3514,7 +3514,7 @@ void restore_states_and_values(DOM::Document& document, Vector<RecordedOverride>
             //    queryCommandValue(command) returns something not equivalent to override, take the action for command,
             //    with value equal to override.
             else if (override.value.has<String>() && !override.command.is_one_of(CommandNames::createLink, CommandNames::fontSize)
-                && document.query_command_value(override.command) != override.value.get<String>()) {
+                && MUST(document.query_command_value(override.command)) != override.value.get<String>()) {
                 take_the_action_for_command(document, override.command, override.value.get<String>());
             }
 
@@ -3761,7 +3761,7 @@ void set_the_selections_value(DOM::Document& document, FlyString const& command,
         }
 
         // 5. Otherwise, if command is "createLink" or it has a value specified, set the value override to new value.
-        else if (command == CommandNames::createLink || !document.query_command_value(CommandNames::createLink).is_empty()) {
+        else if (command == CommandNames::createLink || !MUST(document.query_command_value(CommandNames::createLink)).is_empty()) {
             document.set_command_value_override(command, new_value.value());
         }
 

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-selectAll.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-selectAll.txt
@@ -2,6 +2,6 @@ No range.
 DIV 0 - DIV 0
 BODY 0 - BODY 5
 true
-false
+queryCommandEnabled threw exception of type: InvalidStateError
 false
 Did not crash!

--- a/Tests/LibWeb/Text/expected/wpt-import/editing/other/non-html-document.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/editing/other/non-html-document.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	editing APIs on an XML document should be disabled

--- a/Tests/LibWeb/Text/input/Editing/execCommand-selectAll.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-selectAll.html
@@ -41,8 +41,12 @@
             document.implementation.createHTMLDocument(),
         ];
         for (const doc of documents) {
-            println(doc.queryCommandEnabled('selectAll'));
-            doc.execCommand('selectAll');
+            try {
+                println(doc.queryCommandEnabled('selectAll'));
+                doc.execCommand('selectAll');
+            } catch (e) {
+                println(`queryCommandEnabled threw exception of type: ${e.name}`);
+            }
         }
         println('Did not crash!');
     });

--- a/Tests/LibWeb/Text/input/wpt-import/editing/other/non-html-document.html
+++ b/Tests/LibWeb/Text/input/wpt-import/editing/other/non-html-document.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>Non-HTML document tests</title>
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<script>
+
+test(function() {
+  let xmldoc =
+    document.implementation.createDocument("http://www.w3.org/1999/xlink",
+                                           "html", null);
+  for (let f of [
+         () => xmldoc.execCommand("bold"),
+         () => xmldoc.queryCommandEnabled("bold"),
+         () => xmldoc.queryCommandIndeterm("bold"),
+         () => xmldoc.queryCommandState("bold"),
+         () => xmldoc.queryCommandSupported("bold"),
+         () => xmldoc.queryCommandValue("bold"),
+       ]) {
+    assert_throws_dom("InvalidStateError", f);
+  }
+}, "editing APIs on an XML document should be disabled");
+
+</script>


### PR DESCRIPTION
This is not directly mentioned in the Editing API spec, but all major browsers do this and there is a WPT for this behavior.

Relevant WPT commit: https://github.com/web-platform-tests/wpt/commit/853867249cae98f2f4b2d208d83bb2ee791a8ac6