### PR TITLE
AK: Modify IntrusiveRedBlackTree for Windows

### DIFF
--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -174,7 +174,14 @@ private:
 
     static V* node_to_value(TreeNode& node)
     {
+#ifdef AK_OS_WINDOWS
+        // NOTE: https://learn.microsoft.com/en-us/cpp/build/reference/vmb-vmg-representation-method?view=msvc-170
+        static_assert(sizeof(member) == 4);
+        auto distance = bit_cast<u8*>(static_cast<FlatPtr>(bit_cast<u32>(member)));
+        return bit_cast<V*>(bit_cast<u8*>(&node) - distance);
+#else
         return bit_cast<V*>(bit_cast<u8*>(&node) - bit_cast<u8*>(member));
+#endif
     }
 };
 


### PR DESCRIPTION
IntrusiveRedBlackTree relies on a member pointer for accessing the value of a node. On windows member pointers can be of variable lenght, depending on the inheritance structure of the class. This commit casts the 4 byte member pointer, or rather offset to a full pointer type, so that the bit_cast to u8* works, as previously the source was smaller than the destination, which triggers a static_assert().