### PR TITLE
LibCore: Allow LibCore to build completely on Windows

### DIFF
--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -29,7 +29,6 @@ if (LAGOM_TOOLS_ONLY)
 endif()
 
 set(SOURCES
-    Command.cpp
     ConfigFile.cpp
     DateTime.cpp
     ElapsedTimer.cpp
@@ -44,13 +43,12 @@ set(SOURCES
     ResourceImplementation.cpp
     ResourceImplementationFile.cpp
     SystemServerTakeover.cpp
-    TCPServer.cpp
     ThreadEventQueue.cpp
     Timer.cpp
-    UDPServer.cpp
 )
 
 if (WIN32)
+    # FIXME: Support UDPServer and TCPServer on Windows
     list(APPEND SOURCES
         ProcessWindows.cpp
         SocketWindows.cpp
@@ -58,10 +56,13 @@ if (WIN32)
         EventLoopImplementationWindows.cpp)
 else()
     list(APPEND SOURCES
+        Command.cpp
         Process.cpp
         Socket.cpp
         AnonymousBuffer.cpp
-        EventLoopImplementationUnix.cpp)
+        EventLoopImplementationUnix.cpp
+        UDPServer.cpp
+        TCPServer.cpp)
 endif()
 
 if (NOT WIN32 AND NOT EMSCRIPTEN)

--- a/Libraries/LibCore/EventLoopImplementationWindows.cpp
+++ b/Libraries/LibCore/EventLoopImplementationWindows.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/HashMap.h>
 #include <LibCore/EventLoopImplementationWindows.h>
 #include <LibCore/Notifier.h>
 #include <LibCore/ThreadEventQueue.h>


### PR DESCRIPTION
And a follow-up from #3493.

With this patch, `ninja -C Build]\release LibCore` builds on my machine.