### PR TITLE
AK+LibWeb: Allow `as` and `as_if` to perform dynamic cast when necessary 

### DIFF
--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -36,22 +36,6 @@ ALWAYS_INLINE bool is(NonnullRefPtr<InputType> const& input)
 }
 
 template<typename OutputType, typename InputType>
-ALWAYS_INLINE CopyConst<InputType, OutputType>* as(InputType* input)
-{
-    static_assert(IsBaseOf<InputType, OutputType>);
-    VERIFY(!input || is<OutputType>(*input));
-    return static_cast<CopyConst<InputType, OutputType>*>(input);
-}
-
-template<typename OutputType, typename InputType>
-ALWAYS_INLINE CopyConst<InputType, OutputType>& as(InputType& input)
-{
-    static_assert(IsBaseOf<InputType, OutputType>);
-    VERIFY(is<OutputType>(input));
-    return static_cast<CopyConst<InputType, OutputType>&>(input);
-}
-
-template<typename OutputType, typename InputType>
 ALWAYS_INLINE CopyConst<InputType, OutputType>* as_if(InputType& input)
 {
     if (!is<OutputType>(input))
@@ -69,6 +53,24 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>* as_if(InputType* input)
     if (!input)
         return nullptr;
     return as_if<OutputType>(*input);
+}
+
+template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>& as(InputType& input)
+{
+    auto* result = as_if<OutputType>(input);
+    VERIFY(result);
+    return *result;
+}
+
+template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>* as(InputType* input)
+{
+    if (!input)
+        return nullptr;
+    auto* result = as_if<OutputType>(input);
+    VERIFY(result);
+    return result;
 }
 
 }

--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -56,7 +56,11 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>* as_if(InputType& input)
 {
     if (!is<OutputType>(input))
         return nullptr;
-    return static_cast<CopyConst<InputType, OutputType>*>(&input);
+    if constexpr (IsBaseOf<InputType, OutputType>) {
+        return static_cast<CopyConst<InputType, OutputType>*>(&input);
+    } else {
+        return dynamic_cast<CopyConst<InputType, OutputType>*>(&input);
+    }
 }
 
 template<typename OutputType, typename InputType>

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -791,10 +791,7 @@ GC::Ref<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, Opt
     //     element is either not listed or doesn't have a form attribute, and the intended parent is in the same tree as the element pointed to by the form element pointer,
     //     then associate element with the form element pointed to by the form element pointer and set element's parser inserted flag.
     // FIXME: Check if the element is not a form-associated custom element.
-    if (is<FormAssociatedElement>(*element)) {
-        auto* form_associated_element = dynamic_cast<FormAssociatedElement*>(element.ptr());
-        VERIFY(form_associated_element);
-
+    if (auto* form_associated_element = as_if<FormAssociatedElement>(*element)) {
         auto& html_element = form_associated_element->form_associated_element_to_html_element();
 
         if (m_form_element.ptr()


### PR DESCRIPTION
This means that if `is<OutputType>(x)` is true, that `as_if<OutputType>(x)` should always succeed.

I've also included a commit to use the new `as_if()` functionality to avoid a double dynamic cast in a few places.