### PR TITLE
LibWeb: Iterate over a copy of associated form controls in form.reset()

### DIFF
--- a/Libraries/LibGC/RootVector.h
+++ b/Libraries/LibGC/RootVector.h
@@ -46,6 +46,12 @@ public:
 
     virtual ~RootVector() = default;
 
+    RootVector(Heap& heap, ReadonlySpan<T> other)
+        : RootVectorBase(heap)
+        , Vector<T, inline_capacity>(other)
+    {
+    }
+
     RootVector(RootVector const& other)
         : RootVectorBase(*other.m_heap)
         , Vector<T, inline_capacity>(other)

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -317,7 +317,8 @@ void HTMLFormElement::reset_form()
 
     // 2. If reset is true, then invoke the reset algorithm of each resettable element whose form owner is form.
     if (reset) {
-        for (auto element : m_associated_elements) {
+        GC::RootVector<GC::Ref<HTMLElement>> associated_elements_copy(heap(), m_associated_elements);
+        for (auto element : associated_elements_copy) {
             VERIFY(is<FormAssociatedElement>(*element));
             auto& form_associated_element = dynamic_cast<FormAssociatedElement&>(*element);
             if (form_associated_element.is_resettable())

--- a/Tests/LibWeb/Crash/HTML/reset-form-iteration.html
+++ b/Tests/LibWeb/Crash/HTML/reset-form-iteration.html
@@ -1,0 +1,4 @@
+<form id="theForm"><output><input></output></form>
+<script>
+    theForm.reset();
+</script>


### PR DESCRIPTION
DOM structure may change during reset algorithm invocation, which may lead to form controls being unregistered.
