### PR TITLE
LibWeb: De-Optional ComputedProperties

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -383,16 +383,16 @@ float ComputedProperties::fill_opacity() const
     return resolve_opacity_value(value);
 }
 
-Optional<CSS::StrokeLinecap> ComputedProperties::stroke_linecap() const
+StrokeLinecap ComputedProperties::stroke_linecap() const
 {
     auto const& value = property(CSS::PropertyID::StrokeLinecap);
-    return keyword_to_stroke_linecap(value.to_keyword());
+    return keyword_to_stroke_linecap(value.to_keyword()).release_value();
 }
 
-Optional<CSS::StrokeLinejoin> ComputedProperties::stroke_linejoin() const
+StrokeLinejoin ComputedProperties::stroke_linejoin() const
 {
     auto const& value = property(CSS::PropertyID::StrokeLinejoin);
-    return keyword_to_stroke_linejoin(value.to_keyword());
+    return keyword_to_stroke_linejoin(value.to_keyword()).release_value();
 }
 
 NumberOrCalculated ComputedProperties::stroke_miterlimit() const
@@ -420,31 +420,31 @@ float ComputedProperties::stop_opacity() const
     return resolve_opacity_value(value);
 }
 
-Optional<CSS::FillRule> ComputedProperties::fill_rule() const
+FillRule ComputedProperties::fill_rule() const
 {
     auto const& value = property(CSS::PropertyID::FillRule);
-    return keyword_to_fill_rule(value.to_keyword());
+    return keyword_to_fill_rule(value.to_keyword()).release_value();
 }
 
-Optional<CSS::ClipRule> ComputedProperties::clip_rule() const
+ClipRule ComputedProperties::clip_rule() const
 {
     auto const& value = property(CSS::PropertyID::ClipRule);
-    return keyword_to_fill_rule(value.to_keyword());
+    return keyword_to_fill_rule(value.to_keyword()).release_value();
 }
 
-Optional<CSS::FlexDirection> ComputedProperties::flex_direction() const
+FlexDirection ComputedProperties::flex_direction() const
 {
     auto const& value = property(CSS::PropertyID::FlexDirection);
-    return keyword_to_flex_direction(value.to_keyword());
+    return keyword_to_flex_direction(value.to_keyword()).release_value();
 }
 
-Optional<CSS::FlexWrap> ComputedProperties::flex_wrap() const
+FlexWrap ComputedProperties::flex_wrap() const
 {
     auto const& value = property(CSS::PropertyID::FlexWrap);
-    return keyword_to_flex_wrap(value.to_keyword());
+    return keyword_to_flex_wrap(value.to_keyword()).release_value();
 }
 
-Optional<CSS::FlexBasis> ComputedProperties::flex_basis() const
+FlexBasis ComputedProperties::flex_basis() const
 {
     auto const& value = property(CSS::PropertyID::FlexBasis);
 
@@ -478,10 +478,10 @@ int ComputedProperties::order() const
     return value.as_integer().integer();
 }
 
-Optional<CSS::ImageRendering> ComputedProperties::image_rendering() const
+ImageRendering ComputedProperties::image_rendering() const
 {
     auto const& value = property(CSS::PropertyID::ImageRendering);
-    return keyword_to_image_rendering(value.to_keyword());
+    return keyword_to_image_rendering(value.to_keyword()).release_value();
 }
 
 CSS::Length ComputedProperties::border_spacing_horizontal(Layout::Node const& layout_node) const
@@ -506,10 +506,10 @@ CSS::Length ComputedProperties::border_spacing_vertical(Layout::Node const& layo
     return list.value_at(1, false)->as_length().length();
 }
 
-Optional<CSS::CaptionSide> ComputedProperties::caption_side() const
+CaptionSide ComputedProperties::caption_side() const
 {
     auto const& value = property(CSS::PropertyID::CaptionSide);
-    return keyword_to_caption_side(value.to_keyword());
+    return keyword_to_caption_side(value.to_keyword()).release_value();
 }
 
 CSS::Clip ComputedProperties::clip() const
@@ -520,22 +520,22 @@ CSS::Clip ComputedProperties::clip() const
     return CSS::Clip(value.as_rect().rect());
 }
 
-Optional<CSS::JustifyContent> ComputedProperties::justify_content() const
+JustifyContent ComputedProperties::justify_content() const
 {
     auto const& value = property(CSS::PropertyID::JustifyContent);
-    return keyword_to_justify_content(value.to_keyword());
+    return keyword_to_justify_content(value.to_keyword()).release_value();
 }
 
-Optional<CSS::JustifyItems> ComputedProperties::justify_items() const
+JustifyItems ComputedProperties::justify_items() const
 {
     auto const& value = property(CSS::PropertyID::JustifyItems);
-    return keyword_to_justify_items(value.to_keyword());
+    return keyword_to_justify_items(value.to_keyword()).release_value();
 }
 
-Optional<CSS::JustifySelf> ComputedProperties::justify_self() const
+JustifySelf ComputedProperties::justify_self() const
 {
     auto const& value = property(CSS::PropertyID::JustifySelf);
-    return keyword_to_justify_self(value.to_keyword());
+    return keyword_to_justify_self(value.to_keyword()).release_value();
 }
 
 Vector<Transformation> ComputedProperties::transformations_for_style_value(CSSStyleValue const& value)
@@ -597,10 +597,10 @@ static Optional<LengthPercentage> length_percentage_for_style_value(CSSStyleValu
     return {};
 }
 
-Optional<CSS::TransformBox> ComputedProperties::transform_box() const
+TransformBox ComputedProperties::transform_box() const
 {
     auto const& value = property(CSS::PropertyID::TransformBox);
-    return keyword_to_transform_box(value.to_keyword());
+    return keyword_to_transform_box(value.to_keyword()).release_value();
 }
 
 CSS::TransformOrigin ComputedProperties::transform_origin() const
@@ -625,50 +625,48 @@ Optional<Color> ComputedProperties::accent_color(Layout::NodeWithStyle const& no
     return {};
 }
 
-Optional<CSS::AlignContent> ComputedProperties::align_content() const
+AlignContent ComputedProperties::align_content() const
 {
     auto const& value = property(CSS::PropertyID::AlignContent);
-    return keyword_to_align_content(value.to_keyword());
+    return keyword_to_align_content(value.to_keyword()).release_value();
 }
 
-Optional<CSS::AlignItems> ComputedProperties::align_items() const
+AlignItems ComputedProperties::align_items() const
 {
     auto const& value = property(CSS::PropertyID::AlignItems);
-    return keyword_to_align_items(value.to_keyword());
+    return keyword_to_align_items(value.to_keyword()).release_value();
 }
 
-Optional<CSS::AlignSelf> ComputedProperties::align_self() const
+AlignSelf ComputedProperties::align_self() const
 {
     auto const& value = property(CSS::PropertyID::AlignSelf);
-    return keyword_to_align_self(value.to_keyword());
+    return keyword_to_align_self(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Appearance> ComputedProperties::appearance() const
+Appearance ComputedProperties::appearance() const
 {
     auto const& value = property(CSS::PropertyID::Appearance);
-    auto appearance = keyword_to_appearance(value.to_keyword());
-    if (appearance.has_value()) {
-        switch (*appearance) {
-        // Note: All these compatibility values can be treated as 'auto'
-        case CSS::Appearance::Textfield:
-        case CSS::Appearance::MenulistButton:
-        case CSS::Appearance::Searchfield:
-        case CSS::Appearance::Textarea:
-        case CSS::Appearance::PushButton:
-        case CSS::Appearance::SliderHorizontal:
-        case CSS::Appearance::Checkbox:
-        case CSS::Appearance::Radio:
-        case CSS::Appearance::SquareButton:
-        case CSS::Appearance::Menulist:
-        case CSS::Appearance::Listbox:
-        case CSS::Appearance::Meter:
-        case CSS::Appearance::ProgressBar:
-        case CSS::Appearance::Button:
-            appearance = CSS::Appearance::Auto;
-            break;
-        default:
-            break;
-        }
+    auto appearance = keyword_to_appearance(value.to_keyword()).release_value();
+    switch (appearance) {
+    // Note: All these compatibility values can be treated as 'auto'
+    case CSS::Appearance::Textfield:
+    case CSS::Appearance::MenulistButton:
+    case CSS::Appearance::Searchfield:
+    case CSS::Appearance::Textarea:
+    case CSS::Appearance::PushButton:
+    case CSS::Appearance::SliderHorizontal:
+    case CSS::Appearance::Checkbox:
+    case CSS::Appearance::Radio:
+    case CSS::Appearance::SquareButton:
+    case CSS::Appearance::Menulist:
+    case CSS::Appearance::Listbox:
+    case CSS::Appearance::Meter:
+    case CSS::Appearance::ProgressBar:
+    case CSS::Appearance::Button:
+        appearance = CSS::Appearance::Auto;
+        break;
+    default:
+        break;
     }
     return appearance;
 }
@@ -689,10 +687,10 @@ CSS::Filter ComputedProperties::filter() const
     return Filter::make_none();
 }
 
-Optional<CSS::Positioning> ComputedProperties::position() const
+Positioning ComputedProperties::position() const
 {
     auto const& value = property(CSS::PropertyID::Position);
-    return keyword_to_positioning(value.to_keyword());
+    return keyword_to_positioning(value.to_keyword()).release_value();
 }
 
 bool ComputedProperties::operator==(ComputedProperties const& other) const
@@ -721,34 +719,34 @@ bool ComputedProperties::operator==(ComputedProperties const& other) const
     return true;
 }
 
-Optional<CSS::TextAnchor> ComputedProperties::text_anchor() const
+TextAnchor ComputedProperties::text_anchor() const
 {
     auto const& value = property(CSS::PropertyID::TextAnchor);
-    return keyword_to_text_anchor(value.to_keyword());
+    return keyword_to_text_anchor(value.to_keyword()).release_value();
 }
 
-Optional<CSS::TextAlign> ComputedProperties::text_align() const
+TextAlign ComputedProperties::text_align() const
 {
     auto const& value = property(CSS::PropertyID::TextAlign);
-    return keyword_to_text_align(value.to_keyword());
+    return keyword_to_text_align(value.to_keyword()).release_value();
 }
 
-Optional<CSS::TextJustify> ComputedProperties::text_justify() const
+TextJustify ComputedProperties::text_justify() const
 {
     auto const& value = property(CSS::PropertyID::TextJustify);
-    return keyword_to_text_justify(value.to_keyword());
+    return keyword_to_text_justify(value.to_keyword()).release_value();
 }
 
-Optional<CSS::TextOverflow> ComputedProperties::text_overflow() const
+TextOverflow ComputedProperties::text_overflow() const
 {
     auto const& value = property(CSS::PropertyID::TextOverflow);
-    return keyword_to_text_overflow(value.to_keyword());
+    return keyword_to_text_overflow(value.to_keyword()).release_value();
 }
 
-Optional<CSS::PointerEvents> ComputedProperties::pointer_events() const
+PointerEvents ComputedProperties::pointer_events() const
 {
     auto const& value = property(CSS::PropertyID::PointerEvents);
-    return keyword_to_pointer_events(value.to_keyword());
+    return keyword_to_pointer_events(value.to_keyword()).release_value();
 }
 
 Variant<LengthOrCalculated, NumberOrCalculated> ComputedProperties::tab_size() const
@@ -770,13 +768,13 @@ Variant<LengthOrCalculated, NumberOrCalculated> ComputedProperties::tab_size() c
     return NumberOrCalculated { value.as_number().number() };
 }
 
-Optional<CSS::WordBreak> ComputedProperties::word_break() const
+WordBreak ComputedProperties::word_break() const
 {
     auto const& value = property(CSS::PropertyID::WordBreak);
-    return keyword_to_word_break(value.to_keyword());
+    return keyword_to_word_break(value.to_keyword()).release_value();
 }
 
-Optional<CSS::LengthOrCalculated> ComputedProperties::word_spacing() const
+Optional<LengthOrCalculated> ComputedProperties::word_spacing() const
 {
     auto const& value = property(CSS::PropertyID::WordSpacing);
     if (value.is_calculated()) {
@@ -792,10 +790,10 @@ Optional<CSS::LengthOrCalculated> ComputedProperties::word_spacing() const
     return {};
 }
 
-Optional<CSS::WhiteSpace> ComputedProperties::white_space() const
+WhiteSpace ComputedProperties::white_space() const
 {
     auto const& value = property(CSS::PropertyID::WhiteSpace);
-    return keyword_to_white_space(value.to_keyword());
+    return keyword_to_white_space(value.to_keyword()).release_value();
 }
 
 Optional<LengthOrCalculated> ComputedProperties::letter_spacing() const
@@ -814,34 +812,34 @@ Optional<LengthOrCalculated> ComputedProperties::letter_spacing() const
     return {};
 }
 
-Optional<CSS::LineStyle> ComputedProperties::line_style(CSS::PropertyID property_id) const
+LineStyle ComputedProperties::line_style(CSS::PropertyID property_id) const
 {
     auto const& value = property(property_id);
-    return keyword_to_line_style(value.to_keyword());
+    return keyword_to_line_style(value.to_keyword()).release_value();
 }
 
-Optional<CSS::OutlineStyle> ComputedProperties::outline_style() const
+OutlineStyle ComputedProperties::outline_style() const
 {
     auto const& value = property(CSS::PropertyID::OutlineStyle);
-    return keyword_to_outline_style(value.to_keyword());
+    return keyword_to_outline_style(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Float> ComputedProperties::float_() const
+Float ComputedProperties::float_() const
 {
     auto const& value = property(CSS::PropertyID::Float);
-    return keyword_to_float(value.to_keyword());
+    return keyword_to_float(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Clear> ComputedProperties::clear() const
+Clear ComputedProperties::clear() const
 {
     auto const& value = property(CSS::PropertyID::Clear);
-    return keyword_to_clear(value.to_keyword());
+    return keyword_to_clear(value.to_keyword()).release_value();
 }
 
-Optional<CSS::ColumnSpan> ComputedProperties::column_span() const
+ColumnSpan ComputedProperties::column_span() const
 {
     auto const& value = property(CSS::PropertyID::ColumnSpan);
-    return keyword_to_column_span(value.to_keyword());
+    return keyword_to_column_span(value.to_keyword()).release_value();
 }
 
 ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(DOM::Element& element, u32 initial_quote_nesting_level) const
@@ -946,24 +944,24 @@ ComputedProperties::ContentDataAndQuoteNestingLevel ComputedProperties::content(
     return { {}, quote_nesting_level };
 }
 
-Optional<CSS::ContentVisibility> ComputedProperties::content_visibility() const
+ContentVisibility ComputedProperties::content_visibility() const
 {
     auto const& value = property(CSS::PropertyID::ContentVisibility);
-    return keyword_to_content_visibility(value.to_keyword());
+    return keyword_to_content_visibility(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Cursor> ComputedProperties::cursor() const
+Cursor ComputedProperties::cursor() const
 {
     auto const& value = property(CSS::PropertyID::Cursor);
-    return keyword_to_cursor(value.to_keyword());
+    return keyword_to_cursor(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Visibility> ComputedProperties::visibility() const
+Visibility ComputedProperties::visibility() const
 {
     auto const& value = property(CSS::PropertyID::Visibility);
     if (!value.is_keyword())
         return {};
-    return keyword_to_visibility(value.to_keyword());
+    return keyword_to_visibility(value.to_keyword()).release_value();
 }
 
 Display ComputedProperties::display() const
@@ -995,44 +993,44 @@ Vector<CSS::TextDecorationLine> ComputedProperties::text_decoration_line() const
     return {};
 }
 
-Optional<CSS::TextDecorationStyle> ComputedProperties::text_decoration_style() const
+TextDecorationStyle ComputedProperties::text_decoration_style() const
 {
     auto const& value = property(CSS::PropertyID::TextDecorationStyle);
-    return keyword_to_text_decoration_style(value.to_keyword());
+    return keyword_to_text_decoration_style(value.to_keyword()).release_value();
 }
 
-Optional<CSS::TextTransform> ComputedProperties::text_transform() const
+TextTransform ComputedProperties::text_transform() const
 {
     auto const& value = property(CSS::PropertyID::TextTransform);
-    return keyword_to_text_transform(value.to_keyword());
+    return keyword_to_text_transform(value.to_keyword()).release_value();
 }
 
-Optional<CSS::ListStyleType> ComputedProperties::list_style_type() const
+ListStyleType ComputedProperties::list_style_type() const
 {
     auto const& value = property(CSS::PropertyID::ListStyleType);
-    return keyword_to_list_style_type(value.to_keyword());
+    return keyword_to_list_style_type(value.to_keyword()).release_value();
 }
 
-Optional<CSS::ListStylePosition> ComputedProperties::list_style_position() const
+ListStylePosition ComputedProperties::list_style_position() const
 {
     auto const& value = property(CSS::PropertyID::ListStylePosition);
-    return keyword_to_list_style_position(value.to_keyword());
+    return keyword_to_list_style_position(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Overflow> ComputedProperties::overflow_x() const
+Overflow ComputedProperties::overflow_x() const
 {
     return overflow(CSS::PropertyID::OverflowX);
 }
 
-Optional<CSS::Overflow> ComputedProperties::overflow_y() const
+Overflow ComputedProperties::overflow_y() const
 {
     return overflow(CSS::PropertyID::OverflowY);
 }
 
-Optional<CSS::Overflow> ComputedProperties::overflow(CSS::PropertyID property_id) const
+Overflow ComputedProperties::overflow(CSS::PropertyID property_id) const
 {
     auto const& value = property(property_id);
-    return keyword_to_overflow(value.to_keyword());
+    return keyword_to_overflow(value.to_keyword()).release_value();
 }
 
 Vector<ShadowData> ComputedProperties::shadow(PropertyID property_id, Layout::Node const& layout_node) const
@@ -1105,10 +1103,10 @@ Vector<ShadowData> ComputedProperties::text_shadow(Layout::Node const& layout_no
     return shadow(PropertyID::TextShadow, layout_node);
 }
 
-Optional<CSS::BoxSizing> ComputedProperties::box_sizing() const
+BoxSizing ComputedProperties::box_sizing() const
 {
     auto const& value = property(CSS::PropertyID::BoxSizing);
-    return keyword_to_box_sizing(value.to_keyword());
+    return keyword_to_box_sizing(value.to_keyword()).release_value();
 }
 
 Variant<CSS::VerticalAlign, CSS::LengthPercentage> ComputedProperties::vertical_align() const
@@ -1144,10 +1142,10 @@ Optional<Gfx::FontVariantAlternates> ComputedProperties::font_variant_alternates
     return value.to_font_variant_alternates();
 }
 
-Optional<FontVariantCaps> ComputedProperties::font_variant_caps() const
+FontVariantCaps ComputedProperties::font_variant_caps() const
 {
     auto const& value = property(CSS::PropertyID::FontVariantCaps);
-    return value.to_font_variant_caps();
+    return value.to_font_variant_caps().release_value();
 }
 
 Optional<Gfx::FontVariantEastAsian> ComputedProperties::font_variant_east_asian() const
@@ -1156,10 +1154,10 @@ Optional<Gfx::FontVariantEastAsian> ComputedProperties::font_variant_east_asian(
     return value.to_font_variant_east_asian();
 }
 
-Optional<FontVariantEmoji> ComputedProperties::font_variant_emoji() const
+FontVariantEmoji ComputedProperties::font_variant_emoji() const
 {
     auto const& value = property(CSS::PropertyID::FontVariantEmoji);
-    return value.to_font_variant_emoji();
+    return value.to_font_variant_emoji().release_value();
 }
 
 Optional<Gfx::FontVariantLigatures> ComputedProperties::font_variant_ligatures() const
@@ -1174,10 +1172,10 @@ Optional<Gfx::FontVariantNumeric> ComputedProperties::font_variant_numeric() con
     return value.to_font_variant_numeric();
 }
 
-Optional<FontVariantPosition> ComputedProperties::font_variant_position() const
+FontVariantPosition ComputedProperties::font_variant_position() const
 {
     auto const& value = property(CSS::PropertyID::FontVariantPosition);
-    return value.to_font_variant_position();
+    return value.to_font_variant_position().release_value();
 }
 
 Optional<HashMap<FlyString, IntegerOrCalculated>> ComputedProperties::font_feature_settings() const
@@ -1291,10 +1289,10 @@ CSS::GridTrackPlacement ComputedProperties::grid_row_start() const
     return value.as_grid_track_placement().grid_track_placement();
 }
 
-Optional<CSS::BorderCollapse> ComputedProperties::border_collapse() const
+BorderCollapse ComputedProperties::border_collapse() const
 {
     auto const& value = property(CSS::PropertyID::BorderCollapse);
-    return keyword_to_border_collapse(value.to_keyword());
+    return keyword_to_border_collapse(value.to_keyword()).release_value();
 }
 
 Vector<Vector<String>> ComputedProperties::grid_template_areas() const
@@ -1303,10 +1301,10 @@ Vector<Vector<String>> ComputedProperties::grid_template_areas() const
     return value.as_grid_template_area().grid_template_area();
 }
 
-Optional<CSS::ObjectFit> ComputedProperties::object_fit() const
+ObjectFit ComputedProperties::object_fit() const
 {
     auto const& value = property(CSS::PropertyID::ObjectFit);
-    return keyword_to_object_fit(value.to_keyword());
+    return keyword_to_object_fit(value.to_keyword()).release_value();
 }
 
 CSS::ObjectPosition ComputedProperties::object_position() const
@@ -1329,40 +1327,40 @@ CSS::ObjectPosition ComputedProperties::object_position() const
     return object_position;
 }
 
-Optional<CSS::TableLayout> ComputedProperties::table_layout() const
+TableLayout ComputedProperties::table_layout() const
 {
     auto const& value = property(CSS::PropertyID::TableLayout);
-    return keyword_to_table_layout(value.to_keyword());
+    return keyword_to_table_layout(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Direction> ComputedProperties::direction() const
+Direction ComputedProperties::direction() const
 {
     auto const& value = property(CSS::PropertyID::Direction);
-    return keyword_to_direction(value.to_keyword());
+    return keyword_to_direction(value.to_keyword()).release_value();
 }
 
-Optional<CSS::UnicodeBidi> ComputedProperties::unicode_bidi() const
+UnicodeBidi ComputedProperties::unicode_bidi() const
 {
     auto const& value = property(CSS::PropertyID::UnicodeBidi);
-    return keyword_to_unicode_bidi(value.to_keyword());
+    return keyword_to_unicode_bidi(value.to_keyword()).release_value();
 }
 
-Optional<CSS::WritingMode> ComputedProperties::writing_mode() const
+WritingMode ComputedProperties::writing_mode() const
 {
     auto const& value = property(CSS::PropertyID::WritingMode);
-    return keyword_to_writing_mode(value.to_keyword());
+    return keyword_to_writing_mode(value.to_keyword()).release_value();
 }
 
-Optional<CSS::UserSelect> ComputedProperties::user_select() const
+UserSelect ComputedProperties::user_select() const
 {
     auto const& value = property(CSS::PropertyID::UserSelect);
-    return keyword_to_user_select(value.to_keyword());
+    return keyword_to_user_select(value.to_keyword()).release_value();
 }
 
-Optional<CSS::Isolation> ComputedProperties::isolation() const
+Isolation ComputedProperties::isolation() const
 {
     auto const& value = property(CSS::PropertyID::Isolation);
-    return keyword_to_isolation(value.to_keyword());
+    return keyword_to_isolation(value.to_keyword()).release_value();
 }
 
 CSS::Containment ComputedProperties::contain() const
@@ -1433,16 +1431,16 @@ CSS::Containment ComputedProperties::contain() const
     return containment;
 }
 
-Optional<CSS::MixBlendMode> ComputedProperties::mix_blend_mode() const
+MixBlendMode ComputedProperties::mix_blend_mode() const
 {
     auto const& value = property(CSS::PropertyID::MixBlendMode);
-    return keyword_to_mix_blend_mode(value.to_keyword());
+    return keyword_to_mix_blend_mode(value.to_keyword()).release_value();
 }
 
-Optional<CSS::MaskType> ComputedProperties::mask_type() const
+MaskType ComputedProperties::mask_type() const
 {
     auto const& value = property(CSS::PropertyID::MaskType);
-    return keyword_to_mask_type(value.to_keyword());
+    return keyword_to_mask_type(value.to_keyword()).release_value();
 }
 
 Color ComputedProperties::stop_color() const
@@ -1533,10 +1531,10 @@ Vector<CounterData> ComputedProperties::counter_data(PropertyID property_id) con
     return {};
 }
 
-Optional<CSS::ScrollbarWidth> ComputedProperties::scrollbar_width() const
+ScrollbarWidth ComputedProperties::scrollbar_width() const
 {
     auto const& value = property(CSS::PropertyID::ScrollbarWidth);
-    return keyword_to_scrollbar_width(value.to_keyword());
+    return keyword_to_scrollbar_width(value.to_keyword()).release_value();
 }
 
 }

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2023-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -75,70 +76,70 @@ public:
     LengthBox length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const;
     Color color_or_fallback(CSS::PropertyID, Layout::NodeWithStyle const&, Color fallback) const;
     CSS::PreferredColorScheme color_scheme(CSS::PreferredColorScheme, Optional<Vector<String> const&> document_supported_schemes) const;
-    Optional<CSS::TextAnchor> text_anchor() const;
-    Optional<CSS::TextAlign> text_align() const;
-    Optional<CSS::TextJustify> text_justify() const;
-    Optional<CSS::TextOverflow> text_overflow() const;
+    TextAnchor text_anchor() const;
+    TextAlign text_align() const;
+    TextJustify text_justify() const;
+    TextOverflow text_overflow() const;
     CSS::Length border_spacing_horizontal(Layout::Node const&) const;
     CSS::Length border_spacing_vertical(Layout::Node const&) const;
-    Optional<CSS::CaptionSide> caption_side() const;
+    CaptionSide caption_side() const;
     CSS::Clip clip() const;
     CSS::Display display() const;
-    Optional<CSS::Float> float_() const;
-    Optional<CSS::Clear> clear() const;
-    Optional<CSS::ColumnSpan> column_span() const;
+    Float float_() const;
+    Clear clear() const;
+    ColumnSpan column_span() const;
     struct ContentDataAndQuoteNestingLevel {
         CSS::ContentData content_data;
         u32 final_quote_nesting_level { 0 };
     };
     ContentDataAndQuoteNestingLevel content(DOM::Element&, u32 initial_quote_nesting_level) const;
-    Optional<CSS::ContentVisibility> content_visibility() const;
-    Optional<CSS::Cursor> cursor() const;
+    ContentVisibility content_visibility() const;
+    Cursor cursor() const;
     Variant<LengthOrCalculated, NumberOrCalculated> tab_size() const;
-    Optional<CSS::WhiteSpace> white_space() const;
-    Optional<CSS::WordBreak> word_break() const;
-    Optional<CSS::LengthOrCalculated> word_spacing() const;
+    WhiteSpace white_space() const;
+    WordBreak word_break() const;
+    Optional<LengthOrCalculated> word_spacing() const;
     Optional<LengthOrCalculated> letter_spacing() const;
-    Optional<CSS::LineStyle> line_style(CSS::PropertyID) const;
-    Optional<CSS::OutlineStyle> outline_style() const;
+    LineStyle line_style(CSS::PropertyID) const;
+    OutlineStyle outline_style() const;
     Vector<CSS::TextDecorationLine> text_decoration_line() const;
-    Optional<CSS::TextDecorationStyle> text_decoration_style() const;
-    Optional<CSS::TextTransform> text_transform() const;
+    TextDecorationStyle text_decoration_style() const;
+    TextTransform text_transform() const;
     Vector<CSS::ShadowData> text_shadow(Layout::Node const&) const;
-    Optional<CSS::ListStyleType> list_style_type() const;
-    Optional<CSS::ListStylePosition> list_style_position() const;
-    Optional<CSS::FlexDirection> flex_direction() const;
-    Optional<CSS::FlexWrap> flex_wrap() const;
-    Optional<CSS::FlexBasis> flex_basis() const;
+    ListStyleType list_style_type() const;
+    ListStylePosition list_style_position() const;
+    FlexDirection flex_direction() const;
+    FlexWrap flex_wrap() const;
+    FlexBasis flex_basis() const;
     float flex_grow() const;
     float flex_shrink() const;
     int order() const;
     Optional<Color> accent_color(Layout::NodeWithStyle const&) const;
-    Optional<CSS::AlignContent> align_content() const;
-    Optional<CSS::AlignItems> align_items() const;
-    Optional<CSS::AlignSelf> align_self() const;
-    Optional<CSS::Appearance> appearance() const;
+    AlignContent align_content() const;
+    AlignItems align_items() const;
+    AlignSelf align_self() const;
+    Appearance appearance() const;
     CSS::Filter backdrop_filter() const;
     CSS::Filter filter() const;
     float opacity() const;
-    Optional<CSS::Visibility> visibility() const;
-    Optional<CSS::ImageRendering> image_rendering() const;
-    Optional<CSS::JustifyContent> justify_content() const;
-    Optional<CSS::JustifyItems> justify_items() const;
-    Optional<CSS::JustifySelf> justify_self() const;
-    Optional<CSS::Overflow> overflow_x() const;
-    Optional<CSS::Overflow> overflow_y() const;
+    Visibility visibility() const;
+    ImageRendering image_rendering() const;
+    JustifyContent justify_content() const;
+    JustifyItems justify_items() const;
+    JustifySelf justify_self() const;
+    Overflow overflow_x() const;
+    Overflow overflow_y() const;
     Vector<CSS::ShadowData> box_shadow(Layout::Node const&) const;
-    Optional<CSS::BoxSizing> box_sizing() const;
-    Optional<CSS::PointerEvents> pointer_events() const;
+    BoxSizing box_sizing() const;
+    PointerEvents pointer_events() const;
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
     Optional<Gfx::FontVariantAlternates> font_variant_alternates() const;
-    Optional<FontVariantCaps> font_variant_caps() const;
+    FontVariantCaps font_variant_caps() const;
     Optional<Gfx::FontVariantEastAsian> font_variant_east_asian() const;
-    Optional<FontVariantEmoji> font_variant_emoji() const;
+    FontVariantEmoji font_variant_emoji() const;
     Optional<Gfx::FontVariantLigatures> font_variant_ligatures() const;
     Optional<Gfx::FontVariantNumeric> font_variant_numeric() const;
-    Optional<FontVariantPosition> font_variant_position() const;
+    FontVariantPosition font_variant_position() const;
     Optional<FlyString> font_language_override() const;
     Optional<HashMap<FlyString, IntegerOrCalculated>> font_feature_settings() const;
     Optional<HashMap<FlyString, NumberOrCalculated>> font_variation_settings() const;
@@ -151,37 +152,37 @@ public:
     CSS::GridTrackPlacement grid_column_start() const;
     CSS::GridTrackPlacement grid_row_end() const;
     CSS::GridTrackPlacement grid_row_start() const;
-    Optional<CSS::BorderCollapse> border_collapse() const;
+    BorderCollapse border_collapse() const;
     Vector<Vector<String>> grid_template_areas() const;
-    Optional<CSS::ObjectFit> object_fit() const;
+    ObjectFit object_fit() const;
     CSS::ObjectPosition object_position() const;
-    Optional<CSS::TableLayout> table_layout() const;
-    Optional<CSS::Direction> direction() const;
-    Optional<CSS::UnicodeBidi> unicode_bidi() const;
-    Optional<CSS::WritingMode> writing_mode() const;
-    Optional<CSS::UserSelect> user_select() const;
-    Optional<CSS::Isolation> isolation() const;
+    TableLayout table_layout() const;
+    Direction direction() const;
+    UnicodeBidi unicode_bidi() const;
+    WritingMode writing_mode() const;
+    UserSelect user_select() const;
+    Isolation isolation() const;
     CSS::Containment contain() const;
-    Optional<CSS::MixBlendMode> mix_blend_mode() const;
+    MixBlendMode mix_blend_mode() const;
 
     static Vector<CSS::Transformation> transformations_for_style_value(CSSStyleValue const& value);
     Vector<CSS::Transformation> transformations() const;
-    Optional<CSS::TransformBox> transform_box() const;
+    TransformBox transform_box() const;
     CSS::TransformOrigin transform_origin() const;
     Optional<CSS::Transformation> rotate() const;
     Optional<CSS::Transformation> translate() const;
     Optional<CSS::Transformation> scale() const;
 
-    Optional<CSS::MaskType> mask_type() const;
+    MaskType mask_type() const;
     Color stop_color() const;
     float stop_opacity() const;
     float fill_opacity() const;
-    Optional<CSS::StrokeLinecap> stroke_linecap() const;
-    Optional<CSS::StrokeLinejoin> stroke_linejoin() const;
+    StrokeLinecap stroke_linecap() const;
+    StrokeLinejoin stroke_linejoin() const;
     NumberOrCalculated stroke_miterlimit() const;
     float stroke_opacity() const;
-    Optional<CSS::FillRule> fill_rule() const;
-    Optional<CSS::ClipRule> clip_rule() const;
+    FillRule fill_rule() const;
+    ClipRule clip_rule() const;
 
     Gfx::Font const& first_available_computed_font() const { return m_font_list->first(); }
 
@@ -203,7 +204,7 @@ public:
 
     bool operator==(ComputedProperties const&) const;
 
-    Optional<CSS::Positioning> position() const;
+    Positioning position() const;
     Optional<int> z_index() const;
 
     void set_math_depth(int math_depth);
@@ -212,7 +213,7 @@ public:
     QuotesData quotes() const;
     Vector<CounterData> counter_data(PropertyID) const;
 
-    Optional<CSS::ScrollbarWidth> scrollbar_width() const;
+    ScrollbarWidth scrollbar_width() const;
 
     static NonnullRefPtr<Gfx::Font const> font_fallback(bool monospace, bool bold, float point_size);
 
@@ -228,7 +229,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Optional<CSS::Overflow> overflow(CSS::PropertyID) const;
+    Overflow overflow(CSS::PropertyID) const;
     Vector<CSS::ShadowData> shadow(CSS::PropertyID, Layout::Node const&) const;
 
     GC::Ptr<CSS::CSSStyleDeclaration const> m_animation_name_source;

--- a/Libraries/LibWeb/CSS/ComputedProperties.h
+++ b/Libraries/LibWeb/CSS/ComputedProperties.h
@@ -27,7 +27,7 @@ class ComputedProperties final : public JS::Cell {
     GC_DECLARE_ALLOCATOR(ComputedProperties);
 
 public:
-    static constexpr size_t number_of_properties = to_underlying(CSS::last_property_id) + 1;
+    static constexpr size_t number_of_properties = to_underlying(last_property_id) + 1;
 
     virtual ~ComputedProperties() override;
 
@@ -36,7 +36,7 @@ public:
     {
         for (size_t i = 0; i < m_property_values.size(); ++i) {
             if (m_property_values[i])
-                callback((CSS::PropertyID)i, *m_property_values[i]);
+                callback((PropertyID)i, *m_property_values[i]);
         }
     }
 
@@ -45,51 +45,51 @@ public:
         Yes
     };
 
-    HashMap<CSS::PropertyID, NonnullRefPtr<CSSStyleValue const>> const& animated_property_values() const { return m_animated_property_values; }
+    HashMap<PropertyID, NonnullRefPtr<CSSStyleValue const>> const& animated_property_values() const { return m_animated_property_values; }
     void reset_animated_properties();
 
-    bool is_property_important(CSS::PropertyID property_id) const;
-    bool is_property_inherited(CSS::PropertyID property_id) const;
-    void set_property_important(CSS::PropertyID, Important);
-    void set_property_inherited(CSS::PropertyID, Inherited);
+    bool is_property_important(PropertyID property_id) const;
+    bool is_property_inherited(PropertyID property_id) const;
+    void set_property_important(PropertyID, Important);
+    void set_property_inherited(PropertyID, Inherited);
 
-    void set_property(CSS::PropertyID, NonnullRefPtr<CSSStyleValue const> value, Inherited = Inherited::No, Important = Important::No);
-    void set_animated_property(CSS::PropertyID, NonnullRefPtr<CSSStyleValue const> value);
+    void set_property(PropertyID, NonnullRefPtr<CSSStyleValue const> value, Inherited = Inherited::No, Important = Important::No);
+    void set_animated_property(PropertyID, NonnullRefPtr<CSSStyleValue const> value);
     enum class WithAnimationsApplied {
         No,
         Yes,
     };
-    CSSStyleValue const& property(CSS::PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
-    CSSStyleValue const* maybe_null_property(CSS::PropertyID) const;
-    void revert_property(CSS::PropertyID, ComputedProperties const& style_for_revert);
+    CSSStyleValue const& property(PropertyID, WithAnimationsApplied = WithAnimationsApplied::Yes) const;
+    CSSStyleValue const* maybe_null_property(PropertyID) const;
+    void revert_property(PropertyID, ComputedProperties const& style_for_revert);
 
-    GC::Ptr<CSS::CSSStyleDeclaration const> animation_name_source() const { return m_animation_name_source; }
-    void set_animation_name_source(GC::Ptr<CSS::CSSStyleDeclaration const> declaration) { m_animation_name_source = declaration; }
+    GC::Ptr<CSSStyleDeclaration const> animation_name_source() const { return m_animation_name_source; }
+    void set_animation_name_source(GC::Ptr<CSSStyleDeclaration const> declaration) { m_animation_name_source = declaration; }
 
-    GC::Ptr<CSS::CSSStyleDeclaration const> transition_property_source() const { return m_transition_property_source; }
-    void set_transition_property_source(GC::Ptr<CSS::CSSStyleDeclaration const> declaration) { m_transition_property_source = declaration; }
+    GC::Ptr<CSSStyleDeclaration const> transition_property_source() const { return m_transition_property_source; }
+    void set_transition_property_source(GC::Ptr<CSSStyleDeclaration const> declaration) { m_transition_property_source = declaration; }
 
-    CSS::Size size_value(CSS::PropertyID) const;
-    [[nodiscard]] Variant<LengthPercentage, NormalGap> gap_value(CSS::PropertyID) const;
-    LengthPercentage length_percentage_or_fallback(CSS::PropertyID, LengthPercentage const& fallback) const;
-    Optional<LengthPercentage> length_percentage(CSS::PropertyID) const;
-    LengthBox length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const;
-    Color color_or_fallback(CSS::PropertyID, Layout::NodeWithStyle const&, Color fallback) const;
-    CSS::PreferredColorScheme color_scheme(CSS::PreferredColorScheme, Optional<Vector<String> const&> document_supported_schemes) const;
+    Size size_value(PropertyID) const;
+    [[nodiscard]] Variant<LengthPercentage, NormalGap> gap_value(PropertyID) const;
+    LengthPercentage length_percentage_or_fallback(PropertyID, LengthPercentage const& fallback) const;
+    Optional<LengthPercentage> length_percentage(PropertyID) const;
+    LengthBox length_box(PropertyID left_id, PropertyID top_id, PropertyID right_id, PropertyID bottom_id, Length const& default_value) const;
+    Color color_or_fallback(PropertyID, Layout::NodeWithStyle const&, Color fallback) const;
+    PreferredColorScheme color_scheme(PreferredColorScheme, Optional<Vector<String> const&> document_supported_schemes) const;
     TextAnchor text_anchor() const;
     TextAlign text_align() const;
     TextJustify text_justify() const;
     TextOverflow text_overflow() const;
-    CSS::Length border_spacing_horizontal(Layout::Node const&) const;
-    CSS::Length border_spacing_vertical(Layout::Node const&) const;
+    Length border_spacing_horizontal(Layout::Node const&) const;
+    Length border_spacing_vertical(Layout::Node const&) const;
     CaptionSide caption_side() const;
-    CSS::Clip clip() const;
-    CSS::Display display() const;
+    Clip clip() const;
+    Display display() const;
     Float float_() const;
     Clear clear() const;
     ColumnSpan column_span() const;
     struct ContentDataAndQuoteNestingLevel {
-        CSS::ContentData content_data;
+        ContentData content_data;
         u32 final_quote_nesting_level { 0 };
     };
     ContentDataAndQuoteNestingLevel content(DOM::Element&, u32 initial_quote_nesting_level) const;
@@ -100,12 +100,12 @@ public:
     WordBreak word_break() const;
     Optional<LengthOrCalculated> word_spacing() const;
     Optional<LengthOrCalculated> letter_spacing() const;
-    LineStyle line_style(CSS::PropertyID) const;
+    LineStyle line_style(PropertyID) const;
     OutlineStyle outline_style() const;
-    Vector<CSS::TextDecorationLine> text_decoration_line() const;
+    Vector<TextDecorationLine> text_decoration_line() const;
     TextDecorationStyle text_decoration_style() const;
     TextTransform text_transform() const;
-    Vector<CSS::ShadowData> text_shadow(Layout::Node const&) const;
+    Vector<ShadowData> text_shadow(Layout::Node const&) const;
     ListStyleType list_style_type() const;
     ListStylePosition list_style_position() const;
     FlexDirection flex_direction() const;
@@ -119,8 +119,8 @@ public:
     AlignItems align_items() const;
     AlignSelf align_self() const;
     Appearance appearance() const;
-    CSS::Filter backdrop_filter() const;
-    CSS::Filter filter() const;
+    Filter backdrop_filter() const;
+    Filter filter() const;
     float opacity() const;
     Visibility visibility() const;
     ImageRendering image_rendering() const;
@@ -129,10 +129,10 @@ public:
     JustifySelf justify_self() const;
     Overflow overflow_x() const;
     Overflow overflow_y() const;
-    Vector<CSS::ShadowData> box_shadow(Layout::Node const&) const;
+    Vector<ShadowData> box_shadow(Layout::Node const&) const;
     BoxSizing box_sizing() const;
     PointerEvents pointer_events() const;
-    Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
+    Variant<VerticalAlign, LengthPercentage> vertical_align() const;
     Optional<Gfx::FontVariantAlternates> font_variant_alternates() const;
     FontVariantCaps font_variant_caps() const;
     Optional<Gfx::FontVariantEastAsian> font_variant_east_asian() const;
@@ -143,35 +143,35 @@ public:
     Optional<FlyString> font_language_override() const;
     Optional<HashMap<FlyString, IntegerOrCalculated>> font_feature_settings() const;
     Optional<HashMap<FlyString, NumberOrCalculated>> font_variation_settings() const;
-    CSS::GridTrackSizeList grid_auto_columns() const;
-    CSS::GridTrackSizeList grid_auto_rows() const;
-    CSS::GridTrackSizeList grid_template_columns() const;
-    CSS::GridTrackSizeList grid_template_rows() const;
-    [[nodiscard]] CSS::GridAutoFlow grid_auto_flow() const;
-    CSS::GridTrackPlacement grid_column_end() const;
-    CSS::GridTrackPlacement grid_column_start() const;
-    CSS::GridTrackPlacement grid_row_end() const;
-    CSS::GridTrackPlacement grid_row_start() const;
+    GridTrackSizeList grid_auto_columns() const;
+    GridTrackSizeList grid_auto_rows() const;
+    GridTrackSizeList grid_template_columns() const;
+    GridTrackSizeList grid_template_rows() const;
+    [[nodiscard]] GridAutoFlow grid_auto_flow() const;
+    GridTrackPlacement grid_column_end() const;
+    GridTrackPlacement grid_column_start() const;
+    GridTrackPlacement grid_row_end() const;
+    GridTrackPlacement grid_row_start() const;
     BorderCollapse border_collapse() const;
     Vector<Vector<String>> grid_template_areas() const;
     ObjectFit object_fit() const;
-    CSS::ObjectPosition object_position() const;
+    ObjectPosition object_position() const;
     TableLayout table_layout() const;
     Direction direction() const;
     UnicodeBidi unicode_bidi() const;
     WritingMode writing_mode() const;
     UserSelect user_select() const;
     Isolation isolation() const;
-    CSS::Containment contain() const;
+    Containment contain() const;
     MixBlendMode mix_blend_mode() const;
 
-    static Vector<CSS::Transformation> transformations_for_style_value(CSSStyleValue const& value);
-    Vector<CSS::Transformation> transformations() const;
+    static Vector<Transformation> transformations_for_style_value(CSSStyleValue const& value);
+    Vector<Transformation> transformations() const;
     TransformBox transform_box() const;
-    CSS::TransformOrigin transform_origin() const;
-    Optional<CSS::Transformation> rotate() const;
-    Optional<CSS::Transformation> translate() const;
-    Optional<CSS::Transformation> scale() const;
+    TransformOrigin transform_origin() const;
+    Optional<Transformation> rotate() const;
+    Optional<Transformation> translate() const;
+    Optional<Transformation> scale() const;
 
     MaskType mask_type() const;
     Color stop_color() const;
@@ -229,17 +229,17 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    Overflow overflow(CSS::PropertyID) const;
-    Vector<CSS::ShadowData> shadow(CSS::PropertyID, Layout::Node const&) const;
+    Overflow overflow(PropertyID) const;
+    Vector<ShadowData> shadow(PropertyID, Layout::Node const&) const;
 
-    GC::Ptr<CSS::CSSStyleDeclaration const> m_animation_name_source;
-    GC::Ptr<CSS::CSSStyleDeclaration const> m_transition_property_source;
+    GC::Ptr<CSSStyleDeclaration const> m_animation_name_source;
+    GC::Ptr<CSSStyleDeclaration const> m_transition_property_source;
 
     Array<RefPtr<CSSStyleValue const>, number_of_properties> m_property_values;
     Array<u8, ceil_div(number_of_properties, 8uz)> m_property_important {};
     Array<u8, ceil_div(number_of_properties, 8uz)> m_property_inherited {};
 
-    HashMap<CSS::PropertyID, NonnullRefPtr<CSSStyleValue const>> m_animated_property_values;
+    HashMap<PropertyID, NonnullRefPtr<CSSStyleValue const>> m_animated_property_values;
 
     int m_math_depth { InitialValues::math_depth() };
     mutable RefPtr<Gfx::FontCascadeList> m_font_list;

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -501,7 +501,7 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
     // FIXME: Find the spec for this.
     if (is<HTML::HTMLTableElement>(*this)) {
         auto text_align = new_computed_properties->text_align();
-        if (text_align.has_value() && (text_align.value() == CSS::TextAlign::LibwebLeft || text_align.value() == CSS::TextAlign::LibwebCenter || text_align.value() == CSS::TextAlign::LibwebRight))
+        if (text_align == CSS::TextAlign::LibwebLeft || text_align == CSS::TextAlign::LibwebCenter || text_align == CSS::TextAlign::LibwebRight)
             new_computed_properties->set_property(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Start));
     }
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1194,7 +1194,7 @@ void HTMLInputElement::create_range_input_shadow_tree()
 void HTMLInputElement::computed_properties_changed()
 {
     auto appearance = computed_properties()->appearance();
-    if (!appearance.has_value() || *appearance == CSS::Appearance::None)
+    if (appearance == CSS::Appearance::None)
         return;
 
     auto accent_color = MUST(String::from_utf8(CSS::string_from_keyword(CSS::Keyword::Accentcolor)));

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -572,7 +572,7 @@ void HTMLSelectElement::computed_properties_changed()
     // Hide chevron icon when appearance is none
     if (m_chevron_icon_element) {
         auto appearance = computed_properties()->appearance();
-        if (appearance.has_value() && *appearance == CSS::Appearance::None) {
+        if (appearance == CSS::Appearance::None) {
             MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "none"_string));
         } else {
             MUST(m_chevron_icon_element->style_for_bindings()->set_property(CSS::PropertyID::Display, "block"_string));

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -506,8 +506,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     }
     computed_values.set_background_color(computed_style.color_or_fallback(CSS::PropertyID::BackgroundColor, *this, CSS::InitialValues::background_color()));
 
-    if (auto box_sizing = computed_style.box_sizing(); box_sizing.has_value())
-        computed_values.set_box_sizing(box_sizing.release_value());
+    computed_values.set_box_sizing(computed_style.box_sizing());
 
     if (auto maybe_font_language_override = computed_style.font_language_override(); maybe_font_language_override.has_value())
         computed_values.set_font_language_override(maybe_font_language_override.release_value());
@@ -515,18 +514,15 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_font_feature_settings(maybe_font_feature_settings.release_value());
     if (auto maybe_font_variant_alternates = computed_style.font_variant_alternates(); maybe_font_variant_alternates.has_value())
         computed_values.set_font_variant_alternates(maybe_font_variant_alternates.release_value());
-    if (auto maybe_font_variant_caps = computed_style.font_variant_caps(); maybe_font_variant_caps.has_value())
-        computed_values.set_font_variant_caps(maybe_font_variant_caps.release_value());
+    computed_values.set_font_variant_caps(computed_style.font_variant_caps());
     if (auto maybe_font_variant_east_asian = computed_style.font_variant_east_asian(); maybe_font_variant_east_asian.has_value())
         computed_values.set_font_variant_east_asian(maybe_font_variant_east_asian.release_value());
-    if (auto maybe_font_variant_emoji = computed_style.font_variant_emoji(); maybe_font_variant_emoji.has_value())
-        computed_values.set_font_variant_emoji(maybe_font_variant_emoji.release_value());
+    computed_values.set_font_variant_emoji(computed_style.font_variant_emoji());
     if (auto maybe_font_variant_ligatures = computed_style.font_variant_ligatures(); maybe_font_variant_ligatures.has_value())
         computed_values.set_font_variant_ligatures(maybe_font_variant_ligatures.release_value());
     if (auto maybe_font_variant_numeric = computed_style.font_variant_numeric(); maybe_font_variant_numeric.has_value())
         computed_values.set_font_variant_numeric(maybe_font_variant_numeric.release_value());
-    if (auto maybe_font_variant_position = computed_style.font_variant_position(); maybe_font_variant_position.has_value())
-        computed_values.set_font_variant_position(maybe_font_variant_position.release_value());
+    computed_values.set_font_variant_position(computed_style.font_variant_position());
     if (auto maybe_font_variation_settings = computed_style.font_variation_settings(); maybe_font_variation_settings.has_value())
         computed_values.set_font_variation_settings(maybe_font_variation_settings.release_value());
 
@@ -560,18 +556,9 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     }
     computed_values.set_display(computed_style.display());
 
-    auto flex_direction = computed_style.flex_direction();
-    if (flex_direction.has_value())
-        computed_values.set_flex_direction(flex_direction.value());
-
-    auto flex_wrap = computed_style.flex_wrap();
-    if (flex_wrap.has_value())
-        computed_values.set_flex_wrap(flex_wrap.value());
-
-    auto flex_basis = computed_style.flex_basis();
-    if (flex_basis.has_value())
-        computed_values.set_flex_basis(flex_basis.value());
-
+    computed_values.set_flex_direction(computed_style.flex_direction());
+    computed_values.set_flex_wrap(computed_style.flex_wrap());
+    computed_values.set_flex_basis(computed_style.flex_basis());
     computed_values.set_flex_grow(computed_style.flex_grow());
     computed_values.set_flex_shrink(computed_style.flex_shrink());
     computed_values.set_order(computed_style.order());
@@ -616,135 +603,64 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     if (computed_style.filter().has_filters())
         computed_values.set_filter(resolve_filter(computed_style.filter()));
 
-    auto justify_content = computed_style.justify_content();
-    if (justify_content.has_value())
-        computed_values.set_justify_content(justify_content.value());
-
-    auto justify_items = computed_style.justify_items();
-    if (justify_items.has_value())
-        computed_values.set_justify_items(justify_items.value());
-
-    auto justify_self = computed_style.justify_self();
-    if (justify_self.has_value())
-        computed_values.set_justify_self(justify_self.value());
+    computed_values.set_justify_content(computed_style.justify_content());
+    computed_values.set_justify_items(computed_style.justify_items());
+    computed_values.set_justify_self(computed_style.justify_self());
 
     auto accent_color = computed_style.accent_color(*this);
     if (accent_color.has_value())
         computed_values.set_accent_color(accent_color.value());
 
-    auto align_content = computed_style.align_content();
-    if (align_content.has_value())
-        computed_values.set_align_content(align_content.value());
+    computed_values.set_align_content(computed_style.align_content());
+    computed_values.set_align_items(computed_style.align_items());
+    computed_values.set_align_self(computed_style.align_self());
 
-    auto align_items = computed_style.align_items();
-    if (align_items.has_value())
-        computed_values.set_align_items(align_items.value());
+    computed_values.set_appearance(computed_style.appearance());
 
-    auto align_self = computed_style.align_self();
-    if (align_self.has_value())
-        computed_values.set_align_self(align_self.value());
+    computed_values.set_position(computed_style.position());
 
-    auto appearance = computed_style.appearance();
-    if (appearance.has_value())
-        computed_values.set_appearance(appearance.value());
-
-    auto position = computed_style.position();
-    if (position.has_value())
-        computed_values.set_position(position.value());
-
-    auto text_align = computed_style.text_align();
-    if (text_align.has_value())
-        computed_values.set_text_align(text_align.value());
-
-    auto text_justify = computed_style.text_justify();
-    if (text_align.has_value())
-        computed_values.set_text_justify(text_justify.value());
+    computed_values.set_text_align(computed_style.text_align());
+    computed_values.set_text_justify(computed_style.text_justify());
+    computed_values.set_text_overflow(computed_style.text_overflow());
 
     if (auto text_indent = computed_style.length_percentage(CSS::PropertyID::TextIndent); text_indent.has_value())
         computed_values.set_text_indent(text_indent.release_value());
 
-    if (auto text_overflow = computed_style.text_overflow(); text_overflow.has_value())
-        computed_values.set_text_overflow(text_overflow.release_value());
+    computed_values.set_tab_size(computed_style.tab_size());
 
-    auto tab_size = computed_style.tab_size();
-    computed_values.set_tab_size(tab_size);
-
-    auto white_space = computed_style.white_space();
-    if (white_space.has_value())
-        computed_values.set_white_space(white_space.value());
-
-    auto word_break = computed_style.word_break();
-    if (word_break.has_value())
-        computed_values.set_word_break(word_break.value());
-
-    auto word_spacing = computed_style.word_spacing();
-    if (word_spacing.has_value())
+    computed_values.set_white_space(computed_style.white_space());
+    computed_values.set_word_break(computed_style.word_break());
+    if (auto word_spacing = computed_style.word_spacing(); word_spacing.has_value())
         computed_values.set_word_spacing(word_spacing.value());
 
     auto letter_spacing = computed_style.letter_spacing();
     if (letter_spacing.has_value())
         computed_values.set_letter_spacing(letter_spacing.value());
 
-    auto float_ = computed_style.float_();
-    if (float_.has_value())
-        computed_values.set_float(float_.value());
+    computed_values.set_float(computed_style.float_());
 
     computed_values.set_border_spacing_horizontal(computed_style.border_spacing_horizontal(*this));
     computed_values.set_border_spacing_vertical(computed_style.border_spacing_vertical(*this));
 
-    auto caption_side = computed_style.caption_side();
-    if (caption_side.has_value())
-        computed_values.set_caption_side(caption_side.value());
-
-    auto clear = computed_style.clear();
-    if (clear.has_value())
-        computed_values.set_clear(clear.value());
-
-    auto overflow_x = computed_style.overflow_x();
-    if (overflow_x.has_value())
-        computed_values.set_overflow_x(overflow_x.value());
-
-    auto overflow_y = computed_style.overflow_y();
-    if (overflow_y.has_value())
-        computed_values.set_overflow_y(overflow_y.value());
-
-    auto content_visibility = computed_style.content_visibility();
-    if (content_visibility.has_value())
-        computed_values.set_content_visibility(content_visibility.value());
-
-    auto cursor = computed_style.cursor();
-    if (cursor.has_value())
-        computed_values.set_cursor(cursor.value());
-
-    auto image_rendering = computed_style.image_rendering();
-    if (image_rendering.has_value())
-        computed_values.set_image_rendering(image_rendering.value());
-
-    auto pointer_events = computed_style.pointer_events();
-    if (pointer_events.has_value())
-        computed_values.set_pointer_events(pointer_events.value());
-
+    computed_values.set_caption_side(computed_style.caption_side());
+    computed_values.set_clear(computed_style.clear());
+    computed_values.set_overflow_x(computed_style.overflow_x());
+    computed_values.set_overflow_y(computed_style.overflow_y());
+    computed_values.set_content_visibility(computed_style.content_visibility());
+    computed_values.set_cursor(computed_style.cursor());
+    computed_values.set_image_rendering(computed_style.image_rendering());
+    computed_values.set_pointer_events(computed_style.pointer_events());
     computed_values.set_text_decoration_line(computed_style.text_decoration_line());
+    computed_values.set_text_decoration_style(computed_style.text_decoration_style());
+    computed_values.set_text_transform(computed_style.text_transform());
 
-    auto text_decoration_style = computed_style.text_decoration_style();
-    if (text_decoration_style.has_value())
-        computed_values.set_text_decoration_style(text_decoration_style.value());
-
-    auto text_transform = computed_style.text_transform();
-    if (text_transform.has_value())
-        computed_values.set_text_transform(text_transform.value());
-
-    if (auto list_style_type = computed_style.list_style_type(); list_style_type.has_value())
-        computed_values.set_list_style_type(list_style_type.value());
-
+    computed_values.set_list_style_type(computed_style.list_style_type());
+    computed_values.set_list_style_position(computed_style.list_style_position());
     auto const& list_style_image = computed_style.property(CSS::PropertyID::ListStyleImage);
     if (list_style_image.is_abstract_image()) {
         m_list_style_image = list_style_image.as_abstract_image();
         const_cast<CSS::AbstractImageStyleValue&>(*m_list_style_image).load_any_resources(document());
     }
-
-    if (auto list_style_position = computed_style.list_style_position(); list_style_position.has_value())
-        computed_values.set_list_style_position(list_style_position.value());
 
     // FIXME: The default text decoration color value is `currentcolor`, but since we can't resolve that easily,
     //        we just manually grab the value from `color`. This makes it dependent on `color` being
@@ -760,8 +676,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_z_index(computed_style.z_index());
     computed_values.set_opacity(computed_style.opacity());
 
-    if (auto maybe_visibility = computed_style.visibility(); maybe_visibility.has_value())
-        computed_values.set_visibility(maybe_visibility.release_value());
+    computed_values.set_visibility(computed_style.visibility());
 
     computed_values.set_width(computed_style.size_value(CSS::PropertyID::Width));
     computed_values.set_min_width(computed_style.size_value(CSS::PropertyID::MinWidth));
@@ -787,8 +702,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_scale(scale_value.release_value());
 
     computed_values.set_transformations(computed_style.transformations());
-    if (auto transform_box = computed_style.transform_box(); transform_box.has_value())
-        computed_values.set_transform_box(transform_box.value());
+    computed_values.set_transform_box(computed_style.transform_box());
     computed_values.set_transform_origin(computed_style.transform_origin());
 
     auto const& transition_delay_property = computed_style.property(CSS::PropertyID::TransitionDelay);
@@ -805,7 +719,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         //        we just manually grab the value from `color`. This makes it dependent on `color` being
         //        specified first, so it's far from ideal.
         border.color = computed_style.color_or_fallback(color_property, *this, computed_values.color());
-        border.line_style = computed_style.line_style(style_property).value_or(CSS::LineStyle::None);
+        border.line_style = computed_style.line_style(style_property);
 
         // https://w3c.github.io/csswg-drafts/css-backgrounds/#border-style
         // none
@@ -851,8 +765,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_outline_color(outline_color.to_color(*this));
     if (auto const& outline_offset = computed_style.property(CSS::PropertyID::OutlineOffset); outline_offset.is_length())
         computed_values.set_outline_offset(outline_offset.as_length().length());
-    if (auto const& outline_style = computed_style.outline_style(); outline_style.has_value())
-        computed_values.set_outline_style(outline_style.value());
+    computed_values.set_outline_style(computed_style.outline_style());
     if (auto const& outline_width = computed_style.property(CSS::PropertyID::OutlineWidth); outline_width.is_length())
         computed_values.set_outline_width(outline_width.as_length().length());
 
@@ -910,8 +823,7 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         const_cast<CSS::AbstractImageStyleValue&>(abstract_image).load_any_resources(document());
     }
 
-    if (auto mask_type = computed_style.mask_type(); mask_type.has_value())
-        computed_values.set_mask_type(*mask_type);
+    computed_values.set_mask_type(computed_style.mask_type());
 
     if (auto const& mask = computed_style.property(CSS::PropertyID::Mask); mask.is_url())
         computed_values.set_mask(mask.as_url().url());
@@ -921,12 +833,8 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
         computed_values.set_clip_path(clip_path.as_url().url());
     else if (clip_path.is_basic_shape())
         computed_values.set_clip_path(clip_path.as_basic_shape());
-
-    if (auto clip_rule = computed_style.clip_rule(); clip_rule.has_value())
-        computed_values.set_clip_rule(*clip_rule);
-
-    if (auto fill_rule = computed_style.fill_rule(); fill_rule.has_value())
-        computed_values.set_fill_rule(*fill_rule);
+    computed_values.set_clip_rule(computed_style.clip_rule());
+    computed_values.set_fill_rule(computed_style.fill_rule());
 
     computed_values.set_fill_opacity(computed_style.fill_opacity());
 
@@ -958,35 +866,28 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     else if (stroke_dashoffset.is_percentage())
         computed_values.set_stroke_dashoffset(CSS::LengthPercentage { stroke_dashoffset.as_percentage().percentage() });
 
-    if (auto stroke_linecap = computed_style.stroke_linecap(); stroke_linecap.has_value())
-        computed_values.set_stroke_linecap(stroke_linecap.value());
-    if (auto stroke_linejoin = computed_style.stroke_linejoin(); stroke_linejoin.has_value())
-        computed_values.set_stroke_linejoin(stroke_linejoin.value());
-
+    computed_values.set_stroke_linecap(computed_style.stroke_linecap());
+    computed_values.set_stroke_linejoin(computed_style.stroke_linejoin());
     computed_values.set_stroke_miterlimit(computed_style.stroke_miterlimit());
 
     computed_values.set_stroke_opacity(computed_style.stroke_opacity());
     computed_values.set_stop_opacity(computed_style.stop_opacity());
 
-    if (auto text_anchor = computed_style.text_anchor(); text_anchor.has_value())
-        computed_values.set_text_anchor(*text_anchor);
+    computed_values.set_text_anchor(computed_style.text_anchor());
 
     if (auto const& column_count = computed_style.property(CSS::PropertyID::ColumnCount); column_count.is_integer())
         computed_values.set_column_count(CSS::ColumnCount::make_integer(column_count.as_integer().integer()));
 
-    if (auto column_span = computed_style.column_span(); column_span.has_value())
-        computed_values.set_column_span(column_span.value());
+    computed_values.set_column_span(computed_style.column_span());
 
     computed_values.set_column_width(computed_style.size_value(CSS::PropertyID::ColumnWidth));
 
     computed_values.set_column_gap(computed_style.gap_value(CSS::PropertyID::ColumnGap));
     computed_values.set_row_gap(computed_style.gap_value(CSS::PropertyID::RowGap));
 
-    if (auto border_collapse = computed_style.border_collapse(); border_collapse.has_value())
-        computed_values.set_border_collapse(border_collapse.value());
+    computed_values.set_border_collapse(computed_style.border_collapse());
 
-    if (auto table_layout = computed_style.table_layout(); table_layout.has_value())
-        computed_values.set_table_layout(table_layout.value());
+    computed_values.set_table_layout(computed_style.table_layout());
 
     auto const& aspect_ratio = computed_style.property(CSS::PropertyID::AspectRatio);
     if (aspect_ratio.is_value_list()) {
@@ -1021,31 +922,15 @@ void NodeWithStyle::apply_style(CSS::ComputedProperties const& computed_style)
     computed_values.set_counter_reset(computed_style.counter_data(CSS::PropertyID::CounterReset));
     computed_values.set_counter_set(computed_style.counter_data(CSS::PropertyID::CounterSet));
 
-    if (auto object_fit = computed_style.object_fit(); object_fit.has_value())
-        computed_values.set_object_fit(object_fit.value());
-
+    computed_values.set_object_fit(computed_style.object_fit());
     computed_values.set_object_position(computed_style.object_position());
-
-    if (auto direction = computed_style.direction(); direction.has_value())
-        computed_values.set_direction(direction.value());
-
-    if (auto unicode_bidi = computed_style.unicode_bidi(); unicode_bidi.has_value())
-        computed_values.set_unicode_bidi(unicode_bidi.value());
-
-    if (auto scrollbar_width = computed_style.scrollbar_width(); scrollbar_width.has_value())
-        computed_values.set_scrollbar_width(scrollbar_width.value());
-
-    if (auto writing_mode = computed_style.writing_mode(); writing_mode.has_value())
-        computed_values.set_writing_mode(writing_mode.value());
-
-    if (auto user_select = computed_style.user_select(); user_select.has_value())
-        computed_values.set_user_select(user_select.value());
-
-    if (auto isolation = computed_style.isolation(); isolation.has_value())
-        computed_values.set_isolation(isolation.value());
-
-    if (auto mix_blend_mode = computed_style.mix_blend_mode(); mix_blend_mode.has_value())
-        computed_values.set_mix_blend_mode(mix_blend_mode.value());
+    computed_values.set_direction(computed_style.direction());
+    computed_values.set_unicode_bidi(computed_style.unicode_bidi());
+    computed_values.set_scrollbar_width(computed_style.scrollbar_width());
+    computed_values.set_writing_mode(computed_style.writing_mode());
+    computed_values.set_user_select(computed_style.user_select());
+    computed_values.set_isolation(computed_style.isolation());
+    computed_values.set_mix_blend_mode(computed_style.mix_blend_mode());
 
     propagate_style_to_anonymous_wrappers();
 


### PR DESCRIPTION
We have a lot of methods here which return `Optional<SomeKindOfEnum>` which can never actually fail, they'll always return a value. This is because even though `keyword_to_foo()` returns `Optional`, we've rejected all the invalid values at parse time. This lets us simplify the code a bit.