### PR TITLE
Tests: Disable flaky ref-tests for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -108,6 +108,9 @@ Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-001-right-overflow.xht
 Ref/input/wpt-import/css/CSS2/floats/floats-placement-003.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht
 
+; WPT ref-tests that are flaky due to unknown reasons
+Ref/input/wpt-import/css/css-contain/contain-size-replaced-006.html
+
 ; WPT crash tests are not supported yet - and probably should go in a separate directory
 Text/input/wpt-import/css/css-nesting/delete-other-rule-crash.html
 Text/input/wpt-import/css/css-nesting/implicit-parent-insertion-crash.html
@@ -150,3 +153,6 @@ Text/input/wpt-import/css/css-backgrounds/animations/discrete-no-interpolation.h
 ; Crashes inconsistently on CI
 ; https://github.com/LadybirdBrowser/ladybird/issues/2900
 Text/input/ShadowDOM/css-hover-shadow-dom.html
+
+; WPT ref tests that are flaky, probably due to not supporting class="reftest-wait"
+Ref/input/wpt-import/css/css-contain/contain-paint-change-opacity.html


### PR DESCRIPTION
These were introduced in 67ed6768313 and fail for half of the time on my machine.