### PR TITLE
LibWeb: Resolve SVG issues with inline continuation

### DIFF
--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -1232,6 +1232,10 @@ bool NodeWithStyleAndBoxModelMetrics::should_create_inline_continuation() const
     if (is<SVG::SVGForeignObjectElement>(parent()->dom_node()))
         return false;
 
+    // SVGBoxes are appended directly to their layout parent without changing the parent's (non-)inline behavior.
+    if (is_svg_box())
+        return false;
+
     return true;
 }
 

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -264,6 +265,8 @@ class NodeWithStyleAndBoxModelMetrics : public NodeWithStyle {
 public:
     GC::Ptr<NodeWithStyleAndBoxModelMetrics> continuation_of_node() const { return m_continuation_of_node; }
     void set_continuation_of_node(Badge<TreeBuilder>, GC::Ptr<NodeWithStyleAndBoxModelMetrics> node) { m_continuation_of_node = node; }
+
+    bool should_create_inline_continuation() const;
 
     void propagate_style_along_continuation(CSS::ComputedProperties const&) const;
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -32,7 +32,6 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/TreeBuilder.h>
 #include <LibWeb/Layout/Viewport.h>
-#include <LibWeb/SVG/SVGForeignObjectElement.h>
 
 namespace Web::Layout {
 
@@ -609,11 +608,9 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         // If we completely finished inserting a block level element into an inline parent, we need to fix up the tree so
         // that we can maintain the invariant that all children are either inline or non-inline. We can't do this earlier,
         // because the restructuring adds new children after this node that become part of the ancestor stack.
-        auto* layout_parent = layout_node->parent();
-        if (layout_parent && layout_parent->display().is_inline_outside() && !display.is_contents()
-            && !is<SVG::SVGForeignObjectElement>(layout_parent->dom_node())
-            && !display.is_inline_outside() && layout_parent->display().is_flow_inside() && !layout_node->is_out_of_flow())
-            restructure_block_node_in_inline_parent(static_cast<NodeWithStyleAndBoxModelMetrics&>(*layout_node));
+        if (auto node_with_metrics = as_if<NodeWithStyleAndBoxModelMetrics>(*layout_node);
+            node_with_metrics && node_with_metrics->should_create_inline_continuation())
+            restructure_block_node_in_inline_parent(*node_with_metrics);
     }
 
     // https://www.w3.org/TR/css-contain-2/#containment-style

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -549,12 +549,10 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
             && old_layout_node != layout_node;
         if (may_replace_existing_layout_node) {
             old_layout_node->parent()->replace_child(*layout_node, *old_layout_node);
+        } else if (layout_node->is_svg_box()) {
+            m_ancestor_stack.last()->append_child(*layout_node);
         } else {
-            if (layout_node->is_svg_box()) {
-                m_ancestor_stack.last()->append_child(*layout_node);
-            } else {
-                insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
-            }
+            insert_node_into_inline_or_block_ancestor(*layout_node, display, AppendOrPrepend::Append);
         }
     }
 

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -611,6 +611,7 @@ void TreeBuilder::update_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         // because the restructuring adds new children after this node that become part of the ancestor stack.
         auto* layout_parent = layout_node->parent();
         if (layout_parent && layout_parent->display().is_inline_outside() && !display.is_contents()
+            && !is<SVG::SVGForeignObjectElement>(layout_parent->dom_node())
             && !display.is_inline_outside() && layout_parent->display().is_flow_inside() && !layout_node->is_out_of_flow())
             restructure_block_node_in_inline_parent(static_cast<NodeWithStyleAndBoxModelMetrics&>(*layout_node));
     }

--- a/Tests/LibWeb/Crash/Layout/svg-box-no-inline-continuation.html
+++ b/Tests/LibWeb/Crash/Layout/svg-box-no-inline-continuation.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<!-- SVGBoxes should never be considered for inline continuation; caused a crash previously. -->
+<svg>inline text before <g style="display: block"></g></svg>

--- a/Tests/LibWeb/Layout/expected/svg/svg-foreign-object-with-block-element.txt
+++ b/Tests/LibWeb/Layout/expected/svg/svg-foreign-object-with-block-element.txt
@@ -1,0 +1,18 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x100 children: inline
+      frag 0 from SVGSVGBox start: 0, length: 0, rect: [8,8 100x100] baseline: 100
+      SVGSVGBox <svg> at (8,8) content-size 100x100 [SVG] children: inline
+        SVGForeignObjectBox <foreignObject> at (8,8) content-size 0x0 children: not-inline
+          BlockContainer <div> at (8,8) content-size 100x17 children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [8,8 27.15625x17] baseline: 13.296875
+                "foo"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x100]
+      SVGSVGPaintable (SVGSVGBox<svg>) [8,8 100x100]
+        SVGForeignObjectPaintable (SVGForeignObjectBox<foreignObject>) [8,8 0x0] overflow: [8,8 100x17]
+          PaintableWithLines (BlockContainer<DIV>) [8,8 100x17]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/input/svg/svg-foreign-object-with-block-element.html
+++ b/Tests/LibWeb/Layout/input/svg/svg-foreign-object-with-block-element.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<svg width="100" height="100"><foreignObject width="100" height="100"><div>foo


### PR DESCRIPTION
Fixes #3453 and #3395, both involving https://discord.com.