### PR TITLE
LibWeb: Allow the use of the `Mod_Alt` modifier in `EventHandler`

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1020,7 +1020,7 @@ bool EventHandler::focus_previous_element()
 
 constexpr bool should_ignore_keydown_event(u32 code_point, u32 modifiers)
 {
-    if (modifiers & (UIEvents::KeyModifier::Mod_Ctrl | UIEvents::KeyModifier::Mod_Alt | UIEvents::KeyModifier::Mod_Super))
+    if (modifiers & (UIEvents::KeyModifier::Mod_Ctrl | UIEvents::KeyModifier::Mod_Super))
         return true;
 
     // FIXME: There are probably also keys with non-zero code points that should be filtered out.


### PR DESCRIPTION
This patch fixes a bug where characters requiring the use of the Alt modifier (or Option on macOS) couldn't be typed in `HTMLInputElement`.

This fixes #3463, although maybe I'm not measuring all the impacts this change may have.