### PR TITLE
LibWeb/DOM: Remove FIXME dbgln about unknown element name creation

### DIFF
--- a/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -682,7 +682,6 @@ WebIDL::ExceptionOr<GC::Ref<Element>> create_element(Document& document, FlyStri
 
     // https://dom.spec.whatwg.org/#concept-element-interface
     // The element interface for any name and namespace is Element, unless stated otherwise.
-    dbgln("Potential FIXME: Creating unknown generic element '{}' in namespace '{}'", local_name, namespace_);
     auto element = realm.create<DOM::Element>(document, move(qualified_name));
     element->set_is_value(move(is_value));
     element->set_custom_element_state(CustomElementState::Uncustomized);


### PR DESCRIPTION
Now that we have implemented most of the element types, this dbgln is a lot less useful for detecting issues on live sites, and is in my experience more likely to log cases that are not a FIXME. It also cleans up some of the log spam from running tests.