### PR TITLE
Base: Revert usage of color-scheme in the Inspector

### DIFF
--- a/Base/res/ladybird/inspector.css
+++ b/Base/res/ladybird/inspector.css
@@ -4,6 +4,7 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
+        --background: rgb(23, 23, 23);
         --separator: dimgray;
         --separator-accent: rgb(57, 57, 57);
         --tab-controls: rgb(57, 57, 57);
@@ -29,6 +30,7 @@
 
 @media (prefers-color-scheme: light) {
     :root {
+        --background: white;
         --separator: lightgray;
         --separator-accent: white;
         --tab-controls: rgb(229, 229, 229);
@@ -52,7 +54,7 @@
 }
 
 html {
-    color-scheme: light dark;
+    background-color: var(--background);
 }
 
 body {
@@ -184,7 +186,7 @@ body {
     left: 0;
     right: 0;
     background-color: var(--tab-controls);
-    border-top: 2px solid Canvas;
+    border-top: 2px solid var(--background);
     display: flex;
     padding: 0.5em;
 }


### PR DESCRIPTION
IMO the default colors used by the dark color scheme do not look good in the Inspector window.

Before:
![before](https://github.com/user-attachments/assets/5441d18f-54f1-4646-b09d-5f2d8ade6c25)

After:
![after](https://github.com/user-attachments/assets/7d34a248-9f24-4676-96b2-ce175c9f82c8)
