### PR TITLE
WebDriver: Miscellaneous fixes around session creation and capability validation

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -828,6 +828,7 @@ set(SOURCES
     WebDriver/InputSource.cpp
     WebDriver/InputState.cpp
     WebDriver/JSON.cpp
+    WebDriver/Proxy.cpp
     WebDriver/Response.cpp
     WebDriver/Screenshot.cpp
     WebDriver/TimeoutsConfiguration.cpp

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -174,9 +174,12 @@ static ErrorOr<JsonObject, Error> validate_capabilities(JsonValue const& capabil
         }
 
         // -> name is the key of an extension capability
-        //     If name is known to the implementation, let deserialized be the result of trying to deserialize value in an implementation-specific way. Otherwise, let deserialized be set to value.
-        else if (name == "serenity:ladybird"sv) {
-            deserialized = TRY(deserialize_as_ladybird_options(value));
+        else if (name.contains(':')) {
+            // If name is known to the implementation, let deserialized be the result of trying to deserialize value in
+            // an implementation-specific way. Otherwise, let deserialized be set to value.
+            if (name == "serenity:ladybird"sv) {
+                deserialized = TRY(deserialize_as_ladybird_options(value));
+            }
         }
 
         // -> The remote end is an endpoint node

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -11,6 +11,7 @@
 #include <AK/Optional.h>
 #include <LibWeb/Loader/UserAgent.h>
 #include <LibWeb/WebDriver/Capabilities.h>
+#include <LibWeb/WebDriver/Proxy.h>
 #include <LibWeb/WebDriver/TimeoutsConfiguration.h>
 #include <LibWeb/WebDriver/UserPrompt.h>
 
@@ -29,33 +30,6 @@ static Response deserialize_as_a_page_load_strategy(JsonValue value)
 
     // 3. Return success with data value.
     return value;
-}
-
-// https://w3c.github.io/webdriver/#dfn-deserialize-as-a-proxy
-static ErrorOr<JsonObject, Error> deserialize_as_a_proxy(JsonValue parameter)
-{
-    // 1. If parameter is not a JSON Object return an error with error code invalid argument.
-    if (!parameter.is_object())
-        return Error::from_code(ErrorCode::InvalidArgument, "Capability proxy must be an object"sv);
-
-    // 2. Let proxy be a new, empty proxy configuration object.
-    JsonObject proxy;
-
-    // 3. For each enumerable own property in parameter run the following substeps:
-    TRY(parameter.as_object().try_for_each_member([&](auto const& key, JsonValue const& value) -> ErrorOr<void, Error> {
-        // 1. Let key be the name of the property.
-        // 2. Let value be the result of getting a property named name from capability.
-
-        // FIXME: 3. If there is no matching key for key in the proxy configuration table return an error with error code invalid argument.
-        // FIXME: 4. If value is not one of the valid values for that key, return an error with error code invalid argument.
-
-        // 5. Set a property key to value on proxy.
-        proxy.set(key, value);
-
-        return {};
-    }));
-
-    return proxy;
 }
 
 static InterfaceMode default_interface_mode { InterfaceMode::Graphical };
@@ -332,7 +306,10 @@ static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags
         }
         // -> "proxy"
         else if (name == "proxy"sv) {
-            // FIXME: If the has proxy configuration flag is set, or if the proxy configuration defined in value is not one that passes the endpoint node's implementation-specific validity checks, return success with data null.
+            // If the has proxy configuration flag is set, or if the proxy configuration defined in value is not one that
+            // passes the endpoint node's implementation-specific validity checks, return success with data null.
+            if (has_proxy_configuration())
+                return AK::Error::from_string_literal("proxy");
         }
         // -> "unhandledPromptBehavior"
         else if (name == "unhandledPromptBehavior"sv) {

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -263,7 +263,7 @@ static bool matches_platform_name(StringView requested_platform_name, StringView
 }
 
 // https://w3c.github.io/webdriver/#dfn-matching-capabilities
-static JsonValue match_capabilities(JsonObject const& capabilities, ReadonlySpan<StringView> flags)
+static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags flags)
 {
     static auto browser_name = StringView { BROWSER_NAME, strlen(BROWSER_NAME) }.to_lowercase_string();
     static auto platform_name = StringView { OS_STRING, strlen(OS_STRING) }.to_lowercase_string();
@@ -294,7 +294,7 @@ static JsonValue match_capabilities(JsonObject const& capabilities, ReadonlySpan
     matched_capabilities.set("userAgent"sv, Web::default_user_agent);
 
     // 2. If flags contains "http", add the following entries to matched capabilities:
-    if (flags.contains_slow("http"sv)) {
+    if (has_flag(flags, SessionFlags::Http)) {
         // "strictFileInteractability"
         //     Boolean initially set to false, indicating that interactabilty checks will be applied to <input type=file>.
         matched_capabilities.set("strictFileInteractability"sv, false);
@@ -377,7 +377,7 @@ static JsonValue match_capabilities(JsonObject const& capabilities, ReadonlySpan
 }
 
 // https://w3c.github.io/webdriver/#dfn-capabilities-processing
-Response process_capabilities(JsonValue const& parameters, ReadonlySpan<StringView> flags)
+Response process_capabilities(JsonValue const& parameters, SessionFlags flags)
 {
     if (!parameters.is_object())
         return Error::from_code(ErrorCode::InvalidArgument, "Session parameters is not an object"sv);

--- a/Libraries/LibWeb/WebDriver/Capabilities.h
+++ b/Libraries/LibWeb/WebDriver/Capabilities.h
@@ -6,11 +6,18 @@
 
 #pragma once
 
+#include <AK/EnumBits.h>
 #include <AK/Forward.h>
 #include <AK/StringView.h>
 #include <LibWeb/WebDriver/Response.h>
 
 namespace Web::WebDriver {
+
+enum class SessionFlags {
+    Default = 0x0,
+    Http = 0x1,
+};
+AK_ENUM_BITWISE_OPERATORS(SessionFlags);
 
 // https://w3c.github.io/webdriver/#dfn-page-load-strategy
 enum class PageLoadStrategy {
@@ -42,6 +49,6 @@ struct LadybirdOptions {
     bool headless { false };
 };
 
-Response process_capabilities(JsonValue const& parameters, ReadonlySpan<StringView> flags);
+Response process_capabilities(JsonValue const& parameters, SessionFlags flags);
 
 }

--- a/Libraries/LibWeb/WebDriver/Proxy.cpp
+++ b/Libraries/LibWeb/WebDriver/Proxy.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonValue.h>
+#include <LibURL/URL.h>
+#include <LibWeb/WebDriver/Proxy.h>
+
+namespace Web::WebDriver {
+
+// https://w3c.github.io/webdriver/#dfn-has-proxy-configuration
+// An endpoint node has an associated has proxy configuration flag that indicates whether the proxy is already configured.
+// The default value of the flag is true if the endpoint doesn't support proxy configuration, or false otherwise.
+static constexpr bool s_default_has_proxy_configuration = true;
+static bool s_has_proxy_configuration = s_default_has_proxy_configuration;
+
+bool has_proxy_configuration()
+{
+    return s_has_proxy_configuration;
+}
+
+void set_has_proxy_configuration(bool has_proxy_configuration)
+{
+    s_has_proxy_configuration = has_proxy_configuration;
+}
+
+void reset_has_proxy_configuration()
+{
+    s_has_proxy_configuration = s_default_has_proxy_configuration;
+}
+
+// https://w3c.github.io/webdriver/#dfn-proxy-configuration
+static ErrorOr<void, Error> validate_proxy_item(StringView key, JsonValue const& value)
+{
+    if (key == "proxyType"sv) {
+        if (!value.is_string())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'proxyType' must be a string"sv);
+        if (!value.as_string().is_one_of("pac"sv, "direct"sv, "autodetect"sv, "system"sv, "manual"sv))
+            return Error::from_code(ErrorCode::InvalidArgument, "Invalid 'proxyType' value"sv);
+        return {};
+    }
+
+    if (key == "proxyAutoconfigUrl"sv) {
+        if (!value.is_string())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'proxyAutoconfigUrl' must be a string"sv);
+        if (URL::URL url { value.as_string() }; !url.is_valid())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'proxyAutoconfigUrl' must be a valid URL"sv);
+        return {};
+    }
+
+    if (key == "ftpProxy"sv) {
+        if (!value.is_string())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'ftpProxy' must be a string"sv);
+        if (URL::URL url { value.as_string() }; !url.is_valid() || url.scheme() != "ftp"sv)
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'ftpProxy' must be a valid FTP URL"sv);
+        return {};
+    }
+
+    if (key == "httpProxy"sv) {
+        if (!value.is_string())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'httpProxy' must be a string"sv);
+        if (URL::URL url { value.as_string() }; !url.is_valid() || url.scheme() != "http"sv)
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'httpProxy' must be a valid HTTP URL"sv);
+        return {};
+    }
+
+    if (key == "noProxy"sv) {
+        if (!value.is_array())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'noProxy' must be a list"sv);
+
+        TRY(value.as_array().try_for_each([&](JsonValue const& item) -> ErrorOr<void, Error> {
+            if (!item.is_string())
+                return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'noProxy' must be a list of strings"sv);
+            return {};
+        }));
+
+        return {};
+    }
+
+    if (key == "sslProxy"sv) {
+        if (!value.is_string())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'sslProxy' must be a string"sv);
+        if (URL::URL url { value.as_string() }; !url.is_valid() || url.scheme() != "https"sv)
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'sslProxy' must be a valid HTTPS URL"sv);
+        return {};
+    }
+
+    if (key == "socksProxy"sv) {
+        if (!value.is_string())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'proxyAutoconfigUrl' must be a string"sv);
+        if (URL::URL url { value.as_string() }; !url.is_valid())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'proxyAutoconfigUrl' must be a valid URL"sv);
+        return {};
+    }
+
+    if (key == "socksVersion"sv) {
+        if (!value.is_integer<u8>())
+            return Error::from_code(ErrorCode::InvalidArgument, "Proxy configuration item 'socksVersion' must be an integer in the range [0, 255]"sv);
+        return {};
+    }
+
+    return Error::from_code(ErrorCode::InvalidArgument, "Invalid proxy configuration item"sv);
+}
+
+// https://w3c.github.io/webdriver/#dfn-deserialize-as-a-proxy
+ErrorOr<JsonObject, Error> deserialize_as_a_proxy(JsonValue const& parameter)
+{
+    // 1. If parameter is not a JSON Object return an error with error code invalid argument.
+    if (!parameter.is_object())
+        return Error::from_code(ErrorCode::InvalidArgument, "Capability proxy must be an object"sv);
+
+    // 2. Let proxy be a new, empty proxy configuration object.
+    JsonObject proxy;
+
+    // 3. For each enumerable own property in parameter run the following substeps:
+    TRY(parameter.as_object().try_for_each_member([&](ByteString const& key, JsonValue const& value) -> ErrorOr<void, Error> {
+        // 1. Let key be the name of the property.
+        // 2. Let value be the result of getting a property named name from capability.
+
+        // 3. If there is no matching key for key in the proxy configuration table return an error with error code invalid argument.
+        // 4. If value is not one of the valid values for that key, return an error with error code invalid argument.
+        TRY(validate_proxy_item(key, value));
+
+        // 5. Set a property key to value on proxy.
+        proxy.set(key, value);
+
+        return {};
+    }));
+
+    return proxy;
+}
+
+}

--- a/Libraries/LibWeb/WebDriver/Proxy.h
+++ b/Libraries/LibWeb/WebDriver/Proxy.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonObject.h>
+#include <LibWeb/WebDriver/Error.h>
+
+namespace Web::WebDriver {
+
+bool has_proxy_configuration();
+void set_has_proxy_configuration(bool);
+void reset_has_proxy_configuration();
+
+ErrorOr<JsonObject, Error> deserialize_as_a_proxy(JsonValue const&);
+
+}

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -570,9 +570,8 @@ Messages::WebDriverClient::CloseWindowResponse WebDriverConnection::close_window
 // 11.3 Switch to Window, https://w3c.github.io/webdriver/#dfn-switch-to-window
 Messages::WebDriverClient::SwitchToWindowResponse WebDriverConnection::switch_to_window(String const& handle)
 {
-    // 4. If handle is equal to the associated window handle for some top-level browsing context in the
-    //    current session, let context be the that browsing context, and set the current top-level
-    //    browsing context with context.
+    // 4. If handle is equal to the associated window handle for some top-level browsing context, let context be the that
+    //    browsing context, and set the current top-level browsing context with session and context.
     //    Otherwise, return error with error code no such window.
     bool found_matching_context = false;
 

--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -54,7 +54,7 @@ Web::WebDriver::Response Client::new_session(Web::WebDriver::Parameters, JsonVal
     //           commands may be forwarded to this associated session on subsequent commands.
 
     // 3. Let flags be a set containing "http".
-    static constexpr Array flags { "http"sv };
+    static constexpr auto flags = Web::WebDriver::SessionFlags::Http;
 
     // 4. Let capabilities be the result of trying to process capabilities with parameters and flags.
     auto capabilities = TRY(Web::WebDriver::process_capabilities(payload, flags));

--- a/Services/WebDriver/Client.h
+++ b/Services/WebDriver/Client.h
@@ -11,10 +11,9 @@
 #include <AK/Function.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibCore/EventReceiver.h>
+#include <LibCore/Process.h>
 #include <LibWeb/WebDriver/Client.h>
-#include <LibWeb/WebDriver/Error.h>
 #include <LibWeb/WebDriver/Response.h>
-#include <WebDriver/Session.h>
 
 namespace WebDriver {
 
@@ -31,16 +30,9 @@ public:
     virtual ~Client() override;
 
     LaunchBrowserCallbacks const& launch_browser_callbacks() const { return m_callbacks; }
-    void close_session(String const& session_id);
 
 private:
     Client(NonnullOwnPtr<Core::BufferedTCPSocket>, LaunchBrowserCallbacks, Core::EventReceiver* parent);
-
-    enum class AllowInvalidWindowHandle {
-        No,
-        Yes,
-    };
-    ErrorOr<NonnullRefPtr<Session>, Web::WebDriver::Error> find_session_with_id(StringView session_id, AllowInvalidWindowHandle = AllowInvalidWindowHandle::No);
 
     virtual Web::WebDriver::Response new_session(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response delete_session(Web::WebDriver::Parameters parameters, JsonValue payload) override;
@@ -104,8 +96,6 @@ private:
     virtual Web::WebDriver::Response take_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response take_element_screenshot(Web::WebDriver::Parameters parameters, JsonValue payload) override;
     virtual Web::WebDriver::Response print_page(Web::WebDriver::Parameters parameters, JsonValue payload) override;
-
-    static HashMap<String, NonnullRefPtr<Session>> s_sessions;
 
     LaunchBrowserCallbacks m_callbacks;
 };

--- a/Services/WebDriver/Session.h
+++ b/Services/WebDriver/Session.h
@@ -36,7 +36,8 @@ public:
         No,
         Yes,
     };
-    static ErrorOr<NonnullRefPtr<Session>, Web::WebDriver::Error> find_session(StringView session_id, AllowInvalidWindowHandle = AllowInvalidWindowHandle::No);
+    static ErrorOr<NonnullRefPtr<Session>, Web::WebDriver::Error> find_session(StringView session_id, Web::WebDriver::SessionFlags = Web::WebDriver::SessionFlags::Default, AllowInvalidWindowHandle = AllowInvalidWindowHandle::No);
+    static size_t session_count(Web::WebDriver::SessionFlags);
 
     struct Window {
         String handle;
@@ -54,6 +55,7 @@ public:
     void close();
 
     String session_id() const { return m_session_id; }
+    Web::WebDriver::SessionFlags session_flags() const { return m_session_flags; }
     String const& current_window_handle() const { return m_current_window_handle; }
 
     bool has_window_handle(StringView handle) const { return m_windows.contains(handle); }

--- a/Services/WebDriver/Session.h
+++ b/Services/WebDriver/Session.h
@@ -32,7 +32,11 @@ public:
     static ErrorOr<NonnullRefPtr<Session>> create(NonnullRefPtr<Client> client, JsonObject& capabilities, ReadonlySpan<StringView> flags);
     ~Session();
 
-    String session_id() const { return m_id; }
+    enum class AllowInvalidWindowHandle {
+        No,
+        Yes,
+    };
+    static ErrorOr<NonnullRefPtr<Session>, Web::WebDriver::Error> find_session(StringView session_id, AllowInvalidWindowHandle = AllowInvalidWindowHandle::No);
 
     struct Window {
         String handle;
@@ -47,10 +51,10 @@ public:
         return current_window->web_content_connection;
     }
 
-    String const& current_window_handle() const
-    {
-        return m_current_window_handle;
-    }
+    void close();
+
+    String session_id() const { return m_session_id; }
+    String const& current_window_handle() const { return m_current_window_handle; }
 
     bool has_window_handle(StringView handle) const { return m_windows.contains(handle); }
 
@@ -89,9 +93,7 @@ private:
     NonnullRefPtr<Client> m_client;
     Web::WebDriver::LadybirdOptions m_options;
 
-    bool m_started { false };
-
-    String m_id;
+    String m_session_id;
     bool m_http { false };
 
     HashMap<String, Window> m_windows;

--- a/Services/WebDriver/Session.h
+++ b/Services/WebDriver/Session.h
@@ -29,7 +29,7 @@ struct LaunchBrowserCallbacks;
 
 class Session : public RefCounted<Session> {
 public:
-    static ErrorOr<NonnullRefPtr<Session>> create(NonnullRefPtr<Client> client, JsonObject& capabilities, ReadonlySpan<StringView> flags);
+    static ErrorOr<NonnullRefPtr<Session>> create(NonnullRefPtr<Client> client, JsonObject& capabilities, Web::WebDriver::SessionFlags flags);
     ~Session();
 
     enum class AllowInvalidWindowHandle {
@@ -83,7 +83,7 @@ public:
     }
 
 private:
-    Session(NonnullRefPtr<Client> client, JsonObject const& capabilities, String session_id, bool http);
+    Session(NonnullRefPtr<Client> client, JsonObject const& capabilities, String session_id, Web::WebDriver::SessionFlags flags);
 
     ErrorOr<void> start(LaunchBrowserCallbacks const&);
 
@@ -94,7 +94,7 @@ private:
     Web::WebDriver::LadybirdOptions m_options;
 
     String m_session_id;
-    bool m_http { false };
+    Web::WebDriver::SessionFlags m_session_flags { Web::WebDriver::SessionFlags::Default };
 
     HashMap<String, Window> m_windows;
     String m_current_window_handle;


### PR DESCRIPTION
Fixes ~45 subtests under `/webdriver/tests/classic/new_session`. The remaining failures are, I think, invalid tests (I've opened an issue in the WPT repo already).