### PR TITLE
LibWeb: Make "assign slottables for a tree" fast when there are no slots

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1089,9 +1089,9 @@ void Element::inserted()
         document().element_with_name_was_added({}, *this);
 }
 
-void Element::removed_from(Node* node)
+void Element::removed_from(Node* old_parent, Node& old_root)
 {
-    Base::removed_from(node);
+    Base::removed_from(old_parent, old_root);
 
     if (m_id.has_value())
         document().element_with_id_was_removed({}, *this);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -403,7 +403,7 @@ protected:
     virtual void initialize(JS::Realm&) override;
 
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void children_changed() override;
     virtual i32 default_tab_index_value() const;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -261,7 +261,7 @@ public:
 
     virtual void inserted();
     virtual void post_connection();
-    virtual void removed_from(Node*);
+    virtual void removed_from(Node* old_parent, Node& old_root);
     virtual void children_changed() { }
     virtual void adopted_from(Document&) { }
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const { return {}; }

--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -64,6 +64,20 @@ public:
 
     virtual void finalize() override;
 
+    void increment_slot_count() { ++m_slot_count; }
+    void decrement_slot_count() { --m_slot_count; }
+    [[nodiscard]] size_t slot_count() const { return m_slot_count; }
+
+    template<typename Callback>
+    void for_each_slot(Callback callback)
+    {
+        if (m_slot_count == 0)
+            return;
+        for_each_in_subtree_of_type<HTML::HTMLSlotElement>([&](HTML::HTMLSlotElement& slot) {
+            return callback(slot);
+        });
+    }
+
 protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
@@ -92,6 +106,9 @@ private:
 
     GC::Ptr<CSS::StyleSheetList> m_style_sheets;
     mutable GC::Ptr<WebIDL::ObservableArray> m_adopted_style_sheets;
+
+    // AD-HOC: Number of HTMLSlotElement nodes that are descendants of this ShadowRoot.
+    size_t m_slot_count { 0 };
 };
 
 template<>

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -38,11 +38,11 @@ private:                                                                        
         form_associated_element_was_inserted();                                                                                                                             \
     }                                                                                                                                                                       \
                                                                                                                                                                             \
-    virtual void removed_from(DOM::Node* node) override                                                                                                                     \
+    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override                                                                                          \
     {                                                                                                                                                                       \
-        ElementBaseClass::removed_from(node);                                                                                                                               \
+        ElementBaseClass::removed_from(old_parent, old_root);                                                                                                               \
         form_node_was_removed();                                                                                                                                            \
-        form_associated_element_was_removed(node);                                                                                                                          \
+        form_associated_element_was_removed(old_parent);                                                                                                                    \
     }                                                                                                                                                                       \
                                                                                                                                                                             \
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override \

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -40,9 +40,9 @@ void HTMLBaseElement::inserted()
         set_the_frozen_base_url();
 }
 
-void HTMLBaseElement::removed_from(Node* parent)
+void HTMLBaseElement::removed_from(Node* old_parent, Node& old_root)
 {
-    HTMLElement::removed_from(parent);
+    HTMLElement::removed_from(old_parent, old_root);
     document().update_base_element({});
 }
 

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.h
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.h
@@ -23,7 +23,7 @@ public:
     URL::URL const& frozen_base_url() const { return m_frozen_base_url; }
 
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -45,6 +45,8 @@ void HTMLDetailsElement::initialize(JS::Realm& realm)
 // https://html.spec.whatwg.org/multipage/interactive-elements.html#the-details-element:html-element-insertion-steps
 void HTMLDetailsElement::inserted()
 {
+    Base::inserted();
+
     // 1. Ensure details exclusivity by closing the given element if needed given insertedNode.
     ensure_details_exclusivity_by_closing_the_given_element_if_needed();
 

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -52,8 +52,9 @@ void HTMLDetailsElement::inserted()
     update_shadow_tree_slots();
 }
 
-void HTMLDetailsElement::removed_from(DOM::Node*)
+void HTMLDetailsElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
+    Base::removed_from(old_parent, old_root);
     set_shadow_root(nullptr);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -32,7 +32,7 @@ private:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node*) override;
+    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
     virtual void children_changed() override;
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.cpp
@@ -41,9 +41,9 @@ void HTMLDialogElement::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_close_watcher);
 }
 
-void HTMLDialogElement::removed_from(Node* old_parent)
+void HTMLDialogElement::removed_from(Node* old_parent, Node& old_root)
 {
-    HTMLElement::removed_from(old_parent);
+    HTMLElement::removed_from(old_parent, old_root);
 
     // 1. If removedNode's close watcher is not null, then:
     if (m_close_watcher) {

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -20,7 +20,7 @@ class HTMLDialogElement final : public HTMLElement {
 public:
     virtual ~HTMLDialogElement() override;
 
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
 
     String return_value() const;
     void set_return_value(String);

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -1286,9 +1286,9 @@ void HTMLElement::did_lose_focus()
     document().editing_host_manager()->set_active_contenteditable_element(nullptr);
 }
 
-void HTMLElement::removed_from(Node* old_parent)
+void HTMLElement::removed_from(Node* old_parent, Node& old_root)
 {
-    Element::removed_from(old_parent);
+    Element::removed_from(old_parent, old_root);
 
     // If removedNode's popover attribute is not in the no popover state, then run the hide popover algorithm given removedNode, false, false, and false.
     if (popover().has_value())

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -116,7 +116,7 @@ public:
     WebIDL::ExceptionOr<void> set_popover(Optional<String> value);
     Optional<String> popover() const;
 
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
 
     enum class PopoverVisibilityState {
         Hidden,

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -56,9 +56,9 @@ void HTMLFrameElement::inserted()
 }
 
 // https://html.spec.whatwg.org/multipage/obsolete.html#frames:html-element-removing-steps
-void HTMLFrameElement::removed_from(DOM::Node* node)
+void HTMLFrameElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
-    Base::removed_from(node);
+    Base::removed_from(old_parent, old_root);
 
     // The frame HTML element removing steps, given removedNode, are to destroy a child navigable given removedNode.
     destroy_the_child_navigable();

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.h
@@ -25,7 +25,7 @@ private:
 
     // ^DOM::Element
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -173,9 +173,9 @@ void HTMLIFrameElement::process_the_iframe_attributes(bool initial_insertion)
 }
 
 // https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:the-iframe-element-7
-void HTMLIFrameElement::removed_from(DOM::Node* node)
+void HTMLIFrameElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
-    HTMLElement::removed_from(node);
+    HTMLElement::removed_from(old_parent, old_root);
 
     // When an iframe element is removed from a document, the user agent must destroy the nested navigable of the element.
     destroy_the_child_navigable();

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -45,7 +45,7 @@ private:
 
     // ^DOM::Element
     virtual void post_connection() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual i32 default_tab_index_value() const override;
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -50,9 +50,9 @@ void HTMLLinkElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLLinkElement);
 }
 
-void HTMLLinkElement::removed_from(Node* old_parent)
+void HTMLLinkElement::removed_from(Node* old_parent, Node& old_root)
 {
-    Base::removed_from(old_parent);
+    Base::removed_from(old_parent, old_root);
     if (m_loaded_style_sheet) {
         document_or_shadow_root_style_sheets().remove_a_css_style_sheet(*m_loaded_style_sheet);
         m_loaded_style_sheet = nullptr;

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -28,7 +28,7 @@ public:
     virtual ~HTMLLinkElement() override;
 
     virtual void inserted() override;
-    virtual void removed_from(Node* old_parent) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
 
     String rel() const { return get_attribute_value(HTML::AttributeNames::rel); }
     String type() const { return get_attribute_value(HTML::AttributeNames::type); }

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -112,9 +112,9 @@ void HTMLMediaElement::attribute_changed(FlyString const& name, Optional<String>
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#playing-the-media-resource:media-element-83
-void HTMLMediaElement::removed_from(DOM::Node* node)
+void HTMLMediaElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
-    Base::removed_from(node);
+    Base::removed_from(old_parent, old_root);
 
     // When a media element is removed from a Document, the user agent must run the following steps:
 

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -157,7 +157,7 @@ protected:
     virtual void visit_edges(Cell::Visitor&) override;
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
-    virtual void removed_from(DOM::Node*) override;
+    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
     virtual void children_changed() override;
 
     // Override in subclasses to handle implementation-specific behavior when the element state changes

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.cpp
@@ -151,9 +151,9 @@ void HTMLMetaElement::inserted()
     }
 }
 
-void HTMLMetaElement::removed_from(Node* parent)
+void HTMLMetaElement::removed_from(Node* old_parent, Node& old_root)
 {
-    Base::removed_from(parent);
+    Base::removed_from(old_parent, old_root);
     update_metadata();
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMetaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMetaElement.h
@@ -45,7 +45,7 @@ private:
 
     // ^DOM::Element
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -173,8 +173,9 @@ void HTMLMeterElement::inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLMeterElement::removed_from(DOM::Node*)
+void HTMLMeterElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
+    Base::removed_from(old_parent, old_root);
     set_shadow_root(nullptr);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -170,6 +170,7 @@ WebIDL::ExceptionOr<void> HTMLMeterElement::set_optimum(double value)
 
 void HTMLMeterElement::inserted()
 {
+    Base::inserted();
     create_shadow_tree_if_needed();
 }
 

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.h
@@ -35,7 +35,7 @@ public:
 
     // ^HTMLElement
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node*) override;
+    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
 
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptGroupElement.cpp
@@ -36,9 +36,9 @@ void HTMLOptGroupElement::inserted()
         static_cast<HTMLSelectElement&>(*parent()).update_selectedness();
 }
 
-void HTMLOptGroupElement::removed_from(Node* old_parent)
+void HTMLOptGroupElement::removed_from(Node* old_parent, Node& old_root)
 {
-    Base::removed_from(old_parent);
+    Base::removed_from(old_parent, old_root);
 
     // The optgroup HTML element removing steps, given removedNode and oldParent, are:
     // 1. If oldParent is a select element and removedNode has an option child, then run oldParent's selectedness setting algorithm.

--- a/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptGroupElement.h
@@ -25,7 +25,7 @@ private:
     HTMLOptGroupElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void inserted() override;
 };
 

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -232,9 +232,9 @@ void HTMLOptionElement::inserted()
         static_cast<HTMLSelectElement&>(*parent()->parent()).update_selectedness();
 }
 
-void HTMLOptionElement::removed_from(Node* old_parent)
+void HTMLOptionElement::removed_from(Node* old_parent, Node& old_root)
 {
-    Base::removed_from(old_parent);
+    Base::removed_from(old_parent, old_root);
 
     // The option HTML element removing steps, given removedNode and oldParent, are:
     // 1. If oldParent is a select element, or oldParent is an optgroup element whose parent is a select element,

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -51,7 +51,7 @@ private:
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
     virtual void children_changed() override;
 
     void ask_for_a_reset();

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -92,6 +92,7 @@ double HTMLProgressElement::position() const
 
 void HTMLProgressElement::inserted()
 {
+    Base::inserted();
     create_shadow_tree_if_needed();
 }
 

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.cpp
@@ -95,8 +95,9 @@ void HTMLProgressElement::inserted()
     create_shadow_tree_if_needed();
 }
 
-void HTMLProgressElement::removed_from(DOM::Node*)
+void HTMLProgressElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
+    Base::removed_from(old_parent, old_root);
     set_shadow_root(nullptr);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -29,7 +29,7 @@ public:
 
     // ^HTMLElement
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node*) override;
+    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
 
     virtual void adjust_computed_style(CSS::ComputedProperties&) override;
 

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.cpp
@@ -8,6 +8,7 @@
 #include <LibWeb/Bindings/HTMLSlotElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Element.h>
+#include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLSlotElement.h>
 
@@ -145,6 +146,23 @@ void HTMLSlotElement::attribute_changed(FlyString const& local_name, Optional<St
         // 6. Run assign slottables for a tree with element’s root.
         DOM::assign_slottables_for_a_tree(root());
     }
+}
+
+void HTMLSlotElement::inserted()
+{
+    Base::inserted();
+    auto& root = this->root();
+    if (!root.is_shadow_root())
+        return;
+    static_cast<DOM::ShadowRoot&>(root).increment_slot_count();
+}
+
+void HTMLSlotElement::removed_from(Node* old_parent, Node& old_root)
+{
+    Base::removed_from(old_parent, old_root);
+    if (!old_root.is_shadow_root())
+        return;
+    static_cast<DOM::ShadowRoot&>(old_root).decrement_slot_count();
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLSlotElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSlotElement.h
@@ -45,6 +45,9 @@ private:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
+    virtual void inserted() override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
+
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#manually-assigned-nodes

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.cpp
@@ -47,10 +47,10 @@ void HTMLSourceElement::inserted()
 }
 
 // https://html.spec.whatwg.org/multipage/embedded-content.html#the-source-element:the-source-element-16
-void HTMLSourceElement::removed_from(DOM::Node* old_parent)
+void HTMLSourceElement::removed_from(DOM::Node* old_parent, DOM::Node& old_root)
 {
     // The source HTML element removing steps, given removedNode and oldParent, are:
-    Base::removed_from(old_parent);
+    Base::removed_from(old_parent, old_root);
 
     // FIXME: 1. If removedNode's next sibling was an img element and oldParent is a picture element, then, count this as a
     //           relevant mutation for the img element.

--- a/Libraries/LibWeb/HTML/HTMLSourceElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSourceElement.h
@@ -23,7 +23,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     virtual void inserted() override;
-    virtual void removed_from(DOM::Node*) override;
+    virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -44,10 +44,10 @@ void HTMLStyleElement::inserted()
     Base::inserted();
 }
 
-void HTMLStyleElement::removed_from(Node* old_parent)
+void HTMLStyleElement::removed_from(Node* old_parent, Node& old_root)
 {
     m_style_element_utils.update_a_style_block(*this);
-    Base::removed_from(old_parent);
+    Base::removed_from(old_parent, old_root);
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -21,7 +21,7 @@ public:
 
     virtual void children_changed() override;
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
 
     bool disabled();
     void set_disabled(bool disabled);

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -128,9 +128,9 @@ void SVGElement::update_use_elements_that_reference_this()
     });
 }
 
-void SVGElement::removed_from(Node* parent)
+void SVGElement::removed_from(Node* old_parent, Node& old_root)
 {
-    Base::removed_from(parent);
+    Base::removed_from(old_parent, old_root);
 
     remove_from_use_element_that_reference_this();
 }

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -38,7 +38,7 @@ protected:
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
     virtual void children_changed() override;
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
 
     void update_use_elements_that_reference_this();
     void remove_from_use_element_that_reference_this();

--- a/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -42,10 +42,10 @@ void SVGStyleElement::inserted()
     Base::inserted();
 }
 
-void SVGStyleElement::removed_from(Node* old_parent)
+void SVGStyleElement::removed_from(Node* old_parent, Node& old_root)
 {
     m_style_element_utils.update_a_style_block(*this);
-    Base::removed_from(old_parent);
+    Base::removed_from(old_parent, old_root);
 }
 
 // https://www.w3.org/TR/cssom/#dom-linkstyle-sheet

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -20,7 +20,7 @@ public:
 
     virtual void children_changed() override;
     virtual void inserted() override;
-    virtual void removed_from(Node*) override;
+    virtual void removed_from(Node* old_parent, Node& old_root) override;
 
     CSS::CSSStyleSheet* sheet();
     CSS::CSSStyleSheet const* sheet() const;


### PR DESCRIPTION
We achieve this by keeping track of the number of HTMLSlotElements inside each ShadowRoot (do via ad-hoc insertion and removal steps.)

This allows slottables assignment to skip over entire shadow roots when we know they have no slots anyway.

Massive speedup on https://wpt.fyi/ which no longer takes minutes/hours to load, but instead a "mere" 19 seconds. :^)