### PR TITLE
LibJS: Fix bytecode generation for super property stores and loads

### DIFF
--- a/Libraries/LibJS/Tests/classes/class-inheritance.js
+++ b/Libraries/LibJS/Tests/classes/class-inheritance.js
@@ -181,6 +181,16 @@ test("Issue #7044, super property access before super() call", () => {
     new Foo();
 });
 
+test("super property load and store by identifier", () => {
+    class Foo {
+        constructor() {
+            super.bar += "1337";
+        }
+    }
+
+    new Foo();
+});
+
 test("Issue #8574, super property access before super() call", () => {
     var hit = false;
 


### PR DESCRIPTION
This snippet crashes during bytecode generation due to `emit_super_reference` not correctly generating the reference record for the property access.

```js
class Foo {
    constructor() {
        super.bar += "1337";
    }
}

new Foo();
```