### PR TITLE
LibIPC: Restore `inline` attribute on IPC constexpr booleans

### DIFF
--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -384,7 +384,7 @@ void ArgsParser::print_version(FILE* file)
 {
     // FIXME: Allow applications to override version string for --version.
     //        Especially useful for Lagom applications
-    outln(file, Core::Version::read_long_version_string().release_value_but_fixme_should_propagate_errors());
+    outln(file, Core::Version::read_long_version_string());
 }
 
 void ArgsParser::add_option(Option&& option)

--- a/Libraries/LibCore/Version.cpp
+++ b/Libraries/LibCore/Version.cpp
@@ -10,7 +10,7 @@
 
 namespace Core::Version {
 
-ErrorOr<String> read_long_version_string()
+String read_long_version_string()
 {
     auto validate_git_hash = [](auto hash) {
         if (hash.length() < 4 || hash.length() > 40)

--- a/Libraries/LibCore/Version.h
+++ b/Libraries/LibCore/Version.h
@@ -11,6 +11,6 @@
 
 namespace Core::Version {
 
-ErrorOr<String> read_long_version_string();
+String read_long_version_string();
 
 }

--- a/Libraries/LibIPC/Concepts.h
+++ b/Libraries/LibIPC/Concepts.h
@@ -29,24 +29,24 @@ namespace Detail {
 
 // Cannot use SpecializationOf with these templates because they have non-type parameters. See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1985r3.pdf
 template<typename T>
-constexpr bool IsArray = false;
+constexpr inline bool IsArray = false;
 template<typename T, size_t N>
-constexpr bool IsArray<Array<T, N>> = true;
+constexpr inline bool IsArray<Array<T, N>> = true;
 
 template<typename T>
-constexpr bool IsVector = false;
+constexpr inline bool IsVector = false;
 template<typename T, size_t inline_capacity>
-constexpr bool IsVector<Vector<T, inline_capacity>> = true;
+constexpr inline bool IsVector<Vector<T, inline_capacity>> = true;
 
 template<typename T>
-constexpr bool IsHashMap = false;
+constexpr inline bool IsHashMap = false;
 template<typename K, typename V, typename KeyTraits, typename ValueTraits, bool IsOrdered>
-constexpr bool IsHashMap<HashMap<K, V, KeyTraits, ValueTraits, IsOrdered>> = true;
+constexpr inline bool IsHashMap<HashMap<K, V, KeyTraits, ValueTraits, IsOrdered>> = true;
 
 template<typename T>
-constexpr bool IsSharedSingleProducerCircularQueue = false;
+constexpr inline bool IsSharedSingleProducerCircularQueue = false;
 template<typename T, size_t Size>
-constexpr bool IsSharedSingleProducerCircularQueue<Core::SharedSingleProducerCircularQueue<T, Size>> = true;
+constexpr inline bool IsSharedSingleProducerCircularQueue<Core::SharedSingleProducerCircularQueue<T, Size>> = true;
 
 }
 


### PR DESCRIPTION
+ a  minorcleanup in LibCore