### PR TITLE
LibWeb: Ensure size constraints apply to non-BFC-root abspos boxes

### DIFF
--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1245,6 +1245,15 @@ void FormattingContext::layout_absolutely_positioned_element(Box const& box, Ava
         box_state.set_has_definite_height(true);
     }
 
+    // NOTE: BFC is special, as their abspos auto height depends on performing inside layout.
+    //       For other formatting contexts, the height we've resolved early is good.
+    //       See FormattingContext::compute_auto_height_for_absolutely_positioned_element()
+    //       for the special-casing of BFC roots.
+    if (!creates_block_formatting_context(box)) {
+        box_state.set_has_definite_width(true);
+        box_state.set_has_definite_height(true);
+    }
+
     auto independent_formatting_context = layout_inside(box, LayoutMode::Normal, box_state.available_inner_space_or_constraints_from(available_space));
 
     compute_height_for_absolutely_positioned_element(box, available_space, BeforeOrAfterInsideLayout::After);

--- a/Tests/LibWeb/Layout/expected/abspos-non-bfc-root-with-min-height-constraint.txt
+++ b/Tests/LibWeb/Layout/expected/abspos-non-bfc-root-with-min-height-constraint.txt
@@ -1,0 +1,13 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x0 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 31.15625x300 positioned flex-container(row) [FFC] children: not-inline
+      BlockContainer <div> at (8,8) content-size 31.15625x300 flex-item [BFC] children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 31.15625x17] baseline: 13.296875
+            "Sup"
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x0]
+    PaintableBox (Box<BODY>) [8,8 31.15625x300]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 31.15625x300]
+        TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/abspos-non-bfc-root-with-min-height-constraint.html
+++ b/Tests/LibWeb/Layout/input/abspos-non-bfc-root-with-min-height-constraint.html
@@ -1,0 +1,8 @@
+<!doctype html><style>
+    * { outline: 1px solid black; }
+    body {
+        position: absolute;
+        min-height: 50%;
+        display: flex;
+    }
+</style><body><div>Sup


### PR DESCRIPTION
BFC roots behave differently in that their height is computed twice, before and after inside layout, since automatic height depends on the results of inside layout. Other formatting contexts only require the "before" pass, and so we can treat their content sizes as definite before proceeding with inside layout.

This makes https://play.tailwind.com/ look beautiful. :^)

Before:
<img width="1346" alt="Screenshot 2025-01-30 at 16 21 55" src="https://github.com/user-attachments/assets/cb09bff2-ce8e-49da-a712-aa452a84c66b" />

After:
<img width="1346" alt="Screenshot 2025-01-30 at 16 21 41" src="https://github.com/user-attachments/assets/376e81b2-4c74-403c-aba3-152cc20a01df" />
