### PR TITLE
Revert "WebWorker: Prefer the default EventLoopManager over Qt's specialization"

### DIFF
--- a/Services/WebWorker/main.cpp
+++ b/Services/WebWorker/main.cpp
@@ -24,6 +24,11 @@
 #include <LibWebView/Utilities.h>
 #include <WebWorker/ConnectionFromClient.h>
 
+#if defined(HAVE_QT)
+#    include <LibWebView/EventLoop/EventLoopImplementationQt.h>
+#    include <QCoreApplication>
+#endif
+
 static ErrorOr<void> initialize_resource_loader(GC::Heap&, int request_server_socket);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -45,6 +50,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (wait_for_debugger)
         Core::Process::wait_for_debugger_and_break();
 
+#if defined(HAVE_QT)
+    QCoreApplication app(arguments.argc, arguments.argv);
+    Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
+#endif
     Core::EventLoop event_loop;
 
     WebView::platform_init();


### PR DESCRIPTION
This was causing WPT tests using Workers to time out.

This reverts commit a1cf5271c29f2ec0cfc1c53067b624e5ccbd15a0.