### PR TITLE
LibWeb: Retain `display: contents` in ancestor stack for continuations

### DIFF
--- a/Tests/LibWeb/Ref/expected/block-element-inside-inline-element-ref.html
+++ b/Tests/LibWeb/Ref/expected/block-element-inside-inline-element-ref.html
@@ -18,5 +18,7 @@
     <b>foo</b><div><b>bar</b></div><b>baz</b>
     <hr>
     <span>foo</span><div>bar</div>
+    <hr>
+    <b>foo</b><div><b>bar</b></div><b>baz</b>
 </body>
 </html>

--- a/Tests/LibWeb/Ref/input/block-element-inside-inline-element.html
+++ b/Tests/LibWeb/Ref/input/block-element-inside-inline-element.html
@@ -40,5 +40,8 @@
             target2.setAttribute('style', null);
         });
     </script>
+    <!-- Block inside `display: contents` element -->
+    <hr>
+    <b>foo<div style="display: contents"><div>bar</div></div>baz</b>
 </body>
 </html>


### PR DESCRIPTION
When restructuring inline nodes because of a block element insertion during the layout tree build, we might end up with a `display: contents` element in the ancestor stack that is not part of the actual layout tree, since it's never actually used as a parent for any node. Because we were only rewinding the ancestor stack with actual new layout nodes, it became corrupted and layout nodes were added to the wrong parent.

This new logic leaves the ancestor stack intact, only replacing layout nodes whenever a new one is created.

Fixes the sidebar on https://reddit.com.
Fixes #3590.