### PR TITLE
LibWeb: Fix steps for finding a navigable by target name

### DIFF
--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -518,7 +518,7 @@ GC::Ptr<Navigable> Navigable::find_a_navigable_by_target_name(StringView name)
     auto subtrees_to_search = current_document.inclusive_ancestor_navigables();
 
     // 4. For each subtreeToSearch of subtreesToSearch, in reverse order:
-    for (auto const& subtree_to_search : subtrees_to_search) {
+    for (auto const& subtree_to_search : subtrees_to_search.in_reverse()) {
         // 1. Let documentToSearch be subtreeToSearch's active document.
         auto& document_to_search = *subtree_to_search->active_document();
 


### PR DESCRIPTION
I have no idea how to test this, or what impact it has exactly, but it's definitely closer to what the spec asks us to do.