### PR TITLE
LibWeb: Implement `list-style-type: "string goes here";`

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -96,6 +96,13 @@ public:
     // Creates a new String from another string, repeated N times.
     static ErrorOr<String> repeated(String const&, size_t count);
 
+    enum class Case {
+        Upper,
+        Lower,
+    };
+    [[nodiscard]] static String bijective_base_from(size_t value, Case, unsigned base = 26, StringView map = {});
+    [[nodiscard]] static String roman_number_from(size_t value, Case);
+
     // Creates a new String by case-transforming this String. Using these methods require linking LibUnicode into your application.
     ErrorOr<String> to_lowercase(Optional<StringView> const& locale = {}) const;
     ErrorOr<String> to_uppercase(Optional<StringView> const& locale = {}) const;

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1008,7 +1008,9 @@ TextTransform ComputedProperties::text_transform() const
 ListStyleType ComputedProperties::list_style_type() const
 {
     auto const& value = property(PropertyID::ListStyleType);
-    return keyword_to_list_style_type(value.to_keyword()).release_value();
+    if (value.is_string())
+        return value.as_string().string_value().to_string();
+    return keyword_to_counter_style_name_keyword(value.to_keyword()).release_value();
 }
 
 ListStylePosition ComputedProperties::list_style_position() const

--- a/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Libraries/LibWeb/CSS/ComputedValues.h
@@ -78,6 +78,8 @@ struct Containment {
     bool is_empty() const { return !(size_containment || inline_size_containment || layout_containment || style_containment || paint_containment); }
 };
 
+using ListStyleType = Variant<CounterStyleNameKeyword, String>;
+
 class InitialValues {
 public:
     static AspectRatio aspect_ratio() { return AspectRatio { true, {} }; }
@@ -112,7 +114,7 @@ public:
     static Vector<Gfx::Filter> backdrop_filter() { return {}; }
     static Vector<Gfx::Filter> filter() { return {}; }
     static Color background_color() { return Color::Transparent; }
-    static CSS::ListStyleType list_style_type() { return CSS::ListStyleType::Disc; }
+    static CSS::ListStyleType list_style_type() { return CSS::CounterStyleNameKeyword::Disc; }
     static CSS::ListStylePosition list_style_position() { return CSS::ListStylePosition::Outside; }
     static CSS::Visibility visibility() { return CSS::Visibility::Visible; }
     static CSS::FlexDirection flex_direction() { return CSS::FlexDirection::Row; }

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -122,6 +122,22 @@
     "auto",
     "hidden"
   ],
+  "counter-style-name-keyword": [
+    "circle",
+    "decimal",
+    "decimal-leading-zero",
+    "disc",
+    "disclosure-closed",
+    "disclosure-open",
+    "lower-alpha",
+    "lower-latin",
+    "lower-roman",
+    "none",
+    "square",
+    "upper-alpha",
+    "upper-latin",
+    "upper-roman"
+  ],
   "cursor": [
     "auto",
     "default",
@@ -386,22 +402,6 @@
     "inset",
     "outset"
   ],
-  "list-style-type": [
-    "circle",
-    "decimal",
-    "decimal-leading-zero",
-    "disc",
-    "disclosure-closed",
-    "disclosure-open",
-    "lower-alpha",
-    "lower-latin",
-    "lower-roman",
-    "none",
-    "square",
-    "upper-alpha",
-    "upper-latin",
-    "upper-roman"
-  ],
   "list-style-position": [
     "inside",
     "outside"
@@ -419,10 +419,10 @@
     "compact"
   ],
   "mix-blend-mode": [
-    "normal", 
-    "multiply", 
-    "screen", 
-    "overlay", 
+    "normal",
+    "multiply",
+    "screen",
+    "overlay",
     "darken",
     "lighten",
     "color-dodge",
@@ -434,8 +434,8 @@
     "hue",
     "saturation",
     "color",
-    "luminosity", 
-    "plus-darker", 
+    "luminosity",
+    "plus-darker",
     "plus-lighter"
   ],
   "object-fit": [

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1815,8 +1815,8 @@
     "inherited": true,
     "initial": "disc",
     "valid-types": [
-      "string",
-      "list-style-type"
+      "counter-style-name-keyword",
+      "string"
     ]
   },
   "margin": {

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -75,14 +75,14 @@ static String generate_a_counter_representation(CSSStyleValue const& counter_sty
                     return MUST(String::formatted("{}", value));
                 case ListStyleType::LowerAlpha:
                 case ListStyleType::LowerLatin:
-                    return MUST(String::from_byte_string(ByteString::bijective_base_from(value - 1).to_lowercase()));
+                    return String::bijective_base_from(value - 1, String::Case::Lower);
                 case ListStyleType::UpperAlpha:
                 case ListStyleType::UpperLatin:
-                    return MUST(String::from_byte_string(ByteString::bijective_base_from(value - 1)));
+                    return String::bijective_base_from(value - 1, String::Case::Upper);
                 case ListStyleType::LowerRoman:
-                    return MUST(String::from_byte_string(ByteString::roman_number_from(value).to_lowercase()));
+                    return String::roman_number_from(value, String::Case::Lower);
                 case ListStyleType::UpperRoman:
-                    return MUST(String::from_byte_string(ByteString::roman_number_from(value)));
+                    return String::roman_number_from(value, String::Case::Upper);
                 default:
                     break;
                 }

--- a/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/CounterStyleValue.cpp
@@ -53,35 +53,34 @@ static String generate_a_counter_representation(CSSStyleValue const& counter_sty
         auto counter_style_name = counter_style.as_custom_ident().custom_ident();
         auto keyword = keyword_from_string(counter_style_name);
         if (keyword.has_value()) {
-            auto list_style_type = keyword_to_list_style_type(*keyword);
-            if (list_style_type.has_value()) {
+            if (auto list_style_type = keyword_to_counter_style_name_keyword(*keyword); list_style_type.has_value()) {
                 switch (*list_style_type) {
-                case ListStyleType::Square:
+                case CounterStyleNameKeyword::Square:
                     return "▪"_string;
-                case ListStyleType::Circle:
+                case CounterStyleNameKeyword::Circle:
                     return "◦"_string;
-                case ListStyleType::Disc:
+                case CounterStyleNameKeyword::Disc:
                     return "•"_string;
-                case ListStyleType::DisclosureClosed:
+                case CounterStyleNameKeyword::DisclosureClosed:
                     return "▸"_string;
-                case ListStyleType::DisclosureOpen:
+                case CounterStyleNameKeyword::DisclosureOpen:
                     return "▾"_string;
-                case ListStyleType::Decimal:
+                case CounterStyleNameKeyword::Decimal:
                     return MUST(String::formatted("{}", value));
-                case ListStyleType::DecimalLeadingZero:
+                case CounterStyleNameKeyword::DecimalLeadingZero:
                     // This is weird, but in accordance to spec.
                     if (value < 10)
                         return MUST(String::formatted("0{}", value));
                     return MUST(String::formatted("{}", value));
-                case ListStyleType::LowerAlpha:
-                case ListStyleType::LowerLatin:
+                case CounterStyleNameKeyword::LowerAlpha:
+                case CounterStyleNameKeyword::LowerLatin:
                     return String::bijective_base_from(value - 1, String::Case::Lower);
-                case ListStyleType::UpperAlpha:
-                case ListStyleType::UpperLatin:
+                case CounterStyleNameKeyword::UpperAlpha:
+                case CounterStyleNameKeyword::UpperLatin:
                     return String::bijective_base_from(value - 1, String::Case::Upper);
-                case ListStyleType::LowerRoman:
+                case CounterStyleNameKeyword::LowerRoman:
                     return String::roman_number_from(value, String::Case::Lower);
-                case ListStyleType::UpperRoman:
+                case CounterStyleNameKeyword::UpperRoman:
                     return String::roman_number_from(value, String::Case::Upper);
                 default:
                     break;

--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -1210,12 +1210,12 @@ void BlockFormattingContext::ensure_sizes_correct_for_left_offset_calculation(Li
 
     auto default_marker_width = max(4, marker.first_available_font().pixel_size_rounded_up() - 4);
 
-    auto marker_text = marker.text().value_or("");
+    auto marker_text = marker.text().value_or({});
     if (marker_text.is_empty()) {
         marker_state.set_content_width(image_width + default_marker_width);
     } else {
         // FIXME: Use per-code-point fonts to measure text.
-        auto text_width = marker.first_available_font().width(marker_text);
+        auto text_width = marker.first_available_font().width(marker_text.code_points());
         marker_state.set_content_width(image_width + CSSPixels::nearest_value_for(text_width));
     }
 

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -26,25 +26,25 @@ ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType
     case CSS::ListStyleType::DisclosureOpen:
         break;
     case CSS::ListStyleType::Decimal:
-        m_text = ByteString::formatted("{}.", m_index);
+        m_text = MUST(String::formatted("{}.", m_index));
         break;
     case CSS::ListStyleType::DecimalLeadingZero:
         // This is weird, but in accordance to spec.
-        m_text = m_index < 10 ? ByteString::formatted("0{}.", m_index) : ByteString::formatted("{}.", m_index);
+        m_text = m_index < 10 ? MUST(String::formatted("0{}.", m_index)) : MUST(String::formatted("{}.", m_index));
         break;
     case CSS::ListStyleType::LowerAlpha:
     case CSS::ListStyleType::LowerLatin:
-        m_text = ByteString::bijective_base_from(m_index - 1).to_lowercase();
+        m_text = String::bijective_base_from(m_index - 1, String::Case::Lower);
         break;
     case CSS::ListStyleType::UpperAlpha:
     case CSS::ListStyleType::UpperLatin:
-        m_text = ByteString::bijective_base_from(m_index - 1);
+        m_text = String::bijective_base_from(m_index - 1, String::Case::Upper);
         break;
     case CSS::ListStyleType::LowerRoman:
-        m_text = ByteString::roman_number_from(m_index).to_lowercase();
+        m_text = String::roman_number_from(m_index, String::Case::Lower);
         break;
     case CSS::ListStyleType::UpperRoman:
-        m_text = ByteString::roman_number_from(m_index);
+        m_text = String::roman_number_from(m_index, String::Case::Upper);
         break;
     case CSS::ListStyleType::None:
         break;

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -18,40 +18,43 @@ ListItemMarkerBox::ListItemMarkerBox(DOM::Document& document, CSS::ListStyleType
     , m_list_style_position(style_position)
     , m_index(index)
 {
-    switch (m_list_style_type) {
-    case CSS::ListStyleType::Square:
-    case CSS::ListStyleType::Circle:
-    case CSS::ListStyleType::Disc:
-    case CSS::ListStyleType::DisclosureClosed:
-    case CSS::ListStyleType::DisclosureOpen:
-        break;
-    case CSS::ListStyleType::Decimal:
-        m_text = MUST(String::formatted("{}.", m_index));
-        break;
-    case CSS::ListStyleType::DecimalLeadingZero:
-        // This is weird, but in accordance to spec.
-        m_text = m_index < 10 ? MUST(String::formatted("0{}.", m_index)) : MUST(String::formatted("{}.", m_index));
-        break;
-    case CSS::ListStyleType::LowerAlpha:
-    case CSS::ListStyleType::LowerLatin:
-        m_text = String::bijective_base_from(m_index - 1, String::Case::Lower);
-        break;
-    case CSS::ListStyleType::UpperAlpha:
-    case CSS::ListStyleType::UpperLatin:
-        m_text = String::bijective_base_from(m_index - 1, String::Case::Upper);
-        break;
-    case CSS::ListStyleType::LowerRoman:
-        m_text = String::roman_number_from(m_index, String::Case::Lower);
-        break;
-    case CSS::ListStyleType::UpperRoman:
-        m_text = String::roman_number_from(m_index, String::Case::Upper);
-        break;
-    case CSS::ListStyleType::None:
-        break;
-
-    default:
-        VERIFY_NOT_REACHED();
-    }
+    m_list_style_type.visit(
+        [this](CSS::CounterStyleNameKeyword keyword) {
+            switch (keyword) {
+            case CSS::CounterStyleNameKeyword::Square:
+            case CSS::CounterStyleNameKeyword::Circle:
+            case CSS::CounterStyleNameKeyword::Disc:
+            case CSS::CounterStyleNameKeyword::DisclosureClosed:
+            case CSS::CounterStyleNameKeyword::DisclosureOpen:
+                break;
+            case CSS::CounterStyleNameKeyword::Decimal:
+                m_text = MUST(String::formatted("{}.", m_index));
+                break;
+            case CSS::CounterStyleNameKeyword::DecimalLeadingZero:
+                // This is weird, but in accordance to spec.
+                m_text = m_index < 10 ? MUST(String::formatted("0{}.", m_index)) : MUST(String::formatted("{}.", m_index));
+                break;
+            case CSS::CounterStyleNameKeyword::LowerAlpha:
+            case CSS::CounterStyleNameKeyword::LowerLatin:
+                m_text = String::bijective_base_from(m_index - 1, String::Case::Lower);
+                break;
+            case CSS::CounterStyleNameKeyword::UpperAlpha:
+            case CSS::CounterStyleNameKeyword::UpperLatin:
+                m_text = String::bijective_base_from(m_index - 1, String::Case::Upper);
+                break;
+            case CSS::CounterStyleNameKeyword::LowerRoman:
+                m_text = String::roman_number_from(m_index, String::Case::Lower);
+                break;
+            case CSS::CounterStyleNameKeyword::UpperRoman:
+                m_text = String::roman_number_from(m_index, String::Case::Upper);
+                break;
+            case CSS::CounterStyleNameKeyword::None:
+                break;
+            }
+        },
+        [this](String const& string) {
+            m_text = string;
+        });
 }
 
 ListItemMarkerBox::~ListItemMarkerBox() = default;

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -24,14 +24,14 @@ public:
 
     virtual GC::Ptr<Painting::Paintable> create_paintable() const override;
 
-    CSS::ListStyleType list_style_type() const { return m_list_style_type; }
+    CSS::ListStyleType const& list_style_type() const { return m_list_style_type; }
     CSS::ListStylePosition list_style_position() const { return m_list_style_position; }
 
 private:
     virtual bool is_list_item_marker_box() const final { return true; }
     virtual bool can_have_children() const override { return false; }
 
-    CSS::ListStyleType m_list_style_type { CSS::ListStyleType::None };
+    CSS::ListStyleType m_list_style_type { CSS::CounterStyleNameKeyword::None };
     CSS::ListStylePosition m_list_style_position { CSS::ListStylePosition::Outside };
     size_t m_index;
 

--- a/Libraries/LibWeb/Layout/ListItemMarkerBox.h
+++ b/Libraries/LibWeb/Layout/ListItemMarkerBox.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,7 +20,7 @@ public:
     explicit ListItemMarkerBox(DOM::Document&, CSS::ListStyleType, CSS::ListStylePosition, size_t index, GC::Ref<CSS::ComputedProperties>);
     virtual ~ListItemMarkerBox() override;
 
-    Optional<ByteString> const& text() const { return m_text; }
+    Optional<String> const& text() const { return m_text; }
 
     virtual GC::Ptr<Painting::Paintable> create_paintable() const override;
 
@@ -34,7 +35,7 @@ private:
     CSS::ListStylePosition m_list_style_position { CSS::ListStylePosition::Outside };
     size_t m_index;
 
-    Optional<ByteString> m_text {};
+    Optional<String> m_text {};
 };
 
 template<>

--- a/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -117,7 +117,7 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
             break;
         // FIXME: This should use proper text layout logic!
         // This does not line up with the text in the <li> element which looks very sad :(
-        context.display_list_recorder().draw_text(device_enclosing.to_type<int>(), MUST(String::from_byte_string(*text)), layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
+        context.display_list_recorder().draw_text(device_enclosing.to_type<int>(), *text, layout_box().scaled_font(context), Gfx::TextAlignment::Center, color);
         break;
     }
     case CSS::ListStyleType::None:

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/list-style-type-string-004-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/css-lists/list-style-type-string-004-ref.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>CSS Test: String value of list-style-type changing dynamically</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@gmail.com">
+  <style>
+    .list { list-style-type: "bar" }
+  </style>
+</head>
+<body>
+  <ol class="list">
+    <li>item 1</li>
+    <li>item 2</li>
+    <li>item 3</li>
+    <li>item 4</li>
+  </ol>
+  <ul class="list">
+    <li>item 1</li>
+    <li>item 2</li>
+    <li>item 3</li>
+    <li>item 4</li>
+  </ul>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/list-style-type-string-004.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/css-lists/list-style-type-string-004.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" class="reftest-wait">
+<head>
+  <meta charset="UTF-8">
+  <title>CSS Test: String value of list-style-type changing dynamically</title>
+  <link rel="author" title="Oriol Brufau" href="mailto:obrufau@gmail.com">
+  <link rel="help" href="https://drafts.csswg.org/css-lists-3/#valdef-list-style-type-string">
+  <link rel="match" href="../../../../expected/wpt-import/css/css-lists/list-style-type-string-004-ref.html">
+  <meta name="assert" content="This test checks that the marker text is updated when list-style-type changes.">
+  <style>
+    .list { list-style-type: "foo" }
+  </style>
+</head>
+<body>
+  <ol class="list">
+    <li>item 1</li>
+    <li>item 2</li>
+    <li>item 3</li>
+    <li>item 4</li>
+  </ol>
+  <ul class="list">
+    <li>item 1</li>
+    <li>item 2</li>
+    <li>item 3</li>
+    <li>item 4</li>
+  </ul>
+  <script src="../../common/reftest-wait.js"></script>
+  <script>
+    "use strict";
+    addEventListener("load", function() {
+      requestAnimationFrame(() => {
+        for (const list of document.querySelectorAll(".list")) {
+          list.style.listStyleType = '"bar"';
+        }
+        takeScreenshot();
+      });
+    }, {once: true});
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Fixes #3487.

We've long claimed to support this, but then silently ignored string values, until 4cb20635771a54f59cdb36616dbdcbd402ef080e which would not-so-silently crash instead. (Oops)

So, actually pass the string value along and use it in the list marker.

As part of this, rename our `list-style-type` enum to `counter-style-name-keyword`. This is an awkward name, attempting to be spec-based. (The spec says `<counter-style>`, which is either a `<counter-style-name>` or a function, and the `<counter-style-name>` is a `<custom-ident>` that also has a few predefined values. So this is the best I could come up with.)

Unfortunately only one WPT test for this passes - the others fail because we produce a different layout when text is in `::before` than when it's in `::marker`, and similar issues.