### PR TITLE
LibWeb: Skip pending :has() invalidation if there is no :has()

### DIFF
--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -206,6 +206,14 @@ WeakPtr<T> make_weak_ptr_if_nonnull(T const* ptr)
     return MUST(try_make_weak_ptr_if_nonnull(ptr));
 }
 
+template<typename T>
+struct Traits<WeakPtr<T>> : public DefaultTraits<WeakPtr<T>> {
+    using PeekType = T*;
+    using ConstPeekType = T const*;
+    static unsigned hash(WeakPtr<T> const& p) { return ptr_hash(p.ptr()); }
+    static bool equals(WeakPtr<T> const& a, WeakPtr<T> const& b) { return a.ptr() == b.ptr(); }
+};
+
 }
 
 #if USING_AK_GLOBALLY

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -3172,4 +3172,10 @@ bool StyleComputer::may_have_has_selectors() const
     return m_selector_insights->has_has_selectors;
 }
 
+bool StyleComputer::have_has_selectors() const
+{
+    build_rule_cache_if_needed();
+    return m_selector_insights->has_has_selectors;
+}
+
 }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -177,6 +177,7 @@ public:
     void collect_animation_into(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>, GC::Ref<Animations::KeyframeEffect> animation, ComputedProperties&, AnimationRefresh = AnimationRefresh::No) const;
 
     [[nodiscard]] bool may_have_has_selectors() const;
+    [[nodiscard]] bool have_has_selectors() const;
 
     size_t number_of_css_font_faces_with_loading_in_progress() const;
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1438,7 +1438,7 @@ void Document::update_style()
     // style change event. [CSS-Transitions-2]
     m_transition_generation++;
 
-    invalidate_elements_affected_by_has_in_non_subject_position();
+    invalidate_style_of_elements_affected_by_has();
 
     if (!needs_full_style_update() && !needs_style_update() && !child_needs_style_update())
         return;
@@ -1659,11 +1659,18 @@ static Node* find_common_ancestor(Node* a, Node* b)
     return nullptr;
 }
 
-void Document::invalidate_elements_affected_by_has_in_non_subject_position()
+void Document::invalidate_style_of_elements_affected_by_has()
 {
-    if (!m_needs_invalidate_elements_affected_by_has_in_non_subject_position)
+    if (m_pending_nodes_for_style_invalidation_due_to_presence_of_has.is_empty()) {
         return;
-    m_needs_invalidate_elements_affected_by_has_in_non_subject_position = false;
+    }
+
+    for (auto const& node : m_pending_nodes_for_style_invalidation_due_to_presence_of_has) {
+        if (node.is_null())
+            continue;
+        node->invalidate_ancestors_affected_by_has_in_subject_position();
+    }
+    m_pending_nodes_for_style_invalidation_due_to_presence_of_has.clear();
 
     // Take care of elements that affected by :has() in non-subject position, i.e., ".a:has(.b) > .c".
     // Elements affected by :has() in subject position, i.e., ".a:has(.b)", are handled by


### PR DESCRIPTION
`invalidate_style()` already tries to avoid scheduling invalidation for
`:has()` by checking result of `may_have_has_selectors()`, but it might
still result in unnecessary work because `may_have_has_selectors()`
does not force building of rules cache. This change adds
`have_has_selectors()` that forces building of rules cache and is
invoked in `update_style()` to double-check whether we actually need to
process scheduled `:has()` invalidations.

This allows to skip ~100000 ancestor traversals on this WPT test:
https://wpt.live/html/select/options-length-too-large.html