### PR TITLE
Make `::marker` pseudo-elements inspectable without crashing

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -513,11 +513,15 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
             new_computed_properties->set_property(CSS::PropertyID::TextAlign, CSS::CSSKeywordValue::create(CSS::Keyword::Start));
     }
 
+    bool had_list_marker = false;
+
     CSS::RequiredInvalidationAfterStyleChange invalidation;
-    if (m_computed_properties)
+    if (m_computed_properties) {
         invalidation = compute_required_invalidation(*m_computed_properties, new_computed_properties);
-    else
+        had_list_marker = m_computed_properties->display().is_list_item();
+    } else {
         invalidation = CSS::RequiredInvalidationAfterStyleChange::full();
+    }
 
     if (!invalidation.is_none())
         set_computed_properties(move(new_computed_properties));
@@ -542,6 +546,8 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
 
     recompute_pseudo_element_style(CSS::Selector::PseudoElement::Type::Before);
     recompute_pseudo_element_style(CSS::Selector::PseudoElement::Type::After);
+    if (had_list_marker || m_computed_properties->display().is_list_item())
+        recompute_pseudo_element_style(CSS::Selector::PseudoElement::Type::Marker);
 
     if (invalidation.is_none())
         return invalidation;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -616,12 +616,20 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
             }
 
             auto pseudo_element_style = element.pseudo_element_computed_properties(pseudo_element.value());
-            ByteString computed_values = serialize_json(*pseudo_element_style);
-            ByteString resolved_values = serialize_json(element.resolved_css_values(pseudo_element.value()));
+
+            ByteString computed_values;
+            ByteString fonts_json;
+            ByteString resolved_values;
+            if (pseudo_element_style) {
+                computed_values = serialize_json(*pseudo_element_style);
+                fonts_json = serialize_fonts_json(*pseudo_element_style);
+                resolved_values = serialize_json(element.resolved_css_values(pseudo_element.value()));
+            } else {
+                dbgln("Inspected pseudo-element has no computed style.");
+            }
+
             ByteString custom_properties_json = serialize_custom_properties_json(element, pseudo_element);
             ByteString node_box_sizing_json = serialize_node_box_sizing_json(pseudo_element_node.ptr());
-            ByteString fonts_json = serialize_fonts_json(*pseudo_element_style);
-
             async_did_inspect_dom_node(page_id, true, move(computed_values), move(resolved_values), move(custom_properties_json), move(node_box_sizing_json), {}, move(fonts_json));
             return;
         }

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -529,15 +529,20 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
             HashTable<FlyString> seen_properties;
 
             auto const* element_to_check = &element;
+            auto pseudo_element_to_check = pseudo_element;
             while (element_to_check) {
-                for (auto const& property : element_to_check->custom_properties(pseudo_element)) {
+                for (auto const& property : element_to_check->custom_properties(pseudo_element_to_check)) {
                     if (!seen_properties.contains(property.key)) {
                         seen_properties.set(property.key);
                         MUST(serializer.add(property.key, property.value.value->to_string(Web::CSS::CSSStyleValue::SerializationMode::Normal)));
                     }
                 }
 
-                element_to_check = element_to_check->parent_element();
+                if (pseudo_element_to_check.has_value()) {
+                    pseudo_element_to_check.clear();
+                } else {
+                    element_to_check = element_to_check->parent_element();
+                }
             }
 
             MUST(serializer.finish());


### PR DESCRIPTION
Fixes #2432.

Just to demonstrate, here's me inspecting a `::marker` with `color: orange` set on it, and seeing that show up in the inspector. (It's hard to see the actual orange colour because of the highlight but it is there I promise. :laughing: )

![image](https://github.com/user-attachments/assets/52a0932d-3d19-45a5-ba4a-0a148592219d)

I believe `::marker` is the only generated pseudo-element that did not already have its computed style cached, so this shouldn't affect any other pseudo-elements. However, to avoid such crashes, I've changed the inspection code to print a debug message instead of trying to deref a null ComputedProperties pointer.