### PR TITLE
LibWeb: Skip animation update when target's parent has no paintable

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2502,8 +2502,10 @@ GC::Ref<ComputedProperties> StyleComputer::compute_properties(DOM::Element& elem
                 effect->set_target(&element);
                 element.set_cached_animation_name_animation(animation, pseudo_element);
 
-                HTML::TemporaryExecutionContext context(realm);
-                animation->play().release_value_but_fixme_should_propagate_errors();
+                if (!element.has_display_none_ancestor()) {
+                    HTML::TemporaryExecutionContext context(realm);
+                    animation->play().release_value_but_fixme_should_propagate_errors();
+                }
             } else {
                 // The animation hasn't changed, but some properties of the animation may have
                 if (auto animation = element.cached_animation_name_animation(pseudo_element); animation)

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -209,6 +209,8 @@ public:
     void set_pseudo_element_computed_properties(CSS::Selector::PseudoElement::Type, GC::Ptr<CSS::ComputedProperties>);
     GC::Ptr<CSS::ComputedProperties> pseudo_element_computed_properties(CSS::Selector::PseudoElement::Type);
 
+    bool has_display_none_ancestor();
+    void play_or_cancel_animations_after_display_property_change(Optional<CSS::Display> old_display, Optional<CSS::Display> new_display);
     void reset_animated_css_properties();
 
     GC::Ptr<CSS::ElementInlineCSSStyleDeclaration> inline_style() { return m_inline_style; }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/display-none-prevents-starting-in-subtree.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-animations/display-none-prevents-starting-in-subtree.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Elements in a "display: none" tree cannot start CSS Animations.

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 42 tests
 
-28 Pass
-14 Fail
+31 Pass
+11 Fail
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (-0.3) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0.3) should be [flex]
@@ -32,9 +32,9 @@ Pass	CSS Transitions with transition: all: property <display> from [none] to [fl
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.6) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (1) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (1.5) should be [flex]
-Fail	CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
-Fail	CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
-Fail	CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block]
+Pass	CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
+Pass	CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
+Pass	CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block]
 Fail	CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block]
 Fail	CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block]
 Fail	CSS Animations: property <display> from [none] to [flex] at (1) should be [block]

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-animations/display-none-prevents-starting-in-subtree.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-animations/display-none-prevents-starting-in-subtree.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:graouts@webkit.org">
+<link rel=help href="https://drafts.csswg.org/css-animations/#animations">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../css/css-animations/support/testcommon.js"></script>
+<style>
+@keyframes margin {
+    100% { margin-left: 200px }
+}
+
+#child {
+  animation: margin 1s forwards;
+}
+</style>
+<div id="container">
+    <div>
+        <div id="child"></div>
+    </div>
+</div>
+<script>
+test(() => {
+  const container = document.getElementById("container");
+  const animationCount = () => container.getAnimations({ subtree: true }).length;
+
+  assert_equals(animationCount(), 1, `An animation is running on the child initially with "display: block" on the container.`);
+
+  container.style.display = "none";
+  assert_equals(animationCount(), 0, `Setting "display: none" on the container canceled the animation.`);
+
+  container.style.marginLeft = "50px";
+  container.firstElementChild.style.marginLeft = "100px";
+  assert_equals(animationCount(), 0, `Manipulating styles on the container and a child element does not restart the animation.`);
+}, 'Elements in a "display: none" tree cannot start CSS Animations.');
+</script>


### PR DESCRIPTION
No parent's paintable means animation is nested in a node with `display: none`, so it's safe to skip animation update that won't be visible.

This change improves perfomance on YouTube homepage where we had to invalidate layout on every frame because of animation on `width` property nested in a `display: none` node.