### PR TITLE
IPCCompiler: Allow arguments that are not default-constructible

### DIFF
--- a/Libraries/LibIPC/Message.h
+++ b/Libraries/LibIPC/Message.h
@@ -69,7 +69,6 @@ public:
     virtual u32 endpoint_magic() const = 0;
     virtual int message_id() const = 0;
     virtual char const* message_name() const = 0;
-    virtual bool valid() const = 0;
     virtual ErrorOr<MessageBuffer> encode() const = 0;
 
 protected:

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -345,7 +345,6 @@ public:)~~~");
    typedef class @message.response_type@ ResponseType;)~~~");
 
     message_generator.appendln(R"~~~(
-    @message.pascal_name@(decltype(nullptr)) : m_ipc_message_valid(false) { }
     @message.pascal_name@(@message.pascal_name@ const&) = default;
     @message.pascal_name@(@message.pascal_name@&&) = default;
     @message.pascal_name@& operator=(@message.pascal_name@ const&) = default;
@@ -412,12 +411,8 @@ public:)~~~");
     })~~~");
 
     message_generator.appendln(R"~~~(
-    virtual bool valid() const override { return m_ipc_message_valid; }
-
     virtual ErrorOr<IPC::MessageBuffer> encode() const override
     {
-        VERIFY(valid());
-
         IPC::MessageBuffer buffer;
         IPC::Encoder stream(buffer);
         TRY(stream.encode(endpoint_magic()));
@@ -445,8 +440,7 @@ public:)~~~");
     }
 
     message_generator.appendln(R"~~~(
-private:
-    bool m_ipc_message_valid { true };)~~~");
+private:)~~~");
 
     for (auto const& parameter : parameters) {
         auto parameter_generator = message_generator.fork();
@@ -715,8 +709,6 @@ public:
                     message_generator.appendln(R"~~~(
             [[maybe_unused]] auto& request = static_cast<const Messages::@endpoint.name@::@message.pascal_name@&>(message);
             auto response = @handler_name@(@arguments@);
-            if (!response.valid())
-                return Error::from_string_literal("Failed to handle @endpoint.name@::@message.pascal_name@ message");
             return make<IPC::MessageBuffer>(TRY(response.encode()));)~~~");
                 }
             } else {

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -447,7 +447,7 @@ private:)~~~");
         parameter_generator.set("parameter.type", parameter.type);
         parameter_generator.set("parameter.name", parameter.name);
         parameter_generator.appendln(R"~~~(
-    @parameter.type@ m_@parameter.name@ {};)~~~");
+    @parameter.type@ m_@parameter.name@;)~~~");
     }
 
     message_generator.appendln("\n};");


### PR DESCRIPTION
Previously, all IPC message structs would initialize their members with `{}` so that they would still have a value if the message was invalid. However, we don't ever construct invalid messages, so we can remove the code for constructing them and checking their validity; and then also remove this `{}` initialization. That means something like `Variant<int, String>` can now be sent over IPC.