### PR TITLE
LibWeb: Optimize style invalidation caused by DOM structural changes

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -2656,9 +2656,6 @@ void StyleComputer::collect_selector_insights(Selector const& selector, Selector
                 if (simple_selector.pseudo_class().type == PseudoClass::Has) {
                     insights.has_has_selectors = true;
                 }
-                if (simple_selector.pseudo_class().type == PseudoClass::Defined) {
-                    insights.has_defined_selectors = true;
-                }
                 for (auto const& argument_selector : simple_selector.pseudo_class().argument_selector_list) {
                     collect_selector_insights(*argument_selector, insights);
                 }
@@ -3173,15 +3170,6 @@ bool StyleComputer::may_have_has_selectors() const
 
     build_rule_cache_if_needed();
     return m_selector_insights->has_has_selectors;
-}
-
-bool StyleComputer::may_have_defined_selectors() const
-{
-    if (!has_valid_rule_cache())
-        return true;
-
-    build_rule_cache_if_needed();
-    return m_selector_insights->has_defined_selectors;
 }
 
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -177,7 +177,6 @@ public:
     void collect_animation_into(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, GC::Ref<Animations::KeyframeEffect> animation, ComputedProperties&, AnimationRefresh = AnimationRefresh::No) const;
 
     [[nodiscard]] bool may_have_has_selectors() const;
-    [[nodiscard]] bool may_have_defined_selectors() const;
 
     size_t number_of_css_font_faces_with_loading_in_progress() const;
 
@@ -257,7 +256,6 @@ private:
 
     struct SelectorInsights {
         bool has_has_selectors { false };
-        bool has_defined_selectors { false };
     };
 
     struct RuleCache {

--- a/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
+++ b/Libraries/LibWeb/CSS/StyleInvalidationData.cpp
@@ -69,6 +69,7 @@ static void collect_properties_used_in_has(Selector::SimpleSelector const& selec
         switch (pseudo_class.type) {
         case PseudoClass::Enabled:
         case PseudoClass::Disabled:
+        case PseudoClass::Defined:
         case PseudoClass::PlaceholderShown:
         case PseudoClass::Checked:
             if (in_has)
@@ -122,6 +123,7 @@ static void build_invalidation_sets_for_simple_selector(Selector::SimpleSelector
         auto const& pseudo_class = selector.pseudo_class();
         switch (pseudo_class.type) {
         case PseudoClass::Enabled:
+        case PseudoClass::Defined:
         case PseudoClass::Disabled:
         case PseudoClass::PlaceholderShown:
         case PseudoClass::Checked:

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -494,6 +494,11 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
 {
     VERIFY(parent());
 
+    m_affected_by_has_pseudo_class_in_subject_position = false;
+    m_affected_by_sibling_combinator = false;
+    m_affected_by_first_or_last_child_pseudo_class = false;
+    m_affected_by_nth_child_pseudo_class = false;
+
     auto& style_computer = document().style_computer();
     auto new_computed_properties = style_computer.compute_style(*this);
 

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -1183,6 +1183,9 @@ bool Element::includes_properties_from_invalidation_set(CSS::InvalidationSet con
             case CSS::PseudoClass::Disabled: {
                 return is_actually_disabled();
             }
+            case CSS::PseudoClass::Defined: {
+                return is_defined();
+            }
             case CSS::PseudoClass::Checked: {
                 // FIXME: This could be narrowed down to return true only if element is actually checked.
                 return is<HTML::HTMLInputElement>(*this) || is<HTML::HTMLOptionElement>(*this);
@@ -2366,8 +2369,9 @@ void Element::set_custom_element_state(CustomElementState state)
         return;
     m_custom_element_state = state;
 
-    if (document().style_computer().may_have_defined_selectors())
-        invalidate_style(StyleInvalidationReason::CustomElementStateChange);
+    Vector<CSS::InvalidationSet::Property, 1> changed_properties;
+    changed_properties.append({ .type = CSS::InvalidationSet::Property::Type::PseudoClass, .value = CSS::PseudoClass::Defined });
+    invalidate_style(StyleInvalidationReason::CustomElementStateChange, changed_properties, {});
 }
 
 // https://html.spec.whatwg.org/multipage/dom.html#html-element-constructors

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -423,6 +423,20 @@ public:
     bool affected_by_has_pseudo_class_in_subject_position() const { return m_affected_by_has_pseudo_class_in_subject_position; }
     void set_affected_by_has_pseudo_class_in_subject_position(bool value) { m_affected_by_has_pseudo_class_in_subject_position = value; }
 
+    bool affected_by_sibling_combinator() const { return m_affected_by_sibling_combinator; }
+    void set_affected_by_sibling_combinator(bool value) { m_affected_by_sibling_combinator = value; }
+
+    bool affected_by_first_or_last_child_pseudo_class() const { return m_affected_by_first_or_last_child_pseudo_class; }
+    void set_affected_by_first_or_last_child_pseudo_class(bool value) { m_affected_by_first_or_last_child_pseudo_class = value; }
+
+    bool affected_by_nth_child_pseudo_class() const { return m_affected_by_nth_child_pseudo_class; }
+    void set_affected_by_nth_child_pseudo_class(bool value) { m_affected_by_nth_child_pseudo_class = value; }
+
+    bool style_affected_by_structural_changes() const
+    {
+        return affected_by_sibling_combinator() || affected_by_first_or_last_child_pseudo_class() || affected_by_nth_child_pseudo_class();
+    }
+
 protected:
     Element(Document&, DOM::QualifiedName);
     virtual void initialize(JS::Realm&) override;
@@ -514,6 +528,9 @@ private:
     bool m_rendered_in_top_layer { false };
     bool m_style_uses_css_custom_properties { false };
     bool m_affected_by_has_pseudo_class_in_subject_position { false };
+    bool m_affected_by_sibling_combinator { false };
+    bool m_affected_by_first_or_last_child_pseudo_class { false };
+    bool m_affected_by_nth_child_pseudo_class { false };
 
     OwnPtr<CSS::CountersSet> m_counters_set;
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -524,13 +524,13 @@ private:
 
     Array<CSSPixelPoint, 3> m_scroll_offset;
 
-    bool m_in_top_layer { false };
-    bool m_rendered_in_top_layer { false };
+    bool m_in_top_layer : 1 { false };
+    bool m_rendered_in_top_layer : 1 { false };
     bool m_style_uses_css_custom_properties { false };
-    bool m_affected_by_has_pseudo_class_in_subject_position { false };
-    bool m_affected_by_sibling_combinator { false };
-    bool m_affected_by_first_or_last_child_pseudo_class { false };
-    bool m_affected_by_nth_child_pseudo_class { false };
+    bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
+    bool m_affected_by_sibling_combinator : 1 { false };
+    bool m_affected_by_first_or_last_child_pseudo_class : 1 { false };
+    bool m_affected_by_nth_child_pseudo_class : 1 { false };
 
     OwnPtr<CSS::CountersSet> m_counters_set;
 

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -767,12 +767,6 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
             node->post_connection();
     }
 
-    if (is_connected()) {
-        // FIXME: This will need to become smarter when we implement the :has() selector.
-        invalidate_style(StyleInvalidationReason::ParentOfInsertedNode);
-        set_needs_layout_tree_update(true);
-    }
-
     document().bump_dom_tree_version();
 }
 
@@ -1411,6 +1405,7 @@ void Node::set_needs_style_update(bool value)
 
 void Node::post_connection()
 {
+    set_needs_layout_tree_update(true);
 }
 
 void Node::inserted()

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -439,14 +439,14 @@ void Node::invalidate_style(StyleInvalidationReason reason)
 
     if (reason == StyleInvalidationReason::NodeInsertBefore || reason == StyleInvalidationReason::NodeRemove) {
         for (auto* sibling = previous_sibling(); sibling; sibling = sibling->previous_sibling()) {
-            if (sibling->is_element())
-                sibling->set_entire_subtree_needs_style_update(true);
+            if (auto* element = as_if<Element>(sibling); element && element->style_affected_by_structural_changes())
+                element->set_entire_subtree_needs_style_update(true);
         }
     }
 
     for (auto* sibling = next_sibling(); sibling; sibling = sibling->next_sibling()) {
-        if (sibling->is_element())
-            sibling->set_entire_subtree_needs_style_update(true);
+        if (auto* element = as_if<Element>(sibling); element && element->style_affected_by_structural_changes())
+            element->set_entire_subtree_needs_style_update(true);
     }
 
     for (auto* ancestor = parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host())

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -423,7 +423,7 @@ void Node::invalidate_style(StyleInvalidationReason reason)
     }
 
     // If any ancestor is already marked for an entire subtree update, there's no need to do anything here.
-    for (auto* ancestor = this; ancestor; ancestor = ancestor->parent_or_shadow_host()) {
+    for (auto* ancestor = this->parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host()) {
         if (ancestor->entire_subtree_needs_style_update())
             return;
     }

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -88,7 +88,6 @@ enum class ShouldComputeRole {
     X(NodeRemove)                                   \
     X(NodeSetTextContent)                           \
     X(Other)                                        \
-    X(ParentOfInsertedNode)                         \
     X(SetSelectorText)                              \
     X(SettingsChange)                               \
     X(StyleSheetDeleteRule)                         \

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -18,6 +18,7 @@ Text/input/css/cubic-bezier-infinite-slope-crash.html
 Text/input/css/transition-basics.html
 ; Flaky on CI, see #19
 Text/input/WebAnimations/misc/DocumentTimeline.html
+Text/input/WebAnimations/animation-properties/currentTime.html
 
 ; Worker tests are flaky on CI
 Text/input/Worker/Worker-blob.html

--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -109,6 +109,7 @@ Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-with-margin-001a.tentative.
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-bfc-001-right-overflow.xht
 Ref/input/wpt-import/css/CSS2/floats/floats-placement-003.html
 Ref/input/wpt-import/css/CSS2/floats/floats-wrap-top-below-bfc-003l.xht
+Ref/input/wpt-import/css/CSS2/floats/block-in-inline-become-float.html
 
 ; WPT ref-tests that are flaky due to unknown reasons
 Ref/input/wpt-import/css/css-contain/contain-size-replaced-006.html


### PR DESCRIPTION
With this change, siblings of an inserted node are no longer invalidated
unless the insertion could potentially affect their style. By
"potentially affected," we mean elements that are evaluated against the
following selectors during matching:
- Sibling combinators (+ or ~)
- Pseudo-classes :first-child and :last-child
- Pseudo-classes :nth-child, :nth-last-child, :nth-of-type, and
  :nth-last-of-type