### PR TITLE
Reduce calls to LayoutState::UsedValues::get*()

### DIFF
--- a/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -131,15 +131,13 @@ void BlockFormattingContext::parent_context_did_dimension_child_root_box()
 
     // Left-side floats: offset_from_edge is from left edge (0) to left content edge of floating_box.
     for (auto& floating_box : m_left_floats.all_boxes) {
-        auto& box_state = m_state.get_mutable(floating_box->box);
-        box_state.set_content_x(floating_box->offset_from_edge);
+        floating_box->used_values.set_content_x(floating_box->offset_from_edge);
     }
 
     // Right-side floats: offset_from_edge is from right edge (float_containing_block_width) to the left content edge of floating_box.
     for (auto& floating_box : m_right_floats.all_boxes) {
         auto float_containing_block_width = containing_block_width_for(floating_box->box);
-        auto& box_state = m_state.get_mutable(floating_box->box);
-        box_state.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
+        floating_box->used_values.set_content_x(float_containing_block_width - floating_box->offset_from_edge);
     }
 
     if (m_layout_mode == LayoutMode::Normal) {

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -183,9 +183,8 @@ void FlexFormattingContext::parent_context_did_dimension_child_root_box()
 
     for (auto& child : flex_container().contained_abspos_children()) {
         auto& box = as<Box>(*child);
-        auto& cb_state = m_state.get(*box.containing_block());
-        auto available_width = AvailableSize::make_definite(cb_state.content_width() + cb_state.padding_left + cb_state.padding_right);
-        auto available_height = AvailableSize::make_definite(cb_state.content_height() + cb_state.padding_top + cb_state.padding_bottom);
+        auto available_width = AvailableSize::make_definite(m_flex_container_state.content_width() + m_flex_container_state.padding_left + m_flex_container_state.padding_right);
+        auto available_height = AvailableSize::make_definite(m_flex_container_state.content_height() + m_flex_container_state.padding_top + m_flex_container_state.padding_bottom);
         layout_absolutely_positioned_element(box, AvailableSpace(available_width, available_height));
     }
 }

--- a/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -157,7 +157,10 @@ private:
 
     void set_main_size(Box const&, CSSPixels size);
     void set_cross_size(Box const&, CSSPixels size);
-    void set_offset(Box const&, CSSPixels main_offset, CSSPixels cross_offset);
+    void set_main_size(FlexItem&, CSSPixels size);
+    void set_cross_size(FlexItem&, CSSPixels size);
+    void set_offset(FlexItem&, CSSPixels main_offset, CSSPixels cross_offset);
+
     void set_main_axis_first_margin(FlexItem&, CSSPixels margin);
     void set_main_axis_second_margin(FlexItem&, CSSPixels margin);
 

--- a/Libraries/LibWeb/Layout/GridFormattingContext.h
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.h
@@ -36,6 +36,7 @@ struct GridPosition {
 
 struct GridItem {
     GC::Ref<Box const> box;
+    LayoutState::UsedValues& used_values;
 
     // Position and span are empty if the item is auto-placed which could only be the case for abspos items
     Optional<int> row;
@@ -53,12 +54,11 @@ struct GridItem {
         return dimension == GridDimension::Column ? column.value() : row.value();
     }
 
-    [[nodiscard]] CSSPixels add_margin_box_sizes(CSSPixels content_size, GridDimension dimension, LayoutState const& state) const
+    [[nodiscard]] CSSPixels add_margin_box_sizes(CSSPixels content_size, GridDimension dimension) const
     {
-        auto const& box_state = state.get(box);
         if (dimension == GridDimension::Column)
-            return box_state.margin_box_left() + content_size + box_state.margin_box_right();
-        return box_state.margin_box_top() + content_size + box_state.margin_box_bottom();
+            return used_values.margin_box_left() + content_size + used_values.margin_box_right();
+        return used_values.margin_box_top() + content_size + used_values.margin_box_bottom();
     }
 
     [[nodiscard]] int gap_adjusted_position(GridDimension const dimension) const
@@ -252,6 +252,8 @@ private:
     Vector<GridItem> m_grid_items;
 
     Optional<AvailableSpace> m_available_space;
+
+    LayoutState::UsedValues& m_grid_container_used_values;
 
     void determine_grid_container_height();
     void determine_intrinsic_size_of_grid_container(AvailableSpace const& available_space);

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -186,7 +186,7 @@ struct LayoutState {
         CSSPixels border_top_collapsed() const { return use_collapsing_borders_model() ? round(border_top / 2) : border_top; }
         CSSPixels border_bottom_collapsed() const { return use_collapsing_borders_model() ? round(border_bottom / 2) : border_bottom; }
 
-        GC::Ptr<Layout::NodeWithStyle> m_node { nullptr };
+        GC::Ptr<Layout::NodeWithStyle const> m_node { nullptr };
         UsedValues const* m_containing_block_used_values { nullptr };
 
         CSSPixels m_content_width { 0 };


### PR DESCRIPTION
The `get()` and `get_mutable()` APIs on `LayoutState::UsedValues` enable arbitrary access to the used values of any layout node during layout, even layout nodes outside the scope of the current formatting context.

To enable new layout optimizations like subtree layout caching, we need to stop having arbitrary dependencies between layout nodes.

This PR is one of many steps towards that goal. It doesn't go all the way, a lot more work will be required.