### PR TITLE
LibRegex: Take trailing inversion state into account in block comparison

### DIFF
--- a/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Libraries/LibRegex/RegexOptimizer.cpp
@@ -500,7 +500,8 @@ static bool has_overlap(Vector<CompareTypeAndValuePair> const& lhs, Vector<Compa
         }
     }
 
-    return false;
+    // We got to the end, just double-check that the inverse flag was not left on (which would match everything).
+    return current_lhs_inversion_state();
 }
 
 enum class AtomicRewritePreconditionResult {

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -715,6 +715,7 @@ TEST_CASE(ECMA262_match)
         { "^(\\d{4}|[+-]\\d{6})(?:-?(\\d{2})(?:-?(\\d{2}))?)?(?:[ T]?(\\d{2}):?(\\d{2})(?::?(\\d{2})(?:[,.](\\d{1,}))?)?(?:(Z)|([+-])(\\d{2})(?::?(\\d{2}))?)?)?$"sv,
             ""sv,
             false, }, // See above, also ladybird#2931.
+        { "[^]*[^]"sv, "i"sv, true }, // Optimizer bug, ignoring an enabled trailing 'invert' when comparing blocks, ladybird#3421.
     };
     // clang-format on
 


### PR DESCRIPTION
Fixes #3421.