### PR TITLE
LibWeb: Use invalidation sets for :has() invalidation 

### DIFF
--- a/Libraries/LibWeb/CSS/InvalidationSet.h
+++ b/Libraries/LibWeb/CSS/InvalidationSet.h
@@ -51,7 +51,7 @@ public:
     void set_needs_invalidate_pseudo_class(PseudoClass pseudo_class) { m_properties.set({ Property::Type::PseudoClass, pseudo_class }); }
 
     bool is_empty() const;
-    void for_each_property(Function<void(Property const&)> const& callback) const;
+    void for_each_property(Function<IterationDecision(Property const&)> const& callback) const;
 
 private:
     bool m_needs_invalidate_self { false };

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -549,6 +549,9 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         // :has() cannot be nested in a :has()
         if (selector_kind == SelectorKind::Relative)
             return false;
+        if (context.collect_per_element_selector_involvement_metadata && &element == context.subject) {
+            const_cast<DOM::Element&>(element).set_affected_by_has_pseudo_class_in_subject_position(true);
+        }
         // These selectors should be relative selectors (https://drafts.csswg.org/selectors-4/#relative-selector)
         for (auto& selector : pseudo_class.argument_selector_list) {
             if (matches_has_pseudo_class(selector, element, shadow_host, context))

--- a/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -18,6 +18,8 @@ enum class SelectorKind {
 
 struct MatchContext {
     GC::Ptr<CSS::CSSStyleSheet const> style_sheet_for_rule {};
+    GC::Ptr<DOM::Element const> subject {};
+    bool collect_per_element_selector_involvement_metadata { false };
     bool did_match_any_hover_rules { false };
 };
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -586,7 +586,11 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::Element c
 
         auto const& selector = rule_to_run.selector;
 
-        SelectorEngine::MatchContext context { .style_sheet_for_rule = *rule_to_run.sheet };
+        SelectorEngine::MatchContext context {
+            .style_sheet_for_rule = *rule_to_run.sheet,
+            .subject = element,
+            .collect_per_element_selector_involvement_metadata = true,
+        };
         ScopeGuard guard = [&] {
             if (context.did_match_any_hover_rules)
                 did_match_any_hover_rules = true;

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -190,6 +190,7 @@ static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidati
                         // we need to make all siblings are invalidated.
                         descendant_invalidation_set.set_needs_invalidate_whole_subtree();
                     }
+                    return IterationDecision::Continue;
                 });
             }
 
@@ -216,6 +217,8 @@ static InvalidationSet build_invalidation_sets_for_selector_impl(StyleInvalidati
                     } else {
                         descendant_invalidation_set.include_all_from(invalidation_set_for_rightmost_selector);
                     }
+
+                    return IterationDecision::Continue;
                 });
             }
         }

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -125,6 +125,7 @@ static void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector
         case PseudoClass::Disabled:
         case PseudoClass::PlaceholderShown:
         case PseudoClass::Checked:
+        case PseudoClass::Has:
             invalidation_set.set_needs_invalidate_pseudo_class(pseudo_class.type);
             break;
         default:

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1166,6 +1166,8 @@ bool Element::includes_properties_from_invalidation_set(CSS::InvalidationSet con
         }
         case CSS::InvalidationSet::Property::Type::PseudoClass: {
             switch (property.value.get<CSS::PseudoClass>()) {
+            case CSS::PseudoClass::Has:
+                return true;
             case CSS::PseudoClass::Enabled: {
                 return (is<HTML::HTMLButtonElement>(*this) || is<HTML::HTMLInputElement>(*this) || is<HTML::HTMLSelectElement>(*this) || is<HTML::HTMLTextAreaElement>(*this) || is<HTML::HTMLOptGroupElement>(*this) || is<HTML::HTMLOptionElement>(*this) || is<HTML::HTMLFieldSetElement>(*this))
                     && !is_actually_disabled();

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -266,7 +266,7 @@ public:
     static GC::Ptr<Layout::NodeWithStyle> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, GC::Ref<CSS::ComputedProperties>, Element*);
 
     bool affected_by_hover() const;
-    bool affected_by_invalidation_property(CSS::InvalidationSet::Property const&) const;
+    bool includes_properties_from_invalidation_set(CSS::InvalidationSet const&) const;
 
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, GC::Ptr<Layout::NodeWithStyle>);
     GC::Ptr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -411,6 +411,9 @@ public:
     bool has_style_containment() const;
     bool has_paint_containment() const;
 
+    bool affected_by_has_pseudo_class_in_subject_position() const { return m_affected_by_has_pseudo_class_in_subject_position; }
+    void set_affected_by_has_pseudo_class_in_subject_position(bool value) { m_affected_by_has_pseudo_class_in_subject_position = value; }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -500,6 +503,7 @@ private:
 
     bool m_in_top_layer { false };
     bool m_style_uses_css_custom_properties { false };
+    bool m_affected_by_has_pseudo_class_in_subject_position { false };
 
     OwnPtr<CSS::CountersSet> m_counters_set;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -489,8 +489,11 @@ void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::Invalida
     auto element_has_properties_from_invalidation_set = [&](Element& element) {
         bool result = false;
         invalidation_set.for_each_property([&](auto const& property) {
-            if (element.affected_by_invalidation_property(property))
+            if (element.affected_by_invalidation_property(property)) {
                 result = true;
+                return IterationDecision::Break;
+            }
+            return IterationDecision::Continue;
         });
         return result;
     };

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -486,18 +486,6 @@ void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::Invalida
         set_needs_style_update(true);
     }
 
-    auto element_has_properties_from_invalidation_set = [&](Element& element) {
-        bool result = false;
-        invalidation_set.for_each_property([&](auto const& property) {
-            if (element.affected_by_invalidation_property(property)) {
-                result = true;
-                return IterationDecision::Break;
-            }
-            return IterationDecision::Continue;
-        });
-        return result;
-    };
-
     auto invalidate_entire_subtree = [&](Node& subtree_root) {
         subtree_root.for_each_shadow_including_inclusive_descendant([&](Node& node) {
             if (!node.is_element())
@@ -506,7 +494,7 @@ void Node::invalidate_style(StyleInvalidationReason reason, Vector<CSS::Invalida
             bool needs_style_recalculation = false;
             if (invalidation_set.needs_invalidate_whole_subtree()) {
                 needs_style_recalculation = true;
-            } else if (element_has_properties_from_invalidation_set(element)) {
+            } else if (element.includes_properties_from_invalidation_set(invalidation_set)) {
                 needs_style_recalculation = true;
             } else if (options.invalidate_elements_that_use_css_custom_properties && element.style_uses_css_custom_properties()) {
                 needs_style_recalculation = true;

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -301,6 +301,7 @@ public:
     [[nodiscard]] bool entire_subtree_needs_style_update() const { return m_entire_subtree_needs_style_update; }
     void set_entire_subtree_needs_style_update(bool b) { m_entire_subtree_needs_style_update = b; }
 
+    void invalidate_elements_affected_by_has();
     void invalidate_style(StyleInvalidationReason);
     struct StyleInvalidationOptions {
         bool invalidate_self { false };


### PR DESCRIPTION
Prior to this change, we invalidated all elements in the document if it
used any selectors with :has(). This change aims to improve that by
applying a combination of techniques:
- Collect metadata for each element if it was matched against a selector
  with :has() in the subject position. This is needed to invalidate all
  elements that could be affected by selectors like `div:has(.a:empty)`
  because they are not covered by the invalidation sets.
- Use invalidation sets to invalidate elements that are affected by
  selectors with :has() in a non-subject position.

Selectors like `.a:has(.b) + .c` still cause whole-document invalidation
because invalidation sets cover only descendants, not siblings. As a
result, there is no performance improvement on github.com due to this
limitation. However, youtube.com and discord.com benefit from this
change.