### PR TITLE
LibWeb: Store final box model metrics in paint tree, not layout tree

### DIFF
--- a/Libraries/LibWeb/CMakeLists.txt
+++ b/Libraries/LibWeb/CMakeLists.txt
@@ -554,7 +554,6 @@ set(SOURCES
     Layout/BlockContainer.cpp
     Layout/BlockFormattingContext.cpp
     Layout/Box.cpp
-    Layout/BoxModelMetrics.cpp
     Layout/BreakNode.cpp
     Layout/CanvasBox.cpp
     Layout/CheckBox.cpp
@@ -634,6 +633,7 @@ set(SOURCES
     Painting/BorderPainting.cpp
     Painting/BorderRadiusCornerClipper.cpp
     Painting/BordersData.cpp
+    Painting/BoxModelMetrics.cpp
     Painting/CanvasPaintable.cpp
     Painting/Command.cpp
     Painting/CheckBoxPaintable.cpp

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -15,7 +15,6 @@
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/Layout/BoxModelMetrics.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Painting/Paintable.h>
 #include <LibWeb/TreeNode.h>
@@ -263,9 +262,6 @@ class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {
     GC_CELL(NodeWithStyleAndBoxModelMetrics, NodeWithStyle);
 
 public:
-    BoxModelMetrics& box_model() { return m_box_model; }
-    BoxModelMetrics const& box_model() const { return m_box_model; }
-
     GC::Ptr<NodeWithStyleAndBoxModelMetrics> continuation_of_node() const { return m_continuation_of_node; }
     void set_continuation_of_node(Badge<TreeBuilder>, GC::Ptr<NodeWithStyleAndBoxModelMetrics> node) { m_continuation_of_node = node; }
 
@@ -287,7 +283,6 @@ protected:
 private:
     virtual bool is_node_with_style_and_box_model_metrics() const final { return true; }
 
-    BoxModelMetrics m_box_model;
     GC::Ptr<NodeWithStyleAndBoxModelMetrics> m_continuation_of_node;
 };
 

--- a/Libraries/LibWeb/Painting/BoxModelMetrics.cpp
+++ b/Libraries/LibWeb/Painting/BoxModelMetrics.cpp
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibWeb/Layout/BoxModelMetrics.h>
+#include <LibWeb/Painting/BoxModelMetrics.h>
 
-namespace Web::Layout {
+namespace Web::Painting {
 
 PixelBox BoxModelMetrics::margin_box() const
 {

--- a/Libraries/LibWeb/Painting/BoxModelMetrics.h
+++ b/Libraries/LibWeb/Painting/BoxModelMetrics.h
@@ -1,15 +1,14 @@
 /*
- * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <LibGfx/Size.h>
 #include <LibWeb/PixelUnits.h>
 
-namespace Web::Layout {
+namespace Web::Painting {
 
 struct PixelBox {
     CSSPixels top { 0 };

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2022-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2024, Aliaksandr Kalenik <kalenik.aliaksandr@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -13,6 +13,7 @@
 #include <LibWeb/Painting/BackgroundPainting.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/BoxModelMetrics.h>
 #include <LibWeb/Painting/ClipFrame.h>
 #include <LibWeb/Painting/ClippableAndScrollable.h>
 #include <LibWeb/Painting/Paintable.h>
@@ -49,7 +50,8 @@ public:
     Layout::NodeWithStyleAndBoxModelMetrics& layout_node_with_style_and_box_metrics() { return static_cast<Layout::NodeWithStyleAndBoxModelMetrics&>(Paintable::layout_node()); }
     Layout::NodeWithStyleAndBoxModelMetrics const& layout_node_with_style_and_box_metrics() const { return static_cast<Layout::NodeWithStyleAndBoxModelMetrics const&>(Paintable::layout_node()); }
 
-    auto const& box_model() const { return layout_node_with_style_and_box_metrics().box_model(); }
+    auto& box_model() { return m_box_model; }
+    auto const& box_model() const { return m_box_model; }
 
     struct OverflowData {
         CSSPixelRect scrollable_overflow_rect;
@@ -306,6 +308,8 @@ private:
 
     RefPtr<CSS::GridTrackSizeListStyleValue> m_used_values_for_grid_template_columns;
     RefPtr<CSS::GridTrackSizeListStyleValue> m_used_values_for_grid_template_rows;
+
+    BoxModelMetrics m_box_model;
 };
 
 class PaintableWithLines : public PaintableBox {


### PR DESCRIPTION
This was a weird case of layout results being stored in the layout tree instead of in the paint tree like everything else.