### PR TITLE
LibWeb/CSS: Use fallback var() value if custom property is empty

### DIFF
--- a/Tests/LibWeb/Text/expected/css/var-uses-fallback-value-if-custom-property-is-empty.txt
+++ b/Tests/LibWeb/Text/expected/css/var-uses-fallback-value-if-custom-property-is-empty.txt
@@ -1,0 +1,1 @@
+background-color: rgb(0, 128, 0)

--- a/Tests/LibWeb/Text/input/css/var-uses-fallback-value-if-custom-property-is-empty.html
+++ b/Tests/LibWeb/Text/input/css/var-uses-fallback-value-if-custom-property-is-empty.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<style>
+    :root {
+        --color-green: green;
+        --i: var(--invalid);
+        --dont: var(--invalid);
+        --exist: var(--invalid);
+        --but-i-do: var(--color-green);
+        --green-background-color: var(--i, var(--dont, var(--exist, var(--but-i-do))));
+    }
+    div {
+        width: 300px;
+        height: 300px;
+        background-color: red;
+    }
+    #box {
+        background-color: var(--green-background-color);
+    }
+</style>
+<div id="box"></div>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const box = document.getElementById("box");
+        const computedStyle = window.getComputedStyle(box);
+        println(`background-color: ${computedStyle.backgroundColor}`);
+    });
+</script>


### PR DESCRIPTION
If the expansion of a custom property in variable expansion returns tokens, then the custom property is not the initial guaranteed-invalid value.

If it didn't return any tokens, then it is the initial guaranteed-invalid value, and thus we should move on to the fallback value.

Makes Shopify checkout show the background colours, borders, skeletons, etc.

Before:
![Screenshot 2025-02-14 at 19 31 51](https://github.com/user-attachments/assets/4c1bc129-6e07-46c6-acf5-0535ca9d524e)

After:
![Screenshot 2025-02-14 at 19 32 55](https://github.com/user-attachments/assets/db28491a-3bc6-418b-9a6c-199ccb1be4b6)
