### PR TITLE
LibWeb: Clamp layout content sizes to a max value instead of crashing

### DIFF
--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -4896,10 +4896,7 @@ RefPtr<CSS::CSSStyleValue> parse_dimension_value(StringView string)
     }
     auto integer_value = number_string.string_view().to_number<double>();
 
-    // NOTE: This is apparently the largest value allowed by Firefox.
-    static float max_dimension_value = 17895700;
-
-    float value = min(*integer_value, max_dimension_value);
+    float value = min(*integer_value, CSSPixels::max_dimension_value);
 
     // 6. If position is past the end of input, then return value as a length.
     if (position == input.end())

--- a/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -1466,14 +1466,7 @@ CSSPixels FormattingContext::calculate_min_content_width(Layout::Box const& box)
 
     context->run(AvailableSpace(available_width, available_height));
 
-    cache.min_content_width = context->automatic_content_width();
-
-    if (cache.min_content_width->might_be_saturated()) {
-        // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
-        dbgln("FIXME: Calculated non-finite min-content width for {}", box.debug_description());
-        cache.min_content_width = 0;
-    }
-
+    cache.min_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     return *cache.min_content_width;
 }
 
@@ -1506,14 +1499,7 @@ CSSPixels FormattingContext::calculate_max_content_width(Layout::Box const& box)
 
     context->run(AvailableSpace(available_width, available_height));
 
-    cache.max_content_width = context->automatic_content_width();
-
-    if (cache.max_content_width->might_be_saturated()) {
-        // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
-        dbgln("FIXME: Calculated non-finite max-content width for {}", box.debug_description());
-        cache.max_content_width = 0;
-    }
-
+    cache.max_content_width = clamp_to_max_dimension_value(context->automatic_content_width());
     return *cache.max_content_width;
 }
 
@@ -1550,13 +1536,7 @@ CSSPixels FormattingContext::calculate_min_content_height(Layout::Box const& box
 
     context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_min_content()));
 
-    auto min_content_height = context->automatic_content_height();
-    if (min_content_height.might_be_saturated()) {
-        // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
-        dbgln("FIXME: Calculated non-finite min-content height for {}", box.debug_description());
-        min_content_height = 0;
-    }
-
+    auto min_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
     if (auto* cache_slot = get_cache_slot()) {
         *cache_slot = min_content_height;
     }
@@ -1594,13 +1574,7 @@ CSSPixels FormattingContext::calculate_max_content_height(Layout::Box const& box
 
     context->run(AvailableSpace(AvailableSize::make_definite(width), AvailableSize::make_max_content()));
 
-    auto max_content_height = context->automatic_content_height();
-
-    if (max_content_height.might_be_saturated()) {
-        // HACK: If layout calculates a non-finite result, something went wrong. Force it to zero and log a little whine.
-        dbgln("FIXME: Calculated non-finite max-content height for {}", box.debug_description());
-        max_content_height = 0;
-    }
+    auto max_content_height = clamp_to_max_dimension_value(context->automatic_content_height());
 
     if (auto* cache_slot = get_cache_slot()) {
         *cache_slot = max_content_height;

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -244,4 +244,11 @@ private:
     void resolve_relative_positions();
 };
 
+inline CSSPixels clamp_to_max_dimension_value(CSSPixels value)
+{
+    if (value.might_be_saturated())
+        return CSSPixels(CSSPixels::max_dimension_value);
+    return value;
+}
+
 }

--- a/Libraries/LibWeb/PixelUnits.h
+++ b/Libraries/LibWeb/PixelUnits.h
@@ -66,6 +66,9 @@ public:
     static constexpr i32 max_integer_value = NumericLimits<int>::max() >> fractional_bits;
     static constexpr i32 min_integer_value = NumericLimits<int>::min() >> fractional_bits;
 
+    // NOTE: This is apparently the largest value allowed by Firefox. Probably enough for us as well.
+    static constexpr float max_dimension_value = 17895700;
+
     constexpr CSSPixels() = default;
     template<Signed I>
     constexpr CSSPixels(I value)

--- a/Tests/LibWeb/Crash/CSS/height-calc-infinity-result.html
+++ b/Tests/LibWeb/Crash/CSS/height-calc-infinity-result.html
@@ -1,0 +1,5 @@
+<!doctype html><style>
+html {
+    height: calc(1px / 4e-324);
+}
+</style><body>

--- a/Tests/LibWeb/Crash/CSS/width-calc-infinity-result.html
+++ b/Tests/LibWeb/Crash/CSS/width-calc-infinity-result.html
@@ -1,0 +1,5 @@
+<!doctype html><style>
+html {
+    width: calc(1px / 4e-324);
+}
+</style><body>


### PR DESCRIPTION
We've historically asserted that no "saturated" size values end up as final metrics for boxes in layout. This always had a chance of producing false positives, since you can trivially create extremely large boxes with CSS.

The reason we had those assertions was to catch bugs in our own engine code where we'd incorrectly end up with non-finite values in layout algorithms. At this point, we've found and fixed all known bugs of that nature, and what remains are a bunch of false positives on pages that create very large scrollable areas, iframes etc.

So, let's change it! We now clamp content width and height of boxes to 17895700 pixels, apparently the same cap as Firefox uses.

There's also the issue of calc() being able to produce non-finite values. Note that we don't clamp the result of calc() directly, but instead just clamp values when assigning them to content sizes.

Fixes #645.
Fixes #1236.
Fixes #1249.
Fixes #1908.
Fixes #3057.