### PR TITLE
LibWeb: Narrow `:has()` style invalidation to ancestor nodes

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -121,6 +121,9 @@ static inline bool matches_relative_selector(CSS::Selector const& selector, size
         return has;
     }
     case CSS::Selector::Combinator::NextSibling: {
+        if (context.collect_per_element_selector_involvement_metadata) {
+            const_cast<DOM::Element&>(*anchor).set_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator(true);
+        }
         auto* sibling = element.next_element_sibling();
         if (!sibling)
             return false;
@@ -129,6 +132,9 @@ static inline bool matches_relative_selector(CSS::Selector const& selector, size
         return matches_relative_selector(selector, compound_index + 1, *sibling, shadow_host, context, anchor);
     }
     case CSS::Selector::Combinator::SubsequentSibling: {
+        if (context.collect_per_element_selector_involvement_metadata) {
+            const_cast<DOM::Element&>(*anchor).set_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator(true);
+        }
         for (auto const* sibling = element.next_element_sibling(); sibling; sibling = sibling->next_element_sibling()) {
             if (!matches(selector, compound_index, *sibling, shadow_host, context, {}, SelectorKind::Relative, anchor))
                 continue;

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -510,8 +510,8 @@ public:
     [[nodiscard]] bool needs_full_layout_tree_update() const { return m_needs_full_layout_tree_update; }
     void set_needs_full_layout_tree_update(bool b) { m_needs_full_layout_tree_update = b; }
 
-    bool needs_invalidate_elements_affected_by_has() const { return m_needs_invalidate_elements_affected_by_has; }
-    void set_needs_invalidate_elements_affected_by_has(bool b) { m_needs_invalidate_elements_affected_by_has = b; }
+    bool needs_invalidate_elements_affected_by_has_in_non_subject_position() const { return m_needs_invalidate_elements_affected_by_has_in_non_subject_position; }
+    void set_needs_invalidate_elements_affected_by_has_in_non_subject_position(bool b) { m_needs_invalidate_elements_affected_by_has_in_non_subject_position = b; }
 
     void set_needs_to_refresh_scroll_state(bool b);
 
@@ -817,7 +817,7 @@ private:
     // ^HTML::GlobalEventHandlers
     virtual GC::Ptr<EventTarget> global_event_handlers_to_event_target(FlyString const&) final { return *this; }
 
-    void invalidate_elements_affected_by_has();
+    void invalidate_elements_affected_by_has_in_non_subject_position();
 
     void tear_down_layout_tree();
 
@@ -961,7 +961,7 @@ private:
 
     bool m_needs_full_style_update { false };
     bool m_needs_full_layout_tree_update { false };
-    bool m_needs_invalidate_elements_affected_by_has { false };
+    bool m_needs_invalidate_elements_affected_by_has_in_non_subject_position { false };
 
     bool m_needs_animated_style_update { false };
 

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -423,6 +423,9 @@ public:
     bool affected_by_has_pseudo_class_in_subject_position() const { return m_affected_by_has_pseudo_class_in_subject_position; }
     void set_affected_by_has_pseudo_class_in_subject_position(bool value) { m_affected_by_has_pseudo_class_in_subject_position = value; }
 
+    bool affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator() const { return m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator; }
+    void set_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator(bool value) { m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator = value; }
+
     bool affected_by_sibling_combinator() const { return m_affected_by_sibling_combinator; }
     void set_affected_by_sibling_combinator(bool value) { m_affected_by_sibling_combinator = value; }
 
@@ -531,6 +534,7 @@ private:
     bool m_affected_by_sibling_combinator : 1 { false };
     bool m_affected_by_first_or_last_child_pseudo_class : 1 { false };
     bool m_affected_by_nth_child_pseudo_class : 1 { false };
+    bool m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator : 1 { false };
 
     OwnPtr<CSS::CountersSet> m_counters_set;
 

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -311,6 +311,7 @@ public:
     [[nodiscard]] bool entire_subtree_needs_style_update() const { return m_entire_subtree_needs_style_update; }
     void set_entire_subtree_needs_style_update(bool b) { m_entire_subtree_needs_style_update = b; }
 
+    void invalidate_ancestors_affected_by_has_in_subject_position();
     void invalidate_style(StyleInvalidationReason);
     struct StyleInvalidationOptions {
         bool invalidate_self { false };


### PR DESCRIPTION
The current implementation of `:has()` style invalidation is divided into two cases:
- When used in subject position (e.g., `.a:has(.b)`).
- When in a non-subject position (e.g., `.a > .b:has(.c)`).

This change focuses on improving the first case. For non-subject usage, we still perform a full tree traversal and invalidate all elements affected by the `:has()` pseudo-class invalidation set.

We already optimize subject `:has()` invalidations by limiting invalidated elements to ones that were tested against `has()` selectors during selector matching. However, selectors like `div:has(.a)` currently cause every div element in the document to be invalidated. By modifying the invalidation traversal to consider only ancestor nodes (and, optionally, their siblings), we can drastically reduce the number of invalidated elements for broad selectors like the example above.

On Discord, when scrolling through message history, this change allows to reduce number of invalidated elements from ~1k to ~5.