### PR TITLE
Remove two idiosyncratic hacks in flex layout

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -675,17 +675,6 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
     auto clamp_min = has_main_min_size(child_box) ? specified_main_min_size(child_box) : automatic_minimum_size(item);
     auto clamp_max = has_main_max_size(child_box) ? specified_main_max_size(child_box) : CSSPixels::max();
     item.hypothetical_main_size = max(CSSPixels(0), css_clamp(item.flex_base_size, clamp_min, clamp_max));
-
-    // NOTE: At this point, we set the hypothetical main size as the flex item's *temporary* main size.
-    //       The size may change again when we resolve flexible lengths, but this is necessary in order for
-    //       descendants of this flex item to resolve percentage sizes against something.
-    //
-    //       The spec just barely hand-waves about this, but it seems to *roughly* match what other engines do.
-    //       See "Note" section here: https://drafts.csswg.org/css-flexbox-1/#definite-sizes
-    if (is_row_layout())
-        item.used_values.set_temporary_content_width(item.hypothetical_main_size);
-    else
-        item.used_values.set_temporary_content_height(item.hypothetical_main_size);
 }
 
 // https://drafts.csswg.org/css-flexbox-1/#min-size-auto

--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -648,16 +648,6 @@ void LayoutState::UsedValues::set_content_height(CSSPixels height)
     m_content_height = clamp_to_max_dimension_value(height);
 }
 
-void LayoutState::UsedValues::set_temporary_content_width(CSSPixels width)
-{
-    m_content_width = clamp_to_max_dimension_value(width);
-}
-
-void LayoutState::UsedValues::set_temporary_content_height(CSSPixels height)
-{
-    m_content_height = height;
-}
-
 AvailableSize LayoutState::UsedValues::available_width_inside() const
 {
     if (width_constraint == SizeConstraint::MinContent)

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -88,11 +88,6 @@ struct LayoutState {
         void set_has_definite_width(bool has_definite_width) { m_has_definite_width = has_definite_width; }
         void set_has_definite_height(bool has_definite_height) { m_has_definite_height = has_definite_height; }
 
-        // NOTE: These are used by FlexFormattingContext to assign a temporary main size to items
-        //       early on, so that descendants have something to resolve percentages against.
-        void set_temporary_content_width(CSSPixels);
-        void set_temporary_content_height(CSSPixels);
-
         bool has_definite_width() const { return m_has_definite_width && width_constraint == SizeConstraint::None; }
         bool has_definite_height() const { return m_has_definite_height && height_constraint == SizeConstraint::None; }
 


### PR DESCRIPTION
See individual commits, but basically:

- Remove ad-hoc nested layout in cross size determination in favor of falling back to fit-content.
- Remove temporary content size assignments since nothing relies on it anymore.