### PR TITLE
AK+Everywhere: Store JSON strings as `String`

### DIFF
--- a/AK/CMakeLists.txt
+++ b/AK/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     Format.cpp
     GenericLexer.cpp
     Hex.cpp
+    JsonArray.cpp
     JsonObject.cpp
     JsonParser.cpp
     JsonValue.cpp

--- a/AK/JsonArray.cpp
+++ b/AK/JsonArray.cpp
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonArraySerializer.h>
+#include <AK/StringBuilder.h>
+
+namespace AK {
+
+String JsonArray::serialized() const
+{
+    StringBuilder builder;
+    serialize(builder);
+
+    return MUST(builder.to_string());
+}
+
+void JsonArray::serialize(StringBuilder& builder) const
+{
+    auto serializer = MUST(JsonArraySerializer<>::try_create(builder));
+    for_each([&](auto const& value) {
+        MUST(serializer.add(value));
+    });
+    MUST(serializer.finish());
+}
+
+}

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -8,8 +8,8 @@
 
 #include <AK/Concepts.h>
 #include <AK/Error.h>
-#include <AK/JsonArraySerializer.h>
 #include <AK/JsonValue.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace AK {
@@ -72,11 +72,8 @@ public:
     ErrorOr<void> append(JsonValue value) { return m_values.try_append(move(value)); }
     void set(size_t index, JsonValue value) { m_values.at(index) = move(value); }
 
-    template<typename Builder>
-    typename Builder::OutputType serialized() const;
-
-    template<typename Builder>
-    void serialize(Builder&) const;
+    String serialized() const;
+    void serialize(StringBuilder&) const;
 
     template<typename Callback>
     void for_each(Callback callback)
@@ -117,22 +114,6 @@ public:
 private:
     Vector<JsonValue> m_values;
 };
-
-template<typename Builder>
-inline void JsonArray::serialize(Builder& builder) const
-{
-    auto serializer = MUST(JsonArraySerializer<>::try_create(builder));
-    for_each([&](auto& value) { MUST(serializer.add(value)); });
-    MUST(serializer.finish());
-}
-
-template<typename Builder>
-inline typename Builder::OutputType JsonArray::serialized() const
-{
-    Builder builder;
-    serialize(builder);
-    return builder.to_byte_string();
-}
 
 }
 

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -78,8 +78,6 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    [[nodiscard]] ByteString to_byte_string() const { return serialized<StringBuilder>(); }
-
     template<typename Callback>
     void for_each(Callback callback)
     {

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -123,13 +123,6 @@ Optional<String const&> JsonObject::get_string(StringView key) const
     return {};
 }
 
-Optional<ByteString> JsonObject::get_byte_string(StringView key) const
-{
-    if (auto value = get_string(key); value.has_value())
-        return value->to_byte_string();
-    return {};
-}
-
 Optional<JsonObject&> JsonObject::get_object(StringView key)
 {
     auto maybe_value = get(key);
@@ -280,11 +273,6 @@ void JsonObject::set(StringView key, JsonValue value)
 bool JsonObject::remove(StringView key)
 {
     return m_members.remove(key);
-}
-
-ByteString JsonObject::to_byte_string() const
-{
-    return serialized<StringBuilder>();
 }
 
 }

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -261,9 +261,14 @@ bool JsonObject::has_object(StringView key) const
     return value.has_value() && value->is_object();
 }
 
-void JsonObject::set(ByteString const& key, JsonValue value)
+void JsonObject::set(String key, JsonValue value)
 {
-    m_members.set(key, move(value));
+    m_members.set(move(key), move(value));
+}
+
+void JsonObject::set(StringView key, JsonValue value)
+{
+    set(MUST(String::from_utf8(key)), move(value));
 }
 
 bool JsonObject::remove(StringView key)

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -116,11 +116,17 @@ Optional<bool> JsonObject::get_bool(StringView key) const
     return {};
 }
 
+Optional<String const&> JsonObject::get_string(StringView key) const
+{
+    if (auto value = get(key); value.has_value() && value->is_string())
+        return value->as_string();
+    return {};
+}
+
 Optional<ByteString> JsonObject::get_byte_string(StringView key) const
 {
-    auto maybe_value = get(key);
-    if (maybe_value.has_value() && maybe_value->is_string())
-        return maybe_value->as_string();
+    if (auto value = get_string(key); value.has_value())
+        return value->to_byte_string();
     return {};
 }
 

--- a/AK/JsonObject.cpp
+++ b/AK/JsonObject.cpp
@@ -6,7 +6,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "JsonObject.h"
+#include <AK/JsonObject.h>
+#include <AK/JsonObjectSerializer.h>
+#include <AK/StringBuilder.h>
 
 namespace AK {
 
@@ -273,6 +275,23 @@ void JsonObject::set(StringView key, JsonValue value)
 bool JsonObject::remove(StringView key)
 {
     return m_members.remove(key);
+}
+
+String JsonObject::serialized() const
+{
+    StringBuilder builder;
+    serialize(builder);
+
+    return MUST(builder.to_string());
+}
+
+void JsonObject::serialize(StringBuilder& builder) const
+{
+    auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
+    for_each_member([&](auto& key, auto& value) {
+        MUST(serializer.add(key, value));
+    });
+    MUST(serializer.finish());
 }
 
 }

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -77,7 +77,6 @@ public:
     Optional<bool> get_bool(StringView key) const;
 
     Optional<String const&> get_string(StringView key) const;
-    Optional<ByteString> get_byte_string(StringView key) const;
 
     Optional<JsonObject&> get_object(StringView key);
     Optional<JsonObject const&> get_object(StringView key) const;
@@ -113,8 +112,6 @@ public:
 
     template<typename Builder>
     void serialize(Builder&) const;
-
-    [[nodiscard]] ByteString to_byte_string() const;
 
 private:
     OrderedHashMap<String, JsonValue> m_members;

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -76,6 +76,7 @@ public:
     Optional<FlatPtr> get_addr(StringView key) const;
     Optional<bool> get_bool(StringView key) const;
 
+    Optional<String const&> get_string(StringView key) const;
     Optional<ByteString> get_byte_string(StringView key) const;
 
     Optional<JsonObject&> get_object(StringView key);
@@ -144,7 +145,7 @@ inline void JsonValue::serialize(Builder& builder) const
         [&](Empty const&) { builder.append("null"sv); },
         [&](bool const& value) { builder.append(value ? "true"sv : "false"sv); },
         [&](Arithmetic auto const& value) { builder.appendff("{}", value); },
-        [&](ByteString const& value) {
+        [&](String const& value) {
             builder.append('\"');
             builder.append_escaped_for_json(value.bytes());
             builder.append('\"');

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -15,12 +15,13 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
+#include <AK/String.h>
 
 namespace AK {
 
 class JsonObject {
     template<typename Callback>
-    using CallbackErrorType = decltype(declval<Callback>()(declval<ByteString const&>(), declval<JsonValue const&>()).release_error());
+    using CallbackErrorType = decltype(declval<Callback>()(declval<String const&>(), declval<JsonValue const&>()).release_error());
 
 public:
     JsonObject();
@@ -86,7 +87,8 @@ public:
     Optional<double> get_double_with_precision_loss(StringView key) const;
     Optional<float> get_float_with_precision_loss(StringView key) const;
 
-    void set(ByteString const& key, JsonValue value);
+    void set(String key, JsonValue value);
+    void set(StringView key, JsonValue value);
 
     template<typename Callback>
     void for_each_member(Callback callback) const
@@ -95,7 +97,7 @@ public:
             callback(member.key, member.value);
     }
 
-    template<FallibleFunction<ByteString const&, JsonValue const&> Callback>
+    template<FallibleFunction<String const&, JsonValue const&> Callback>
     ErrorOr<void, CallbackErrorType<Callback>> try_for_each_member(Callback&& callback) const
     {
         for (auto const& member : m_members)
@@ -114,7 +116,7 @@ public:
     [[nodiscard]] ByteString to_byte_string() const;
 
 private:
-    OrderedHashMap<ByteString, JsonValue> m_members;
+    OrderedHashMap<String, JsonValue> m_members;
 };
 
 template<typename Builder>

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -57,7 +57,7 @@ public:
         return {};
     }
 
-    ErrorOr<void> add(StringView key, ByteString const& value)
+    ErrorOr<void> add(StringView key, String const& value)
     {
         TRY(begin_item(key));
         if constexpr (IsLegacyBuilder<Builder>) {

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -153,17 +153,17 @@ JsonValue::JsonValue(long long unsigned value)
 }
 
 JsonValue::JsonValue(double value)
-    : m_value(double { value })
-{
-}
-
-JsonValue::JsonValue(ByteString const& value)
     : m_value(value)
 {
 }
 
+JsonValue::JsonValue(String value)
+    : m_value(move(value))
+{
+}
+
 JsonValue::JsonValue(StringView value)
-    : m_value(ByteString { value })
+    : m_value(MUST(String::from_utf8(value)))
 {
 }
 

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -152,11 +152,6 @@ JsonValue::JsonValue(long long unsigned value)
 {
 }
 
-JsonValue::JsonValue(char const* cstring)
-    : m_value(ByteString { cstring })
-{
-}
-
 JsonValue::JsonValue(double value)
     : m_value(double { value })
 {

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -13,28 +13,16 @@
 
 namespace AK {
 
-namespace {
-using JsonValueStorage = Variant<
-    Empty,
-    bool,
-    i64,
-    u64,
-    double,
-    ByteString,
-    NonnullOwnPtr<JsonArray>,
-    NonnullOwnPtr<JsonObject>>;
-
-static ErrorOr<JsonValueStorage> clone(JsonValueStorage const& other)
+static ErrorOr<JsonValue::Storage> clone(JsonValue::Storage const& other)
 {
     return other.visit(
-        [](NonnullOwnPtr<JsonArray> const& value) -> ErrorOr<JsonValueStorage> {
+        [](NonnullOwnPtr<JsonArray> const& value) -> ErrorOr<JsonValue::Storage> {
             return TRY(try_make<JsonArray>(*value));
         },
-        [](NonnullOwnPtr<JsonObject> const& value) -> ErrorOr<JsonValueStorage> {
+        [](NonnullOwnPtr<JsonObject> const& value) -> ErrorOr<JsonValue::Storage> {
             return TRY(try_make<JsonObject>(*value));
         },
-        [](auto const& value) -> ErrorOr<JsonValueStorage> { return JsonValueStorage(value); });
-}
+        [](auto const& value) -> ErrorOr<JsonValue::Storage> { return JsonValue::Storage(value); });
 }
 
 JsonValue::JsonValue() = default;

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -9,8 +9,8 @@
 
 #include <AK/ByteString.h>
 #include <AK/Forward.h>
+#include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
-#include <AK/OwnPtr.h>
 #include <AK/StringBuilder.h>
 
 namespace AK {
@@ -25,6 +25,16 @@ public:
         Array,
         Object,
     };
+
+    using Storage = Variant<
+        Empty,
+        bool,
+        i64,
+        u64,
+        double,
+        ByteString,
+        NonnullOwnPtr<JsonArray>,
+        NonnullOwnPtr<JsonObject>>;
 
     static ErrorOr<JsonValue> from_string(StringView);
 
@@ -222,16 +232,7 @@ public:
     bool equals(JsonValue const& other) const;
 
 private:
-    Variant<
-        Empty,
-        bool,
-        i64,
-        u64,
-        double,
-        ByteString,
-        NonnullOwnPtr<JsonArray>,
-        NonnullOwnPtr<JsonObject>>
-        m_value;
+    Storage m_value;
 };
 
 template<>

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/Forward.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
 
 namespace AK {
@@ -32,7 +32,7 @@ public:
         i64,
         u64,
         double,
-        ByteString,
+        String,
         NonnullOwnPtr<JsonArray>,
         NonnullOwnPtr<JsonObject>>;
 
@@ -53,9 +53,9 @@ public:
     JsonValue(long unsigned);
     JsonValue(long long);
     JsonValue(long long unsigned);
-
     JsonValue(double);
-    JsonValue(ByteString const&);
+
+    JsonValue(String);
     JsonValue(StringView);
 
     template<typename T>
@@ -119,9 +119,9 @@ public:
         return m_value.get<bool>();
     }
 
-    ByteString const& as_string() const
+    String const& as_string() const
     {
-        return m_value.get<ByteString>();
+        return m_value.get<String>();
     }
 
     JsonObject& as_object()
@@ -155,14 +155,14 @@ public:
             [](Empty const&) { return Type::Null; },
             [](bool const&) { return Type::Bool; },
             [](Arithmetic auto const&) { return Type::Number; },
-            [](ByteString const&) { return Type::String; },
+            [](String const&) { return Type::String; },
             [](NonnullOwnPtr<JsonArray> const&) { return Type::Array; },
             [](NonnullOwnPtr<JsonObject> const&) { return Type::Object; });
     }
 
     bool is_null() const { return m_value.has<Empty>(); }
     bool is_bool() const { return m_value.has<bool>(); }
-    bool is_string() const { return m_value.has<ByteString>(); }
+    bool is_string() const { return m_value.has<String>(); }
     bool is_array() const { return m_value.has<NonnullOwnPtr<JsonArray>>(); }
     bool is_object() const { return m_value.has<NonnullOwnPtr<JsonObject>>(); }
     bool is_number() const

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -11,7 +11,6 @@
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
-#include <AK/StringBuilder.h>
 
 namespace AK {
 
@@ -77,10 +76,8 @@ public:
     JsonValue& operator=(JsonArray&&);
     JsonValue& operator=(JsonObject&&);
 
-    template<typename Builder>
-    typename Builder::OutputType serialized() const;
-    template<typename Builder>
-    void serialize(Builder&) const;
+    String serialized() const;
+    void serialize(StringBuilder&) const;
 
     Optional<int> get_int() const { return get_integer<int>(); }
     Optional<i32> get_i32() const { return get_integer<i32>(); }
@@ -224,7 +221,7 @@ template<>
 struct Formatter<JsonValue> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, JsonValue const& value)
     {
-        return Formatter<StringView>::format(builder, value.serialized<StringBuilder>());
+        return Formatter<StringView>::format(builder, value.serialized());
     }
 };
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -55,7 +55,6 @@ public:
     JsonValue(long long unsigned);
 
     JsonValue(double);
-    JsonValue(char const*);
     JsonValue(ByteString const&);
     JsonValue(StringView);
 

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -83,20 +83,6 @@ public:
     template<typename Builder>
     void serialize(Builder&) const;
 
-    ByteString as_string_or(ByteString const& alternative) const
-    {
-        if (is_string())
-            return as_string();
-        return alternative;
-    }
-
-    ByteString deprecated_to_byte_string() const
-    {
-        if (is_string())
-            return as_string();
-        return serialized<StringBuilder>();
-    }
-
     Optional<int> get_int() const { return get_integer<int>(); }
     Optional<i32> get_i32() const { return get_integer<i32>(); }
     Optional<i64> get_i64() const { return get_integer<i64>(); }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -19,7 +19,6 @@ public:
     static constexpr size_t inline_capacity = 256;
 
     using Buffer = Detail::ByteBuffer<inline_capacity>;
-    using OutputType = ByteString;
 
     static ErrorOr<StringBuilder> create(size_t initial_capacity = inline_capacity);
 

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -754,7 +754,7 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, ReadonlySpan<
         object.set("invariant_offset"sv, has_invariant ? option_to_complete.length() : 0u);
         object.set("display_trivia"sv, StringView { option.help_string, strlen(option.help_string) });
         object.set("trailing_trivia"sv, option.argument_mode == OptionArgumentMode::Required ? " "sv : ""sv);
-        outln(file, "{}", object.serialized<StringBuilder>());
+        outln(file, "{}", object.serialized());
     };
 
     if (option_to_complete.starts_with("--"sv)) {

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -749,7 +749,7 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, ReadonlySpan<
 
     auto write_completion = [&](auto format, auto& option, auto has_invariant, auto... args) {
         JsonObject object;
-        object.set("completion"sv, ByteString::formatted(StringView { format, strlen(format) }, args...));
+        object.set("completion"sv, MUST(String::formatted(StringView { format, strlen(format) }, args...)));
         object.set("static_offset"sv, 0);
         object.set("invariant_offset"sv, has_invariant ? option_to_complete.length() : 0u);
         object.set("display_trivia"sv, StringView { option.help_string, strlen(option.help_string) });

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -754,7 +754,7 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, ReadonlySpan<
         object.set("invariant_offset"sv, has_invariant ? option_to_complete.length() : 0u);
         object.set("display_trivia"sv, StringView { option.help_string, strlen(option.help_string) });
         object.set("trailing_trivia"sv, option.argument_mode == OptionArgumentMode::Required ? " "sv : ""sv);
-        outln(file, "{}", object.to_byte_string());
+        outln(file, "{}", object.serialized<StringBuilder>());
     };
 
     if (option_to_complete.starts_with("--"sv)) {

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -752,8 +752,8 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, ReadonlySpan<
         object.set("completion", ByteString::formatted(StringView { format, strlen(format) }, args...));
         object.set("static_offset", 0);
         object.set("invariant_offset", has_invariant ? option_to_complete.length() : 0u);
-        object.set("display_trivia", option.help_string);
-        object.set("trailing_trivia", option.argument_mode == OptionArgumentMode::Required ? " " : "");
+        object.set("display_trivia", StringView { option.help_string, strlen(option.help_string) });
+        object.set("trailing_trivia", option.argument_mode == OptionArgumentMode::Required ? " "sv : ""sv);
         outln(file, "{}", object.to_byte_string());
     };
 

--- a/Libraries/LibCore/ArgsParser.cpp
+++ b/Libraries/LibCore/ArgsParser.cpp
@@ -749,11 +749,11 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, ReadonlySpan<
 
     auto write_completion = [&](auto format, auto& option, auto has_invariant, auto... args) {
         JsonObject object;
-        object.set("completion", ByteString::formatted(StringView { format, strlen(format) }, args...));
-        object.set("static_offset", 0);
-        object.set("invariant_offset", has_invariant ? option_to_complete.length() : 0u);
-        object.set("display_trivia", StringView { option.help_string, strlen(option.help_string) });
-        object.set("trailing_trivia", option.argument_mode == OptionArgumentMode::Required ? " "sv : ""sv);
+        object.set("completion"sv, ByteString::formatted(StringView { format, strlen(format) }, args...));
+        object.set("static_offset"sv, 0);
+        object.set("invariant_offset"sv, has_invariant ? option_to_complete.length() : 0u);
+        object.set("display_trivia"sv, StringView { option.help_string, strlen(option.help_string) });
+        object.set("trailing_trivia"sv, option.argument_mode == OptionArgumentMode::Required ? " "sv : ""sv);
         outln(file, "{}", object.to_byte_string());
     };
 

--- a/Libraries/LibDevTools/Actor.cpp
+++ b/Libraries/LibDevTools/Actor.cpp
@@ -11,10 +11,9 @@
 
 namespace DevTools {
 
-// FIXME: Convert `name` to a String.
-Actor::Actor(DevToolsServer& devtools, ByteString name)
+Actor::Actor(DevToolsServer& devtools, String name)
     : m_devtools(devtools)
-    , m_name(MUST(String::from_byte_string(name)))
+    , m_name(move(name))
 {
 }
 

--- a/Libraries/LibDevTools/Actor.cpp
+++ b/Libraries/LibDevTools/Actor.cpp
@@ -11,9 +11,10 @@
 
 namespace DevTools {
 
+// FIXME: Convert `name` to a String.
 Actor::Actor(DevToolsServer& devtools, ByteString name)
     : m_devtools(devtools)
-    , m_name(move(name))
+    , m_name(MUST(String::from_byte_string(name)))
 {
 }
 
@@ -36,7 +37,7 @@ void Actor::send_missing_parameter_error(StringView parameter)
     JsonObject error;
     error.set("from"sv, name());
     error.set("error"sv, "missingParameter"sv);
-    error.set("message"sv, ByteString::formatted("Missing parameter: '{}'", parameter));
+    error.set("message"sv, MUST(String::formatted("Missing parameter: '{}'", parameter)));
     send_message(move(error));
 }
 
@@ -46,7 +47,7 @@ void Actor::send_unrecognized_packet_type_error(StringView type)
     JsonObject error;
     error.set("from"sv, name());
     error.set("error"sv, "unrecognizedPacketType"sv);
-    error.set("message"sv, ByteString::formatted("Unrecognized packet type: '{}'", type));
+    error.set("message"sv, MUST(String::formatted("Unrecognized packet type: '{}'", type)));
     send_message(move(error));
 }
 
@@ -57,7 +58,7 @@ void Actor::send_unknown_actor_error(StringView actor)
     JsonObject error;
     error.set("from"sv, name());
     error.set("error"sv, "unknownActor"sv);
-    error.set("message"sv, ByteString::formatted("Unknown actor: '{}'", actor));
+    error.set("message"sv, MUST(String::formatted("Unknown actor: '{}'", actor)));
     send_message(move(error));
 }
 

--- a/Libraries/LibDevTools/Actor.h
+++ b/Libraries/LibDevTools/Actor.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Badge.h>
-#include <AK/ByteString.h>
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
@@ -49,7 +48,7 @@ public:
     void send_unknown_actor_error(StringView actor);
 
 protected:
-    explicit Actor(DevToolsServer&, ByteString name);
+    explicit Actor(DevToolsServer&, String name);
 
     DevToolsServer& devtools() { return m_devtools; }
     DevToolsServer const& devtools() const { return m_devtools; }

--- a/Libraries/LibDevTools/Actor.h
+++ b/Libraries/LibDevTools/Actor.h
@@ -10,6 +10,7 @@
 #include <AK/ByteString.h>
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <AK/WeakPtr.h>
@@ -24,7 +25,7 @@ class Actor
 public:
     virtual ~Actor();
 
-    ByteString const& name() const { return m_name; }
+    String const& name() const { return m_name; }
     virtual void handle_message(StringView type, JsonObject const&) = 0;
 
     class [[nodiscard]] BlockToken {
@@ -57,7 +58,7 @@ protected:
 
 private:
     DevToolsServer& m_devtools;
-    ByteString m_name;
+    String m_name;
 
     Vector<JsonValue> m_blocked_responses;
     bool m_block_responses { false };

--- a/Libraries/LibDevTools/Actors/CSSPropertiesActor.cpp
+++ b/Libraries/LibDevTools/Actors/CSSPropertiesActor.cpp
@@ -36,7 +36,7 @@ void CSSPropertiesActor::handle_message(StringView type, JsonObject const&)
 
         for (auto const& css_property : css_property_list) {
             JsonArray subproperties;
-            subproperties.must_append(css_property.name);
+            subproperties.must_append(MUST(String::from_byte_string(css_property.name)));
 
             JsonObject property;
             property.set("isInherited"sv, css_property.is_inherited);

--- a/Libraries/LibDevTools/Actors/CSSPropertiesActor.cpp
+++ b/Libraries/LibDevTools/Actors/CSSPropertiesActor.cpp
@@ -12,12 +12,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<CSSPropertiesActor> CSSPropertiesActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<CSSPropertiesActor> CSSPropertiesActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new CSSPropertiesActor(devtools, move(name)));
 }
 
-CSSPropertiesActor::CSSPropertiesActor(DevToolsServer& devtools, ByteString name)
+CSSPropertiesActor::CSSPropertiesActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }
@@ -36,7 +36,7 @@ void CSSPropertiesActor::handle_message(StringView type, JsonObject const&)
 
         for (auto const& css_property : css_property_list) {
             JsonArray subproperties;
-            subproperties.must_append(MUST(String::from_byte_string(css_property.name)));
+            subproperties.must_append(css_property.name);
 
             JsonObject property;
             property.set("isInherited"sv, css_property.is_inherited);

--- a/Libraries/LibDevTools/Actors/CSSPropertiesActor.h
+++ b/Libraries/LibDevTools/Actors/CSSPropertiesActor.h
@@ -6,14 +6,14 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
 #include <LibDevTools/Actor.h>
 
 namespace DevTools {
 
 struct CSSProperty {
-    ByteString name;
+    String name;
     bool is_inherited { false };
 };
 
@@ -21,13 +21,13 @@ class CSSPropertiesActor final : public Actor {
 public:
     static constexpr auto base_name = "css-properties"sv;
 
-    static NonnullRefPtr<CSSPropertiesActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<CSSPropertiesActor> create(DevToolsServer&, String name);
     virtual ~CSSPropertiesActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
 private:
-    CSSPropertiesActor(DevToolsServer&, ByteString name);
+    CSSPropertiesActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/DeviceActor.cpp
+++ b/Libraries/LibDevTools/Actors/DeviceActor.cpp
@@ -12,12 +12,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<DeviceActor> DeviceActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<DeviceActor> DeviceActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new DeviceActor(devtools, move(name)));
 }
 
-DeviceActor::DeviceActor(DevToolsServer& devtools, ByteString name)
+DeviceActor::DeviceActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/DeviceActor.cpp
+++ b/Libraries/LibDevTools/Actors/DeviceActor.cpp
@@ -27,16 +27,16 @@ DeviceActor::~DeviceActor() = default;
 void DeviceActor::handle_message(StringView type, JsonObject const&)
 {
     if (type == "getDescription"sv) {
-        auto build_id = Core::Version::read_long_version_string().to_byte_string();
+        auto build_id = Core::Version::read_long_version_string();
 
-        static constexpr auto browser_name = StringView { BROWSER_NAME, __builtin_strlen(BROWSER_NAME) };
-        static constexpr auto browser_version = StringView { BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) };
-        static constexpr auto platform_name = StringView { OS_STRING, __builtin_strlen(OS_STRING) };
-        static constexpr auto arch = StringView { CPU_STRING, __builtin_strlen(CPU_STRING) };
+        static auto browser_name = String::from_utf8_without_validation({ BROWSER_NAME, __builtin_strlen(BROWSER_NAME) });
+        static auto browser_version = String::from_utf8_without_validation({ BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) });
+        static auto platform_name = String::from_utf8_without_validation({ OS_STRING, __builtin_strlen(OS_STRING) });
+        static auto arch = String::from_utf8_without_validation({ CPU_STRING, __builtin_strlen(CPU_STRING) });
 
         // https://github.com/mozilla/gecko-dev/blob/master/devtools/shared/system.js
         JsonObject value;
-        value.set("apptype"sv, browser_name.to_lowercase_string());
+        value.set("apptype"sv, browser_name.to_ascii_lowercase());
         value.set("name"sv, browser_name);
         value.set("brandName"sv, browser_name);
         value.set("version"sv, browser_version);

--- a/Libraries/LibDevTools/Actors/DeviceActor.cpp
+++ b/Libraries/LibDevTools/Actors/DeviceActor.cpp
@@ -29,18 +29,23 @@ void DeviceActor::handle_message(StringView type, JsonObject const&)
     if (type == "getDescription"sv) {
         auto build_id = Core::Version::read_long_version_string().to_byte_string();
 
+        static constexpr auto browser_name = StringView { BROWSER_NAME, __builtin_strlen(BROWSER_NAME) };
+        static constexpr auto browser_version = StringView { BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) };
+        static constexpr auto platform_name = StringView { OS_STRING, __builtin_strlen(OS_STRING) };
+        static constexpr auto arch = StringView { CPU_STRING, __builtin_strlen(CPU_STRING) };
+
         // https://github.com/mozilla/gecko-dev/blob/master/devtools/shared/system.js
         JsonObject value;
-        value.set("apptype"sv, "ladybird"sv);
-        value.set("name"sv, BROWSER_NAME);
-        value.set("brandName"sv, BROWSER_NAME);
-        value.set("version"sv, BROWSER_VERSION);
+        value.set("apptype"sv, browser_name.to_lowercase_string());
+        value.set("name"sv, browser_name);
+        value.set("brandName"sv, browser_name);
+        value.set("version"sv, browser_version);
         value.set("appbuildid"sv, build_id);
         value.set("platformbuildid"sv, build_id);
         value.set("platformversion"sv, "135.0"sv);
         value.set("useragent"sv, Web::default_user_agent);
-        value.set("os"sv, OS_STRING);
-        value.set("arch"sv, CPU_STRING);
+        value.set("os"sv, platform_name);
+        value.set("arch"sv, arch);
 
         JsonObject response;
         response.set("from"sv, name());

--- a/Libraries/LibDevTools/Actors/DeviceActor.h
+++ b/Libraries/LibDevTools/Actors/DeviceActor.h
@@ -15,13 +15,13 @@ class DeviceActor final : public Actor {
 public:
     static constexpr auto base_name = "device"sv;
 
-    static NonnullRefPtr<DeviceActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<DeviceActor> create(DevToolsServer&, String name);
     virtual ~DeviceActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
 private:
-    DeviceActor(DevToolsServer&, ByteString name);
+    DeviceActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -56,9 +56,9 @@ void FrameActor::send_frame_update_message()
     }
 
     JsonObject message;
-    message.set("from", name());
-    message.set("type", "frameUpdate"sv);
-    message.set("frames", move(frames));
+    message.set("from"sv, name());
+    message.set("type"sv, "frameUpdate"sv);
+    message.set("frames"sv, move(frames));
     send_message(move(message));
 }
 

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -14,12 +14,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<FrameActor> FrameActor::create(DevToolsServer& devtools, ByteString name, WeakPtr<TabActor> tab, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<InspectorActor> inspector, WeakPtr<ThreadActor> thread)
+NonnullRefPtr<FrameActor> FrameActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<InspectorActor> inspector, WeakPtr<ThreadActor> thread)
 {
     return adopt_ref(*new FrameActor(devtools, move(name), move(tab), move(css_properties), move(inspector), move(thread)));
 }
 
-FrameActor::FrameActor(DevToolsServer& devtools, ByteString name, WeakPtr<TabActor> tab, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<InspectorActor> inspector, WeakPtr<ThreadActor> thread)
+FrameActor::FrameActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab, WeakPtr<CSSPropertiesActor> css_properties, WeakPtr<InspectorActor> inspector, WeakPtr<ThreadActor> thread)
     : Actor(devtools, move(name))
     , m_tab(move(tab))
     , m_css_properties(move(css_properties))
@@ -50,8 +50,8 @@ void FrameActor::send_frame_update_message()
     if (auto tab_actor = m_tab.strong_ref()) {
         JsonObject frame;
         frame.set("id"sv, tab_actor->description().id);
-        frame.set("title"sv, MUST(String::from_byte_string(tab_actor->description().title)));
-        frame.set("url"sv, MUST(String::from_byte_string(tab_actor->description().url)));
+        frame.set("title"sv, tab_actor->description().title);
+        frame.set("url"sv, tab_actor->description().url);
         frames.must_append(move(frame));
     }
 
@@ -76,8 +76,8 @@ JsonObject FrameActor::serialize_target() const
     target.set("actor"sv, name());
 
     if (auto tab_actor = m_tab.strong_ref()) {
-        target.set("title"sv, MUST(String::from_byte_string(tab_actor->description().title)));
-        target.set("url"sv, MUST(String::from_byte_string(tab_actor->description().url)));
+        target.set("title"sv, tab_actor->description().title);
+        target.set("url"sv, tab_actor->description().url);
         target.set("browsingContextID"sv, tab_actor->description().id);
         target.set("outerWindowID"sv, tab_actor->description().id);
         target.set("isTopLevelTarget"sv, true);

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -50,8 +50,8 @@ void FrameActor::send_frame_update_message()
     if (auto tab_actor = m_tab.strong_ref()) {
         JsonObject frame;
         frame.set("id"sv, tab_actor->description().id);
-        frame.set("title"sv, tab_actor->description().title);
-        frame.set("url"sv, tab_actor->description().url);
+        frame.set("title"sv, MUST(String::from_byte_string(tab_actor->description().title)));
+        frame.set("url"sv, MUST(String::from_byte_string(tab_actor->description().url)));
         frames.must_append(move(frame));
     }
 
@@ -76,8 +76,8 @@ JsonObject FrameActor::serialize_target() const
     target.set("actor"sv, name());
 
     if (auto tab_actor = m_tab.strong_ref()) {
-        target.set("title"sv, tab_actor->description().title);
-        target.set("url"sv, tab_actor->description().url);
+        target.set("title"sv, MUST(String::from_byte_string(tab_actor->description().title)));
+        target.set("url"sv, MUST(String::from_byte_string(tab_actor->description().url)));
         target.set("browsingContextID"sv, tab_actor->description().id);
         target.set("outerWindowID"sv, tab_actor->description().id);
         target.set("isTopLevelTarget"sv, true);

--- a/Libraries/LibDevTools/Actors/FrameActor.h
+++ b/Libraries/LibDevTools/Actors/FrameActor.h
@@ -15,7 +15,7 @@ class FrameActor final : public Actor {
 public:
     static constexpr auto base_name = "frame"sv;
 
-    static NonnullRefPtr<FrameActor> create(DevToolsServer&, ByteString name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<InspectorActor>, WeakPtr<ThreadActor>);
+    static NonnullRefPtr<FrameActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<InspectorActor>, WeakPtr<ThreadActor>);
     virtual ~FrameActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -24,7 +24,7 @@ public:
     JsonObject serialize_target() const;
 
 private:
-    FrameActor(DevToolsServer&, ByteString name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<InspectorActor>, WeakPtr<ThreadActor>);
+    FrameActor(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<InspectorActor>, WeakPtr<ThreadActor>);
 
     WeakPtr<TabActor> m_tab;
 

--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -9,12 +9,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<HighlighterActor> HighlighterActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<HighlighterActor> HighlighterActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new HighlighterActor(devtools, move(name)));
 }
 
-HighlighterActor::HighlighterActor(DevToolsServer& devtools, ByteString name)
+HighlighterActor::HighlighterActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/HighlighterActor.h
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.h
@@ -15,14 +15,14 @@ class HighlighterActor final : public Actor {
 public:
     static constexpr auto base_name = "highlighter"sv;
 
-    static NonnullRefPtr<HighlighterActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<HighlighterActor> create(DevToolsServer&, String name);
     virtual ~HighlighterActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
     JsonValue serialize_highlighter() const;
 
 private:
-    HighlighterActor(DevToolsServer&, ByteString name);
+    HighlighterActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -16,12 +16,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<InspectorActor> InspectorActor::create(DevToolsServer& devtools, ByteString name, WeakPtr<TabActor> tab)
+NonnullRefPtr<InspectorActor> InspectorActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
 {
     return adopt_ref(*new InspectorActor(devtools, move(name), move(tab)));
 }
 
-InspectorActor::InspectorActor(DevToolsServer& devtools, ByteString name, WeakPtr<TabActor> tab)
+InspectorActor::InspectorActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
     : Actor(devtools, move(name))
     , m_tab(move(tab))
 {

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -15,13 +15,13 @@ class InspectorActor final : public Actor {
 public:
     static constexpr auto base_name = "inspector"sv;
 
-    static NonnullRefPtr<InspectorActor> create(DevToolsServer&, ByteString name, WeakPtr<TabActor>);
+    static NonnullRefPtr<InspectorActor> create(DevToolsServer&, String name, WeakPtr<TabActor>);
     virtual ~InspectorActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
 private:
-    InspectorActor(DevToolsServer&, ByteString name, WeakPtr<TabActor>);
+    InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
     void received_dom_tree(JsonObject, BlockToken);
 

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -9,12 +9,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<PageStyleActor> PageStyleActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<PageStyleActor> PageStyleActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new PageStyleActor(devtools, move(name)));
 }
 
-PageStyleActor::PageStyleActor(DevToolsServer& devtools, ByteString name)
+PageStyleActor::PageStyleActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/PageStyleActor.h
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.h
@@ -15,14 +15,14 @@ class PageStyleActor final : public Actor {
 public:
     static constexpr auto base_name = "page-style"sv;
 
-    static NonnullRefPtr<PageStyleActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<PageStyleActor> create(DevToolsServer&, String name);
     virtual ~PageStyleActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
     JsonValue serialize_style() const;
 
 private:
-    PageStyleActor(DevToolsServer&, ByteString name);
+    PageStyleActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/PreferenceActor.cpp
+++ b/Libraries/LibDevTools/Actors/PreferenceActor.cpp
@@ -9,12 +9,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<PreferenceActor> PreferenceActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<PreferenceActor> PreferenceActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new PreferenceActor(devtools, move(name)));
 }
 
-PreferenceActor::PreferenceActor(DevToolsServer& devtools, ByteString name)
+PreferenceActor::PreferenceActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/PreferenceActor.h
+++ b/Libraries/LibDevTools/Actors/PreferenceActor.h
@@ -15,13 +15,13 @@ class PreferenceActor final : public Actor {
 public:
     static constexpr auto base_name = "preference"sv;
 
-    static NonnullRefPtr<PreferenceActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<PreferenceActor> create(DevToolsServer&, String name);
     virtual ~PreferenceActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
 private:
-    PreferenceActor(DevToolsServer&, ByteString name);
+    PreferenceActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/ProcessActor.cpp
+++ b/Libraries/LibDevTools/Actors/ProcessActor.cpp
@@ -9,12 +9,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<ProcessActor> ProcessActor::create(DevToolsServer& devtools, ByteString name, ProcessDescription description)
+NonnullRefPtr<ProcessActor> ProcessActor::create(DevToolsServer& devtools, String name, ProcessDescription description)
 {
     return adopt_ref(*new ProcessActor(devtools, move(name), move(description)));
 }
 
-ProcessActor::ProcessActor(DevToolsServer& devtools, ByteString name, ProcessDescription description)
+ProcessActor::ProcessActor(DevToolsServer& devtools, String name, ProcessDescription description)
     : Actor(devtools, move(name))
     , m_description(move(description))
 {

--- a/Libraries/LibDevTools/Actors/ProcessActor.h
+++ b/Libraries/LibDevTools/Actors/ProcessActor.h
@@ -21,7 +21,7 @@ class ProcessActor final : public Actor {
 public:
     static constexpr auto base_name = "process"sv;
 
-    static NonnullRefPtr<ProcessActor> create(DevToolsServer&, ByteString name, ProcessDescription);
+    static NonnullRefPtr<ProcessActor> create(DevToolsServer&, String name, ProcessDescription);
     virtual ~ProcessActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -30,7 +30,7 @@ public:
     JsonObject serialize_description() const;
 
 private:
-    ProcessActor(DevToolsServer&, ByteString name, ProcessDescription);
+    ProcessActor(DevToolsServer&, String name, ProcessDescription);
 
     ProcessDescription m_description;
 };

--- a/Libraries/LibDevTools/Actors/RootActor.cpp
+++ b/Libraries/LibDevTools/Actors/RootActor.cpp
@@ -16,7 +16,7 @@
 namespace DevTools {
 
 // https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#the-root-actor
-NonnullRefPtr<RootActor> RootActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<RootActor> RootActor::create(DevToolsServer& devtools, String name)
 {
     auto actor = adopt_ref(*new RootActor(devtools, move(name)));
 
@@ -35,7 +35,7 @@ NonnullRefPtr<RootActor> RootActor::create(DevToolsServer& devtools, ByteString 
     return actor;
 }
 
-RootActor::RootActor(DevToolsServer& devtools, ByteString name)
+RootActor::RootActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }
@@ -57,9 +57,9 @@ void RootActor::handle_message(StringView type, JsonObject const& message)
 
         for (auto const& actor : devtools().actor_registry()) {
             if (is<DeviceActor>(*actor.value))
-                response.set("deviceActor"sv, MUST(String::from_byte_string(actor.key)));
+                response.set("deviceActor"sv, actor.key);
             else if (is<PreferenceActor>(*actor.value))
-                response.set("preferenceActor"sv, MUST(String::from_byte_string(actor.key)));
+                response.set("preferenceActor"sv, actor.key);
         }
 
         send_message(move(response));

--- a/Libraries/LibDevTools/Actors/RootActor.cpp
+++ b/Libraries/LibDevTools/Actors/RootActor.cpp
@@ -57,9 +57,9 @@ void RootActor::handle_message(StringView type, JsonObject const& message)
 
         for (auto const& actor : devtools().actor_registry()) {
             if (is<DeviceActor>(*actor.value))
-                response.set("deviceActor"sv, actor.key);
+                response.set("deviceActor"sv, MUST(String::from_byte_string(actor.key)));
             else if (is<PreferenceActor>(*actor.value))
-                response.set("preferenceActor"sv, actor.key);
+                response.set("preferenceActor"sv, MUST(String::from_byte_string(actor.key)));
         }
 
         send_message(move(response));

--- a/Libraries/LibDevTools/Actors/RootActor.h
+++ b/Libraries/LibDevTools/Actors/RootActor.h
@@ -15,7 +15,7 @@ class RootActor final : public Actor {
 public:
     static constexpr auto base_name = "root"sv;
 
-    static NonnullRefPtr<RootActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<RootActor> create(DevToolsServer&, String name);
     virtual ~RootActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -23,7 +23,7 @@ public:
     void send_tab_list_changed_message();
 
 private:
-    RootActor(DevToolsServer&, ByteString name);
+    RootActor(DevToolsServer&, String name);
 
     // https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#the-request-reply-notify-pattern
     // the root actor sends at most one "tabListChanged" notification after each "listTabs" request.

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -60,8 +60,8 @@ JsonObject TabActor::serialize_description() const
     //        provide different IDs for browserId, browsingContextID, and outerWindowID.
     JsonObject description;
     description.set("actor"sv, name());
-    description.set("title"sv, m_description.title);
-    description.set("url"sv, m_description.url);
+    description.set("title"sv, MUST(String::from_byte_string(m_description.title)));
+    description.set("url"sv, MUST(String::from_byte_string(m_description.url)));
     description.set("browserId"sv, m_description.id);
     description.set("browsingContextID"sv, m_description.id);
     description.set("outerWindowID"sv, m_description.id);

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -11,12 +11,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<TabActor> TabActor::create(DevToolsServer& devtools, ByteString name, TabDescription description)
+NonnullRefPtr<TabActor> TabActor::create(DevToolsServer& devtools, String name, TabDescription description)
 {
     return adopt_ref(*new TabActor(devtools, move(name), move(description)));
 }
 
-TabActor::TabActor(DevToolsServer& devtools, ByteString name, TabDescription description)
+TabActor::TabActor(DevToolsServer& devtools, String name, TabDescription description)
     : Actor(devtools, move(name))
     , m_description(move(description))
 {
@@ -60,8 +60,8 @@ JsonObject TabActor::serialize_description() const
     //        provide different IDs for browserId, browsingContextID, and outerWindowID.
     JsonObject description;
     description.set("actor"sv, name());
-    description.set("title"sv, MUST(String::from_byte_string(m_description.title)));
-    description.set("url"sv, MUST(String::from_byte_string(m_description.url)));
+    description.set("title"sv, m_description.title);
+    description.set("url"sv, m_description.url);
     description.set("browserId"sv, m_description.id);
     description.set("browsingContextID"sv, m_description.id);
     description.set("outerWindowID"sv, m_description.id);

--- a/Libraries/LibDevTools/Actors/TabActor.h
+++ b/Libraries/LibDevTools/Actors/TabActor.h
@@ -7,21 +7,22 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
 #include <LibDevTools/Actor.h>
 
 namespace DevTools {
 
 struct TabDescription {
     u64 id { 0 };
-    ByteString title;
-    ByteString url;
+    String title;
+    String url;
 };
 
 class TabActor final : public Actor {
 public:
     static constexpr auto base_name = "tab"sv;
 
-    static NonnullRefPtr<TabActor> create(DevToolsServer&, ByteString name, TabDescription);
+    static NonnullRefPtr<TabActor> create(DevToolsServer&, String name, TabDescription);
     virtual ~TabActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -30,7 +31,7 @@ public:
     JsonObject serialize_description() const;
 
 private:
-    TabActor(DevToolsServer&, ByteString name, TabDescription);
+    TabActor(DevToolsServer&, String name, TabDescription);
 
     TabDescription m_description;
     WeakPtr<WatcherActor> m_watcher;

--- a/Libraries/LibDevTools/Actors/TargetConfigurationActor.cpp
+++ b/Libraries/LibDevTools/Actors/TargetConfigurationActor.cpp
@@ -10,12 +10,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<TargetConfigurationActor> TargetConfigurationActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<TargetConfigurationActor> TargetConfigurationActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new TargetConfigurationActor(devtools, move(name)));
 }
 
-TargetConfigurationActor::TargetConfigurationActor(DevToolsServer& devtools, ByteString name)
+TargetConfigurationActor::TargetConfigurationActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/TargetConfigurationActor.h
+++ b/Libraries/LibDevTools/Actors/TargetConfigurationActor.h
@@ -15,7 +15,7 @@ class TargetConfigurationActor final : public Actor {
 public:
     static constexpr auto base_name = "target-configuration"sv;
 
-    static NonnullRefPtr<TargetConfigurationActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<TargetConfigurationActor> create(DevToolsServer&, String name);
     virtual ~TargetConfigurationActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -23,7 +23,7 @@ public:
     JsonObject serialize_configuration() const;
 
 private:
-    TargetConfigurationActor(DevToolsServer&, ByteString name);
+    TargetConfigurationActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/ThreadActor.cpp
+++ b/Libraries/LibDevTools/Actors/ThreadActor.cpp
@@ -8,12 +8,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<ThreadActor> ThreadActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<ThreadActor> ThreadActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new ThreadActor(devtools, move(name)));
 }
 
-ThreadActor::ThreadActor(DevToolsServer& devtools, ByteString name)
+ThreadActor::ThreadActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/ThreadActor.h
+++ b/Libraries/LibDevTools/Actors/ThreadActor.h
@@ -15,13 +15,13 @@ class ThreadActor final : public Actor {
 public:
     static constexpr auto base_name = "thread"sv;
 
-    static NonnullRefPtr<ThreadActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<ThreadActor> create(DevToolsServer&, String name);
     virtual ~ThreadActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
 private:
-    ThreadActor(DevToolsServer&, ByteString name);
+    ThreadActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/ThreadConfigurationActor.cpp
+++ b/Libraries/LibDevTools/Actors/ThreadConfigurationActor.cpp
@@ -10,12 +10,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<ThreadConfigurationActor> ThreadConfigurationActor::create(DevToolsServer& devtools, ByteString name)
+NonnullRefPtr<ThreadConfigurationActor> ThreadConfigurationActor::create(DevToolsServer& devtools, String name)
 {
     return adopt_ref(*new ThreadConfigurationActor(devtools, move(name)));
 }
 
-ThreadConfigurationActor::ThreadConfigurationActor(DevToolsServer& devtools, ByteString name)
+ThreadConfigurationActor::ThreadConfigurationActor(DevToolsServer& devtools, String name)
     : Actor(devtools, move(name))
 {
 }

--- a/Libraries/LibDevTools/Actors/ThreadConfigurationActor.h
+++ b/Libraries/LibDevTools/Actors/ThreadConfigurationActor.h
@@ -15,7 +15,7 @@ class ThreadConfigurationActor final : public Actor {
 public:
     static constexpr auto base_name = "thread-configuration"sv;
 
-    static NonnullRefPtr<ThreadConfigurationActor> create(DevToolsServer&, ByteString name);
+    static NonnullRefPtr<ThreadConfigurationActor> create(DevToolsServer&, String name);
     virtual ~ThreadConfigurationActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -23,7 +23,7 @@ public:
     JsonObject serialize_configuration() const;
 
 private:
-    ThreadConfigurationActor(DevToolsServer&, ByteString name);
+    ThreadConfigurationActor(DevToolsServer&, String name);
 };
 
 }

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -193,7 +193,7 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     serialized.set("causesOverflow"sv, false);
     serialized.set("containerType"sv, JsonValue {});
     serialized.set("displayName"sv, name.to_lowercase());
-    serialized.set("displayType"sv, "block");
+    serialized.set("displayType"sv, "block"sv);
     serialized.set("host"sv, JsonValue {});
     serialized.set("isAfterPseudoElement"sv, false);
     serialized.set("isAnonymous"sv, false);

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -93,7 +93,7 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
         send_message(move(response));
 
         JsonObject message;
-        message.set("from", name());
+        message.set("from"sv, name());
         send_message(move(message));
 
         return;
@@ -175,12 +175,12 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     JsonArray attrs;
 
     if (auto attributes = node.get_object("attributes"sv); attributes.has_value()) {
-        attributes->for_each_member([&](ByteString const& name, JsonValue const& value) {
+        attributes->for_each_member([&](String const& name, JsonValue const& value) {
             if (!value.is_string())
                 return;
 
             JsonObject attr;
-            attr.set("name"sv, name);
+            attr.set("name"sv, name.to_byte_string());
             attr.set("value"sv, value.as_string());
             attrs.must_append(move(attr));
         });

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -18,7 +18,7 @@ class WalkerActor final : public Actor {
 public:
     static constexpr auto base_name = "walker"sv;
 
-    static NonnullRefPtr<WalkerActor> create(DevToolsServer&, ByteString name, WeakPtr<TabActor>, JsonObject dom_tree);
+    static NonnullRefPtr<WalkerActor> create(DevToolsServer&, String name, WeakPtr<TabActor>, JsonObject dom_tree);
     virtual ~WalkerActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -27,7 +27,7 @@ public:
     JsonValue serialize_root() const;
 
 private:
-    WalkerActor(DevToolsServer&, ByteString name, WeakPtr<TabActor>, JsonObject dom_tree);
+    WalkerActor(DevToolsServer&, String name, WeakPtr<TabActor>, JsonObject dom_tree);
 
     JsonValue serialize_node(JsonObject const&) const;
     Optional<JsonObject const&> find_node_by_selector(JsonObject const& node, StringView selector);
@@ -38,7 +38,7 @@ private:
     JsonObject m_dom_tree;
 
     HashMap<JsonObject const*, JsonObject const*> m_dom_node_to_parent_map;
-    HashMap<ByteString, JsonObject const*> m_actor_to_dom_node_map;
+    HashMap<String, JsonObject const*> m_actor_to_dom_node_map;
     size_t m_dom_node_count { 0 };
 };
 

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -88,7 +88,7 @@ void WatcherActor::handle_message(StringView type, JsonObject const& message)
             target.send_frame_update_message();
 
             JsonObject message;
-            message.set("from", name());
+            message.set("from"sv, name());
             send_message(move(message));
 
             return;

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -18,12 +18,12 @@
 
 namespace DevTools {
 
-NonnullRefPtr<WatcherActor> WatcherActor::create(DevToolsServer& devtools, ByteString name, WeakPtr<TabActor> tab)
+NonnullRefPtr<WatcherActor> WatcherActor::create(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
 {
     return adopt_ref(*new WatcherActor(devtools, move(name), move(tab)));
 }
 
-WatcherActor::WatcherActor(DevToolsServer& devtools, ByteString name, WeakPtr<TabActor> tab)
+WatcherActor::WatcherActor(DevToolsServer& devtools, String name, WeakPtr<TabActor> tab)
     : Actor(devtools, move(name))
     , m_tab(move(tab))
 {
@@ -67,7 +67,7 @@ void WatcherActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "watchTargets"sv) {
-        auto target_type = message.get_byte_string("targetType"sv);
+        auto target_type = message.get_string("targetType"sv);
         if (!target_type.has_value()) {
             send_missing_parameter_error("targetType"sv);
             return;

--- a/Libraries/LibDevTools/Actors/WatcherActor.h
+++ b/Libraries/LibDevTools/Actors/WatcherActor.h
@@ -15,7 +15,7 @@ class WatcherActor final : public Actor {
 public:
     static constexpr auto base_name = "watcher"sv;
 
-    static NonnullRefPtr<WatcherActor> create(DevToolsServer&, ByteString name, WeakPtr<TabActor>);
+    static NonnullRefPtr<WatcherActor> create(DevToolsServer&, String name, WeakPtr<TabActor>);
     virtual ~WatcherActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
@@ -23,7 +23,7 @@ public:
     JsonObject serialize_description() const;
 
 private:
-    WatcherActor(DevToolsServer&, ByteString name, WeakPtr<TabActor>);
+    WatcherActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<Actor> m_target;

--- a/Libraries/LibDevTools/Connection.cpp
+++ b/Libraries/LibDevTools/Connection.cpp
@@ -7,7 +7,6 @@
 #include <AK/Debug.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
-#include <AK/StringBuilder.h>
 #include <LibCore/EventLoop.h>
 #include <LibDevTools/Connection.h>
 
@@ -34,7 +33,7 @@ Connection::~Connection() = default;
 // https://firefox-source-docs.mozilla.org/devtools/backend/protocol.html#packets
 void Connection::send_message(JsonValue const& message)
 {
-    auto serialized = message.serialized<StringBuilder>();
+    auto serialized = message.serialized();
 
     if constexpr (DEVTOOLS_DEBUG) {
         if (message.is_object() && message.as_object().get("error"sv).has_value())
@@ -43,7 +42,7 @@ void Connection::send_message(JsonValue const& message)
             dbgln("\x1b[1;32m<<\x1b[0m {}", serialized);
     }
 
-    if (m_socket->write_formatted("{}:{}", serialized.length(), serialized).is_error()) {
+    if (m_socket->write_formatted("{}:{}", serialized.byte_count(), serialized).is_error()) {
         if (on_connection_closed)
             on_connection_closed();
     }

--- a/Libraries/LibDevTools/DevToolsServer.cpp
+++ b/Libraries/LibDevTools/DevToolsServer.cpp
@@ -85,7 +85,7 @@ ErrorOr<void> DevToolsServer::on_new_client()
 
 void DevToolsServer::on_message_received(JsonObject const& message)
 {
-    auto to = message.get_byte_string("to"sv);
+    auto to = message.get_string("to"sv);
     if (!to.has_value()) {
         m_root_actor->send_missing_parameter_error("to"sv);
         return;
@@ -97,7 +97,7 @@ void DevToolsServer::on_message_received(JsonObject const& message)
         return;
     }
 
-    auto type = message.get_byte_string("type"sv);
+    auto type = message.get_string("type"sv);
     if (!type.has_value()) {
         actor->value->send_missing_parameter_error("type"sv);
         return;

--- a/Libraries/LibDevTools/DevToolsServer.h
+++ b/Libraries/LibDevTools/DevToolsServer.h
@@ -10,13 +10,14 @@
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
 #include <LibCore/Socket.h>
 #include <LibDevTools/Actors/RootActor.h>
 #include <LibDevTools/Forward.h>
 
 namespace DevTools {
 
-using ActorRegistry = HashMap<ByteString, NonnullRefPtr<Actor>>;
+using ActorRegistry = HashMap<String, NonnullRefPtr<Actor>>;
 
 class DevToolsServer {
 public:
@@ -30,12 +31,12 @@ public:
     template<typename ActorType, typename... Args>
     ActorType& register_actor(Args&&... args)
     {
-        ByteString name;
+        String name;
 
         if constexpr (IsSame<ActorType, RootActor>) {
-            name = ActorType::base_name;
+            name = String::from_utf8_without_validation(ActorType::base_name.bytes());
         } else {
-            name = ByteString::formatted("server{}-{}{}", m_server_id, ActorType::base_name, m_actor_count);
+            name = MUST(String::formatted("server{}-{}{}", m_server_id, ActorType::base_name, m_actor_count));
         }
 
         auto actor = ActorType::create(*this, name, forward<Args>(args)...);

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -188,16 +188,16 @@ public:
                     node.set("root"sv, ByteString::formatted("Root {} {}:{}", location->function_name(), location->filename(), location->line_number()));
                     break;
                 case HeapRoot::Type::RootVector:
-                    node.set("root"sv, "RootVector");
+                    node.set("root"sv, "RootVector"sv);
                     break;
                 case HeapRoot::Type::RegisterPointer:
-                    node.set("root"sv, "RegisterPointer");
+                    node.set("root"sv, "RegisterPointer"sv);
                     break;
                 case HeapRoot::Type::StackPointer:
-                    node.set("root"sv, "StackPointer");
+                    node.set("root"sv, "StackPointer"sv);
                     break;
                 case HeapRoot::Type::VM:
-                    node.set("root"sv, "VM");
+                    node.set("root"sv, "VM"sv);
                     break;
                 default:
                     VERIFY_NOT_REACHED();

--- a/Libraries/LibGC/Heap.cpp
+++ b/Libraries/LibGC/Heap.cpp
@@ -176,7 +176,7 @@ public:
         for (auto& it : m_graph) {
             AK::JsonArray edges;
             for (auto const& value : it.value.edges) {
-                edges.must_append(ByteString::formatted("{}", value));
+                edges.must_append(MUST(String::formatted("{}", value)));
             }
 
             auto node = AK::JsonObject();
@@ -185,7 +185,7 @@ public:
                 auto location = it.value.root_origin->location;
                 switch (type) {
                 case HeapRoot::Type::Root:
-                    node.set("root"sv, ByteString::formatted("Root {} {}:{}", location->function_name(), location->filename(), location->line_number()));
+                    node.set("root"sv, MUST(String::formatted("Root {} {}:{}", location->function_name(), location->filename(), location->line_number())));
                     break;
                 case HeapRoot::Type::RootVector:
                     node.set("root"sv, "RootVector"sv);

--- a/Libraries/LibIPC/Encoder.cpp
+++ b/Libraries/LibIPC/Encoder.cpp
@@ -82,7 +82,7 @@ ErrorOr<void> encode(Encoder& encoder, ByteBuffer const& value)
 template<>
 ErrorOr<void> encode(Encoder& encoder, JsonValue const& value)
 {
-    return encoder.encode(value.serialized<StringBuilder>());
+    return encoder.encode(value.serialized());
 }
 
 template<>

--- a/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -448,7 +448,7 @@ Object* JSONObject::parse_json_object(VM& vm, JsonObject const& json_object)
     auto& realm = *vm.current_realm();
     auto object = Object::create(realm, realm.intrinsics().object_prototype());
     json_object.for_each_member([&](auto& key, auto& value) {
-        object->define_direct_property(key, parse_json_value(vm, value), default_attributes);
+        object->define_direct_property(key.to_byte_string(), parse_json_value(vm, value), default_attributes);
     });
     return object;
 }

--- a/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Libraries/LibTest/JavaScriptTestRunner.h
@@ -370,12 +370,12 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
         file_result.logged_messages.append(message.to_string_without_side_effects().to_byte_string());
     }
 
-    test_json.value().as_object().for_each_member([&](ByteString const& suite_name, JsonValue const& suite_value) {
+    test_json.value().as_object().for_each_member([&](String const& suite_name, JsonValue const& suite_value) {
         Test::Suite suite { test_path, suite_name };
 
         VERIFY(suite_value.is_object());
 
-        suite_value.as_object().for_each_member([&](ByteString const& test_name, JsonValue const& test_value) {
+        suite_value.as_object().for_each_member([&](String const& test_name, JsonValue const& test_value) {
             Test::Case test { test_name, Test::Result::Fail, "", 0 };
 
             VERIFY(test_value.is_object());
@@ -427,10 +427,10 @@ inline JSFileResult TestRunner::run_file_test(ByteString const& test_path)
     });
 
     if (top_level_result.is_error()) {
-        Test::Suite suite { test_path, "<top-level>" };
+        Test::Suite suite { test_path, "<top-level>"_string };
         suite.most_severe_test_result = Result::Crashed;
 
-        Test::Case test_case { "<top-level>", Test::Result::Fail, "", 0 };
+        Test::Case test_case { "<top-level>"_string, Test::Result::Fail, "", 0 };
         auto error = top_level_result.release_error().release_value().release_value();
         if (error.is_object()) {
             StringBuilder detail_builder;

--- a/Libraries/LibTest/Results.h
+++ b/Libraries/LibTest/Results.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <AK/ByteString.h>
+#include <AK/String.h>
 #include <AK/Vector.h>
 
 namespace Test {
@@ -23,7 +24,7 @@ enum class Result {
 };
 
 struct Case {
-    ByteString name;
+    String name;
     Result result;
     ByteString details;
     u64 duration_us;
@@ -31,7 +32,7 @@ struct Case {
 
 struct Suite {
     ByteString path;
-    ByteString name;
+    String name;
     // A failed test takes precedence over a skipped test, which both have
     // precedence over a passed test
     Result most_severe_test_result { Result::Pass };

--- a/Libraries/LibTest/Results.h
+++ b/Libraries/LibTest/Results.h
@@ -26,7 +26,7 @@ enum class Result {
 struct Case {
     String name;
     Result result;
-    ByteString details;
+    String details;
     u64 duration_us;
 };
 

--- a/Libraries/LibTest/TestRunner.h
+++ b/Libraries/LibTest/TestRunner.h
@@ -274,7 +274,7 @@ inline void TestRunner::print_test_results_as_json() const
         root.set("files_total"sv, m_counts.files_total);
         root.set("duration"sv, m_total_elapsed_time_in_ms / 1000.0);
     }
-    outln("{}", root.to_byte_string());
+    outln("{}", root.serialized<StringBuilder>());
 }
 
 }

--- a/Libraries/LibTest/TestRunner.h
+++ b/Libraries/LibTest/TestRunner.h
@@ -274,7 +274,7 @@ inline void TestRunner::print_test_results_as_json() const
         root.set("files_total"sv, m_counts.files_total);
         root.set("duration"sv, m_total_elapsed_time_in_ms / 1000.0);
     }
-    outln("{}", root.serialized<StringBuilder>());
+    outln("{}", root.serialized());
 }
 
 }

--- a/Libraries/LibTest/TestRunner.h
+++ b/Libraries/LibTest/TestRunner.h
@@ -243,36 +243,36 @@ inline void TestRunner::print_test_results_as_json() const
 
                 auto name = suite.name;
                 if (name == "__$$TOP_LEVEL$$__"sv)
-                    name = ByteString::empty();
+                    name = String {};
 
                 auto path = *LexicalPath::relative_path(suite.path, m_test_root);
 
-                tests.set(ByteString::formatted("{}/{}::{}", path, name, case_.name), result_name);
+                tests.set(MUST(String::formatted("{}/{}::{}", path, name, case_.name)), result_name);
             }
         }
 
-        root.set("duration", static_cast<double>(duration_us) / 1000000.);
-        root.set("results", move(tests));
+        root.set("duration"sv, static_cast<double>(duration_us) / 1000000.);
+        root.set("results"sv, move(tests));
     } else {
         JsonObject suites;
-        suites.set("failed", m_counts.suites_failed);
-        suites.set("passed", m_counts.suites_passed);
-        suites.set("total", m_counts.suites_failed + m_counts.suites_passed);
+        suites.set("failed"sv, m_counts.suites_failed);
+        suites.set("passed"sv, m_counts.suites_passed);
+        suites.set("total"sv, m_counts.suites_failed + m_counts.suites_passed);
 
         JsonObject tests;
-        tests.set("failed", m_counts.tests_failed);
-        tests.set("passed", m_counts.tests_passed);
-        tests.set("skipped", m_counts.tests_skipped);
-        tests.set("xfail", m_counts.tests_expected_failed);
-        tests.set("total", m_counts.tests_failed + m_counts.tests_passed + m_counts.tests_skipped + m_counts.tests_expected_failed);
+        tests.set("failed"sv, m_counts.tests_failed);
+        tests.set("passed"sv, m_counts.tests_passed);
+        tests.set("skipped"sv, m_counts.tests_skipped);
+        tests.set("xfail"sv, m_counts.tests_expected_failed);
+        tests.set("total"sv, m_counts.tests_failed + m_counts.tests_passed + m_counts.tests_skipped + m_counts.tests_expected_failed);
 
         JsonObject results;
-        results.set("suites", suites);
-        results.set("tests", tests);
+        results.set("suites"sv, suites);
+        results.set("tests"sv, tests);
 
-        root.set("results", results);
-        root.set("files_total", m_counts.files_total);
-        root.set("duration", m_total_elapsed_time_in_ms / 1000.0);
+        root.set("results"sv, results);
+        root.set("files_total"sv, m_counts.files_total);
+        root.set("duration"sv, m_total_elapsed_time_in_ms / 1000.0);
     }
     outln("{}", root.to_byte_string());
 }

--- a/Libraries/LibWeb/Crypto/CryptoBindings.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoBindings.cpp
@@ -15,9 +15,9 @@
 
 namespace Web::Bindings {
 
-#define JWK_PARSE_STRING_PROPERTY(name)                                                     \
-    if (json_object.has_string(#name##sv)) {                                                \
-        key.name = MUST(String::from_byte_string(*json_object.get_byte_string(#name##sv))); \
+#define JWK_PARSE_STRING_PROPERTY(name)                                      \
+    if (auto value = json_object.get_string(#name##sv); value.has_value()) { \
+        key.name = value.release_value();                                    \
     }
 
 JS::ThrowCompletionOr<JsonWebKey> JsonWebKey::parse(JS::Realm& realm, ReadonlyBytes data)

--- a/Libraries/LibWeb/Crypto/CryptoBindings.cpp
+++ b/Libraries/LibWeb/Crypto/CryptoBindings.cpp
@@ -68,7 +68,7 @@ JS::ThrowCompletionOr<JsonWebKey> JsonWebKey::parse(JS::Realm& realm, ReadonlyBy
         key.key_ops->ensure_capacity(key_ops->size());
 
         key_ops->for_each([&](auto const& value) {
-            key.key_ops->append(MUST(String::from_byte_string(value.as_string())));
+            key.key_ops->append(value.as_string());
         });
     }
 

--- a/Libraries/LibWeb/WebDriver/Actions.cpp
+++ b/Libraries/LibWeb/WebDriver/Actions.cpp
@@ -106,7 +106,7 @@ static Optional<ActionObject::Origin> determine_origin(ActionsOptions const& act
 
     if (origin->is_object()) {
         if (actions_options.is_element_origin(origin->as_object()))
-            return MUST(String::from_byte_string(extract_web_element_reference(origin->as_object())));
+            return extract_web_element_reference(origin->as_object());
     }
 
     return {};
@@ -229,7 +229,7 @@ static ErrorOr<PointerParameters, WebDriver::Error> process_pointer_parameters(O
 
     // 3. If parameters data is not an Object, return error with error code invalid argument.
     if (!parameters_data->is_object())
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'parameters' is not an Object");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'parameters' is not an Object"sv);
 
     // 4. Let pointer type be the result of getting a property named "pointerType" from parameters data.
     auto pointer_type = TRY(get_optional_property(parameters_data->as_object(), "pointerType"sv));
@@ -241,7 +241,7 @@ static ErrorOr<PointerParameters, WebDriver::Error> process_pointer_parameters(O
         auto parsed_pointer_type = pointer_input_source_subtype_from_string(*pointer_type);
 
         if (!parsed_pointer_type.has_value())
-            return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'pointerType' must be one of 'mouse', 'pen', or 'touch'");
+            return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'pointerType' must be one of 'mouse', 'pen', or 'touch'"sv);
 
         // 2. Set the pointerType property of parameters to pointer type.
         parameters.pointer_type = *parsed_pointer_type;
@@ -272,7 +272,7 @@ static ErrorOr<ActionObject, WebDriver::Error> process_null_action(String id, Js
 
     // 2. If subtype is not "pause", return error with error code invalid argument.
     if (subtype != ActionObject::Subtype::Pause)
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be 'pause'");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be 'pause'"sv);
 
     // 3. Let action be an action object constructed with arguments id, "none", and subtype.
     ActionObject action { move(id), InputSourceType::None, *subtype };
@@ -294,7 +294,7 @@ static ErrorOr<ActionObject, WebDriver::Error> process_key_action(String id, Jso
 
     // 2. If subtype is not one of the values "keyUp", "keyDown", or "pause", return an error with error code invalid argument.
     if (!first_is_one_of(subtype, KeyUp, KeyDown, Pause))
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'keyUp', 'keyDown', or 'pause'");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'keyUp', 'keyDown', or 'pause'"sv);
 
     // 3. Let action be an action object constructed with arguments id, "key", and subtype.
     ActionObject action { move(id), InputSourceType::Key, *subtype };
@@ -317,7 +317,7 @@ static ErrorOr<ActionObject, WebDriver::Error> process_key_action(String id, Jso
         // FIXME: The spec seems undecided on whether grapheme clusters should be supported. Update this step to check
         //        for graphemes if we end up needing to support them. We would also need to update Page's key event
         //        handlers to support multi-code point events.
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'value' must be a single code point");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'value' must be a single code point"sv);
     }
 
     // 7. Set the value property on action to key.
@@ -412,7 +412,7 @@ static ErrorOr<void, WebDriver::Error> process_pointer_move_action(JsonObject co
     // 6. If origin is not equal to "viewport" or "pointer", and actions options is element origin steps given origin
     //    return false, return error with error code invalid argument.
     if (!origin.has_value())
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'origin' must be 'viewport', 'pointer', or an element origin");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'origin' must be 'viewport', 'pointer', or an element origin"sv);
 
     // 7. Set the origin property of action to origin.
     fields.origin = origin.release_value();
@@ -440,7 +440,7 @@ static ErrorOr<ActionObject, WebDriver::Error> process_pointer_action(String id,
 
     // 2. If subtype is not one of the values "pause", "pointerUp", "pointerDown", "pointerMove", or "pointerCancel", return an error with error code invalid argument.
     if (!first_is_one_of(subtype, Pause, PointerUp, PointerDown, PointerMove, PointerCancel))
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'pause', 'pointerUp', 'pointerDown', 'pointerMove', or 'pointerCancel'");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'pause', 'pointerUp', 'pointerDown', 'pointerMove', or 'pointerCancel'"sv);
 
     // 3. Let action be an action object constructed with arguments id, "pointer", and subtype.
     ActionObject action { move(id), InputSourceType::Pointer, *subtype };
@@ -487,7 +487,7 @@ static ErrorOr<ActionObject, WebDriver::Error> process_wheel_action(String id, J
 
     // 2. If subtype is not the value "pause", or "scroll", return an error with error code invalid argument.
     if (!first_is_one_of(subtype, Pause, Scroll))
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'pause' or 'scroll'");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'pause' or 'scroll'"sv);
 
     // 3. Let action be an action object constructed with arguments id, "wheel", and subtype.
     ActionObject action { move(id), InputSourceType::Wheel, *subtype };
@@ -514,7 +514,7 @@ static ErrorOr<ActionObject, WebDriver::Error> process_wheel_action(String id, J
     // 10. If origin is not equal to "viewport", or actions options' is element origin steps given origin return false,
     //     return error with error code invalid argument.
     if (!origin.has_value() || origin == ActionObject::OriginType::Pointer)
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'origin' must be 'viewport' or an element origin");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'origin' must be 'viewport' or an element origin"sv);
 
     // 11. Set the origin property of action to origin.
     fields.origin = origin.release_value();
@@ -551,11 +551,11 @@ static ErrorOr<Vector<ActionObject>, WebDriver::Error> process_input_source_acti
 
     // 2. If type is not "key", "pointer", "wheel", or "none", return an error with error code invalid argument.
     if (!type.has_value())
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'key', 'pointer', 'wheel', or 'none'");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' must be one of 'key', 'pointer', 'wheel', or 'none'"sv);
 
     // 3. Let id be the result of getting the property "id" from action sequence.
     // 4. If id is undefined or is not a String, return error with error code invalid argument.
-    auto const id = MUST(String::from_byte_string(TRY(get_property(action_sequence, "id"sv))));
+    auto const id = TRY(get_property(action_sequence, "id"sv));
 
     // 5. If type is equal to "pointer", let parameters data be the result of getting the property "parameters" from
     //    action sequence. Then let parameters be the result of trying to process pointer parameters with argument
@@ -575,7 +575,7 @@ static ErrorOr<Vector<ActionObject>, WebDriver::Error> process_input_source_acti
     //    return an error with error code invalid argument.
     if (auto const* pointer_input_source = source.get_pointer<PointerInputSource>(); pointer_input_source && parameters.has_value()) {
         if (parameters->pointer_type != pointer_input_source->subtype)
-            return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Invalid 'pointerType' property");
+            return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Invalid 'pointerType' property"sv);
     }
 
     // 8. Let action items be the result of getting a property named "actions" from action sequence.
@@ -589,7 +589,7 @@ static ErrorOr<Vector<ActionObject>, WebDriver::Error> process_input_source_acti
     TRY(action_items.try_for_each([&](auto const& action_item) -> ErrorOr<void, WebDriver::Error> {
         // 1. If action item is not an Object return error with error code invalid argument.
         if (!action_item.is_object())
-            return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'actions' item is not an Object");
+            return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'actions' item is not an Object"sv);
 
         auto action = TRY([&]() {
             switch (*type) {
@@ -1240,11 +1240,11 @@ static ErrorOr<void, WebDriver::Error> dispatch_pointer_move_action(ActionObject
 
     // 5. If x is less than 0 or greater than the width of the viewport in CSS pixels, then return error with error code move target out of bounds.
     if (coordinates.x() < 0 || coordinates.x() > viewport.width())
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::MoveTargetOutOfBounds, ByteString::formatted("Coordinates {} are out of bounds", coordinates));
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::MoveTargetOutOfBounds, MUST(String::formatted("Coordinates {} are out of bounds", coordinates)));
 
     // 6. If y is less than 0 or greater than the height of the viewport in CSS pixels, then return error with error code move target out of bounds.
     if (coordinates.y() < 0 || coordinates.y() > viewport.height())
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::MoveTargetOutOfBounds, ByteString::formatted("Coordinates {} are out of bounds", coordinates));
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::MoveTargetOutOfBounds, MUST(String::formatted("Coordinates {} are out of bounds", coordinates)));
 
     // 7. Let duration be equal to action object's duration property if it is not undefined, or tick duration otherwise.
     [[maybe_unused]] auto duration = action_object.duration.value_or(tick_duration);

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -236,6 +236,7 @@ static bool matches_platform_name(StringView requested_platform_name, StringView
 static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags flags)
 {
     static auto browser_name = StringView { BROWSER_NAME, strlen(BROWSER_NAME) }.to_lowercase_string();
+    static constexpr auto browser_version = StringView { BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) };
     static auto platform_name = StringView { OS_STRING, strlen(OS_STRING) }.to_lowercase_string();
 
     // 1. Let matched capabilities be a JSON Object with the following entries:
@@ -245,7 +246,7 @@ static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags
     matched_capabilities.set("browserName"sv, browser_name);
     // "browserVersion"
     //     The user agent version, as a string.
-    matched_capabilities.set("browserVersion"sv, BROWSER_VERSION);
+    matched_capabilities.set("browserVersion"sv, browser_version);
     // "platformName"
     //     ASCII Lowercase name of the current platform as a string.
     matched_capabilities.set("platformName"sv, platform_name);

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -91,7 +91,7 @@ static ErrorOr<JsonObject, Error> validate_capabilities(JsonValue const& capabil
         else if (name.is_one_of("browserName"sv, "browserVersion"sv, "platformName"sv)) {
             // If value is not a string return an error with error code invalid argument. Otherwise, let deserialized be set to value.
             if (!value.is_string())
-                return Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Capability {} must be a string", name));
+                return Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Capability {} must be a string", name)));
             deserialized = value;
         }
 
@@ -152,7 +152,7 @@ static ErrorOr<JsonObject, Error> validate_capabilities(JsonValue const& capabil
         // -> The remote end is an endpoint node
         else {
             // Return an error with error code invalid argument.
-            return Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Unrecognized capability: {}", name));
+            return Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Unrecognized capability: {}", name)));
         }
 
         // d. If deserialized is not null, set a property on result with name name and value deserialized.
@@ -195,7 +195,7 @@ static ErrorOr<JsonObject, Error> merge_capabilities(JsonObject const& primary, 
 
         // d. If primary value is not undefined, return an error with error code invalid argument.
         if (primary_value.has_value())
-            return Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Unable to merge capability {}", name));
+            return Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Unable to merge capability {}", name)));
 
         // e. Set a property on result with name name and value value.
         result.set(name, value);
@@ -290,13 +290,13 @@ static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags
         else if (name == "browserVersion"sv) {
             // Compare value to the "browserVersion" entry in matched capabilities using an implementation-defined comparison algorithm. The comparison is to accept a value that places constraints on the version using the "<", "<=", ">", and ">=" operators.
             // If the two values do not match, return success with data null.
-            if (!matches_browser_version(value.as_string(), matched_capabilities.get_byte_string(name).value()))
+            if (!matches_browser_version(value.as_string(), matched_capabilities.get_string(name).value()))
                 return AK::Error::from_string_literal("browserVersion");
         }
         // -> "platformName"
         else if (name == "platformName"sv) {
             // If value is not a string equal to the "platformName" entry in matched capabilities, return success with data null.
-            if (!matches_platform_name(value.as_string(), matched_capabilities.get_byte_string(name).value()))
+            if (!matches_platform_name(value.as_string(), matched_capabilities.get_string(name).value()))
                 return AK::Error::from_string_literal("platformName");
         }
         // -> "acceptInsecureCerts"

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -145,7 +145,7 @@ static ErrorOr<JsonObject, Error> validate_capabilities(JsonValue const& capabil
         else if (name.contains(':')) {
             // If name is known to the implementation, let deserialized be the result of trying to deserialize value in
             // an implementation-specific way. Otherwise, let deserialized be set to value.
-            if (name.starts_with("ladybird:"sv))
+            if (name.starts_with_bytes("ladybird:"sv))
                 deserialized = TRY(deserialize_as_ladybird_capability(name, value));
         }
 

--- a/Libraries/LibWeb/WebDriver/Capabilities.cpp
+++ b/Libraries/LibWeb/WebDriver/Capabilities.cpp
@@ -235,9 +235,9 @@ static bool matches_platform_name(StringView requested_platform_name, StringView
 // https://w3c.github.io/webdriver/#dfn-matching-capabilities
 static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags flags)
 {
-    static auto browser_name = StringView { BROWSER_NAME, strlen(BROWSER_NAME) }.to_lowercase_string();
-    static constexpr auto browser_version = StringView { BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) };
-    static auto platform_name = StringView { OS_STRING, strlen(OS_STRING) }.to_lowercase_string();
+    static auto browser_name = String::from_utf8_without_validation({ BROWSER_NAME, __builtin_strlen(BROWSER_NAME) }).to_ascii_lowercase();
+    static auto browser_version = String::from_utf8_without_validation({ BROWSER_VERSION, __builtin_strlen(BROWSER_VERSION) });
+    static auto platform_name = String::from_utf8_without_validation({ OS_STRING, __builtin_strlen(OS_STRING) }).to_ascii_lowercase();
 
     // 1. Let matched capabilities be a JSON Object with the following entries:
     JsonObject matched_capabilities;
@@ -283,7 +283,7 @@ static JsonValue match_capabilities(JsonObject const& capabilities, SessionFlags
         // -> "browserName"
         if (name == "browserName"sv) {
             // If value is not a string equal to the "browserName" entry in matched capabilities, return success with data null.
-            if (value.as_string() != matched_capabilities.get_byte_string(name).value())
+            if (value.as_string() != matched_capabilities.get_string(name).value())
                 return AK::Error::from_string_literal("browserName");
         }
         // -> "browserVersion"

--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -329,8 +329,8 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     auto reason = HTTP::HttpResponse::reason_phrase_for_code(error.http_status);
 
     JsonObject error_response;
-    error_response.set("error"sv, error.error);
-    error_response.set("message"sv, error.message);
+    error_response.set("error"sv, MUST(String::from_byte_string(error.error)));
+    error_response.set("message"sv, MUST(String::from_byte_string(error.message)));
     error_response.set("stacktrace"sv, ""sv);
     if (error.data.has_value())
         error_response.set("data"sv, *error.data);

--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -173,7 +173,7 @@ static ErrorOr<MatchedRoute, Error> match_route(HTTP::HttpRequest const& request
 static JsonValue make_success_response(JsonValue value)
 {
     JsonObject result;
-    result.set("value", move(value));
+    result.set("value"sv, move(value));
     return result;
 }
 
@@ -329,14 +329,14 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     auto reason = HTTP::HttpResponse::reason_phrase_for_code(error.http_status);
 
     JsonObject error_response;
-    error_response.set("error", error.error);
-    error_response.set("message", error.message);
-    error_response.set("stacktrace", ""sv);
+    error_response.set("error"sv, error.error);
+    error_response.set("message"sv, error.message);
+    error_response.set("stacktrace"sv, ""sv);
     if (error.data.has_value())
-        error_response.set("data", *error.data);
+        error_response.set("data"sv, *error.data);
 
     JsonObject result;
-    result.set("value", move(error_response));
+    result.set("value"sv, move(error_response));
 
     auto content = result.serialized<StringBuilder>();
 

--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -167,7 +167,7 @@ static ErrorOr<MatchedRoute, Error> match_route(HTTP::HttpRequest const& request
         }
     }
 
-    return Error::from_code(ErrorCode::UnknownCommand, "The command was not recognized.");
+    return Error::from_code(ErrorCode::UnknownCommand, "The command was not recognized."sv);
 }
 
 static JsonValue make_success_response(JsonValue value)
@@ -329,8 +329,8 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     auto reason = HTTP::HttpResponse::reason_phrase_for_code(error.http_status);
 
     JsonObject error_response;
-    error_response.set("error"sv, MUST(String::from_byte_string(error.error)));
-    error_response.set("message"sv, MUST(String::from_byte_string(error.message)));
+    error_response.set("error"sv, error.error);
+    error_response.set("message"sv, error.message);
     error_response.set("stacktrace"sv, ""sv);
     if (error.data.has_value())
         error_response.set("data"sv, *error.data);

--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -298,7 +298,7 @@ ErrorOr<void, Client::WrappedError> Client::send_success_response(HTTP::HttpRequ
         keep_alive = it->value.trim_whitespace().equals_ignoring_ascii_case("keep-alive"sv);
 
     result = make_success_response(move(result));
-    auto content = result.serialized<StringBuilder>();
+    auto content = result.serialized();
 
     StringBuilder builder;
     builder.append("HTTP/1.1 200 OK\r\n"sv);
@@ -309,7 +309,7 @@ ErrorOr<void, Client::WrappedError> Client::send_success_response(HTTP::HttpRequ
         builder.append("Connection: keep-alive\r\n"sv);
     builder.append("Cache-Control: no-cache\r\n"sv);
     builder.append("Content-Type: application/json; charset=utf-8\r\n"sv);
-    builder.appendff("Content-Length: {}\r\n", content.length());
+    builder.appendff("Content-Length: {}\r\n", content.byte_count());
     builder.append("\r\n"sv);
     builder.append(content);
 
@@ -338,13 +338,13 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     JsonObject result;
     result.set("value"sv, move(error_response));
 
-    auto content = result.serialized<StringBuilder>();
+    auto content = result.serialized();
 
     StringBuilder builder;
     builder.appendff("HTTP/1.1 {} {}\r\n", error.http_status, reason);
     builder.append("Cache-Control: no-cache\r\n"sv);
     builder.append("Content-Type: application/json; charset=utf-8\r\n"sv);
-    builder.appendff("Content-Length: {}\r\n", content.length());
+    builder.appendff("Content-Length: {}\r\n", content.byte_count());
     builder.append("\r\n"sv);
     builder.append(content);
 

--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -331,7 +331,7 @@ ErrorOr<void, Client::WrappedError> Client::send_error_response(HTTP::HttpReques
     JsonObject error_response;
     error_response.set("error", error.error);
     error_response.set("message", error.message);
-    error_response.set("stacktrace", "");
+    error_response.set("stacktrace", ""sv);
     if (error.data.has_value())
         error_response.set("data", *error.data);
 

--- a/Libraries/LibWeb/WebDriver/Contexts.cpp
+++ b/Libraries/LibWeb/WebDriver/Contexts.cpp
@@ -14,10 +14,10 @@
 namespace Web::WebDriver {
 
 // https://w3c.github.io/webdriver/#dfn-web-window-identifier
-static ByteString const WEB_WINDOW_IDENTIFIER = "window-fcc6-11e5-b4f8-330a88ab9d7f"sv;
+static JS::PropertyKey const WEB_WINDOW_IDENTIFIER { "window-fcc6-11e5-b4f8-330a88ab9d7f" };
 
 // https://w3c.github.io/webdriver/#dfn-web-frame-identifier
-static ByteString const WEB_FRAME_IDENTIFIER = "frame-075b-4da1-b6ba-e579c2d3230a"sv;
+static JS::PropertyKey const WEB_FRAME_IDENTIFIER { "frame-075b-4da1-b6ba-e579c2d3230a" };
 
 // https://w3c.github.io/webdriver/#dfn-windowproxy-reference-object
 JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)
@@ -30,7 +30,7 @@ JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)
     //      Ref: https://html.spec.whatwg.org/multipage/document-sequences.html#bc-traversable
     auto navigable = window.associated_browsing_context()->active_document()->navigable();
 
-    auto identifier = navigable->is_top_level_traversable()
+    auto const& identifier = navigable->is_top_level_traversable()
         ? WEB_WINDOW_IDENTIFIER
         : WEB_FRAME_IDENTIFIER;
 
@@ -39,7 +39,7 @@ JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)
 
     // identifier
     //    Associated window handle of the window’s browsing context.
-    object.set(identifier, navigable->traversable_navigable()->window_handle());
+    object.set(identifier.as_string(), navigable->traversable_navigable()->window_handle());
 
     return object;
 }
@@ -64,7 +64,7 @@ bool represents_a_web_frame(JS::Value value)
     if (!value.is_object())
         return false;
 
-    auto result = value.as_object().has_own_property(WEB_FRAME_IDENTIFIER);
+    auto result = value.as_object().has_own_property(WEB_WINDOW_IDENTIFIER);
     return !result.is_error() && result.value();
 }
 

--- a/Libraries/LibWeb/WebDriver/Contexts.cpp
+++ b/Libraries/LibWeb/WebDriver/Contexts.cpp
@@ -39,7 +39,7 @@ JsonObject window_proxy_reference_object(HTML::WindowProxy const& window)
 
     // identifier
     //    Associated window handle of the window’s browsing context.
-    object.set(identifier, navigable->traversable_navigable()->window_handle().to_byte_string());
+    object.set(identifier, navigable->traversable_navigable()->window_handle());
 
     return object;
 }

--- a/Libraries/LibWeb/WebDriver/ElementReference.cpp
+++ b/Libraries/LibWeb/WebDriver/ElementReference.cpp
@@ -132,7 +132,7 @@ JsonObject web_element_reference_object(HTML::BrowsingContext const& browsing_co
 
     // 3. Return a JSON Object initialized with a property with name identifier and value reference.
     JsonObject object;
-    object.set(identifier, reference);
+    object.set(identifier, MUST(String::from_byte_string(reference)));
     return object;
 }
 
@@ -422,7 +422,7 @@ JsonObject shadow_root_reference_object(HTML::BrowsingContext const& browsing_co
 
     // 3. Return a JSON Object initialized with a property with name identifier and value reference.
     JsonObject object;
-    object.set(identifier, reference);
+    object.set(identifier, MUST(String::from_byte_string(reference)));
     return object;
 }
 

--- a/Libraries/LibWeb/WebDriver/ElementReference.h
+++ b/Libraries/LibWeb/WebDriver/ElementReference.h
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/Error.h>
 #include <AK/JsonObject.h>
+#include <AK/String.h>
 #include <LibGC/Ptr.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Value.h>
@@ -19,16 +19,16 @@
 namespace Web::WebDriver {
 
 GC::Ptr<Web::DOM::Node> get_node(HTML::BrowsingContext const&, StringView reference);
-ByteString get_or_create_a_node_reference(HTML::BrowsingContext const&, Web::DOM::Node const&);
+String get_or_create_a_node_reference(HTML::BrowsingContext const&, Web::DOM::Node const&);
 bool node_reference_is_known(HTML::BrowsingContext const&, StringView reference);
 
-ByteString get_or_create_a_web_element_reference(HTML::BrowsingContext const&, Web::DOM::Node const& element);
+String get_or_create_a_web_element_reference(HTML::BrowsingContext const&, Web::DOM::Node const& element);
 JsonObject web_element_reference_object(HTML::BrowsingContext const&, Web::DOM::Node const& element);
 bool represents_a_web_element(JsonValue const&);
 bool represents_a_web_element(JS::Value);
 ErrorOr<GC::Ref<Web::DOM::Element>, WebDriver::Error> deserialize_web_element(Web::HTML::BrowsingContext const&, JsonObject const&);
 ErrorOr<GC::Ref<Web::DOM::Element>, WebDriver::Error> deserialize_web_element(Web::HTML::BrowsingContext const&, JS::Object const&);
-ByteString extract_web_element_reference(JsonObject const&);
+String extract_web_element_reference(JsonObject const&);
 ErrorOr<GC::Ref<Web::DOM::Element>, Web::WebDriver::Error> get_web_element_origin(Web::HTML::BrowsingContext const&, StringView origin);
 ErrorOr<GC::Ref<Web::DOM::Element>, Web::WebDriver::Error> get_known_element(Web::HTML::BrowsingContext const&, StringView reference);
 
@@ -46,7 +46,7 @@ bool is_element_in_view(ReadonlySpan<GC::Ref<Web::DOM::Element>> paint_tree, Web
 bool is_element_obscured(ReadonlySpan<GC::Ref<Web::DOM::Element>> paint_tree, Web::DOM::Element&);
 GC::RootVector<GC::Ref<Web::DOM::Element>> pointer_interactable_tree(Web::HTML::BrowsingContext&, Web::DOM::Element&);
 
-ByteString get_or_create_a_shadow_root_reference(HTML::BrowsingContext const&, Web::DOM::ShadowRoot const&);
+String get_or_create_a_shadow_root_reference(HTML::BrowsingContext const&, Web::DOM::ShadowRoot const&);
 JsonObject shadow_root_reference_object(HTML::BrowsingContext const&, Web::DOM::ShadowRoot const&);
 bool represents_a_shadow_root(JsonValue const&);
 bool represents_a_shadow_root(JS::Value);

--- a/Libraries/LibWeb/WebDriver/Error.cpp
+++ b/Libraries/LibWeb/WebDriver/Error.cpp
@@ -13,43 +13,43 @@ namespace Web::WebDriver {
 struct ErrorCodeData {
     ErrorCode error_code;
     unsigned http_status;
-    ByteString json_error_code;
+    String json_error_code;
 };
 
 // https://w3c.github.io/webdriver/#dfn-error-code
 static Vector<ErrorCodeData> const s_error_code_data = {
-    { ErrorCode::ElementClickIntercepted, 400, "element click intercepted" },
-    { ErrorCode::ElementNotInteractable, 400, "element not interactable" },
-    { ErrorCode::InsecureCertificate, 400, "insecure certificate" },
-    { ErrorCode::InvalidArgument, 400, "invalid argument" },
-    { ErrorCode::InvalidCookieDomain, 400, "invalid cookie domain" },
-    { ErrorCode::InvalidElementState, 400, "invalid element state" },
-    { ErrorCode::InvalidSelector, 400, "invalid selector" },
-    { ErrorCode::InvalidSessionId, 404, "invalid session id" },
-    { ErrorCode::JavascriptError, 500, "javascript error" },
-    { ErrorCode::MoveTargetOutOfBounds, 500, "move target out of bounds" },
-    { ErrorCode::NoSuchAlert, 404, "no such alert" },
-    { ErrorCode::NoSuchCookie, 404, "no such cookie" },
-    { ErrorCode::NoSuchElement, 404, "no such element" },
-    { ErrorCode::NoSuchFrame, 404, "no such frame" },
-    { ErrorCode::NoSuchWindow, 404, "no such window" },
-    { ErrorCode::NoSuchShadowRoot, 404, "no such shadow root" },
-    { ErrorCode::ScriptTimeoutError, 500, "script timeout" },
-    { ErrorCode::SessionNotCreated, 500, "session not created" },
-    { ErrorCode::StaleElementReference, 404, "stale element reference" },
-    { ErrorCode::DetachedShadowRoot, 404, "detached shadow root" },
-    { ErrorCode::Timeout, 500, "timeout" },
-    { ErrorCode::UnableToSetCookie, 500, "unable to set cookie" },
-    { ErrorCode::UnableToCaptureScreen, 500, "unable to capture screen" },
-    { ErrorCode::UnexpectedAlertOpen, 500, "unexpected alert open" },
-    { ErrorCode::UnknownCommand, 404, "unknown command" },
-    { ErrorCode::UnknownError, 500, "unknown error" },
-    { ErrorCode::UnknownMethod, 405, "unknown method" },
-    { ErrorCode::UnsupportedOperation, 500, "unsupported operation" },
-    { ErrorCode::OutOfMemory, 500, "out of memory" },
+    { ErrorCode::ElementClickIntercepted, 400, "element click intercepted"_string },
+    { ErrorCode::ElementNotInteractable, 400, "element not interactable"_string },
+    { ErrorCode::InsecureCertificate, 400, "insecure certificate"_string },
+    { ErrorCode::InvalidArgument, 400, "invalid argument"_string },
+    { ErrorCode::InvalidCookieDomain, 400, "invalid cookie domain"_string },
+    { ErrorCode::InvalidElementState, 400, "invalid element state"_string },
+    { ErrorCode::InvalidSelector, 400, "invalid selector"_string },
+    { ErrorCode::InvalidSessionId, 404, "invalid session id"_string },
+    { ErrorCode::JavascriptError, 500, "javascript error"_string },
+    { ErrorCode::MoveTargetOutOfBounds, 500, "move target out of bounds"_string },
+    { ErrorCode::NoSuchAlert, 404, "no such alert"_string },
+    { ErrorCode::NoSuchCookie, 404, "no such cookie"_string },
+    { ErrorCode::NoSuchElement, 404, "no such element"_string },
+    { ErrorCode::NoSuchFrame, 404, "no such frame"_string },
+    { ErrorCode::NoSuchWindow, 404, "no such window"_string },
+    { ErrorCode::NoSuchShadowRoot, 404, "no such shadow root"_string },
+    { ErrorCode::ScriptTimeoutError, 500, "script timeout"_string },
+    { ErrorCode::SessionNotCreated, 500, "session not created"_string },
+    { ErrorCode::StaleElementReference, 404, "stale element reference"_string },
+    { ErrorCode::DetachedShadowRoot, 404, "detached shadow root"_string },
+    { ErrorCode::Timeout, 500, "timeout"_string },
+    { ErrorCode::UnableToSetCookie, 500, "unable to set cookie"_string },
+    { ErrorCode::UnableToCaptureScreen, 500, "unable to capture screen"_string },
+    { ErrorCode::UnexpectedAlertOpen, 500, "unexpected alert open"_string },
+    { ErrorCode::UnknownCommand, 404, "unknown command"_string },
+    { ErrorCode::UnknownError, 500, "unknown error"_string },
+    { ErrorCode::UnknownMethod, 405, "unknown method"_string },
+    { ErrorCode::UnsupportedOperation, 500, "unsupported operation"_string },
+    { ErrorCode::OutOfMemory, 500, "out of memory"_string },
 };
 
-Error Error::from_code(ErrorCode code, ByteString message, Optional<JsonValue> data)
+Error Error::from_code(ErrorCode code, String message, Optional<JsonValue> data)
 {
     auto const& error_code_data = s_error_code_data[to_underlying(code)];
 
@@ -61,13 +61,18 @@ Error Error::from_code(ErrorCode code, ByteString message, Optional<JsonValue> d
     };
 }
 
+Error Error::from_code(ErrorCode code, StringView message, Optional<JsonValue> data)
+{
+    return from_code(code, String::from_utf8_without_validation(message.bytes()), move(data));
+}
+
 Error::Error(AK::Error const& error)
 {
     VERIFY(error.code() == ENOMEM);
-    *this = from_code(ErrorCode::OutOfMemory, {}, {});
+    *this = from_code(ErrorCode::OutOfMemory, String {}, {});
 }
 
-Error::Error(unsigned http_status_, ByteString error_, ByteString message_, Optional<JsonValue> data_)
+Error::Error(unsigned http_status_, String error_, String message_, Optional<JsonValue> data_)
     : http_status(http_status_)
     , error(move(error_))
     , message(move(message_))

--- a/Libraries/LibWeb/WebDriver/Error.h
+++ b/Libraries/LibWeb/WebDriver/Error.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/JsonValue.h>
+#include <AK/String.h>
 
 namespace Web::WebDriver {
 
@@ -50,13 +50,14 @@ enum class ErrorCode {
 // https://w3c.github.io/webdriver/#errors
 struct Error {
     unsigned http_status;
-    ByteString error;
-    ByteString message;
+    String error;
+    String message;
     Optional<JsonValue> data;
 
-    static Error from_code(ErrorCode, ByteString message, Optional<JsonValue> data = {});
+    static Error from_code(ErrorCode, String message, Optional<JsonValue> data = {});
+    static Error from_code(ErrorCode, StringView message, Optional<JsonValue> data = {});
 
-    Error(unsigned http_status, ByteString error, ByteString message, Optional<JsonValue> data);
+    Error(unsigned http_status, String error, String message, Optional<JsonValue> data);
     Error(AK::Error const&);
 };
 
@@ -66,6 +67,6 @@ template<>
 struct AK::Formatter<Web::WebDriver::Error> : Formatter<StringView> {
     ErrorOr<void> format(FormatBuilder& builder, Web::WebDriver::Error const& error)
     {
-        return Formatter<StringView>::format(builder, ByteString::formatted("Error {}, {}: {}", error.http_status, error.error, error.message));
+        return Formatter<StringView>::format(builder, MUST(String::formatted("Error {}, {}: {}", error.http_status, error.error, error.message)));
     }
 };

--- a/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.cpp
@@ -22,7 +22,7 @@
 namespace Web::WebDriver {
 
 // https://w3c.github.io/webdriver/#dfn-execute-a-function-body
-static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingContext const& browsing_context, ByteString const& body, ReadonlySpan<JS::Value> parameters)
+static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingContext const& browsing_context, StringView body, ReadonlySpan<JS::Value> parameters)
 {
     // 1. Let window be the associated window of the current browsing context’s active document.
     auto window = browsing_context.active_document()->window();
@@ -84,7 +84,7 @@ static JS::ThrowCompletionOr<JS::Value> execute_a_function_body(HTML::BrowsingCo
     return completion;
 }
 
-void execute_script(HTML::BrowsingContext const& browsing_context, ByteString body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
+void execute_script(HTML::BrowsingContext const& browsing_context, String body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
 {
     auto const* document = browsing_context.active_document();
     auto& realm = document->realm();
@@ -142,7 +142,7 @@ void execute_script(HTML::BrowsingContext const& browsing_context, ByteString bo
 }
 
 // https://w3c.github.io/webdriver/#execute-async-script
-void execute_async_script(HTML::BrowsingContext const& browsing_context, ByteString body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
+void execute_async_script(HTML::BrowsingContext const& browsing_context, String body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete)
 {
     auto const* document = browsing_context.active_document();
     auto& realm = document->realm();

--- a/Libraries/LibWeb/WebDriver/ExecuteScript.h
+++ b/Libraries/LibWeb/WebDriver/ExecuteScript.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/String.h>
 #include <LibGC/Function.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Promise.h>
@@ -23,7 +24,7 @@ struct ExecutionResult {
 
 using OnScriptComplete = GC::Function<void(ExecutionResult)>;
 
-void execute_script(HTML::BrowsingContext const&, ByteString body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
-void execute_async_script(HTML::BrowsingContext const&, ByteString body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
+void execute_script(HTML::BrowsingContext const&, String body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
+void execute_async_script(HTML::BrowsingContext const&, String body, GC::RootVector<JS::Value> arguments, Optional<u64> const& timeout_ms, GC::Ref<OnScriptComplete> on_complete);
 
 }

--- a/Libraries/LibWeb/WebDriver/InputSource.cpp
+++ b/Libraries/LibWeb/WebDriver/InputSource.cpp
@@ -176,7 +176,7 @@ ErrorOr<InputSource*, WebDriver::Error> get_or_create_input_source(InputState& i
         // FIXME: Spec issue: It does not make sense to check if "source is a pointer input source". This would errantly
         //        prevent the ability to perform two pointer actions in a row.
         //        https://github.com/w3c/webdriver/issues/1810
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' does not match existing input source type");
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, "Property 'type' does not match existing input source type"sv);
     }
 
     // 3. If source is undefined, set source to the result of trying to create an input source with input state and type.

--- a/Libraries/LibWeb/WebDriver/Properties.h
+++ b/Libraries/LibWeb/WebDriver/Properties.h
@@ -40,7 +40,7 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& pa
     if constexpr (IsSame<PropertyType, ByteString>) {
         if (!property->is_string())
             return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a String", key));
-        return property->as_string();
+        return property->as_string().to_byte_string();
     } else if constexpr (IsSame<PropertyType, bool>) {
         if (!property->is_bool())
             return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a Boolean", key));

--- a/Libraries/LibWeb/WebDriver/Properties.h
+++ b/Libraries/LibWeb/WebDriver/Properties.h
@@ -6,22 +6,22 @@
 
 #pragma once
 
-#include <AK/ByteString.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
+#include <AK/String.h>
 #include <LibJS/Runtime/Value.h>
 #include <LibWeb/WebDriver/Error.h>
 
 namespace Web::WebDriver {
 
-template<typename PropertyType = ByteString>
+template<typename PropertyType = String>
 static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& payload, StringView key)
 {
     auto property = payload.get(key);
 
     if (!property.has_value())
-        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("No property called '{}' present", key));
+        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("No property called '{}' present", key)));
 
     auto is_safe_number = []<typename T>(T value) {
         if constexpr (sizeof(T) >= 8) {
@@ -37,29 +37,29 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& pa
         return true;
     };
 
-    if constexpr (IsSame<PropertyType, ByteString>) {
+    if constexpr (IsSame<PropertyType, String>) {
         if (!property->is_string())
-            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a String", key));
-        return property->as_string().to_byte_string();
+            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' is not a String", key)));
+        return property->as_string();
     } else if constexpr (IsSame<PropertyType, bool>) {
         if (!property->is_bool())
-            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a Boolean", key));
+            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' is not a Boolean", key)));
         return property->as_bool();
     } else if constexpr (IsIntegral<PropertyType>) {
         if (auto maybe_number = property->get_integer<PropertyType>(); maybe_number.has_value() && is_safe_number(*maybe_number))
             return *maybe_number;
-        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not an Integer", key));
+        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' is not an Integer", key)));
     } else if constexpr (IsSame<PropertyType, double>) {
         if (auto maybe_number = property->get_double_with_precision_loss(); maybe_number.has_value() && is_safe_number(*maybe_number))
             return *maybe_number;
-        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not a Number", key));
+        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' is not a Number", key)));
     } else if constexpr (IsSame<PropertyType, JsonArray const*>) {
         if (!property->is_array())
-            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not an Array", key));
+            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' is not an Array", key)));
         return &property->as_array();
     } else if constexpr (IsSame<PropertyType, JsonObject const*>) {
         if (!property->is_object())
-            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' is not an Object", key));
+            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' is not an Object", key)));
         return &property->as_object();
     } else {
         static_assert(DependentFalse<PropertyType>, "get_property invoked with unknown property type");
@@ -67,15 +67,15 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonObject const& pa
     }
 }
 
-template<typename PropertyType = ByteString>
+template<typename PropertyType = String>
 static ErrorOr<PropertyType, WebDriver::Error> get_property(JsonValue const& payload, StringView key)
 {
     if (!payload.is_object())
-        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return WebDriver::Error::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object"sv);
     return get_property<PropertyType>(payload.as_object(), key);
 }
 
-template<typename PropertyType = ByteString>
+template<typename PropertyType = String>
 static ErrorOr<Optional<PropertyType>, WebDriver::Error> get_optional_property(JsonObject const& object, StringView key)
 {
     if (!object.has(key))
@@ -89,9 +89,9 @@ static ErrorOr<PropertyType, WebDriver::Error> get_property_with_limits(JsonObje
     auto value = TRY(get_property<PropertyType>(object, key));
 
     if (min.has_value() && value < *min)
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' must not be less than {}", key, *min));
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' must not be less than {}", key, *min)));
     if (max.has_value() && value > *max)
-        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, ByteString::formatted("Property '{}' must not be greater than {}", key, *max));
+        return WebDriver::Error::from_code(WebDriver::ErrorCode::InvalidArgument, MUST(String::formatted("Property '{}' must not be greater than {}", key, *max)));
 
     return value;
 }

--- a/Libraries/LibWeb/WebDriver/Proxy.cpp
+++ b/Libraries/LibWeb/WebDriver/Proxy.cpp
@@ -116,7 +116,7 @@ ErrorOr<JsonObject, Error> deserialize_as_a_proxy(JsonValue const& parameter)
     JsonObject proxy;
 
     // 3. For each enumerable own property in parameter run the following substeps:
-    TRY(parameter.as_object().try_for_each_member([&](ByteString const& key, JsonValue const& value) -> ErrorOr<void, Error> {
+    TRY(parameter.as_object().try_for_each_member([&](String const& key, JsonValue const& value) -> ErrorOr<void, Error> {
         // 1. Let key be the name of the property.
         // 2. Let value be the result of getting a property named name from capability.
 

--- a/Libraries/LibWeb/WebDriver/Response.cpp
+++ b/Libraries/LibWeb/WebDriver/Response.cpp
@@ -58,8 +58,8 @@ ErrorOr<Web::WebDriver::Response> IPC::decode(Decoder& decoder)
 
     case ResponseType::Error: {
         auto http_status = TRY(decoder.decode<unsigned>());
-        auto error = TRY(decoder.decode<ByteString>());
-        auto message = TRY(decoder.decode<ByteString>());
+        auto error = TRY(decoder.decode<String>());
+        auto message = TRY(decoder.decode<String>());
         auto data = TRY(decoder.decode<Optional<JsonValue>>());
 
         return Web::WebDriver::Error { http_status, move(error), move(message), move(data) };

--- a/Libraries/LibWeb/WebDriver/Screenshot.cpp
+++ b/Libraries/LibWeb/WebDriver/Screenshot.cpp
@@ -85,7 +85,7 @@ Response encode_canvas_element(HTML::HTMLCanvasElement& canvas)
     auto encoded_string = MUST(data_url.substring_from_byte_offset(*index + 1));
 
     // 7. Return success with data encoded string.
-    return JsonValue { encoded_string.to_byte_string() };
+    return JsonValue { move(encoded_string) };
 }
 
 }

--- a/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.cpp
+++ b/Libraries/LibWeb/WebDriver/TimeoutsConfiguration.cpp
@@ -46,7 +46,7 @@ ErrorOr<void, Error> json_deserialize_as_a_timeouts_configuration_into(JsonValue
 {
     // 1. Set timeouts to the result of converting a JSON-derived JavaScript value to an Infra value with timeouts.
     if (!timeouts.is_object())
-        return Error::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Error::from_code(ErrorCode::InvalidArgument, "Payload is not a JSON object"sv);
 
     // 3. For each key → value in timeouts:
     TRY(timeouts.as_object().try_for_each_member([&](auto const& key, JsonValue const& value) -> ErrorOr<void, Error> {
@@ -62,7 +62,7 @@ ErrorOr<void, Error> json_deserialize_as_a_timeouts_configuration_into(JsonValue
             auto duration = value.get_integer<u64>();
 
             if (!duration.has_value() || *duration > JS::MAX_ARRAY_LIKE_INDEX)
-                return Error::from_code(ErrorCode::InvalidArgument, "Invalid timeout value");
+                return Error::from_code(ErrorCode::InvalidArgument, "Invalid timeout value"sv);
 
             parsed_value = static_cast<u64>(*duration);
         }

--- a/Libraries/LibWeb/WebDriver/UserPrompt.cpp
+++ b/Libraries/LibWeb/WebDriver/UserPrompt.cpp
@@ -71,7 +71,7 @@ static constexpr PromptType prompt_type_from_string(StringView prompt_type)
 
 PromptHandlerConfiguration PromptHandlerConfiguration::deserialize(JsonValue const& configuration)
 {
-    auto handler = prompt_handler_from_string(*configuration.as_object().get_byte_string("handler"sv));
+    auto handler = prompt_handler_from_string(*configuration.as_object().get_string("handler"sv));
 
     auto notify = *configuration.as_object().get_bool("notify"sv)
         ? PromptHandlerConfiguration::Notify::Yes
@@ -138,7 +138,7 @@ Response deserialize_as_an_unhandled_prompt_behavior(JsonValue value)
     TRY(value.as_object().try_for_each_member([&](String const& prompt_type, JsonValue const& handler_value) -> ErrorOr<void, WebDriver::Error> {
         // 1. If is string value is false and valid prompt types does not contain prompt type return error with error code invalid argument.
         if (!is_string_value && !valid_prompt_types.contains_slow(prompt_type))
-            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("'{}' is not a valid prompt type", prompt_type));
+            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("'{}' is not a valid prompt type", prompt_type)));
 
         // 2. If known prompt handlers does not contain an entry with handler key handler return error with error code invalid argument.
         if (!handler_value.is_string())
@@ -147,7 +147,7 @@ Response deserialize_as_an_unhandled_prompt_behavior(JsonValue value)
         StringView handler = handler_value.as_string();
 
         if (!known_prompt_handlers.contains_slow(handler))
-            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("'{}' is not a known prompt handler", handler));
+            return WebDriver::Error::from_code(ErrorCode::InvalidArgument, MUST(String::formatted("'{}' is not a known prompt handler", handler)));
 
         // 3. Let notify be false.
         bool notify = false;

--- a/Libraries/LibWeb/WebDriver/UserPrompt.cpp
+++ b/Libraries/LibWeb/WebDriver/UserPrompt.cpp
@@ -135,7 +135,7 @@ Response deserialize_as_an_unhandled_prompt_behavior(JsonValue value)
     JsonObject user_prompt_handler;
 
     // 6. For each prompt type → handler in value:
-    TRY(value.as_object().try_for_each_member([&](ByteString const& prompt_type, JsonValue const& handler_value) -> ErrorOr<void, WebDriver::Error> {
+    TRY(value.as_object().try_for_each_member([&](String const& prompt_type, JsonValue const& handler_value) -> ErrorOr<void, WebDriver::Error> {
         // 1. If is string value is false and valid prompt types does not contain prompt type return error with error code invalid argument.
         if (!is_string_value && !valid_prompt_types.contains_slow(prompt_type))
             return WebDriver::Error::from_code(ErrorCode::InvalidArgument, ByteString::formatted("'{}' is not a valid prompt type", prompt_type));
@@ -192,7 +192,7 @@ bool check_user_prompt_handler_matches(JsonObject const& requested_prompt_handle
         return true;
 
     // 2. For each request prompt type → request handler in requested prompt handler:
-    auto result = requested_prompt_handler.try_for_each_member([&](ByteString const& request_prompt_type, JsonValue const& request_handler) -> ErrorOr<void> {
+    auto result = requested_prompt_handler.try_for_each_member([&](String const& request_prompt_type, JsonValue const& request_handler) -> ErrorOr<void> {
         // 1. If the user prompt handler contains request prompt type:
         if (auto handler = s_user_prompt_handler->get(prompt_type_from_string(request_prompt_type)); handler.has_value()) {
             // 1. If the requested prompt handler's handler is not equal to the user prompt handler's handler, return false.
@@ -215,7 +215,7 @@ void update_the_user_prompt_handler(JsonObject const& requested_prompt_handler)
         s_user_prompt_handler = UserPromptHandler::ValueType {};
 
     // 2. For each request prompt type → request handler in requested prompt handler:
-    requested_prompt_handler.for_each_member([&](ByteString const& request_prompt_type, JsonValue const& request_handler) {
+    requested_prompt_handler.for_each_member([&](String const& request_prompt_type, JsonValue const& request_handler) {
         // 1. Set user prompt handler[request prompt type] to request handler.
         s_user_prompt_handler->set(
             prompt_type_from_string(request_prompt_type),

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -340,7 +340,7 @@ Vector<DevTools::TabDescription> Application::tab_list() const
     Vector<DevTools::TabDescription> tabs;
 
     ViewImplementation::for_each_view([&](ViewImplementation& view) {
-        tabs.empend(view.view_id(), view.title(), view.url().to_byte_string());
+        tabs.empend(view.view_id(), MUST(String::from_byte_string(view.title())), view.url().to_string());
         return IterationDecision::Continue;
     });
 
@@ -355,7 +355,7 @@ Vector<DevTools::CSSProperty> Application::css_property_list() const
         auto property_id = static_cast<Web::CSS::PropertyID>(i);
 
         DevTools::CSSProperty property;
-        property.name = Web::CSS::string_from_property_id(property_id).to_string().to_byte_string();
+        property.name = Web::CSS::string_from_property_id(property_id).to_string();
         property.is_inherited = Web::CSS::is_inherited_property(property_id);
         property_list.append(move(property));
     }

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -546,7 +546,7 @@ template<typename Generator>
 static void generate_tree(StringBuilder& builder, JsonObject const& node, Generator&& generator)
 {
     if (auto children = node.get_array("children"sv); children.has_value() && !children->is_empty()) {
-        auto name = node.get_byte_string("name"sv).value_or({});
+        auto name = node.get_string("name"sv).value_or({});
         builder.append("<details>"sv);
 
         builder.append("<summary>"sv);
@@ -570,8 +570,8 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
     StringBuilder builder;
 
     generate_tree(builder, dom_tree, [&](JsonObject const& node) {
-        auto type = node.get_byte_string("type"sv).value_or("unknown"sv);
-        auto name = node.get_byte_string("name"sv).value_or({});
+        auto type = node.get_string("type"sv).value_or("unknown"_string);
+        auto name = node.get_string("name"sv).value_or({});
 
         StringBuilder data_attributes;
         auto append_data_attribute = [&](auto name, auto value) {
@@ -592,10 +592,9 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
         append_data_attribute("id"sv, node_id);
 
         if (type == "text"sv) {
-            auto deprecated_text = node.get_byte_string("text"sv).release_value();
-            deprecated_text = escape_html_entities(deprecated_text);
-
+            auto deprecated_text = escape_html_entities(*node.get_string("text"sv));
             auto text = MUST(Web::Infra::strip_and_collapse_whitespace(deprecated_text));
+
             builder.appendff("<span data-node-type=\"text\" class=\"hoverable editable\" {}>", data_attributes.string_view());
 
             if (text.is_empty())
@@ -608,8 +607,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
         }
 
         if (type == "comment"sv) {
-            auto comment = node.get_byte_string("data"sv).release_value();
-            comment = escape_html_entities(comment);
+            auto comment = escape_html_entities(*node.get_string("data"sv));
 
             builder.appendff("<span class=\"hoverable comment\" {}>", data_attributes.string_view());
             builder.append("<span>&lt;!--</span>"sv);
@@ -620,7 +618,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
         }
 
         if (type == "shadow-root"sv) {
-            auto mode = node.get_byte_string("mode"sv).release_value();
+            auto mode = node.get_string("mode"sv).release_value();
 
             builder.appendff("<span class=\"hoverable internal\" {}>", data_attributes.string_view());
             builder.appendff("{} ({})", name, mode);
@@ -636,8 +634,8 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
                 m_body_or_frameset_node_id = node_id;
 
             auto tag = name;
-            if (node.get_byte_string("namespace"sv) == Web::Namespace::HTML.bytes_as_string_view())
-                tag = tag.to_lowercase();
+            if (node.get_string("namespace"sv) == Web::Namespace::HTML.bytes_as_string_view())
+                tag = MUST(tag.to_lowercase());
 
             builder.appendff("<span class=\"hoverable\" {}>", data_attributes.string_view());
             builder.append("<span>&lt;</span>"sv);
@@ -693,12 +691,11 @@ String InspectorClient::generate_accessibility_tree(JsonObject const& accessibil
     StringBuilder builder;
 
     generate_tree(builder, accessibility_tree, [&](JsonObject const& node) {
-        auto type = node.get_byte_string("type"sv).value_or("unknown"sv);
-        auto role = node.get_byte_string("role"sv).value_or({});
+        auto type = node.get_string("type"sv).value_or("unknown"_string);
+        auto role = node.get_string("role"sv).value_or({});
 
         if (type == "text"sv) {
-            auto text = node.get_byte_string("text"sv).release_value();
-            text = escape_html_entities(text);
+            auto text = escape_html_entities(*node.get_string("text"sv));
 
             builder.appendff("<span class=\"hoverable\">");
             builder.append(MUST(Web::Infra::strip_and_collapse_whitespace(text)));
@@ -708,16 +705,16 @@ String InspectorClient::generate_accessibility_tree(JsonObject const& accessibil
 
         if (type != "element"sv) {
             builder.appendff("<span class=\"hoverable internal\">");
-            builder.appendff(role.to_lowercase());
+            builder.appendff(MUST(role.to_lowercase()));
             builder.append("</span>"sv);
             return;
         }
 
-        auto name = node.get_byte_string("name"sv).value_or({});
-        auto description = node.get_byte_string("description"sv).value_or({});
+        auto name = node.get_string("name"sv).value_or({});
+        auto description = node.get_string("description"sv).value_or({});
 
         builder.appendff("<span class=\"hoverable\">");
-        builder.append(role.to_lowercase());
+        builder.append(MUST(role.to_lowercase()));
         builder.appendff(" name: \"{}\", description: \"{}\"", name, description);
         builder.append("</span>"sv);
     });

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -655,7 +655,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
                     builder.appendff("<span class=\"attribute-value\">\"{}\"</span>", escape_html_entities(value_string));
                     builder.append("</span>"sv);
 
-                    dom_node_attributes.empend(MUST(String::from_byte_string(name)), MUST(String::from_byte_string(value_string)));
+                    dom_node_attributes.empend(name, MUST(String::from_byte_string(value_string)));
                 });
             }
 

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -655,7 +655,7 @@ String InspectorClient::generate_dom_tree(JsonObject const& dom_tree)
                     builder.appendff("<span class=\"attribute-value\">\"{}\"</span>", escape_html_entities(value_string));
                     builder.append("</span>"sv);
 
-                    dom_node_attributes.empend(name, MUST(String::from_byte_string(value_string)));
+                    dom_node_attributes.empend(name, value_string);
                 });
             }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateAriaRoles.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateAriaRoles.cpp
@@ -29,8 +29,8 @@ namespace Web::ARIA {
         JsonObject const& value_object = value.as_object();
 
         auto class_definition_generator = generator.fork();
-        class_definition_generator.set("spec_link"sv, value_object.get_byte_string("specLink"sv).value());
-        class_definition_generator.set("description"sv, value_object.get_byte_string("description"sv).value());
+        class_definition_generator.set("spec_link"sv, value_object.get_string("specLink"sv).release_value());
+        class_definition_generator.set("description"sv, value_object.get_string("description"sv).release_value());
         class_definition_generator.set("name"sv, name);
         class_definition_generator.append(R"~~~(
 // @spec_link@

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -128,7 +128,7 @@ Optional<@name:titlecase@> keyword_to_@name:snakecase@(Keyword keyword)
             auto member_generator = enum_generator.fork();
             auto member_name = member.as_string();
             if (member_name.contains('=')) {
-                auto parts = member_name.split_view('=');
+                auto parts = MUST(member_name.split('='));
                 member_generator.set("valueid:titlecase", title_casify(parts[0]));
                 member_generator.set("member:titlecase", title_casify(parts[1]));
             } else {

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMathFunctions.cpp
@@ -126,7 +126,7 @@ RefPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
     functions_data.for_each_member([&](auto& name, JsonValue const& value) -> void {
         auto& function_data = value.as_object();
         auto& parameters = function_data.get_array("parameters"sv).value();
-        auto parameter_validation_rule = function_data.get_byte_string("parameter-validation"sv);
+        auto parameter_validation_rule = function_data.get_string("parameter-validation"sv);
         bool requires_same_parameters = parameter_validation_rule.has_value() ? (parameter_validation_rule == "same"sv) : true;
 
         auto function_generator = generator.fork();
@@ -158,7 +158,7 @@ RefPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
             // Generate some type checks
             VERIFY(parameters.size() == 1);
             auto& parameter_data = parameters[0].as_object();
-            auto parameter_type_string = parameter_data.get_byte_string("type"sv).value();
+            auto parameter_type_string = parameter_data.get_string("type"sv).value();
             function_generator.set("type_check", generate_calculation_type_check("argument_type"sv, parameter_type_string));
             function_generator.append(R"~~~(
             if (!(@type_check@)) {
@@ -221,11 +221,11 @@ RefPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
             size_t parameter_index = 0;
             parameters.for_each([&](JsonValue const& parameter_value) {
                 auto& parameter = parameter_value.as_object();
-                auto parameter_type_string = parameter.get_byte_string("type"sv).value();
+                auto parameter_type_string = parameter.get_string("type"sv).value();
                 auto parameter_required = parameter.get_bool("required"sv).value();
 
                 auto parameter_generator = function_generator.fork();
-                parameter_generator.set("parameter_name", parameter.get_byte_string("name"sv).value());
+                parameter_generator.set("parameter_name", parameter.get_string("name"sv).value());
                 parameter_generator.set("parameter_index", String::number(parameter_index));
 
                 bool parameter_is_calculation;
@@ -235,7 +235,7 @@ RefPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
                     parameter_generator.set("parse_function", "parse_rounding_strategy(arguments[argument_index])"_string);
                     parameter_generator.set("check_function", ".has_value()"_string);
                     parameter_generator.set("release_function", ".release_value()"_string);
-                    if (auto default_value = parameter.get_byte_string("default"sv); default_value.has_value()) {
+                    if (auto default_value = parameter.get_string("default"sv); default_value.has_value()) {
                         parameter_generator.set("parameter_default", MUST(String::formatted(" = RoundingStrategy::{}", title_casify(default_value.value()))));
                     } else {
                         parameter_generator.set("parameter_default", ""_string);
@@ -250,7 +250,7 @@ RefPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
 
                     // NOTE: We have exactly one default value in the data right now, and it's a `<calc-constant>`,
                     //       so that's all we handle.
-                    if (auto default_value = parameter.get_byte_string("default"sv); default_value.has_value()) {
+                    if (auto default_value = parameter.get_string("default"sv); default_value.has_value()) {
                         parameter_generator.set("parameter_default", MUST(String::formatted(" = ConstantCalculationNode::create(CalculationNode::constant_type_from_string(\"{}\"sv).value())", default_value.value())));
                     } else {
                         parameter_generator.set("parameter_default", ""_string);
@@ -343,7 +343,7 @@ RefPtr<CalculationNode> Parser::parse_math_function(Function const& function, Ca
             parameter_index = 0;
             parameters.for_each([&](JsonValue const& parameter_value) {
                 auto& parameter = parameter_value.as_object();
-                auto parameter_type_string = parameter.get_byte_string("type"sv).value();
+                auto parameter_type_string = parameter.get_string("type"sv).value();
 
                 auto parameter_generator = function_generator.fork();
                 parameter_generator.set("parameter_index"sv, String::number(parameter_index));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -140,9 +140,9 @@ bool media_feature_type_is_range(MediaFeatureID media_feature_id)
         auto member_generator = generator.fork();
         member_generator.set("name:titlecase", title_casify(name));
         VERIFY(feature.has("type"sv));
-        auto feature_type = feature.get_byte_string("type"sv);
+        auto feature_type = feature.get_string("type"sv);
         VERIFY(feature_type.has_value());
-        member_generator.set("is_range", feature_type.value() == "range" ? "true"_string : "false"_string);
+        member_generator.set("is_range", feature_type.value() == "range"sv ? "true"_string : "false"_string);
         member_generator.append(R"~~~(
     case MediaFeatureID::@name:titlecase@:
         return @is_range@;)~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSMediaFeatureID.cpp
@@ -182,7 +182,7 @@ bool media_feature_accepts_type(MediaFeatureID media_feature_id, MediaFeatureVal
                 VERIFY(type.is_string());
                 auto type_name = type.as_string();
                 // Skip keywords.
-                if (type_name[0] != '<')
+                if (!type_name.starts_with('<'))
                     continue;
                 if (type_name == "<mq-boolean>") {
                     append_value_type_switch_if_needed();
@@ -258,9 +258,9 @@ bool media_feature_accepts_keyword(MediaFeatureID media_feature_id, Keyword keyw
             auto& values_array = values.value();
             for (auto& keyword : values_array.values()) {
                 VERIFY(keyword.is_string());
-                auto keyword_name = keyword.as_string();
+                auto const& keyword_name = keyword.as_string();
                 // Skip types.
-                if (keyword_name[0] == '<')
+                if (keyword_name.starts_with('<'))
                     continue;
                 append_keyword_switch_if_needed();
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -420,7 +420,7 @@ Optional<PropertyID> property_id_from_camel_case_string(StringView string)
         auto member_generator = generator.fork();
         member_generator.set("name", name);
         member_generator.set("name:camelcase", camel_casify(name));
-        if (auto legacy_alias_for = value.as_object().get_byte_string("legacy-alias-for"sv); legacy_alias_for.has_value()) {
+        if (auto legacy_alias_for = value.as_object().get_string("legacy-alias-for"sv); legacy_alias_for.has_value()) {
             member_generator.set("name:titlecase", title_casify(legacy_alias_for.value()));
         } else {
             member_generator.set("name:titlecase", title_casify(name));
@@ -449,7 +449,7 @@ Optional<PropertyID> property_id_from_string(StringView string)
 
         auto member_generator = generator.fork();
         member_generator.set("name", name);
-        if (auto legacy_alias_for = value.as_object().get_byte_string("legacy-alias-for"sv); legacy_alias_for.has_value()) {
+        if (auto legacy_alias_for = value.as_object().get_string("legacy-alias-for"sv); legacy_alias_for.has_value()) {
             member_generator.set("name:titlecase", title_casify(legacy_alias_for.value()));
         } else {
             member_generator.set("name:titlecase", title_casify(name));
@@ -552,7 +552,7 @@ AnimationType animation_type_from_longhand_property(PropertyID property_id)
             VERIFY_NOT_REACHED();
         }
 
-        auto animation_type = value.as_object().get_byte_string("animation-type"sv).value();
+        auto animation_type = value.as_object().get_string("animation-type"sv).value();
         member_generator.set("value", title_casify(animation_type));
         member_generator.append(R"~~~(
     case PropertyID::@name:titlecase@:
@@ -681,7 +681,7 @@ NonnullRefPtr<CSSStyleValue> property_initial_value(PropertyID property_id)
             dbgln("No initial value specified for property '{}'", name);
             VERIFY_NOT_REACHED();
         }
-        auto initial_value = object.get_byte_string("initial"sv);
+        auto initial_value = object.get_string("initial"sv);
         VERIFY(initial_value.has_value());
         auto& initial_value_string = initial_value.value();
 
@@ -921,7 +921,7 @@ Optional<ValueType> property_resolves_percentages_relative_to(PropertyID propert
         if (is_legacy_alias(value.as_object()))
             return;
 
-        if (auto resolved_type = value.as_object().get_byte_string("percentages-resolve-to"sv); resolved_type.has_value()) {
+        if (auto resolved_type = value.as_object().get_string("percentages-resolve-to"sv); resolved_type.has_value()) {
             auto property_generator = generator.fork();
             property_generator.set("name:titlecase", title_casify(name));
             property_generator.set("resolved_type:titlecase", title_casify(resolved_type.value()));
@@ -1057,7 +1057,7 @@ bool is_animatable_property(JsonObject& properties, StringView property_name)
     auto property = properties.get_object(property_name);
     VERIFY(property.has_value());
 
-    if (auto animation_type = property.value().get_byte_string("animation-type"sv); animation_type.has_value()) {
+    if (auto animation_type = property.value().get_string("animation-type"sv); animation_type.has_value()) {
         return animation_type != "none";
     }
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -69,7 +69,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto properties = json.as_object();
 
     // Check we're in alphabetical order
-    ByteString most_recent_name = "";
+    String most_recent_name;
     properties.for_each_member([&](auto& name, auto&) {
         if (name < most_recent_name) {
             warnln("`{}` is in the wrong position in `{}`. Please keep this list alphabetical!", name, properties_json_path);
@@ -91,7 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 void replace_logical_aliases(JsonObject& properties)
 {
-    AK::HashMap<ByteString, ByteString> logical_aliases;
+    AK::HashMap<String, ByteString> logical_aliases;
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
         auto const& value_as_object = value.as_object();
@@ -142,10 +142,10 @@ enum class PropertyID {
     All,
 )~~~");
 
-    Vector<ByteString> inherited_shorthand_property_ids;
-    Vector<ByteString> inherited_longhand_property_ids;
-    Vector<ByteString> noninherited_shorthand_property_ids;
-    Vector<ByteString> noninherited_longhand_property_ids;
+    Vector<String> inherited_shorthand_property_ids;
+    Vector<String> inherited_longhand_property_ids;
+    Vector<String> noninherited_shorthand_property_ids;
+    Vector<String> noninherited_longhand_property_ids;
 
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
@@ -573,7 +573,7 @@ bool is_animatable_property(PropertyID property_id)
 
     properties.for_each_member([&](auto& name, auto& value) {
         VERIFY(value.is_object());
-        VERIFY(!name.is_empty() && !is_ascii_digit(name[0])); // Ensure `PropertyKey`s are not Numbers.
+        VERIFY(!name.is_empty() && !is_ascii_digit(name.bytes_as_string_view()[0])); // Ensure `PropertyKey`s are not Numbers.
         if (is_legacy_alias(value.as_object()))
             return;
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPseudoClass.cpp
@@ -149,14 +149,14 @@ PseudoClassMetadata pseudo_class_metadata(PseudoClass pseudo_class)
     pseudo_classes_data.for_each_member([&](auto& name, JsonValue const& value) {
         auto member_generator = generator.fork();
         auto& pseudo_class = value.as_object();
-        auto argument_string = pseudo_class.get_byte_string("argument"sv).value();
+        auto argument_string = pseudo_class.get_string("argument"sv).value();
 
         bool is_valid_as_identifier = argument_string.is_empty();
         bool is_valid_as_function = !argument_string.is_empty();
 
         if (argument_string.ends_with('?')) {
             is_valid_as_identifier = true;
-            argument_string = argument_string.substring(0, argument_string.length() - 1);
+            argument_string = MUST(argument_string.substring_from_byte_offset(0, argument_string.byte_count() - 1));
         }
 
         String parameter_type = "None"_string;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSStyleProperties.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSStyleProperties.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     return 0;
 }
 
-static String get_snake_case_function_name_for_css_property_name(ByteString const& name)
+static String get_snake_case_function_name_for_css_property_name(StringView name)
 {
     auto snake_case_name = snake_casify(name);
     if (snake_case_name.starts_with('_'))
@@ -182,7 +182,7 @@ interface mixin GeneratedCSSStyleProperties {
         // For each CSS property property that is a supported CSS property and that begins with the string -webkit-,
         // the following partial interface applies where webkit-cased attribute is obtained by running the CSS property
         // to IDL attribute algorithm for property, with the lowercase first flag set.
-        if (name.starts_with("-webkit-"sv)) {
+        if (name.starts_with_bytes("-webkit-"sv)) {
             member_generator.set("name:webkit", css_property_to_idl_attribute(name, /* lowercase_first= */ true));
             member_generator.append(R"~~~(
     [CEReactions, LegacyNullToEmptyString, AttributeCallbackName=@name:snakecase@_webkit, ImplementedAs=@name:acceptable_cpp@] attribute CSSOMString @name:webkit@;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -171,7 +171,7 @@ TransformFunctionMetadata transform_function_metadata(TransformFunction transfor
         JsonArray const& parameters = value.as_object().get_array("parameters"sv).value();
         bool first = true;
         parameters.for_each([&](JsonValue const& value) {
-            GenericLexer lexer { value.as_object().get_byte_string("type"sv).value() };
+            GenericLexer lexer { value.as_object().get_string("type"sv).value() };
             VERIFY(lexer.consume_specific('<'));
             auto parameter_type_name = lexer.consume_until('>');
             VERIFY(lexer.consume_specific('>'));

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -98,10 +98,10 @@ static JsonValue serialize_cookie(Web::Cookie::Cookie const& cookie)
 static JsonValue serialize_rect(Gfx::IntRect const& rect)
 {
     JsonObject serialized_rect = {};
-    serialized_rect.set("x", rect.x());
-    serialized_rect.set("y", rect.y());
-    serialized_rect.set("width", rect.width());
-    serialized_rect.set("height", rect.height());
+    serialized_rect.set("x"sv, rect.x());
+    serialized_rect.set("y"sv, rect.y());
+    serialized_rect.set("width"sv, rect.width());
+    serialized_rect.set("height"sv, rect.height());
 
     return serialized_rect;
 }

--- a/Services/WebContent/WebDriverConnection.cpp
+++ b/Services/WebContent/WebDriverConnection.cpp
@@ -83,10 +83,10 @@ namespace WebContent {
 static JsonValue serialize_cookie(Web::Cookie::Cookie const& cookie)
 {
     JsonObject serialized_cookie;
-    serialized_cookie.set("name"sv, cookie.name.to_byte_string());
-    serialized_cookie.set("value"sv, cookie.value.to_byte_string());
-    serialized_cookie.set("path"sv, cookie.path.to_byte_string());
-    serialized_cookie.set("domain"sv, cookie.domain.to_byte_string());
+    serialized_cookie.set("name"sv, cookie.name);
+    serialized_cookie.set("value"sv, cookie.value);
+    serialized_cookie.set("path"sv, cookie.path);
+    serialized_cookie.set("domain"sv, cookie.domain);
     serialized_cookie.set("secure"sv, cookie.secure);
     serialized_cookie.set("httpOnly"sv, cookie.http_only);
     serialized_cookie.set("expiry"sv, cookie.expiry_time.seconds_since_epoch());
@@ -346,7 +346,7 @@ Messages::WebDriverClient::GetCurrentUrlResponse WebDriverConnection::get_curren
         auto url = current_top_level_browsing_context()->active_document()->url();
 
         // 4. Return success with data url.
-        async_driver_execution_complete({ url.to_byte_string() });
+        async_driver_execution_complete({ url.to_string() });
     });
 
     return JsonValue {};
@@ -529,7 +529,7 @@ Messages::WebDriverClient::GetTitleResponse WebDriverConnection::get_title()
         auto title = current_top_level_browsing_context()->active_document()->title();
 
         // 4. Return success with data title.
-        async_driver_execution_complete({ title.to_byte_string() });
+        async_driver_execution_complete({ move(title) });
     });
 
     return JsonValue {};
@@ -1323,7 +1323,7 @@ Messages::WebDriverClient::GetElementAttributeResponse WebDriverConnection::get_
         }
 
         // 5. Return success with data result.
-        async_driver_execution_complete({ result.to_byte_string() });
+        async_driver_execution_complete({ move(result) });
     });
 
     return JsonValue {};
@@ -1389,7 +1389,7 @@ Messages::WebDriverClient::GetElementCssValueResponse WebDriverConnection::get_e
         //     "" (empty string)
 
         // 5. Return success with data computed value.
-        async_driver_execution_complete({ computed_value.to_byte_string() });
+        async_driver_execution_complete({ move(computed_value) });
     });
 
     return JsonValue {};
@@ -1411,7 +1411,7 @@ Messages::WebDriverClient::GetElementTextResponse WebDriverConnection::get_eleme
         auto rendered_text = Web::WebDriver::element_rendered_text(element);
 
         // 5. Return success with data rendered text.
-        async_driver_execution_complete({ rendered_text.to_byte_string() });
+        async_driver_execution_complete({ move(rendered_text) });
     });
 
     return JsonValue {};
@@ -1434,7 +1434,7 @@ Messages::WebDriverClient::GetElementTagNameResponse WebDriverConnection::get_el
         auto qualified_name = element->local_name();
 
         // 5. Return success with data qualified name.
-        async_driver_execution_complete({ qualified_name.to_string().to_byte_string() });
+        async_driver_execution_complete({ qualified_name.to_string() });
     });
 
     return JsonValue {};
@@ -1541,7 +1541,7 @@ Messages::WebDriverClient::GetComputedLabelResponse WebDriverConnection::get_com
         auto label = element->accessible_name(element->document()).release_value_but_fixme_should_propagate_errors();
 
         // 5. Return success with data label.
-        async_driver_execution_complete({ label.to_byte_string() });
+        async_driver_execution_complete({ move(label) });
     });
 
     return JsonValue {};
@@ -2047,7 +2047,7 @@ Messages::WebDriverClient::GetSourceResponse WebDriverConnection::get_source()
             source = MUST(document->serialize_fragment(Web::DOMParsing::RequireWellFormed::No));
 
         // 5. Return success with data source.
-        async_driver_execution_complete({ source->to_byte_string() });
+        async_driver_execution_complete({ source.release_value() });
     });
 
     return JsonValue {};
@@ -2465,7 +2465,7 @@ Messages::WebDriverClient::GetAlertTextResponse WebDriverConnection::get_alert_t
 
     // 4. Return success with data message.
     if (message.has_value())
-        return message->to_byte_string();
+        return message.value();
     return JsonValue {};
 }
 
@@ -2679,7 +2679,7 @@ static Web::WebDriver::Error create_annotated_unexpected_alert_open_error(Option
     //         The current user prompt's message.
     auto data = text.map([&](auto const& text) -> JsonValue {
         JsonObject data;
-        data.set("text"sv, text.to_byte_string());
+        data.set("text"sv, text);
         return data;
     });
 

--- a/Services/WebContent/WebDriverConnection.h
+++ b/Services/WebContent/WebDriverConnection.h
@@ -123,7 +123,7 @@ private:
 
     Web::WebDriver::Response element_click_impl(String const& element_id);
     Web::WebDriver::Response element_clear_impl(String const& element_id);
-    Web::WebDriver::Response element_send_keys_impl(String const& element_id, ByteString const& text);
+    Web::WebDriver::Response element_send_keys_impl(String const& element_id, String const& text);
     Web::WebDriver::Response add_cookie_impl(JsonObject const&);
 
     Web::WebDriver::PromptHandlerConfiguration get_the_prompt_handler(Web::WebDriver::PromptType type) const;
@@ -142,10 +142,10 @@ private:
 
     using GetStartNode = GC::Ref<GC::Function<ErrorOr<GC::Ref<Web::DOM::ParentNode>, Web::WebDriver::Error>()>>;
     using OnFindComplete = GC::Ref<GC::Function<void(Web::WebDriver::Response)>>;
-    void find(Web::WebDriver::LocationStrategy, ByteString, GetStartNode, OnFindComplete);
+    void find(Web::WebDriver::LocationStrategy, String, GetStartNode, OnFindComplete);
 
     struct ScriptArguments {
-        ByteString script;
+        String script;
         GC::RootVector<JS::Value> arguments;
     };
     ErrorOr<ScriptArguments, Web::WebDriver::Error> extract_the_script_arguments_from_a_request(JS::VM&, JsonValue const& payload);

--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -76,10 +76,10 @@ Web::WebDriver::Response Client::new_session(Web::WebDriver::Parameters, JsonVal
     JsonObject body;
     // "sessionId"
     //     session's session ID.
-    body.set("sessionId", JsonValue { session->session_id() });
+    body.set("sessionId"sv, JsonValue { session->session_id() });
     // "capabilities"
     //     capabilities
-    body.set("capabilities", move(capabilities));
+    body.set("capabilities"sv, move(capabilities));
 
     // 8. Set session' current top-level browsing context to one of the endpoint node's top-level browsing contexts,
     //    preferring the top-level browsing context that has system focus, or otherwise preferring any top-level
@@ -130,8 +130,8 @@ Web::WebDriver::Response Client::get_status(Web::WebDriver::Parameters, JsonValu
     //    "message"
     //        An implementation-defined string explaining the remote end's readiness state.
     JsonObject body;
-    body.set("ready", readiness_state);
-    body.set("message", ByteString::formatted("{} to accept a new session", readiness_state ? "Ready"sv : "Not ready"sv));
+    body.set("ready"sv, readiness_state);
+    body.set("message"sv, ByteString::formatted("{} to accept a new session", readiness_state ? "Ready"sv : "Not ready"sv));
 
     // 2. Return success with data body.
     return JsonValue { body };

--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -68,7 +68,7 @@ Web::WebDriver::Response Client::new_session(Web::WebDriver::Parameters, JsonVal
     // 6. Let session be the result of create a session, with capabilities, and flags.
     auto maybe_session = Session::create(*this, capabilities.as_object(), flags);
     if (maybe_session.is_error())
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::SessionNotCreated, ByteString::formatted("Failed to start session: {}", maybe_session.error()));
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::SessionNotCreated, MUST(String::formatted("Failed to start session: {}", maybe_session.error())));
 
     auto session = maybe_session.release_value();
 
@@ -258,14 +258,14 @@ Web::WebDriver::Response Client::switch_to_window(Web::WebDriver::Parameters par
     auto session = TRY(Session::find_session(parameters[0], Web::WebDriver::SessionFlags::Default, Session::AllowInvalidWindowHandle::Yes));
 
     if (!payload.is_object())
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "Payload is not a JSON object"sv);
 
     // 1. Let handle be the result of getting the property "handle" from the parameters argument.
     auto handle = payload.as_object().get("handle"sv);
 
     // 2. If handle is undefined, return error with error code invalid argument.
     if (!handle.has_value())
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'handle' present");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidArgument, "No property called 'handle' present"sv);
 
     return session->switch_to_window(handle->as_string());
 }
@@ -300,7 +300,7 @@ Web::WebDriver::Response Client::new_window(Web::WebDriver::Parameters parameter
     });
 
     if (timeout_fired)
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::Timeout, "Timed out waiting for window handle");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::Timeout, "Timed out waiting for window handle"sv);
 
     return handle;
 }

--- a/Services/WebDriver/Client.cpp
+++ b/Services/WebDriver/Client.cpp
@@ -131,7 +131,7 @@ Web::WebDriver::Response Client::get_status(Web::WebDriver::Parameters, JsonValu
     //        An implementation-defined string explaining the remote end's readiness state.
     JsonObject body;
     body.set("ready"sv, readiness_state);
-    body.set("message"sv, ByteString::formatted("{} to accept a new session", readiness_state ? "Ready"sv : "Not ready"sv));
+    body.set("message"sv, MUST(String::formatted("{} to accept a new session", readiness_state ? "Ready"sv : "Not ready"sv)));
 
     // 2. Return success with data body.
     return JsonValue { body };

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -221,7 +221,7 @@ ErrorOr<NonnullRefPtr<Core::LocalServer>> Session::create_server(NonnullRefPtr<S
             return;
         }
 
-        auto window_handle = MUST(String::from_byte_string(maybe_window_handle.value().as_string()));
+        auto const& window_handle = maybe_window_handle.value().as_string();
 
         web_content_connection->on_close = [this, window_handle]() {
             dbgln_if(WEBDRIVER_DEBUG, "Window {} was closed remotely.", window_handle);

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -47,7 +47,7 @@ ErrorOr<NonnullRefPtr<Session>> Session::create(NonnullRefPtr<Client> client, Js
     // -> Otherwise
     else {
         // Set a property of capabilities with name "proxy" and a value that is a new JSON Object.
-        capabilities.set("proxy", JsonObject {});
+        capabilities.set("proxy"sv, JsonObject {});
     }
 
     // FIXME: 4. If capabilites has a property named "acceptInsecureCerts", set the endpoint node's accept insecure TLS flag

--- a/Services/WebDriver/Session.cpp
+++ b/Services/WebDriver/Session.cpp
@@ -73,7 +73,7 @@ ErrorOr<NonnullRefPtr<Session>> Session::create(NonnullRefPtr<Client> client, Js
         // 1. Let strategy be the result of getting property "pageLoadStrategy" from capabilities. If strategy is a
         //    string, set the session's page loading strategy to strategy. Otherwise, set the page loading strategy to
         //    normal and set a property of capabilities with name "pageLoadStrategy" and value "normal".
-        if (auto strategy = capabilities.get_byte_string("pageLoadStrategy"sv); strategy.has_value()) {
+        if (auto strategy = capabilities.get_string("pageLoadStrategy"sv); strategy.has_value()) {
             session->m_page_load_strategy = Web::WebDriver::page_load_strategy_from_string(*strategy);
             session->web_content_connection().async_set_page_load_strategy(session->m_page_load_strategy);
         } else {
@@ -139,7 +139,7 @@ ErrorOr<NonnullRefPtr<Session>, Web::WebDriver::Error> Session::find_session(Str
         return *session.release_value();
     }
 
-    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidSessionId, "Invalid session id");
+    return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::InvalidSessionId, "Invalid session id"sv);
 }
 
 size_t Session::session_count(Web::WebDriver::SessionFlags session_flags)
@@ -306,7 +306,7 @@ Web::WebDriver::Response Session::switch_to_window(StringView handle)
     if (auto it = m_windows.find(handle); it != m_windows.end())
         m_current_window_handle = it->key;
     else
-        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found");
+        return Web::WebDriver::Error::from_code(Web::WebDriver::ErrorCode::NoSuchWindow, "Window not found"sv);
 
     // 5. Update any implementation-specific state that would result from the user selecting the current
     //    browsing context for interaction, without altering OS-level focus.

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -6,14 +6,13 @@
 
 #include <LibTest/TestCase.h>
 
-#include <AK/ByteString.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
 #include <AK/StringBuilder.h>
 
 TEST_CASE(load_form)
 {
-    ByteString raw_form_json = R"(
+    static constexpr auto raw_form_json = R"(
     {
         "name": "Form1",
         "widgets": [
@@ -33,13 +32,13 @@ TEST_CASE(load_form)
                 "visible":true
             }
         ]
-    })";
+    })"sv;
 
     JsonValue form_json = JsonValue::from_string(raw_form_json).value();
 
     EXPECT(form_json.is_object());
 
-    auto name = form_json.as_object().get_byte_string("name"sv);
+    auto name = form_json.as_object().get_string("name"sv);
     EXPECT(name.has_value());
 
     EXPECT_EQ(name.value(), "Form1");
@@ -49,7 +48,7 @@ TEST_CASE(load_form)
 
     widgets->for_each([&](JsonValue const& widget_value) {
         auto& widget_object = widget_value.as_object();
-        auto widget_class = widget_object.get_byte_string("class"sv).value();
+        auto widget_class = widget_object.get_string("class"sv).value();
         widget_object.for_each_member([&]([[maybe_unused]] auto& property_name, [[maybe_unused]] JsonValue const& property_value) {
         });
     });
@@ -161,7 +160,7 @@ TEST_CASE(json_duplicate_keys)
     json.set("test"sv, "foo"sv);
     json.set("test"sv, "bar"sv);
     json.set("test"sv, "baz"sv);
-    EXPECT_EQ(json.to_byte_string(), "{\"test\":\"baz\"}");
+    EXPECT_EQ(json.serialized<StringBuilder>(), "{\"test\":\"baz\"}");
 }
 
 TEST_CASE(json_u64_roundtrip)
@@ -346,12 +345,12 @@ private:
 
 TEST_CASE(fallible_json_object_for_each)
 {
-    ByteString raw_json = R"(
+    static constexpr auto raw_json = R"(
     {
         "name": "anon",
         "home": "/home/anon",
         "default_browser": "Ladybird"
-    })";
+    })"sv;
 
     auto json = JsonValue::from_string(raw_json).value();
     auto const& object = json.as_object();
@@ -386,12 +385,12 @@ TEST_CASE(fallible_json_object_for_each)
 
 TEST_CASE(fallible_json_array_for_each)
 {
-    ByteString raw_json = R"(
+    static constexpr auto raw_json = R"(
     [
         "anon",
         "/home/anon",
         "Ladybird"
-    ])";
+    ])"sv;
 
     auto json = JsonValue::from_string(raw_json).value();
     auto const& array = json.as_array();
@@ -543,7 +542,7 @@ TEST_CASE(json_array_serialize)
     auto array = json_value.as_array();
     StringBuilder builder {};
     array.serialize(builder);
-    EXPECT_EQ(builder.to_byte_string(), raw_json);
+    EXPECT_EQ(builder.string_view(), raw_json);
 }
 
 TEST_CASE(json_array_values)

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -158,9 +158,9 @@ TEST_CASE(json_64_bit_value_coerced_to_32_bit)
 TEST_CASE(json_duplicate_keys)
 {
     JsonObject json;
-    json.set("test", "foo");
-    json.set("test", "bar");
-    json.set("test", "baz");
+    json.set("test", "foo"sv);
+    json.set("test", "bar"sv);
+    json.set("test", "baz"sv);
     EXPECT_EQ(json.to_byte_string(), "{\"test\":\"baz\"}");
 }
 

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -66,7 +66,7 @@ TEST_CASE(json_string)
 {
     auto json = JsonValue::from_string("\"A\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().length(), size_t { 1 });
+    EXPECT_EQ(json.as_string().byte_count(), size_t { 1 });
     EXPECT_EQ(json.as_string() == "A", true);
 }
 
@@ -74,7 +74,7 @@ TEST_CASE(json_utf8_character)
 {
     auto json = JsonValue::from_string("\"\\u0041\""sv).value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().length(), size_t { 1 });
+    EXPECT_EQ(json.as_string().byte_count(), size_t { 1 });
     EXPECT_EQ(json.as_string() == "A", true);
 }
 
@@ -83,19 +83,19 @@ TEST_CASE(json_encoded_surrogates)
     {
         auto json = JsonValue::from_string("\"\\uD83E\\uDD13\""sv).value();
         EXPECT_EQ(json.type(), JsonValue::Type::String);
-        EXPECT_EQ(json.as_string().length(), 4u);
+        EXPECT_EQ(json.as_string().byte_count(), 4u);
         EXPECT_EQ(json.as_string(), "🤓"sv);
     }
     {
         auto json = JsonValue::from_string("\"\\uD83E\""sv).value();
         EXPECT_EQ(json.type(), JsonValue::Type::String);
-        EXPECT_EQ(json.as_string().length(), 3u);
+        EXPECT_EQ(json.as_string().byte_count(), 3u);
         EXPECT_EQ(json.as_string(), "\xED\xA0\xBE"sv);
     }
     {
         auto json = JsonValue::from_string("\"\\uDD13\""sv).value();
         EXPECT_EQ(json.type(), JsonValue::Type::String);
-        EXPECT_EQ(json.as_string().length(), 3u);
+        EXPECT_EQ(json.as_string().byte_count(), 3u);
         EXPECT_EQ(json.as_string(), "\xED\xB4\x93"sv);
     }
 }
@@ -110,7 +110,7 @@ TEST_CASE(json_utf8_multibyte)
 
     auto& json = json_or_error.value();
     EXPECT_EQ(json.type(), JsonValue::Type::String);
-    EXPECT_EQ(json.as_string().length(), size_t { 2 });
+    EXPECT_EQ(json.as_string().byte_count(), size_t { 2 });
     EXPECT_EQ(json.as_string() == "š", true);
     EXPECT_EQ(json.as_string() == "\xc5\xa1", true);
 }

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -158,9 +158,9 @@ TEST_CASE(json_64_bit_value_coerced_to_32_bit)
 TEST_CASE(json_duplicate_keys)
 {
     JsonObject json;
-    json.set("test", "foo"sv);
-    json.set("test", "bar"sv);
-    json.set("test", "baz"sv);
+    json.set("test"sv, "foo"sv);
+    json.set("test"sv, "bar"sv);
+    json.set("test"sv, "baz"sv);
     EXPECT_EQ(json.to_byte_string(), "{\"test\":\"baz\"}");
 }
 

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -160,13 +160,13 @@ TEST_CASE(json_duplicate_keys)
     json.set("test"sv, "foo"sv);
     json.set("test"sv, "bar"sv);
     json.set("test"sv, "baz"sv);
-    EXPECT_EQ(json.serialized<StringBuilder>(), "{\"test\":\"baz\"}");
+    EXPECT_EQ(json.serialized(), "{\"test\":\"baz\"}");
 }
 
 TEST_CASE(json_u64_roundtrip)
 {
     auto big_value = 0xffffffffffffffffull;
-    auto json = JsonValue(big_value).serialized<StringBuilder>();
+    auto json = JsonValue(big_value).serialized();
     auto value = JsonValue::from_string(json);
     EXPECT_EQ_FORCE(value.is_error(), false);
     EXPECT_EQ(value.value().as_integer<u64>(), big_value);
@@ -531,7 +531,7 @@ TEST_CASE(json_array_serialized)
     auto raw_json = R"(["Hello",2,3.14,4,"World"])"sv;
     auto json_value = MUST(JsonValue::from_string(raw_json));
     auto array = json_value.as_array();
-    auto const& serialized_json = array.serialized<StringBuilder>();
+    auto const& serialized_json = array.serialized();
     EXPECT_EQ(serialized_json, raw_json);
 }
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -166,19 +166,19 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
 
     bool test_passed = true;
     ByteString message;
-    ByteString expectation_string;
+    String expectation_string;
 
     switch (expectation) {
     case Early:
     case Fail:
-        expectation_string = "File should not parse";
+        expectation_string = "File should not parse"_string;
         test_passed = !parse_succeeded;
         if (!test_passed)
             message = "Expected the file to fail parsing, but it did not";
         break;
     case Pass:
     case ExplicitPass:
-        expectation_string = "File should parse";
+        expectation_string = "File should parse"_string;
         test_passed = parse_succeeded;
         if (!test_passed)
             message = "Expected the file to parse, but it did not";
@@ -193,6 +193,6 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
         {},
         duration_ms,
         test_result,
-        { Test::Suite { test_path, "Parse file", test_result, { { expectation_string, test_result, message, static_cast<u64>(duration_ms) * 1000u } } } }
+        { Test::Suite { test_path, "Parse file"_string, test_result, { { move(expectation_string), test_result, message, static_cast<u64>(duration_ms) * 1000u } } } }
     };
 }

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -165,7 +165,7 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
         parse_succeeded = !Test::JS::parse_script(test_file, realm).is_error();
 
     bool test_passed = true;
-    ByteString message;
+    String message;
     String expectation_string;
 
     switch (expectation) {
@@ -174,14 +174,14 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
         expectation_string = "File should not parse"_string;
         test_passed = !parse_succeeded;
         if (!test_passed)
-            message = "Expected the file to fail parsing, but it did not";
+            message = "Expected the file to fail parsing, but it did not"_string;
         break;
     case Pass:
     case ExplicitPass:
         expectation_string = "File should parse"_string;
         test_passed = parse_succeeded;
         if (!test_passed)
-            message = "Expected the file to parse, but it did not";
+            message = "Expected the file to parse, but it did not"_string;
         break;
     }
 
@@ -193,6 +193,6 @@ TESTJS_RUN_FILE_FUNCTION(ByteString const& test_file, JS::Realm& realm, JS::Exec
         {},
         duration_ms,
         test_result,
-        { Test::Suite { test_path, "Parse file"_string, test_result, { { move(expectation_string), test_result, message, static_cast<u64>(duration_ms) * 1000u } } } }
+        { Test::Suite { test_path, "Parse file"_string, test_result, { { move(expectation_string), test_result, move(message), static_cast<u64>(duration_ms) * 1000u } } } }
     };
 }

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -162,7 +162,7 @@ static ErrorOr<HashMap<size_t, TestResult>> run_test_files(Span<ByteString> file
             auto result_object_or_error = parser.parse();
             if (!result_object_or_error.is_error() && result_object_or_error.value().is_object()) {
                 auto& result_object = result_object_or_error.value().as_object();
-                if (auto result_string = result_object.get_byte_string("result"sv); result_string.has_value()) {
+                if (auto result_string = result_object.get_string("result"sv); result_string.has_value()) {
                     auto const& view = result_string.value();
                     // Timeout and assert fail already are the result of the stopping test
                     if (view == "timeout"sv || view == "assert_fail"sv) {
@@ -320,7 +320,7 @@ void write_per_file(HashMap<size_t, TestResult> const& result_map, Vector<ByteSt
     complete_results.set("duration"sv, time_taken_in_ms / 1000.);
     complete_results.set("results"sv, result_object);
 
-    if (file->write_until_depleted(complete_results.to_byte_string()).is_error())
+    if (file->write_until_depleted(complete_results.to_string()).is_error())
         warnln("Failed to write per-file");
     file->close();
 }

--- a/Tests/LibJS/test-test262.cpp
+++ b/Tests/LibJS/test-test262.cpp
@@ -317,8 +317,8 @@ void write_per_file(HashMap<size_t, TestResult> const& result_map, Vector<ByteSt
         result_object.set(paths[test], name_for_result(value));
 
     JsonObject complete_results {};
-    complete_results.set("duration", time_taken_in_ms / 1000.);
-    complete_results.set("results", result_object);
+    complete_results.set("duration"sv, time_taken_in_ms / 1000.);
+    complete_results.set("results"sv, result_object);
 
     if (file->write_until_depleted(complete_results.to_byte_string()).is_error())
         warnln("Failed to write per-file");

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -416,7 +416,7 @@ static bool verify_test(ErrorOr<void, TestError>& result, TestMetadata const& me
     }
 
     if (metadata.is_async && output.has("output"sv)) {
-        auto output_messages = output.get_byte_string("output"sv);
+        auto output_messages = output.get_string("output"sv);
         VERIFY(output_messages.has_value());
         if (output_messages->contains("AsyncTestFailure:InternalError: TODO("sv)) {
             output.set("todo_error"sv, true);
@@ -532,7 +532,7 @@ static bool g_in_assert = false;
         assert_fail_result.set("assert_fail"sv, true);
         assert_fail_result.set("result"sv, "assert_fail"sv);
         assert_fail_result.set("output"sv, StringView { assert_failed_message, strlen(assert_failed_message) });
-        outln(saved_stdout_fd, "RESULT {}{}", assert_fail_result.to_byte_string(), '\0');
+        outln(saved_stdout_fd, "RESULT {}{}", assert_fail_result.serialized<StringBuilder>(), '\0');
         // (Attempt to) Ensure that messages are written before quitting.
         fflush(saved_stdout_fd);
         fflush(stderr);
@@ -733,7 +733,7 @@ int main(int argc, char** argv)
         result_object.set("test"sv, path);
 
         ScopeGuard output_guard = [&] {
-            outln(saved_stdout_fd, "RESULT {}{}", result_object.to_byte_string(), '\0');
+            outln(saved_stdout_fd, "RESULT {}{}", result_object.serialized<StringBuilder>(), '\0');
             fflush(saved_stdout_fd);
         };
 

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -403,14 +403,14 @@ static bool verify_test(ErrorOr<void, TestError>& result, TestMetadata const& me
         if (result.error().phase == NegativePhase::Harness) {
             output.set("harness_error", true);
             output.set("harness_file", result.error().harness_file);
-            output.set("result", "harness_error");
+            output.set("result", "harness_error"sv);
         } else if (result.error().phase == NegativePhase::Runtime) {
             auto& error_type = result.error().type;
             auto& error_details = result.error().details;
             if ((error_type == "InternalError"sv && error_details.starts_with("TODO("sv))
                 || (error_type == "Test262Error"sv && error_details.ends_with(" but got a InternalError"sv))) {
                 output.set("todo_error", true);
-                output.set("result", "todo_error");
+                output.set("result", "todo_error"sv);
             }
         }
     }
@@ -420,20 +420,20 @@ static bool verify_test(ErrorOr<void, TestError>& result, TestMetadata const& me
         VERIFY(output_messages.has_value());
         if (output_messages->contains("AsyncTestFailure:InternalError: TODO("sv)) {
             output.set("todo_error", true);
-            output.set("result", "todo_error");
+            output.set("result", "todo_error"sv);
         }
     }
 
     auto phase_to_string = [](NegativePhase phase) {
         switch (phase) {
         case NegativePhase::ParseOrEarly:
-            return "parse";
+            return "parse"sv;
         case NegativePhase::Resolution:
-            return "resolution";
+            return "resolution"sv;
         case NegativePhase::Runtime:
-            return "runtime";
+            return "runtime"sv;
         case NegativePhase::Harness:
-            return "harness";
+            return "harness"sv;
         }
         VERIFY_NOT_REACHED();
     };
@@ -530,8 +530,8 @@ static bool g_in_assert = false;
         JsonObject assert_fail_result;
         assert_fail_result.set("test", s_current_test);
         assert_fail_result.set("assert_fail", true);
-        assert_fail_result.set("result", "assert_fail");
-        assert_fail_result.set("output", assert_failed_message);
+        assert_fail_result.set("result", "assert_fail"sv);
+        assert_fail_result.set("output", StringView { assert_failed_message, strlen(assert_failed_message) });
         outln(saved_stdout_fd, "RESULT {}{}", assert_fail_result.to_byte_string(), '\0');
         // (Attempt to) Ensure that messages are written before quitting.
         fflush(saved_stdout_fd);
@@ -739,7 +739,7 @@ int main(int argc, char** argv)
 
         auto metadata_or_error = extract_metadata(original_contents);
         if (metadata_or_error.is_error()) {
-            result_object.set("result", "metadata_error");
+            result_object.set("result", "metadata_error"sv);
             result_object.set("metadata_error", true);
             result_object.set("metadata_output", metadata_or_error.error());
             continue;
@@ -747,7 +747,7 @@ int main(int argc, char** argv)
 
         auto& metadata = metadata_or_error.value();
         if (metadata.skip_test == SkipTest::Yes) {
-            result_object.set("result", "skipped");
+            result_object.set("result", "skipped"sv);
             continue;
         }
 

--- a/Tests/LibJS/test262-runner.cpp
+++ b/Tests/LibJS/test262-runner.cpp
@@ -532,7 +532,7 @@ static bool g_in_assert = false;
         assert_fail_result.set("assert_fail"sv, true);
         assert_fail_result.set("result"sv, "assert_fail"sv);
         assert_fail_result.set("output"sv, StringView { assert_failed_message, strlen(assert_failed_message) });
-        outln(saved_stdout_fd, "RESULT {}{}", assert_fail_result.serialized<StringBuilder>(), '\0');
+        outln(saved_stdout_fd, "RESULT {}{}", assert_fail_result.serialized(), '\0');
         // (Attempt to) Ensure that messages are written before quitting.
         fflush(saved_stdout_fd);
         fflush(stderr);
@@ -733,7 +733,7 @@ int main(int argc, char** argv)
         result_object.set("test"sv, path);
 
         ScopeGuard output_guard = [&] {
-            outln(saved_stdout_fd, "RESULT {}{}", result_object.serialized<StringBuilder>(), '\0');
+            outln(saved_stdout_fd, "RESULT {}{}", result_object.serialized(), '\0');
             fflush(saved_stdout_fd);
         };
 


### PR DESCRIPTION
Found myself using `ByteString` for definitively UTF-8 strings a bit too much in LibDevTools, so I figure it's high time to use `String` for our JSON classes.

This ports `JsonValue` values and `JsonObject` keys to `String`. And as a follow-up, ports WebDriver and DevTools (the primary users of JSON at runtime) to `String` as well.