### PR TITLE
LibWeb: Add formatters for WebIDL exception types

### DIFF
--- a/Libraries/LibWeb/WebIDL/DOMException.h
+++ b/Libraries/LibWeb/WebIDL/DOMException.h
@@ -148,3 +148,15 @@ inline JS::Completion throw_completion(GC::Ref<WebIDL::DOMException> exception)
 }
 
 }
+
+namespace AK {
+
+template<>
+struct Formatter<Web::WebIDL::DOMException> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::WebIDL::DOMException const& exception)
+    {
+        return Formatter<FormatString>::format(builder, "[{}]: {}"sv, exception.name(), exception.message());
+    }
+};
+
+}


### PR DESCRIPTION
This adds formatters for `WebIDL::Exception`, `WebIDL::SimpleException` and `WebIDL::DOMException`. These are useful for displaying the content of errors when debugging.