### PR TITLE
LibWeb: Prevent double page title update in DOM::Document

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1029,9 +1029,6 @@ WebIDL::ExceptionOr<void> Document::set_title(String const& title)
         return {};
     }
 
-    if (browsing_context() == &page().top_level_browsing_context())
-        page().client().page_did_change_title(title.to_byte_string());
-
     return {};
 }
 


### PR DESCRIPTION
This ad-hoc code informs the client of a potentially changed page title. But because we always update the title element (either the SVG or HTML title) the client was already informed, causing the code to run twice.