### PR TITLE
WebContent: Track the ongoing script execution with an ID

### DIFF
--- a/Services/WebContent/WebDriverConnection.h
+++ b/Services/WebContent/WebDriverConnection.h
@@ -149,7 +149,7 @@ private:
         GC::RootVector<JS::Value> arguments;
     };
     ErrorOr<ScriptArguments, Web::WebDriver::Error> extract_the_script_arguments_from_a_request(JS::VM&, JsonValue const& payload);
-    void handle_script_response(Web::WebDriver::ExecutionResult);
+    void handle_script_response(Web::WebDriver::ExecutionResult, size_t script_execution_id);
 
     void delete_cookies(Optional<StringView> const& name = {});
 
@@ -172,7 +172,9 @@ private:
     GC::Ptr<Web::HTML::BrowsingContext> m_current_top_level_browsing_context;
 
     size_t m_pending_window_rect_requests { 0 };
-    bool m_has_pending_script_execution { false };
+
+    size_t m_script_execution_id_counter { 0 };
+    Optional<size_t> m_current_script_execution_id;
 
     friend class ElementLocator;
     GC::Ptr<ElementLocator> m_element_locator;


### PR DESCRIPTION
Executing scripts via WebDriver has a bit of awkwardness around dealing with user dialogs that open during script execution. When this happens, we must return control back to the client immediately with a null response, while allowing the script to continue executing. When the script completes, we must then ignore its result.

We've previously handled this by tracking a boolean for the ongoing script execution, set to true when the script begins and false when it ends (either via normal script completion or the above dialog handling). However, this failed to handle the following scenario, running two scripts in a row:

```python
execute_script("alert('hi'); return 1;")
execute_script("return 2;")
```

The first script would execute and open a dialog, and thus return a null response to the client while the script continued and the dialog remains open. The second script would "handle any user prompts", which closes the dialog. This would end the execution of the first script. But since we're now executing a script again, the boolean flag is true, and we'd return the result of the first script back to the client. The client would then think this is the result of the second script.

So we now track script execution with a simple ID. If a script completes whose execution ID is not the ID of the currently executing script, we drop the result.

This fixes `/webdriver/tests/classic/new_session/unhandled_prompt_behavior.py`.