### PR TITLE
Break early from rule testing in hover style invalidation

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -420,16 +420,6 @@ StyleComputer::RuleCache const* StyleComputer::rule_cache_for_cascade_origin(Cas
     return true;
 }
 
-bool StyleComputer::should_reject_with_ancestor_filter(Selector const& selector) const
-{
-    for (u32 hash : selector.ancestor_hashes()) {
-        if (hash == 0)
-            break;
-        if (!m_ancestor_filter.may_contain(hash))
-            return true;
-    }
-    return false;
-}
 Vector<MatchingRule> const& StyleComputer::get_hover_rules() const
 {
     build_rule_cache_if_needed();

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -186,7 +186,7 @@ public:
     void absolutize_values(ComputedProperties&) const;
     void compute_font(ComputedProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement::Type>) const;
 
-    [[nodiscard]] bool should_reject_with_ancestor_filter(Selector const&) const;
+    [[nodiscard]] inline bool should_reject_with_ancestor_filter(Selector const&) const;
 
 private:
     enum class ComputeStyleMode {
@@ -337,5 +337,16 @@ private:
     Function<void(FontLoader const&)> m_on_load;
     Function<void()> m_on_fail;
 };
+
+inline bool StyleComputer::should_reject_with_ancestor_filter(Selector const& selector) const
+{
+    for (u32 hash : selector.ancestor_hashes()) {
+        if (hash == 0)
+            break;
+        if (!m_ancestor_filter.may_contain(hash))
+            return true;
+    }
+    return false;
+}
 
 }


### PR DESCRIPTION
Before this change, we did the following:
1. Created a bitmap with the matching state for each rule containing
   `:hover`.
2. Changed the actively hovered element in the document.
3. Created another bitmap with the matching state for each rule
   containing `:hover`.

With this change, we iterate rule by rule and compare the matching
state. This allows us to break early once we find the first rule whose
matching state changes after the hovered element update. Additionally,
this removes the need to allocate a bitmap.