### PR TITLE
 LibWeb: Treat `execCommand` command names as case insensitive

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -80,6 +80,12 @@ public:
         return (... || this->operator==(forward<Ts>(strings)));
     }
 
+    template<typename... Ts>
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of_ignoring_ascii_case(Ts&&... strings) const
+    {
+        return (... || this->equals_ignoring_ascii_case(forward<Ts>(strings)));
+    }
+
 private:
     friend class Optional<FlyString>;
 

--- a/Tests/LibWeb/Text/expected/Editing/execCommand-case-insensitivity.txt
+++ b/Tests/LibWeb/Text/expected/Editing/execCommand-case-insensitivity.txt
@@ -1,0 +1,9 @@
+queryCommandSupported("selectall"): true
+queryCommandEnabled("selectall"): true
+execCommand("selectall"): PASS
+queryCommandSupported("SELECTALL"): true
+queryCommandEnabled("SELECTALL"): true
+execCommand("SELECTALL"): PASS
+queryCommandSupported("SeLeCtAlL"): true
+queryCommandEnabled("SeLeCtAlL"): true
+execCommand("SeLeCtAlL"): PASS

--- a/Tests/LibWeb/Text/input/Editing/execCommand-case-insensitivity.html
+++ b/Tests/LibWeb/Text/input/Editing/execCommand-case-insensitivity.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<body></body>
+<script>
+    function execCommandCaseInsensitivityTest(command) {
+        return new Promise((resolve) => {
+            const iframe = document.createElement("iframe");
+            iframe.srcdoc = `<div>PASS</div>`;
+            document.body.appendChild(iframe);
+            iframe.onload = () => {
+                const iframeDocument = iframe.contentDocument;
+                iframeDocument.execCommand(command);
+
+                const selection = iframeDocument.getSelection();
+                println(`queryCommandSupported("${command}"): ${iframeDocument.queryCommandSupported(command)}`);
+                println(`queryCommandEnabled("${command}"): ${iframeDocument.queryCommandEnabled(command)}`);
+                println(`execCommand("${command}"): ${selection.toString()}`);
+                iframe.remove();
+                resolve();
+            };
+        });
+    }
+    asyncTest(async done => {
+        for (command of ["selectall", "SELECTALL", "SeLeCtAlL"]) {
+            await execCommandCaseInsensitivityTest(command);
+        }
+        done();
+    });
+</script>


### PR DESCRIPTION
This fixes ~80 WPT subtests in `editing`.