### PR TITLE
Documentation: Add instructions to uncheck 'Enable profile' for Debug

### DIFF
--- a/Documentation/EditorConfiguration/CLionConfiguration.md
+++ b/Documentation/EditorConfiguration/CLionConfiguration.md
@@ -4,7 +4,8 @@ CLion can integrate with CMake to provide code comprehension features.
 
 After opening the `ladybird` repository in CLion as a new project, the "`Open Project Wizard`" window will open.
 
-Select the `default` Preset in the `Settings -> Build, Execution and Deployment -> CMake` window and click the `Enable Profile` checkbox.
+Select the `default` Preset in the `Settings -> Build, Execution and Deployment -> CMake` window and check the `Enable profile` checkbox.
+Then select the `Debug` profile and uncheck the `Enable profile` checkbox.
 
 If the build complains that there is no `Default` Toolchain, go to the `Settings -> Build, Execution and Deployment -> Toolchains`
 tab and copy the currently defaulted host toolchain and rename it to `Default`. Make sure that the compiler chosen has a version of


### PR DESCRIPTION
The `Debug` profile is enabled by default and it must be unchecked in order for CLion to work properly.