### PR TITLE
LibWeb: Make a elements honor base element's target

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -152,6 +152,7 @@ public:
 
     void update_base_element(Badge<HTML::HTMLBaseElement>);
     GC::Ptr<HTML::HTMLBaseElement const> first_base_element_with_href_in_tree_order() const;
+    GC::Ptr<HTML::HTMLBaseElement const> first_base_element_with_target_in_tree_order() const;
 
     String url_string() const { return m_url.to_string(); }
     String document_uri() const { return url_string(); }
@@ -1022,8 +1023,9 @@ private:
     // https://w3c.github.io/selection-api/#dfn-selection
     GC::Ptr<Selection::Selection> m_selection;
 
-    // NOTE: This is a cache to make finding the first <base href> element O(1).
+    // NOTE: This is a cache to make finding the first <base href> or <base target> element O(1).
     GC::Ptr<HTML::HTMLBaseElement const> m_first_base_element_with_href_in_tree_order;
+    GC::Ptr<HTML::HTMLBaseElement const> m_first_base_element_with_target_in_tree_order;
 
     // https://html.spec.whatwg.org/multipage/images.html#list-of-available-images
     GC::Ptr<HTML::ListOfAvailableImages> m_list_of_available_images;

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -948,8 +948,10 @@ String HTMLElement::get_an_elements_target(Optional<String> target) const
         if (auto maybe_target = attribute(AttributeNames::target); maybe_target.has_value()) {
             target = maybe_target.release_value();
         }
-        // FIXME: 2. Otherwise, if element's node document contains a base element with a target attribute,
+        // 2. Otherwise, if element's node document contains a base element with a target attribute,
         //    set target to the value of the target attribute of the first such base element.
+        if (auto base_element = document().first_base_element_with_target_in_tree_order())
+            target = base_element->attribute(AttributeNames::target);
     }
 
     // 2. If target is not null, and contains an ASCII tab or newline and a U+003C (<), then set target to "_blank".

--- a/Tests/LibWeb/Text/data/base/a-element-target-sub-alt.html
+++ b/Tests/LibWeb/Text/data/base/a-element-target-sub-alt.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+SUCCESS!

--- a/Tests/LibWeb/Text/data/base/a-element-target-sub-sub.html
+++ b/Tests/LibWeb/Text/data/base/a-element-target-sub-sub.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<base target="_parent">
+<a id="a" href="a-element-target-sub-alt.html">Click me!</a>

--- a/Tests/LibWeb/Text/data/base/a-element-target-sub.html
+++ b/Tests/LibWeb/Text/data/base/a-element-target-sub.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<iframe id="frame" src="a-element-target-sub-sub.html"></iframe>

--- a/Tests/LibWeb/Text/expected/base/a-element-target.txt
+++ b/Tests/LibWeb/Text/expected/base/a-element-target.txt
@@ -1,0 +1,1 @@
+Parent frame navigated successfully!

--- a/Tests/LibWeb/Text/input/base/a-element-target.html
+++ b/Tests/LibWeb/Text/input/base/a-element-target.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<iframe id="frame" src="../../data/base/a-element-target-sub.html"></iframe>
+<script>
+    asyncTest(done => {
+        window.onload = () => {
+            frame.onload = () => {
+                frame.onload = () => {
+                    println(frame.contentDocument.location.href.includes("a-element-target-sub-alt.html")? "Parent frame navigated successfully!" : "Parent frame incorrectly navigated to " + frame.contentDocument.location.href);
+                    done();
+                }
+            }
+            frame.contentDocument.getElementById("frame").contentDocument.getElementById("a").click();
+        };
+    });
+</script>


### PR DESCRIPTION
This makes [johnvertisements](https://john.citrons.xyz/) work properly in ladybird.