### PR TITLE
LibWeb: Add NavigateEvent.sourceElement

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -146,11 +146,12 @@ public:
         Optional<Vector<XHR::FormDataEntry>&> form_data_entry_list = {};
         ReferrerPolicy::ReferrerPolicy referrer_policy = ReferrerPolicy::ReferrerPolicy::EmptyString;
         UserNavigationInvolvement user_involvement = UserNavigationInvolvement::None;
+        GC::Ptr<DOM::Element> source_element = nullptr;
     };
 
     WebIDL::ExceptionOr<void> navigate(NavigateParams);
 
-    WebIDL::ExceptionOr<void> navigate_to_a_fragment(URL::URL const&, HistoryHandlingBehavior, UserNavigationInvolvement, Optional<SerializationRecord> navigation_api_state, String navigation_id);
+    WebIDL::ExceptionOr<void> navigate_to_a_fragment(URL::URL const&, HistoryHandlingBehavior, UserNavigationInvolvement, GC::Ptr<DOM::Element> source_element, Optional<SerializationRecord> navigation_api_state, String navigation_id);
 
     GC::Ptr<DOM::Document> evaluate_javascript_url(URL::URL const&, URL::Origin const& new_document_origin, UserNavigationInvolvement, String navigation_id);
     void navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, URL::Origin const& initiator_origin, UserNavigationInvolvement, CSPNavigationType csp_navigation_type, String navigation_id);

--- a/Libraries/LibWeb/HTML/NavigateEvent.cpp
+++ b/Libraries/LibWeb/HTML/NavigateEvent.cpp
@@ -42,6 +42,7 @@ NavigateEvent::NavigateEvent(JS::Realm& realm, FlyString const& event_name, Navi
     , m_download_request(event_init.download_request)
     , m_info(event_init.info.value_or(JS::js_undefined()))
     , m_has_ua_visual_transition(event_init.has_ua_visual_transition)
+    , m_source_element(event_init.source_element)
 {
 }
 
@@ -62,6 +63,7 @@ void NavigateEvent::visit_edges(JS::Cell::Visitor& visitor)
     visitor.visit(m_signal);
     visitor.visit(m_form_data);
     visitor.visit(m_info);
+    visitor.visit(m_source_element);
 }
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-intercept

--- a/Libraries/LibWeb/HTML/NavigateEvent.h
+++ b/Libraries/LibWeb/HTML/NavigateEvent.h
@@ -9,7 +9,6 @@
 #include <LibWeb/Bindings/NavigateEventPrototype.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/HTML/NavigationType.h>
-#include <LibWeb/HTML/StructuredSerialize.h>
 
 namespace Web::HTML {
 
@@ -25,6 +24,7 @@ struct NavigateEventInit : public DOM::EventInit {
     Optional<String> download_request = {};
     Optional<JS::Value> info;
     bool has_ua_visual_transition = false;
+    GC::Ptr<DOM::Element> source_element = nullptr;
 };
 
 // https://html.spec.whatwg.org/multipage/nav-history-apis.html#navigationintercepthandler
@@ -54,8 +54,8 @@ public:
 
     [[nodiscard]] static GC::Ref<NavigateEvent> construct_impl(JS::Realm&, FlyString const& event_name, NavigateEventInit const&);
 
-    // The navigationType, destination, canIntercept, userInitiated, hashChange, signal, formData,
-    // downloadRequest, info, and hasUAVisualTransition attributes must return the values they are initialized to.
+    // The navigationType, destination, canIntercept, userInitiated, hashChange, signal, formData, downloadRequest,
+    // info, hasUAVisualTransition, and sourceElement attributes must return the values they are initialized to.
     Bindings::NavigationType navigation_type() const { return m_navigation_type; }
     GC::Ref<NavigationDestination> destination() const { return m_destination; }
     bool can_intercept() const { return m_can_intercept; }
@@ -66,6 +66,7 @@ public:
     Optional<String> download_request() const { return m_download_request; }
     JS::Value info() const { return m_info; }
     bool has_ua_visual_transition() const { return m_has_ua_visual_transition; }
+    GC::Ptr<DOM::Element> source_element() const { return m_source_element; }
 
     WebIDL::ExceptionOr<void> intercept(NavigationInterceptOptions const&);
     WebIDL::ExceptionOr<void> scroll();
@@ -141,6 +142,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-hasuavisualtransition
     bool m_has_ua_visual_transition { false };
+
+    // https://html.spec.whatwg.org/multipage/nav-history-apis.html#dom-navigateevent-sourceelement
+    GC::Ptr<DOM::Element> m_source_element { nullptr };
 };
 
 }

--- a/Libraries/LibWeb/HTML/NavigateEvent.idl
+++ b/Libraries/LibWeb/HTML/NavigateEvent.idl
@@ -19,6 +19,7 @@ interface NavigateEvent : Event {
     readonly attribute DOMString? downloadRequest;
     readonly attribute any info;
     readonly attribute boolean hasUAVisualTransition;
+    readonly attribute Element? sourceElement;
 
     undefined intercept(optional NavigationInterceptOptions options = {});
     undefined scroll();
@@ -35,6 +36,7 @@ dictionary NavigateEventInit : EventInit {
     DOMString? downloadRequest = null;
     any info;
     boolean hasUAVisualTransition = false;
+    Element? sourceElement = null;
 };
 
 dictionary NavigationInterceptOptions {

--- a/Libraries/LibWeb/HTML/Navigation.h
+++ b/Libraries/LibWeb/HTML/Navigation.h
@@ -116,10 +116,11 @@ public:
         URL::URL destination_url,
         bool is_same_document,
         UserNavigationInvolvement = UserNavigationInvolvement::None,
+        GC::Ptr<DOM::Element> source_element = {},
         Optional<Vector<XHR::FormDataEntry>&> form_data_entry_list = {},
         Optional<SerializationRecord> navigation_api_state = {},
         Optional<SerializationRecord> classic_history_api_state = {});
-    bool fire_a_download_request_navigate_event(URL::URL destination_url, UserNavigationInvolvement user_involvement, String filename);
+    bool fire_a_download_request_navigate_event(URL::URL destination_url, UserNavigationInvolvement user_involvement, GC::Ptr<DOM::Element> source_element, String filename);
 
     void initialize_the_navigation_api_entries_for_a_new_document(Vector<GC::Ref<SessionHistoryEntry>> const& new_shes, GC::Ref<SessionHistoryEntry> initial_she);
     void update_the_navigation_api_entries_for_a_same_document_navigation(GC::Ref<SessionHistoryEntry> destination_she, Bindings::NavigationType);
@@ -154,6 +155,7 @@ private:
         Bindings::NavigationType,
         GC::Ref<NavigationDestination>,
         UserNavigationInvolvement,
+        GC::Ptr<DOM::Element> source_element,
         Optional<Vector<XHR::FormDataEntry>&> form_data_entry_list,
         Optional<String> download_request_filename,
         Optional<SerializationRecord> classic_history_api_state);

--- a/Tests/LibWeb/Text/input/wpt-import/navigation-api/navigate-event/event-constructor.html
+++ b/Tests/LibWeb/Text/input/wpt-import/navigation-api/navigate-event/event-constructor.html
@@ -78,8 +78,7 @@ async_test(t => {
     assert_equals(event.downloadRequest, downloadRequest);
     assert_equals(event.info, info);
     assert_equals(event.hasUAVisualTransition, hasUAVisualTransition);
-    // NavigateEvent sourceElement is still in development, so test whether it is available.
-    if ("sourceElement" in e) assert_equals(event.sourceElement, sourceElement);
+    assert_equals(event.sourceElement, sourceElement);
   });
   history.pushState(2, null, "#2");
 }, "all properties are reflected back");
@@ -99,8 +98,7 @@ async_test(t => {
     assert_equals(event.formData, null);
     assert_equals(event.downloadRequest, null);
     assert_equals(event.info, undefined);
-    // NavigateEvent sourceElement is still in development, so test whether it is available.
-    if ("sourceElement" in e) assert_equals(event.sourceElement, null);
+    assert_equals(event.sourceElement, null);
   });
   history.pushState(3, null, "#3");
 }, "defaults are as expected");


### PR DESCRIPTION
Corresponds to https://github.com/whatwg/html/pull/10898

This is with https://github.com/whatwg/html/pull/10971 also applied - the original PR missed `sourceElement` from the `NavigateEventInit` dictionary.

I've also updated the imported WPT test as it's been recently changed to account for 10898 being merged.