### PR TITLE
Meta: Disable clang-tidy “implicit-bool-conversion” check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,6 +45,7 @@ Checks: >
   -readability-named-parameter,
   -readability-uppercase-literal-suffix,
   -readability-use-anyofallof,
+  -readability-implicit-bool-conversion,
 WarningsAsErrors: ''
 HeaderFilterRegex: 'AK|Libraries|Services|Tests|Utilities'
 FormatStyle: none
@@ -52,6 +53,4 @@ CheckOptions:
   - key: bugprone-dangling-handle.HandleClasses
     value: 'AK::StringView;AK::Span'
   - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
-    value: true
-  - key: readability-implicit-bool-conversion.AllowPointerConditions
     value: true


### PR DESCRIPTION
This change causes the `readability-implicit-bool-conversion` check to be completely skipped by clang-tidy.

We have many places in the existing code where we’re doing implicit conversions to booleans — not just for pointers (which our clang-tidy config already has an exception for), but also for integers and for other types as well.

Given that, the readability-implicit-bool-conversion generates a lot of unwelcome/distracting noise with our existing code.