### PR TITLE
LibWeb: Implement playbackRate

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -109,6 +109,12 @@ public:
     double volume() const { return m_volume; }
     WebIDL::ExceptionOr<void> set_volume(double);
 
+    double default_playback_rate() const { return m_default_playback_rate; }
+    void set_default_playback_rate(double);
+
+    double playback_rate() const { return m_playback_rate; }
+    WebIDL::ExceptionOr<void> set_playback_rate(double);
+
     bool muted() const { return m_muted; }
     void set_muted(bool);
 
@@ -265,6 +271,12 @@ private:
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-paused
     bool m_paused { true };
+
+    // https://html.spec.whatwg.org/multipage/media.html#dom-media-defaultplaybackrate
+    double m_default_playback_rate { 1.0 };
+
+    // https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate
+    double m_playback_rate { 1.0 };
 
     // https://html.spec.whatwg.org/multipage/media.html#dom-media-volume
     double m_volume { 1.0 };

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -59,8 +59,8 @@ interface HTMLMediaElement : HTMLElement {
     readonly attribute unrestricted double duration;
     [FIXME] object getStartDate();
     readonly attribute boolean paused;
-    [FIXME] attribute double defaultPlaybackRate;
-    [FIXME] attribute double playbackRate;
+    attribute double defaultPlaybackRate;
+    attribute double playbackRate;
     [FIXME] attribute boolean preservesPitch;
     [FIXME] readonly attribute TimeRanges played;
     [FIXME] readonly attribute TimeRanges seekable;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/media-elements/playing-the-media-resource/playbackRate.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/media-elements/playing-the-media-resource/playbackRate.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 7 tests
+
+7 Pass
+Pass	playbackRate initial value
+Pass	playbackRate set to small positive value
+Pass	playbackRate set to large positive value
+Pass	playbackRate set to small negative value
+Pass	playbackRate set to large negative value
+Pass	playbackRate set to 0
+Pass	playbackRate set to -1

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/media-elements/playing-the-media-resource/playbackRate.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/media-elements/playing-the-media-resource/playbackRate.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<title>playbackRate</title>
+<script src="../../../../../resources/testharness.js"></script>
+<script src="../../../../../resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+test(function() {
+  var v = document.createElement('video');
+  assert_equals(v.playbackRate, 1);
+}, 'playbackRate initial value');
+
+function testPlaybackRateHelper(t, newPlaybackRate) {
+  var v = document.createElement('video');
+  var initialRate = v.playbackRate;
+
+  v.addEventListener('ratechange', t.step_func_done(function() {
+    assert_equals(v.playbackRate, newPlaybackRate);
+  }));
+
+  try {
+    v.playbackRate = newPlaybackRate;
+  } catch(e) {
+    assert_equals(e.name, 'NotSupportedError');
+    assert_equals(v.playbackRate, initialRate);
+    t.done();
+  }
+}
+
+async_test(function(t) {
+  testPlaybackRateHelper(this, 3);
+}, "playbackRate set to small positive value");
+
+async_test(function(t) {
+  testPlaybackRateHelper(this, 100);
+}, "playbackRate set to large positive value");
+
+async_test(function(t) {
+  testPlaybackRateHelper(this, -3);
+}, "playbackRate set to small negative value");
+
+async_test(function(t) {
+  testPlaybackRateHelper(this, -100);
+}, "playbackRate set to large negative value");
+
+async_test(function(t) {
+  testPlaybackRateHelper(this, 0);
+}, "playbackRate set to 0");
+
+async_test(function(t) {
+  testPlaybackRateHelper(this, -1);
+}, "playbackRate set to -1");
+
+</script>


### PR DESCRIPTION
Implements the `playbackRate` and `defaultPlaybackRate` attributes of the HTMLMediaElement.
Note that currently, the only supported playbackRate is 1. Trying to set any others throws a "NotSupportedError" DOMException, as per [the spec](https://html.spec.whatwg.org/multipage/media.html#dom-media-playbackrate).

Somehow, this makes us pass the web platform test for this so I've imported that.

Mainly did this cause it continuously spams the console on Youtube videos so having a basic implementation will probably make debugging Youtube easier.