### PR TITLE
ImageDecoder+LibThreading: Fix ImageDecoder memory leaks

### DIFF
--- a/Libraries/LibThreading/BackgroundAction.h
+++ b/Libraries/LibThreading/BackgroundAction.h
@@ -65,7 +65,7 @@ private:
             promise->on_resolution = [](NonnullRefPtr<Core::EventReceiver>& object) -> ErrorOr<void> {
                 auto self = static_ptr_cast<BackgroundAction<Result>>(object);
                 VERIFY(self->m_result.has_value());
-                if (auto maybe_error = self->m_on_complete(self->m_result.value()); maybe_error.is_error())
+                if (auto maybe_error = self->m_on_complete(self->m_result.release_value()); maybe_error.is_error())
                     self->m_on_error(maybe_error.release_error());
 
                 return {};

--- a/Services/ImageDecoder/ConnectionFromClient.cpp
+++ b/Services/ImageDecoder/ConnectionFromClient.cpp
@@ -126,7 +126,7 @@ static ErrorOr<ConnectionFromClient::DecodeResult> decode_image_to_details(Core:
     if (bitmaps.is_empty())
         return Error::from_string_literal("Could not decode image");
 
-    result.bitmaps = Gfx::BitmapSequence { bitmaps };
+    result.bitmaps = Gfx::BitmapSequence { move(bitmaps) };
 
     return result;
 }
@@ -138,7 +138,7 @@ NonnullRefPtr<ConnectionFromClient::Job> ConnectionFromClient::make_decode_image
             return TRY(decode_image_to_details(encoded_buffer, ideal_size, mime_type));
         },
         [strong_this = NonnullRefPtr(*this), image_id](DecodeResult result) -> ErrorOr<void> {
-            strong_this->async_did_decode_image(image_id, result.is_animated, result.loop_count, result.bitmaps, result.durations, result.scale, result.color_profile);
+            strong_this->async_did_decode_image(image_id, result.is_animated, result.loop_count, move(result.bitmaps), move(result.durations), result.scale, move(result.color_profile));
             strong_this->m_pending_jobs.remove(image_id);
             return {};
         },


### PR DESCRIPTION
We have to be careful to always destroy the jpeglib decompression struct
before returning from `JPEGLoadingContext::decode`. We were doing this in
jpeglib error handlers, but we have a couple of paths that bail from the
decoder via TRY. These paths were neither cleaning up memory nor setting
the image decoder to an error state.

So this patch sets up a scope guard to ensure we free the decompressor
upon exit from the function. And it delegates the responsibility of
setting the decoder state to the caller (of which there is only one),
to ensure all error paths result in an error state.

When loading a [test image](https://examplefile.com/image/jpg/100-mb-jpg) that we failed to decode, the memory use of ImageDecoder would previously rise to nearly 10GB and remain there:
![Screenshot_20250209_105441](https://github.com/user-attachments/assets/fb7db3e0-9891-4a05-89c0-e7c80c92af3d)
