### PR TITLE
LibCore: Do not delete ThreadEventQueue

### DIFF
--- a/Libraries/LibCore/ThreadEventQueue.cpp
+++ b/Libraries/LibCore/ThreadEventQueue.cpp
@@ -11,8 +11,6 @@
 #include <LibCore/Promise.h>
 #include <LibCore/ThreadEventQueue.h>
 #include <LibThreading/Mutex.h>
-#include <errno.h>
-#include <pthread.h>
 
 namespace Core {
 
@@ -40,23 +38,9 @@ struct ThreadEventQueue::Private {
     bool warned_promise_count { false };
 };
 
-static pthread_key_t s_current_thread_event_queue_key;
-static pthread_once_t s_current_thread_event_queue_key_once = PTHREAD_ONCE_INIT;
-
 ThreadEventQueue& ThreadEventQueue::current()
 {
-    pthread_once(&s_current_thread_event_queue_key_once, [] {
-        pthread_key_create(&s_current_thread_event_queue_key, [](void* value) {
-            if (value)
-                delete static_cast<ThreadEventQueue*>(value);
-        });
-    });
-
-    auto* ptr = static_cast<ThreadEventQueue*>(pthread_getspecific(s_current_thread_event_queue_key));
-    if (!ptr) {
-        ptr = new ThreadEventQueue;
-        pthread_setspecific(s_current_thread_event_queue_key, ptr);
-    }
+    thread_local auto ptr = new ThreadEventQueue;
     return *ptr;
 }
 


### PR DESCRIPTION
Partially reverts 920f4707358.

On Linux the deleted code doesn't work anyway -- ThreadEventQueue destructor is never called. To test this, add dbgln to ~ThreadEventQueue and run either headless-browser or ladybird.

On Windows it works, but results in use-after-free: ~ThreadEventQueue is called after WebView::WebContentClient::s_clients destructor, but ~ThreadEventQueue indirectly calls
~WebContentClient, which calls `s_clients.remove(this);`

I tried to use OwnPtr\<ThreadEventQueue> (see #3240), but LibWeb tests started failing.

Deleting ThreadEventQueue is pointless. Raymond Chen, in [this article](https://devblogs.microsoft.com/oldnewthing/20120105-00/?p=8683):
> The process is exiting. All that memory will be freed when the address space is destroyed. *Stop wasting time and just exit already.*
