### PR TITLE
LibWeb: Optimize inherited style update

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -533,11 +533,8 @@ void Node::invalidate_style(StyleInvalidationReason, Vector<CSS::InvalidationSet
             } else if (options.invalidate_elements_that_use_css_custom_properties && element.style_uses_css_custom_properties()) {
                 needs_style_recalculation = true;
             }
-            if (needs_style_recalculation) {
+            if (needs_style_recalculation)
                 element.set_needs_style_update(true);
-            } else {
-                element.set_needs_inherited_style_update(true);
-            }
             return TraversalDecision::Continue;
         });
     };
@@ -1392,22 +1389,6 @@ EventTarget* Node::get_parent(Event const&)
         return assigned_slot.ptr();
 
     return parent();
-}
-
-void Node::set_needs_inherited_style_update(bool value)
-{
-    if (m_needs_inherited_style_update == value)
-        return;
-    m_needs_inherited_style_update = value;
-
-    if (m_needs_inherited_style_update) {
-        for (auto* ancestor = parent_or_shadow_host(); ancestor; ancestor = ancestor->parent_or_shadow_host()) {
-            if (ancestor->m_child_needs_style_update)
-                break;
-            ancestor->m_child_needs_style_update = true;
-        }
-        document().schedule_style_update();
-    }
 }
 
 void Node::set_needs_layout_tree_update(bool value)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -303,9 +303,6 @@ public:
     void set_needs_style_update(bool);
     void set_needs_style_update_internal(bool) { m_needs_style_update = true; }
 
-    bool needs_inherited_style_update() const { return m_needs_inherited_style_update; }
-    void set_needs_inherited_style_update(bool);
-
     bool child_needs_style_update() const { return m_child_needs_style_update; }
     void set_child_needs_style_update(bool b) { m_child_needs_style_update = b; }
 
@@ -535,7 +532,6 @@ protected:
     bool m_child_needs_layout_tree_update { false };
 
     bool m_needs_style_update { false };
-    bool m_needs_inherited_style_update { false };
     bool m_child_needs_style_update { false };
     bool m_entire_subtree_needs_style_update { false };
 


### PR DESCRIPTION
This commit changes the strategy for updating inherited styles. Instead of marking all potentially affected nodes during style invalidation, the decision is now made on-the-fly during style recalculation. Child nodes will only have their inherited styles recalculated if their parent's properties have changed.

On Discord this allows to 1000x reduce number of nodes with recalculated inherited style.