### PR TITLE
LibWeb/SVG: Rename text-space-collapse to white-space-collapse

### DIFF
--- a/Libraries/LibWeb/SVG/Default.css
+++ b/Libraries/LibWeb/SVG/Default.css
@@ -11,7 +11,7 @@ svg:not(:root), image, marker, pattern, symbol { overflow: hidden; }
 }
 
 *[xml|space=preserve] {
-    text-space-collapse: preserve-spaces;
+    white-space-collapse: preserve-spaces;
 }
 
 /* FIXME: Allow setting the rest of these to `display: none`.


### PR DESCRIPTION
This is the current name for this property in CSS-Text-4. We don't implement it, but at least our "missing property" message can be about one we haven't implemented instead of one that's redundant. :^)

Made a spec PR here: https://github.com/w3c/svgwg/pull/966