### PR TITLE
AK/Checked: Dont verify overflow bit in lvalue operations

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -255,7 +255,7 @@ public:
     constexpr Checked& operator+=(Checked const& other)
     {
         m_overflow |= other.m_overflow;
-        add(other.value());
+        add(other.value_unchecked());
         return *this;
     }
 
@@ -268,7 +268,7 @@ public:
     constexpr Checked& operator-=(Checked const& other)
     {
         m_overflow |= other.m_overflow;
-        sub(other.value());
+        sub(other.value_unchecked());
         return *this;
     }
 
@@ -281,7 +281,7 @@ public:
     constexpr Checked& operator*=(Checked const& other)
     {
         m_overflow |= other.m_overflow;
-        mul(other.value());
+        mul(other.value_unchecked());
         return *this;
     }
 
@@ -294,7 +294,7 @@ public:
     constexpr Checked& operator/=(Checked const& other)
     {
         m_overflow |= other.m_overflow;
-        div(other.value());
+        div(other.value_unchecked());
         return *this;
     }
 
@@ -307,7 +307,7 @@ public:
     constexpr Checked& operator%=(Checked const& other)
     {
         m_overflow |= other.m_overflow;
-        mod(other.value());
+        mod(other.value_unchecked());
         return *this;
     }
 
@@ -434,7 +434,7 @@ template<typename T>
 constexpr Checked<T> operator+(Checked<T> const& a, Checked<T> const& b)
 {
     Checked<T> c { a };
-    c.add(b.value());
+    c += b;
     return c;
 }
 
@@ -442,7 +442,7 @@ template<typename T>
 constexpr Checked<T> operator-(Checked<T> const& a, Checked<T> const& b)
 {
     Checked<T> c { a };
-    c.sub(b.value());
+    c -= b;
     return c;
 }
 
@@ -450,7 +450,7 @@ template<typename T>
 constexpr Checked<T> operator*(Checked<T> const& a, Checked<T> const& b)
 {
     Checked<T> c { a };
-    c.mul(b.value());
+    c *= b;
     return c;
 }
 
@@ -458,7 +458,7 @@ template<typename T>
 constexpr Checked<T> operator/(Checked<T> const& a, Checked<T> const& b)
 {
     Checked<T> c { a };
-    c.div(b.value());
+    c /= b;
     return c;
 }
 
@@ -466,7 +466,7 @@ template<typename T>
 constexpr Checked<T> operator%(Checked<T> const& a, Checked<T> const& b)
 {
     Checked<T> c { a };
-    c.mod(b.value());
+    c %= b;
     return c;
 }
 

--- a/Tests/AK/TestChecked.cpp
+++ b/Tests/AK/TestChecked.cpp
@@ -135,6 +135,49 @@ TEST_CASE(detects_unsigned_overflow)
     EXPECT((Checked<u64>(0x4000000000000000) - Checked<u64>(0x4000000000000001)).has_overflow());
 }
 
+TEST_CASE(operations_with_overflowed)
+{
+    {
+        Checked<u32> overflowed(0x100000000);
+        EXPECT((Checked<u32>(0x100000000) + Checked<u32>(0xff)).has_overflow());
+        EXPECT((Checked<u32>(0xff) + Checked<u32>(0x100000000)).has_overflow());
+        EXPECT((overflowed += Checked<u32>(0xff)).has_overflow());
+        EXPECT((overflowed += Checked<u32>(0x100000000)).has_overflow());
+    }
+
+    {
+        Checked<u32> overflowed(0x100000000);
+        EXPECT((Checked<u32>(0x100000000) - Checked<u32>(0xff)).has_overflow());
+        EXPECT((Checked<u32>(0xff) - Checked<u32>(0x100000000)).has_overflow());
+        EXPECT((overflowed -= Checked<u32>(0xff)).has_overflow());
+        EXPECT((overflowed -= Checked<u32>(0x100000000)).has_overflow());
+    }
+
+    {
+        Checked<u32> overflowed(0x100000000);
+        EXPECT((Checked<u32>(0x100000000) * Checked<u32>(0xff)).has_overflow());
+        EXPECT((Checked<u32>(0xff) * Checked<u32>(0x100000000)).has_overflow());
+        EXPECT((overflowed *= Checked<u32>(0xff)).has_overflow());
+        EXPECT((overflowed *= Checked<u32>(0x100000000)).has_overflow());
+    }
+
+    {
+        Checked<u32> overflowed(0x100000000);
+        EXPECT((Checked<u32>(0x100000000) / Checked<u32>(0xff)).has_overflow());
+        EXPECT((Checked<u32>(0xff) / Checked<u32>(0x100000000)).has_overflow());
+        EXPECT((overflowed /= Checked<u32>(0xff)).has_overflow());
+        EXPECT((overflowed /= Checked<u32>(0x100000000)).has_overflow());
+    }
+
+    {
+        Checked<u32> overflowed(0x100000000);
+        EXPECT((Checked<u32>(0x100000000) % Checked<u32>(0xff)).has_overflow());
+        EXPECT((Checked<u32>(0xff) % Checked<u32>(0x100000000)).has_overflow());
+        EXPECT((overflowed %= Checked<u32>(0xff)).has_overflow());
+        EXPECT((overflowed %= Checked<u32>(0x100000000)).has_overflow());
+    }
+}
+
 TEST_CASE(should_constexpr_default_construct)
 {
     constexpr Checked<int> checked_value {};


### PR DESCRIPTION
Adding an overflow'n `Checked<T>` to another `Checked<T>` causes a verification faliure when instead it should propogate m_overflow and allow the user to handle the overflow.

Meaning something like this crashes:
```js
let byte_offset = 0;
let length = 0x100000000;

new Uint32Array(new ArrayBuffer(), byte_offset, length);
```