### PR TITLE
LibWeb/HTML: Add CanvasColorType

### DIFF
--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -17,11 +17,13 @@
 #import <HTML/Canvas/CanvasUserInterface.idl>
 
 enum PredefinedColorSpace { "srgb", "display-p3" };
+enum CanvasColorType { "unorm8", "float16" };
 
 dictionary CanvasRenderingContext2DSettings {
     boolean alpha = true;
     boolean desynchronized = false;
     PredefinedColorSpace colorSpace = "srgb";
+    CanvasColorType colorType = "unorm8";
     boolean willReadFrequently = false;
 };
 


### PR DESCRIPTION
We don't implement the affected algorithms, and so the only change to apply here is adding the dictionary member to IDL.

Corresponds to https://github.com/whatwg/html/commit/a5853ca8fa828ee9c13907146ee5fd118da56df2