### PR TITLE
LibWeb: Remove unintentional recursion in `ValidityState::valid`

### DIFF
--- a/Libraries/LibWeb/HTML/ValidityState.cpp
+++ b/Libraries/LibWeb/HTML/ValidityState.cpp
@@ -109,7 +109,7 @@ bool ValidityState::custom_error() const
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-validitystate-valid
 bool ValidityState::valid() const
 {
-    return !(value_missing() || type_mismatch() || pattern_mismatch() || too_long() || too_short() || range_underflow() || range_overflow() || step_mismatch() || bad_input() || custom_error() || valid());
+    return !(value_missing() || type_mismatch() || pattern_mismatch() || too_long() || too_short() || range_underflow() || range_overflow() || step_mismatch() || bad_input() || custom_error());
 }
 
 }

--- a/Tests/LibWeb/Crash/HTML/validity-attribute.html
+++ b/Tests/LibWeb/Crash/HTML/validity-attribute.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<input>
+<script>
+    const input = document.querySelector('input');
+    const isValid = input.validity.valid;
+</script>


### PR DESCRIPTION
Fixes a crash in: https://wpt.live/html/dom/idlharness.https.html?exclude=(Document\|Window|HTML.+)