### PR TITLE
LibWeb/WebGL: Implement copyTex(Sub)Image2D

### DIFF
--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
@@ -66,7 +66,7 @@ interface mixin WebGLRenderingContextBase {
     undefined colorMask(GLboolean red, GLboolean green, GLboolean blue, GLboolean alpha);
     undefined compileShader(WebGLShader shader);
 
-    [FIXME] undefined copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border);
+    undefined copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border);
     [FIXME] undefined copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
 
     WebGLBuffer? createBuffer();

--- a/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
+++ b/Libraries/LibWeb/WebGL/WebGLRenderingContextBase.idl
@@ -67,7 +67,7 @@ interface mixin WebGLRenderingContextBase {
     undefined compileShader(WebGLShader shader);
 
     undefined copyTexImage2D(GLenum target, GLint level, GLenum internalformat, GLint x, GLint y, GLsizei width, GLsizei height, GLint border);
-    [FIXME] undefined copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
+    undefined copyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
 
     WebGLBuffer? createBuffer();
     WebGLFramebuffer? createFramebuffer();


### PR DESCRIPTION
Used by d3wasm for effects that use the current framebuffer as the texture, such as screen wipes.