### PR TITLE
LibGfx+LibWeb: Reuse graphics contexts and surfaces as much as possible

### DIFF
--- a/Libraries/LibGfx/PaintingSurface.cpp
+++ b/Libraries/LibGfx/PaintingSurface.cpp
@@ -27,14 +27,14 @@ struct PaintingSurface::Impl {
     RefPtr<SkiaBackendContext> context;
 };
 
-NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(RefPtr<SkiaBackendContext> context, Gfx::IntSize size, Gfx::BitmapFormat color_type, Gfx::AlphaType alpha_type)
+NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(RefPtr<SkiaBackendContext> context, IntSize size, BitmapFormat color_type, AlphaType alpha_type)
 {
     auto sk_color_type = to_skia_color_type(color_type);
-    auto sk_alpha_type = alpha_type == Gfx::AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto sk_alpha_type = alpha_type == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
     auto image_info = SkImageInfo::Make(size.width(), size.height(), sk_color_type, sk_alpha_type, SkColorSpace::MakeSRGB());
 
     if (!context) {
-        auto bitmap = Gfx::Bitmap::create(color_type, alpha_type, size).value();
+        auto bitmap = Bitmap::create(color_type, alpha_type, size).value();
         auto surface = SkSurfaces::WrapPixels(image_info, bitmap->begin(), bitmap->pitch());
         VERIFY(surface);
         return adopt_ref(*new PaintingSurface(make<Impl>(size, surface, bitmap, context)));
@@ -48,7 +48,7 @@ NonnullRefPtr<PaintingSurface> PaintingSurface::create_with_size(RefPtr<SkiaBack
 NonnullRefPtr<PaintingSurface> PaintingSurface::wrap_bitmap(Bitmap& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
-    auto alpha_type = bitmap.alpha_type() == Gfx::AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto alpha_type = bitmap.alpha_type() == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
     auto size = bitmap.size();
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     auto surface = SkSurfaces::WrapPixels(image_info, bitmap.begin(), bitmap.pitch());
@@ -87,19 +87,19 @@ PaintingSurface::PaintingSurface(NonnullOwnPtr<Impl>&& impl)
 
 PaintingSurface::~PaintingSurface() = default;
 
-void PaintingSurface::read_into_bitmap(Gfx::Bitmap& bitmap)
+void PaintingSurface::read_into_bitmap(Bitmap& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
-    auto alpha_type = bitmap.alpha_type() == Gfx::AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto alpha_type = bitmap.alpha_type() == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->readPixels(pixmap, 0, 0);
 }
 
-void PaintingSurface::write_from_bitmap(Gfx::Bitmap const& bitmap)
+void PaintingSurface::write_from_bitmap(Bitmap const& bitmap)
 {
     auto color_type = to_skia_color_type(bitmap.format());
-    auto alpha_type = bitmap.alpha_type() == Gfx::AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
+    auto alpha_type = bitmap.alpha_type() == AlphaType::Premultiplied ? kPremul_SkAlphaType : kUnpremul_SkAlphaType;
     auto image_info = SkImageInfo::Make(bitmap.width(), bitmap.height(), color_type, alpha_type, SkColorSpace::MakeSRGB());
     SkPixmap const pixmap(image_info, bitmap.begin(), bitmap.pitch());
     m_impl->surface->writePixels(pixmap, 0, 0);

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Function.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
@@ -29,6 +30,8 @@ public:
         BottomLeft,
     };
 
+    Function<void(PaintingSurface&)> on_flush;
+
     static NonnullRefPtr<PaintingSurface> create_with_size(RefPtr<SkiaBackendContext> context, IntSize size, BitmapFormat color_type, AlphaType alpha_type);
     static NonnullRefPtr<PaintingSurface> wrap_bitmap(Bitmap&);
 
@@ -50,7 +53,7 @@ public:
     template<typename T>
     T sk_image_snapshot() const;
 
-    void flush() const;
+    void flush();
 
     ~PaintingSurface();
 

--- a/Libraries/LibGfx/PaintingSurface.h
+++ b/Libraries/LibGfx/PaintingSurface.h
@@ -29,7 +29,7 @@ public:
         BottomLeft,
     };
 
-    static NonnullRefPtr<PaintingSurface> create_with_size(RefPtr<SkiaBackendContext> context, Gfx::IntSize size, Gfx::BitmapFormat color_type, Gfx::AlphaType alpha_type);
+    static NonnullRefPtr<PaintingSurface> create_with_size(RefPtr<SkiaBackendContext> context, IntSize size, BitmapFormat color_type, AlphaType alpha_type);
     static NonnullRefPtr<PaintingSurface> wrap_bitmap(Bitmap&);
 
 #ifdef AK_OS_MACOS

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -5,8 +5,6 @@
  */
 
 #include <AK/NonnullOwnPtr.h>
-#include <AK/OwnPtr.h>
-#include <AK/Platform.h>
 #include <AK/RefPtr.h>
 #include <LibGfx/SkiaBackendContext.h>
 

--- a/Libraries/LibGfx/SkiaBackendContext.cpp
+++ b/Libraries/LibGfx/SkiaBackendContext.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefPtr.h>
+#include <LibGfx/Bitmap.h>
 #include <LibGfx/SkiaBackendContext.h>
 
 #include <core/SkSurface.h>

--- a/Libraries/LibGfx/SkiaBackendContext.h
+++ b/Libraries/LibGfx/SkiaBackendContext.h
@@ -9,12 +9,12 @@
 #include <AK/Noncopyable.h>
 #include <AK/RefCounted.h>
 
-#ifdef AK_OS_MACOS
-#    include <LibGfx/MetalContext.h>
-#endif
-
 #ifdef USE_VULKAN
 #    include <LibGfx/VulkanContext.h>
+#endif
+
+#ifdef AK_OS_MACOS
+#    include <LibGfx/MetalContext.h>
 #endif
 
 class GrDirectContext;
@@ -30,11 +30,11 @@ class SkiaBackendContext : public RefCounted<SkiaBackendContext> {
 
 public:
 #ifdef USE_VULKAN
-    static RefPtr<SkiaBackendContext> create_vulkan_context(Gfx::VulkanContext&);
+    static RefPtr<SkiaBackendContext> create_vulkan_context(VulkanContext&);
 #endif
 
 #ifdef AK_OS_MACOS
-    static RefPtr<Gfx::SkiaBackendContext> create_metal_context(MetalContext&);
+    static RefPtr<SkiaBackendContext> create_metal_context(MetalContext&);
 #endif
 
     SkiaBackendContext() { }

--- a/Libraries/LibGfx/VulkanContext.h
+++ b/Libraries/LibGfx/VulkanContext.h
@@ -8,8 +8,6 @@
 
 #ifdef USE_VULKAN
 
-#    include <AK/Forward.h>
-#    include <AK/Function.h>
 #    include <vulkan/vulkan.h>
 
 namespace Gfx {

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -170,7 +170,7 @@ public:
 
     CSSPixelPoint viewport_scroll_offset() const { return m_viewport_scroll_offset; }
     CSSPixelRect viewport_rect() const { return { m_viewport_scroll_offset, m_size }; }
-    void set_viewport_size(CSSPixelSize);
+    virtual void set_viewport_size(CSSPixelSize);
     void perform_scroll_of_viewport(CSSPixelPoint position);
 
     void set_needs_display(InvalidateDisplayList = InvalidateDisplayList::Yes);

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -17,6 +17,7 @@
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BackingStore.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWeb/Platform/EventLoopPlugin.h>
 

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -30,9 +30,9 @@ TraversableNavigable::TraversableNavigable(GC::Ref<Page> page)
 {
 #ifdef AK_OS_MACOS
     auto display_list_player_type = page->client().display_list_player_type();
-    if (display_list_player_type == DisplayListPlayerType::SkiaGPUIfAvailable) {
-        m_metal_context = Gfx::get_metal_context();
-        m_skia_backend_context = Gfx::SkiaBackendContext::create_metal_context(*m_metal_context);
+    if (display_list_player_type == DisplayListPlayerType::SkiaGPUIfAvailable)
+        auto metal_context = Gfx::get_metal_context();
+        m_skia_backend_context = Gfx::SkiaBackendContext::create_metal_context(*metal_context);
     }
 #endif
 
@@ -1402,7 +1402,7 @@ void TraversableNavigable::paint(DevicePixelRect const& content_rect, Painting::
     switch (page().client().display_list_player_type()) {
     case DisplayListPlayerType::SkiaGPUIfAvailable: {
 #ifdef AK_OS_MACOS
-        if (m_metal_context && m_skia_backend_context && is<Painting::IOSurfaceBackingStore>(target)) {
+        if (m_skia_backend_context && is<Painting::IOSurfaceBackingStore>(target)) {
             auto& iosurface_backing_store = static_cast<Painting::IOSurfaceBackingStore&>(target);
             auto painting_surface = Gfx::PaintingSurface::wrap_iosurface(iosurface_backing_store.iosurface_handle(), *m_skia_backend_context);
             Painting::DisplayListPlayerSkia player(*m_skia_backend_context, painting_surface);

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -15,12 +15,12 @@
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/StorageAPI/StorageShed.h>
 
-#ifdef AK_OS_MACOS
-#    include <LibGfx/MetalContext.h>
-#endif
-
 #ifdef USE_VULKAN
 #    include <LibGfx/VulkanContext.h>
+#endif
+
+#ifdef AK_OS_MACOS
+#    include <LibGfx/MetalContext.h>
 #endif
 
 namespace Web::HTML {

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -14,13 +14,14 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/StorageAPI/StorageShed.h>
-
-#ifdef USE_VULKAN
-#    include <LibGfx/VulkanContext.h>
-#endif
+#include <WebContent/BackingStoreManager.h>
 
 #ifdef AK_OS_MACOS
 #    include <LibGfx/MetalContext.h>
+#endif
+
+#ifdef USE_VULKAN
+#    include <LibGfx/VulkanContext.h>
 #endif
 
 namespace Web::HTML {
@@ -110,6 +111,8 @@ public:
     StorageAPI::StorageShed& storage_shed() { return m_storage_shed; }
     StorageAPI::StorageShed const& storage_shed() const { return m_storage_shed; }
 
+    void set_viewport_size(CSSPixelSize) override;
+
 private:
     TraversableNavigable(GC::Ref<Page>);
 
@@ -130,6 +133,8 @@ private:
     Vector<GC::Ref<SessionHistoryEntry>> get_session_history_entries_for_the_navigation_api(GC::Ref<Navigable>, int);
 
     [[nodiscard]] bool can_go_forward() const;
+
+    NonnullRefPtr<Gfx::PaintingSurface> painting_surface_for_backing_store(Painting::BackingStore&);
 
     // https://html.spec.whatwg.org/multipage/document-sequences.html#tn-current-session-history-step
     int m_current_session_history_step { 0 };
@@ -154,6 +159,8 @@ private:
     String m_window_handle;
 
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
+    OwnPtr<Painting::DisplayListPlayerSkia> m_skia_player;
+    HashMap<Gfx::Bitmap*, NonnullRefPtr<Gfx::PaintingSurface>> m_bitmap_to_surface;
 };
 
 struct BrowsingContextAndDocument {

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -155,10 +155,6 @@ private:
     String m_window_handle;
 
     RefPtr<Gfx::SkiaBackendContext> m_skia_backend_context;
-
-#ifdef AK_OS_MACOS
-    RefPtr<Gfx::MetalContext> m_metal_context;
-#endif
 };
 
 struct BrowsingContextAndDocument {

--- a/Libraries/LibWeb/HTML/TraversableNavigable.h
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.h
@@ -14,7 +14,6 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/StorageAPI/StorageShed.h>
-#include <WebContent/BackingStoreManager.h>
 
 #ifdef AK_OS_MACOS
 #    include <LibGfx/MetalContext.h>

--- a/Libraries/LibWeb/Painting/BackingStore.h
+++ b/Libraries/LibWeb/Painting/BackingStore.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Forward.h>
 #include <AK/Noncopyable.h>
 #include <LibGfx/Size.h>
 

--- a/Libraries/LibWeb/Painting/DisplayList.cpp
+++ b/Libraries/LibWeb/Painting/DisplayList.cpp
@@ -41,6 +41,8 @@ void DisplayListPlayer::execute(DisplayList& display_list)
     auto const& scroll_state = display_list.scroll_state();
     auto device_pixels_per_css_pixel = display_list.device_pixels_per_css_pixel();
 
+    VERIFY(m_surface);
+
     size_t next_command_index = 0;
     while (next_command_index < commands.size()) {
         auto scroll_frame_id = commands[next_command_index].scroll_frame_id;
@@ -128,6 +130,8 @@ void DisplayListPlayer::execute(DisplayList& display_list)
         else VERIFY_NOT_REACHED();
         // clang-format on
     }
+
+    flush();
 }
 
 }

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,9 +26,14 @@ class DisplayListPlayer {
 public:
     virtual ~DisplayListPlayer() = default;
 
-    void execute(DisplayList& display_list);
+    void execute(DisplayList&);
+    void set_surface(NonnullRefPtr<Gfx::PaintingSurface> surface) { m_surface = surface; }
+
+protected:
+    Gfx::PaintingSurface& surface() const { return *m_surface; }
 
 private:
+    virtual void flush() = 0;
     virtual void draw_glyph_run(DrawGlyphRun const&) = 0;
     virtual void fill_rect(FillRect const&) = 0;
     virtual void draw_painting_surface(DrawPaintingSurface const&) = 0;
@@ -65,6 +71,8 @@ private:
     virtual void apply_transform(ApplyTransform const&) = 0;
     virtual void apply_mask_bitmap(ApplyMaskBitmap const&) = 0;
     virtual bool would_be_fully_clipped_by_painter(Gfx::IntRect) const = 0;
+
+    RefPtr<Gfx::PaintingSurface> m_surface;
 };
 
 class DisplayList : public RefCounted<DisplayList> {

--- a/Libraries/LibWeb/Painting/DisplayList.h
+++ b/Libraries/LibWeb/Painting/DisplayList.h
@@ -9,26 +9,12 @@
 #include <AK/Forward.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/SegmentedVector.h>
-#include <AK/Utf8View.h>
-#include <AK/Vector.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
-#include <LibGfx/Gradients.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/PaintStyle.h>
-#include <LibGfx/Palette.h>
-#include <LibGfx/Point.h>
-#include <LibGfx/Rect.h>
-#include <LibGfx/Size.h>
-#include <LibGfx/TextAlignment.h>
-#include <LibGfx/TextLayout.h>
 #include <LibWeb/CSS/Enums.h>
-#include <LibWeb/Painting/BorderRadiiData.h>
-#include <LibWeb/Painting/BorderRadiusCornerClipper.h>
 #include <LibWeb/Painting/Command.h>
-#include <LibWeb/Painting/GradientData.h>
-#include <LibWeb/Painting/PaintBoxShadowParams.h>
-#include <LibWeb/Painting/ScrollFrame.h>
 #include <LibWeb/Painting/ScrollState.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -7,12 +7,9 @@
 #include <core/SkBitmap.h>
 #include <core/SkBlurTypes.h>
 #include <core/SkCanvas.h>
-#include <core/SkColorFilter.h>
 #include <core/SkFont.h>
-#include <core/SkFontMgr.h>
 #include <core/SkMaskFilter.h>
 #include <core/SkPath.h>
-#include <core/SkPathBuilder.h>
 #include <core/SkPathEffect.h>
 #include <core/SkRRect.h>
 #include <core/SkSurface.h>
@@ -25,7 +22,6 @@
 #include <pathops/SkPathOps.h>
 
 #include <LibGfx/Font/ScaledFont.h>
-#include <LibGfx/PathSkia.h>
 #include <LibGfx/SkiaUtils.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <LibGfx/Bitmap.h>
 #include <LibGfx/PaintingSurface.h>
 #include <LibGfx/SkiaBackendContext.h>
 #include <LibWeb/Painting/DisplayListRecorder.h>

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.h
@@ -14,21 +14,13 @@ class GrDirectContext;
 
 namespace Web::Painting {
 
-class DisplayListPlayerSkia : public DisplayListPlayer {
+class DisplayListPlayerSkia final : public DisplayListPlayer {
 public:
-    DisplayListPlayerSkia(Gfx::Bitmap&);
-
-#ifdef USE_VULKAN
-    DisplayListPlayerSkia(Gfx::SkiaBackendContext&, Gfx::Bitmap&);
-#endif
-
-#ifdef AK_OS_MACOS
-    DisplayListPlayerSkia(Gfx::SkiaBackendContext&, NonnullRefPtr<Gfx::PaintingSurface>);
-#endif
-
-    virtual ~DisplayListPlayerSkia() override;
+    DisplayListPlayerSkia(RefPtr<Gfx::SkiaBackendContext>);
+    DisplayListPlayerSkia();
 
 private:
+    void flush() override;
     void draw_glyph_run(DrawGlyphRun const&) override;
     void fill_rect(FillRect const&) override;
     void draw_painting_surface(DrawPaintingSurface const&) override;
@@ -68,12 +60,7 @@ private:
 
     bool would_be_fully_clipped_by_painter(Gfx::IntRect) const override;
 
-    Gfx::PaintingSurface& surface() const;
-
-    RefPtr<Gfx::SkiaBackendContext> m_context {};
-    RefPtr<Gfx::PaintingSurface> m_surface {};
-
-    Function<void()> m_flush_context;
+    RefPtr<Gfx::SkiaBackendContext> m_context;
 };
 
 }

--- a/Libraries/LibWeb/Painting/SVGMaskable.cpp
+++ b/Libraries/LibWeb/Painting/SVGMaskable.cpp
@@ -90,7 +90,9 @@ RefPtr<Gfx::ImmutableBitmap> SVGMaskable::calculate_mask_of_svg(PaintContext& co
         paint_context.set_svg_transform(graphics_element.get_transform());
         paint_context.set_draw_svg_geometry_for_clip_path(is<SVGClipPaintable>(paintable));
         StackingContext::paint_svg(paint_context, paintable, PaintPhase::Foreground);
-        DisplayListPlayerSkia display_list_player { *mask_bitmap };
+        auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*mask_bitmap);
+        DisplayListPlayerSkia display_list_player;
+        display_list_player.set_surface(painting_surface);
         display_list_player.execute(display_list);
         return mask_bitmap;
     };

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -103,7 +103,9 @@ RefPtr<Gfx::Bitmap> SVGDecodedImageData::render(Gfx::IntSize size) const
     switch (painting_command_executor_type) {
     case DisplayListPlayerType::SkiaGPUIfAvailable:
     case DisplayListPlayerType::SkiaCPU: {
-        Painting::DisplayListPlayerSkia display_list_player { *bitmap };
+        auto painting_surface = Gfx::PaintingSurface::wrap_bitmap(*bitmap);
+        Painting::DisplayListPlayerSkia display_list_player;
+        display_list_player.set_surface(painting_surface);
         display_list_player.execute(*display_list);
         break;
     }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -15,7 +15,6 @@
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/HTML/Window.h>
 #include <LibWeb/HTML/WindowProxy.h>
-#include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/DisplayListPlayerSkia.h>
 #include <LibWeb/Painting/PaintContext.h>

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Namespace.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/BackingStore.h>
 #include <LibWeb/WebDriver/Screenshot.h>
 
 namespace Web::WebDriver {

--- a/Services/WebContent/BackingStoreManager.h
+++ b/Services/WebContent/BackingStoreManager.h
@@ -6,8 +6,6 @@
 
 #pragma once
 
-#include <LibCore/Forward.h>
-#include <LibWeb/Page/Page.h>
 #include <LibWeb/Painting/BackingStore.h>
 #include <WebContent/Forward.h>
 


### PR DESCRIPTION
This effectively changes two things about how we allocate and use surfaces:

* No longer do we create a Vulkan/Metal context per `TraversableNavigable`; it is now cached on a process level.
* Instead of creating a `PaintingSurface` (and calling into Skia) for every paint call, do it once for every unique backing bitmap that's passed in by caching them inside `TraversableNavigable`.

This has improved loading https://tweakers.net for me significantly since it uses multiple navigables on their homepage;

| Backend | Before | After |
|---|---|---|
| Vulkan | 7.5s | 3.5s |
| Metal | 2.9s | 3.0s |

Above measurements were made by repeatedly loading the website and measuring how long it took between the first draw call and the page "settling in". There doesn't seem to be a significant effect on the Metal backend.