### PR TITLE
LibWasm: Port to Windows

### DIFF
--- a/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -20,6 +20,7 @@
 namespace Wasm {
 
 class Configuration;
+class Result;
 struct Interpreter;
 
 struct InstantiationError {

--- a/Libraries/LibWasm/CMakeLists.txt
+++ b/Libraries/LibWasm/CMakeLists.txt
@@ -5,8 +5,11 @@ set(SOURCES
     AbstractMachine/Validator.cpp
     Parser/Parser.cpp
     Printer/Printer.cpp
-    WASI/Wasi.cpp
 )
+
+if (NOT WIN32)
+    list(APPEND SOURCES WASI/Wasi.cpp)
+endif()
 
 serenity_lib(LibWasm wasm)
 target_link_libraries(LibWasm PRIVATE LibCore LibGC LibJS)


### PR DESCRIPTION
After excluding Wasi.cpp on Windows I kept getting these link errors, but then they disappeared after I `touch`ed Forward.h.
```
lld-link : error : <root>: undefined symbol: class ValueType::ValueType Wasm::Wasi::ABI::CompatibleValueType<char> [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class ValueType::ValueType Wasm::Wasi::ABI::CompatibleValueType<short> [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class ValueType::ValueType Wasm::Wasi::ABI::CompatibleValueType<int> [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class ValueType::ValueType Wasm::Wasi::ABI::CompatibleValueType<__int64> [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: struct AK::BaseRedBlackTree<unsigned int>::Node `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: struct AK::RedBlackTree<unsigned int, struct AK::Variant<unsigned int, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned __int64>, struct Wasm::Wasi::PreopenedDirectoryDescriptor_tag, enum AK::DistinctNumericFeature::Comparison, enum AK::DistinctNumericFeature::CastToUnderlying, enum AK::DistinctNumericFeature::Increment>>>::Node `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$args_get(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::Detail::__Pointer_tag<class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::Detail::__Pointer_tag<unsigned char>, enum AK::DistinctNumericFeature::Comparison>>, enum AK::DistinctNumericFeature::Comparison>, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::Detail::__Pointer_tag<unsigned char>, enum AK::DistinctNumericFeature::Comparison>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<class Wasm::Wasi::LittleEndian<unsigned __int64>, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$clock_res_get(class Wasm::Configuration &, enum Wasm::Wasi::ClockID)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<class Wasm::Wasi::LittleEndian<unsigned __int64>, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$clock_time_get(class Wasm::Configuration &, enum Wasm::Wasi::ClockID, class Wasm::Wasi::LittleEndian<unsigned __int64>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$environ_get(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::Detail::__Pointer_tag<class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::Detail::__Pointer_tag<unsigned char>, enum AK::DistinctNumericFeature::Comparison>>, enum AK::DistinctNumericFeature::Comparison>, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::Detail::__Pointer_tag<unsigned char>, enum AK::DistinctNumericFeature::Comparison>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_advise(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>, class Wasm::Wasi::LittleEndian<unsigned __int64>, class Wasm::Wasi::LittleEndian<unsigned __int64>, enum Wasm::Wasi::Advice)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_allocate(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>, class Wasm::Wasi::LittleEndian<unsigned __int64>, class Wasm::Wasi::LittleEndian<unsigned __int64>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_close(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_datasync(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<struct Wasm::Wasi::FDStat, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_fdstat_get(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_fdstat_set_flags(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>, struct Wasm::Wasi::FDFlags)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_fdstat_set_rights(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>, struct Wasm::Wasi::Rights, struct Wasm::Wasi::Rights)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<struct Wasm::Wasi::FileStat, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_filestat_get(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_filestat_set_size(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>, class Wasm::Wasi::LittleEndian<unsigned __int64>)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : <root>: undefined symbol: class AK::Function<class Wasm::Result __cdecl(class Wasm::Configuration &, class AK::Vector<class Wasm::Value, 0> &)>::CallableWrapper<class `public: class Wasm::HostFunction __cdecl Wasm::Wasi::ABI::InvocationOf<&private: class AK::ErrorOr<struct Wasm::Wasi::Result<void, unsigned int>, class AK::Error> __cdecl Wasm::Wasi::Implementation::impl$fd_filestat_set_times(class Wasm::Configuration &, class AK::DistinctNumeric<class Wasm::Wasi::LittleEndian<unsigned int>, struct Wasm::Wasi::__FD_tag, enum AK::DistinctNumericFeature::Comparison>, class Wasm::Wasi::LittleEndian<unsigned __int64>, class Wasm::Wasi::LittleEndian<unsigned __int64>, struct Wasm::Wasi::FSTFlags)>::operator()(struct Wasm::Wasi::Implementation &, class AK::StringView)'::`1'::<lambda_2>> `RTTI Type Descriptor' [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
lld-link : error : too many errors emitted, stopping now (use /errorlimit:0 to see all errors) [E:\Users\stas\Projects\ladybird\lb\Build\release\Lagom\Libraries\LibWasm\LibWasm.vcxproj]
```