### PR TITLE
LibWeb: Ignore fragments with pointer-events: none in hit-testing

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -1060,7 +1060,7 @@ TraversalDecision PaintableWithLines::hit_test(CSSPixelPoint position, HitTestTy
         return TraversalDecision::Continue;
 
     for (auto const& fragment : fragments()) {
-        if (fragment.paintable().has_stacking_context())
+        if (fragment.paintable().has_stacking_context() || !fragment.paintable().visible_for_hit_testing())
             continue;
         auto fragment_absolute_rect = fragment.absolute_rect();
         if (fragment_absolute_rect.contains(transformed_position_adjusted_by_scroll_offset)) {

--- a/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -6,10 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/Layout/LineBoxFragment.h>
 #include <LibWeb/Layout/Node.h>
-#include <LibWeb/Painting/BackgroundPainting.h>
-#include <LibWeb/Painting/BorderRadiiData.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/TextPaintable.cpp
+++ b/Libraries/LibWeb/Painting/TextPaintable.cpp
@@ -36,7 +36,7 @@ TextPaintable::DispatchEventOfSameName TextPaintable::handle_mousedown(Badge<Eve
     if (!label)
         return DispatchEventOfSameName::No;
     const_cast<Layout::Label*>(label)->handle_mousedown_on_label({}, position, button);
-    const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(this);
+    navigable()->event_handler().set_mouse_event_tracking_paintable(this);
     return DispatchEventOfSameName::Yes;
 }
 
@@ -47,7 +47,7 @@ TextPaintable::DispatchEventOfSameName TextPaintable::handle_mouseup(Badge<Event
         return DispatchEventOfSameName::No;
 
     const_cast<Layout::Label*>(label)->handle_mouseup_on_label({}, position, button);
-    const_cast<HTML::Navigable&>(*navigable()).event_handler().set_mouse_event_tracking_paintable(nullptr);
+    navigable()->event_handler().set_mouse_event_tracking_paintable(nullptr);
     return DispatchEventOfSameName::Yes;
 }
 

--- a/Tests/LibWeb/Text/expected/hit_testing/pointer-events.txt
+++ b/Tests/LibWeb/Text/expected/hit_testing/pointer-events.txt
@@ -13,3 +13,6 @@
 <DIV id="e2">
 <BODY>
 ---
+<A id="f1">
+<BODY>
+---

--- a/Tests/LibWeb/Text/input/hit_testing/pointer-events.html
+++ b/Tests/LibWeb/Text/input/hit_testing/pointer-events.html
@@ -23,6 +23,9 @@
     <!-- div creates its own stacking context, #e2 must be hit instead of crashing -->
     <div id="e1" style="position: fixed; width: 100px; height: 100px; pointer-events: none; background-color: red"></div>
     <div id="e2" style="width: 100px; height: 100px; background-color: green"></div>
+
+    <!-- #f1 must be hit instead of #f2 -->
+    <a id="f1"><img id="f2" style="height: 30px; width: 30px; pointer-events: none"></a>
 </body>
 <script>
     test(() => {
@@ -38,5 +41,6 @@
         printHit(c1.offsetLeft + 50, c1.offsetTop + 50);
         printHit(d4.offsetLeft + 10, d4.offsetTop + 8);
         printHit(e1.offsetLeft + 50, e1.offsetTop + 50);
+        printHit(f1.offsetLeft + 15, f1.offsetTop + 15);
     });
 </script>


### PR DESCRIPTION
Fixes a crash when hovering on some images on https://tweakers.net.