### PR TITLE
LibWeb: Add optimizations to the insertion/children changed steps for <select> element

### DIFF
--- a/Libraries/LibWeb/DOM/CharacterData.cpp
+++ b/Libraries/LibWeb/DOM/CharacterData.cpp
@@ -126,7 +126,7 @@ WebIDL::ExceptionOr<void> CharacterData::replace_data(size_t offset, size_t coun
 
     // 12. If node’s parent is non-null, then run the children changed steps for node’s parent.
     if (parent())
-        parent()->children_changed();
+        parent()->children_changed(nullptr);
 
     // NOTE: Since the text node's data has changed, we need to invalidate the text for rendering.
     //       This ensures that the new text is reflected in layout, even if we don't end up

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1107,9 +1107,9 @@ void Element::removed_from(Node* old_parent, Node& old_root)
         document().element_with_name_was_removed({}, *this);
 }
 
-void Element::children_changed()
+void Element::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Node::children_changed();
+    Node::children_changed(metadata);
     set_needs_style_update(true);
 }
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -404,7 +404,7 @@ protected:
 
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual i32 default_tab_index_value() const;
 
     // https://dom.spec.whatwg.org/#concept-element-attributes-change-ext

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -751,7 +751,8 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
     }
 
     // 9. Run the children changed steps for parent.
-    children_changed();
+    ChildrenChangedMetadata metadata { ChildrenChangedMetadata::Type::Inserted, node };
+    children_changed(&metadata);
 
     // 10. Let staticNodeList be a list of nodes, initially « ».
     // Spec-Note: We collect all nodes before calling the post-connection steps on any one of them, instead of calling
@@ -983,7 +984,7 @@ void Node::remove(bool suppress_observers)
     }
 
     // 21. Run the children changed steps for parent.
-    parent->children_changed();
+    parent->children_changed(nullptr);
 
     document().bump_dom_tree_version();
 }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -262,7 +262,18 @@ public:
     virtual void inserted();
     virtual void post_connection();
     virtual void removed_from(Node* old_parent, Node& old_root);
-    virtual void children_changed() { }
+    struct ChildrenChangedMetadata {
+        enum class Type {
+            Inserted,
+            Removal,
+            Mutation,
+        };
+        Type type {};
+        GC::Ref<Node> node;
+    };
+    // FIXME: It would be good if we could always provide this metadata for use in optimizations.
+    virtual void children_changed(ChildrenChangedMetadata const*) { }
+
     virtual void adopted_from(Document&) { }
     virtual WebIDL::ExceptionOr<void> cloned(Node&, bool) const { return {}; }
 

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.cpp
@@ -100,9 +100,9 @@ void HTMLDetailsElement::attribute_changed(FlyString const& local_name, Optional
     }
 }
 
-void HTMLDetailsElement::children_changed()
+void HTMLDetailsElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
     update_shadow_tree_slots();
 }
 

--- a/Libraries/LibWeb/HTML/HTMLDetailsElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDetailsElement.h
@@ -33,7 +33,7 @@ private:
 
     virtual void inserted() override;
     virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void attribute_changed(FlyString const& local_name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     void queue_a_details_toggle_event_task(String old_state, String new_state);

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -766,9 +766,9 @@ private:
 
 GC_DEFINE_ALLOCATOR(SourceElementSelector);
 
-void HTMLMediaElement::children_changed()
+void HTMLMediaElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
 
     if (m_source_element_selector)
         m_source_element_selector->process_next_candidate().release_value_but_fixme_should_propagate_errors();

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -158,7 +158,7 @@ protected:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual void removed_from(DOM::Node* old_parent, DOM::Node& old_root) override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const* metadata) override;
 
     // Override in subclasses to handle implementation-specific behavior when the element state changes
     // to playing or paused, e.g. to start/stop play timers.

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -234,8 +234,10 @@ void HTMLOptionElement::inserted()
     //    If insertedNode's parent is a select element,
     //    or insertedNode's parent is an optgroup element whose parent is a select element,
     //    then run that select element's selectedness setting algorithm.
-    if (auto select_element = owner_select_element())
-        select_element->update_selectedness();
+    if (auto select_element = owner_select_element()) {
+        if (!select_element->can_skip_selectedness_update_for_inserted_option(*this))
+            select_element->update_selectedness();
+    }
 }
 
 void HTMLOptionElement::removed_from(Node* old_parent, Node& old_root)

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -253,9 +253,9 @@ void HTMLOptionElement::removed_from(Node* old_parent, Node& old_root)
     }
 }
 
-void HTMLOptionElement::children_changed()
+void HTMLOptionElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
 
     update_selection_label();
 }

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -55,7 +55,7 @@ private:
 
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
 
     void ask_for_a_reset();
     void update_selection_label();

--- a/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -36,9 +36,12 @@ public:
 
     bool disabled() const;
 
-    GC::Ptr<HTML::HTMLFormElement> form() const;
+    GC::Ptr<HTML::HTMLFormElement const> form() const;
 
     virtual Optional<ARIA::Role> default_role() const override;
+
+    GC::Ptr<HTMLSelectElement> owner_select_element();
+    GC::Ptr<HTMLSelectElement const> owner_select_element() const { return const_cast<HTMLOptionElement&>(*this).owner_select_element(); }
 
 private:
     friend class Bindings::OptionConstructor;

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -572,9 +572,9 @@ void HTMLScriptElement::prepare_script()
 }
 
 // https://html.spec.whatwg.org/multipage/scripting.html#script-processing-model:html-element-post-connection-steps-4
-void HTMLScriptElement::children_changed()
+void HTMLScriptElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
 
     // 1. Run the script HTML element post-connection steps, given the script element.
     post_connection();

--- a/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -43,7 +43,7 @@ public:
 
     bool is_parser_inserted() const { return !!m_parser_document; }
 
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void post_connection() override;
 
     // https://html.spec.whatwg.org/multipage/scripting.html#dom-script-supports

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -505,11 +505,6 @@ void HTMLSelectElement::did_select_item(Optional<u32> const& id)
 void HTMLSelectElement::form_associated_element_was_inserted()
 {
     create_shadow_tree_if_needed();
-
-    // Wait until children are ready
-    queue_an_element_task(HTML::Task::Source::Microtask, [this] {
-        update_selectedness();
-    });
 }
 
 void HTMLSelectElement::form_associated_element_was_removed(DOM::Node*)

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -297,11 +297,9 @@ Optional<ARIA::Role> HTMLSelectElement::default_role() const
     // https://www.w3.org/TR/html-aria/#el-select-multiple-or-size-greater-1
     if (has_attribute(AttributeNames::multiple))
         return ARIA::Role::listbox;
-    if (has_attribute(AttributeNames::size)) {
-        if (auto size_string = get_attribute(HTML::AttributeNames::size); size_string.has_value()) {
-            if (auto size = size_string->to_number<int>(); size.has_value() && *size > 1)
-                return ARIA::Role::listbox;
-        }
+    if (auto size_string = get_attribute(HTML::AttributeNames::size); size_string.has_value()) {
+        if (auto size = size_string->to_number<int>(); size.has_value() && *size > 1)
+            return ARIA::Role::listbox;
     }
     // https://www.w3.org/TR/html-aria/#el-select
     return ARIA::Role::combobox;

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -380,11 +380,8 @@ void HTMLSelectElement::show_the_picker_if_applicable()
     // To show the picker, if applicable for a select element:
 
     // 1. If element's relevant global object does not have transient activation, then return.
-    auto& global_object = relevant_global_object(*this);
-    if (!is<HTML::Window>(global_object))
-        return;
-    auto& relevant_global_object = static_cast<HTML::Window&>(global_object);
-    if (!relevant_global_object.has_transient_activation())
+    auto& relevant_global = as<HTML::Window>(relevant_global_object(*this));
+    if (!relevant_global.has_transient_activation())
         return;
 
     // 2. If element is not mutable, then return.
@@ -392,7 +389,7 @@ void HTMLSelectElement::show_the_picker_if_applicable()
         return;
 
     // 3. Consume user activation given element's relevant global object.
-    relevant_global_object.consume_user_activation();
+    relevant_global.consume_user_activation();
 
     // 4. If element's type attribute is in the File Upload state, then run these steps in parallel:
     // Not Applicable to select elements
@@ -454,9 +451,8 @@ WebIDL::ExceptionOr<void> HTMLSelectElement::show_picker()
     }
 
     // 3. If this's relevant global object does not have transient activation, then throw a "NotAllowedError" DOMException.
-    // FIXME: The global object we get here should probably not need casted to Window to check for transient activation
     auto& global_object = relevant_global_object(*this);
-    if (!is<HTML::Window>(global_object) || !static_cast<HTML::Window&>(global_object).has_transient_activation()) {
+    if (!as<HTML::Window>(global_object).has_transient_activation()) {
         return WebIDL::NotAllowedError::create(realm(), "Too long since user activation to show picker"_string);
     }
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -292,9 +292,9 @@ i32 HTMLSelectElement::default_tab_index_value() const
     return 0;
 }
 
-void HTMLSelectElement::children_changed()
+void HTMLSelectElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
     update_cached_list_of_options();
     update_selectedness();
 }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -293,6 +293,20 @@ i32 HTMLSelectElement::default_tab_index_value() const
     return 0;
 }
 
+bool HTMLSelectElement::can_skip_selectedness_update_for_inserted_option(HTMLOptionElement const& option) const
+{
+    if (option.selected())
+        return false;
+
+    if (m_cached_number_of_selected_options >= 2)
+        return false;
+
+    if (display_size() == 1 && m_cached_number_of_selected_options == 0)
+        return false;
+
+    return true;
+}
+
 bool HTMLSelectElement::can_skip_children_changed_selectedness_update(ChildrenChangedMetadata const& metadata) const
 {
     // If the following criteria are met, there is no need to re-run the selectedness algorithm.
@@ -300,18 +314,8 @@ bool HTMLSelectElement::can_skip_children_changed_selectedness_update(ChildrenCh
     if (metadata.type != ChildrenChangedMetadata::Type::Inserted)
         return false;
 
-    if (auto* option = as_if<HTMLOptionElement>(*metadata.node)) {
-        if (option->selected())
-            return false;
-
-        if (m_cached_number_of_selected_options >= 2)
-            return false;
-
-        if (display_size() == 1 && m_cached_number_of_selected_options == 0)
-            return false;
-
-        return true;
-    }
+    if (auto* option = as_if<HTMLOptionElement>(*metadata.node))
+        return can_skip_selectedness_update_for_inserted_option(*option);
 
     return false;
 }

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -110,6 +110,7 @@ private:
     virtual void computed_properties_changed() override;
 
     virtual void children_changed(ChildrenChangedMetadata const*) override;
+    bool can_skip_children_changed_selectedness_update(ChildrenChangedMetadata const& metadata) const;
 
     void update_cached_list_of_options() const;
     void show_the_picker_if_applicable();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -98,6 +98,8 @@ public:
 
     void update_inner_text_element(Badge<HTMLOptionElement>);
 
+    bool can_skip_selectedness_update_for_inserted_option(HTMLOptionElement const&) const;
+
 private:
     HTMLSelectElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -109,7 +109,7 @@ private:
 
     virtual void computed_properties_changed() override;
 
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
 
     void update_cached_list_of_options() const;
     void show_the_picker_if_applicable();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -111,6 +111,7 @@ private:
 
     virtual void children_changed() override;
 
+    void update_cached_list_of_options() const;
     void show_the_picker_if_applicable();
 
     void create_shadow_tree_if_needed();
@@ -118,6 +119,9 @@ private:
     void queue_input_and_change_events();
 
     u32 display_size() const;
+
+    mutable Vector<GC::Ref<HTMLOptionElement>> m_cached_list_of_options;
+    mutable size_t m_cached_number_of_selected_options { 0 };
 
     GC::Ptr<HTMLOptionsCollection> m_options;
     GC::Ptr<DOM::HTMLCollection> m_selected_options;

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -32,9 +32,9 @@ void HTMLStyleElement::visit_edges(Cell::Visitor& visitor)
     m_style_element_utils.visit_edges(visitor);
 }
 
-void HTMLStyleElement::children_changed()
+void HTMLStyleElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
     m_style_element_utils.update_a_style_block(*this);
 }
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -19,7 +19,7 @@ class HTMLStyleElement final : public HTMLElement {
 public:
     virtual ~HTMLStyleElement() override;
 
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
 

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -429,9 +429,9 @@ void HTMLTextAreaElement::update_placeholder_visibility()
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#the-textarea-element:children-changed-steps
-void HTMLTextAreaElement::children_changed()
+void HTMLTextAreaElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
 
     // The children changed steps for textarea elements must, if the element's dirty value flag is false,
     // set the element's raw value to its child text content.

--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -70,7 +70,7 @@ public:
     virtual void form_associated_element_was_removed(DOM::Node*) override;
     virtual void form_associated_element_attribute_changed(FlyString const&, Optional<String> const&, Optional<FlyString> const&) override;
 
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
 
     // https://www.w3.org/TR/html-aria/#el-textarea
     virtual Optional<ARIA::Role> default_role() const override { return ARIA::Role::textbox; }

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -27,9 +27,9 @@ void HTMLTitleElement::initialize(JS::Realm& realm)
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLTitleElement);
 }
 
-void HTMLTitleElement::children_changed()
+void HTMLTitleElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    HTMLElement::children_changed();
+    HTMLElement::children_changed(metadata);
     auto navigable = this->navigable();
     if (navigable && navigable->is_traversable()) {
         navigable->traversable_navigable()->page().client().page_did_change_title(document().title().to_byte_string());

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.h
@@ -24,7 +24,7 @@ private:
     HTMLTitleElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
 };
 
 }

--- a/Libraries/LibWeb/SVG/SVGElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGElement.cpp
@@ -98,9 +98,9 @@ void SVGElement::inserted()
     update_use_elements_that_reference_this();
 }
 
-void SVGElement::children_changed()
+void SVGElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
 
     update_use_elements_that_reference_this();
 }

--- a/Libraries/LibWeb/SVG/SVGElement.h
+++ b/Libraries/LibWeb/SVG/SVGElement.h
@@ -36,7 +36,7 @@ protected:
 
     virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
     virtual WebIDL::ExceptionOr<void> cloned(DOM::Node&, bool) const override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
 

--- a/Libraries/LibWeb/SVG/SVGStyleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.cpp
@@ -30,9 +30,9 @@ void SVGStyleElement::visit_edges(Cell::Visitor& visitor)
     m_style_element_utils.visit_edges(visitor);
 }
 
-void SVGStyleElement::children_changed()
+void SVGStyleElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
     m_style_element_utils.update_a_style_block(*this);
 }
 

--- a/Libraries/LibWeb/SVG/SVGStyleElement.h
+++ b/Libraries/LibWeb/SVG/SVGStyleElement.h
@@ -18,7 +18,7 @@ class SVGStyleElement final : public SVGElement {
 public:
     virtual ~SVGStyleElement() override;
 
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
 

--- a/Libraries/LibWeb/SVG/SVGTitleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.cpp
@@ -30,9 +30,9 @@ GC::Ptr<Layout::Node> SVGTitleElement::create_layout_node(GC::Ref<CSS::ComputedP
     return nullptr;
 }
 
-void SVGTitleElement::children_changed()
+void SVGTitleElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
-    Base::children_changed();
+    Base::children_changed(metadata);
 
     auto& page = document().page();
     if (document().browsing_context() != &page.top_level_browsing_context())

--- a/Libraries/LibWeb/SVG/SVGTitleElement.h
+++ b/Libraries/LibWeb/SVG/SVGTitleElement.h
@@ -20,7 +20,7 @@ private:
     virtual void initialize(JS::Realm&) override;
 
     virtual GC::Ptr<Layout::Node> create_layout_node(GC::Ref<CSS::ComputedProperties>) override;
-    virtual void children_changed() override;
+    virtual void children_changed(ChildrenChangedMetadata const*) override;
 };
 
 }


### PR DESCRIPTION
This set of optimizations (the last two in particular) improve the runtime of http://wpt.live/html/select/options-length-too-large.html to something which was so slow that I don't know what the total runtime is (many minutes at minimum), to finishing in ~800ms.

There is most definitely a lot of further improvements that we can make here, but making the test actually run is a good start :^)