### PR TITLE
LibWeb: Recompute relative units in Element::recompute_inherited_style()

### DIFF
--- a/Tests/LibWeb/Text/expected/invlidate-properties-with-relative-units-in-inherited-style-update.txt
+++ b/Tests/LibWeb/Text/expected/invlidate-properties-with-relative-units-in-inherited-style-update.txt
@@ -1,0 +1,6 @@
+(before) child.style.width: 192px
+(before) child.style.height: 192px
+(before) child.style.fontSize: 96px
+(after) child.style.width: 600px
+(after) child.style.height: 600px
+(after) child.style.fontSize: 300px

--- a/Tests/LibWeb/Text/input/invlidate-properties-with-relative-units-in-inherited-style-update.html
+++ b/Tests/LibWeb/Text/input/invlidate-properties-with-relative-units-in-inherited-style-update.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<head>
+  <script src="include.js"></script>
+  <style>
+    .parent {
+      font-size: 32px;
+    }
+    
+    .child {
+      font-size: 3em;
+      width: 2em;
+      height: 2em;
+      color: blue;
+      background-color: magenta;
+    }
+  </style>
+</head>
+<body>
+  <div class="parent" id="parentElement">
+    <p class="child">
+      Hello!
+    </p>
+  </div>
+
+  <script>
+    function increaseParentSize() {
+      document.getElementById('parentElement').style.fontSize = '100px';
+    }
+
+    test(() => {
+        const childStyleBefore = window.getComputedStyle(document.querySelector('.child'));
+        println("(before) child.style.width: " + childStyleBefore.width);
+        println("(before) child.style.height: " + childStyleBefore.height);
+        println("(before) child.style.fontSize: " + childStyleBefore.fontSize);
+        increaseParentSize();
+        const childStyleAfter = window.getComputedStyle(document.querySelector('.child'));
+        println("(after) child.style.width: " + childStyleAfter.width);
+        println("(after) child.style.height: " + childStyleAfter.height);
+        println("(after) child.style.fontSize: " + childStyleAfter.fontSize);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Properties with relative units has to be recomputed in inherited style update as they depend on the parent's style.

Fixes https://github.com/LadybirdBrowser/ladybird/issues/3364