### PR TITLE
Libweb: Apply some `HTMLHRElement` presentational hints

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLHRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHRElement.cpp
@@ -36,7 +36,7 @@ bool HTMLHRElement::is_presentational_hint(FlyString const& name) const
     if (Base::is_presentational_hint(name))
         return true;
 
-    return first_is_one_of(name, HTML::AttributeNames::color, HTML::AttributeNames::noshade, HTML::AttributeNames::width);
+    return first_is_one_of(name, HTML::AttributeNames::align, HTML::AttributeNames::color, HTML::AttributeNames::noshade, HTML::AttributeNames::width);
 }
 
 void HTMLHRElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
@@ -48,6 +48,19 @@ void HTMLHRElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> 
             cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderRightStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
             cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderBottomStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
             cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderLeftStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
+        }
+
+        if (name == HTML::AttributeNames::align) {
+            if (value.equals_ignoring_ascii_case("left"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::MarginLeft, CSS::LengthStyleValue::create(CSS::Length::make_px(0)));
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::MarginRight, CSS::CSSKeywordValue::create(CSS::Keyword::Auto));
+            } else if (value.equals_ignoring_ascii_case("right"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::MarginLeft, CSS::CSSKeywordValue::create(CSS::Keyword::Auto));
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::MarginRight, CSS::LengthStyleValue::create(CSS::Length::make_px(0)));
+            } else if (value.equals_ignoring_ascii_case("center"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::MarginLeft, CSS::CSSKeywordValue::create(CSS::Keyword::Auto));
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::MarginRight, CSS::CSSKeywordValue::create(CSS::Keyword::Auto));
+            }
         }
 
         // https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2:attr-hr-color-3

--- a/Libraries/LibWeb/HTML/HTMLHRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHRElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2025, Tim Ledbetter <tim.ledbetter@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +8,8 @@
 #include <LibWeb/Bindings/HTMLHRElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/CSS/ComputedProperties.h>
+#include <LibWeb/CSS/StyleValues/CSSColorValue.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/HTML/HTMLHRElement.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
@@ -33,12 +36,28 @@ bool HTMLHRElement::is_presentational_hint(FlyString const& name) const
     if (Base::is_presentational_hint(name))
         return true;
 
-    return first_is_one_of(name, HTML::AttributeNames::width);
+    return first_is_one_of(name, HTML::AttributeNames::color, HTML::AttributeNames::noshade, HTML::AttributeNames::width);
 }
 
 void HTMLHRElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
 {
     for_each_attribute([&](auto& name, auto& value) {
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2
+        if (name == HTML::AttributeNames::color || name == HTML::AttributeNames::noshade) {
+            cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderTopStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
+            cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderRightStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
+            cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderBottomStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
+            cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderLeftStyle, CSS::CSSKeywordValue::create(CSS::Keyword::Solid));
+        }
+
+        // https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2:attr-hr-color-3
+        // When an hr element has a color attribute, its value is expected to be parsed using the rules for parsing a legacy color value, and if that does not return failure,
+        // the user agent is expected to treat the attribute as a presentational hint setting the element's 'color' property to the resulting color.
+        if (name == HTML::AttributeNames::color) {
+            if (auto parsed_value = parse_legacy_color_value(value); parsed_value.has_value()) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Color, CSS::CSSColorValue::create_from_color(*parsed_value));
+            }
+        }
         // https://html.spec.whatwg.org/multipage/rendering.html#the-hr-element-2:maps-to-the-dimension-property
         if (name == HTML::AttributeNames::width) {
             if (auto parsed_value = parse_dimension_value(value)) {

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/align-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/align-ref.html
@@ -1,0 +1,31 @@
+
+<!doctype html>
+<meta charset=utf-8>
+<style>
+.hr {
+  color: gray;
+  border-style: inset;
+  border-width: 1px;
+  margin: 0.5em auto;
+  width: 100px;
+}
+
+.left {
+  margin-left: 0;
+}
+
+.right {
+  margin-right: 0;
+}
+</style>
+<div class='hr'></div>
+<div class='hr left'></div>
+<div class='hr'></div>
+<div class='hr right'></div>
+<div class='hr'></div>
+
+<div class='hr'></div>
+<div class='hr left'></div>
+<div class='hr'></div>
+<div class='hr right'></div>
+<div class='hr'></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/color-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/color-ref.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset=utf-8>
+<style>
+.hr {
+  color: gray;
+  border-style: inset;
+  border-width: 1px;
+  margin: 0.5em auto;
+}
+
+.green {
+  color: green;
+}
+
+.no-inset {
+  border-style: solid;
+}
+</style>
+<div class='hr'></div>
+<div class='hr no-inset'></div>
+<div class='hr no-inset'></div>
+<div class='hr green no-inset'></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/align.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/align.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset="utf-8">
+<link rel="match" href="../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/align-ref.html">
+<style>
+hr {
+  width: 100px;
+}
+</style>
+
+<hr align=>
+<hr align=left>
+<hr align=center>
+<hr align=right>
+<hr align=foobar>
+
+<script>
+// Test the IDL attribute
+const values = ['', 'left', 'center', 'right', 'foobar'];
+values.forEach(value => {
+  const hr = document.createElement('hr');
+  hr.align = value;
+  document.body.appendChild(hr);
+});
+</script>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/color.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/color.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<meta charset=utf-8>
+<link rel=match href="../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/the-hr-element-0/color-ref.html">
+<hr>
+<hr color="">
+<hr color=transparent>
+<hr color=green>


### PR DESCRIPTION
This PR applies presentational hints for the `align`, `color` and `noshade` attributes of `HTMLHRElement`.

This fixes all remaining WPT tests in https://wpt.live/html/rendering/non-replaced-elements/the-hr-element-0/   