### PR TITLE
LibJS: Add support in Date.parse for non-standard date strings

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -151,6 +151,12 @@ public:
 
     T& value() { return m_value_or_error.template get<T>(); }
     T const& value() const { return m_value_or_error.template get<T>(); }
+    [[nodiscard]] ALWAYS_INLINE T const& value_or(T const& fallback) const
+    {
+        if (is_error())
+            return fallback;
+        return m_value_or_error.template get<T>();
+    }
 
     ErrorType& error() { return m_value_or_error.template get<ErrorType>(); }
     ErrorType const& error() const { return m_value_or_error.template get<ErrorType>(); }

--- a/Libraries/LibJS/Runtime/DateParser.h
+++ b/Libraries/LibJS/Runtime/DateParser.h
@@ -1,0 +1,937 @@
+/*
+ * Copyright (c) 2025, Manuel Zahariev <manuel@duck.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/GenericLexer.h>
+#include <AK/Optional.h>
+#include <AK/StringView.h>
+#include <AK/Time.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
+#include <LibJS/Runtime/Date.h>
+
+#include <cctype> // Not included by default on macOS.
+
+// Parse simplified ISO8601 and non-standard date formats to milliseconds
+// from epoch (double). Synopsis:
+// (1) Try to parse the string as simplified ISO8601 (case sensitive).
+//   - if that worked, assemble result (4 below)
+//   - hard fail (return NAN) if the input string "looks like" ISO8601,
+//     but deviates.
+// (2) If parsing ISO8601 "soft" fails (unlike "hard" above), continue
+//     shallow parsing (case insensitive) date string components: time,
+//     timezone, keywords, numbers...
+// (3) Guess ambiguous date parts, like "1/2/3" --> Jan 2, 2003
+// (4) Assemble result from parts (year, month,...) and convert to milliseconds
+//     from epoch.
+//
+// Overall objectives:
+// - compliance with ECMA date time string format, incl. ISO8601 extensions
+//   for signed 6-digit year and extended time offset format (:SS.nanosecs)
+//   https://tc39.es/ecma262/#sec-date-time-string-format
+// - Support for Date.toString and Date.toUTCString formats.
+// - Compatible with Mozilla Firefox 134.0.1 and Chromium 131.0.6778.264. Within
+//   reason. Differences indicated in comments.
+//   - Where Firefox and Chrome agree on a parse, support it.
+//   - Where they disagree, support the one that seems more sane.
+//   - In very limited cases, pick our own way. Example: "<number> Month":
+//     - Firefox fails on all "<number> Month" date strings.
+//     - In most cases, Chrome interprets "<number> Month" as "Month 01, Year".
+//     - Chrome parses "7 Feb" as "Feb 7, 2001".
+//     - We always parse as "Month 01, Year".
+// - Support Firefox less permissive punctuation but more permissive punctuation
+//   syntax.
+class DateParser : public GenericLexer {
+private:
+    Vector<u64> m_numbers;
+
+    Optional<i8> m_sign;
+    Optional<i64> m_year;
+    Optional<u8> m_month;
+    Optional<u8> m_day;
+    Optional<u8> m_hours;
+    Optional<u8> m_minutes;
+    Optional<u8> m_seconds;
+    Optional<u16> m_milliseconds;
+
+    // True if GMT/UTC/Z specified and there is no timezone offset; false if timezone offset.
+    // No value if there is no timezone information: we have to guess whether the date was given in GMT or local time.
+    Optional<bool> m_timezone_utc;
+    Optional<i8> m_timezone_sign; // +1 or -1 if there is a timezone offset.
+    Optional<u8> m_timezone_hours;
+    Optional<u8> m_timezone_minutes;
+    Optional<u8> m_timezone_seconds;
+    Optional<u64> m_timezone_nanoseconds;
+
+    constexpr static u64 pow10(size_t pow)
+    {
+        switch (pow) {
+        case 0:
+            return 1;
+        case 1:
+            return 10;
+        case 2:
+            return 100;
+        case 3:
+            return 1'000;
+        case 4:
+            return 10'000;
+        case 5:
+            return 100'000;
+        case 6:
+            return 1'000'000;
+        case 7:
+            return 10'000'000;
+        case 8:
+            return 100'000'000;
+        case 9:
+            return 1'000'000'000;
+        }
+
+        VERIFY_NOT_REACHED();
+    }
+    // Reads a contiguous sequence of digits. Ignores digits read past MaxLength.
+    // Returns the numeric value of the sequence and the number of digits not ignored.
+    template<typename T, size_t MaxLength>
+    ALWAYS_INLINE std::pair<T, size_t> read_number()
+    {
+        static_assert(std::is_unsigned<T>(), "Type must be unsigned.");
+        static_assert(MaxLength < 11, "Number too long.");
+        static_assert((sizeof(T) >= 1) || (MaxLength <= 2), "Number too long.");
+        static_assert((sizeof(T) >= 2) || (MaxLength <= 4), "Number too long.");
+        static_assert((sizeof(T) >= 4) || (MaxLength <= 9), "Number too long.");
+        static_assert((sizeof(T) >= 8) || (MaxLength <= 19), "Number too long.");
+
+        auto result = std::make_pair(T(0), size_t(0));
+        for (result.second = 0; result.second < MaxLength; ++result.second) {
+            if (is_eof() || !next_is(isdigit))
+                return result;
+            result.first *= 10;
+            result.first += consume() - '0';
+        }
+
+        ignore_while(isdigit);
+        return result;
+    }
+
+    ALWAYS_INLINE bool guess_date_from_numbers() // Guess an ambiguous date, like 1/1/1.
+    {
+        switch (m_numbers.size()) {
+        case 0:
+            return true; // The year and possibly month may have already been calculated. Verify later
+        case 1:
+            return guess_date_from_1_number();
+        case 2:
+            return guess_date_from_2_numbers();
+        case 3:
+            return guess_date_from_3_numbers();
+        }
+
+        return false; // Too many numbers
+    }
+    ALWAYS_INLINE bool guess_date_from_3_numbers() // Only "month-day-year" (default) and "year-month-day" are supported (same as firefox and chrome).
+    {
+        VERIFY(m_numbers.size() == 3);
+
+        u64 const number0 = m_numbers.at(0);
+        u64 const number1 = m_numbers.at(1);
+        u64 const number2 = m_numbers.at(2);
+
+        if (m_year.has_value() || m_month.has_value())
+            return false; // Too many numbers
+
+        if ((number0 > 31) || number0 == 0) { // YMD
+            if (number1 > 12)
+                return false;
+            if (number2 > 31)
+                return false;
+
+            if ((number1 == 0) || (number2 == 0)) // 0 for day or month
+                return false;
+
+            m_month = number1;
+            m_day = number2;
+            m_year = guess_year(number0);
+
+            return true;
+        }
+
+        // MDY
+        if (number0 > 12)
+            return false; // Both Firefox and Chrome fail for the first number >12 and <=31. Weird. We do the same
+        if (number1 > 31)
+            return false;
+
+        if ((number0 == 0) || (number1 == 0)) // 0 for day or month
+            return false;
+
+        m_month = number0;
+        m_day = number1;
+        m_year = guess_year(number2);
+
+        return true;
+    }
+    ALWAYS_INLINE bool guess_date_from_2_numbers() // Guess default order "day-year" or adapt.
+    {
+        VERIFY(m_numbers.size() == 2);
+
+        u64 const number0 = m_numbers.at(0);
+        u64 const number1 = m_numbers.at(1);
+
+        if (m_year.has_value() && m_month.has_value())
+            return false; // Too many numbers
+
+        if (m_year.has_value()) {
+            if (number0 <= 12) { // ... is a month
+                if (number1 > 31)
+                    return false;
+                if ((number0 == 0) || (number1 == 0)) // 0 for day or month
+                    return false;
+
+                m_month = number0;
+                m_day = number1;
+                return true;
+            }
+
+            if (number0 <= 31) { // ... is a day
+                if (number1 > 12)
+                    return false;
+
+                if ((number0 == 0) || (number1 == 0)) // 0 for day or month
+                    return false;
+
+                m_month = number1;
+                m_day = number0;
+                return true;
+            }
+        }
+
+        // At this point, one of the numbers is the year
+        if (!m_month.has_value())
+            return false; // Firefox fails on guessing 2 numbers. We do the same
+
+        // At this point, the month has been read from a month name
+        if ((number0 > 31) && (number1 > 31))
+            return false;                       // Neither of the numbers can be a day
+        if ((number0 > 31) || (number0 == 0)) { // ... is a year
+            if (number1 == 0)                   // 0 for day
+                return false;
+
+            m_day = number1;
+            m_year = guess_year(number0);
+            return true;
+        }
+
+        // Default order is day -> year
+        if (number0 == 0) // 0 for day
+            return false;
+
+        m_day = number0;
+        m_year = guess_year(number1);
+
+        return true;
+    }
+    ALWAYS_INLINE bool guess_date_from_1_number() // Guess in this order: year, month, day.
+    {
+        VERIFY(m_numbers.size() == 1);
+
+        u64 const number0 = m_numbers.at(0);
+
+        if (!m_year.has_value() && !m_month.has_value())
+            return one_number(number0);
+
+        if (!m_year.has_value()) { // the number must be a year
+            m_year = guess_year(number0);
+            return true;
+        }
+
+        if (!m_month.has_value()) // Firefox fails on two numbers. So do we. Chrome is weird.
+            return false;
+
+        // At this point, the year and month must have been specified some other way (e.g. "Feb +002002").
+        if ((number0 > 31) || (number0 == 0)) // Invalid day number.
+            return false;
+
+        m_day = number0;
+
+        return true;
+    }
+    ALWAYS_INLINE static u64 guess_year(u64 const number) // Guess one- or two-digit year.
+    {
+        switch (number) {
+        case 0 ... 49:
+            return 2000 + number;
+        case 50 ... 99:
+            return 1900 + number;
+        }
+
+        return number;
+    }
+    ALWAYS_INLINE bool one_number(u64 const number) // The whole input string is just one stand-alone number.}
+    {
+        switch (number) {
+        case 0:
+            m_year = 2000;
+            return true;
+        case 1 ... 12:
+            m_year = 2001;
+            m_month = number; // Firefox and Chrome interpret standalone numbers below 12 as months in 2001. Weird! We do the same.
+            return true;
+        case 13 ... 31:
+            return false; // Firefox and Chrome fail on standalone numbers between 12 and 31. Weird! We do the same.
+        case 32 ... 49:
+            m_year = 2000 + number;
+            return true;
+        case 50 ... 99:
+            m_year = 1900 + number;
+            return true;
+        }
+        m_year = number;
+        return true;
+    }
+
+    // Permissive, greedy shallow date parser for date components.
+    // Returns:
+    // - false: Hard fail. Some invalid input condition has been found. Caller should return NAN.
+    // - true: Parsing can continue.
+    ALWAYS_INLINE bool loop()
+    {
+        switch (peek()) {
+        case '0' ... '9':
+            return maybe_number(); // Also captures time.
+        case '+':
+        case '-':
+            return maybe_sign(); // Also captures signed 6-digit year and timezone offset.
+        case 'A' ... 'Z':
+            return maybe_word(); // Captures all date string "keywords". Accepts any kind of "junk" before date and time..
+        case ' ':
+        case '.':
+        case ',':
+        case '/':
+            // Firefox seems to accept (ignore) this punctuation. So do we.
+            // Firefox also accepts a bare '+' sometimes. We do not.
+            // Chrome is a lot more permissive.
+            ignore(); // Ignore punctuation.
+            return true;
+        case '(':
+            ignore_until(')'); // Consume time zone name (Anything in brackets).
+            ignore();
+            ignore_while(isspace);
+            return true;
+        }
+
+        return false;
+    }
+    ALWAYS_INLINE bool maybe_ampm() // Side effect: consumes space at the end of a time component, even if there is no AM/PM.
+    {
+        VERIFY(m_hours.has_value());
+
+        consume_while(isspace);
+
+        if (consume_specific("AM"sv)) {
+            if (!separator())
+                return false; // 12:34 AMsomething
+
+            if (m_hours.value() > 12)
+                return false; // 14:45AM
+            if (m_hours.value() == 12)
+                m_hours = 0; // 12:05AM -> 00:05
+            return true;
+        }
+
+        if (consume_specific("PM"sv)) {
+            if (!separator())
+                return false; // 12:34 PMsomething
+            if (m_hours.value() > 12)
+                return false; // 14:45PM
+            if (m_hours.value() < 12)
+                m_hours = m_hours.value() + 12;
+            return true;
+        }
+
+        return true;
+    }
+    ALWAYS_INLINE bool maybe_time(std::pair<u32, size_t> const& hours) // H[H]:MM[:SS[.mss[...]]][ ][AM|PM] At this point, H[H]: has already been read.
+    {
+        if (m_hours.has_value())
+            return false; // Time has already been read.
+
+        if (hours.second > 2)
+            return false; // 123:
+        if (hours.first > 24)
+            return false;
+        m_hours = hours.first; // No precision loss during the conversion u32 -> u8 since the hours has at most 2 digits.
+
+        auto const minutes = read_number<u32, 3>();
+        if (minutes.second != 2)
+            return false; // 12:345 or 12:3
+        if (minutes.first > 59)
+            return false;
+        m_minutes = minutes.first;
+
+        if (consume_specific('.'))
+            return false; // 12:34.
+        if (!consume_specific(':'))
+            return true;
+
+        auto const seconds = read_number<u32, 3>();
+        if (seconds.second != 2)
+            return false; // 12:34:567 or 12:34:5
+        if (seconds.first > 59)
+            return false;
+        m_seconds = seconds.first;
+
+        if (!consume_specific('.'))
+            return true;
+
+        auto const milliseconds = read_number<u32, 3>();
+        switch (milliseconds.second) {
+        case 0:
+            return false; // 12:34:56.
+        case 1:
+            m_milliseconds = milliseconds.first * 100;
+            break;
+        case 2:
+            m_milliseconds = milliseconds.first * 10;
+            break;
+        case 3:
+            m_milliseconds = milliseconds.first;
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+
+        return true;
+    }
+    ALWAYS_INLINE bool maybe_number()
+    {
+        auto const number = read_number<u32, 7>();
+        VERIFY(number.second > 0);
+
+        if (number.second > 6)
+            return false; // 1234567
+
+        if (consume_specific(':')) {
+            if (!maybe_time(number))
+                return false;
+            if (!maybe_ampm())
+                return false;
+            return true;
+        }
+
+        m_numbers.append(number.first);
+
+        return separator(); // Must be followed by a separator.
+    }
+    ALWAYS_INLINE bool maybe_sign()
+    {
+        i8 const sign = (consume() == '-') ? -1 : +1;
+        auto const number = read_number<u32, 7>();
+
+        switch (number.second) {
+        case 0: // Not a sign after all; '+' is forbidden if it is not a sign. '-' is ignored as punctuation.
+            return (sign == -1);
+        case 1 ... 5: // Too small to be a signed year;
+            if (m_hours.has_value())
+                break; // Candidate for timezone offset.
+
+            m_numbers.append(number.first); // Ignore the sign and treat it as a number.
+            return true;
+        case 6:
+            if (m_hours.has_value())
+                break; // Candidate for timezone offset.
+
+            if (m_year.has_value())
+                return false; // To many digits to be anything else than a signed year.
+
+            m_year = sign * number.first; // Candidate for signed year
+            return true;
+        default:
+            return false;
+        }
+
+        m_timezone_sign = sign;
+        return tz_offset(number);
+    }
+
+    ALWAYS_INLINE bool tz_offset() // Read a full timezone offset, including the sign.
+    {
+        m_timezone_sign = (consume() == '-') ? -1 : +1;
+        auto const number = read_number<u32, 7>();
+        return tz_offset(number);
+    }
+    // Continue reading a timezone offset, after the sign and the first number have beeen read.
+    ALWAYS_INLINE bool tz_offset(std::pair<u32, size_t> const& number, bool iso_8601_format = false)
+    {
+        if (m_timezone_hours.has_value()) // Cannot have more than one timezone offset or a timezone name followed by a timezone offset.
+            return false;
+
+        m_timezone_utc = false;
+        switch (number.second) {
+        case 0:
+            return false;
+        case 1:
+            if (iso_8601_format)
+                return false; // +1
+            [[fallthrough]];
+        case 2:
+            break; // Candidate for timezone offset with colon.
+        case 3:
+            if (iso_8601_format)
+                return false; // +123
+            [[fallthrough]];
+        case 4: { // "Military" timezone offset
+            u16 const tz_hhmm = number.first;
+            m_timezone_hours = tz_hhmm / 100;
+            m_timezone_minutes = tz_hhmm % 100;
+            return true;
+        }
+        case 5:
+            if (iso_8601_format)
+                return false; // +12345
+            [[fallthrough]];
+        case 6: { // "Military" timezone offset
+            u32 const tz_hhmmss = number.first;
+            m_timezone_hours = tz_hhmmss / 10000;
+            m_timezone_minutes = tz_hhmmss % 10000 / 100;
+            m_timezone_seconds = tz_hhmmss % 100;
+            return true;
+        }
+        default:
+            return false;
+        }
+
+        m_timezone_hours = number.first; // Guaranteed to be a 1- or 2-digit number.
+
+        if (!consume_specific(':'))
+            return true; // +H[H] "military" time offset
+
+        // Timezone with colon
+        auto const minutes = read_number<u16, 3>();
+        if (minutes.second != 2)
+            return false;
+        m_timezone_minutes = minutes.first;
+
+        if (!consume_specific(':'))
+            return true;
+
+        auto const seconds = read_number<u16, 3>();
+        if (seconds.second != 2)
+            return false;
+        m_timezone_seconds = seconds.first;
+
+        if (!consume_specific('.'))
+            return true;
+
+        auto const nanoseconds = read_number<u64, 10>();
+        if (nanoseconds.second == 0)
+            return false;
+        if (nanoseconds.second > 9)
+            return false;
+
+        m_timezone_nanoseconds = nanoseconds.first * pow10(9 - nanoseconds.second);
+
+        return true;
+    }
+    ALWAYS_INLINE bool separator() // Ignore space and Firefox punctuation.
+    {
+        if (is_eof())
+            return true;
+        switch (peek()) {
+        case ' ':
+        case ',':
+        case '.':
+        case '/':
+        case '-':
+            ignore();
+            return true;
+        }
+        return false;
+    }
+    ALWAYS_INLINE bool gmt(StringView const& str) // Z or GMT or UTC can be used interchangeably.
+    {
+        if (!consume_specific(str))
+            return false;
+
+        m_timezone_utc = true;
+
+        bool space = consume_while(isspace).length() > 0;
+        switch (peek()) {
+        case '+':
+        case '-':
+            return tz_offset(); // GMT+1234
+        }
+
+        return space || separator();
+    }
+    // Same as Chrome and Firefox, we only support abbreviations for timezones covering the US mainland.
+    ALWAYS_INLINE bool us_timezone(StringView const& str, u8 hours, u8 minutes = 0, i8 sign = -1)
+    {
+        VERIFY(str.length() == 3); // only 3-letter timezone names
+        if (!consume_specific(str))
+            return false;
+
+        if (!m_hours.has_value() && m_numbers.is_empty() && !m_year.has_value()) // Ignore timezone before date or time.
+            return false;
+
+        m_timezone_sign = sign;
+        m_timezone_hours = hours;
+        m_timezone_minutes = minutes;
+
+        return separator(); // Must end with a separator.
+    }
+    ALWAYS_INLINE bool month_name(StringView const& str, u8 month)
+    {
+        VERIFY(str.length() == 3); // Only looking for 3-letter month prefixes.
+        for (size_t i = 0; i < 3; ++i)
+            if (str[i] != peek(i))
+                return false;
+
+        ignore_while(isalpha); // ... which can followed by anything. Just like Firefox and Chrome.
+        m_month = month;
+
+        return separator(); // Must end with a separator.
+    }
+    ALWAYS_INLINE bool word() // Alphanumeric strings that are not date "keywords".
+    {
+        std::ignore = consume_while(isalpha);
+        // Just like Firefox and Chrome:
+        // - Ignore junk (bare words) at the beginning (before time or a date fragment has been read).
+        // - Fail if a word is read later in the date string (exception: final time zone name, in brackets).
+        return (m_numbers.is_empty() && !m_hours.has_value() && !m_year.has_value());
+    }
+    ALWAYS_INLINE bool maybe_word() // The top of a trie catching date "keywords".
+    {
+        switch (peek()) {
+        case 'A': // APR AUG
+            return month_name("APR"sv, 4) || month_name("AUG"sv, 8) || word();
+        case 'C': // CST CDT
+            return us_timezone("CST"sv, 6) || us_timezone("CDT"sv, 5) || word();
+        case 'D': // DEC
+            return month_name("DEC"sv, 12) || word();
+        case 'E': // EST EDT
+            return us_timezone("EST"sv, 5) || us_timezone("EDT"sv, 4) || word();
+        case 'F': // FEB
+            return month_name("FEB"sv, 2) || word();
+        case 'G': // GMT
+            return gmt("GMT"sv) || word();
+        case 'J': // JAN JUN JUL
+            return month_name("JAN"sv, 1) || month_name("JUN"sv, 6) || month_name("JUL"sv, 7) || word();
+        case 'M': // MAR MAY MST MDT
+            return month_name("MAR"sv, 3) || month_name("MAY"sv, 5) || us_timezone("MST"sv, 7) || us_timezone("MDT"sv, 6) || word();
+        case 'N': // NOV
+            return month_name("NOV"sv, 11) || word();
+        case 'O': // OCT
+            return month_name("OCT"sv, 10) || word();
+        case 'P': // PST PDT
+            return us_timezone("PST"sv, 8) || us_timezone("PDT"sv, 7) || word();
+        case 'S': // SEP
+            return month_name("SEP"sv, 9) || word();
+        case 'U': // UTC
+            return gmt("UTC"sv) || word();
+        case 'Z': // Z
+            return gmt("Z"sv) || word();
+        }
+
+        return word();
+    }
+
+    // Capture simplified ISO8601 date format. https://tc39.es/ecma262/#sec-date-time-string-format
+    // All of the iso_... functions return:
+    // - true: if the input can be parsed as an ISO8601 date.
+    // - false: cannot be parsed as an ISO8601 date. Will be defered to a non-standard date string.
+    // - Error: hard fail; caller is supposed to return NAN.
+    ALWAYS_INLINE ErrorOr<bool> maybe_iso_8601()
+    {
+        for (size_t step = 0; step < 4; ++step) {
+            switch (step) {
+            case 0:
+                if (!TRY(maybe_iso_year()))
+                    return false;
+                break;
+            case 1:
+                if (!TRY(maybe_iso_month_day()))
+                    return false;
+                break;
+            case 2:
+                if (!TRY(maybe_iso_time()))
+                    return false;
+                break;
+            case 3:
+                TRY(maybe_iso_tz());
+                break;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+
+            if (is_eof())
+                return true;
+        }
+
+        return Error::from_string_literal("Read ISO8601 format, but have some input left over.");
+    }
+    ALWAYS_INLINE ErrorOr<bool> maybe_iso_year()
+    {
+        switch (peek()) {
+        case '0' ... '9':
+            if (TRY(maybe_iso_year4()))
+                return true;
+            break;
+        case '+':
+        case '-':
+            if (TRY(maybe_iso_signed_year6()))
+                return true;
+            break;
+        default:
+            return false;
+        }
+
+        return false;
+    }
+    ALWAYS_INLINE ErrorOr<bool> maybe_iso_year4() // Like "2025".
+    {
+        auto number = read_number<u32, 7>();
+
+        switch (number.second) {
+        case 0:
+            return false; // no digits
+        case 1:
+        case 2:
+            if (next_is(':')) { // This may not be a year after all but the start of a "time" component.
+                ignore();
+                if (!maybe_time(number))
+                    return Error::from_string_literal("Cannot parse time.");
+                if (!maybe_ampm())
+                    return Error::from_string_literal("Cannot parse am/pm.");
+                return false;
+            }
+            [[fallthrough]];
+        case 3:
+        case 5:
+        case 6: // Six-digit year number; no sign means not ISO8601 date.
+            // At this point, this is not an ISO8601 date.
+            m_numbers.append(number.first);
+            return false;
+        case 4: // Four-digit year number.
+            m_year = number.first;
+            return true; // This can be the start of an ISO8601 date.
+        }
+
+        return Error::from_string_literal("String too long to be a year.");
+    }
+    ALWAYS_INLINE ErrorOr<bool> maybe_iso_signed_year6() // Like "+002025".
+    {
+        i64 sign = +1;
+        if (consume() == '-')
+            sign = -1;
+        auto number = read_number<u32, 7>();
+
+        switch (number.second) {
+        case 0:
+            if (sign == +1) // Standalone '+' is invalid.
+                return Error::from_string_literal("Invalid character in date string ('+').");
+            return false;
+        case 1 ... 5:
+            m_numbers.append(number.first); // This is not an ISO8601 date.
+            return false;
+        case 6:
+            break;
+        default:
+            return Error::from_string_literal("String too long to be a 6-digit signed year.");
+        }
+
+        m_year = sign * number.first;
+
+        // "The representation of the year 0 as -000000 is invalid." https://tc39.es/ecma262/#sec-expanded-years
+        // Firefox interprets "-000000" as "Jan 1, 2000".
+        if ((sign == -1) && (m_year == 0))
+            return Error::from_string_literal("The representation of the year 0 as '-000000' is invalid.");
+
+        return true;
+    }
+    ALWAYS_INLINE ErrorOr<bool> maybe_iso_month_day() // [-MM[-DD]]
+    {
+        if (!consume_specific('-'))
+            return true;
+
+        auto month = read_number<u16, 3>();
+        if (consume_specific(':')) { // Like "2000-12:34". Firefox and Chrome parse it correctly. We do the same.
+            if (maybe_time(month))
+                return false;
+            return Error::from_string_literal("Found something that looks like time, but is not.");
+        }
+
+        switch (month.second) {
+        case 0:
+            return false; // Not ISO8601 date format. Continue reading.
+        case 1:
+            m_month = month.first;
+            if (m_month == 0)
+                return Error::from_string_literal("Month number cannot be zero.");
+            return false;
+        case 2:
+            break;
+        default: // month number too long
+            return Error::from_string_literal("Month number too long.");
+        }
+
+        m_month = month.first;
+
+        if ((m_month == 0) || (m_month.value() > 12))
+            return Error::from_string_literal("Invalid month number.");
+
+        if (!consume_specific('-'))
+            return true;
+
+        if (is_eof())
+            return Error::from_string_literal("Expecting month number. Got eof.");
+
+        auto day = read_number<u16, 3>();
+
+        switch (day.second) {
+        case 0:
+            return false; // Not ISO8601 date format. Continue reading.
+        case 1:
+            m_day = day.first;
+            if (m_day == 0)
+                return Error::from_string_literal("Day number cannot be zero.");
+            return false;
+        case 2:
+            break;
+        default: // month number too long
+            return Error::from_string_literal("Day number too long.");
+        }
+
+        m_day = day.first;
+        if ((m_day == 0) || (m_day.value() > 31))
+            return Error::from_string_literal("Invalid day number.");
+
+        return true;
+    }
+    ALWAYS_INLINE ErrorOr<bool> maybe_iso_time() // THH:MM[:SS[.M[SS...]]]
+    {
+        // The ECMA date string format requires uppercase 'T' and 'Z' https://tc39.es/ecma262/#sec-date-time-string-format
+        // - Chrome supports lower case occurrences.
+        // - Firefox and us do not.
+        if (!consume_specific('T'))
+            return false;
+
+        // After reading the 'T', any failures return NAN (failed parse)
+        auto hours = read_number<u16, 3>();
+
+        if (!consume_specific(':')) // 12
+            return Error::from_string_literal("Well specified time needs minutes.");
+
+        if (hours.second != 2)
+            return Error::from_string_literal("Hours: invalid length.");
+
+        if (!maybe_time(hours)) // The only difference is that ISO8601 requires 2-digit hours.
+            return Error::from_string_literal("Cannot parse time.");
+
+        return true;
+    }
+    ALWAYS_INLINE ErrorOr<void> maybe_iso_tz() // After the 'T' for iso_time has been read, reading an ISO8601 timezone either succeeds or the whole parse fails.
+    {
+        switch (consume()) {
+        case 'Z':
+            m_timezone_utc = true;
+            return {};
+        case '-':
+            m_timezone_sign = -1;
+            break;
+        case '+':
+            m_timezone_sign = +1;
+            break;
+        default:
+            return Error::from_string_literal("Invalid timezone offset format.");
+        }
+
+        if (!tz_offset(read_number<u32, 7>(), true)) // A sign and a number have been read. Continue reading a timezone offset..
+            return Error::from_string_literal("Invalid timezone offset format.");
+
+        return {};
+    }
+
+    ALWAYS_INLINE double build_date(bool is_iso8601_date = false) // Build a date (milliseconds since epoch) from parts collected.
+    {
+        VERIFY(is_eof());
+
+        if (!m_year.has_value())
+            return NAN; // Needs at least one year.
+
+        if ((m_hours == 24) && ((m_minutes.value_or(0) > 0) || (m_seconds.value_or(0) > 0)))
+            return NAN; // 24:01:02
+
+        AK::UnixDateTime time = AK::UnixDateTime::from_unix_time_parts( // local time
+            m_year.value(),
+            m_month.value_or(1),
+            m_day.value_or(1),
+            m_hours.value_or(0),
+            m_minutes.value_or(0),
+            m_seconds.value_or(0),
+            m_milliseconds.value_or(0));
+
+        double time_ms = static_cast<double>(time.milliseconds_since_epoch()); // Assume the date was given in UTC.
+
+        if (m_timezone_sign.has_value()) { // A timezone offset was specified.
+            if (m_timezone_hours.has_value() && (m_timezone_hours.value() > 24))
+                return NAN;
+            if (m_timezone_minutes.has_value() && (m_timezone_minutes.value() > 59))
+                return NAN;
+            if (m_timezone_seconds.has_value() && (m_timezone_seconds.value() > 59))
+                return NAN;
+
+            time_ms -= 1.0 * m_timezone_sign.value() * static_cast<double>( // Convert to a UTC timestamp: local timestamp minus timezone offset.
+                           m_timezone_hours.value_or(0) * 3'600'000 + m_timezone_minutes.value_or(0) * 60'000 + m_timezone_seconds.value_or(0) * 1'000 + static_cast<u64>(m_timezone_nanoseconds.value_or(0) / 1'000'000));
+        } else if (!m_timezone_utc.has_value() && (!is_iso8601_date || m_hours.has_value())) {
+            // If a timezone offset or GMT/UTC/Z was not specified and:
+            // - Either this is not an ISO8601 [simplified] date
+            // - Or this is a date-time form [of an ISO8601 date].
+            // https://tc39.es/ecma262/#sec-date.parse:
+            // "When the UTC offset representation is absent, date-only forms are interpreted as a UTC time and date-time forms are interpreted as a local time."
+
+            time_ms = JS::utc_time(time_ms); // The date was given in local time; convert it to a UTC timestamp.
+        } else {                             // An ISO8601 date-only form
+            ;                                // nop; leave timestamp as UTC
+        }
+
+        return JS::time_clip(time_ms);
+    }
+    ALWAYS_INLINE ErrorOr<double> parse()
+    {
+        if (TRY(maybe_iso_8601()))
+            return build_date(true);
+
+        // Convert the input string to uppercase only ~after~ parsing ISO8601 failed.
+        // This saves some time (two string copies) if parsing a ISO8601 date succeeds.
+        // The index stays exactly where it was before converting to uppercase.
+        auto str_uppercase = m_input.to_ascii_uppercase_string();
+        m_input = str_uppercase;
+        // FIXME: Two full string copies could be avoided, if to_uppercase can be done in place.
+        // The underlying StringView m_input protects itself from modifying its contents. Bummer.
+
+        while (!is_eof())
+            if (!loop())
+                return Error::from_string_literal("Cannot parse date components.");
+
+        if (!guess_date_from_numbers())
+            return Error::from_string_literal("Cannot guess date.");
+
+        return build_date();
+    }
+    DateParser(StringView const& str)
+        : GenericLexer(str)
+    {
+    }
+
+public:
+    ALWAYS_INLINE static double parse(StringView const& str)
+    {
+        return DateParser(str).parse().value_or(NAN);
+    }
+};

--- a/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -25,7 +25,7 @@ test("basic functionality", () => {
     expect(Date.parse("2024-01-08 9:00Z")).toBe(1704704400000);
     expect(Date.parse("Wed, 17 Jan 2024 11:36:34 +0000")).toBe(1705491394000);
     expect(Date.parse("Thu, 09 Jan 2025 23:00:00")).toBe(1736485200000);
-    expect(Date.parse("Sun Jan 21 2024 21:11:31 GMT 0100 (Central European Standard Time)")).toBe(
+    expect(Date.parse("Sun Jan 21 2024 21:11:31 GMT +0100 (Central European Standard Time)")).toBe(
         1705867891000
     );
     expect(Date.parse("05 Jul 2024 00:00")).toBe(1720155600000);
@@ -37,7 +37,7 @@ test("basic functionality", () => {
     expect(Date.parse("Tue Nov 07 2023 10:05:55  UTC")).toBe(1699351555000);
     expect(Date.parse("Wed Apr 17 23:08:53 2019")).toBe(1555560533000);
     expect(Date.parse("Wed Apr 17 2019 23:08:53")).toBe(1555560533000);
-    expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011000); // FIXME: support sub-second precision
+    expect(Date.parse("2024-01-26T22:10:11.306+0000")).toBe(1706307011306);
     expect(Date.parse("1/27/2024, 9:28:30 AM")).toBe(1706369310000);
     expect(Date.parse("01 February 2013")).toBe(1359698400000);
     expect(Date.parse("Tuesday, October 29, 2024, 18:00 UTC")).toBe(1730224800000);
@@ -50,13 +50,14 @@ test("basic functionality", () => {
     expect(Date.parse("1 Jan 2001 00:00:00 GMT")).toBe(978307200000);
     expect(Date.parse("Jul 05, 2024")).toBe(1720155600000);
 
+    expect(Date.parse("+1980")).toBe(315554400000);
+    expect(Date.parse("1980-")).toBe(315554400000);
+
     // FIXME: Create a scoped time zone helper when bytecode supports the `using` declaration.
     setTimeZone(originalTimeZone);
 
     expect(Date.parse(2020)).toBe(1577836800000);
 
-    expect(Date.parse("+1980")).toBe(NaN);
-    expect(Date.parse("1980-")).toBe(NaN);
     expect(Date.parse("1980-05-")).toBe(NaN);
     expect(Date.parse("1980-05-00T")).toBe(NaN);
     expect(Date.parse("1980-05-00T15:15:")).toBe(NaN);

--- a/Libraries/LibJS/Tests/builtins/Date/Date.parse.nonStandard.js
+++ b/Libraries/LibJS/Tests/builtins/Date/Date.parse.nonStandard.js
@@ -1,0 +1,776 @@
+/*
+ * Copyright (c) 2025, Manuel Zahariev <manuel@duck.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+// NOTE: Using ISOString rather than "milliseconds since epoch" in test cases, for readability.
+// The result ISOString on the left ("expect") side, so that the source strings are nicely aligned.
+
+// NOTE: Using "new Date" vs. Date.parse for brevity in most tests, since:
+// "[new Date returns] the result of parsing v as a date, in exactly the same manner as for the parse method"
+// https://tc39.es/ecma262/#sec-date
+
+// NOTE: I decided to do setTimeZone("America/Vancouver") vs. setTimeZone("PST"), since the former
+// flips between PST/PDT (ok) and the latter overrides PDT seasonally (arguably incorrect).
+
+// NOTE: After 1884, "America/Vancouver" is PST. After 1941 PDT is added seasonally.
+// Before 1884 it is Local Mean Time (Vancouver); 12min 28s offset vs. PST
+// Don't be alarmed if you see it in some of the examples. Firefox and Chrome behave the same way.
+// https://en.wikipedia.org/wiki/Standard_time#North_America
+
+test("canonical format: ECMA date time string format", () => {
+    // https://tc39.es/ecma262/#sec-date-time-string-format
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    // No time zone
+    // Date only is GMT
+    expect("2023-01-01T00:00:00.000Z").toBe(new Date("2023").toISOString());
+    expect("2023-10-01T00:00:00.000Z").toBe(new Date("2023-10").toISOString());
+    expect("2023-10-11T00:00:00.000Z").toBe(new Date("2023-10-11").toISOString());
+
+    // Strings that are not compliant with the ECMA date time string format
+    // (e.g. slash or space date separators) are interpreted as local time
+    expect("2023-10-11T07:00:00.000Z").toBe(new Date("2023/10/11").toISOString());
+    expect("2023-10-11T07:00:00.000Z").toBe(new Date("2023 10 11").toISOString());
+
+    // Date-time
+    expect("2023-01-01T20:34:00.000Z").toBe(new Date("2023T12:34").toISOString()); // Daylight
+    expect("2023-10-01T19:34:00.000Z").toBe(new Date("2023-10T12:34").toISOString());
+    expect("2023-10-11T19:34:00.000Z").toBe(new Date("2023-10-11T12:34").toISOString());
+
+    expect("2023-01-01T20:34:56.000Z").toBe(new Date("2023T12:34:56").toISOString());
+    expect("2023-10-01T19:34:56.000Z").toBe(new Date("2023-10T12:34:56").toISOString());
+    expect("2023-10-11T19:34:56.000Z").toBe(new Date("2023-10-11T12:34:56").toISOString());
+
+    expect("2023-01-01T20:34:56.789Z").toBe(new Date("2023T12:34:56.789").toISOString());
+    expect("2023-10-01T19:34:56.789Z").toBe(new Date("2023-10T12:34:56.789").toISOString());
+    expect("2023-10-11T19:34:56.789Z").toBe(new Date("2023-10-11T12:34:56.789").toISOString());
+
+    // Z
+    expect("2023-01-01T12:34:00.000Z").toBe(new Date("2023T12:34Z").toISOString());
+    expect("2023-10-01T12:34:00.000Z").toBe(new Date("2023-10T12:34Z").toISOString());
+    expect("2023-10-11T12:34:00.000Z").toBe(new Date("2023-10-11T12:34Z").toISOString());
+
+    expect("2023-01-01T12:34:56.000Z").toBe(new Date("2023T12:34:56Z").toISOString());
+    expect("2023-10-01T12:34:56.000Z").toBe(new Date("2023-10T12:34:56Z").toISOString());
+    expect("2023-10-11T12:34:56.000Z").toBe(new Date("2023-10-11T12:34:56Z").toISOString());
+
+    expect("2023-01-01T12:34:56.789Z").toBe(new Date("2023T12:34:56.789Z").toISOString());
+    expect("2023-10-01T12:34:56.789Z").toBe(new Date("2023-10T12:34:56.789Z").toISOString());
+    expect("2023-10-11T12:34:56.789Z").toBe(new Date("2023-10-11T12:34:56.789Z").toISOString());
+
+    // Timezone offset HHMM[SS] ("military")
+    expect("1980-01-01T10:34:00.000Z").toBe(new Date("1980T12:34+0200").toISOString());
+    expect("1980-10-01T10:34:00.000Z").toBe(new Date("1980-10T12:34+0200").toISOString());
+    expect("1980-10-11T10:34:00.000Z").toBe(new Date("1980-10-11T12:34+0200").toISOString());
+
+    expect("1980-01-01T10:34:56.000Z").toBe(new Date("1980T12:34:56+0200").toISOString());
+    expect("1980-10-01T10:34:56.000Z").toBe(new Date("1980-10T12:34:56+0200").toISOString());
+    expect("1980-10-11T10:34:56.000Z").toBe(new Date("1980-10-11T12:34:56+0200").toISOString());
+
+    expect("1980-01-01T10:34:56.789Z").toBe(new Date("1980T12:34:56.789+0200").toISOString());
+    expect("1980-10-01T10:34:56.789Z").toBe(new Date("1980-10T12:34:56.789+0200").toISOString());
+    expect("1980-10-11T10:34:56.789Z").toBe(new Date("1980-10-11T12:34:56.789+0200").toISOString());
+
+    expect("1980-10-11T10:34:54.789Z").toBe(
+        new Date("1980-10-11T12:34:56.789+020002").toISOString()
+    );
+
+    // Timezone offset HH:MM
+    expect("1980-01-01T10:34:00.000Z").toBe(new Date("1980T12:34+02:00").toISOString());
+    expect("1980-10-01T10:34:00.000Z").toBe(new Date("1980-10T12:34+02:00").toISOString());
+    expect("1980-10-11T10:34:00.000Z").toBe(new Date("1980-10-11T12:34+02:00").toISOString());
+
+    expect("1980-01-01T10:34:56.000Z").toBe(new Date("1980T12:34:56+02:00").toISOString());
+    expect("1980-10-01T10:34:56.000Z").toBe(new Date("1980-10T12:34:56+02:00").toISOString());
+    expect("1980-10-11T10:34:56.000Z").toBe(new Date("1980-10-11T12:34:56+02:00").toISOString());
+
+    expect("1980-01-01T10:34:56.789Z").toBe(new Date("1980T12:34:56.789+02:00").toISOString());
+    expect("1980-10-01T10:34:56.789Z").toBe(new Date("1980-10T12:34:56.789+02:00").toISOString());
+    expect("1980-10-11T10:34:56.789Z").toBe(
+        new Date("1980-10-11T12:34:56.789+02:00").toISOString()
+    );
+
+    setTimeZone(originalTimeZone);
+});
+
+test('canonical format: ECMA + ISO8601 extensions ("simplified" ISO8601)', () => {
+    const originalTimeZone = setTimeZone("America/Vancouver");
+    // Timezone offset HH:MM:SS
+    // https://tc39.es/ecma262/#sec-time-zone-offset-strings
+    // NOTE: At this time, neither Firefox nor Chrome support nanoseconds in the timezone offset. We do.
+    expect("1980-01-01T10:33:15.000Z").toBe(new Date("1980T12:34+02:00:45").toISOString());
+    expect("1980-10-01T10:33:15.000Z").toBe(new Date("1980-10T12:34+02:00:45").toISOString());
+    expect("1980-10-11T10:33:15.000Z").toBe(new Date("1980-10-11T12:34+02:00:45").toISOString());
+
+    expect("1980-01-01T10:34:11.000Z").toBe(new Date("1980T12:34:56+02:00:45").toISOString());
+    expect("1980-10-01T10:34:11.000Z").toBe(new Date("1980-10T12:34:56+02:00:45").toISOString());
+    expect("1980-10-11T10:34:11.000Z").toBe(new Date("1980-10-11T12:34:56+02:00:45").toISOString());
+
+    expect("1980-01-01T10:34:11.789Z").toBe(new Date("1980T12:34:56.789+02:00:45").toISOString());
+    expect("1980-10-01T10:34:11.789Z").toBe(
+        new Date("1980-10T12:34:56.789+02:00:45").toISOString()
+    );
+    expect("1980-10-11T10:34:11.789Z").toBe(
+        new Date("1980-10-11T12:34:56.789+02:00:45").toISOString()
+    );
+
+    // The ECMA date-time string format requires literal uppercase 'T' and 'Z'.
+    // Chrome also accepts lowercase.
+    // Firefox and us only accept uppercase.
+    expect(Date.parse("2001-02-03t12:34:56.123z")).toBeNaN();
+    expect(Date.parse("2001-02-03t12:34:56.123Z")).toBeNaN();
+    expect(Date.parse("2001-02-03T12:34:56.123z")).toBeNaN();
+
+    // Timezone offset HH:MM:SS.Ns
+    expect("1980-01-01T10:33:14.322Z").toBe(new Date("1980T12:34+02:00:45.678").toISOString());
+    expect("1980-10-01T10:33:14.322Z").toBe(new Date("1980-10T12:34+02:00:45.678").toISOString());
+    expect("1980-10-11T10:33:14.322Z").toBe(
+        new Date("1980-10-11T12:34+02:00:45.678").toISOString()
+    );
+
+    expect("1980-01-01T10:34:10.322Z").toBe(new Date("1980T12:34:56+02:00:45.678").toISOString());
+    expect("1980-10-01T10:34:10.322Z").toBe(
+        new Date("1980-10T12:34:56+02:00:45.678").toISOString()
+    );
+    expect("1980-10-11T10:34:10.322Z").toBe(
+        new Date("1980-10-11T12:34:56+02:00:45.678").toISOString()
+    );
+
+    expect("1980-01-01T10:34:11.111Z").toBe(
+        new Date("1980T12:34:56.789+02:00:45.678").toISOString()
+    );
+    expect("1980-10-01T10:34:11.111Z").toBe(
+        new Date("1980-10T12:34:56.789+02:00:45.678").toISOString()
+    );
+    expect("1980-10-11T10:34:11.111Z").toBe(
+        new Date("1980-10-11T12:34:56.789+02:00:45.678").toISOString()
+    );
+
+    expect("1980-01-01T10:34:11.666Z").toBe(
+        new Date("1980T12:34:56.789+02:00:45.123456879").toISOString()
+    );
+    expect("1980-10-01T10:34:11.666Z").toBe(
+        new Date("1980-10T12:34:56.789+02:00:45.123456879").toISOString()
+    );
+    expect("1980-10-11T10:34:11.666Z").toBe(
+        new Date("1980-10-11T12:34:56.789+02:00:45.123456879").toISOString()
+    );
+
+    // Expanded years https://tc39.es/ecma262/#sec-expanded-years
+    expect("2023-01-01T00:00:00.000Z").toBe(new Date("+002023").toISOString());
+    expect("2023-10-01T00:00:00.000Z").toBe(new Date("+002023-10").toISOString());
+    expect("2023-10-11T00:00:00.000Z").toBe(new Date("+002023-10-11").toISOString());
+
+    expect("2023-10-11T19:34:00.000Z").toBe(new Date("+002023-10-11T12:34").toISOString());
+    expect("2023-10-11T19:34:56.000Z").toBe(new Date("+002023-10-11T12:34:56").toISOString());
+    expect("2023-10-11T19:34:56.789Z").toBe(new Date("+002023-10-11T12:34:56.789").toISOString());
+    expect("2023-10-11T12:34:56.000Z").toBe(new Date("+002023-10-11T12:34:56Z").toISOString());
+    expect("2023-10-11T12:34:56.789Z").toBe(new Date("+002023-10-11T12:34:56.789Z").toISOString());
+    expect("2023-10-11T10:34:56.789Z").toBe(
+        new Date("+002023-10-11T12:34:56.789+0200").toISOString()
+    );
+    expect("2023-10-11T10:34:56.789Z").toBe(
+        new Date("+002023-10-11T12:34:56.789+02:00").toISOString()
+    );
+    expect("2023-10-11T10:34:11.666Z").toBe(
+        new Date("+002023-10-11T12:34:56.789+02:00:45.123").toISOString()
+    );
+    expect("2023-10-11T10:34:11.666Z").toBe(
+        new Date("+002023-10-11T12:34:56.789+02:00:45.123456789").toISOString()
+    );
+
+    expect("-002023-10-11T00:00:00.000Z").toBe(new Date("-002023-10-11").toISOString());
+    expect("-002023-10-11T20:46:28.000Z").toBe(new Date("-002023-10-11T12:34").toISOString());
+    expect("-002023-10-11T20:47:24.000Z").toBe(new Date("-002023-10-11T12:34:56").toISOString());
+    expect("-002023-10-11T20:47:24.789Z").toBe(
+        new Date("-002023-10-11T12:34:56.789").toISOString()
+    );
+    expect("-002023-10-11T10:34:56.789Z").toBe(
+        new Date("-002023-10-11T12:34:56.789+0200").toISOString()
+    );
+    expect("-002023-10-11T10:34:56.789Z").toBe(
+        new Date("-002023-10-11T12:34:56.789+02:00").toISOString()
+    );
+    expect("-002023-10-11T10:34:11.789Z").toBe(
+        new Date("-002023-10-11T12:34:56.789+02:00:45").toISOString()
+    );
+    expect("-002023-10-11T10:34:11.666Z").toBe(
+        new Date("-002023-10-11T12:34:56.789+02:00:45.123").toISOString()
+    );
+    expect("-002023-10-11T10:34:11.666Z").toBe(
+        new Date("-002023-10-11T12:34:56.789+02:00:45.123456789").toISOString()
+    );
+
+    expect("0000-02-03T12:34:56.789Z").toBe(new Date("+000000-02-03T12:34:56.789Z").toISOString());
+
+    // "The representation of the year 0 as -000000 is invalid." https://tc39.es/ecma262/#sec-expanded-years
+    // Firefox and Chrome do not agree on parsing it. We fail everywhere.
+    expect(Date.parse("-000000-02-03T12:34:56.123Z")).toBeNaN(); // Both Firefox and Chrome fail.
+    expect(Date.parse("-000000-02-03")).toBeNaN(); // Firefox: "2000-02-03T08:00:00.000Z"; Chrome: "2001-02-03T08:00:00.000Z". We fail.
+    expect(Date.parse("-000000-02")).toBeNaN(); // Firefox fails; Chrome: "2001-02-01T08:00:00.000Z". We fail.
+    expect(Date.parse("-000000")).toBeNaN(); // Firefox: "2000-01-01T08:00:00.000Z"; Chrome fails. We fail.
+
+    setTimeZone(originalTimeZone);
+});
+
+test("canonical format: Date.toString", () => {
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("1999-12-08T12:34:56.000Z").toBe(new Date("Wed Dec 08 1999 12:34:56 GMT").toISOString()); // Clint Eastwood elected mayor of Carmel
+    expect("1999-12-08T20:34:56.000Z").toBe(
+        new Date("Wed Dec 08 1999 12:34:56 GMT-0800").toISOString()
+    );
+    expect("1999-12-08T20:34:56.000Z").toBe(
+        new Date("Wed Dec 08 1999 12:34:56 GMT-0800 (Pacific Standard Time)").toISOString()
+    );
+    expect("1999-12-08T20:34:56.000Z").toBe(
+        new Date("Wed Dec 08 1999 12:34:56 GMT-0800 (Central European Time)").toISOString()
+    ); // The time zone name is ignored
+    expect("1999-12-08T12:34:56.000Z").toBe(new Date("Sat Dec 08 1999 12:34:56 GMT").toISOString()); // Wrong weekday is ignored
+
+    setTimeZone(originalTimeZone);
+});
+
+test("canonical format: Date.toUTCString", () => {
+    expect("1999-12-08T08:00:00.000Z").toBe(
+        new Date("Wed, 08 Dec 1999 08:00:00 GMT").toISOString()
+    );
+    expect("1999-12-08T08:00:00.000Z").toBe(
+        new Date("Thu, 08 Dec 1999 08:00:00 GMT").toISOString()
+    ); // Wrong weekday is ignored
+});
+
+test("ambiguous date: 1 number", () => {
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("1970-01-01T00:00:00.000Z").toBe(new Date("1970").toISOString()); // GMT because it matches simplified ISO8601
+
+    // Everything else local time
+    expect("1970-01-01T08:00:00.000Z").toBe(new Date("-1970").toISOString());
+    expect("1970-01-01T08:00:00.000Z").toBe(new Date("/1970").toISOString());
+    expect("1970-01-01T08:00:00.000Z").toBe(new Date(".1970").toISOString());
+    expect("1970-01-01T08:00:00.000Z").toBe(new Date("+1970").toISOString());
+    expect("1970-01-01T08:00:00.000Z").toBe(new Date("./.-/////  /// // 1970").toISOString());
+    expect("1970-01-01T08:00:00.000Z").toBe(
+        // "Firefox" punctuation is ignored. Chrome is a lot more permissive
+        new Date("// ,./.-/////  /// // 1970 ---").toISOString()
+    );
+    expect(Date.parse("!1970")).toBeNaN(); // Other punctuation is rejected everywhere in the string.
+    expect(Date.parse("?1970")).toBeNaN();
+    expect(Date.parse("~1970")).toBeNaN();
+    expect(Date.parse("{1970")).toBeNaN();
+    expect(Date.parse("}1970")).toBeNaN();
+    expect(Date.parse("!1970")).toBeNaN();
+    expect(Date.parse("@1970")).toBeNaN();
+    expect(Date.parse("#1970")).toBeNaN();
+    expect(Date.parse("$1970")).toBeNaN();
+    expect(Date.parse("&1970")).toBeNaN();
+    expect(Date.parse("*1970")).toBeNaN();
+    expect(Date.parse("(1970")).toBeNaN();
+    expect(Date.parse(")1970")).toBeNaN();
+    expect(Date.parse("=1970")).toBeNaN();
+    expect(Date.parse("`1970")).toBeNaN();
+    expect(Date.parse(">1970")).toBeNaN();
+    expect(Date.parse(";1970")).toBeNaN();
+    expect(Date.parse("<1970")).toBeNaN();
+
+    expect("2000-01-01T08:00:00.000Z").toBe(new Date("0").toISOString());
+    expect("2000-01-01T08:00:00.000Z").toBe(new Date("00").toISOString());
+    expect("2000-01-01T08:00:00.000Z").toBe(new Date("000").toISOString());
+    expect("2000-01-01T08:00:00.000Z").toBe(new Date("000000").toISOString());
+
+    expect("2001-01-01T08:00:00.000Z").toBe(new Date("01").toISOString()); // 1-12 month number, 2001
+    expect("2001-01-01T08:00:00.000Z").toBe(new Date("1").toISOString());
+    expect("2001-02-01T08:00:00.000Z").toBe(new Date("2").toISOString());
+    expect("2001-12-01T08:00:00.000Z").toBe(new Date("12").toISOString());
+
+    expect(Date.parse("13")).toBeNaN(); // Firefox and Chrome fail on 13-31. We also fail.
+    expect(Date.parse("31")).toBeNaN();
+    expect(Date.parse("-14")).toBeNaN(); // Punctuation/sign does not make a difference.
+
+    expect("2032-01-01T08:00:00.000Z").toBe(new Date("32").toISOString()); // 32-49 2000+
+    expect("2041-01-01T08:00:00.000Z").toBe(new Date("41").toISOString());
+    expect("2049-01-01T08:00:00.000Z").toBe(new Date("49").toISOString());
+    expect("1950-01-01T08:00:00.000Z").toBe(new Date("50").toISOString()); // 50-99 1900+
+    expect("1978-01-01T08:00:00.000Z").toBe(new Date("78").toISOString());
+    expect("1999-01-01T08:00:00.000Z").toBe(new Date("99").toISOString());
+
+    // Punctuation is generally ignored.
+    expect("2001-01-01T08:00:00.000Z").toBe(new Date("-/--1").toISOString()); // 2001 month number
+    expect("2001-11-01T08:00:00.000Z").toBe(new Date("-11").toISOString());
+    expect("2032-01-01T08:00:00.000Z").toBe(new Date("-32").toISOString()); // 32-99 year number
+    expect("2040-01-01T08:00:00.000Z").toBe(new Date("-40").toISOString());
+    expect("1950-01-01T08:00:00.000Z").toBe(new Date("-50").toISOString());
+    expect("0100-01-01T08:12:28.000Z").toBe(new Date("-100").toISOString());
+    expect("1999-01-01T08:00:00.000Z").toBe(new Date("-99").toISOString());
+    expect("1970-01-01T08:00:00.000Z").toBe(new Date("-70").toISOString());
+
+    setTimeZone(originalTimeZone);
+});
+
+test("ambiguous date: 2 numbers", () => {
+    // Firefox fails on all. Chrome is weird. We fail on all.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect(Date.parse("10 1970")).toBeNaN(); // Chrome also fails.
+    expect(Date.parse("1970 12")).toBeNaN();
+    expect(Date.parse("1970 7")).toBeNaN();
+    expect(Date.parse("2024 7")).toBeNaN();
+    expect(Date.parse("2024 12")).toBeNaN();
+    expect(Date.parse("1 2")).toBeNaN();
+    expect(Date.parse("1 12")).toBeNaN(); // Chrome parses as Jan-12-2001
+    expect(Date.parse("1 32")).toBeNaN(); // Chrome also fails
+    expect(Date.parse("2 12")).toBeNaN(); // Chrome parses as Feb-12-2001
+    expect(Date.parse("32 1")).toBeNaN();
+    expect(Date.parse("32 2")).toBeNaN();
+    expect(Date.parse("2034 1")).toBeNaN();
+    expect(Date.parse("-002002 2")).toBeNaN();
+    setTimeZone(originalTimeZone);
+});
+
+test("ambiguous date: 3 numbers", () => {
+    // Compatible with Firefox and Chrome.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    // 3 digits-only default to MDY
+    expect("2024-07-07T07:00:00.000Z").toBe(new Date("7 7 2024").toISOString());
+    expect("2007-05-06T07:00:00.000Z").toBe(new Date("5 6 7").toISOString());
+    expect("2006-11-05T08:00:00.000Z").toBe(new Date("11 5 6").toISOString());
+    expect("2006-05-11T07:00:00.000Z").toBe(new Date("5 11 6").toISOString());
+    expect("2011-05-06T07:00:00.000Z").toBe(new Date("5 6 11").toISOString());
+    expect("2005-10-11T07:00:00.000Z").toBe(new Date("10 11 5").toISOString());
+    expect("2011-10-05T07:00:00.000Z").toBe(new Date("10 5 11").toISOString());
+    expect("2011-05-10T07:00:00.000Z").toBe(new Date("5 10 11").toISOString());
+
+    expect("2001-05-06T07:00:00.000Z").toBe(new Date("5 6 1").toISOString());
+    expect("2012-05-06T07:00:00.000Z").toBe(new Date("5 6 12").toISOString());
+    expect("2013-05-06T07:00:00.000Z").toBe(new Date("5 6 13").toISOString());
+    expect("2031-05-06T07:00:00.000Z").toBe(new Date("5 6 31").toISOString());
+    expect("2032-05-06T07:00:00.000Z").toBe(new Date("5 6 32").toISOString());
+    expect("2049-05-06T07:00:00.000Z").toBe(new Date("5 6 49").toISOString()); // Below 50: 2000+
+    expect("1950-05-06T07:00:00.000Z").toBe(new Date("5 6 50").toISOString()); // 50 or more: 1900+
+    expect("1988-05-06T07:00:00.000Z").toBe(new Date("5 6 88").toISOString());
+    expect("1999-05-06T07:00:00.000Z").toBe(new Date("5 6 99").toISOString());
+
+    // YMD if first number can only be a year (with exceptions)
+    expect("2024-12-03T08:00:00.000Z").toBe(new Date("2024 12 3").toISOString());
+    expect("2024-12-03T08:00:00.000Z").toBe(new Date("2024-12-3").toISOString());
+    expect("2024-07-07T07:00:00.000Z").toBe(new Date("2024 7 7").toISOString());
+    expect("2024-07-07T07:00:00.000Z").toBe(new Date("2024.7.7").toISOString());
+    expect("2024-12-03T08:00:00.000Z").toBe(new Date("2024.12.3").toISOString());
+    expect("2032-10-11T07:00:00.000Z").toBe(new Date("32 10 11").toISOString());
+    expect("2037-10-11T07:00:00.000Z").toBe(new Date("37 10 11").toISOString());
+    expect("1964-10-11T07:00:00.000Z").toBe(new Date("64 10 11").toISOString());
+    expect("1999-10-11T07:00:00.000Z").toBe(new Date("99 10 11").toISOString());
+    expect("0898-10-11T08:12:28.000Z").toBe(new Date("898 10 11").toISOString());
+
+    expect("2011-12-24T08:00:00.000Z").toBe(new Date("+12/-24/+2011").toISOString()); // Permissive punctuation
+
+    expect("2000-02-03T08:00:00.000Z").toBe(new Date("0 2 3").toISOString()); // First zero is a year number.
+    expect("2003-10-02T07:00:00.000Z").toBe(new Date("10 2 3").toISOString()); // MDY
+
+    expect(Date.parse("13 10 11")).toBeNaN(); // First number between 13-31 fails
+    expect(Date.parse("20 10 11")).toBeNaN();
+    expect(Date.parse("30 10 11")).toBeNaN();
+    expect(Date.parse("31 10 11")).toBeNaN();
+
+    expect(Date.parse("40 18 10")).toBeNaN(); // YDM fails
+
+    expect(Date.parse("7 8 9 Feb")).toBeNaN(); // Introducing an explicit month fails (too many numbers).
+    expect(Date.parse("7 8 Feb 9")).toBeNaN();
+    expect(Date.parse("7 Feb 8 9")).toBeNaN();
+    expect(Date.parse("Feb 7 8 9")).toBeNaN();
+
+    expect(Date.parse("0 0")).toBeNaN(); // YM with M=0
+    expect(Date.parse("2000 0")).toBeNaN();
+    expect(Date.parse("0 0 0")).toBeNaN(); // YMD
+    expect(Date.parse("0 0 1")).toBeNaN();
+    expect(Date.parse("0 1 0")).toBeNaN();
+    expect(Date.parse("10 0 0")).toBeNaN(); // MDY
+    expect(Date.parse("10 0 1")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("ambiguous date: month + number", () => {
+    // Firefox fails every time; Chrome is [arguably] inconsistent. We are [arguably] correct every time.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2024-12-01T08:00:00.000Z").toBe(new Date("Dec 2024").toISOString());
+    expect("1970-10-01T07:00:00.000Z").toBe(new Date("Octebor 1970").toISOString()); // Only the first three letters of the month count.
+    expect("1970-02-01T08:00:00.000Z").toBe(new Date("FebluAli-70").toISOString()); // Normal 2-digit year guessing applies (<50 -- +2000; >=50 +1900)
+    expect("1970-02-01T08:00:00.000Z").toBe(new Date("February 70").toISOString());
+    expect("2022-05-01T07:00:00.000Z").toBe(new Date("mayberry-22").toISOString());
+    expect("2011-06-01T07:00:00.000Z").toBe(new Date("junter-11").toISOString());
+    expect("-022024-12-01T08:12:28.000Z").toBe(new Date("-022024 December").toISOString());
+    expect("2024-12-01T08:00:00.000Z").toBe(new Date("2024 December").toISOString());
+    expect("1989-02-01T08:00:00.000Z").toBe(new Date("89-FebluAli").toISOString());
+    expect("2024-09-01T07:00:00.000Z").toBe(new Date("24 SePaRaTiNG").toISOString());
+    expect("1978-08-01T07:00:00.000Z").toBe(new Date("78 auger").toISOString());
+    expect("1971-12-01T08:00:00.000Z").toBe(new Date("71 decimate").toISOString());
+
+    // Chrome interprets numbers 1-31 as days in the given month in 2001. Weird. We interepret everything as a year.
+    expect("2007-02-01T08:00:00.000Z").toBe(new Date("7.FebluAli").toISOString());
+    expect("2021-02-01T08:00:00.000Z").toBe(new Date("21.FebluAli").toISOString());
+    expect("2031-02-01T08:00:00.000Z").toBe(new Date("31.FebluAli").toISOString());
+    expect("2032-02-01T08:00:00.000Z").toBe(new Date("32.FebluAli").toISOString());
+
+    setTimeZone(originalTimeZone);
+});
+
+test("ambiguous date: month + 2 numbers", () => {
+    // Compatible with Firefox and Chrome.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    // Unambiguous is obvious:
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Dec 5 2024").toISOString());
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Dec 2024 5").toISOString());
+    expect("2017-06-20T07:00:00.000Z").toBe(new Date("20 Jun 2017").toISOString());
+    expect("2017-06-20T07:00:00.000Z").toBe(new Date("2017 Jun 20").toISOString());
+    expect("1986-04-18T08:00:00.000Z").toBe(new Date("18 1986 Apr").toISOString());
+    expect("1986-04-18T08:00:00.000Z").toBe(new Date("1986 18 Apr").toISOString());
+
+    expect("2006-12-05T08:00:00.000Z").toBe(new Date("5 dec 6").toISOString()); // Ambiguous defaults to "D month Y".
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("5 dec 32").toISOString());
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("32 dec 5").toISOString()); // High first number is year.
+
+    expect("2006-12-05T08:00:00.000Z").toBe(new Date("dec 5 6").toISOString()); // Ambiguous defaults to "month D Y".
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("dec 5 32").toISOString());
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("dec 32 5").toISOString()); // High first number is year.
+
+    expect("2006-12-05T08:00:00.000Z").toBe(new Date("5 6 dec").toISOString()); // Ambiguous defaults to "D Y month"
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("5 32 dec").toISOString());
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("32 5 dec").toISOString()); // High first number is year.
+
+    // Only first 3 letters of the month name matter.
+    // All kinds of punctuation is accepted.
+    expect("1999-01-20T08:00:00.000Z").toBe(new Date("20-janitors-1999").toISOString());
+    expect("1999-06-20T07:00:00.000Z").toBe(new Date("20.Junuary, 1999").toISOString());
+    expect("2004-06-23T07:00:00.000Z").toBe(new Date("Junuary, 23 2004").toISOString());
+    expect("2004-04-11T07:00:00.000Z").toBe(new Date("2004/Apron/11").toISOString());
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("Decision/5-32").toISOString());
+    expect("2032-12-05T08:00:00.000Z").toBe(new Date("DeciMates 32 5").toISOString());
+
+    expect(Date.parse("20+Junuary, 1999")).toBeNaN(); // Invalid punctuation.
+    expect(Date.parse("33 34 dec")).toBeNaN(); // Neither of the numbers can be a day.
+    expect(Date.parse("33 dec 34")).toBeNaN();
+    expect(Date.parse("dec 33 34")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("time with colon", () => {
+    // Compatible with Chrome and Firefox.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2048-12-24T09:23:00.000Z").toBe(new Date("12/24/2048 1:23").toISOString());
+    expect("2048-12-24T09:23:45.000Z").toBe(new Date("12/24/2048 1:23:45").toISOString());
+    expect("2048-12-24T09:23:45.600Z").toBe(new Date("12/24/2048 1:23:45.6").toISOString());
+    expect("2048-12-24T09:23:45.670Z").toBe(new Date("12/24/2048 1:23:45.67").toISOString());
+    expect("2048-12-24T09:23:45.678Z").toBe(new Date("12/24/2048 1:23:45.678").toISOString());
+    expect("2048-12-24T09:23:45.678Z").toBe(new Date("12/24/2048 1:23:45.6789").toISOString()); // Truncated to milliseconds.
+    expect("2048-12-24T09:23:45.678Z").toBe(new Date("12/24/2048 1:23:45.678999999").toISOString());
+    // An insane number of digits.
+    expect("2048-12-24T09:23:45.678Z").toBe(
+        new Date(
+            "12/24/2048 1:23:45.67899999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+        ).toISOString()
+    );
+
+    // 24:00
+    expect("2048-12-24T08:00:00.000Z").toBe(new Date("12/24/2048 00:00").toISOString());
+    expect("2048-12-25T08:00:00.000Z").toBe(new Date("12/24/2048 24:00").toISOString()); // Time 24:00 is the next day
+    expect("2048-12-25T08:00:00.000Z").toBe(new Date("12/24/2048 24:00:00").toISOString());
+
+    // Partial date.
+    expect("2048-01-01T20:34:00.000Z").toBe(new Date("2048 12:34").toISOString());
+    expect("2048-09-01T19:34:00.000Z").toBe(new Date("Sep 2048 12:34").toISOString());
+    expect("2048-07-01T19:34:00.000Z").toBe(new Date("2048 Julie 12:34").toISOString());
+    expect("1999-07-01T19:34:00.000Z").toBe(new Date("99 Julie 12:34").toISOString());
+    expect("2012-07-01T19:34:00.000Z").toBe(new Date("12 Julie 12:34").toISOString());
+    expect("2000-01-01T20:23:00.000Z").toBe(new Date("2000-12:23").toISOString()); // Recover from unexpected time in ISO8601 date format.
+
+    expect(Date.parse("12/24/2048 1")).toBeNaN(); // Bare hours fail. At a minimum, time needs a colon ':'.
+    expect(Date.parse("12/24/2048 01")).toBeNaN();
+    expect(Date.parse("12/24/2048 1:2")).toBeNaN(); // Two digits needed for minutes.
+    expect(Date.parse("12/24/2048 1:23:4")).toBeNaN(); // Two digits needed for seconds
+
+    expect(Date.parse("12/24/2048 24:01")).toBeNaN(); // '24' hour needs 0 min 0 sec
+    expect(Date.parse("12/24/2048 24:01:00")).toBeNaN();
+    expect(Date.parse("12/24/2048 24:00:01")).toBeNaN();
+
+    expect(Date.parse("12/24/2048 44:12")).toBeNaN(); // Hour must be at most 24
+    expect(Date.parse("12/24/2048 12:66")).toBeNaN(); // Minutes must be at most 59
+    expect(Date.parse("12/24/2048 12:34:66")).toBeNaN(); // Seconds must be at most 59
+    expect(Date.parse("2048 11 12:34")).toBeNaN(); // guessing date from 2-digits still fails
+
+    expect(Date.parse("2000-09-12:23")).toBeNaN(); // Firefox and Chrome fail. So do we.
+    expect(Date.parse("2000-09-08-12:23")).toBeNaN(); // Firefox parses correctly. Chrome and us fail.
+
+    // Time before date.
+    expect("2048-12-24T09:23:00.000Z").toBe(new Date("1:23 12/24/2048").toISOString());
+    expect("2048-12-24T21:23:00.000Z").toBe(new Date("1:23PM 12/24/2048").toISOString());
+    expect("2048-12-24T09:23:45.000Z").toBe(new Date("1:23:45 12/24/2048").toISOString());
+    expect("2048-12-24T09:23:45.678Z").toBe(new Date("1:23:45.678 12/24/2048").toISOString());
+    expect("2048-12-24T09:23:45.678Z").toBe(new Date("1:23:45.678999 12/24/2048").toISOString());
+    expect("2048-12-01T09:23:00.000Z").toBe(new Date("1:23 Dec 2048").toISOString());
+    expect("2048-01-01T09:23:00.000Z").toBe(new Date("1:23 2048").toISOString());
+
+    expect(Date.parse("1:23 12/2048")).toBeNaN(); // Two numbers cannot be converted to a date..
+
+    setTimeZone(originalTimeZone);
+});
+
+test("am/pm", () => {
+    // Compatible with Chrome (mostly) and Firefox.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2019-05-12T08:24:00.000Z").toBe(new Date("5/12/2019 1:24AM").toISOString()); // Chrome needs space between time and AM/PM
+    expect("2019-05-12T08:24:00.000Z").toBe(new Date("5/12/2019 1:24 Am").toISOString()); // Space and capitalization.
+    expect("2019-05-12T08:24:38.000Z").toBe(new Date("5/12/2019 1:24:38 Am").toISOString());
+    expect("2019-05-12T20:24:38.123Z").toBe(new Date("5/12/2019 1:24:38.123pM").toISOString());
+
+    // Time before date.
+    expect("2048-12-24T09:23:00.000Z").toBe(new Date("1:23AM 12/24/2048").toISOString()); // Chrome fails on AM/PM time before date. Firefox and us support it.
+    expect("2048-12-24T09:23:45.000Z").toBe(new Date("1:23:45AM 12/24/2048").toISOString());
+    expect("2048-12-24T09:23:45.678Z").toBe(new Date("1:23:45.678AM 12/24/2048").toISOString());
+
+    expect("2019-05-12T07:34:00.000Z").toBe(new Date("5/12/2019 00:34 AM").toISOString()); // Midnight
+    expect("2019-05-12T07:34:00.000Z").toBe(new Date("5/12/2019 12:34 AM").toISOString());
+    expect("2019-05-12T19:34:00.000Z").toBe(new Date("5/12/2019 00:34 PM").toISOString()); // Noon
+    expect("2019-05-12T19:34:00.000Z").toBe(new Date("5/12/2019 12:34 PM").toISOString());
+
+    // Absurdly many digits
+    expect("2025-02-11T21:02:03.123Z").toBe(
+        new Date(
+            "2/11/25 1:02:03.123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890 PM"
+        ).toISOString()
+    );
+
+    expect(Date.parse("8/15/1999 3AM")).toBeNaN(); // Needs time with colon (at least HH:MM)
+    expect(Date.parse("8/15/1999 14:33AM")).toBeNaN(); // Hour less than or equal to 12
+
+    setTimeZone(originalTimeZone);
+});
+
+test("timezone offset", () => {
+    // Mostly compatible with Chrome and Firefox.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2019-07-18T11:22:00.000Z").toBe(new Date("07/18/2019 11:22Z").toISOString());
+    expect("2019-07-18T11:22:00.000Z").toBe(new Date("07/18/2019 11:22GMT").toISOString()); // Firefox and Chrome expect a space between time and GMT/UTC. We do not.
+    expect("2019-07-18T11:22:00.000Z").toBe(new Date("07/18/2019 11:22UTC").toISOString());
+    expect("2019-07-18T11:22:00.000Z").toBe(new Date("07/18/2019 11:22 z").toISOString()); // Space and capitalization
+    expect("2019-07-18T11:22:00.000Z").toBe(new Date("07/18/2019 11:22 UTC").toISOString());
+    expect("2019-07-18T11:22:00.000Z").toBe(new Date("07/18/2019 11:22 GMT").toISOString());
+
+    expect("2019-07-18T08:22:00.000Z").toBe(new Date("07/18/2019 11:22 +03").toISOString());
+    expect("2019-07-18T08:22:00.000Z").toBe(new Date("07/18/2019 11:22 +3").toISOString()); // 1-digit hour
+    expect("2019-07-18T08:22:00.000Z").toBe(new Date("07/18/2019 11:22+3").toISOString()); // No space
+    expect("2019-07-18T08:01:00.000Z").toBe(new Date("07/18/2019 11:22 +03:21").toISOString());
+    expect("2019-07-18T08:01:00.000Z").toBe(new Date("07/18/2019 11:22 +3:21").toISOString());
+
+    expect("2019-07-18T08:00:51.000Z").toBe(new Date("07/18/2019 11:22 +03:21:09").toISOString()); // Chrome and Firefox do not support seconds in timezone offset
+    expect("2019-07-18T08:00:50.877Z").toBe(
+        new Date("07/18/2019 11:22 +03:21:09.123").toISOString()
+    );
+    expect("2019-07-18T08:00:50.877Z").toBe(
+        new Date("07/18/2019 11:22 +03:21:09.12345678").toISOString()
+    ); // Truncate to milliseconds
+
+    expect("2019-07-18T08:22:00.000Z").toBe(new Date("07/18/2019 11:22 GMT+03").toISOString());
+    expect("2019-07-18T08:22:00.000Z").toBe(new Date("07/18/2019 11:22 UTC+03").toISOString());
+    expect("2019-07-18T08:22:00.000Z").toBe(new Date("07/18/2019 11:22 Z+03").toISOString());
+
+    expect(Date.parse("3/8/89 +01:23")).toBeNaN(); // Firefox and Chrome need GMT/Z/UTC before timezone offset when time is not specified. So do we.
+
+    // Military timezone offset
+    expect("2025-02-11T00:02:00.000Z").toBe(new Date("2/11/25 1:02+1").toISOString()); // Same as +01:00.
+    expect("2025-02-11T00:02:00.000Z").toBe(new Date("2/11/25 1:02+01").toISOString());
+    expect("2025-02-11T00:50:00.000Z").toBe(new Date("2/11/25 1:02+012").toISOString()); // Same as +00:12.
+    expect("2025-02-10T23:39:00.000Z").toBe(new Date("2/11/25 1:02+0123").toISOString());
+    expect("2025-02-11T00:49:26.000Z").toBe(new Date("2/11/25 1:02+01234").toISOString()); // Same as +00:12:34 (below).
+    // Chrome does not support 5 or 6 digit timezone offset. Firefox ignores seconds. We support it.
+    expect("2025-02-10T23:38:15.000Z").toBe(new Date("2/11/25 1:02+012345").toISOString());
+
+    // Date-only timezone offset needs GMT/UTC/Z
+    expect("1989-03-08T01:00:00.000Z").toBe(new Date("3/8/89 GMT-1").toISOString());
+    expect("1989-03-08T12:00:00.000Z").toBe(new Date("3/8/89 GMT-12").toISOString());
+    expect("1989-03-08T01:23:00.000Z").toBe(new Date("3/8/89 GMT-123").toISOString());
+    expect("1989-03-08T12:34:00.000Z").toBe(new Date("3/8/89 GMT-1234").toISOString());
+    expect("1989-03-08T01:00:00.000Z").toBe(new Date("3/8/89 UTC-1").toISOString());
+    expect("1989-03-08T01:00:00.000Z").toBe(new Date("3/8/89 Z-1").toISOString());
+
+    // 6-digit signed year is not timezone offset
+    expect("2025-02-11T08:00:00.000Z").toBe(new Date("Feb 11 +002025").toISOString());
+    expect("2025-02-11T08:00:00.000Z").toBe(new Date("2/11 +002025").toISOString());
+
+    expect(Date.parse("2/11 GMT+002025")).toBeNaN(); // GMT introduces a 6-digit "military" time offset, but we cannot guess date from two numbers.
+    expect(Date.parse("2/11/25 +1")).toBeNaN(); // Date-only military timezone needs GMT/UTC/Z.
+    expect(Date.parse("2/11/25 +12")).toBeNaN();
+    expect(Date.parse("2/11/25 +123")).toBeNaN();
+    expect(Date.parse("2/11/25 +1234")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("us timezones", () => {
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    // Compatible with Chrome and Firefox
+    // US mainland time zones are supported
+    expect("2024-12-08T23:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 PST").toISOString());
+    expect("2024-12-08T23:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 pSt").toISOString()); // Capitalization does not matter.
+    expect("2024-12-08T22:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 MST").toISOString());
+    expect("2024-12-08T21:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 CST").toISOString());
+    expect("2024-12-08T20:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 EST").toISOString());
+    expect("2024-12-08T22:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 PDT").toISOString()); // Daylight can be explicitly on any date (arguably incorrect).
+    expect("2024-12-08T21:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 MDT").toISOString());
+    expect("2024-12-08T20:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 CDT").toISOString());
+    expect("2024-12-08T19:30:00.000Z").toBe(new Date("8-Dec-2024 15:30:00 EDT").toISOString());
+
+    // Timezone (or GMT) indicator can be placed anywhere
+    expect("2025-02-23T08:00:00.000Z").toBe(new Date("EST 23 feb 2025").toISOString()); // Timezone name before time of the start of the date is ignored.
+
+    expect("2025-02-23T17:34:00.000Z").toBe(new Date("23 EST feb 2025 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 GMT feb 2025 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 UTC feb 2025 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 Z feb 2025 12:34").toISOString());
+
+    expect("2025-02-23T17:34:00.000Z").toBe(new Date("23 feb EST 2025 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb GMT 2025 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb UTC 2025 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb Z 2025 12:34").toISOString());
+
+    expect("2025-02-23T17:34:00.000Z").toBe(new Date("23 feb 2025 EST 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb 2025 GMT 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb 2025 UTC 12:34").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb 2025 Z 12:34").toISOString());
+
+    expect("2025-02-23T17:34:00.000Z").toBe(new Date("23 feb 2025 12:34 EST").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb 2025 12:34 GMT").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb 2025 12:34 UTC").toISOString());
+    expect("2025-02-23T12:34:00.000Z").toBe(new Date("23 feb 2025 12:34 Z").toISOString());
+
+    expect("2025-02-23T18:34:00.000Z").toBe(
+        new Date("23 EST feb PDT 2025 CST 12:34").toISOString()
+    ); // For multiple occurrences, the last one wins
+    expect("2022-02-12T20:34:00.000Z").toBe(new Date("2/12/22 12:34 +0100 PST").toISOString()); // Timezone name wins after timezone offset.
+
+    expect(Date.parse("12-Dec-2024 15:30:00 PT")).toBeNaN(); // Non-qualified timezone names ("PT"="Pacific Time"; no S/D) are not recognized
+
+    expect(Date.parse("12-Dec-2024 15:30:00 HST")).toBeNaN(); // Hawaii and Alaska are not recognized
+    expect(Date.parse("12-Dec-2024 15:30:00 AKST")).toBeNaN();
+
+    expect(Date.parse("12-Dec-2024 15:30:00 AST")).toBeNaN(); // Canadian Atlantic Standard Time (AST) and Newfoundland Standard Time are not recognized
+    expect(Date.parse("12-Dec-2024 15:30:00 NST")).toBeNaN();
+
+    // Chrome overwrites the timezone name. Firefox and us fail on timezone offset after time zone name.
+    expect(Date.parse("2/12/22 12:34 PST +0100")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("weekdays", () => {
+    // Weekday names are ignored. Compatible with Chrome and Firefox.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Thu Dec 5 2024").toISOString());
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Thursday Dec 5 2024").toISOString());
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Thurnip Dec 5 2024").toISOString());
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Mon Dec 5 2024").toISOString()); // Incorrect weekday is ignored.
+    expect("2024-12-05T08:00:00.000Z").toBe(new Date("Theater Dec 5 2024").toISOString()); // Anything before the first number is ignored.
+    expect("2024-12-05T08:00:00.000Z").toBe(
+        new Date("Mon Tue Wed Dec Thu YMCA 5 2024").toISOString()
+    );
+
+    expect(Date.parse("Mon Dec Tue 5 Wed 2024")).toBeNaN(); // Weekday names (or any other word) fail after the first number
+    expect(Date.parse("Mon Dec Tue 5 Wed 2024 Thu")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("timezone name", () => {
+    // Compatible with Chrome and Firefox. Anything that is not a closing bracket following an open bracket is ignored.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2020-12-05T20:23:00.000Z").toBe(
+        new Date("Thu Dec 5 2020 12:23 -0800 (America/Vancouver)").toISOString()
+    );
+    expect("2020-12-05T20:23:00.000Z").toBe(
+        new Date("Thu Dec 5 2020 12:23 -0800 (America/Chicago)").toISOString()
+    ); // Incorrect time zone name.
+    expect("2020-12-05T20:23:00.000Z").toBe(
+        new Date("Thu Dec 5 2020 12:23 (America/Chicago)").toISOString()
+    ); // Missing timezone offset makes it local time. Timezone name is ignored.
+    expect("2020-12-05T20:23:00.000Z").toBe(
+        new Date(
+            "Thu Dec 5 2020 12:23 -0800 (Whatever alpha 123 numerics or punctuation $# ({}[] works )"
+        ).toISOString()
+    );
+
+    expect(Date.parse("Mon Dec Tue 5 Wed 2024 (Cannot close a bracket ) twice)")).toBeNaN();
+    expect(Date.parse("Mon Dec Tue 5 Wed 2024 (Nothing after final bracket).")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("garbage", () => {
+    // Mostly compatible with Firefox. Chrome has more permissive punctuation but more restrictive syntax.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    expect("2204-01-20T02:32:00.000Z").toBe(
+        // Garbage (words and punctuation) are accepted at the start.
+        new Date(
+            "--sapdoaisfdm -,./ /dev/null world, .hello 2204 Jan 20 10:32 GMT+08:00" // Firefox and us accept -,./ Chrome is more permissive.
+        ).toISOString()
+    );
+
+    // Accept punctuation at any point before time.
+    // Firefox fails in some conditions before time.
+    // Chrome is finnicky on interior punctuation.
+    expect("2204-01-20T02:32:00.000Z").toBe(
+        new Date("2204 //. -/, Jan ./- 20 ..- 10:32 GMT+08:00").toISOString()
+    );
+
+    // Chrome does not accept punctuation after time. Firefox accepts some. We accept punctuation.
+    expect("2204-01-29T18:30:00.000Z").toBe(new Date("2204 Jan 29 10:30 /--/").toISOString());
+    expect("2204-01-29T23:04:00.000Z").toBe(new Date("2204 Jan 29 10:30 /--/ -1234").toISOString());
+
+    expect(Date.parse("2204 Jan 29 10:30. /-/")).toBeNaN(); // But we do not accept a dot after time.
+    expect(Date.parse("2204 Jan 29 10:30:28.")).toBeNaN();
+    expect(Date.parse("2204 twice Jan 29")).toBeNaN(); // No words after first number.
+    expect(Date.parse("+- 2204 Jan 29")).toBeNaN(); // '+' accepted by Chrome rejected by Firefox in some weird conditions. We reject it always.
+
+    expect(Date.parse("2204 + Jan 29")).toBeNaN();
+    expect(Date.parse("2204 Jan + 29")).toBeNaN();
+    expect(Date.parse("2204 + Jan 29")).toBeNaN();
+
+    setTimeZone(originalTimeZone);
+});
+
+test("multiple month names", () => {
+    // Compatible with Chrome and Firefox.
+    const originalTimeZone = setTimeZone("America/Vancouver");
+
+    // Multiple month names are accepted. Last one wins.
+    expect("1981-03-23T22:56:00.000Z").toBe(
+        new Date("March 23, 1981 14:56 GMT-08:00").toISOString()
+    );
+    expect("1981-04-23T22:56:00.000Z").toBe(
+        new Date("March 23, Apr 1981 14:56 GMT-08:00").toISOString()
+    );
+    expect("1981-05-23T22:56:00.000Z").toBe(
+        new Date("March 23, Apron 1981 mAY 14:56 GMT-08:00").toISOString()
+    );
+    expect("1981-06-23T22:56:00.000Z").toBe(
+        new Date("March 23, Apron 1981 mAY 14:56 junuary GMT-08:00").toISOString()
+    );
+    expect("1981-07-23T22:56:00.000Z").toBe(
+        new Date("March 23, Apron 1981 mAY 14:56 junuary GMT-08:00 Julie").toISOString()
+    );
+
+    setTimeZone(originalTimeZone);
+});


### PR DESCRIPTION
Fixes #2625 
- Compatibility with Mozilla Firefox (134.0.1) and Chromium (131.0.6778.264), where they agree
- When hitting incompatibilities between browsers, choose the more sane one
- Add support for [ES timezone offset](https://tc39.es/ecma262/#sec-time-zone-offset-strings), including timezone nanoseconds (not in Firefox or Chrome at this time)

How? `RegexParser` (based on `GenericLexer`):
- Tries to parse ES date string with ISO8601 extensions.
- If that fails, continues with a greedy shallow parse, looking for all sorts of date parts. 
- Minor adjustments to the `Date.parse.js` unit tests, to bring them into compliance.

Bonus: added `AK::ErrorOr::value_or` convenience method in the spirit of `Optional::value_or`. Easy to remove from PR if there are objections :]m