### PR TITLE
Fix unnecessary wheel event consumption with overflow: scroll

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1650,7 +1650,7 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
         }
 
         if (paintable_box()) {
-            if (paintable_box()->is_scrollable()) {
+            if (paintable_box()->could_be_scrolled_by_wheel_event()) {
                 MUST(object.add("scrollable"sv, true));
             }
             if (!paintable_box()->is_visible()) {

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -335,7 +335,7 @@ void PaintableBox::after_paint(PaintContext& context, [[maybe_unused]] PaintPhas
     }
 }
 
-bool PaintableBox::is_scrollable(ScrollDirection direction) const
+bool PaintableBox::could_be_scrolled_by_wheel_event(ScrollDirection direction) const
 {
     auto overflow = direction == ScrollDirection::Horizontal ? computed_values().overflow_x() : computed_values().overflow_y();
     auto scrollable_overflow_rect = this->scrollable_overflow_rect();
@@ -348,9 +348,9 @@ bool PaintableBox::is_scrollable(ScrollDirection direction) const
     return overflow == CSS::Overflow::Scroll;
 }
 
-bool PaintableBox::is_scrollable() const
+bool PaintableBox::could_be_scrolled_by_wheel_event() const
 {
-    return is_scrollable(ScrollDirection::Horizontal) || is_scrollable(ScrollDirection::Vertical);
+    return could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal) || could_be_scrolled_by_wheel_event(ScrollDirection::Vertical);
 }
 
 static constexpr CSSPixels scrollbar_thumb_thickness = 8;
@@ -375,7 +375,7 @@ Optional<CSSPixelRect> PaintableBox::scroll_thumb_rect(ScrollDirection direction
 
 Optional<PaintableBox::ScrollbarData> PaintableBox::compute_scrollbar_data(ScrollDirection direction) const
 {
-    if (!is_scrollable(direction)) {
+    if (!could_be_scrolled_by_wheel_event(direction)) {
         return {};
     }
 
@@ -907,7 +907,7 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mousemove(Badge<EventHan
 
 bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
 {
-    if (!is_scrollable()) {
+    if (!could_be_scrolled_by_wheel_event()) {
         return false;
     }
 
@@ -1360,7 +1360,7 @@ PaintableBox const* PaintableBox::nearest_scrollable_ancestor() const
 {
     auto const* paintable = this->containing_block();
     while (paintable) {
-        if (paintable->is_scrollable())
+        if (paintable->could_be_scrolled_by_wheel_event())
             return paintable;
         if (paintable->is_fixed_position())
             return nullptr;

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -232,7 +232,7 @@ public:
     StickyInsets const& sticky_insets() const { return *m_sticky_insets; }
     void set_sticky_insets(OwnPtr<StickyInsets> sticky_insets) { m_sticky_insets = move(sticky_insets); }
 
-    [[nodiscard]] bool is_scrollable() const;
+    [[nodiscard]] bool could_be_scrolled_by_wheel_event() const;
 
     void set_used_values_for_grid_template_columns(RefPtr<CSS::GridTrackSizeListStyleValue> style_value) { m_used_values_for_grid_template_columns = move(style_value); }
     RefPtr<CSS::GridTrackSizeListStyleValue> const& used_values_for_grid_template_columns() const { return m_used_values_for_grid_template_columns; }
@@ -262,7 +262,7 @@ protected:
     };
     Optional<ScrollbarData> compute_scrollbar_data(ScrollDirection) const;
     [[nodiscard]] Optional<CSSPixelRect> scroll_thumb_rect(ScrollDirection) const;
-    [[nodiscard]] bool is_scrollable(ScrollDirection) const;
+    [[nodiscard]] bool could_be_scrolled_by_wheel_event(ScrollDirection) const;
 
     TraversalDecision hit_test_scrollbars(CSSPixelPoint position, Function<TraversalDecision(HitTestResult)> const& callback) const;
 

--- a/Libraries/LibWeb/Painting/ViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/ViewportPaintable.cpp
@@ -194,7 +194,7 @@ void ViewportPaintable::refresh_scroll_state()
         CSSPixels min_x_offset_relative_to_nearest_scrollable_ancestor;
         CSSPixels max_x_offset_relative_to_nearest_scrollable_ancestor;
         auto const* containing_block_of_sticky_box = sticky_box.containing_block();
-        if (containing_block_of_sticky_box->is_scrollable()) {
+        if (containing_block_of_sticky_box->could_be_scrolled_by_wheel_event()) {
             min_y_offset_relative_to_nearest_scrollable_ancestor = 0;
             max_y_offset_relative_to_nearest_scrollable_ancestor = containing_block_of_sticky_box->scrollable_overflow_rect()->height() - sticky_box.absolute_border_box_rect().height();
             min_x_offset_relative_to_nearest_scrollable_ancestor = 0;

--- a/Tests/LibWeb/Text/expected/scroll-by-dispatching-wheel-event-on-overflow-scroll-without-scrollable-overflow.txt
+++ b/Tests/LibWeb/Text/expected/scroll-by-dispatching-wheel-event-on-overflow-scroll-without-scrollable-overflow.txt
@@ -1,0 +1,1 @@
+new scrollY: 100

--- a/Tests/LibWeb/Text/input/scroll-by-dispatching-wheel-event-on-overflow-scroll-without-scrollable-overflow.html
+++ b/Tests/LibWeb/Text/input/scroll-by-dispatching-wheel-event-on-overflow-scroll-without-scrollable-overflow.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<script src="include.js"></script>
+<head>
+    <style>
+        body {
+            margin: 0;
+        }
+
+        .scroll-container {
+            height: 300px;
+            width: 300px;
+            overflow: auto;
+            border: 2px solid #333;
+            background-color: #f0f0f0;
+        }
+
+        .box {
+            overflow: scroll;
+        }
+
+        .nested {
+            border: 2px solid #777;
+            background-color: white;
+            height: 100px;
+        }
+    </style>
+</head>
+<body>
+    <div class="scroll-container">
+        <div class="box"><div class="nested">Box 1</div></div>
+        <div class="box"><div class="nested">Box 2</div></div>
+        <div class="box"><div class="nested">Box 3</div></div>
+        <div class="box"><div class="nested">Box 4</div></div>
+        <div class="box"><div class="nested">Box 5</div></div>
+        <div class="box"><div class="nested">Box 6</div></div>
+        <div class="box"><div class="nested">Box 7</div></div>
+        <div class="box"><div class="nested">Box 8</div></div>
+    </div>
+</body>
+<script>
+    asyncTest(done => {
+        const container = document.querySelector(".scroll-container");
+        container.onscroll = () => {
+            println(`new scrollY: ${container.scrollTop}`);
+            done();
+        };
+        internals.wheel(50, 50, 0, 100);
+    });
+</script>
+</html>


### PR DESCRIPTION
Allow wheel event to be consumed by a `overflow: scroll` box only if it
has content that overflows a scrollport.

This fixes the timing issue in the
`Text/input/scroll-window-using-wheel-event.html` test, where a `<body>`
element with `overflow: scroll` was incorrectly consuming wheel events
that should have propagated to the window.