### PR TITLE
LibWeb: Move layout tree invalidation back in `Node::insert_before()`

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -767,6 +767,10 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
             node->post_connection();
     }
 
+    if (is_connected()) {
+        set_needs_layout_tree_update(true);
+    }
+
     document().bump_dom_tree_version();
 }
 
@@ -1405,7 +1409,6 @@ void Node::set_needs_style_update(bool value)
 
 void Node::post_connection()
 {
-    set_needs_layout_tree_update(true);
 }
 
 void Node::inserted()


### PR DESCRIPTION
By moving layout tree invalidation into post connection hook in
https://github.com/LadybirdBrowser/ladybird/commit/f7a3f785a84632116c290e84907654a575d558bc we no longer invalidate layout tree of the parent of inserted
node. Likely that's the reason why newly imported tests for css
containment invalidation are flaky.