### PR TITLE
headless-browser: Allow the `-f` argument to be used multiple times

### DIFF
--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -544,7 +544,7 @@ void ArgsParser::add_option(Optional<double>& value, char const* help_string, ch
 void ArgsParser::add_option(Vector<ByteString>& values, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode)
 {
     Option option {
-        OptionArgumentMode::Optional,
+        OptionArgumentMode::Required,
         help_string,
         long_name,
         short_name,

--- a/Libraries/LibTest/TestRunner.h
+++ b/Libraries/LibTest/TestRunner.h
@@ -42,7 +42,7 @@ public:
 
     virtual ~TestRunner() { s_the = nullptr; }
 
-    virtual void run(ByteString test_glob);
+    virtual void run(ReadonlySpan<ByteString> test_globs);
 
     Test::Counts const& counts() const { return m_counts; }
 
@@ -92,12 +92,12 @@ inline void cleanup()
     exit(1);
 }
 
-inline void TestRunner::run(ByteString test_glob)
+inline void TestRunner::run(ReadonlySpan<ByteString> test_globs)
 {
     size_t progress_counter = 0;
     auto test_paths = get_test_paths();
     for (auto& path : test_paths) {
-        if (!path.matches(test_glob))
+        if (!any_of(test_globs, [&](auto& glob) { return path.matches(glob); }))
             continue;
         ++progress_counter;
         do_run_single_test(path, progress_counter, test_paths.size());

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -37,7 +37,7 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     args_parser.add_option(test_concurrency, "Maximum number of tests to run at once", "test-concurrency", 'j', "jobs");
     args_parser.add_option(python_executable_path, "Path to python3", "python-executable", 'P', "path");
     args_parser.add_option(test_root_path, "Run tests in path", "run-tests", 'R', "test-root-path");
-    args_parser.add_option(test_glob, "Only run tests matching the given glob", "filter", 'f', "glob");
+    args_parser.add_option(test_globs, "Only run tests matching the given glob", "filter", 'f', "glob");
     args_parser.add_option(test_dry_run, "List the tests that would be run, without running them", "dry-run");
     args_parser.add_option(dump_failed_ref_tests, "Dump screenshots of failing ref tests", "dump-failed-ref-tests", 'D');
     args_parser.add_option(dump_gc_graph, "Dump GC graph", "dump-gc-graph", 'G');

--- a/UI/Headless/Application.h
+++ b/UI/Headless/Application.h
@@ -58,7 +58,7 @@ public:
     size_t test_concurrency { 1 };
     ByteString python_executable_path;
     ByteString test_root_path;
-    ByteString test_glob;
+    Vector<ByteString> test_globs;
     bool test_dry_run { false };
     bool rebaseline { false };
     u8 verbosity { 0 };


### PR DESCRIPTION
A test path is now included if it matches any of the given globs.