### PR TITLE
LibJS+LibGC: Run FinalizationRegistry cleanup host hook *after* GC

### DIFF
--- a/Libraries/LibGC/Heap.h
+++ b/Libraries/LibGC/Heap.h
@@ -76,6 +76,8 @@ public:
 
     bool is_gc_deferred() const { return m_gc_deferrals > 0; }
 
+    void enqueue_post_gc_task(AK::Function<void()>);
+
 private:
     friend class MarkingVisitor;
     friend class GraphConstructorVisitor;
@@ -151,6 +153,8 @@ private:
     bool m_collecting_garbage { false };
     StackInfo m_stack_info;
     AK::Function<void(HashMap<Cell*, GC::HeapRoot>&)> m_gather_embedder_roots;
+
+    Vector<AK::Function<void()>> m_post_gc_tasks;
 } SWIFT_IMMORTAL_REFERENCE;
 
 inline void Heap::did_create_root(Badge<RootImpl>, RootImpl& impl)

--- a/Tests/LibWeb/Crash/JS/finalization-registry-basic.html
+++ b/Tests/LibWeb/Crash/JS/finalization-registry-basic.html
@@ -1,0 +1,19 @@
+<script src="../include.js"></script>
+<script>
+
+// NOTE: This test is only reliable when GC'ing after each allocation.
+
+const registry = new FinalizationRegistry((heldValue) => {
+    console.log(heldValue);
+});
+
+const makeGarbage = () => {
+    registry.register(new String("ok"), "hello");
+};
+makeGarbage();
+
+if (window.internals !== undefined)
+    internals.gc();
+
+println("PASS");
+</script>


### PR DESCRIPTION
Before this change, it was possible for a second GC to get triggered in the middle of a first GC, due to allocations happening in the FinalizationRegistry cleanup host hook. To avoid this causing problems, we add a "post-GC task" mechanism and use that to invoke the host hook once all other GC activity is finished, and we've unset the "collecting garbage" flag.

Note that the test included here only fails reliably when running with the -g flag (collect garbage after each allocation).

Fixes #3051