### PR TITLE
Meta: Update copyright year to "2018 - present"

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018-2024, the Ladybird developers.
+Copyright (c) 2018 - present, the Ladybird developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Specifying the current year in the license is not legally required and may lead to unecessary maintenance.

A lot of well-known open-source projects have already removed the current year, such as:
- [React](https://github.com/facebook/react?tab=MIT-1-ov-file) (has no year at all),
- [Visual Studio Code](https://github.com/microsoft/vscode?tab=MIT-1-ov-file) (has "2015 - present"), or
- [Go](https://github.com/golang/go?tab=BSD-3-Clause-1-ov-file) (only lists the initial year of release).

I think we should consider rewriting it as "2018 - present", so that no more "update year" changes need to be made while preserving the initial release year.