### PR TITLE
LibWeb: Minor fix on keyboard event

### DIFF
--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -871,7 +871,15 @@ void FormAssociatedTextControlElement::decrement_cursor_position_offset(Collapse
         } else {
             m_selection_end = *offset;
         }
+    } else if (auto text_length = text_node->whole_text().to_byte_string().length(); m_selection_end == text_length && m_selection_end > 0) {
+
+        if (collapse == CollapseSelection::Yes) {
+            collapse_selection_to_offset(m_selection_end - 1);
+        } else {
+            m_selection_end = m_selection_end - 1;
+        }
     }
+
     selection_was_changed();
 }
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1253,6 +1253,29 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
         }
     }
 
+    if (key == UIEvents::KeyCode::Key_Return) {
+        if (auto* element = m_navigable->active_document()->focused_element(); is<HTML::HTMLElement>(element)) {
+            auto& html_element = static_cast<HTML::HTMLElement&>(*element);
+
+            HTML::HTMLFormElement* form = nullptr;
+            if (is<HTML::HTMLFormElement>(element->parent_element())) {
+                form = static_cast<HTML::HTMLFormElement*>(element->parent_element());
+            } else {
+                for (auto* parent = element->parent_element(); parent; parent = parent->parent_element()) {
+                    if (is<HTML::HTMLFormElement>(parent)) {
+                        form = static_cast<HTML::HTMLFormElement*>(parent);
+                        break;
+                    }
+                }
+            }
+            if (form) {
+                return EventResult::Handled;
+            }
+            html_element.click();
+            return EventResult::Handled;
+        }
+    }
+
     // FIXME: Implement scroll by line and by page instead of approximating the behavior of other browsers.
     auto arrow_key_scroll_distance = 100;
     auto page_scroll_distance = document->window()->inner_height() - (document->window()->outer_height() - document->window()->inner_height());


### PR DESCRIPTION
Trigger click on Return KeyDown event.
Fix Move Left cursor at the end of the text