### PR TITLE
Meta+UI: Some fixes for Fedora Asahi 41

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,9 @@ if (ENABLE_QT AND ENABLE_GUI_TARGETS)
     find_package(Qt6 REQUIRED COMPONENTS Core Widgets Network)
 endif()
 
+# We need to find OpenSSL in order to link it explicitly with all targets.
+find_package(OpenSSL REQUIRED)
+
 include(CTest) # for BUILD_TESTING option, default ON
 
 if (ENABLE_GUI_TARGETS)

--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -26,6 +26,7 @@ target_include_directories(requestserverservice PRIVATE ${LADYBIRD_SOURCE_DIR}/S
 
 target_link_libraries(RequestServer PRIVATE requestserverservice)
 target_link_libraries(requestserverservice PUBLIC LibCore LibDNS LibMain LibCrypto LibFileSystem LibIPC LibMain LibTLS LibWebView LibWebSocket LibURL LibTextCodec LibThreading CURL::libcurl)
+target_link_libraries(requestserverservice PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
     # Solaris has socket and networking related functions in two extra libraries

--- a/Services/WebContent/CMakeLists.txt
+++ b/Services/WebContent/CMakeLists.txt
@@ -29,6 +29,7 @@ target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD
 target_include_directories(webcontentservice PUBLIC $<BUILD_INTERFACE:${LADYBIRD_SOURCE_DIR}/Services/>)
 
 target_link_libraries(webcontentservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibMedia LibWeb LibWebSocket LibRequests LibWebView LibImageDecoderClient LibGC)
+target_link_libraries(webcontentservice PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 if (ENABLE_QT)
     qt_add_executable(WebContent main.cpp)

--- a/Services/WebDriver/CMakeLists.txt
+++ b/Services/WebDriver/CMakeLists.txt
@@ -13,3 +13,4 @@ target_include_directories(WebDriver PRIVATE ${LADYBIRD_SOURCE_DIR})
 target_include_directories(WebDriver PRIVATE ${LADYBIRD_SOURCE_DIR}/Services)
 
 target_link_libraries(WebDriver PRIVATE LibCore LibFileSystem LibGfx LibIPC LibJS LibMain LibWeb LibWebSocket LibWebView)
+target_link_libraries(WebDriver PRIVATE OpenSSL::Crypto OpenSSL::SSL)

--- a/Services/WebWorker/CMakeLists.txt
+++ b/Services/WebWorker/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR})
 target_include_directories(webworkerservice PRIVATE ${LADYBIRD_SOURCE_DIR}/Services/)
 
 target_link_libraries(webworkerservice PUBLIC LibCore LibFileSystem LibGfx LibIPC LibJS LibRequests LibWeb LibWebView LibUnicode LibImageDecoderClient LibMain LibURL LibGC)
+target_link_libraries(webworkerservice PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 if (ENABLE_QT)
     qt_add_executable(WebWorker main.cpp)

--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -70,6 +70,7 @@ endif()
 
 set(LADYBIRD_LIBS AK LibCore LibFileSystem LibGfx LibImageDecoderClient LibIPC LibJS LibMain LibWeb LibWebView LibRequests LibURL)
 target_link_libraries(${LADYBIRD_TARGET} PRIVATE ${LADYBIRD_LIBS})
+target_link_libraries(${LADYBIRD_TARGET} PRIVATE OpenSSL::Crypto OpenSSL::SSL)
 
 target_include_directories(${LADYBIRD_TARGET} ${CMAKE_CURRENT_BINARY_DIR})
 target_include_directories(${LADYBIRD_TARGET} ${LADYBIRD_SOURCE_DIR})

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -479,7 +479,7 @@ ErrorOr<void> run_tests(Core::AnonymousBuffer const& theme, Web::DevicePixelSize
     TRY(collect_dump_tests(app, tests, ByteString::formatted("{}/Text", app.test_root_path), "."sv, TestMode::Text));
     TRY(collect_ref_tests(app, tests, ByteString::formatted("{}/Ref", app.test_root_path), "."sv));
     TRY(collect_crash_tests(app, tests, ByteString::formatted("{}/Crash", app.test_root_path), "."sv));
-#if !defined(AK_OS_MACOS)
+#if defined(AK_OS_LINUX) && ARCH(X86_64)
     TRY(collect_ref_tests(app, tests, ByteString::formatted("{}/Screenshot", app.test_root_path), "."sv));
 #endif
 


### PR DESCRIPTION
I pulled a commit from https://github.com/LadybirdBrowser/ladybird/pull/3571 to fix OpenSSL linkage on Fedora. That change fixes two WebCryptoAPI tests on any distro that has disabled SHA-1 in the distro-provided OpenSSL library.

The second commit establishes that yes, Screenshot tests are only reproducible on x86_64 Linux. And probably only with glibc as well, though I'll wait for someone with Alpine to verify that.