### PR TITLE
LibWeb: Coalesce entire-subtree style invalidations

### DIFF
--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -290,12 +290,16 @@ public:
 
     bool needs_style_update() const { return m_needs_style_update; }
     void set_needs_style_update(bool);
+    void set_needs_style_update_internal(bool) { m_needs_style_update = true; }
 
     bool needs_inherited_style_update() const { return m_needs_inherited_style_update; }
     void set_needs_inherited_style_update(bool);
 
     bool child_needs_style_update() const { return m_child_needs_style_update; }
     void set_child_needs_style_update(bool b) { m_child_needs_style_update = b; }
+
+    [[nodiscard]] bool entire_subtree_needs_style_update() const { return m_entire_subtree_needs_style_update; }
+    void set_entire_subtree_needs_style_update(bool b) { m_entire_subtree_needs_style_update = b; }
 
     enum class ForceSelfStyleInvalidation : bool {
         Yes,
@@ -807,6 +811,7 @@ protected:
     bool m_needs_style_update { false };
     bool m_needs_inherited_style_update { false };
     bool m_child_needs_style_update { false };
+    bool m_entire_subtree_needs_style_update { false };
 
     UniqueNodeID m_unique_id;
 


### PR DESCRIPTION
Instead of traversing the entire DOM subtrees and marking nodes for style update, this patch adds a new mechanism where we can mark a subtree root as "entire subtree needs style update".

A new pass in Document::update_style() then takes care of coalescing all these invalidations in a single traversal of the DOM.

This shaves *minutes* of loading time off of https://wpt.fyi/ subpages.