### PR TITLE
LibURL: Further progress towards removal of URL::is_valid

### DIFF
--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -33,16 +33,12 @@ URL::URL(StringView string)
     }
 }
 
-URL URL::complete_url(StringView relative_url) const
+Optional<URL> URL::complete_url(StringView relative_url) const
 {
     if (!is_valid())
         return {};
 
-    auto result = Parser::basic_parse(relative_url, *this);
-    if (!result.has_value())
-        return {};
-
-    return result.release_value();
+    return Parser::basic_parse(relative_url, *this);
 }
 
 ByteString URL::path_segment_at_index(size_t index) const

--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -475,6 +475,16 @@ String percent_encode(StringView input, PercentEncodeSet set, SpaceAsPlus space_
     return MUST(builder.to_string());
 }
 
+URL URL::about(String path)
+{
+    URL url;
+    url.m_data->valid = true;
+    url.m_data->scheme = "about"_string;
+    url.m_data->paths = { move(path) };
+    url.m_data->cannot_be_a_base_url = true;
+    return url;
+}
+
 // https://url.spec.whatwg.org/#percent-decode
 ByteString percent_decode(StringView input)
 {

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -147,6 +147,8 @@ public:
     Optional<BlobURLEntry> const& blob_url_entry() const { return m_data->blob_url_entry; }
     void set_blob_url_entry(Optional<BlobURLEntry> entry) { m_data->blob_url_entry = move(entry); }
 
+    static URL about(String path);
+
 private:
     bool compute_validity() const;
 
@@ -210,6 +212,12 @@ URL create_with_data(StringView mime_type, StringView payload, bool is_base64 = 
 
 bool is_public_suffix(StringView host);
 Optional<String> get_public_suffix(StringView host);
+
+inline URL about_blank() { return URL::about("blank"_string); }
+inline URL about_srcdoc() { return URL::about("srcdoc"_string); }
+inline URL about_error() { return URL::about("error"_string); }
+inline URL about_version() { return URL::about("version"_string); }
+inline URL about_newtab() { return URL::about("newtab"_string); }
 
 }
 

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -135,7 +135,7 @@ public:
 
     bool equals(URL const& other, ExcludeFragment = ExcludeFragment::No) const;
 
-    URL complete_url(StringView) const;
+    Optional<URL> complete_url(StringView) const;
 
     [[nodiscard]] bool operator==(URL const& other) const
     {

--- a/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -45,8 +45,8 @@ WebIDL::ExceptionOr<GC::Ref<CSSStyleSheet>> CSSStyleSheet::construct_impl(JS::Re
             sheet_location_url = sheet->location().release_value();
 
         // AD-HOC: This isn't explicitly mentioned in the specification, but multiple modern browsers do this.
-        URL::URL url = sheet->location().has_value() ? sheet_location_url->complete_url(options->base_url.value()) : options->base_url.value();
-        if (!url.is_valid())
+        Optional<URL::URL> url = sheet->location().has_value() ? sheet_location_url->complete_url(options->base_url.value()) : options->base_url.value();
+        if (!url.has_value())
             return WebIDL::NotAllowedError::create(realm, "Constructed style sheets must have a valid base URL"_string);
 
         sheet->set_base_url(url);

--- a/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1761,7 +1761,7 @@ bool Parser::is_parsing_svg_presentation_attribute() const
 
 // https://www.w3.org/TR/css-values-4/#relative-urls
 // FIXME: URLs shouldn't be completed during parsing, but when used.
-URL::URL Parser::complete_url(StringView relative_url) const
+Optional<URL::URL> Parser::complete_url(StringView relative_url) const
 {
     return m_url.complete_url(relative_url);
 }

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -460,7 +460,7 @@ private:
     JS::Realm& realm() const;
     bool in_quirks_mode() const;
     bool is_parsing_svg_presentation_attribute() const;
-    URL::URL complete_url(StringView) const;
+    Optional<URL::URL> complete_url(StringView) const;
 
     GC::Ptr<DOM::Document const> m_document;
     GC::Ptr<JS::Realm> m_realm;

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2470,7 +2470,7 @@ Optional<URL::URL> Parser::parse_url_function(TokenStream<ComponentValue>& token
 
     auto convert_string_to_url = [&](StringView url_string) -> Optional<URL::URL> {
         auto url = complete_url(url_string);
-        if (url.is_valid()) {
+        if (url.has_value()) {
             transaction.commit();
             return url;
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -422,7 +422,7 @@ GC::Ref<Document> Document::create(JS::Realm& realm, URL::URL const& url)
 
 GC::Ref<Document> Document::create_for_fragment_parsing(JS::Realm& realm)
 {
-    return realm.create<Document>(realm, "about:blank"sv, TemporaryDocumentForFragmentParsing::Yes);
+    return realm.create<Document>(realm, URL::about_blank(), TemporaryDocumentForFragmentParsing::Yes);
 }
 
 Document::Document(JS::Realm& realm, const URL::URL& url, TemporaryDocumentForFragmentParsing temporary_document_for_fragment_parsing)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -103,7 +103,7 @@ public:
 
     static WebIDL::ExceptionOr<GC::Ref<Document>> create_and_initialize(Type, String content_type, HTML::NavigationParams const&);
 
-    [[nodiscard]] static GC::Ref<Document> create(JS::Realm&, URL::URL const& url = "about:blank"sv);
+    [[nodiscard]] static GC::Ref<Document> create(JS::Realm&, URL::URL const& url = URL::about_blank());
     [[nodiscard]] static GC::Ref<Document> create_for_fragment_parsing(JS::Realm&);
     static WebIDL::ExceptionOr<GC::Ref<Document>> construct_impl(JS::Realm&);
     virtual ~Document() override;

--- a/Libraries/LibWeb/DOM/DocumentLoading.h
+++ b/Libraries/LibWeb/DOM/DocumentLoading.h
@@ -33,7 +33,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     //    origin: origin
     //    opener policy: coop
     HTML::OpenerPolicyEnforcementResult coop_enforcement_result {
-        .url = URL::URL("about:error"), // AD-HOC
+        .url = URL::about_error(), // AD-HOC
         .origin = origin,
         .opener_policy = coop
     };
@@ -55,7 +55,7 @@ GC::Ref<DOM::Document> create_document_for_inline_content(GC::Ptr<HTML::Navigabl
     //    about base URL: null
     //    user involvement: userInvolvement
     auto response = Fetch::Infrastructure::Response::create(vm);
-    response->url_list().append(URL::URL("about:error")); // AD-HOC: https://github.com/whatwg/html/issues/9122
+    response->url_list().append(URL::about_error()); // AD-HOC: https://github.com/whatwg/html/issues/9122
     auto navigation_params = vm.heap().allocate<HTML::NavigationParams>();
     navigation_params->id = navigation_id;
     navigation_params->navigable = navigable;

--- a/Libraries/LibWeb/DOM/XMLDocument.h
+++ b/Libraries/LibWeb/DOM/XMLDocument.h
@@ -15,7 +15,7 @@ class XMLDocument final : public Document {
     GC_DECLARE_ALLOCATOR(XMLDocument);
 
 public:
-    static GC::Ref<XMLDocument> create(JS::Realm&, URL::URL const& url = "about:blank"sv);
+    static GC::Ref<XMLDocument> create(JS::Realm&, URL::URL const& url = URL::about_blank());
     virtual ~XMLDocument() override = default;
 
 private:

--- a/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -73,7 +73,7 @@ URL::Origin determine_the_origin(Optional<URL::URL const&> url, SandboxingFlagSe
     }
 
     // 3. If url is about:srcdoc, then:
-    if (url == "about:srcdoc"sv) {
+    if (url == URL::about_srcdoc()) {
         // 1. Assert: sourceOrigin is non-null.
         VERIFY(source_origin.has_value());
 
@@ -167,7 +167,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     SandboxingFlagSet sandbox_flags = {};
 
     // 7. Let origin be the result of determining the origin given about:blank, sandboxFlags, and creatorOrigin.
-    auto origin = determine_the_origin(URL::URL("about:blank"sv), sandbox_flags, creator_origin);
+    auto origin = determine_the_origin(URL::about_blank(), sandbox_flags, creator_origin);
 
     // FIXME: 8. Let permissionsPolicy be the result of creating a permissions policy given embedder and origin. [PERMISSIONSPOLICY]
 
@@ -192,7 +192,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
         });
 
     // 11. Let topLevelCreationURL be about:blank if embedder is null; otherwise embedder's relevant settings object's top-level creation URL.
-    auto top_level_creation_url = !embedder ? URL::URL("about:blank") : relevant_settings_object(*embedder).top_level_creation_url;
+    auto top_level_creation_url = !embedder ? URL::about_blank() : relevant_settings_object(*embedder).top_level_creation_url;
 
     // 12. Let topLevelOrigin be origin if embedder is null; otherwise embedder's relevant settings object's top-level origin.
     auto top_level_origin = !embedder ? origin : relevant_settings_object(*embedder).origin();
@@ -200,7 +200,7 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     // 13. Set up a window environment settings object with about:blank, realm execution context, null, topLevelCreationURL, and topLevelOrigin.
     WindowEnvironmentSettingsObject::setup(
         page,
-        URL::URL("about:blank"),
+        URL::about_blank(),
         move(realm_execution_context),
         {},
         top_level_creation_url,
@@ -271,8 +271,8 @@ WebIDL::ExceptionOr<BrowsingContext::BrowsingContextAndDocument> BrowsingContext
     }
 
     // 17. Assert: document's URL and document's relevant settings object's creation URL are about:blank.
-    VERIFY(document->url() == "about:blank"sv);
-    VERIFY(document->relevant_settings_object().creation_url == "about:blank"sv);
+    VERIFY(document->url() == URL::about_blank());
+    VERIFY(document->relevant_settings_object().creation_url == URL::about_blank());
 
     // 18. Mark document as ready for post-load tasks.
     document->set_ready_for_post_load_tasks(true);

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -194,7 +194,9 @@ String FormAssociatedElement::form_action() const
     }
 
     auto document_base_url = html_element.document().base_url();
-    return document_base_url.complete_url(form_action_attribute.value()).to_string();
+    if (auto maybe_url = document_base_url.complete_url(form_action_attribute.value()); maybe_url.has_value())
+        return maybe_url->to_string();
+    return {};
 }
 
 WebIDL::ExceptionOr<void> FormAssociatedElement::set_form_action(String const& value)

--- a/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBaseElement.cpp
@@ -74,12 +74,12 @@ void HTMLBaseElement::set_the_frozen_base_url()
 
     // 3. Set element's frozen base URL to document's fallback base URL, if urlRecord is failure or running Is base allowed for Document? on the resulting URL record and document returns "Blocked", and to urlRecord otherwise.
     // FIXME: Apply "Is base allowed for Document?" CSP
-    if (!url_record.is_valid()) {
+    if (!url_record.has_value()) {
         m_frozen_base_url = document.fallback_base_url();
         return;
     }
 
-    m_frozen_base_url = move(url_record);
+    m_frozen_base_url = url_record.release_value();
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href
@@ -96,11 +96,11 @@ String HTMLBaseElement::href() const
     auto url_record = document.fallback_base_url().complete_url(url);
 
     // 4. If urlRecord is failure, return url.
-    if (!url_record.is_valid())
+    if (!url_record.has_value())
         return url;
 
     // 5. Return the serialization of urlRecord.
-    return url_record.to_string();
+    return url_record->to_string();
 }
 
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-base-href

--- a/Libraries/LibWeb/HTML/HTMLDocument.h
+++ b/Libraries/LibWeb/HTML/HTMLDocument.h
@@ -21,7 +21,7 @@ class HTMLDocument final : public DOM::Document {
 public:
     virtual ~HTMLDocument() override;
 
-    [[nodiscard]] static GC::Ref<HTMLDocument> create(JS::Realm&, URL::URL const& url = "about:blank"sv);
+    [[nodiscard]] static GC::Ref<HTMLDocument> create(JS::Realm&, URL::URL const& url = URL::about_blank());
     WebIDL::ExceptionOr<GC::Ref<HTMLDocument>> construct_impl(JS::Realm&);
 
 private:

--- a/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -619,7 +619,9 @@ String HTMLFormElement::action() const
         return document().url_string();
     }
 
-    return document().base_url().complete_url(form_action_attribute.value()).to_string();
+    if (auto maybe_url = document().base_url().complete_url(form_action_attribute.value()); maybe_url.has_value())
+        return maybe_url->to_string();
+    return {};
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-fs-action

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -104,7 +104,7 @@ void HTMLIFrameElement::process_the_iframe_attributes(bool initial_insertion)
             // 1. Set element's lazy load resumption steps to the rest of this algorithm starting with the step labeled navigate to the srcdoc resource.
             set_lazy_load_resumption_steps([this]() {
                 // 3. Navigate to the srcdoc resource: navigate an iframe or frame given element, about:srcdoc, the empty string, and the value of element's srcdoc attribute.
-                navigate_an_iframe_or_frame(URL::URL("about:srcdoc"sv), ReferrerPolicy::ReferrerPolicy::EmptyString, get_attribute(HTML::AttributeNames::srcdoc));
+                navigate_an_iframe_or_frame(URL::about_srcdoc(), ReferrerPolicy::ReferrerPolicy::EmptyString, get_attribute(HTML::AttributeNames::srcdoc));
 
                 // FIXME: The resulting Document must be considered an iframe srcdoc document.
             });
@@ -120,7 +120,7 @@ void HTMLIFrameElement::process_the_iframe_attributes(bool initial_insertion)
         }
 
         // 3. Navigate to the srcdoc resource: navigate an iframe or frame given element, about:srcdoc, the empty string, and the value of element's srcdoc attribute.
-        navigate_an_iframe_or_frame(URL::URL("about:srcdoc"sv), ReferrerPolicy::ReferrerPolicy::EmptyString, get_attribute(HTML::AttributeNames::srcdoc));
+        navigate_an_iframe_or_frame(URL::about_srcdoc(), ReferrerPolicy::ReferrerPolicy::EmptyString, get_attribute(HTML::AttributeNames::srcdoc));
 
         // FIXME: The resulting Document must be considered an iframe srcdoc document.
 

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -112,7 +112,7 @@ URL::URL Location::url() const
     // A Location object has an associated url, which is this Location object's relevant Document's URL,
     // if this Location object's relevant Document is non-null, and about:blank otherwise.
     auto const relevant_document = this->relevant_document();
-    return relevant_document ? relevant_document->url() : "about:blank"sv;
+    return relevant_document ? relevant_document->url() : URL::about_blank();
 }
 
 // https://html.spec.whatwg.org/multipage/history.html#dom-location-href

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -625,7 +625,7 @@ static PolicyContainer determine_navigation_params_policy_container(URL::URL con
     }
 
     // 2. If responseURL is about:srcdoc, then:
-    if (response_url == "about:srcdoc"sv) {
+    if (response_url == URL::about_srcdoc()) {
         // 1. Assert: parentPolicyContainer is not null.
         VERIFY(parent_policy_container.has_value());
 
@@ -699,7 +699,7 @@ static GC::Ref<NavigationParams> create_navigation_params_from_a_srcdoc_resource
     //    header list: (`Content-Type`, `text/html`)
     //    body: the UTF-8 encoding of documentResource, as a body
     auto response = Fetch::Infrastructure::Response::create(vm);
-    response->url_list().append(URL::URL("about:srcdoc"));
+    response->url_list().append(URL::about_srcdoc());
 
     auto header = Fetch::Infrastructure::Header::from_string_pair("Content-Type"sv, "text/html"sv);
     response->header_list()->append(move(header));
@@ -1254,7 +1254,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
             auto error_html = load_error_page(entry->url(), error_message).release_value_but_fixme_should_propagate_errors();
             entry->document_state()->set_document(create_document_for_inline_content(this, navigation_id, user_involvement, [this, error_html](auto& document) {
                 auto parser = HTML::HTMLParser::create(document, error_html, "utf-8"sv);
-                document.set_url(URL::URL("about:error"));
+                document.set_url(URL::about_error());
                 parser->run();
 
                 // NOTE: Once the page has been set up, the user agent must act as if it had stopped parsing.

--- a/Libraries/LibWeb/HTML/NavigableContainer.cpp
+++ b/Libraries/LibWeb/HTML/NavigableContainer.cpp
@@ -203,7 +203,7 @@ Optional<URL::URL> NavigableContainer::shared_attribute_processing_steps_for_ifr
         return {};
 
     // 1. Let url be the URL record about:blank.
-    auto url = URL::URL("about:blank");
+    auto url = URL::about_blank();
 
     // 2. If element has a src attribute specified, and its value is not the empty string,
     //    then parse the value of that attribute relative to element's node document.

--- a/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -26,7 +26,7 @@ GC::Ref<ClassicScript> ClassicScript::create(ByteString filename, StringView sou
 
     // 1. If muted errors is true, then set baseURL to about:blank.
     if (muted_errors == MutedErrors::Yes)
-        base_url = "about:blank"sv;
+        base_url = URL::about_blank();
 
     // 2. If scripting is disabled for realm, then set source to the empty string.
     if (is_scripting_disabled(realm))

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -255,7 +255,7 @@ WebIDL::ExceptionOr<Window::OpenedWindow> Window::window_open_steps_internal(Str
 
         // 3. If urlRecord is null, then set urlRecord to a URL record representing about:blank.
         if (!url_record.has_value())
-            url_record = URL::URL("about:blank"sv);
+            url_record = URL::about_blank();
 
         // 4. If urlRecord matches about:blank, then perform the URL and history update steps given targetNavigable's active document and urlRecord.
         if (url_matches_about_blank(url_record.value())) {

--- a/Libraries/LibWeb/Page/Page.cpp
+++ b/Libraries/LibWeb/Page/Page.cpp
@@ -73,7 +73,7 @@ void Page::load_html(StringView html)
     // FIXME: #23909 Figure out why GC threshold does not stay low when repeatedly loading html from the WebView
     heap().collect_garbage();
 
-    (void)top_level_traversable()->navigate({ .url = "about:srcdoc"sv,
+    (void)top_level_traversable()->navigate({ .url = URL::about_srcdoc(),
         .source_document = *top_level_traversable()->active_document(),
         .document_resource = String::from_utf8(html).release_value_but_fixme_should_propagate_errors(),
         .user_involvement = HTML::UserNavigationInvolvement::BrowserUI });

--- a/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGTextPathElement.cpp
@@ -25,7 +25,9 @@ GC::Ptr<SVGGeometryElement const> SVGTextPathElement::path_or_shape() const
     if (!href.has_value())
         return {};
     auto url = document().url().complete_url(*href);
-    return try_resolve_url_to<SVGGeometryElement const>(url);
+    if (!url.has_value())
+        return {};
+    return try_resolve_url_to<SVGGeometryElement const>(*url);
 }
 
 void SVGTextPathElement::initialize(JS::Realm& realm)

--- a/Libraries/LibWeb/SVG/SVGUseElement.h
+++ b/Libraries/LibWeb/SVG/SVGUseElement.h
@@ -65,7 +65,7 @@ private:
     Optional<float> m_x;
     Optional<float> m_y;
 
-    URL::URL m_href;
+    Optional<URL::URL> m_href;
 
     GC::Ptr<DOM::DocumentObserver> m_document_observer;
     GC::Ptr<HTML::SharedResourceRequest> m_resource_request;

--- a/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
+++ b/Libraries/LibWeb/SecureContexts/AbstractOperations.cpp
@@ -72,7 +72,7 @@ Trustworthiness is_origin_potentially_trustworthy(URL::Origin const& origin)
 Trustworthiness is_url_potentially_trustworthy(URL::URL const& url)
 {
     // 1. If url is "about:blank" or "about:srcdoc", return "Potentially Trustworthy".
-    if (url == "about:blank"sv || url == "about:srcdoc"sv)
+    if (url == URL::about_blank() || url == URL::about_srcdoc())
         return Trustworthiness::PotentiallyTrustworthy;
 
     // 2. If url’s scheme is "data", return "Potentially Trustworthy".

--- a/Services/WebContent/PageHost.cpp
+++ b/Services/WebContent/PageHost.cpp
@@ -19,7 +19,7 @@ PageHost::PageHost(ConnectionFromClient& client)
     : m_client(client)
 {
     auto& first_page = create_page();
-    Web::HTML::TraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::URL("about:blank")).release_value_but_fixme_should_propagate_errors();
+    Web::HTML::TraversableNavigable::create_a_fresh_top_level_traversable(first_page.page(), URL::about_blank()).release_value_but_fixme_should_propagate_errors();
 }
 
 PageClient& PageHost::create_page()

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -195,10 +195,10 @@ TEST_CASE(file_url_serialization)
 
 TEST_CASE(file_url_relative)
 {
-    EXPECT_EQ(URL::URL("https://vkoskiv.com/index.html"sv).complete_url("/static/foo.js"sv).serialize(), "https://vkoskiv.com/static/foo.js");
-    EXPECT_EQ(URL::URL("file:///home/vkoskiv/test/index.html"sv).complete_url("/static/foo.js"sv).serialize(), "file:///static/foo.js");
-    EXPECT_EQ(URL::URL("https://vkoskiv.com/index.html"sv).complete_url("static/foo.js"sv).serialize(), "https://vkoskiv.com/static/foo.js");
-    EXPECT_EQ(URL::URL("file:///home/vkoskiv/test/index.html"sv).complete_url("static/foo.js"sv).serialize(), "file:///home/vkoskiv/test/static/foo.js");
+    EXPECT_EQ(URL::URL("https://vkoskiv.com/index.html"sv).complete_url("/static/foo.js"sv)->serialize(), "https://vkoskiv.com/static/foo.js");
+    EXPECT_EQ(URL::URL("file:///home/vkoskiv/test/index.html"sv).complete_url("/static/foo.js"sv)->serialize(), "file:///static/foo.js");
+    EXPECT_EQ(URL::URL("https://vkoskiv.com/index.html"sv).complete_url("static/foo.js"sv)->serialize(), "https://vkoskiv.com/static/foo.js");
+    EXPECT_EQ(URL::URL("file:///home/vkoskiv/test/index.html"sv).complete_url("static/foo.js"sv)->serialize(), "file:///home/vkoskiv/test/static/foo.js");
 }
 
 TEST_CASE(about_url)
@@ -243,10 +243,10 @@ TEST_CASE(mailto_url_with_subject)
 
 TEST_CASE(trailing_slash_with_complete_url)
 {
-    EXPECT_EQ(URL::URL("http://a/b/"sv).complete_url("c/"sv).serialize(), "http://a/b/c/");
-    EXPECT_EQ(URL::URL("http://a/b/"sv).complete_url("c"sv).serialize(), "http://a/b/c");
-    EXPECT_EQ(URL::URL("http://a/b"sv).complete_url("c/"sv).serialize(), "http://a/c/");
-    EXPECT_EQ(URL::URL("http://a/b"sv).complete_url("c"sv).serialize(), "http://a/c");
+    EXPECT_EQ(URL::URL("http://a/b/"sv).complete_url("c/"sv)->serialize(), "http://a/b/c/");
+    EXPECT_EQ(URL::URL("http://a/b/"sv).complete_url("c"sv)->serialize(), "http://a/b/c");
+    EXPECT_EQ(URL::URL("http://a/b"sv).complete_url("c/"sv)->serialize(), "http://a/c/");
+    EXPECT_EQ(URL::URL("http://a/b"sv).complete_url("c"sv)->serialize(), "http://a/c");
 }
 
 TEST_CASE(trailing_port)
@@ -297,15 +297,15 @@ TEST_CASE(create_with_file_scheme)
 TEST_CASE(complete_url)
 {
     URL::URL base_url("http://serenityos.org/index.html#fragment"sv);
-    URL::URL url = base_url.complete_url("test.html"sv);
-    EXPECT(url.is_valid());
-    EXPECT_EQ(url.scheme(), "http");
-    EXPECT_EQ(url.serialized_host(), "serenityos.org");
-    EXPECT_EQ(url.serialize_path(), "/test.html");
-    EXPECT(!url.query().has_value());
-    EXPECT_EQ(url.cannot_be_a_base_url(), false);
+    auto url = base_url.complete_url("test.html"sv);
+    EXPECT(url.has_value());
+    EXPECT_EQ(url->scheme(), "http");
+    EXPECT_EQ(url->serialized_host(), "serenityos.org");
+    EXPECT_EQ(url->serialize_path(), "/test.html");
+    EXPECT(!url->query().has_value());
+    EXPECT_EQ(url->cannot_be_a_base_url(), false);
 
-    EXPECT(base_url.complete_url("../index.html#fragment"sv).equals(base_url));
+    EXPECT(base_url.complete_url("../index.html#fragment"sv)->equals(base_url));
 }
 
 TEST_CASE(leading_whitespace)
@@ -385,8 +385,8 @@ TEST_CASE(complete_file_url_with_base)
     EXPECT_EQ(url.path_segment_at_index(1), "index.html");
 
     auto sub_url = url.complete_url("js/app.js"sv);
-    EXPECT(sub_url.is_valid());
-    EXPECT_EQ(sub_url.serialize_path(), "/home/js/app.js");
+    EXPECT(sub_url.has_value());
+    EXPECT_EQ(sub_url->serialize_path(), "/home/js/app.js");
 }
 
 TEST_CASE(empty_url_with_base_url)

--- a/Tests/LibWeb/TestFetchURL.cpp
+++ b/Tests/LibWeb/TestFetchURL.cpp
@@ -102,12 +102,12 @@ TEST_CASE(data_url_base64_encoded_with_inline_whitespace)
 TEST_CASE(data_url_completed_with_fragment)
 {
     auto url = URL::URL("data:text/plain,test"sv).complete_url("#a"sv);
-    EXPECT(url.is_valid());
-    EXPECT_EQ(url.scheme(), "data");
-    EXPECT_EQ(url.fragment(), "a");
-    EXPECT(!url.host().has_value());
+    EXPECT(url.has_value());
+    EXPECT_EQ(url->scheme(), "data");
+    EXPECT_EQ(url->fragment(), "a");
+    EXPECT(!url->host().has_value());
 
-    auto data_url = TRY_OR_FAIL(Web::Fetch::Infrastructure::process_data_url(url));
+    auto data_url = TRY_OR_FAIL(Web::Fetch::Infrastructure::process_data_url(*url));
     EXPECT_EQ(data_url.mime_type.serialized(), "text/plain");
     EXPECT_EQ(StringView(data_url.body.bytes()), "test"sv);
 }

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -180,7 +180,7 @@
         return;
     }
 
-    [self createNewTab:URL::URL("about:version"sv)
+    [self createNewTab:URL::URL(URL::about_version())
                fromTab:(Tab*)current_tab
            activateTab:Web::HTML::ActivateTab::Yes];
 }

--- a/UI/Headless/Test.cpp
+++ b/UI/Headless/Test.cpp
@@ -382,7 +382,7 @@ static void run_test(HeadlessWebView& view, Test& test, Application& app)
     auto promise = Core::Promise<Empty>::construct();
 
     view.on_load_finish = [promise](auto const& url) {
-        if (!url.equals("about:blank"sv))
+        if (!url.equals(URL::about_blank()))
             return;
 
         Core::deferred_invoke([promise]() {
@@ -411,7 +411,7 @@ static void run_test(HeadlessWebView& view, Test& test, Application& app)
         VERIFY_NOT_REACHED();
     });
 
-    view.load("about:blank"sv);
+    view.load(URL::about_blank());
 }
 
 static void set_ui_callbacks_for_tests(HeadlessWebView& view)

--- a/UI/Headless/main.cpp
+++ b/UI/Headless/main.cpp
@@ -63,7 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     WebView::platform_init();
 
-    auto app = Ladybird::Application::create(arguments, "about:newtab"sv);
+    auto app = Ladybird::Application::create(arguments, URL::about_newtab());
     TRY(app->launch_services());
 
     Core::ResourceImplementation::install(make<Core::ResourceImplementationFile>(MUST(String::from_byte_string(app->resources_folder))));


### PR DESCRIPTION
Leaving the main API left which relies  onURL::valid being the implicit String/StringView/ByteString constructor for URL.