### PR TITLE
LibWeb: Make namespace attributes writable and configurable by default

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020-2023, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
- * Copyright (c) 2021-2023, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2021-2025, Luke Wilde <luke@ladybird.org>
  * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
  * Copyright (c) 2023-2024, Kenneth Myhra <kennethmyhra@serenityos.org>
  * Copyright (c) 2023-2025, Shannon Booth <shannon@serenityos.org>
@@ -4523,7 +4523,7 @@ GC_DEFINE_ALLOCATOR(@namespace_class@);
 void @namespace_class@::initialize(JS::Realm& realm)
 {
     [[maybe_unused]] auto& vm = this->vm();
-    [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable;
+    [[maybe_unused]] u8 default_attributes = JS::Attribute::Enumerable | JS::Attribute::Configurable | JS::Attribute::Writable;
 
     Base::initialize(realm);
 

--- a/Tests/LibWeb/Text/expected/namespace-objects-default-property-attributes.txt
+++ b/Tests/LibWeb/Text/expected/namespace-objects-default-property-attributes.txt
@@ -1,0 +1,62 @@
+== CSS property descriptors
+supports writable: true
+supports configurable: true
+supports enumerable: true
+supports value before: function supports() { [native code] }
+supports value after: replaced
+escape writable: true
+escape configurable: true
+escape enumerable: true
+escape value before: function escape() { [native code] }
+escape value after: replaced
+== WebAssembly property descriptors
+compile writable: true
+compile configurable: true
+compile enumerable: true
+compile value before: function compile() { [native code] }
+compile value after: replaced
+instantiate writable: true
+instantiate configurable: true
+instantiate enumerable: true
+instantiate value before: function instantiate() { [native code] }
+instantiate value after: replaced
+compileStreaming writable: true
+compileStreaming configurable: true
+compileStreaming enumerable: true
+compileStreaming value before: function compileStreaming() { [native code] }
+compileStreaming value after: replaced
+instantiateStreaming writable: true
+instantiateStreaming configurable: true
+instantiateStreaming enumerable: true
+instantiateStreaming value before: function instantiateStreaming() { [native code] }
+instantiateStreaming value after: replaced
+validate writable: true
+validate configurable: true
+validate enumerable: true
+validate value before: function validate() { [native code] }
+validate value after: replaced
+Global writable: true
+Global configurable: true
+Global enumerable: false
+Global value before: function Global() { [native code] }
+Global value after: replaced
+Instance writable: true
+Instance configurable: true
+Instance enumerable: false
+Instance value before: function Instance() { [native code] }
+Instance value after: replaced
+Memory writable: true
+Memory configurable: true
+Memory enumerable: false
+Memory value before: function Memory() { [native code] }
+Memory value after: replaced
+Module writable: true
+Module configurable: true
+Module enumerable: false
+Module value before: function Module() { [native code] }
+Module value after: replaced
+Table writable: true
+Table configurable: true
+Table enumerable: false
+Table value before: function Table() { [native code] }
+Table value after: replaced

--- a/Tests/LibWeb/Text/input/namespace-objects-default-property-attributes.html
+++ b/Tests/LibWeb/Text/input/namespace-objects-default-property-attributes.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<script src="include.js"></script>
+<script>
+    test(() => {
+        "use strict";
+        println("== CSS property descriptors");
+        const cssNamespaceDescriptors = Object.getOwnPropertyDescriptors(CSS);
+        const cssNamespaceKeys = Object.keys(cssNamespaceDescriptors);
+
+        for (const key of cssNamespaceKeys) {
+            const descriptor = cssNamespaceDescriptors[key];
+            println(`${key} writable: ${descriptor.writable}`);
+            println(`${key} configurable: ${descriptor.configurable}`);
+            println(`${key} enumerable: ${descriptor.enumerable}`);
+            if (descriptor.writable) {
+                println(`${key} value before: ${CSS[key]}`);
+                CSS[key] = "replaced";
+                println(`${key} value after: ${CSS[key]}`);
+            }
+        }
+
+        println("== WebAssembly property descriptors");
+        const wasmNamespaceDescriptors = Object.getOwnPropertyDescriptors(WebAssembly);
+        const wasmNamespaceKeys = Object.keys(wasmNamespaceDescriptors);
+
+        for (const key of wasmNamespaceKeys) {
+            const descriptor = wasmNamespaceDescriptors[key];
+            println(`${key} writable: ${descriptor.writable}`);
+            println(`${key} configurable: ${descriptor.configurable}`);
+            println(`${key} enumerable: ${descriptor.enumerable}`);
+            if (descriptor.writable) {
+                println(`${key} value before: ${WebAssembly[key]}`);
+                WebAssembly[key] = "replaced";
+                println(`${key} value after: ${WebAssembly[key]}`);
+            }
+        }
+    });
+</script>


### PR DESCRIPTION
This matches the prototype attributes.

Used by https://chatgpt.com/, where it runs this code:
```js
CSS.supports('animation-timeline: --works')
```
If this returns false, it will attempt to polyfill Animation Timeline and override CSS.supports to support Animation Timeline properties.