### PR TITLE
LibWeb: Schedule input event processing on HTML event loop

### DIFF
--- a/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
+++ b/Libraries/LibWeb/HTML/EventLoop/EventLoop.h
@@ -95,6 +95,7 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
+    void process_input_events() const;
     void update_the_rendering();
 
     Type m_type { Type::Window };

--- a/Libraries/LibWeb/Page/InputEvent.h
+++ b/Libraries/LibWeb/Page/InputEvent.h
@@ -85,6 +85,12 @@ struct DragEvent {
 
 using InputEvent = Variant<KeyEvent, MouseEvent, DragEvent>;
 
+struct QueuedInputEvent {
+    u64 page_id { 0 };
+    InputEvent event;
+    size_t coalesced_event_count { 0 };
+};
+
 }
 
 namespace IPC {

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -323,6 +323,8 @@ public:
     virtual void paint_next_frame() = 0;
     virtual void process_screenshot_requests() = 0;
     virtual void paint(DevicePixelRect const&, Painting::BackingStore&, PaintOptions = {}) = 0;
+    virtual Queue<QueuedInputEvent>& input_event_queue() = 0;
+    virtual void report_finished_handling_input_event(u64 page_id, EventResult event_was_handled) = 0;
     virtual void page_did_change_title(ByteString const&) { }
     virtual void page_did_change_url(URL::URL const&) { }
     virtual void page_did_request_refresh() { }

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.h
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.h
@@ -80,6 +80,8 @@ public:
     virtual void process_screenshot_requests() override { }
     virtual void paint(DevicePixelRect const&, Painting::BackingStore&, Web::PaintOptions = {}) override { }
     virtual bool is_ready_to_paint() const override { return true; }
+    virtual Queue<QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
+    virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] EventResult event_was_handled) override { }
 
     virtual DisplayListPlayerType display_list_player_type() const override { return m_host_page->client().display_list_player_type(); }
     virtual bool is_headless() const override { return m_host_page->client().is_headless(); }

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -47,6 +47,8 @@ public:
 
     Function<void(IPC::File const&)> on_image_decoder_connection;
 
+    Queue<Web::QueuedInputEvent>& input_event_queue() { return m_input_event_queue; }
+
 private:
     explicit ConnectionFromClient(GC::Heap&, IPC::Transport);
 
@@ -149,26 +151,15 @@ private:
 
     virtual void system_time_zone_changed() override;
 
-    void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled);
-
     GC::Heap& m_heap;
     NonnullOwnPtr<PageHost> m_page_host;
 
     HashMap<int, Web::FileRequest> m_requested_files {};
     int last_id { 0 };
 
-    struct QueuedInputEvent {
-        u64 page_id { 0 };
-        Web::InputEvent event;
-        size_t coalesced_event_count { 0 };
-    };
+    void enqueue_input_event(Web::QueuedInputEvent);
 
-    void enqueue_input_event(QueuedInputEvent);
-    void process_next_input_event();
-
-    Queue<QueuedInputEvent> m_input_event_queue;
-
-    GC::Root<Web::Platform::Timer> m_input_event_queue_timer;
+    Queue<Web::QueuedInputEvent> m_input_event_queue;
 };
 
 }

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -223,6 +223,16 @@ void PageClient::paint(Web::DevicePixelRect const& content_rect, Web::Painting::
     page().top_level_traversable()->paint(content_rect, target, paint_options);
 }
 
+Queue<Web::QueuedInputEvent>& PageClient::input_event_queue()
+{
+    return client().input_event_queue();
+}
+
+void PageClient::report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled)
+{
+    client().async_did_finish_handling_input_event(page_id, event_was_handled);
+}
+
 void PageClient::set_viewport_size(Web::DevicePixelSize const& size)
 {
     page().top_level_traversable()->set_viewport_size(page().device_to_css_size(size));

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -48,6 +48,9 @@ public:
     virtual void process_screenshot_requests() override;
     virtual void paint(Web::DevicePixelRect const& content_rect, Web::Painting::BackingStore&, Web::PaintOptions = {}) override;
 
+    virtual Queue<Web::QueuedInputEvent>& input_event_queue() override;
+    virtual void report_finished_handling_input_event(u64 page_id, Web::EventResult event_was_handled) override;
+
     void set_palette_impl(Gfx::PaletteImpl&);
     void set_viewport_size(Web::DevicePixelSize const&);
     void set_screen_rects(Vector<Web::DevicePixelRect, 4> const& rects, size_t main_screen_index) { m_screen_rect = rects[main_screen_index]; }

--- a/Services/WebWorker/PageHost.h
+++ b/Services/WebWorker/PageHost.h
@@ -38,6 +38,8 @@ public:
     virtual bool is_ready_to_paint() const override { return true; }
     virtual Web::DisplayListPlayerType display_list_player_type() const override { VERIFY_NOT_REACHED(); }
     virtual bool is_headless() const override { VERIFY_NOT_REACHED(); }
+    virtual Queue<Web::QueuedInputEvent>& input_event_queue() override { VERIFY_NOT_REACHED(); }
+    virtual void report_finished_handling_input_event([[maybe_unused]] u64 page_id, [[maybe_unused]] Web::EventResult event_was_handled) override { VERIFY_NOT_REACHED(); }
 
 private:
     explicit PageHost(ConnectionFromClient&);


### PR DESCRIPTION
Our existing coalescing mechanism for input events didn't prevent multiple mousemove/mousewheel events from being processed between paint cycles. Since handling these events can trigger style & layout updates solely for hit-testing purposes, we might end up doing work that won't be observable by a user and could be avoided by shceduling input events processing to happen right before painting the next frame.