### PR TITLE
LibWeb: Avoid full tree traversal for non-subject `:has()` invalidation

### DIFF
--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -508,8 +508,12 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         // :has() cannot be nested in a :has()
         if (selector_kind == SelectorKind::Relative)
             return false;
-        if (context.collect_per_element_selector_involvement_metadata && &element == context.subject) {
-            const_cast<DOM::Element&>(element).set_affected_by_has_pseudo_class_in_subject_position(true);
+        if (context.collect_per_element_selector_involvement_metadata) {
+            if (&element == context.subject) {
+                const_cast<DOM::Element&>(element).set_affected_by_has_pseudo_class_in_subject_position(true);
+            } else {
+                const_cast<DOM::Element&>(element).set_affected_by_has_pseudo_class_in_non_subject_position(true);
+            }
         }
         // These selectors should be relative selectors (https://drafts.csswg.org/selectors-4/#relative-selector)
         for (auto& selector : pseudo_class.argument_selector_list) {

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -498,6 +498,8 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
     VERIFY(parent());
 
     m_affected_by_has_pseudo_class_in_subject_position = false;
+    m_affected_by_has_pseudo_class_in_non_subject_position = false;
+    m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator = false;
     m_affected_by_sibling_combinator = false;
     m_affected_by_first_or_last_child_pseudo_class = false;
     m_affected_by_nth_child_pseudo_class = false;
@@ -1310,6 +1312,16 @@ bool Element::includes_properties_from_invalidation_set(CSS::InvalidationSet con
         return IterationDecision::Continue;
     });
     return includes_any;
+}
+
+void Element::invalidate_style_if_affected_by_has()
+{
+    if (affected_by_has_pseudo_class_in_subject_position()) {
+        set_needs_style_update(true);
+    }
+    if (affected_by_has_pseudo_class_in_non_subject_position()) {
+        invalidate_style(StyleInvalidationReason::Other, { { CSS::InvalidationSet::Property::Type::PseudoClass, CSS::PseudoClass::Has } }, {});
+    }
 }
 
 bool Element::has_pseudo_elements() const

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -427,8 +427,13 @@ public:
     bool matches_link_pseudo_class() const;
     bool matches_local_link_pseudo_class() const;
 
+    void invalidate_style_if_affected_by_has();
+
     bool affected_by_has_pseudo_class_in_subject_position() const { return m_affected_by_has_pseudo_class_in_subject_position; }
     void set_affected_by_has_pseudo_class_in_subject_position(bool value) { m_affected_by_has_pseudo_class_in_subject_position = value; }
+
+    bool affected_by_has_pseudo_class_in_non_subject_position() const { return m_affected_by_has_pseudo_class_in_non_subject_position; }
+    void set_affected_by_has_pseudo_class_in_non_subject_position(bool value) { m_affected_by_has_pseudo_class_in_non_subject_position = value; }
 
     bool affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator() const { return m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator; }
     void set_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator(bool value) { m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator = value; }
@@ -538,6 +543,7 @@ private:
     bool m_rendered_in_top_layer : 1 { false };
     bool m_style_uses_css_custom_properties { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
+    bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };
     bool m_affected_by_sibling_combinator : 1 { false };
     bool m_affected_by_first_or_last_child_pseudo_class : 1 { false };
     bool m_affected_by_nth_child_pseudo_class : 1 { false };

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -309,7 +309,6 @@ public:
     [[nodiscard]] bool entire_subtree_needs_style_update() const { return m_entire_subtree_needs_style_update; }
     void set_entire_subtree_needs_style_update(bool b) { m_entire_subtree_needs_style_update = b; }
 
-    void invalidate_ancestors_affected_by_has_in_subject_position();
     void invalidate_style(StyleInvalidationReason);
     struct StyleInvalidationOptions {
         bool invalidate_self { false };


### PR DESCRIPTION
Instead of checking all elements in a document for containment in `:has()` invalidation set, we could narrow this down to ancestors and ancestor siblings, like we already do for subject `:has()` invalidation.

This change brings great improvement on GitHub that has selectors with non-subject `:has()` and sibling combinators (e.g., `.a:has(.b) ~ .c`) which prior to this change meant style invalidation for whole document.