### PR TITLE
LibJS+LIbCrypto: Propogate allocation errors in BigInt constructor functions

### DIFF
--- a/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
+++ b/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
@@ -27,6 +27,8 @@ public:
     static void divide_without_allocation(UnsignedBigInteger const& numerator, UnsignedBigInteger const& denominator, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
     static void divide_u16_without_allocation(UnsignedBigInteger const& numerator, UnsignedBigInteger::Word denominator, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
 
+    static ErrorOr<void> try_shift_left_without_allocation(UnsignedBigInteger const& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
+
     static void extended_GCD_without_allocation(UnsignedBigInteger const& a, UnsignedBigInteger const& b, UnsignedBigInteger& x, UnsignedBigInteger& y, UnsignedBigInteger& gcd, UnsignedBigInteger& temp_quotient, UnsignedBigInteger& temp_1, UnsignedBigInteger& temp_2, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_r, UnsignedBigInteger& temp_s, UnsignedBigInteger& temp_t);
     static void destructive_GCD_without_allocation(UnsignedBigInteger& temp_a, UnsignedBigInteger& temp_b, UnsignedBigInteger& temp_quotient, UnsignedBigInteger& temp_remainder, UnsignedBigInteger& output);
     static void modular_inverse_without_allocation(UnsignedBigInteger const& a, UnsignedBigInteger const& b, UnsignedBigInteger& result, UnsignedBigInteger& temp_y, UnsignedBigInteger& temp_gcd, UnsignedBigInteger& temp_quotient, UnsignedBigInteger& temp_1, UnsignedBigInteger& temp_2, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_r, UnsignedBigInteger& temp_s, UnsignedBigInteger& temp_t);
@@ -39,6 +41,8 @@ private:
     static void shift_left_by_n_words(UnsignedBigInteger const& number, size_t number_of_words, UnsignedBigInteger& output);
     static void shift_right_by_n_words(UnsignedBigInteger const& number, size_t number_of_words, UnsignedBigInteger& output);
     ALWAYS_INLINE static UnsignedBigInteger::Word shift_left_get_one_word(UnsignedBigInteger const& number, size_t num_bits, size_t result_word_index);
+
+    static ErrorOr<void> try_shift_left_by_n_words(UnsignedBigInteger const& number, size_t number_of_words, UnsignedBigInteger& output);
 };
 
 }

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -276,9 +276,14 @@ bool SignedBigInteger::operator>(UnsignedBigInteger const& other) const
     return *this != other && !(*this < other);
 }
 
+FLATTEN ErrorOr<SignedBigInteger> SignedBigInteger::try_shift_left(size_t num_bits) const
+{
+    return SignedBigInteger { TRY(m_unsigned_data.try_shift_left(num_bits)), m_sign };
+}
+
 FLATTEN SignedBigInteger SignedBigInteger::shift_left(size_t num_bits) const
 {
-    return SignedBigInteger { m_unsigned_data.shift_left(num_bits), m_sign };
+    return MUST(try_shift_left(num_bits));
 }
 
 FLATTEN SignedBigInteger SignedBigInteger::shift_right(size_t num_bits) const

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -120,6 +120,8 @@ public:
     [[nodiscard]] SignedBigInteger multiplied_by(SignedBigInteger const& other) const;
     [[nodiscard]] SignedDivisionResult divided_by(SignedBigInteger const& divisor) const;
 
+    [[nodiscard]] ErrorOr<SignedBigInteger> try_shift_left(size_t num_bits) const;
+
     [[nodiscard]] SignedBigInteger plus(UnsignedBigInteger const& other) const;
     [[nodiscard]] SignedBigInteger minus(UnsignedBigInteger const& other) const;
     [[nodiscard]] SignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -481,15 +481,20 @@ FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_not_fill_to_one_based_ind
     return result;
 }
 
-FLATTEN UnsignedBigInteger UnsignedBigInteger::shift_left(size_t num_bits) const
+FLATTEN ErrorOr<UnsignedBigInteger> UnsignedBigInteger::try_shift_left(size_t num_bits) const
 {
     UnsignedBigInteger output;
     UnsignedBigInteger temp_result;
     UnsignedBigInteger temp_plus;
 
-    UnsignedBigIntegerAlgorithms::shift_left_without_allocation(*this, num_bits, temp_result, temp_plus, output);
+    TRY(UnsignedBigIntegerAlgorithms::try_shift_left_without_allocation(*this, num_bits, temp_result, temp_plus, output));
 
     return output;
+}
+
+FLATTEN UnsignedBigInteger UnsignedBigInteger::shift_left(size_t num_bits) const
+{
+    return MUST(try_shift_left(num_bits));
 }
 
 FLATTEN UnsignedBigInteger UnsignedBigInteger::shift_right(size_t num_bits) const

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -120,6 +120,8 @@ public:
     [[nodiscard]] UnsignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;
     [[nodiscard]] UnsignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
 
+    [[nodiscard]] ErrorOr<UnsignedBigInteger> try_shift_left(size_t num_bits) const;
+
     [[nodiscard]] u32 hash() const;
 
     void set_bit_inplace(size_t bit_index);

--- a/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -75,7 +75,7 @@ JS_DEFINE_NATIVE_FUNCTION(BigIntConstructor::as_int_n)
     // 3. Let mod be ℝ(bigint) modulo 2^bits.
     // FIXME: For large values of `bits`, this can likely be improved with a SignedBigInteger API to
     //        drop the most significant bits.
-    auto bits_shift_left = BIGINT_ONE.shift_left(bits);
+    auto bits_shift_left = TRY_OR_THROW_OOM(vm, BIGINT_ONE.try_shift_left(bits));
     auto mod = modulo(bigint->big_integer(), bits_shift_left);
 
     // 4. If mod ≥ 2^(bits-1), return ℤ(mod - 2^bits); otherwise, return ℤ(mod).
@@ -101,7 +101,7 @@ JS_DEFINE_NATIVE_FUNCTION(BigIntConstructor::as_uint_n)
     // 3. Return the BigInt value that represents ℝ(bigint) modulo 2bits.
     // FIXME: For large values of `bits`, this can likely be improved with a SignedBigInteger API to
     //        drop the most significant bits.
-    return BigInt::create(vm, modulo(bigint->big_integer(), BIGINT_ONE.shift_left(bits)));
+    return BigInt::create(vm, modulo(bigint->big_integer(), TRY_OR_THROW_OOM(vm, BIGINT_ONE.try_shift_left(bits))));
 }
 
 }

--- a/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asIntN.js
+++ b/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asIntN.js
@@ -22,6 +22,12 @@ describe("errors", () => {
             BigInt.asIntN(1, "foo");
         }).toThrowWithMessage(SyntaxError, "Invalid value for BigInt: foo");
     });
+
+    test("large allocation", () => {
+        expect(() => {
+            BigInt.asIntN(0x4000000000000, 1n);
+        }).toThrowWithMessage(InternalError, "Out of memory");
+    });
 });
 
 describe("correct behavior", () => {

--- a/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asUintN.js
+++ b/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asUintN.js
@@ -22,6 +22,12 @@ describe("errors", () => {
             BigInt.asUintN(1, "foo");
         }).toThrowWithMessage(SyntaxError, "Invalid value for BigInt: foo");
     });
+
+    test("large allocation", () => {
+        expect(() => {
+            BigInt.asUintN(0x4000000000000, 1n);
+        }).toThrowWithMessage(InternalError, "Out of memory");
+    });
 });
 
 describe("correct behavior", () => {


### PR DESCRIPTION
`BigInt.asIntN` and `BigInt.asUintN` use both use `SignedBigInteger::shift_left` which is subject to allocation failures.
So the following crashes (On my machine):
```js
BigInt.asIntN(0x4000000000000, 1n);
```