### PR TITLE
LibWeb: Editing improvements

### DIFF
--- a/Libraries/LibWeb/DOM/AbstractRange.h
+++ b/Libraries/LibWeb/DOM/AbstractRange.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2022, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -39,6 +40,14 @@ public:
     {
         // A range is collapsed if its start node is its end node and its start offset is its end offset.
         return start_container() == end_container() && start_offset() == end_offset();
+    }
+
+    bool operator==(AbstractRange const& other) const
+    {
+        return start_container() == other.start_container()
+            && start_offset() == other.start_offset()
+            && end_container() == other.end_container()
+            && end_offset() == other.end_offset();
     }
 
 protected:

--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -135,6 +135,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
         static_cast<Layout::TextNode&>(*layout_node).invalidate_text_for_rendering();
 
     document().set_needs_layout();
+    document().bump_character_data_version();
 
     if (m_grapheme_segmenter)
         m_grapheme_segmenter->set_segmented_text(m_data);

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -113,6 +113,11 @@ public:
     u64 dom_tree_version() const { return m_dom_tree_version; }
     void bump_dom_tree_version() { ++m_dom_tree_version; }
 
+    // AD-HOC: This number increments whenever CharacterData is modified in the document. It is used together with
+    //         dom_tree_version() to understand whether either the DOM tree structure or contents were changed.
+    u64 character_data_version() const { return m_character_data_version; }
+    void bump_character_data_version() { ++m_character_data_version; }
+
     WebIDL::ExceptionOr<void> populate_with_html_head_and_body();
 
     GC::Ptr<Selection::Selection> get_selection() const;
@@ -1067,6 +1072,7 @@ private:
     Optional<Core::DateTime> m_last_modified;
 
     u64 m_dom_tree_version { 0 };
+    u64 m_character_data_version { 0 };
 
     // https://drafts.csswg.org/css-position-4/#document-top-layer
     // Documents have a top layer, an ordered set containing elements from the document.

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1101,6 +1101,8 @@ private:
 
     GC::Ref<EditingHostManager> m_editing_host_manager;
 
+    bool m_inside_exec_command { false };
+
     // https://w3c.github.io/editing/docs/execCommand/#default-single-line-container-name
     FlyString m_default_single_line_container_name { HTML::TagNames::div };
 

--- a/Libraries/LibWeb/DOM/MutationObserver.h
+++ b/Libraries/LibWeb/DOM/MutationObserver.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/RefCounted.h>
 #include <LibGC/Root.h>
 #include <LibWeb/DOM/MutationRecord.h>
 #include <LibWeb/WebIDL/CallbackType.h>

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -35,9 +35,10 @@ bool command_back_color_action(DOM::Document& document, String const& value)
         resulting_value = MUST(String::formatted("#{}", resulting_value));
 
         // 2. If value is still not a valid CSS color, or if it is currentColor, return false.
+        // AD-HOC: No browser does this. They always return true.
         if (!Color::from_string(resulting_value).has_value()) {
-            // FIXME: Also return false in case of currentColor.
-            return false;
+            // FIXME: Also return true in case of currentColor.
+            return true;
         }
     }
 
@@ -602,9 +603,10 @@ bool command_fore_color_action(DOM::Document& document, String const& value)
         resulting_value = MUST(String::formatted("#{}", resulting_value));
 
         // 2. If value is still not a valid CSS color, or if it is currentColor, return false.
+        // AD-HOC: No browser does this. They always return true.
         if (!Color::from_string(resulting_value).has_value()) {
-            // FIXME: Also return false in case of currentColor.
-            return false;
+            // FIXME: Also return true in case of currentColor.
+            return true;
         }
     }
 

--- a/Libraries/LibWeb/Editing/Commands.cpp
+++ b/Libraries/LibWeb/Editing/Commands.cpp
@@ -2464,6 +2464,7 @@ static Array const commands {
         .command = CommandNames::backColor,
         .action = command_back_color_action,
         .relevant_css_property = CSS::PropertyID::BackgroundColor,
+        .mapped_value = "formatBackColor"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-bold-command
     CommandDefinition {
@@ -2471,17 +2472,20 @@ static Array const commands {
         .action = command_bold_action,
         .relevant_css_property = CSS::PropertyID::FontWeight,
         .inline_activated_values = { "bold"sv, "600"sv, "700"sv, "800"sv, "900"sv },
+        .mapped_value = "formatBold"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-createlink-command
     CommandDefinition {
         .command = CommandNames::createLink,
         .action = command_create_link_action,
+        .mapped_value = "insertLink"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-delete-command
     CommandDefinition {
         .command = CommandNames::delete_,
         .action = command_delete_action,
         .preserves_overrides = true,
+        .mapped_value = "deleteContentBackward"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-defaultparagraphseparator-command
     CommandDefinition {
@@ -2494,6 +2498,7 @@ static Array const commands {
         .command = CommandNames::fontName,
         .action = command_font_name_action,
         .relevant_css_property = CSS::PropertyID::FontFamily,
+        .mapped_value = "formatFontName"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-fontsize-command
     CommandDefinition {
@@ -2507,6 +2512,7 @@ static Array const commands {
         .command = CommandNames::foreColor,
         .action = command_fore_color_action,
         .relevant_css_property = CSS::PropertyID::Color,
+        .mapped_value = "formatFontColor"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-formatblock-command
     CommandDefinition {
@@ -2521,6 +2527,7 @@ static Array const commands {
         .command = CommandNames::forwardDelete,
         .action = command_forward_delete_action,
         .preserves_overrides = true,
+        .mapped_value = "deleteContentForward"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-hilitecolor-command
     CommandDefinition {
@@ -2533,12 +2540,14 @@ static Array const commands {
         .command = CommandNames::indent,
         .action = command_indent_action,
         .preserves_overrides = true,
+        .mapped_value = "formatIndent"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-inserthorizontalrule-command
     CommandDefinition {
         .command = CommandNames::insertHorizontalRule,
         .action = command_insert_horizontal_rule_action,
         .preserves_overrides = true,
+        .mapped_value = "insertHorizontalRule"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-inserthtml-command
     CommandDefinition {
@@ -2557,6 +2566,7 @@ static Array const commands {
         .command = CommandNames::insertLineBreak,
         .action = command_insert_linebreak_action,
         .preserves_overrides = true,
+        .mapped_value = "insertLineBreak"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-insertorderedlist-command
     CommandDefinition {
@@ -2565,17 +2575,20 @@ static Array const commands {
         .indeterminate = command_insert_ordered_list_indeterminate,
         .state = command_insert_ordered_list_state,
         .preserves_overrides = true,
+        .mapped_value = "insertOrderedList"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-insertparagraph-command
     CommandDefinition {
         .command = CommandNames::insertParagraph,
         .action = command_insert_paragraph_action,
         .preserves_overrides = true,
+        .mapped_value = "insertParagraph"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-inserttext-command
     CommandDefinition {
         .command = CommandNames::insertText,
         .action = command_insert_text_action,
+        .mapped_value = "insertText"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-insertunorderedlist-command
     CommandDefinition {
@@ -2584,6 +2597,7 @@ static Array const commands {
         .indeterminate = command_insert_unordered_list_indeterminate,
         .state = command_insert_unordered_list_state,
         .preserves_overrides = true,
+        .mapped_value = "insertUnorderedList"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-italic-command
     CommandDefinition {
@@ -2600,6 +2614,7 @@ static Array const commands {
         .state = command_justify_center_state,
         .value = command_justify_center_value,
         .preserves_overrides = true,
+        .mapped_value = "formatJustifyCenter"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-justifyfull-command
     CommandDefinition {
@@ -2609,6 +2624,7 @@ static Array const commands {
         .state = command_justify_full_state,
         .value = command_justify_full_value,
         .preserves_overrides = true,
+        .mapped_value = "formatJustifyFull"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-justifyleft-command
     CommandDefinition {
@@ -2618,6 +2634,7 @@ static Array const commands {
         .state = command_justify_left_state,
         .value = command_justify_left_value,
         .preserves_overrides = true,
+        .mapped_value = "formatJustifyLeft"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-justifyright-command
     CommandDefinition {
@@ -2627,12 +2644,14 @@ static Array const commands {
         .state = command_justify_right_state,
         .value = command_justify_right_value,
         .preserves_overrides = true,
+        .mapped_value = "formatJustifyRight"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-outdent-command
     CommandDefinition {
         .command = CommandNames::outdent,
         .action = command_outdent_action,
         .preserves_overrides = true,
+        .mapped_value = "formatOutdent"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-removeformat-command
     CommandDefinition {
@@ -2649,6 +2668,7 @@ static Array const commands {
         .command = CommandNames::strikethrough,
         .action = command_strikethrough_action,
         .inline_activated_values = { "line-through"sv },
+        .mapped_value = "formatStrikeThrough"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-stylewithcss-command
     CommandDefinition {
@@ -2669,6 +2689,7 @@ static Array const commands {
         .action = command_superscript_action,
         .indeterminate = command_superscript_indeterminate,
         .inline_activated_values = { "superscript"sv },
+        .mapped_value = "formatSuperscript"_fly_string,
     },
     // https://w3c.github.io/editing/docs/execCommand/#the-underline-command
     CommandDefinition {

--- a/Libraries/LibWeb/Editing/Commands.h
+++ b/Libraries/LibWeb/Editing/Commands.h
@@ -24,6 +24,9 @@ struct CommandDefinition {
 
     // https://w3c.github.io/editing/docs/execCommand/#inline-command-activated-values
     Vector<StringView> inline_activated_values {};
+
+    // https://w3c.github.io/editing/docs/execCommand/#dfn-map-an-edit-command-to-input-type-value
+    FlyString mapped_value {};
 };
 
 Optional<CommandDefinition const&> find_command_definition(FlyString const&);

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -171,6 +171,7 @@ WebIDL::ExceptionOr<bool> Document::query_command_enabled(FlyString const& comma
             Editing::CommandNames::fontName,
             Editing::CommandNames::fontSize,
             Editing::CommandNames::foreColor,
+            Editing::CommandNames::formatBlock, // AD-HOC: https://github.com/w3c/editing/issues/478
             Editing::CommandNames::hiliteColor,
             Editing::CommandNames::indent,
             Editing::CommandNames::insertHorizontalRule,

--- a/Libraries/LibWeb/Editing/ExecCommand.cpp
+++ b/Libraries/LibWeb/Editing/ExecCommand.cpp
@@ -20,6 +20,12 @@ WebIDL::ExceptionOr<bool> Document::exec_command(FlyString const& command, [[may
     if (!is_html_document())
         return WebIDL::InvalidStateError::create(realm(), "execCommand is only supported on HTML documents"_string);
 
+    // AD-HOC: All major browsers refuse to recursively execute execCommand() (e.g. inside input event handlers).
+    if (m_inside_exec_command)
+        return false;
+    ScopeGuard guard_recursion = [&] { m_inside_exec_command = false; };
+    m_inside_exec_command = true;
+
     // 1. If only one argument was provided, let show UI be false.
     // 2. If only one or two arguments were provided, let value be the empty string.
     // NOTE: these steps are dealt by the default values for both show_ui and value

--- a/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Libraries/LibWeb/Selection/Selection.cpp
@@ -467,6 +467,7 @@ void Selection::set_range(GC::Ptr<DOM::Range> range)
     if (m_range)
         m_range->set_associated_selection({}, nullptr);
 
+    auto range_changed = ((m_range == nullptr) != (range == nullptr)) || (m_range && *m_range != *range);
     m_range = range;
 
     if (m_range)
@@ -476,8 +477,10 @@ void Selection::set_range(GC::Ptr<DOM::Range> range)
     // Whenever the number of ranges in the selection changes to something different, and whenever a boundary point of
     // the range at a given index in the selection changes to something different, the state override and value override
     // must be unset for every command.
-    m_document->reset_command_state_overrides();
-    m_document->reset_command_value_overrides();
+    if (range_changed) {
+        m_document->reset_command_state_overrides();
+        m_document->reset_command_value_overrides();
+    }
 }
 
 GC::Ptr<DOM::Position> Selection::cursor_position() const

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-backColor.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-backColor.txt
@@ -1,2 +1,3 @@
 Div contents: "<span style="background-color: rgb(0, 0, 255);">foo</span>bar"
 Div contents: "<span style="background-color: rgb(0, 0, 255);">foo</span><span style="background-color: red;">bar</span>"
+Invalid color result: true

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-insertText.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-insertText.txt
@@ -1,1 +1,2 @@
+input triggered
 foobazbar

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-no-recursion.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-no-recursion.txt
@@ -1,0 +1,4 @@
+input event
+inner result: false
+outer result: true
+foo

--- a/Tests/LibWeb/Text/input/Editing/execCommand-backColor.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-backColor.html
@@ -18,5 +18,8 @@
         range.setEnd(divElm.childNodes[1], 3);
         document.execCommand('hiliteColor', false, 'red');
         println(`Div contents: "${divElm.innerHTML}"`);
+
+        // Invalid color
+        println(`Invalid color result: ${document.execCommand('backColor', false, '%*&')}`);
     });
 </script>

--- a/Tests/LibWeb/Text/input/Editing/execCommand-insertText.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-insertText.html
@@ -3,6 +3,7 @@
 <script>
     test(() => {
         var divElm = document.querySelector('div');
+        divElm.addEventListener('input', (e) => println('input triggered'));
 
         // Put cursor between 'foo' and 'bar'
         var range = document.createRange();

--- a/Tests/LibWeb/Text/input/Editing/execCommand-no-recursion.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-no-recursion.html
@@ -1,0 +1,20 @@
+<script src="../include.js"></script>
+<div contenteditable="true"></div>
+<script>
+    test(() => {
+        const range = document.createRange();
+        getSelection().addRange(range);
+
+        const divElm = document.querySelector('div');
+        range.setStart(divElm, 0);
+        range.setEnd(divElm, 0);
+
+        divElm.addEventListener('input', () => {
+            println('input event');
+            println(`inner result: ${document.execCommand('insertText', false, 'bar')}`);
+        });
+
+        println(`outer result: ${document.execCommand('insertText', false, 'foo')}`);
+        println(divElm.innerHTML);
+    });
+</script>


### PR DESCRIPTION
Editing commands now fire the `input` event. Comes with a random selection of fixes.

New WPT passes:

* `editing/event.html`: +56
* `editing/other`: +42
* `editing/plaintext-only`: +10
* `editing/run`: +98