### PR TITLE
LibWeb: Use `as_if` in Editing API where useful

### DIFF
--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -146,8 +146,8 @@ bool Document::query_command_enabled(FlyString const& command)
 
     // NOTE: Commands can define additional conditions for being enabled, and currently the only condition mentioned in
     //       the spec is that certain commands must not be enabled if the editing host is in the plaintext-only state.
-    if (is<HTML::HTMLElement>(start_node_editing_host.ptr())
-        && static_cast<HTML::HTMLElement&>(*start_node_editing_host).content_editable_state() == HTML::ContentEditableState::PlaintextOnly
+    if (auto const* html_element = as_if<HTML::HTMLElement>(start_node_editing_host.ptr()); html_element
+        && html_element->content_editable_state() == HTML::ContentEditableState::PlaintextOnly
         && command.is_one_of(
             Editing::CommandNames::backColor,
             Editing::CommandNames::bold,


### PR DESCRIPTION
This arguably improves readability in a couple of places. No functional changes.