### PR TITLE
LibWeb: Fix vertical float positioning when pushing a new float against the edge

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1128,10 +1128,11 @@ void BlockFormattingContext::layout_floating_box(Box const& box, BlockContainer 
                 float_to_edge();
                 CSSPixels lowest_margin_edge = 0;
                 for (auto const& current : side_data.current_boxes) {
-                    lowest_margin_edge = max(lowest_margin_edge, current.used_values.margin_box_height());
+                    auto current_rect = margin_box_rect_in_ancestor_coordinate_space(current.used_values, root());
+                    lowest_margin_edge = max(lowest_margin_edge, current_rect.bottom());
                 }
 
-                side_data.y_offset += lowest_margin_edge;
+                side_data.y_offset += max<CSSPixels>(0, lowest_margin_edge - y_in_root + box_state.margin_box_top());
 
                 // Also, forget all previous boxes floated to this side while since they're no longer relevant.
                 side_data.clear();

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -691,22 +691,6 @@ AvailableSpace LayoutState::UsedValues::available_inner_space_or_constraints_fro
     return AvailableSpace(inner_width, inner_height);
 }
 
-void LayoutState::UsedValues::set_content_offset(CSSPixelPoint new_offset)
-{
-    set_content_x(new_offset.x());
-    set_content_y(new_offset.y());
-}
-
-void LayoutState::UsedValues::set_content_x(CSSPixels x)
-{
-    offset.set_x(x);
-}
-
-void LayoutState::UsedValues::set_content_y(CSSPixels y)
-{
-    offset.set_y(y);
-}
-
 void LayoutState::UsedValues::set_indefinite_content_width()
 {
     m_has_definite_width = false;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -101,9 +101,9 @@ struct LayoutState {
         // the constraint is used in that axis instead.
         AvailableSpace available_inner_space_or_constraints_from(AvailableSpace const& outer_space) const;
 
-        void set_content_offset(CSSPixelPoint);
-        void set_content_x(CSSPixels);
-        void set_content_y(CSSPixels);
+        void set_content_offset(CSSPixelPoint new_offset) { offset = new_offset; }
+        void set_content_x(CSSPixels x) { offset.set_x(x); }
+        void set_content_y(CSSPixels y) { offset.set_y(y); }
 
         CSSPixelPoint offset;
 

--- a/Tests/LibWeb/Layout/expected/block-and-inline/float-vertical-offset-by-preceding-float.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/float-vertical-offset-by-preceding-float.txt
@@ -1,0 +1,33 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,16) content-size 784x51 children: not-inline
+      BlockContainer <div> at (8,16) content-size 50x50 floating [BFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,16) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <p> at (8,16) content-size 784x51 children: inline
+        frag 0 from TextNode start: 0, length: 1, rect: [58,16 14.265625x17] baseline: 13.296875
+            "A"
+        frag 1 from TextNode start: 0, length: 1, rect: [58,33 9.34375x17] baseline: 13.296875
+            "B"
+        frag 2 from TextNode start: 0, length: 1, rect: [58,50 10.3125x17] baseline: 13.296875
+            "C"
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+        BreakNode <br>
+        TextNode <#text>
+      BlockContainer <div> at (8,83) content-size 50x50 floating [BFC] children: not-inline
+      BlockContainer <(anonymous)> at (8,83) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,16 784x51] overflow: [8,16 784x117]
+      PaintableWithLines (BlockContainer<DIV>) [8,16 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,16 784x0]
+      PaintableWithLines (BlockContainer<P>) [8,16 784x51]
+        TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<DIV>) [8,83 50x50]
+      PaintableWithLines (BlockContainer(anonymous)) [8,83 784x0]

--- a/Tests/LibWeb/Layout/input/block-and-inline/float-vertical-offset-by-preceding-float.html
+++ b/Tests/LibWeb/Layout/input/block-and-inline/float-vertical-offset-by-preceding-float.html
@@ -1,0 +1,3 @@
+<div style="height: 50px; width: 50px; background-color: blue; float: left"></div>
+<p>A<br>B<br>C
+</p><div style="height: 50px; width: 50px; background-color: green; float: left"></div>


### PR DESCRIPTION
See commit messages for details.

Fixes the layout for https://tweakers.net/info/over-tweakers/:

| Before | After |
|---|---|
| ![Screenshot_20250127_122044](https://github.com/user-attachments/assets/64e9a926-169a-4a97-87db-63e97e657cf2) | ![Screenshot_20250127_122017](https://github.com/user-attachments/assets/25f18555-943f-4bea-986d-d88daf2ff8c5) |

