### PR TITLE
LibWeb: Implement inert subtree behaviors

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2110,6 +2110,17 @@ bool Node::is_default_namespace(Optional<String> namespace_) const
     return default_namespace == namespace_;
 }
 
+bool Node::is_inert() const
+{
+    if (auto* html_element = as_if<HTML::HTMLElement>(*this))
+        return html_element->is_inert();
+
+    if (auto* enclosing_html_element = this->enclosing_html_element())
+        return enclosing_html_element->is_inert();
+
+    return false;
+}
+
 // https://dom.spec.whatwg.org/#in-a-document-tree
 bool Node::in_a_document_tree() const
 {

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -1311,6 +1311,12 @@ bool Node::is_editable() const
     if (!parent() || !parent()->is_editable_or_editing_host())
         return false;
 
+    // https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees
+    // When a node is inert:
+    // - If it is editable, the node behaves as if it were non-editable.
+    if (is_inert())
+        return false;
+
     // and either it is an HTML element,
     if (is<HTML::HTMLElement>(this))
         return true;

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -499,6 +499,8 @@ public:
     Optional<String> lookup_prefix(Optional<String> namespace_) const;
     bool is_default_namespace(Optional<String> namespace_) const;
 
+    bool is_inert() const;
+
 protected:
     Node(JS::Realm&, Document&, NodeType);
     Node(Document&, NodeType);

--- a/Libraries/LibWeb/HTML/Focus.cpp
+++ b/Libraries/LibWeb/HTML/Focus.cpp
@@ -216,7 +216,9 @@ void run_focusing_steps(DOM::Node* new_focus_target, DOM::Node* fallback_target,
             new_focus_target = content_navigable->active_document();
     }
 
-    // FIXME: 4. If new focus target is a focusable area and its DOM anchor is inert, then return.
+    // 4. If new focus target is a focusable area and its DOM anchor is inert, then return.
+    if (new_focus_target->is_inert())
+        return;
 
     // 5. If new focus target is the currently focused area of a top-level browsing context, then return.
     if (!new_focus_target->document().browsing_context())
@@ -264,7 +266,9 @@ void run_unfocusing_steps(DOM::Node* old_focus_target)
         }
     }
 
-    // FIXME: 2. If old focus target is inert, then return.
+    // 2. If old focus target is inert, then return.
+    if (old_focus_target->is_inert())
+        return;
 
     // FIXME: 3. If old focus target is an area element and one of its shapes is the currently focused area of a
     //    top-level browsing context, or, if old focus target is an element with one or more scrollable regions, and one

--- a/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Libraries/LibWeb/HTML/HTMLElement.h
@@ -149,6 +149,8 @@ public:
     static void hide_all_popovers_until(Variant<GC::Ptr<HTMLElement>, GC::Ptr<DOM::Document>> endpoint, FocusPreviousElement focus_previous_element, FireEvents fire_events);
     static GC::Ptr<HTMLElement> topmost_popover_ancestor(GC::Ptr<DOM::Node> new_popover_or_top_layer_element, Vector<GC::Ref<HTMLElement>> const& popover_list, GC::Ptr<HTMLElement> invoker, IsPopover is_popover);
 
+    bool is_inert() const { return m_inert; }
+
 protected:
     HTMLElement(DOM::Document&, DOM::QualifiedName);
 
@@ -168,6 +170,9 @@ protected:
     bool is_potentially_render_blocking();
     // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#implicitly-potentially-render-blocking
     virtual bool is_implicitly_potentially_render_blocking() const { return false; }
+
+    void set_inert(bool inert) { m_inert = inert; }
+    void set_subtree_inertness(bool is_inert);
 
 private:
     virtual bool is_html_element() const final { return true; }
@@ -199,6 +204,8 @@ private:
 
     // https://html.spec.whatwg.org/multipage/interaction.html#click-in-progress-flag
     bool m_click_in_progress { false };
+
+    bool m_inert { false };
 
     // Popover API
 

--- a/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Libraries/LibWeb/Painting/Paintable.cpp
@@ -83,6 +83,17 @@ CSS::ImmutableComputedValues const& Paintable::computed_values() const
     return m_layout_node->computed_values();
 }
 
+bool Paintable::visible_for_hit_testing() const
+{
+    // https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees
+    // When a node is inert:
+    // - Hit-testing must act as if the 'pointer-events' CSS property were set to 'none'.
+    if (auto dom_node = this->dom_node(); dom_node && dom_node->is_inert())
+        return false;
+
+    return computed_values().pointer_events() != CSS::PointerEvents::None;
+}
+
 void Paintable::set_dom_node(GC::Ptr<DOM::Node> dom_node)
 {
     m_dom_node = dom_node;

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -109,7 +109,7 @@ public:
 
     CSS::ImmutableComputedValues const& computed_values() const;
 
-    bool visible_for_hit_testing() const { return computed_values().pointer_events() != CSS::PointerEvents::None; }
+    bool visible_for_hit_testing() const;
 
     GC::Ptr<HTML::Navigable> navigable() const;
 

--- a/Tests/LibWeb/Text/expected/HTML/Window-find-inert.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find-inert.txt
@@ -1,0 +1,2 @@
+window.find("inert") initial result: true
+window.find("inert") second call: false

--- a/Tests/LibWeb/Text/expected/wpt-import/inert/inert-computed-style.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/inert/inert-computed-style.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	inert isn't hit-testable, but that isn't expose in the computed style

--- a/Tests/LibWeb/Text/expected/wpt-import/inert/inert-node-is-unfocusable.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/inert/inert-node-is-unfocusable.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	Button outside of inert container is focusable.
+Pass	Button with inert atribute is unfocusable.
+Pass	All focusable elements inside inert subtree are unfocusable
+Pass	Can get inert via property
+Pass	Elements inside of inert subtrees return false when getting 'inert'
+Pass	Setting inert via property correctly modifies inert state

--- a/Tests/LibWeb/Text/input/HTML/Window-find-inert.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-find-inert.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div>not inert</div>
+<div inert>inert</div>
+<script>
+    test(() => {
+        let initialResult = window.find("inert");
+        let secondCallResult = window.find("inert");
+        println(`window.find("inert") initial result: ${initialResult}`);
+        println(`window.find("inert") second call: ${secondCallResult}`);
+    });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/inert/inert-computed-style.html
+++ b/Tests/LibWeb/Text/input/wpt-import/inert/inert-computed-style.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>inert isn't hit-testable, but that isn't expose in the computed style</title>
+<link rel="author" title="Emilio Cobos Álvarez" href="mailto:emilio@crisal.io">
+<link rel="author" title="Mozilla" href="https://mozilla.org">
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<style>
+  body { margin: 0 }
+  div {
+    width: 100px;
+    height: 100px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: blue;
+  }
+  #nonInert {
+    background-color: red;
+  }
+</style>
+<div id="nonInert"></div>
+<div id="inert"></div>
+<script>
+  test(function() {
+    let inert = document.getElementById("inert");
+    assert_equals(
+      document.elementFromPoint(50, 50),
+      inert,
+      "not-yet-inert node hit-test before non-inert node",
+    );
+    inert.inert = true;
+    assert_equals(
+      document.elementFromPoint(50, 50),
+      nonInert,
+      "inert node is transparent to events (as pointer-events: none)",
+    );
+    assert_equals(
+      getComputedStyle(inert).pointerEvents,
+      getComputedStyle(nonInert).pointerEvents,
+      "inert node doesn't change pointer-events computed value",
+    );
+    assert_equals(
+      getComputedStyle(inert).userSelect,
+      getComputedStyle(nonInert).userSelect,
+      "inert node doesn't change user-select computed value",
+    );
+  });
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/inert/inert-node-is-unfocusable.html
+++ b/Tests/LibWeb/Text/input/wpt-import/inert/inert-node-is-unfocusable.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>inert nodes are unfocusable</title>
+    <link rel="author" title="Alice Boxhall" href="aboxhall@chromium.org">
+    <script src="../resources/testharness.js"></script>
+    <script src="../resources/testharnessreport.js"></script>
+  </head>
+<body id="body" tabindex="1">
+  <button id="focusable">Outside of inert container</button>
+  <button inert id="inert">Inert button</button>
+  <div inert id="container">
+    <input id="text" type="text">
+    <input id="datetime" type="datetime">
+    <input id="color" type="color">
+    <select id="select">
+        <optgroup id="optgroup">
+            <option id="option">Option</option>
+        </optgroup>
+    </select>
+    <div id="contenteditable-div" contenteditable>I'm editable</div>
+    <span id="tabindex-span" tabindex="0">I'm tabindexed.</div>
+    <embed id="embed" type="application/x-blink-test-plugin" width=100 height=100></embed>
+    <a id="anchor" href="">Link</a>
+  </div>
+<script>
+function testFocus(element, expectFocus) {
+    focusedElement = null;
+    element.addEventListener('focus', function() { focusedElement = element; }, false);
+    element.focus();
+    theElement = element;
+    assert_equals(focusedElement === theElement, expectFocus);
+}
+
+function testTree(element, expectFocus, excludeCurrent) {
+    if (element.nodeType == Node.ELEMENT_NODE && !excludeCurrent)
+        testFocus(element, expectFocus);
+    if (element.tagName === "SELECT")
+        return;
+    var childNodes = element.childNodes;
+    for (var i = 0; i < childNodes.length; i++)
+        testTree(childNodes[i], expectFocus);
+}
+
+
+test(function() {
+    testFocus(document.getElementById('focusable'), true);
+}, "Button outside of inert container is focusable.");
+
+test(function() {
+    testFocus(document.getElementById('inert'), false);
+}, "Button with inert atribute is unfocusable.");
+
+test(function() {
+    testTree(document.getElementById('container'), false);
+}, "All focusable elements inside inert subtree are unfocusable");
+
+test(function() {
+    assert_false(document.getElementById("focusable").inert, "Inert not set explicitly is false")
+    assert_true(document.getElementById("inert").inert, "Inert set explicitly is true");
+    assert_true(document.getElementById("container").inert, "Inert set on container is true");
+}, "Can get inert via property");
+
+test(function() {
+    assert_false(document.getElementById("text").inert, "Elements inside of inert subtrees return false when getting inert");
+}, "Elements inside of inert subtrees return false when getting 'inert'");
+
+test(function() {
+    document.getElementById('focusable').inert = true;
+    testFocus(document.getElementById('focusable'), false);
+    document.getElementById('inert').inert = false;
+    testFocus(document.getElementById('inert'), true);
+    document.getElementById('container').inert = false;
+    testTree(document.getElementById('container'), true, true);
+}, "Setting inert via property correctly modifies inert state");
+</script>
+</body>
+</html>


### PR DESCRIPTION
When a HTML element has the `inert` attribute, that attribute and all of its flat-tree descendants now implement the behaviors specified in https://html.spec.whatwg.org/multipage/interaction.html#inert-subtrees, namely:

Inert elements are:
* Treated as not visible for hit-testing
* Not selectable
* Not editable
* Ignored by find-in-page queries