### PR TITLE
LibWeb: Optimize pseudo elements presence check in hover style update

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1753,9 +1753,11 @@ void Document::invalidate_style_for_elements_affected_by_hover_change(Node& old_
             bool selector_matched = false;
             if (SelectorEngine::matches(selector, element, {}, context, {}))
                 selector_matched = true;
-            if (element.has_pseudo_elements()) {
+            if (element.has_pseudo_element(CSS::Selector::PseudoElement::Type::Before)) {
                 if (SelectorEngine::matches(selector, element, {}, context, CSS::Selector::PseudoElement::Type::Before))
                     selector_matched = true;
+            }
+            if (element.has_pseudo_element(CSS::Selector::PseudoElement::Type::After)) {
                 if (SelectorEngine::matches(selector, element, {}, context, CSS::Selector::PseudoElement::Type::After))
                     selector_matched = true;
             }

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -273,6 +273,7 @@ public:
 
     void set_pseudo_element_node(Badge<Layout::TreeBuilder>, CSS::Selector::PseudoElement::Type, GC::Ptr<Layout::NodeWithStyle>);
     GC::Ptr<Layout::NodeWithStyle> get_pseudo_element_node(CSS::Selector::PseudoElement::Type) const;
+    bool has_pseudo_element(CSS::Selector::PseudoElement::Type) const;
     bool has_pseudo_elements() const;
     void clear_pseudo_element_nodes(Badge<Layout::TreeBuilder>);
     void serialize_pseudo_elements_as_json(JsonArraySerializer<StringBuilder>& children_array) const;
@@ -587,6 +588,15 @@ inline bool Element::has_class(FlyString const& class_name, CaseSensitivity case
     return any_of(m_classes, [&](auto& it) {
         return it.equals_ignoring_ascii_case(class_name);
     });
+}
+
+inline bool Element::has_pseudo_element(CSS::Selector::PseudoElement::Type type) const
+{
+    if (!m_pseudo_element_data)
+        return false;
+    if (!CSS::Selector::PseudoElement::is_known_pseudo_element_type(type))
+        return false;
+    return m_pseudo_element_data->at(to_underlying(type)).layout_node;
 }
 
 WebIDL::ExceptionOr<QualifiedName> validate_and_extract(JS::Realm&, Optional<FlyString> namespace_, FlyString const& qualified_name);


### PR DESCRIPTION
Instead of using `has_pseudo_elements()` that iterates over all pseudo elements, only check if `::before` or `::after` are present.

Before this change, `has_pseudo_elements()` was 10% of profiles on Discord while now it's 1-2%.