### PR TITLE
CMake/WebWorker: Remove the Qt-specific path

### DIFF
--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -7,7 +7,6 @@ set(WEBWORKER_SOURCES
 # FIXME: Add Android service
 
 add_library(webworkerservice STATIC ${WEBWORKER_SOURCES})
-set_target_properties(webworkerservice PROPERTIES AUTOMOC OFF AUTORCC OFF AUTOUIC OFF)
 
 target_include_directories(webworkerservice PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/../..)
 target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR})
@@ -15,13 +14,6 @@ target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Servi
 
 target_link_libraries(webworkerservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibRequests LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL LibGC)
 
-if (ENABLE_QT)
-    qt_add_executable(WebWorker main.cpp)
-    target_link_libraries(WebWorker PRIVATE webworkerservice LibWebSocket)
-    target_compile_definitions(WebWorker PRIVATE HAVE_QT=1)
-else()
-    add_executable(WebWorker main.cpp)
-endif()
-
+add_executable(WebWorker main.cpp)
 target_include_directories(WebWorker PRIVATE ${LADYBIRD_SOURCE_DIR})
 target_link_libraries(WebWorker PRIVATE webworkerservice)


### PR DESCRIPTION
This should have been done in a1cf5271.

---
Follow up of #3145.