### PR TITLE
LibWeb: Change animation to schedule repaint only when necessary

### DIFF
--- a/Libraries/LibWeb/Animations/Animation.cpp
+++ b/Libraries/LibWeb/Animations/Animation.cpp
@@ -1331,9 +1331,6 @@ void Animation::invalidate_effect()
 
     if (auto* target = m_effect->target(); target) {
         target->document().set_needs_animated_style_update();
-        if (target->paintable()) {
-            target->paintable()->set_needs_display();
-        }
     }
 }
 

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -961,8 +961,10 @@ void KeyframeEffect::update_computed_properties()
         document.set_needs_layout();
     if (invalidation.rebuild_layout_tree)
         document.invalidate_layout_tree();
-    if (invalidation.repaint)
+    if (invalidation.repaint) {
+        document.set_needs_display();
         document.set_needs_to_resolve_paint_only_properties();
+    }
     if (invalidation.rebuild_stacking_context_tree)
         document.invalidate_stacking_context_tree();
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -2646,9 +2646,6 @@ void Document::dispatch_events_for_animation_if_necessary(GC::Ref<Animations::An
     if (!target)
         return;
 
-    if (target->paintable())
-        target->paintable()->set_needs_display();
-
     auto previous_phase = effect->previous_phase();
     auto current_phase = effect->phase();
     auto current_iteration = effect->current_iteration().value_or(0.0);


### PR DESCRIPTION
Animation should trigger repaint only if it's required by animated style update.