### PR TITLE
RequestServer: Remove IPV6 bracket notation on host before resolving

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -353,6 +353,11 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString const& metho
     }
 
     auto host = url.serialized_host().to_byte_string();
+
+    // Check if host has the bracket notation for IPV6 addresses and remove them
+    if (host.starts_with("["sv) && host.ends_with("]"sv))
+        host = host.substring(1, host.length() - 2);
+
     m_resolver->dns.lookup(host, DNS::Messages::Class::IN, { DNS::Messages::ResourceType::A, DNS::Messages::ResourceType::AAAA })
         ->when_rejected([this, request_id](auto const& error) {
             dbgln("StartRequest: DNS lookup failed: {}", error);


### PR DESCRIPTION
Previously, we were passing in the serialized value which included square brackets but that isn't a valid IPV6 address.

Partially addresses #3596