### PR TITLE
LibJS: Parse dates like "1 Jan 2001 00:00:00 GMT"

### DIFF
--- a/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -195,6 +195,7 @@ static double parse_date_string(VM& vm, StringView date_string)
         "%Y-%m-%d%t%H:%M:%S%z"sv,              // "2024-12-30 03:00:00+0000"
         "%Y-%m-%d%t%H:%M:%S%X"sv,              // "2025-01-13 00:00:00.000"
         "%Y-%m-%eT%T%z"sv,                     // "2021-04-21T15:00:00+0000"
+        "%d%t%b%t%Y%t%T%t%Z"sv,                // "1 Jan 2001 00:00:00 GMT"
     };
 
     for (auto const& format : extra_formats) {

--- a/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -47,6 +47,7 @@ test("basic functionality", () => {
     expect(Date.parse("Wednesday, Jan 15, 2025")).toBe(1736920800000);
     expect(Date.parse("2025-01-13 00:00:00.000")).toBe(1736748000000);
     expect(Date.parse("2021-04-21T15:00:00+0000")).toBe(1619017200000);
+    expect(Date.parse("1 Jan 2001 00:00:00 GMT")).toBe(978307200000);
 
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
     setTimeZone(originalTimeZone);


### PR DESCRIPTION
Apple Maps uses this date format.