### PR TITLE
LibWeb: Support both ::before/::after pseudo elements on button elements

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.h
+++ b/Libraries/LibWeb/Layout/TreeBuilder.h
@@ -31,6 +31,7 @@ private:
 
     void update_layout_tree_before_children(DOM::Node&, GC::Ref<Layout::Node>, Context&, bool element_has_content_visibility_hidden);
     void update_layout_tree_after_children(DOM::Node&, GC::Ref<Layout::Node>, Context&, bool element_has_content_visibility_hidden);
+    void wrap_in_button_layout_tree_if_needed(DOM::Node&, GC::Ref<Layout::Node>);
     enum class MustCreateSubtree {
         No,
         Yes,

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-abspos-pseudo-element.txt
@@ -4,9 +4,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 0 from BlockContainer start: 0, length: 0, rect: [29,29 0x0] baseline: 42
       BlockContainer <button> at (29,29) content-size 0x0 positioned inline-block [BFC] children: not-inline
         BlockContainer <(anonymous)> at (29,29) content-size 0x0 flex-container(column) [FFC] children: not-inline
-          BlockContainer <(anonymous)> at (29,29) content-size 0x0 [BFC] children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 40x40 positioned [BFC] children: inline
-          TextNode <#text>
+          BlockContainer <(anonymous)> at (29,29) content-size 0x0 flex-item [BFC] children: not-inline
+            BlockContainer <(anonymous)> at (9,9) content-size 40x40 positioned [BFC] children: inline
+              TextNode <#text>
       TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
@@ -15,4 +15,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
       PaintableWithLines (BlockContainer<BUTTON>) [8,8 42x42]
         PaintableWithLines (BlockContainer(anonymous)) [29,29 0x0]
           PaintableWithLines (BlockContainer(anonymous)) [29,29 0x0]
-        PaintableWithLines (BlockContainer(anonymous)) [9,9 40x40]
+            PaintableWithLines (BlockContainer(anonymous)) [9,9 40x40]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-after-pseudo.txt
@@ -8,8 +8,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.703125x55] baseline: 42.484375
                 "See more games"
             TextNode <#text>
-        BlockContainer <(anonymous)> at (9,9) content-size 422.703125x57 positioned [BFC] children: inline
-          TextNode <#text>
+            BlockContainer <(anonymous)> at (9,9) content-size 422.703125x57 positioned [BFC] children: inline
+              TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x75]
@@ -18,4 +18,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x55]
           PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x55]
             TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer(anonymous)) [9,9 422.703125x57]
+            PaintableWithLines (BlockContainer(anonymous)) [9,9 422.703125x57]

--- a/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/button-with-before-pseudo.txt
@@ -3,19 +3,19 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
     BlockContainer <body> at (8,8) content-size 784x59 children: inline
       frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 414.703125x55] baseline: 44.484375
       BlockContainer <button.button_button___eDCW> at (13,10) content-size 414.703125x55 positioned inline-block [BFC] children: not-inline
-        BlockContainer <(anonymous)> at (9,9) content-size 422.703125x57 positioned [BFC] children: inline
-          TextNode <#text>
         BlockContainer <(anonymous)> at (13,10) content-size 414.703125x55 flex-container(column) [FFC] children: not-inline
           BlockContainer <(anonymous)> at (13,10) content-size 414.703125x55 flex-item [BFC] children: inline
             frag 0 from TextNode start: 0, length: 14, rect: [13,10 414.703125x55] baseline: 42.484375
                 "See more games"
+            BlockContainer <(anonymous)> at (9,9) content-size 422.703125x57 positioned [BFC] children: inline
+              TextNode <#text>
             TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x75]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x59]
       PaintableWithLines (BlockContainer<BUTTON>.button_button___eDCW) [8,8 424.703125x59]
-        PaintableWithLines (BlockContainer(anonymous)) [9,9 422.703125x57]
         PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x55]
           PaintableWithLines (BlockContainer(anonymous)) [13,10 414.703125x55]
+            PaintableWithLines (BlockContainer(anonymous)) [9,9 422.703125x57]
             TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/button-with-before-and-after-pseudo-elements.txt
+++ b/Tests/LibWeb/Layout/expected/button-with-before-and-after-pseudo-elements.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x37 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x21 children: inline
+      frag 0 from BlockContainer start: 0, length: 0, rect: [13,10 82x17] baseline: 15.296875
+      BlockContainer <button> at (13,10) content-size 82x17 inline-block [BFC] children: not-inline
+        BlockContainer <(anonymous)> at (13,10) content-size 82x17 flex-container(column) [FFC] children: not-inline
+          BlockContainer <(anonymous)> at (13,10) content-size 82x17 flex-item [BFC] children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [40.15625,10 27.640625x17] baseline: 13.296875
+                "bar"
+            InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 3, rect: [13,10 27.15625x17] baseline: 13.296875
+                  "foo"
+              TextNode <#text>
+            TextNode <#text>
+            InlineNode <(anonymous)>
+              frag 0 from TextNode start: 0, length: 3, rect: [67.796875,10 27.203125x17] baseline: 13.296875
+                  "baz"
+              TextNode <#text>
+      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x37]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x21]
+      PaintableWithLines (BlockContainer<BUTTON>) [8,8 92x21]
+        PaintableWithLines (BlockContainer(anonymous)) [13,10 82x17]
+          PaintableWithLines (BlockContainer(anonymous)) [13,10 82x17]
+            PaintableWithLines (InlineNode(anonymous))
+              TextPaintable (TextNode<#text>)
+            TextPaintable (TextNode<#text>)
+            PaintableWithLines (InlineNode(anonymous))
+              TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/button-with-before-and-after-pseudo-elements.html
+++ b/Tests/LibWeb/Layout/input/button-with-before-and-after-pseudo-elements.html
@@ -1,0 +1,5 @@
+<!doctype html><style>
+    *, ::before, ::after { outline: 1px solid black; }
+    button:before { content: "foo"; }
+    button:after { content: "baz"; }
+</style><body><button>bar</button>


### PR DESCRIPTION
This was mainly a matter of deferring the wrapping of the button's children until after its internal layout tree has been constructed. That way we don't lose any pseudo elements spawned along the way.

Visual progression on https://blt.se/ cookie banners.

Before:
<img width="1503" alt="Screenshot 2025-02-03 at 12 48 05" src="https://github.com/user-attachments/assets/f0f8de86-f40d-4b1b-841d-fd8dfec04cac" />

After:
<img width="1503" alt="Screenshot 2025-02-03 at 12 47 46" src="https://github.com/user-attachments/assets/ca334807-9390-4ec6-a2ed-3c15bd3ac765" />
