### PR TITLE
LibWeb: Prevent crash with custom cursor

### DIFF
--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -953,6 +953,9 @@ ContentVisibility ComputedProperties::content_visibility() const
 Cursor ComputedProperties::cursor() const
 {
     auto const& value = property(PropertyID::Cursor);
+    // FIXME: We don't currently support custom cursors.
+    if (value.is_url())
+        return Cursor::Auto;
     return keyword_to_cursor(value.to_keyword()).release_value();
 }
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -83,12 +83,9 @@ static bool parent_element_for_event_dispatch(Painting::Paintable& paintable, GC
     return node && layout_node;
 }
 
-static Gfx::StandardCursor cursor_css_to_gfx(Optional<CSS::Cursor> cursor)
+static Gfx::StandardCursor cursor_css_to_gfx(CSS::Cursor cursor)
 {
-    if (!cursor.has_value()) {
-        return Gfx::StandardCursor::None;
-    }
-    switch (cursor.value()) {
+    switch (cursor) {
     case CSS::Cursor::Crosshair:
     case CSS::Cursor::Cell:
         return Gfx::StandardCursor::Crosshair;


### PR DESCRIPTION
Fixes #3567.

We don't support url/custom cursors, use the default instead of crashing. 
Also clean up a bit of dead code from when Cursor was optional.