### PR TITLE
LibJS: Handle call stack limit exceptions in NewPromiseReactionJob

### DIFF
--- a/Libraries/LibJS/Runtime/Completion.h
+++ b/Libraries/LibJS/Runtime/Completion.h
@@ -31,24 +31,23 @@ namespace JS {
         _temporary_result.release_value();                                                                            \
     })
 
-#define MUST_OR_THROW_OOM(...)                                                                         \
-    ({                                                                                                 \
-        /* Ignore -Wshadow to allow nesting the macro. */                                              \
-        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                               \
-            auto&& _temporary_result = (__VA_ARGS__));                                                 \
-        if (_temporary_result.is_error()) {                                                            \
-            auto _completion = _temporary_result.release_error();                                      \
-                                                                                                       \
-            /* We can't explicitly check for OOM because InternalError does not store the ErrorType */ \
-            VERIFY(_completion.value().has_value());                                                   \
-            VERIFY(_completion.value()->is_object());                                                  \
-            VERIFY(::AK::is<JS::InternalError>(_completion.value()->as_object()));                     \
-                                                                                                       \
-            return _completion;                                                                        \
-        }                                                                                              \
-        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>,   \
-            "Do not return a reference from a fallible expression");                                   \
-        _temporary_result.release_value();                                                             \
+#define MUST_OR_THROW_INTERNAL_ERROR(...)                                                            \
+    ({                                                                                               \
+        /* Ignore -Wshadow to allow nesting the macro. */                                            \
+        AK_IGNORE_DIAGNOSTIC("-Wshadow",                                                             \
+            auto&& _temporary_result = (__VA_ARGS__));                                               \
+        if (_temporary_result.is_error()) {                                                          \
+            auto _completion = _temporary_result.release_error();                                    \
+                                                                                                     \
+            VERIFY(_completion.value().has_value());                                                 \
+            VERIFY(_completion.value()->is_object());                                                \
+            VERIFY(::AK::is<JS::InternalError>(_completion.value()->as_object()));                   \
+                                                                                                     \
+            return _completion;                                                                      \
+        }                                                                                            \
+        static_assert(!::AK::Detail::IsLvalueReference<decltype(_temporary_result.release_value())>, \
+            "Do not return a reference from a fallible expression");                                 \
+        _temporary_result.release_value();                                                           \
     })
 
 // 6.2.3 The Completion Record Specification Type, https://tc39.es/ecma262/#sec-completion-record-specification-type

--- a/Libraries/LibJS/Runtime/Intrinsics.cpp
+++ b/Libraries/LibJS/Runtime/Intrinsics.cpp
@@ -143,7 +143,7 @@ static void initialize_constructor(VM& vm, PropertyKey const& property_key, Obje
 }
 
 // 9.3.2 CreateIntrinsics ( realmRec ), https://tc39.es/ecma262/#sec-createintrinsics
-ThrowCompletionOr<GC::Ref<Intrinsics>> Intrinsics::create(Realm& realm)
+GC::Ref<Intrinsics> Intrinsics::create(Realm& realm)
 {
     auto& vm = realm.vm();
 
@@ -165,7 +165,7 @@ ThrowCompletionOr<GC::Ref<Intrinsics>> Intrinsics::create(Realm& realm)
     //    is the specified value of the function's [[Prototype]] internal slot. The
     //    creation of the intrinsics and their properties must be ordered to avoid
     //    any dependencies upon objects that have not yet been created.
-    MUST_OR_THROW_OOM(intrinsics->initialize_intrinsics(realm));
+    intrinsics->initialize_intrinsics(realm);
 
     // 3. Perform AddRestrictedFunctionProperties(realmRec.[[Intrinsics]].[[%Function.prototype%]], realmRec).
     add_restricted_function_properties(static_cast<FunctionObject&>(*realm.intrinsics().function_prototype()), realm);
@@ -174,7 +174,7 @@ ThrowCompletionOr<GC::Ref<Intrinsics>> Intrinsics::create(Realm& realm)
     return *intrinsics;
 }
 
-ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
+void Intrinsics::initialize_intrinsics(Realm& realm)
 {
     auto& vm = this->vm();
 
@@ -271,8 +271,6 @@ ThrowCompletionOr<void> Intrinsics::initialize_intrinsics(Realm& realm)
     m_json_parse_function = &json_object()->get_without_side_effects(vm.names.parse).as_function();
     m_json_stringify_function = &json_object()->get_without_side_effects(vm.names.stringify).as_function();
     m_object_prototype_to_string_function = &object_prototype()->get_without_side_effects(vm.names.toString).as_function();
-
-    return {};
 }
 
 template<typename T>

--- a/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Libraries/LibJS/Runtime/Intrinsics.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <LibGC/CellAllocator.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
 

--- a/Libraries/LibJS/Runtime/Intrinsics.h
+++ b/Libraries/LibJS/Runtime/Intrinsics.h
@@ -18,7 +18,7 @@ class Intrinsics final : public Cell {
     GC_DECLARE_ALLOCATOR(Intrinsics);
 
 public:
-    static ThrowCompletionOr<GC::Ref<Intrinsics>> create(Realm&);
+    static GC::Ref<Intrinsics> create(Realm&);
 
     GC::Ref<Shape> empty_object_shape() { return *m_empty_object_shape; }
 
@@ -107,7 +107,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    ThrowCompletionOr<void> initialize_intrinsics(Realm&);
+    void initialize_intrinsics(Realm&);
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     void initialize_##snake_name();

--- a/Libraries/LibJS/Runtime/PromiseJobs.cpp
+++ b/Libraries/LibJS/Runtime/PromiseJobs.cpp
@@ -58,7 +58,7 @@ static ThrowCompletionOr<Value> run_reaction_job(VM& vm, PromiseReaction& reacti
     // f. If promiseCapability is undefined, then
     if (promise_capability == nullptr) {
         // i. Assert: handlerResult is not an abrupt completion.
-        VERIFY(!handler_result.is_abrupt());
+        MUST_OR_THROW_INTERNAL_ERROR(handler_result);
 
         // ii. Return empty.
         dbgln_if(PROMISE_DEBUG, "run_reaction_job: Reaction has no PromiseCapability, returning empty value");

--- a/Libraries/LibJS/Runtime/Realm.cpp
+++ b/Libraries/LibJS/Runtime/Realm.cpp
@@ -25,7 +25,7 @@ ThrowCompletionOr<NonnullOwnPtr<ExecutionContext>> Realm::initialize_host_define
     auto realm = vm.heap().allocate<Realm>();
 
     // 2. Perform CreateIntrinsics(realm).
-    MUST(Intrinsics::create(*realm));
+    Intrinsics::create(*realm);
 
     // FIXME: 3. Set realm.[[AgentSignifier]] to AgentSignifier().
 

--- a/Libraries/LibJS/Runtime/TypedArray.h
+++ b/Libraries/LibJS/Runtime/TypedArray.h
@@ -130,7 +130,7 @@ inline bool is_valid_integer_index(TypedArrayBase const& typed_array, CanonicalI
 
 // 10.4.5.17 TypedArrayGetElement ( O, index ), https://tc39.es/ecma262/#sec-typedarraygetelement
 template<typename T>
-inline ThrowCompletionOr<Value> typed_array_get_element(TypedArrayBase const& typed_array, CanonicalIndex property_index)
+inline Value typed_array_get_element(TypedArrayBase const& typed_array, CanonicalIndex property_index)
 {
     // 1. If IsValidIntegerIndex(O, index) is false, return undefined.
     if (!is_valid_integer_index(typed_array, property_index))
@@ -238,7 +238,7 @@ public:
             // b. If numericIndex is not undefined, then
             if (!numeric_index.is_undefined()) {
                 // i. Let value be TypedArrayGetElement(O, numericIndex).
-                auto value = MUST_OR_THROW_OOM(typed_array_get_element<T>(*this, numeric_index));
+                auto value = typed_array_get_element<T>(*this, numeric_index);
 
                 // ii. If value is undefined, return undefined.
                 if (value.is_undefined())

--- a/Libraries/LibJS/Tests/runtime-error-call-stack-size.js
+++ b/Libraries/LibJS/Tests/runtime-error-call-stack-size.js
@@ -18,4 +18,16 @@ test("infinite recursion", () => {
     expect(() => {
         new Proxy({}, { get: (_, __, p) => p.foo }).foo;
     }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
+
+    expect(() => {
+        function outer() {
+            async function inner() {
+                await outer;
+            }
+            inner();
+            outer();
+        }
+
+        outer();
+    }).toThrowWithMessage(InternalError, "Call stack size limit exceeded");
 });


### PR DESCRIPTION
The promise job's fulfillment / rejection handlers may push an execution
context onto the VM, which will throw an internal error if our ad-hoc
call stack size limit has been reached. Thus, we cannot blindly VERIFY
that the result of invoking these handlers is non-abrupt.

This patch will propagate any internal error forward, and retains the
condition that any other error type is not thrown.

Fixes #3449

(The first couple commits are to remove the last users of `MUST_OR_THROW_OOM` so that it may be repurposed for use in the actual fix).