### PR TITLE
LibUnicode: Fix off-by-one text length bounds check in segmenter

### DIFF
--- a/Libraries/LibUnicode/Segmenter.cpp
+++ b/Libraries/LibUnicode/Segmenter.cpp
@@ -183,14 +183,14 @@ private:
 
         return m_segmented_text.visit(
             [&](String const& text) -> Optional<i32> {
-                if (boundary >= text.byte_count())
+                if (boundary > text.byte_count())
                     return {};
 
                 U8_SET_CP_START(text.bytes().data(), 0, icu_boundary);
                 return icu_boundary;
             },
             [&](icu::UnicodeString const& text) -> Optional<i32> {
-                if (icu_boundary >= text.length())
+                if (icu_boundary > text.length())
                     return {};
 
                 return text.getChar32Start(icu_boundary);

--- a/Tests/LibUnicode/TestSegmenter.cpp
+++ b/Tests/LibUnicode/TestSegmenter.cpp
@@ -136,10 +136,10 @@ TEST_CASE(out_of_bounds)
         auto segmenter = Unicode::Segmenter::create(Unicode::SegmenterGranularity::Word);
         segmenter->set_segmented_text(text);
 
-        auto result = segmenter->previous_boundary(text.byte_count());
+        auto result = segmenter->previous_boundary(text.byte_count() + 1);
         EXPECT(!result.has_value());
 
-        result = segmenter->next_boundary(text.byte_count());
+        result = segmenter->next_boundary(text.byte_count() + 1);
         EXPECT(!result.has_value());
     }
     {
@@ -148,10 +148,10 @@ TEST_CASE(out_of_bounds)
         auto segmenter = Unicode::Segmenter::create(Unicode::SegmenterGranularity::Word);
         segmenter->set_segmented_text(Utf16View { text });
 
-        auto result = segmenter->previous_boundary(text.size());
+        auto result = segmenter->previous_boundary(text.size() + 1);
         EXPECT(!result.has_value());
 
-        result = segmenter->next_boundary(text.size());
+        result = segmenter->next_boundary(text.size() + 1);
         EXPECT(!result.has_value());
     }
 }

--- a/Tests/LibWeb/Text/expected/HTML/FormAssociatedElement-caret-bounds.txt
+++ b/Tests/LibWeb/Text/expected/HTML/FormAssociatedElement-caret-bounds.txt
@@ -1,0 +1,6 @@
+Initial caret position for input: 0
+Caret position after pressing right for input: 1
+Caret position after pressing left for input: 0
+Initial caret position for textarea: 0
+Caret position after pressing right for textarea: 1
+Caret position after pressing left for textarea: 0

--- a/Tests/LibWeb/Text/input/HTML/FormAssociatedElement-caret-bounds.html
+++ b/Tests/LibWeb/Text/input/HTML/FormAssociatedElement-caret-bounds.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<input type="text" value="a">
+<textarea>a</textarea>
+<script>
+    test(() => {
+        function printCaretPosition(element, description) {
+            println(`${description} for ${element.tagName.toLocaleLowerCase()}: ${element.selectionStart}`);
+        }
+
+        for (const textControl of ["input", "textarea"]) {
+            const element = document.querySelector(textControl);
+            element.focus();
+            printCaretPosition(element, "Initial caret position");
+            internals.sendKey(element, "Right");
+            printCaretPosition(element, "Caret position after pressing right");
+            internals.sendKey(element, "Left");
+            printCaretPosition(element, "Caret position after pressing left");
+        }
+    });
+</script>


### PR DESCRIPTION
Previously, moving the caret to the end of a text control then attempting to move it back again would fail because an overly aggressive bounds check in LibUnicode's segmenter would cause an invalid early return.