### PR TITLE
LibWeb: Call set_children_are_inline when inserting SVG box

### DIFF
--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -553,6 +553,13 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         } else {
             if (layout_node->is_svg_box()) {
                 m_ancestor_stack.last()->append_child(*layout_node);
+                if (display.is_inline_outside()) {
+                    // After inserting an inline-level box into a parent, mark the parent as having inline children.
+                    layout_node->parent()->set_children_are_inline(true);
+                } else if (layout_node->is_in_flow()) {
+                    // After inserting an in-flow block-level box into a parent, mark the parent as having non-inline children.
+                    layout_node->parent()->set_children_are_inline(false);
+                }
             } else {
                 insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
             }

--- a/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
+++ b/Tests/LibWeb/Layout/expected/css-namespace-tag-name-selector.txt
@@ -6,8 +6,8 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         frag 1 from TextNode start: 0, length: 1, rect: [310,146 8x17] baseline: 13.296875
             " "
         frag 2 from BlockContainer start: 0, length: 0, rect: [319,51 0x108] baseline: 110
-        SVGSVGBox <svg> at (9,9) content-size 300x150 [SVG] children: not-inline
-          SVGGraphicsBox <a> at (33.765625,32.4375) content-size 188.71875x60.15625 children: not-inline
+        SVGSVGBox <svg> at (9,9) content-size 300x150 [SVG] children: inline
+          SVGGraphicsBox <a> at (33.765625,32.4375) content-size 188.71875x60.15625 children: inline
             SVGTextBox <text> at (33.765625,32.4375) content-size 188.71875x60.15625 children: inline
               TextNode <#text>
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex-container-max-content-width-with-definite-height-and-item-that-has-aspect-ratio.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     Box <body> at (8,8) content-size 100x100 flex-container(row) [FFC] children: not-inline
-      SVGSVGBox <svg> at (8,8) content-size 100x100 flex-item [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 100x100 flex-item [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 100x100 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/flex-column-item-with-natural-aspect-ratio-and-automatic-cross-size.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x100 [BFC] children: not-inline
     Box <body> at (0,0) content-size 800x100 flex-container(column) [FFC] children: not-inline
-      SVGSVGBox <svg> at (0,0) content-size 200x100 flex-item [SVG] children: not-inline
+      SVGSVGBox <svg> at (0,0) content-size 200x100 flex-item [SVG] children: inline
         SVGGeometryBox <rect> at (0,0) content-size 200x100 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/intrinsic-height-of-flex-container-with-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     Box <body> at (8,8) content-size 784x784 flex-container(column) [FFC] children: not-inline
-      SVGSVGBox <svg> at (8,8) content-size 784x784 flex-item [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 784x784 flex-item [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 392x392 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]

--- a/Tests/LibWeb/Layout/expected/flex/no-stretch-fit-width-for-item-that-can-resolve-aspect-ratio-through-height.txt
+++ b/Tests/LibWeb/Layout/expected/flex/no-stretch-fit-width-for-item-that-can-resolve-aspect-ratio-through-height.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x36 [BFC] children: not-inline
     Box <body> at (8,8) content-size 200x20 flex-container(row) [FFC] children: not-inline
-      SVGSVGBox <svg> at (8,8) content-size 20x20 flex-item [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 20x20 flex-item [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 10x10 children: not-inline
       BlockContainer <div> at (28,8) content-size 100x20 flex-item [BFC] children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.txt
+++ b/Tests/LibWeb/Layout/expected/flex/stretch-fit-width-for-column-layout-svg-item-that-only-has-natural-aspect-ratio.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     Box <body> at (8,8) content-size 784x784 flex-container(row) [FFC] children: not-inline
-      SVGSVGBox <svg> at (8,8) content-size 784x784 flex-item [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 784x784 flex-item [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 392x392 children: not-inline
       BlockContainer <(anonymous)> (not painted) [BFC] children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-percentage-max-size.txt
+++ b/Tests/LibWeb/Layout/expected/flex/svg-flex-item-with-percentage-max-size.txt
@@ -2,9 +2,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     Box <body> at (8,8) content-size 784x100 flex-container(row) [FFC] children: not-inline
       Box <div> at (8,8) content-size 100x100 flex-container(row) flex-item [FFC] children: not-inline
-        SVGSVGBox <svg.c-ico> at (8,8) content-size 100x100 flex-item [SVG] children: not-inline
-          SVGGraphicsBox <use> at (8,8) content-size 100x100 children: not-inline
-            SVGGraphicsBox <symbol#icon-cart> at (8,8) content-size 100x100 [BFC] children: not-inline
+        SVGSVGBox <svg.c-ico> at (8,8) content-size 100x100 flex-item [SVG] children: inline
+          SVGGraphicsBox <use> at (8,8) content-size 100x100 children: inline
+            SVGGraphicsBox <symbol#icon-cart> at (8,8) content-size 100x100 [BFC] children: inline
               SVGGeometryBox <rect> at (8,8) content-size 100x100 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/replaced-within-max-content.txt
+++ b/Tests/LibWeb/Layout/expected/replaced-within-max-content.txt
@@ -8,7 +8,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         ImageBox <img.replaced> at (8,8) content-size 150x150 children: not-inline
           (SVG-as-image isolated context)
           Viewport <#document> at (0,0) content-size 150x150 [BFC] children: not-inline
-            SVGSVGBox <svg> at (0,0) content-size 150x150 [SVG] children: not-inline
+            SVGSVGBox <svg> at (0,0) content-size 150x150 [SVG] children: inline
               SVGGeometryBox <path> at (0,0) content-size 150x150 children: not-inline
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
+++ b/Tests/LibWeb/Layout/expected/select-with-option-selected.txt
@@ -10,7 +10,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           BlockContainer <div> at (86.109375,10.5) content-size 16x16 flex-item [BFC] children: inline
             frag 0 from SVGSVGBox start: 0, length: 0, rect: [86.109375,10.5 16x16] baseline: 16
-            SVGSVGBox <svg> at (86.109375,10.5) content-size 16x16 [SVG] children: not-inline
+            SVGSVGBox <svg> at (86.109375,10.5) content-size 16x16 [SVG] children: inline
               SVGGeometryBox <path> at (90.109375,16.21875) content-size 8x4.953125 children: not-inline
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/svg-block-inside-inline-crash.txt
+++ b/Tests/LibWeb/Layout/expected/svg-block-inside-inline-crash.txt
@@ -1,0 +1,23 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x316 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x300 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x150 children: inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
+        SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
+          TextNode <#text>
+      BlockContainer <(anonymous)> at (8,158) content-size 784x0 children: not-inline continuation
+        SVGGraphicsBox <g> at (8,158) content-size 784x0 children: not-inline
+      BlockContainer <(anonymous)> at (8,158) content-size 784x150 children: inline
+        frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,158 300x150] baseline: 150
+        SVGSVGBox <svg> at (8,158) content-size 300x150 [SVG] children: not-inline continuation
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x316]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x300]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x150]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,8 300x150]
+      PaintableWithLines (BlockContainer(anonymous)) [8,158 784x0]
+        SVGGraphicsPaintable (SVGGraphicsBox<g>) [8,158 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,158 784x150]
+        SVGSVGPaintable (SVGSVGBox<svg>) [8,158 300x150]

--- a/Tests/LibWeb/Layout/expected/svg/natural-width-from-svg-attributes.txt
+++ b/Tests/LibWeb/Layout/expected/svg/natural-width-from-svg-attributes.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x144 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 128x128 children: not-inline
-      SVGSVGBox <svg> at (8,8) content-size 64x64 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 64x64 [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 64x64 children: not-inline
       BlockContainer <(anonymous)> at (8,72) content-size 128x0 children: inline
         TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
+++ b/Tests/LibWeb/Layout/expected/svg/objectBoundingBox-mask.txt
@@ -5,7 +5,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       SVGSVGBox <svg> at (8,8) content-size 400x400 [SVG] children: inline
         TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (8,8) content-size 200x200 children: not-inline
+        SVGGeometryBox <rect> at (8,8) content-size 200x200 children: inline
           SVGMaskBox <mask#myMask> at (8,8) content-size 200x200 children: inline
             TextNode <#text>
             SVGGeometryBox <rect> at (8,8) content-size 200x200 children: not-inline
@@ -13,7 +13,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             SVGGeometryBox <circle> at (26.75,26.75) content-size 162.5x162.5 children: not-inline
             TextNode <#text>
         TextNode <#text>
-        SVGGeometryBox <rect> at (208,208) content-size 200x100 children: not-inline
+        SVGGeometryBox <rect> at (208,208) content-size 200x100 children: inline
           SVGMaskBox <mask#myMask> at (208,208) content-size 200x100 children: inline
             TextNode <#text>
             SVGGeometryBox <rect> at (208,208) content-size 200x100 children: not-inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-as-image-implicit-viewbox.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       ImageBox <img> at (8,8) content-size 50x100 children: not-inline
         (SVG-as-image isolated context)
         Viewport <#document> at (0,0) content-size 50x100 [BFC] children: not-inline
-          SVGSVGBox <svg> at (0,0) content-size 50x100 [SVG] children: not-inline
+          SVGSVGBox <svg> at (0,0) content-size 50x100 [SVG] children: inline
             SVGGeometryBox <rect> at (0,0) content-size 50x100 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/svg/svg-circle-percentage-attr.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-circle-percentage-attr.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x366 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x350 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x350] baseline: 350
-      SVGSVGBox <svg> at (8,8) content-size 784x350 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 784x350 [SVG] children: inline
         SVGGeometryBox <circle> at (250,28) content-size 300x300 children: not-inline
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-fill-with-bogus-url.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784] baseline: 784
-      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]

--- a/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-inside-svg.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 24x24] baseline: 24
       SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: inline
         SVGGraphicsBox <g> at (8,8) content-size 24x24 children: inline
-          SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: not-inline
+          SVGSVGBox <svg> at (8,8) content-size 24x24 [SVG] children: inline
             SVGGeometryBox <rect> at (8,8) content-size 24x24 children: not-inline
         TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-intrinsic-size-in-one-dimension.txt
@@ -1,9 +1,9 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x170 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x154 children: not-inline
-      SVGSVGBox <svg> at (9,9) content-size 100x50 [SVG] children: not-inline
+      SVGSVGBox <svg> at (9,9) content-size 100x50 [SVG] children: inline
         SVGGeometryBox <rect> at (21.5,21.5) content-size 75x25 children: not-inline
-      SVGSVGBox <svg> at (9,61) content-size 200x100 [SVG] children: not-inline
+      SVGSVGBox <svg> at (9,61) content-size 200x100 [SVG] children: inline
         SVGGeometryBox <rect> at (34,86) content-size 150x50 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-negative-elliptical-arg-number.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
-      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
         SVGGeometryBox <path> at (8,10) content-size 100x48 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-path-with-implicit-lineto.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x100 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
-      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
         SVGGeometryBox <path> at (28,28) content-size 60x60 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-symbol-with-viewbox.txt
@@ -9,7 +9,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TextNode <#text>
         SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
           TextNode <#text>
-          SVGGraphicsBox <use> at (8,8) content-size 300x150 children: not-inline
+          SVGGraphicsBox <use> at (8,8) content-size 300x150 children: inline
             SVGGraphicsBox <symbol#braces> at (8,8) content-size 300x150 [BFC] children: inline
               TextNode <#text>
               SVGGeometryBox <path> at (92.375,26.75) content-size 131.25x112.15625 children: inline

--- a/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-use-element-crashtest.txt
@@ -4,7 +4,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
       SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
         TextNode <#text>
-        SVGGraphicsBox <use> at (8,8) content-size 300x150 children: not-inline
+        SVGGraphicsBox <use> at (8,8) content-size 300x150 children: inline
           SVGGraphicsBox <symbol#myid> at (8,8) content-size 300x150 [BFC] children: not-inline
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-css-variable-in-presentation-hint.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x118 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x102 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [9,9 100x100] baseline: 102
-      SVGSVGBox <svg> at (9,9) content-size 100x100 [SVG] children: not-inline
+      SVGSVGBox <svg> at (9,9) content-size 100x100 [SVG] children: inline
         SVGGeometryBox <rect> at (29,29) content-size 60x60 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]

--- a/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-with-display-block.txt
@@ -1,7 +1,7 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: not-inline
-      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 784x784 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]

--- a/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
+++ b/Tests/LibWeb/Layout/expected/svg/text-fill-none.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x150 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 300x150] baseline: 150
-      SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 300x150 [SVG] children: inline
         SVGTextBox <text> at (8,8) content-size 0x0 children: not-inline
       TextNode <#text>
 

--- a/Tests/LibWeb/Layout/expected/treat-intrinsic-sizing-keywords-as-auto-when-aspect-ratio-cant-be-resolved.txt
+++ b/Tests/LibWeb/Layout/expected/treat-intrinsic-sizing-keywords-as-auto-when-aspect-ratio-cant-be-resolved.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x800 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x784 children: inline
       frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 784x784] baseline: 784
-      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: not-inline
+      SVGSVGBox <svg> at (8,8) content-size 784x784 [SVG] children: inline
         SVGGeometryBox <rect> at (8,8) content-size 392x392 children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,0 800x800]

--- a/Tests/LibWeb/Layout/input/svg-block-inside-inline-crash.html
+++ b/Tests/LibWeb/Layout/input/svg-block-inside-inline-crash.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<svg>inline text <g style="display: block"></g></svg>


### PR DESCRIPTION
Prevents a crash when a block-level SVG box is inside an inline SVG box.
Fixes #3395.

This involves duplicating a very small amount of logic from `TreeBuilder::insert_node_into_inline_or_block_ancestor`, feel free to suggest ways to avoid that.