### PR TITLE
LibWeb: Reset find-in-page index if selection is cleared

### DIFF
--- a/Tests/LibWeb/Text/expected/HTML/Window-find-clear-selection.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-find-clear-selection.txt
@@ -1,0 +1,2 @@
+window.find("test") initial result: true
+window.find("test") after clearing the previous selection: true

--- a/Tests/LibWeb/Text/input/HTML/Window-find-clear-selection.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-find-clear-selection.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div>test</div>
+<script>
+    test(() => {
+        let result = window.find("test");
+        println(`window.find("test") initial result: ${result}`);
+        window.getSelection().removeAllRanges();
+        result = window.find("test");
+        println(`window.find("test") after clearing the previous selection: ${result}`);
+    });
+</script>


### PR DESCRIPTION
Previously, if the user made a find-in-page query, then cleared the selection made by that query, subsequent queries would inadvertently advance to the next match instead of reselecting the first match.