### PR TITLE
LibJS: Add environment type checks to instruction lookup caches

### DIFF
--- a/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -1399,7 +1399,7 @@ inline ThrowCompletionOr<CalleeAndThis> get_callee_and_this_from_environment(Byt
         auto const* environment = interpreter.running_execution_context().lexical_environment.ptr();
         for (size_t i = 0; i < cache.hops; ++i)
             environment = environment->outer_environment();
-        if (!environment->is_permanently_screwed_by_eval()) {
+        if (!environment->is_permanently_screwed_by_eval() && environment->is_declarative_environment()) {
             callee = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, cache.index));
             this_value = js_undefined();
             if (auto base_object = environment->with_base_object())
@@ -2179,7 +2179,7 @@ ThrowCompletionOr<void> GetBinding::execute_impl(Bytecode::Interpreter& interpre
         auto const* environment = interpreter.running_execution_context().lexical_environment.ptr();
         for (size_t i = 0; i < m_cache.hops; ++i)
             environment = environment->outer_environment();
-        if (!environment->is_permanently_screwed_by_eval()) {
+        if (!environment->is_permanently_screwed_by_eval() && environment->is_declarative_environment()) {
             interpreter.set(dst(), TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, m_cache.index)));
             return {};
         }
@@ -2328,7 +2328,7 @@ static ThrowCompletionOr<void> initialize_or_set_binding(Interpreter& interprete
     if (cache.is_valid()) {
         for (size_t i = 0; i < cache.hops; ++i)
             environment = environment->outer_environment();
-        if (!environment->is_permanently_screwed_by_eval()) {
+        if (!environment->is_permanently_screwed_by_eval() && environment->is_declarative_environment()) {
             if constexpr (initialization_mode == BindingInitializationMode::Initialize) {
                 TRY(static_cast<DeclarativeEnvironment&>(*environment).initialize_binding_direct(vm, cache.index, value, Environment::InitializeBindingHint::Normal));
             } else {
@@ -2950,7 +2950,7 @@ ThrowCompletionOr<void> TypeofBinding::execute_impl(Bytecode::Interpreter& inter
         auto const* environment = interpreter.running_execution_context().lexical_environment.ptr();
         for (size_t i = 0; i < m_cache.hops; ++i)
             environment = environment->outer_environment();
-        if (!environment->is_permanently_screwed_by_eval()) {
+        if (!environment->is_permanently_screwed_by_eval() && environment->is_declarative_environment()) {
             auto value = TRY(static_cast<DeclarativeEnvironment const&>(*environment).get_binding_value_direct(vm, m_cache.index));
             interpreter.set(dst(), value.typeof_(vm));
             return {};

--- a/Libraries/LibJS/Tests/regress/environment-type-confusion.js
+++ b/Libraries/LibJS/Tests/regress/environment-type-confusion.js
@@ -1,0 +1,20 @@
+test("PR: #3620; Don't crash when running with UBSAN", () => {
+    async function outer(a) {
+        try {
+            let [] = this;
+        } catch(e17) {
+            a.foo = a;
+            try {
+            } catch(e20) {
+            }
+        } finally {
+            function inner() {
+                a;
+            }
+            inner();
+        }
+    }
+
+    outer();
+    outer(outer);
+});


### PR DESCRIPTION
Fuzzilli found the following:
```js
async function f0(a1) {
    try {
        let [] = this;
    } catch(e17) {
        a1.h = a1;
        try {
        } catch(e20) {
        }
    } finally {
        function f21() {
            a1;
        }
        f21();
    }
}

f0();
f0(f0);
```
Which makes UBSAN mad:
```shell
/home/jess/code/ladybird/Libraries/LibJS/Bytecode/Interpreter.cpp:2183:36: runtime error: member call on address 0x7fe702e75040 which does not point to an object of type 'DeclarativeEnvironment'
0x7fe702e75040: note: object is of type 'JS::GlobalEnvironment'
 00 00 00 00  20 56 e6 0d e7 7f 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'JS::GlobalEnvironment'
/home/jess/code/ladybird/Libraries/LibJS/Runtime/DeclarativeEnvironment.h:135:36: runtime error: member call on address 0x7fe702e75040 which does not point to an object of type 'DeclarativeEnvironment'
0x7fe702e75040: note: object is of type 'JS::GlobalEnvironment'
 00 00 00 00  20 56 e6 0d e7 7f 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'JS::GlobalEnvironment'
```