### PR TITLE
LibWeb: Disable the beforeunload-canceling test for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -160,3 +160,7 @@ Ref/input/wpt-import/css/css-contain/contain-paint-change-opacity.html
 
 ; Test is flaky on CI, as navigationStart time is not set according to spec.
 Text/input/wpt-import/user-timing/measure_associated_with_navigation_timing.html
+
+; Cancelling the beforeunload event in this test causes the subsequent test to fail.
+; https://github.com/LadybirdBrowser/ladybird/issues/3461
+Text/input/wpt-import/html/browsers/browsing-the-web/unloading-documents/beforeunload-canceling.html


### PR DESCRIPTION
It is causing whatever test that follows to time out very consistently.