### PR TITLE
LibWeb: Apply a couple of presentational hints to table elements

### DIFF
--- a/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Libraries/LibWeb/HTML/AttributeNames.h
@@ -33,6 +33,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(behavior, "behavior")                                     \
     __ENUMERATE_HTML_ATTRIBUTE(bgcolor, "bgcolor")                                       \
     __ENUMERATE_HTML_ATTRIBUTE(border, "border")                                         \
+    __ENUMERATE_HTML_ATTRIBUTE(bordercolor, "bordercolor")                               \
     __ENUMERATE_HTML_ATTRIBUTE(bottommargin, "bottommargin")                             \
     __ENUMERATE_HTML_ATTRIBUTE(cellpadding, "cellpadding")                               \
     __ENUMERATE_HTML_ATTRIBUTE(cellspacing, "cellspacing")                               \

--- a/Libraries/LibWeb/HTML/HTMLTableElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableElement.cpp
@@ -62,6 +62,7 @@ bool HTMLTableElement::is_presentational_hint(FlyString const& name) const
         HTML::AttributeNames::background,
         HTML::AttributeNames::bgcolor,
         HTML::AttributeNames::border,
+        HTML::AttributeNames::bordercolor,
         HTML::AttributeNames::cellpadding,
         HTML::AttributeNames::cellspacing,
         HTML::AttributeNames::height,
@@ -122,6 +123,19 @@ void HTMLTableElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropertie
             apply_border_style(CSS::PropertyID::BorderTopStyle, CSS::PropertyID::BorderTopWidth, CSS::PropertyID::BorderTopColor);
             apply_border_style(CSS::PropertyID::BorderRightStyle, CSS::PropertyID::BorderRightWidth, CSS::PropertyID::BorderRightColor);
             apply_border_style(CSS::PropertyID::BorderBottomStyle, CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor);
+        }
+        if (name == HTML::AttributeNames::bordercolor) {
+            // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:attr-table-bordercolor
+            // When a table element has a bordercolor attribute, its value is expected to be parsed using the rules for parsing a legacy color value,
+            // and if that does not return failure, the user agent is expected to treat the attribute as a presentational hint setting the element's
+            // 'border-top-color', 'border-right-color', 'border-bottom-color', and 'border-left-color' properties to the resulting color.
+            if (auto parsed_color = parse_legacy_color_value(value); parsed_color.has_value()) {
+                auto color_value = CSS::CSSColorValue::create_from_color(parsed_color.value());
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderTopColor, color_value);
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderRightColor, color_value);
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderBottomColor, color_value);
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BorderLeftColor, color_value);
+            }
         }
     });
 }

--- a/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableSectionElement.cpp
@@ -107,7 +107,8 @@ bool HTMLTableSectionElement::is_presentational_hint(FlyString const& name) cons
 
     return first_is_one_of(name,
         HTML::AttributeNames::background,
-        HTML::AttributeNames::bgcolor);
+        HTML::AttributeNames::bgcolor,
+        HTML::AttributeNames::height);
 }
 
 void HTMLTableSectionElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
@@ -122,6 +123,9 @@ void HTMLTableSectionElement::apply_presentational_hints(GC::Ref<CSS::CascadedPr
         else if (name == HTML::AttributeNames::bgcolor) {
             if (auto color = parse_legacy_color_value(value); color.has_value())
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BackgroundColor, CSS::CSSColorValue::create_from_color(color.value()));
+        } else if (name == HTML::AttributeNames::height) {
+            if (auto parsed_value = parse_dimension_value(value))
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::Height, parsed_value.release_nonnull());
         }
     });
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/tables/table-bordercolor-001-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/tables/table-bordercolor-001-ref.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference case for table bordercolor attribute behaving like border-color property</title>
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<style>
+  table { margin: 5px }
+</style>
+<table>
+  <td>I should not have a border.</td>
+</table>
+<table>
+  <td>I should not have a border.</td>
+</table>
+<table>
+  <td>I should not have a border.</td>
+</table>
+<table>
+  <td>I should not have a border.</td>
+</table>
+<table style="border-color: lime; border-style: solid">
+  <td>I should have a border.</td>
+</table>
+<table style="border-color: lime; border-style: solid">
+  <td>I should have a border.</td>
+</table>

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/tables/table-row-group-height-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/tables/table-row-group-height-ref.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<table style="border: 1px solid red">
+  <thead style="display: block; height: 100px">
+    <tr>
+      <td>
+        thead text
+      </td>
+    </tr>
+  </tr>
+</table>
+
+<table style="border: 1px solid red">
+  <tbody style="display: block; height: 100px">
+    <tr>
+      <td>
+        tbody text
+      </td>
+    </tr>
+  </tr>
+</table>
+
+<table style="border: 1px solid red">
+  <tfoot style="display: block; height: 100px">
+    <tr>
+      <td>
+        tfoot text
+      </td>
+    </tr>
+  </tr>
+</table>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/tables/table-bordercolor-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/tables/table-bordercolor-001.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Test for table bordercolor attribute behaving like border-color property</title>
+<link rel="author" title="Daniel Holbert" href="mailto:dholbert@mozilla.com">
+<link rel="author" title="Mozilla" href="https://www.mozilla.org/">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/rendering.html#tables-2">
+<link rel="match" href="../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/tables/table-bordercolor-001-ref.html">
+<meta name="assert" content="bordercolor is treated as a presentation hint, equivalent to setting the border-color property">
+<style>
+  table { margin: 5px }
+</style>
+<table bordercolor="red">
+  <td>I should not have a border.</td>
+</table>
+<table style="border-color: red">
+  <td>I should not have a border.</td>
+</table>
+<table bordercolor="red" style="border-width: 10px">
+  <td>I should not have a border.</td>
+</table>
+<table style="border-color: red; border-width: 10px">
+  <td>I should not have a border.</td>
+</table>
+<table bordercolor="lime" style="border-style: solid">
+  <td>I should have a border.</td>
+</table>
+<table style="border-color: lime; border-style: solid">
+  <td>I should have a border.</td>
+</table>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/tables/table-row-group-height.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/tables/table-row-group-height.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<link rel="match" href="../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/tables/table-row-group-height-ref.html">
+<table style="border: 1px solid red">
+  <thead style="display: block" height="100">
+    <tr>
+      <td>
+        thead text
+      </td>
+    </tr>
+  </tr>
+</table>
+
+<table style="border: 1px solid red">
+  <tbody style="display: block" height="100">
+    <tr>
+      <td>
+        tbody text
+      </td>
+    </tr>
+  </tr>
+</table>
+
+<table style="border: 1px solid red">
+  <tfoot style="display: block" height="100">
+    <tr>
+      <td>
+        tfoot text
+      </td>
+    </tr>
+  </tr>
+</table>


### PR DESCRIPTION
This PR applies the presentational hint for `HTMLTableElement`'s `bordercolor` attribute and `HTMLTableSectionElement`'s `height` attribute.