### PR TITLE
RequestServer: Check for empty list of IP addresses in DNS result

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -350,7 +350,7 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString const& metho
             async_request_finished(request_id, 0, Requests::NetworkError::UnableToResolveHost);
         })
         .when_resolved([this, request_id, host, url, method, request_body, request_headers, proxy_data](auto const& dns_result) {
-            if (dns_result->records().is_empty()) {
+            if (dns_result->records().is_empty() || dns_result->cached_addresses().is_empty()) {
                 dbgln("StartRequest: DNS lookup failed for '{}'", host);
                 async_request_finished(request_id, 0, Requests::NetworkError::UnableToResolveHost);
                 return;


### PR DESCRIPTION
Before, if something went wrong with DNS lookup and there were unrelated records (i.e. not A or AAAA) then we would still attempt to build a resolve list. This resulted in curl errors related to the option itself and displayed as "unknown network error" to the user.