### PR TITLE
LibWeb: Initialize AnalyserNode previous block at construction time

### DIFF
--- a/Tests/LibWeb/Crash/WebAudio/AnalyserNode-previous-block-initialization.html
+++ b/Tests/LibWeb/Crash/WebAudio/AnalyserNode-previous-block-initialization.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<script>
+    const context = new OfflineAudioContext(1, 1, 44100)
+    const analyser = context.createAnalyser()
+    const dataArray = new Float32Array(analyser.frequencyBinCount)
+    analyser.getFloatFrequencyData(dataArray);
+</script>


### PR DESCRIPTION
Previously, we attempted to read from `m_previous_block` without initializing it to the correct size.