### PR TITLE
LibWeb: Clear stylesheet pointer when disabling link element

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -166,8 +166,10 @@ void HTMLLinkElement::attribute_changed(FlyString const& name, Optional<String> 
         m_explicitly_enabled = true;
 
     if (m_relationship & Relationship::Stylesheet) {
-        if (name == HTML::AttributeNames::disabled && m_loaded_style_sheet)
+        if (name == HTML::AttributeNames::disabled && m_loaded_style_sheet) {
             document_or_shadow_root_style_sheets().remove_a_css_style_sheet(*m_loaded_style_sheet);
+            m_loaded_style_sheet = nullptr;
+        }
 
         // https://html.spec.whatwg.org/multipage/links.html#link-type-stylesheet:fetch-and-process-the-linked-resource
         // The appropriate times to fetch and process this type of link are:

--- a/Tests/LibWeb/Text/expected/link-re-enable-crash.txt
+++ b/Tests/LibWeb/Text/expected/link-re-enable-crash.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/link-re-enable-crash.html
+++ b/Tests/LibWeb/Text/input/link-re-enable-crash.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<link rel="stylesheet" href="valid.css">
+<script>
+    test(() => {
+        const link = document.querySelector("link");
+        link.onload = () => {
+            link.disabled = true;
+            link.disabled = false;
+            println("PASS (didn't crash)");
+        };
+    });
+</script>


### PR DESCRIPTION
This fixes a crash when enabling or disabling an already disabled link element. 
Fixes a crash when changing mdbook themes. (e.g. on https://doc.rust-lang.org/stable/book/)