### PR TITLE
Nix: Fix OpenGL linking issue in the devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1731676054,
-        "narHash": "sha256-OZiZ3m8SCMfh3B6bfGC/Bm4x3qc1m2SVEAlkV6iY7Yg=",
+        "lastModified": 1738410390,
+        "narHash": "sha256-xvTo0Aw0+veek7hvEVLzErmJyQkEcRk6PSR4zsRQFEc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e4fbfb6b3de1aa2872b76d49fafc942626e2add",
+        "rev": "3a228057f5b619feb3186e986dbe76278d707b6e",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -22,6 +22,10 @@ pkgs.mkShell {
       prettier
     ];
 
+  # Fix for: https://github.com/LadybirdBrowser/ladybird/issues/371#issuecomment-2616415434
+  # https://github.com/NixOS/nixpkgs/commit/049a854b4be087eaa3a09012b9c452fbc838dd41
+  NIX_LDFLAGS = "-lGL";
+
   shellHook = ''
     # NOTE: This is required to make it find the wayland platform plugin installed
     #       above, but should probably be fixed upstream.

--- a/shell.nix
+++ b/shell.nix
@@ -4,15 +4,7 @@
 
 pkgs.mkShell {
   inputsFrom = [
-    (pkgs.ladybird.override (prev: {
-      # Apply fix expanding skia's public api
-      # See #4d7b717
-      skia = prev.skia.overrideAttrs (prev: {
-        gnFlags = prev.gnFlags ++ [
-          "extra_cflags+=[\"-DSKCMS_API=__attribute__((visibility(\\\"default\\\")))\"]"
-        ];
-      });
-    }))
+    pkgs.ladybird
   ];
 
   packages =


### PR DESCRIPTION
This just brings the nixpkgs fix to the devshell.
As said https://github.com/LadybirdBrowser/ladybird/issues/371#issuecomment-2621455684, this is probably an issue with the nix libGL package or libglvnd? Im not sure