### PR TITLE
LibWeb: Use `as` to cast global object to WindowOrWorkerGlobalScopeMixin

### DIFF
--- a/Libraries/LibWeb/Bindings/MainThreadVM.cpp
+++ b/Libraries/LibWeb/Bindings/MainThreadVM.cpp
@@ -779,9 +779,8 @@ void invoke_custom_element_reactions(Vector<GC::Root<DOM::Element>>& element_que
                         auto& realm = callback.callback->shape().realm();
                         auto& global = realm.global_object();
 
-                        auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&global);
-                        VERIFY(window_or_worker);
-                        window_or_worker->report_an_exception(maybe_exception.error_value());
+                        auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(global);
+                        window_or_worker.report_an_exception(maybe_exception.error_value());
                     }
                 },
                 [&](DOM::CustomElementCallbackReaction& custom_element_callback_reaction) -> void {

--- a/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -151,11 +151,10 @@ WebIDL::ExceptionOr<GC::Ref<AbortSignal>> AbortSignal::timeout(JS::VM& vm, WebID
 
     // 2. Let global be signal’s relevant global object.
     auto& global = HTML::relevant_global_object(signal);
-    auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&global);
-    VERIFY(window_or_worker);
+    auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(global);
 
     // 3. Run steps after a timeout given global, "AbortSignal-timeout", milliseconds, and the following step:
-    window_or_worker->run_steps_after_a_timeout(milliseconds, [&realm, &global, signal]() {
+    window_or_worker.run_steps_after_a_timeout(milliseconds, [&realm, &global, signal]() {
         // 1. Queue a global task on the timer task source given global to signal abort given signal and a new "TimeoutError" DOMException.
         HTML::queue_global_task(HTML::Task::Source::TimerTask, global, GC::create_function(realm.heap(), [&realm, signal]() mutable {
             auto reason = WebIDL::TimeoutError::create(realm, "Signal timed out"_string);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3850,8 +3850,7 @@ Vector<GC::Root<HTML::Navigable>> Document::document_tree_child_navigables()
 void Document::run_unloading_cleanup_steps()
 {
     // 1. Let window be document's relevant global object.
-    auto* window = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&HTML::relevant_global_object(*this));
-    VERIFY(window);
+    auto& window = as<HTML::WindowOrWorkerGlobalScopeMixin>(HTML::relevant_global_object(*this));
 
     // FIXME: 2. For each WebSocket object webSocket whose relevant global object is window, make disappear webSocket.
     //            If this affected any WebSocket objects, then set document's salvageable state to false.
@@ -3861,10 +3860,10 @@ void Document::run_unloading_cleanup_steps()
     // 4. If document's salvageable state is false, then:
     if (!m_salvageable) {
         // 1. For each EventSource object eventSource whose relevant global object is equal to window, forcibly close eventSource.
-        window->forcibly_close_all_event_sources();
+        window.forcibly_close_all_event_sources();
 
         // 2. Clear window's map of active timers.
-        window->clear_map_of_active_timers();
+        window.clear_map_of_active_timers();
     }
 
     FileAPI::run_unloading_cleanup_steps(*this);

--- a/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -96,9 +96,8 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<GC::Root<DOM::DOMEventLi
         // If this throws an exception, then:
         if (result.is_error()) {
             // 1. Report exception for listener’s callback’s corresponding JavaScript object’s associated realm’s global object.
-            auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&global);
-            VERIFY(window_or_worker);
-            window_or_worker->report_an_exception(*result.release_error().value());
+            auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(global);
+            window_or_worker.report_an_exception(*result.release_error().value());
 
             // 2. Set legacyOutputDidListenersThrowFlag if given. (Only used by IndexedDB currently)
             legacy_output_did_listeners_throw = true;

--- a/Libraries/LibWeb/HTML/EventSource.cpp
+++ b/Libraries/LibWeb/HTML/EventSource.cpp
@@ -176,9 +176,8 @@ void EventSource::initialize(JS::Realm& realm)
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(EventSource);
 
-    auto* relevant_global = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&HTML::relevant_global_object(*this));
-    VERIFY(relevant_global);
-    relevant_global->register_event_source({}, *this);
+    auto& relevant_global = as<HTML::WindowOrWorkerGlobalScopeMixin>(HTML::relevant_global_object(*this));
+    relevant_global.register_event_source({}, *this);
 }
 
 // https://html.spec.whatwg.org/multipage/server-sent-events.html#garbage-collection
@@ -191,9 +190,8 @@ void EventSource::finalize()
             m_fetch_controller->abort(realm(), {});
     }
 
-    auto* relevant_global = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&HTML::relevant_global_object(*this));
-    VERIFY(relevant_global);
-    relevant_global->unregister_event_source({}, *this);
+    auto& relevant_global = as<HTML::WindowOrWorkerGlobalScopeMixin>(HTML::relevant_global_object(*this));
+    relevant_global.unregister_event_source({}, *this);
 }
 
 void EventSource::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -128,9 +128,8 @@ JS::Completion ClassicScript::run(RethrowErrors rethrow_errors, GC::Ptr<JS::Envi
         VERIFY(rethrow_errors == RethrowErrors::No);
 
         // 1. Report an exception given by evaluationStatus.[[Value]] for realms's global object.
-        auto* window_or_worker = dynamic_cast<WindowOrWorkerGlobalScopeMixin*>(&realm.global_object());
-        VERIFY(window_or_worker);
-        window_or_worker->report_an_exception(*evaluation_status.value());
+        auto& window_or_worker = as<WindowOrWorkerGlobalScopeMixin>(realm.global_object());
+        window_or_worker.report_an_exception(*evaluation_status.value());
 
         // 2. Clean up after running script with realm.
         clean_up_after_running_script(realm);

--- a/Libraries/LibWeb/HighResolutionTime/Performance.cpp
+++ b/Libraries/LibWeb/HighResolutionTime/Performance.cpp
@@ -363,9 +363,7 @@ WebIDL::ExceptionOr<Vector<GC::Root<PerformanceTimeline::PerformanceEntry>>> Per
 
 HTML::WindowOrWorkerGlobalScopeMixin& Performance::window_or_worker()
 {
-    auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&realm().global_object());
-    VERIFY(window_or_worker);
-    return *window_or_worker;
+    return as<HTML::WindowOrWorkerGlobalScopeMixin>(realm().global_object());
 }
 
 HTML::WindowOrWorkerGlobalScopeMixin const& Performance::window_or_worker() const

--- a/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
+++ b/Libraries/LibWeb/PerformanceTimeline/PerformanceObserver.cpp
@@ -50,8 +50,7 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
     auto& realm = this->realm();
 
     // 1. Let relevantGlobal be this's relevant global object.
-    auto* relevant_global = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&HTML::relevant_global_object(*this));
-    VERIFY(relevant_global);
+    auto& relevant_global = as<HTML::WindowOrWorkerGlobalScopeMixin>(HTML::relevant_global_object(*this));
 
     // 2. If options's entryTypes and type members are both omitted, then throw a "TypeError".
     if (!options.entry_types.has_value() && !options.type.has_value())
@@ -123,7 +122,7 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
         //       performance observer object.
         m_options_list.clear();
         m_options_list.append(options);
-        relevant_global->register_performance_observer({}, *this);
+        relevant_global.register_performance_observer({}, *this);
     }
     // 7. Otherwise, run the following steps:
     else {
@@ -149,7 +148,7 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
 
         // 3. If the list of registered performance observer objects of relevantGlobal contains a registered performance
         //    observer obs whose observer is this:
-        if (relevant_global->has_registered_performance_observer(*this)) {
+        if (relevant_global.has_registered_performance_observer(*this)) {
             // 1. If obs's options list contains a PerformanceObserverInit item currentOptions whose type is equal to options's type,
             //    replace currentOptions with options in obs's options list.
             auto index = m_options_list.find_first_index_if([&options](PerformanceObserverInit const& entry) {
@@ -168,13 +167,13 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
         else {
             m_options_list.clear();
             m_options_list.append(options);
-            relevant_global->register_performance_observer({}, *this);
+            relevant_global.register_performance_observer({}, *this);
         }
 
         // 5. If options's buffered flag is set:
         if (options.buffered.has_value() && options.buffered.value()) {
             // 1. Let tuple be the relevant performance entry tuple of options's type and relevantGlobal.
-            auto const& tuple = relevant_global->relevant_performance_entry_tuple(type);
+            auto const& tuple = relevant_global.relevant_performance_entry_tuple(type);
 
             // 2. For each entry in tuple's performance entry buffer:
             for (auto const& entry : tuple.performance_entry_buffer) {
@@ -184,7 +183,7 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
             }
 
             // 3. Queue the PerformanceObserver task with relevantGlobal as input.
-            relevant_global->queue_the_performance_observer_task();
+            relevant_global.queue_the_performance_observer_task();
         }
     }
 
@@ -195,9 +194,8 @@ WebIDL::ExceptionOr<void> PerformanceObserver::observe(PerformanceObserverInit& 
 void PerformanceObserver::disconnect()
 {
     // 1. Remove this from the list of registered performance observer objects of relevant global object.
-    auto* relevant_global = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&HTML::relevant_global_object(*this));
-    VERIFY(relevant_global);
-    relevant_global->unregister_performance_observer({}, *this);
+    auto& relevant_global = as<HTML::WindowOrWorkerGlobalScopeMixin>(HTML::relevant_global_object(*this));
+    relevant_global.unregister_performance_observer({}, *this);
 
     // 2. Empty this's observer buffer.
     m_observer_buffer.clear();
@@ -221,11 +219,10 @@ Vector<GC::Root<PerformanceTimeline::PerformanceEntry>> PerformanceObserver::tak
 GC::Ref<JS::Object> PerformanceObserver::supported_entry_types(JS::VM& vm)
 {
     // 1. Let globalObject be the environment settings object's global object.
-    auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&vm.get_global_object());
-    VERIFY(window_or_worker);
+    auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(vm.get_global_object());
 
     // 2. Return globalObject's frozen array of supported entry types.
-    return window_or_worker->supported_entry_types();
+    return window_or_worker.supported_entry_types();
 }
 
 void PerformanceObserver::unset_requires_dropped_entries(Badge<HTML::WindowOrWorkerGlobalScopeMixin>)

--- a/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
+++ b/Libraries/LibWeb/WebIDL/AbstractOperations.cpp
@@ -327,9 +327,8 @@ JS::Completion invoke_callback(WebIDL::CallbackType& callback, Optional<JS::Valu
             // FIXME: 1. Assert: callable’s return type is undefined or any.
 
             // 2. Report an exception completion.[[Value]] for relevant realm’s global object.
-            auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&relevant_realm.global_object());
-            VERIFY(window_or_worker);
-            window_or_worker->report_an_exception(*completion.release_value());
+            auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(relevant_realm.global_object());
+            window_or_worker.report_an_exception(*completion.release_value());
 
             // 3. Return the unique undefined IDL value.
             return JS::js_undefined();

--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -123,9 +123,8 @@ ErrorOr<void> WebSocket::establish_web_socket_connection(URL::URL& url_record, V
 {
     // FIXME: Integrate properly with FETCH as per https://fetch.spec.whatwg.org/#websocket-opening-handshake
 
-    auto* window_or_worker = dynamic_cast<HTML::WindowOrWorkerGlobalScopeMixin*>(&client.global_object());
-    VERIFY(window_or_worker);
-    auto origin_string = window_or_worker->origin().to_byte_string();
+    auto& window_or_worker = as<HTML::WindowOrWorkerGlobalScopeMixin>(client.global_object());
+    auto origin_string = window_or_worker.origin().to_byte_string();
 
     Vector<ByteString> protcol_byte_strings;
     for (auto const& protocol : protocols)


### PR DESCRIPTION
This just makes the code slightly less verbose.

No functional changes.