### PR TITLE
LibWeb: Implement more things needed for Youtube

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.cpp
@@ -173,6 +173,18 @@ GC::Ref<TimeRanges> HTMLMediaElement::buffered() const
     return realm.create<TimeRanges>(realm);
 }
 
+// https://html.spec.whatwg.org/multipage/media.html#dom-media-played
+GC::Ref<TimeRanges> HTMLMediaElement::played() const
+{
+    auto& realm = this->realm();
+
+    // The played attribute must return a new static normalized TimeRanges object that represents the ranges of points on the media timeline of the media resource reached through the
+    // usual monotonic increase of the current playback position during normal playback, if any, at the time the attribute is evaluated.
+    auto time_ranges = realm.create<TimeRanges>(realm);
+    // FIXME: Actually add the correct ranges
+    return time_ranges;
+}
+
 // https://html.spec.whatwg.org/multipage/media.html#dom-navigator-canplaytype
 Bindings::CanPlayTypeResult HTMLMediaElement::can_play_type(StringView type) const
 {

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -57,6 +57,7 @@ public:
     NetworkState network_state() const { return m_network_state; }
 
     [[nodiscard]] GC::Ref<TimeRanges> buffered() const;
+    [[nodiscard]] GC::Ref<TimeRanges> played() const;
 
     static inline constexpr auto supported_video_subtypes = Array {
         "webm"sv,

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.h
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.h
@@ -58,6 +58,7 @@ public:
 
     [[nodiscard]] GC::Ref<TimeRanges> buffered() const;
     [[nodiscard]] GC::Ref<TimeRanges> played() const;
+    [[nodiscard]] GC::Ref<TimeRanges> seekable() const;
 
     static inline constexpr auto supported_video_subtypes = Array {
         "webm"sv,

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -62,7 +62,7 @@ interface HTMLMediaElement : HTMLElement {
     attribute double defaultPlaybackRate;
     attribute double playbackRate;
     [FIXME] attribute boolean preservesPitch;
-    [FIXME] readonly attribute TimeRanges played;
+    readonly attribute TimeRanges played;
     [FIXME] readonly attribute TimeRanges seekable;
     readonly attribute boolean ended;
     [Reflect, CEReactions] attribute boolean autoplay;

--- a/Libraries/LibWeb/HTML/HTMLMediaElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLMediaElement.idl
@@ -63,7 +63,7 @@ interface HTMLMediaElement : HTMLElement {
     attribute double playbackRate;
     [FIXME] attribute boolean preservesPitch;
     readonly attribute TimeRanges played;
-    [FIXME] readonly attribute TimeRanges seekable;
+    readonly attribute TimeRanges seekable;
     readonly attribute boolean ended;
     [Reflect, CEReactions] attribute boolean autoplay;
     [Reflect, CEReactions] attribute boolean loop;

--- a/Libraries/LibWeb/HTML/TimeRanges.cpp
+++ b/Libraries/LibWeb/HTML/TimeRanges.cpp
@@ -27,24 +27,44 @@ void TimeRanges::initialize(JS::Realm& realm)
 // https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-length
 size_t TimeRanges::length() const
 {
-    // FIXME: The length IDL attribute must return the number of ranges represented by the object.
-    return 0;
+    return m_ranges.size();
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-start
-double TimeRanges::start(u32) const
+WebIDL::ExceptionOr<double> TimeRanges::start(u32 index) const
 {
-    // FIXME: The start(index) method must return the position of the start of the indexth range represented by the object,
-    //        in seconds measured from the start of the timeline that the object covers.
-    return 0.0;
+    // These methods must throw "IndexSizeError" DOMExceptions if called with an index argument greater than or equal to the number of ranges represented by the object.
+    if (index >= m_ranges.size())
+        return WebIDL::IndexSizeError::create(realm(), "Index argument is greater than or equal to the number of ranges represented by this TimeRanges object"_string);
+
+    // The start(index) method must return the position of the start of the indexth range represented by the object,
+    // in seconds measured from the start of the timeline that the object covers.
+    return m_ranges[index].start;
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-end
-double TimeRanges::end(u32) const
+WebIDL::ExceptionOr<double> TimeRanges::end(u32 index) const
 {
-    // FIXME: The end(index) method must return the position of the end of the indexth range represented by the object,
-    //        in seconds measured from the start of the timeline that the object covers.
-    return 0.0;
+    // These methods must throw "IndexSizeError" DOMExceptions if called with an index argument greater than or equal to the number of ranges represented by the object.
+    if (index >= m_ranges.size())
+        return WebIDL::IndexSizeError::create(realm(), "Index argument is greater than or equal to the number of ranges represented by this TimeRanges object"_string);
+
+    // The end(index) method must return the position of the end of the indexth range represented by the object,
+    // in seconds measured from the start of the timeline that the object covers.
+    return m_ranges[index].end;
+}
+
+void TimeRanges::add_range(double start, double end)
+{
+    m_ranges.append({ start, end });
+}
+bool TimeRanges::in_range(double point)
+{
+    for (auto range : m_ranges) {
+        if (point >= range.start && point <= range.end)
+            return true;
+    }
+    return false;
 }
 
 }

--- a/Libraries/LibWeb/HTML/TimeRanges.h
+++ b/Libraries/LibWeb/HTML/TimeRanges.h
@@ -8,22 +8,39 @@
 
 #include <LibJS/Forward.h>
 #include <LibWeb/Bindings/PlatformObject.h>
+#include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {
 
+// https://html.spec.whatwg.org/multipage/media.html#time-ranges
 class TimeRanges final : public Bindings::PlatformObject {
     WEB_PLATFORM_OBJECT(TimeRanges, Bindings::PlatformObject);
     GC_DECLARE_ALLOCATOR(TimeRanges);
 
 public:
+    // https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-length
     size_t length() const;
-    double start(u32 index) const;
-    double end(u32 index) const;
+
+    // https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-start
+    WebIDL::ExceptionOr<double> start(u32 index) const;
+
+    // https://html.spec.whatwg.org/multipage/media.html#dom-timeranges-end
+    WebIDL::ExceptionOr<double> end(u32 index) const;
+
+    void add_range(double start, double end);
+    bool in_range(double);
 
 private:
     explicit TimeRanges(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
+
+    struct Range {
+        double start;
+        double end;
+    };
+
+    Vector<Range> m_ranges;
 };
 
 }


### PR DESCRIPTION
This implements `HTMLMediaElement.seekable()`, all features of [TimeRanges](https://html.spec.whatwg.org/multipage/media.html#time-ranges), and a stub for `HTMLMediaElement.played()`.

Youtube tries to access all of these when loading a video, though I don't think this actually gets us closer to actually playing the video.

The [web platform test for this](https://wpt.live/media-source/mediasource-seekable.html) still fails for unrelated reasons, so I haven't imported it.