### PR TITLE
Inspector: Improve property filtering

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -293,7 +293,11 @@ details > :not(:first-child) {
     text-overflow: ellipsis;
 }
 
-.property-table tr:nth-child(even) {
+.hidden-row {
+    display: none;
+}
+
+.property-table tr:nth-child(even of :not(.hidden-row)) {
     background-color: var(--property-table-row);
 }
 

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -62,6 +62,14 @@ const selectTab = (tabButton, tabID, selectedTab, selectedTabButton) => {
     tab.style.display = "block";
     tabButton.classList.add("active");
 
+    // Apply any filtering if we have it
+    let filterInput = tab.querySelector(".property-filter");
+    let propertyTable = tab.querySelector(".property-table");
+    if (filterInput && propertyTable) {
+        filterInput.value = inspector.propertyFilterText || "";
+        filterInput.dispatchEvent(new InputEvent("input"));
+    }
+
     return tab;
 };
 
@@ -361,12 +369,12 @@ const setupPropertyFilter = inputId => {
     const filterInput = document.getElementById(`${inputId}-filter`);
 
     filterInput.addEventListener("input", event => {
-        const searchText = event.target.value.toLowerCase();
+        inspector.propertyFilterText = event.target.value.toLowerCase();
         const tbody = document.getElementById(`${inputId}-table`);
         const rows = tbody.getElementsByTagName("tr");
 
         for (let row of rows) {
-            applyPropertyFilter(row, searchText);
+            applyPropertyFilter(row, inspector.propertyFilterText);
         }
     });
 };
@@ -376,8 +384,6 @@ inspector.createPropertyTables = (computedStyle, resolvedStyle, customProperties
         let oldTable = document.getElementById(tableID);
         let newTable = document.createElement("tbody");
         newTable.setAttribute("id", tableID);
-
-        let searchText = oldTable.parentNode.parentNode.querySelector(".property-filter").value;
 
         Object.keys(properties)
             .sort((a, b) => {
@@ -403,8 +409,8 @@ inspector.createPropertyTables = (computedStyle, resolvedStyle, customProperties
                 let valueColumn = row.insertCell();
                 valueColumn.innerText = properties[name];
 
-                if (searchText) {
-                    applyPropertyFilter(row, searchText);
+                if (inspector.propertyFilterText) {
+                    applyPropertyFilter(row, inspector.propertyFilterText);
                 }
             });
 

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -337,9 +337,18 @@ inspector.setStyleSheetSource = (identifier, sourceBase64) => {
 };
 
 const applyPropertyFilter = (row, searchText) => {
-    const nameMatch = row.cells[0].textContent.toLowerCase().includes(searchText);
-    const valueMatch = row.cells[1].textContent.toLowerCase().includes(searchText);
-    let matches = nameMatch || valueMatch;
+    let matches = false;
+    if (searchText) {
+        for (let cell of row.cells) {
+            if (cell.textContent.toLowerCase().includes(searchText)) {
+                matches = true;
+                break;
+            }
+        }
+    } else {
+        // Empty searchText matches everything, so skip the checks.
+        matches = true;
+    }
 
     if (matches) {
         row.classList.remove("hidden-row");

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -336,6 +336,12 @@ inspector.setStyleSheetSource = (identifier, sourceBase64) => {
     styleSheetSource.innerHTML = decodeBase64(sourceBase64);
 };
 
+const applyPropertyFilter = (row, searchText) => {
+    const nameMatch = row.cells[0].textContent.toLowerCase().includes(searchText);
+    const valueMatch = row.cells[1].textContent.toLowerCase().includes(searchText);
+    row.style.display = nameMatch || valueMatch ? "" : "none";
+};
+
 const setupPropertyFilter = inputId => {
     const filterInput = document.getElementById(`${inputId}-filter`);
 
@@ -345,10 +351,7 @@ const setupPropertyFilter = inputId => {
         const rows = tbody.getElementsByTagName("tr");
 
         for (let row of rows) {
-            const nameMatch = row.cells[0].textContent.toLowerCase().includes(searchText);
-            const valueMatch = row.cells[1].textContent.toLowerCase().includes(searchText);
-
-            row.style.display = nameMatch || valueMatch ? "" : "none";
+            applyPropertyFilter(row, searchText);
         }
     });
 };
@@ -358,6 +361,8 @@ inspector.createPropertyTables = (computedStyle, resolvedStyle, customProperties
         let oldTable = document.getElementById(tableID);
         let newTable = document.createElement("tbody");
         newTable.setAttribute("id", tableID);
+
+        let searchText = oldTable.parentNode.parentNode.querySelector(".property-filter").value;
 
         Object.keys(properties)
             .sort((a, b) => {
@@ -382,6 +387,10 @@ inspector.createPropertyTables = (computedStyle, resolvedStyle, customProperties
 
                 let valueColumn = row.insertCell();
                 valueColumn.innerText = properties[name];
+
+                if (searchText) {
+                    applyPropertyFilter(row, searchText);
+                }
             });
 
         oldTable.parentNode.replaceChild(newTable, oldTable);

--- a/Base/res/ladybird/inspector.js
+++ b/Base/res/ladybird/inspector.js
@@ -339,7 +339,13 @@ inspector.setStyleSheetSource = (identifier, sourceBase64) => {
 const applyPropertyFilter = (row, searchText) => {
     const nameMatch = row.cells[0].textContent.toLowerCase().includes(searchText);
     const valueMatch = row.cells[1].textContent.toLowerCase().includes(searchText);
-    row.style.display = nameMatch || valueMatch ? "" : "none";
+    let matches = nameMatch || valueMatch;
+
+    if (matches) {
+        row.classList.remove("hidden-row");
+    } else {
+        row.classList.add("hidden-row");
+    }
 };
 
 const setupPropertyFilter = inputId => {


### PR DESCRIPTION
A few tweaks to make the new filtering feature feel nicer to use:

- Keep property filter across tabs
- Do less work when filtering properties
- Preserve zebra-striping when hiding table rows
- Keep current property filter when switching selected node