### PR TITLE
LibWeb: Apply `type` presentational hint to list elements

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLIElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/HTMLLIElementPrototype.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/HTML/HTMLLIElement.h>
 #include <LibWeb/HTML/Numbers.h>
 #include <LibWeb/HTML/Window.h>
@@ -36,6 +37,42 @@ WebIDL::Long HTMLLIElement::value()
     if (auto maybe_number = HTML::parse_integer(content_attribute_value); maybe_number.has_value())
         return *maybe_number;
     return 0;
+}
+
+bool HTMLLIElement::is_presentational_hint(FlyString const& name) const
+{
+    if (Base::is_presentational_hint(name))
+        return true;
+
+    return name == HTML::AttributeNames::type;
+}
+
+void HTMLLIElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
+{
+    // https://html.spec.whatwg.org/multipage/rendering.html#lists
+    for_each_attribute([&](auto& name, auto& value) {
+        if (name == HTML::AttributeNames::type) {
+            if (value == "1"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Decimal));
+            } else if (value == "a"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::LowerAlpha));
+            } else if (value == "A"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::UpperAlpha));
+            } else if (value == "i"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::LowerRoman));
+            } else if (value == "I"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::UpperRoman));
+            } else if (value.equals_ignoring_ascii_case("none"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::None));
+            } else if (value.equals_ignoring_ascii_case("disc"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Disc));
+            } else if (value.equals_ignoring_ascii_case("circle"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Circle));
+            } else if (value.equals_ignoring_ascii_case("square"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Square));
+            }
+        }
+    });
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLLIElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLIElement.h
@@ -45,6 +45,9 @@ private:
     HTMLLIElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+
+    virtual bool is_presentational_hint(FlyString const&) const override;
+    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLOListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/HTMLOListElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/HTML/HTMLOListElement.h>
 #include <LibWeb/HTML/Numbers.h>
 
@@ -34,6 +35,34 @@ WebIDL::Long HTMLOListElement::start()
     if (auto maybe_number = HTML::parse_integer(content_attribute_value); maybe_number.has_value())
         return *maybe_number;
     return 1;
+}
+
+bool HTMLOListElement::is_presentational_hint(FlyString const& name) const
+{
+    if (Base::is_presentational_hint(name))
+        return true;
+
+    return name == HTML::AttributeNames::type;
+}
+
+void HTMLOListElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
+{
+    // https://html.spec.whatwg.org/multipage/rendering.html#lists
+    for_each_attribute([&](auto& name, auto& value) {
+        if (name == HTML::AttributeNames::type) {
+            if (value == "1"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Decimal));
+            } else if (value == "a"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::LowerAlpha));
+            } else if (value == "A"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::UpperAlpha));
+            } else if (value == "i"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::LowerRoman));
+            } else if (value == "I"sv) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::UpperRoman));
+            }
+        }
+    });
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLOListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLOListElement.h
@@ -32,6 +32,9 @@ private:
     HTMLOListElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+
+    virtual bool is_presentational_hint(FlyString const&) const override;
+    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 };
 
 }

--- a/Libraries/LibWeb/HTML/HTMLUListElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLUListElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/HTMLUListElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/HTML/HTMLUListElement.h>
 
 namespace Web::HTML {
@@ -23,6 +24,32 @@ void HTMLUListElement::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(HTMLUListElement);
+}
+
+bool HTMLUListElement::is_presentational_hint(FlyString const& name) const
+{
+    if (Base::is_presentational_hint(name))
+        return true;
+
+    return name == HTML::AttributeNames::type;
+}
+
+void HTMLUListElement::apply_presentational_hints(GC::Ref<CSS::CascadedProperties> cascaded_properties) const
+{
+    // https://html.spec.whatwg.org/multipage/rendering.html#lists
+    for_each_attribute([&](auto& name, auto& value) {
+        if (name == HTML::AttributeNames::type) {
+            if (value.equals_ignoring_ascii_case("none"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::None));
+            } else if (value.equals_ignoring_ascii_case("disc"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Disc));
+            } else if (value.equals_ignoring_ascii_case("circle"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Circle));
+            } else if (value.equals_ignoring_ascii_case("square"sv)) {
+                cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::ListStyleType, CSS::CSSKeywordValue::create(CSS::Keyword::Square));
+            }
+        }
+    });
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLUListElement.h
+++ b/Libraries/LibWeb/HTML/HTMLUListElement.h
@@ -25,6 +25,9 @@ private:
     HTMLUListElement(DOM::Document&, DOM::QualifiedName);
 
     virtual void initialize(JS::Realm&) override;
+
+    virtual bool is_presentational_hint(FlyString const&) const override;
+    virtual void apply_presentational_hints(GC::Ref<CSS::CascadedProperties>) const override;
 };
 
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/lists/li-type-supported-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/lists/li-type-supported-ref.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>li@type: supported types</title>
+<style>
+  .decimal { list-style-type: decimal; }
+  .lower-alpha { list-style-type: lower-alpha; }
+  .upper-alpha { list-style-type: upper-alpha; }
+  .lower-roman { list-style-type: lower-roman; }
+  .upper-roman { list-style-type: upper-roman; }
+  .disc { list-style-type: disc; }
+  .circle { list-style-type: circle; }
+  .square { list-style-type: square; }
+  .none { list-style-type: none; }
+</style>
+<li class="decimal">first item</li>
+<li class="lower-alpha">second item</li>
+<li class="upper-alpha">third item</li>
+<li class="lower-roman">fourth item</li>
+<li class="upper-roman">fifth item</li>
+<li class="disc">sixth item</li>
+<li class="circle">seventh item</li>
+<li class="square">eighth item</li>
+<li class="none">ninth item</li>
+<ol>
+  <li class="decimal">first ordered item</li>
+  <li class="lower-alpha">second ordered item</li>
+  <li class="upper-alpha">third ordered item</li>
+  <li class="lower-roman">fourth ordered item</li>
+  <li class="upper-roman">fifth ordered item</li>
+  <li class="disc">sixth ordered item</li>
+  <li class="circle">seventh ordered item</li>
+  <li class="square">eighth ordered item</li>
+  <li class="none">ninth ordered item</li>
+</ol>
+<ul>
+  <li class="decimal">first unordered item</li>
+  <li class="lower-alpha">second unordered item</li>
+  <li class="upper-alpha">third unordered item</li>
+  <li class="lower-roman">fourth unordered item</li>
+  <li class="upper-roman">fifth unordered item</li>
+  <li class="disc">sixth unordered item</li>
+  <li class="circle">seventh unordered item</li>
+  <li class="square">eighth unordered item</li>
+  <li class="none">ninth unordered item</li>
+</ul>

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/lists/ol-type-supported-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/lists/ol-type-supported-ref.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>ol@type: supported types</title>
+<style>
+.decimal {
+  list-style-type: decimal;
+}
+.lower-alpha {
+  list-style-type: lower-alpha;
+}
+.upper-alpha {
+  list-style-type: upper-alpha;
+}
+.lower-roman {
+  list-style-type: lower-roman;
+}
+.upper-roman {
+  list-style-type: upper-roman;
+}
+</style>
+<ol class=decimal><li>1<li>2</ol>
+<ol class=lower-alpha><li>a<li>b</ol>
+<ol class=upper-alpha><li>A<li>B</ol>
+<ol class=lower-roman><li>i<li>ii</ol>
+<ol class=upper-roman><li>I<li>II</ol>

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/lists/ul-type-supported-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/lists/ul-type-supported-ref.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>ul@type: supported types</title>
+<style>
+.disc {
+  list-style-type: disc;
+}
+.circle {
+  list-style-type: circle;
+}
+.square {
+  list-style-type: square;
+}
+.none {
+  list-style-type: none;
+}
+</style>
+<ul class="disc"><li>first disc</li><li>second disc</li></ul>
+<ul class="circle"><li>first circle</li><li>second circle</li></ul>
+<ul class="square"><li>first square</li><li>second square</li></ul>
+<ul class="none"><li>first none</li><li>second none</li></ul>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/lists/li-type-supported.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/lists/li-type-supported.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>li@type: supported types</title>
+<link rel=match href=../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/lists/li-type-supported-ref.html>
+<li type=1>first item</li>
+<li type=a>second item</li>
+<li type=A>third item</li>
+<li type=i>fourth item</li>
+<li type=I>fifth item</li>
+<li type=disc>sixth item</li>
+<li type=circle>seventh item</li>
+<li type=square>eighth item</li>
+<li type=none>ninth item</li>
+<ol>
+  <li type=1>first ordered item</li>
+  <li type=a>second ordered item</li>
+  <li type=A>third ordered item</li>
+  <li type=i>fourth ordered item</li>
+  <li type=I>fifth ordered item</li>
+  <li type=disc>sixth ordered item</li>
+  <li type=circle>seventh ordered item</li>
+  <li type=square>eighth ordered item</li>
+  <li type=none>ninth ordered item</li>
+</ol>
+<ul>
+  <li type=1>first unordered item</li>
+  <li type=a>second unordered item</li>
+  <li type=A>third unordered item</li>
+  <li type=i>fourth unordered item</li>
+  <li type=I>fifth unordered item</li>
+  <li type=disc>sixth unordered item</li>
+  <li type=circle>seventh unordered item</li>
+  <li type=square>eighth unordered item</li>
+  <li type=none>ninth unordered item</li>
+</ul>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/lists/ol-type-supported.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/lists/ol-type-supported.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>ol@type: supported types</title>
+<link rel=match href=../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/lists/ol-type-supported-ref.html>
+<ol type=1><li>1<li>2</ol>
+<ol type=a><li>a<li>b</ol>
+<ol type=A><li>A<li>B</ol>
+<ol type=i><li>i<li>ii</ol>
+<ol type=I><li>I<li>II</ol>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/lists/ul-type-supported.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/lists/ul-type-supported.html
@@ -1,0 +1,8 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>ul@type: supported types</title>
+<link rel=match href=../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/lists/ul-type-supported-ref.html>
+<ul type=disc><li>first disc</li><li>second disc</li></ul>
+<ul type=circle><li>first circle</li><li>second circle</li></ul>
+<ul type=square><li>first square</li><li>second square</li></ul>
+<ul type=none><li>first none</li><li>second none</li></ul>

--- a/Tests/LibWeb/Text/expected/wpt-import/html/rendering/non-replaced-elements/lists/lists-presentational-hints-ascii-case-insensitive.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/rendering/non-replaced-elements/lists/lists-presentational-hints-ascii-case-insensitive.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	keyword disc
+Pass	keyword square

--- a/Tests/LibWeb/Text/input/wpt-import/html/rendering/non-replaced-elements/lists/lists-presentational-hints-ascii-case-insensitive.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/rendering/non-replaced-elements/lists/lists-presentational-hints-ascii-case-insensitive.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/#lists:presentational-hints">
+<link rel="help" href="https://drafts.csswg.org/selectors-4/#attribute-case">
+<meta name="assert" content="ul@type + li@type values are ASCII case-insensitive">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<ul type="circle"><li type="disc"></ul>
+<ul type="circle"><li type="DiSc"></ul>
+<ul type="circle"><li type="diſc"></ul>
+<ul type="circle"><li type="square"></ul>
+<ul type="circle"><li type="SqUaRe"></ul>
+<ul type="circle"><li type="ſquare"></ul>
+<script>
+const li = document.querySelectorAll("li");
+
+test(() => {
+  assert_equals(getComputedStyle(li[0]).getPropertyValue("list-style-type"),
+  	"disc", "lowercase valid");
+  assert_equals(getComputedStyle(li[1]).getPropertyValue("list-style-type"),
+  	"disc", "mixed case valid");
+  assert_equals(getComputedStyle(li[2]).getPropertyValue("list-style-type"),
+  	"circle", "non-ASCII invalid");
+}, "keyword disc");
+
+test(() => {
+  assert_equals(getComputedStyle(li[3]).getPropertyValue("list-style-type"),
+  	"square", "lowercase valid");
+  assert_equals(getComputedStyle(li[4]).getPropertyValue("list-style-type"),
+  	"square", "mixed case valid");
+  assert_equals(getComputedStyle(li[5]).getPropertyValue("list-style-type"),
+  	"circle", "non-ASCII invalid");
+}, "keyword square");
+</script>


### PR DESCRIPTION
This PR applies the appropriate presentational hints for the `type` attribute of `HTMLOListElement`, `HTMLUListElement` and `HTMLIElement`. This ensures that changing the `type` attribute renders the correct list type for these elements.