### PR TITLE
LibWeb: Segregate StyleComputer rule caches per Document-or-ShadowRoot + 2 smol speedups

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Bindings/KeyframeEffectPrototype.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -364,13 +364,6 @@ bool CSSStyleValue::has_auto() const
     return is_keyword() && as_keyword().keyword() == Keyword::Auto;
 }
 
-Keyword CSSStyleValue::to_keyword() const
-{
-    if (is_keyword())
-        return as_keyword().keyword();
-    return Keyword::Invalid;
-}
-
 int CSSStyleValue::to_font_weight() const
 {
     if (is_keyword()) {

--- a/Libraries/LibWeb/CSS/FontFaceSet.cpp
+++ b/Libraries/LibWeb/CSS/FontFaceSet.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/ShorthandStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StringStyleValue.h>
 #include <LibWeb/CSS/StyleValues/StyleValueList.h>

--- a/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/RuleParsing.cpp
@@ -26,6 +26,7 @@
 #include <LibWeb/CSS/CSSSupportsRule.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyName.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/IntegerStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/OpenTypeTaggedStyleValue.h>

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -273,23 +273,28 @@ private:
         HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
     };
 
-    struct BuiltRuleCaches {
-        NonnullOwnPtr<RuleCache> main_rules;
-        HashMap<FlyString, NonnullOwnPtr<RuleCache>> layer_rules;
+    struct RuleCaches {
+        RuleCache main;
+        HashMap<FlyString, NonnullOwnPtr<RuleCache>> by_layer;
     };
-    [[nodiscard]] BuiltRuleCaches make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&, Vector<MatchingRule>& hover_rules);
 
-    [[nodiscard]] RuleCache const* rule_cache_for_cascade_origin(CascadeOrigin, FlyString const& qualified_layer_name) const;
+    struct RuleCachesForDocumentAndShadowRoots {
+        RuleCaches for_document;
+        HashMap<GC::Ref<DOM::ShadowRoot const>, NonnullOwnPtr<RuleCaches>> for_shadow_roots;
+    };
+
+    void make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&, Vector<MatchingRule>& hover_rules);
+
+    [[nodiscard]] RuleCache const* rule_cache_for_cascade_origin(CascadeOrigin, FlyString const& qualified_layer_name, GC::Ptr<DOM::ShadowRoot const>) const;
 
     static void collect_selector_insights(Selector const&, SelectorInsights&);
 
     OwnPtr<SelectorInsights> m_selector_insights;
     Vector<MatchingRule> m_hover_rules;
     OwnPtr<StyleInvalidationData> m_style_invalidation_data;
-    OwnPtr<RuleCache> m_author_rule_cache;
-    HashMap<FlyString, NonnullOwnPtr<RuleCache>> m_layer_rule_caches;
-    OwnPtr<RuleCache> m_user_rule_cache;
-    OwnPtr<RuleCache> m_user_agent_rule_cache;
+    OwnPtr<RuleCachesForDocumentAndShadowRoots> m_author_rule_cache;
+    OwnPtr<RuleCachesForDocumentAndShadowRoots> m_user_rule_cache;
+    OwnPtr<RuleCachesForDocumentAndShadowRoots> m_user_agent_rule_cache;
     GC::Root<CSSStyleSheet> m_user_style_sheet;
 
     using FontLoaderList = Vector<NonnullOwnPtr<FontLoader>>;

--- a/Libraries/LibWeb/CSS/StyleInvalidation.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidation.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleInvalidation.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/BorderRadiusStyleValue.cpp
@@ -28,6 +28,8 @@ ValueComparingNonnullRefPtr<CSSStyleValue const> BorderRadiusStyleValue::absolut
         absolutized_horizontal_radius = m_properties.horizontal_radius.length().absolutized(viewport_rect, font_metrics, root_font_metrics);
     if (m_properties.vertical_radius.is_length())
         absolutized_vertical_radius = m_properties.vertical_radius.length().absolutized(viewport_rect, font_metrics, root_font_metrics);
+    if (absolutized_vertical_radius == m_properties.vertical_radius && absolutized_horizontal_radius == m_properties.horizontal_radius)
+        return *this;
     return BorderRadiusStyleValue::create(absolutized_horizontal_radius, absolutized_vertical_radius);
 }
 

--- a/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSColorValue.cpp
@@ -10,6 +10,7 @@
 #include "CSSColorValue.h"
 #include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/CSSRGB.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>

--- a/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSKeywordValue.h
@@ -66,4 +66,11 @@ private:
     Keyword m_keyword { Keyword::Invalid };
 };
 
+inline Keyword CSSStyleValue::to_keyword() const
+{
+    if (is_keyword())
+        return static_cast<CSSKeywordValue const&>(*this).keyword();
+    return Keyword::Invalid;
+}
+
 }

--- a/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CSSRGB.cpp
@@ -7,6 +7,7 @@
 #include "CSSRGB.h"
 #include <AK/TypeCasts.h>
 #include <LibWeb/CSS/Serialize.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/CalculatedStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -8,6 +8,7 @@
 #include "ShorthandStyleValue.h"
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleValues/BorderRadiusStyleValue.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>


### PR DESCRIPTION
This means we only need to consider rules from the document and the
current shadow root, instead of the document and *every* shadow root.

Dramatically reduces the amount of rules processed on many pages.

Shaves 2.5 seconds of load time off of https://wpt.fyi/ :^)

+ 2 bonus commits for more speedups on the same page..