### PR TITLE
Tests: Skip tests that rely on the reftest-wait mechanism

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -158,7 +158,11 @@ Text/input/wpt-import/css/css-backgrounds/animations/discrete-no-interpolation.h
 Text/input/ShadowDOM/css-hover-shadow-dom.html
 
 ; WPT ref tests that are flaky, probably due to not supporting class="reftest-wait"
+Ref/input/wpt-import/css/css-contain/contain-layout-020.html
+Ref/input/wpt-import/css/css-contain/contain-paint-050.html
 Ref/input/wpt-import/css/css-contain/contain-paint-change-opacity.html
+Ref/input/wpt-import/css/css-lists/list-style-type-string-004.html
+Ref/input/wpt-import/css/css-transforms/individual-transform/stacking-context-001.html
 
 ; Test is flaky on CI, as navigationStart time is not set according to spec.
 Text/input/wpt-import/user-timing/measure_associated_with_navigation_timing.html


### PR DESCRIPTION
The WPT runner uses this mechanism to delay test completion. This is not supported by our runner and causes tests that use it to be flaky.