### PR TITLE
LibWeb+LibURL: Implement the simple IDL functions for URLPattern

### DIFF
--- a/Libraries/LibURL/CMakeLists.txt
+++ b/Libraries/LibURL/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     Site.cpp
     URL.cpp
     ${PUBLIC_SUFFIX_SOURCES}
+    Pattern/Pattern.cpp
 )
 
 serenity_lib(LibURL url)

--- a/Libraries/LibURL/CMakeLists.txt
+++ b/Libraries/LibURL/CMakeLists.txt
@@ -10,5 +10,5 @@ set(SOURCES
 )
 
 serenity_lib(LibURL url)
-target_link_libraries(LibURL PRIVATE LibUnicode LibTextCodec)
+target_link_libraries(LibURL PRIVATE LibUnicode LibTextCodec LibRegex)
 target_compile_definitions(LibURL PRIVATE ENABLE_PUBLIC_SUFFIX=$<BOOL:${ENABLE_PUBLIC_SUFFIX_DOWNLOAD}>)

--- a/Libraries/LibURL/Pattern/Component.h
+++ b/Libraries/LibURL/Pattern/Component.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/OwnPtr.h>
+#include <AK/String.h>
+#include <LibRegex/Regex.h>
+
+namespace URL::Pattern {
+
+// https://urlpattern.spec.whatwg.org/#component
+struct Component {
+    // https://urlpattern.spec.whatwg.org/#component-pattern-string
+    // pattern string, a well formed pattern string
+    String pattern_string;
+
+    // https://urlpattern.spec.whatwg.org/#component-regular-expression
+    // regular expression, a RegExp
+    OwnPtr<Regex<ECMA262>> regular_expression;
+
+    // https://urlpattern.spec.whatwg.org/#component-group-name-list
+    // group name list, a list of strings
+    Vector<String> group_name_list;
+
+    // https://urlpattern.spec.whatwg.org/#component-has-regexp-groups
+    // has regexp groups, a boolean
+    bool has_regexp_groups {};
+};
+
+}

--- a/Libraries/LibURL/Pattern/Pattern.cpp
+++ b/Libraries/LibURL/Pattern/Pattern.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Shannon Booth <shannon@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibURL/Pattern/Pattern.h>
+
+namespace URL::Pattern {
+
+// https://urlpattern.spec.whatwg.org/#url-pattern-has-regexp-groups
+bool Pattern::has_regexp_groups() const
+{
+    // 1. If urlPattern’s protocol component has regexp groups is true, then return true.
+    if (m_protocol_component.has_regexp_groups)
+        return true;
+
+    // 2. If urlPattern’s username component has regexp groups is true, then return true.
+    if (m_username_component.has_regexp_groups)
+        return true;
+
+    // 3. If urlPattern’s password component has regexp groups is true, then return true.
+    if (m_password_component.has_regexp_groups)
+        return true;
+
+    // 4. If urlPattern’s hostname component has regexp groups is true, then return true.
+    if (m_hostname_component.has_regexp_groups)
+        return true;
+
+    // 5. If urlPattern’s port component has regexp groups is true, then return true.
+    if (m_port_component.has_regexp_groups)
+        return true;
+
+    // 6. If urlPattern’s pathname component has regexp groups is true, then return true.
+    if (m_pathname_component.has_regexp_groups)
+        return true;
+
+    // 7. If urlPattern’s search component has regexp groups is true, then return true.
+    if (m_search_component.has_regexp_groups)
+        return true;
+
+    // 8. If urlPattern’s hash component has regexp groups is true, then return true.
+    if (m_hash_component.has_regexp_groups)
+        return true;
+
+    // 9. Return false.
+    return false;
+}
+
+}

--- a/Libraries/LibURL/Pattern/Pattern.h
+++ b/Libraries/LibURL/Pattern/Pattern.h
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibURL/Pattern/Component.h>
 #include <LibURL/Pattern/Init.h>
 
 namespace URL::Pattern {
@@ -40,6 +41,54 @@ struct Result {
     ComponentResult pathname;
     ComponentResult search;
     ComponentResult hash;
+};
+
+// https://urlpattern.spec.whatwg.org/#url-pattern
+class Pattern {
+public:
+    bool has_regexp_groups() const;
+
+    Component const& protocol_component() const { return m_protocol_component; }
+    Component const& username_component() const { return m_username_component; }
+    Component const& password_component() const { return m_password_component; }
+    Component const& hostname_component() const { return m_hostname_component; }
+    Component const& port_component() const { return m_port_component; }
+    Component const& pathname_component() const { return m_pathname_component; }
+    Component const& search_component() const { return m_search_component; }
+    Component const& hash_component() const { return m_hash_component; }
+
+private:
+    // https://urlpattern.spec.whatwg.org/#url-pattern-protocol-component
+    // protocol component, a component
+    Component m_protocol_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-username-component
+    // username component, a component
+    Component m_username_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-password-component
+    // password component, a component
+    Component m_password_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-hostname-component
+    // hostname component, a component
+    Component m_hostname_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-port-component
+    // port component, a component
+    Component m_port_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-pathname-component
+    // pathname component, a component
+    Component m_pathname_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-search-component
+    // search component, a component
+    Component m_search_component;
+
+    // https://urlpattern.spec.whatwg.org/#url-pattern-hash-component
+    // hash component, a component
+    Component m_hash_component;
 };
 
 }

--- a/Libraries/LibWeb/URLPattern/URLPattern.cpp
+++ b/Libraries/LibWeb/URLPattern/URLPattern.cpp
@@ -43,4 +43,71 @@ Optional<URLPatternResult> URLPattern::exec(URLPatternInput const&, Optional<Str
     return {};
 }
 
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-protocol
+String const& URLPattern::protocol() const
+{
+    // 1. Return this's associated URL pattern's protocol component's pattern string.
+    return m_url_pattern.protocol_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-username
+String const& URLPattern::username() const
+{
+    // 1. Return this's associated URL pattern's username component's pattern string.
+    return m_url_pattern.username_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-password
+String const& URLPattern::password() const
+{
+    // 1. Return this's associated URL pattern's password component's pattern string.
+    return m_url_pattern.password_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-hostname
+String const& URLPattern::hostname() const
+{
+    // 1. Return this's associated URL pattern's hostname component's pattern string.
+    return m_url_pattern.hostname_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-port
+String const& URLPattern::port() const
+{
+    // 1. Return this's associated URL pattern's port component's pattern string.
+    return m_url_pattern.port_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-pathname
+String const& URLPattern::pathname() const
+{
+    // 1. Return this's associated URL pattern's pathname component's pattern string.
+    return m_url_pattern.pathname_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-search
+String const& URLPattern::search() const
+{
+    // 1. Return this's associated URL pattern's search component's pattern string.
+    return m_url_pattern.search_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-hash
+String const& URLPattern::hash() const
+{
+    // 1. Return this's associated URL pattern's hash component's pattern string.
+    return m_url_pattern.hash_component().pattern_string;
+}
+
+// https://urlpattern.spec.whatwg.org/#dom-urlpattern-hasregexpgroups
+bool URLPattern::has_reg_exp_groups() const
+{
+    // 1. If this's associated URL pattern's has regexp groups, then return true.
+    if (m_url_pattern.has_regexp_groups())
+        return true;
+
+    // 2. Return false.
+    return false;
+}
+
 }

--- a/Libraries/LibWeb/URLPattern/URLPattern.h
+++ b/Libraries/LibWeb/URLPattern/URLPattern.h
@@ -29,12 +29,28 @@ public:
 
     Optional<URLPatternResult> exec(URLPatternInput const&, Optional<String> const&) const;
 
+    String const& protocol() const;
+    String const& username() const;
+    String const& password() const;
+    String const& hostname() const;
+    String const& port() const;
+    String const& pathname() const;
+    String const& search() const;
+    String const& hash() const;
+
+    bool has_reg_exp_groups() const;
+
     virtual ~URLPattern() override;
 
 protected:
     virtual void initialize(JS::Realm&) override;
 
     explicit URLPattern(JS::Realm&);
+
+private:
+    // https://urlpattern.spec.whatwg.org/#ref-for-url-pattern%E2%91%A0
+    // Each URLPattern has an associated URL pattern, a URL pattern.
+    URL::Pattern::Pattern m_url_pattern;
 };
 
 }

--- a/Libraries/LibWeb/URLPattern/URLPattern.idl
+++ b/Libraries/LibWeb/URLPattern/URLPattern.idl
@@ -10,16 +10,16 @@ interface URLPattern {
 
     URLPatternResult? exec(optional URLPatternInput input = {}, optional USVString baseURL);
 
-    [FIXME] readonly attribute USVString protocol;
-    [FIXME] readonly attribute USVString username;
-    [FIXME] readonly attribute USVString password;
-    [FIXME] readonly attribute USVString hostname;
-    [FIXME] readonly attribute USVString port;
-    [FIXME] readonly attribute USVString pathname;
-    [FIXME] readonly attribute USVString search;
-    [FIXME] readonly attribute USVString hash;
+    readonly attribute USVString protocol;
+    readonly attribute USVString username;
+    readonly attribute USVString password;
+    readonly attribute USVString hostname;
+    readonly attribute USVString port;
+    readonly attribute USVString pathname;
+    readonly attribute USVString search;
+    readonly attribute USVString hash;
 
-    [FIXME] readonly attribute boolean hasRegExpGroups;
+    readonly attribute boolean hasRegExpGroups;
 };
 
 // https://urlpattern.spec.whatwg.org/#dictdef-urlpatterninit


### PR DESCRIPTION
This implements the simple getters of the URLPattern interface. Next steps after this are the actual meat of the URLPattern interface which are the two different parsers and the tokenizer which are needed to implement the constructor. From the constructed URLPattern a regex match can be made on a URL.