### PR TITLE
LibWeb: Use fast CSS selector matching in default matches() code path

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -268,12 +268,15 @@ public:
 
     auto const& ancestor_hashes() const { return m_ancestor_hashes; }
 
+    bool can_use_fast_matches() const { return m_can_use_fast_matches; }
+
 private:
     explicit Selector(Vector<CompoundSelector>&&);
 
     Vector<CompoundSelector> m_compound_selectors;
     mutable Optional<u32> m_specificity;
     Optional<Selector::PseudoElement> m_pseudo_element;
+    bool m_can_use_fast_matches { false };
     bool m_contains_the_nesting_selector { false };
     bool m_contains_hover_pseudo_class { false };
 

--- a/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -25,9 +25,4 @@ struct MatchContext {
 
 bool matches(CSS::Selector const&, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context, Optional<CSS::Selector::PseudoElement::Type> = {}, GC::Ptr<DOM::ParentNode const> scope = {}, SelectorKind selector_kind = SelectorKind::Normal, GC::Ptr<DOM::Element const> anchor = nullptr);
 
-[[nodiscard]] bool fast_matches(CSS::Selector const&, DOM::Element const&, GC::Ptr<DOM::Element const> shadow_host, MatchContext& context);
-[[nodiscard]] bool can_use_fast_matches(CSS::Selector const&);
-
-[[nodiscard]] bool matches_hover_pseudo_class(DOM::Element const&);
-
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -595,13 +595,8 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::Element c
             if (context.did_match_any_hover_rules)
                 did_match_any_hover_rules = true;
         };
-        if (rule_to_run.can_use_fast_matches) {
-            if (!SelectorEngine::fast_matches(selector, element, shadow_host_to_use, context))
-                continue;
-        } else {
-            if (!SelectorEngine::matches(selector, element, shadow_host_to_use, context, pseudo_element))
-                continue;
-        }
+        if (!SelectorEngine::matches(selector, element, shadow_host_to_use, context, pseudo_element))
+            continue;
         matching_rules.append(&rule_to_run);
     }
 
@@ -2686,7 +2681,6 @@ void StyleComputer::make_rule_cache_for_cascade_origin(CascadeOrigin cascade_ori
                     selector.specificity(),
                     cascade_origin,
                     false,
-                    SelectorEngine::can_use_fast_matches(selector),
                     false,
                 };
 

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -86,7 +86,6 @@ struct MatchingRule {
     u32 specificity { 0 };
     CascadeOrigin cascade_origin;
     bool contains_pseudo_element { false };
-    bool can_use_fast_matches { false };
     bool must_be_hovered { false };
 
     // Helpers to deal with the fact that `rule` might be a CSSStyleRule or a CSSNestedDeclarations

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1728,13 +1728,8 @@ void Document::invalidate_style_for_elements_affected_by_hover_change(Node& old_
 
             SelectorEngine::MatchContext context;
             bool selector_matched = false;
-            if (rule.can_use_fast_matches) {
-                if (SelectorEngine::fast_matches(selector, element, {}, context))
-                    selector_matched = true;
-            } else {
-                if (SelectorEngine::matches(selector, element, {}, context, {}))
-                    selector_matched = true;
-            }
+            if (SelectorEngine::matches(selector, element, {}, context, {}))
+                selector_matched = true;
             if (element.has_pseudo_elements()) {
                 if (SelectorEngine::matches(selector, element, {}, context, CSS::Selector::PseudoElement::Type::Before))
                     selector_matched = true;


### PR DESCRIPTION
Before this change, checking if fast selector matching could be used was only enabled in style recalculation and hover invalidation. With this change it's enabled for all callers of SelectorEngine::matches() by default. This way APIs like `Element::matches()` and `Document::querySelector()` could take advantage of this optimization.