### PR TITLE
LibWeb: Sync AriaRoles.json w/ Characteristics data in current spec

### DIFF
--- a/Libraries/LibWeb/ARIA/AriaRoles.json
+++ b/Libraries/LibWeb/ARIA/AriaRoles.json
@@ -8,10 +8,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -23,7 +21,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -52,10 +49,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -67,7 +62,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -96,10 +90,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -143,8 +135,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -157,7 +148,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -233,10 +223,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -248,7 +236,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -277,10 +264,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -290,7 +275,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -300,6 +284,8 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
+      "aria-brailleroledescription",
       "aria-label",
       "aria-labelledby",
       "aria-roledescription"
@@ -320,10 +306,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -335,7 +319,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -346,6 +329,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -365,14 +349,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid",
-      "aria-valuemax",
-      "aria-valuemin",
-      "aria-valuenow",
-      "aria-valuetext"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -384,14 +362,17 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
       "aria-live",
       "aria-owns",
       "aria-relevant",
-      "aria-roledescription"
+      "aria-roledescription",
+      "aria-valuemax",
+      "aria-valuemin",
+      "aria-valuenow",
+      "aria-valuetext"
     ],
     "requiredStates": [],
     "requiredProperties": [],
@@ -399,7 +380,7 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
-    "nameFromSource": "Author",
+    "nameFromSource": null,
     "accessibleNameRequired": false,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
@@ -413,10 +394,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -428,7 +407,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -446,7 +424,9 @@
       "table",
       "treegrid"
     ],
-    "requiredOwnedElements": [],
+    "requiredOwnedElements": [
+      "row"
+    ],
     "nameFromSource": "Author",
     "accessibleNameRequired": false,
     "childrenArePresentational": false,
@@ -461,10 +441,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -476,7 +454,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -505,10 +482,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -520,9 +495,7 @@
       "aria-details",
       "aria-dropeffect",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -551,10 +524,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -566,9 +537,7 @@
       "aria-details",
       "aria-dropeffect",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -599,8 +568,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -612,7 +580,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -641,10 +608,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -656,7 +621,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -671,7 +635,7 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
-    "nameFromSource": "AuthorContent",
+    "nameFromSource": null,
     "accessibleNameRequired": false,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
@@ -687,8 +651,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -700,7 +663,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -740,9 +702,7 @@
       "aria-busy",
       "aria-current",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid",
-      "aria-orientation"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -754,11 +714,11 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
       "aria-live",
+      "aria-orientation",
       "aria-owns",
       "aria-relevant",
       "aria-roledescription"
@@ -785,10 +745,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -800,7 +758,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -831,10 +788,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -846,7 +801,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -856,7 +810,6 @@
       "aria-roledescription",
       "aria-valuemax",
       "aria-valuemin",
-      "aria-valuenow",
       "aria-valuetext"
     ],
     "requiredStates": [],
@@ -884,10 +837,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -899,7 +850,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -938,8 +888,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -951,7 +900,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -966,7 +914,6 @@
     ],
     "requiredStates": [],
     "requiredProperties": [
-      "aria-brailleroledescription",
       "aria-controls",
       "aria-valuenow"
     ],
@@ -995,8 +942,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1052,8 +998,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1066,7 +1011,6 @@
       "aria-dropeffect",
       "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1103,10 +1047,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1117,15 +1059,11 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
-      "aria-invalid",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
       "aria-live",
-      "aria-modal",
       "aria-owns",
       "aria-relevant",
       "aria-roledescription"
@@ -1153,10 +1091,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1168,7 +1104,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1197,10 +1132,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1211,7 +1144,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -1222,12 +1154,15 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
     "requiredContextRoles": [
       "figure",
       "grid",
+      "group",
+      "radiogroup",
       "table",
       "treegrid"
     ],
@@ -1246,25 +1181,22 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
       "aria-braillelabel",
+      "aria-brailleroledescription",
       "aria-colindex",
       "aria-colindextext",
       "aria-colspan",
-      "aria-brailleroledescription",
       "aria-controls",
       "aria-describedby",
       "aria-description",
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1298,10 +1230,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1312,7 +1242,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -1323,6 +1252,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -1342,10 +1272,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1356,7 +1284,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1368,7 +1295,11 @@
     "requiredStates": [],
     "requiredProperties": [],
     "prohibitedStates": [],
-    "prohibitedProperties": [],
+    "prohibitedProperties": [
+      "aria-braillelabel",
+      "aria-label",
+      "aria-labelledby"
+    ],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
     "nameFromSource": "Author",
@@ -1385,10 +1316,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1399,7 +1328,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -1410,6 +1338,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -1429,10 +1358,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1443,7 +1370,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -1454,6 +1380,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -1473,10 +1400,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1488,7 +1413,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1519,8 +1443,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -1533,7 +1456,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1562,10 +1484,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1577,7 +1497,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1606,10 +1525,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1620,7 +1537,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -1631,6 +1547,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -1650,10 +1567,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1665,7 +1580,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1694,10 +1608,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1709,7 +1621,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1740,10 +1651,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1755,7 +1664,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1790,10 +1698,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1805,7 +1711,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1836,10 +1741,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1851,7 +1754,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1867,7 +1769,7 @@
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
     "nameFromSource": "Author",
-    "accessibleNameRequired": true,
+    "accessibleNameRequired": false,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
   },
@@ -1880,10 +1782,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1895,7 +1795,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1924,10 +1823,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1939,7 +1836,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -1968,10 +1864,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -1982,7 +1876,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -1993,6 +1886,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -2012,10 +1906,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2027,7 +1919,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2051,18 +1942,16 @@
     }
   },
   "Strong": {
-    "specLink": "",
-    "description": "",
+    "specLink": "https://w3c.github.io/aria/#strong",
+    "description": "Content that is important, serious, or urgent.",
     "superClassRoles": [
       "Section"
     ],
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2073,7 +1962,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -2084,6 +1972,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -2103,10 +1992,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2117,7 +2004,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -2128,6 +2014,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -2147,11 +2034,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-errormessage",
       "aria-grabbed",
-      "aria-haspopup",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2162,7 +2046,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -2172,9 +2055,16 @@
     "requiredStates": [],
     "requiredProperties": [],
     "prohibitedStates": [],
-    "prohibitedProperties": [],
+    "prohibitedProperties": [
+      "aria-braillelabel",
+      "aria-label",
+      "aria-labelledby"
+    ],
     "requiredContextRoles": [],
-    "requiredOwnedElements": [],
+    "requiredOwnedElements": [
+      "insertion",
+      "deletion"
+    ],
     "nameFromSource": "Prohibited",
     "accessibleNameRequired": false,
     "childrenArePresentational": false,
@@ -2189,10 +2079,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2203,7 +2091,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -2214,6 +2101,7 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [
+      "aria-braillelabel",
       "aria-label",
       "aria-labelledby"
     ],
@@ -2233,23 +2121,20 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
       "aria-braillelabel",
-      "aria-colcount",
       "aria-brailleroledescription",
+      "aria-colcount",
       "aria-controls",
       "aria-describedby",
       "aria-description",
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2265,7 +2150,9 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [
-      "row"
+      "caption",
+      "row",
+      "rowgroup"
     ],
     "nameFromSource": "Author",
     "accessibleNameRequired": true,
@@ -2281,10 +2168,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2296,7 +2181,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2325,10 +2209,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2339,7 +2221,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2351,10 +2232,14 @@
     "requiredStates": [],
     "requiredProperties": [],
     "prohibitedStates": [],
-    "prohibitedProperties": [],
+    "prohibitedProperties": [
+      "aria-braillelabel",
+      "aria-label",
+      "aria-labelledby"
+    ],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
-    "nameFromSource": "Author",
+    "nameFromSource": "Prohibited",
     "accessibleNameRequired": false,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
@@ -2368,10 +2253,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2382,7 +2265,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2394,10 +2276,14 @@
     "requiredStates": [],
     "requiredProperties": [],
     "prohibitedStates": [],
-    "prohibitedProperties": [],
+    "prohibitedProperties": [
+      "aria-braillelabel",
+      "aria-label",
+      "aria-labelledby"
+    ],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
-    "nameFromSource": "Author",
+    "nameFromSource": "Prohibited",
     "accessibleNameRequired": false,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
@@ -2411,10 +2297,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2426,7 +2310,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2442,7 +2325,7 @@
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
     "nameFromSource": "AuthorContent",
-    "accessibleNameRequired": true,
+    "accessibleNameRequired": false,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
   },
@@ -2455,10 +2338,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2469,9 +2350,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2502,10 +2381,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -2517,11 +2394,11 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
       "aria-live",
+      "aria-modal",
       "aria-owns",
       "aria-relevant",
       "aria-roledescription"
@@ -2533,7 +2410,7 @@
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
     "nameFromSource": "Author",
-    "accessibleNameRequired": false,
+    "accessibleNameRequired": true,
     "childrenArePresentational": false,
     "implicitValueForRole": {}
   },
@@ -2557,9 +2434,10 @@
     "supportedProperties": [
       "aria-atomic",
       "aria-braillelabel",
-      "aria-colindex",
-      "aria-colspan",
       "aria-brailleroledescription",
+      "aria-colindex",
+      "aria-colindextext",
+      "aria-colspan",
       "aria-controls",
       "aria-describedby",
       "aria-description",
@@ -2578,6 +2456,7 @@
       "aria-required",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-rowspan"
     ],
     "requiredStates": [],
@@ -2613,9 +2492,10 @@
     "supportedProperties": [
       "aria-atomic",
       "aria-braillelabel",
-      "aria-colindex",
-      "aria-colspan",
       "aria-brailleroledescription",
+      "aria-colindex",
+      "aria-colindextext",
+      "aria-colspan",
       "aria-controls",
       "aria-describedby",
       "aria-description",
@@ -2629,10 +2509,12 @@
       "aria-labelledby",
       "aria-live",
       "aria-owns",
+      "aria-readonly",
       "aria-relevant",
       "aria-required",
       "aria-roledescription",
       "aria-rowindex",
+      "aria-rowindextext",
       "aria-rowspan",
       "aria-sort"
     ],
@@ -2669,9 +2551,9 @@
     "supportedProperties": [
       "aria-atomic",
       "aria-braillelabel",
+      "aria-brailleroledescription",
       "aria-colindex",
       "aria-colspan",
-      "aria-brailleroledescription",
       "aria-controls",
       "aria-describedby",
       "aria-description",
@@ -2718,7 +2600,6 @@
       "aria-expanded",
       "aria-grabbed",
       "aria-hidden",
-      "aria-invalid",
       "aria-selected"
     ],
     "supportedProperties": [
@@ -2734,7 +2615,6 @@
       "aria-dropeffect",
       "aria-expanded",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2781,8 +2661,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -2794,9 +2673,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2828,8 +2705,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -2842,7 +2718,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2893,7 +2768,6 @@
       "aria-errormessage",
       "aria-expanded",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2903,8 +2777,8 @@
       "aria-owns",
       "aria-readonly",
       "aria-relevant",
-      "aria-roledescription",
-      "aria-required"
+      "aria-required",
+      "aria-roledescription"
     ],
     "requiredStates": [],
     "requiredProperties": [],
@@ -2912,6 +2786,7 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [
+      "group",
       "option"
     ],
     "nameFromSource": "Author",
@@ -2932,8 +2807,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -2946,7 +2820,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -2962,9 +2835,11 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [
+      "group",
       "menuitem",
       "menuitemradio",
-      "menuitemcheckbox"
+      "menuitemcheckbox",
+      "separator"
     ],
     "nameFromSource": "Author",
     "accessibleNameRequired": false,
@@ -2999,7 +2874,6 @@
       "aria-dropeffect",
       "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3016,9 +2890,7 @@
     "prohibitedStates": [],
     "prohibitedProperties": [],
     "requiredContextRoles": [],
-    "requiredOwnedElements": [
-      "radio"
-    ],
+    "requiredOwnedElements": [],
     "nameFromSource": "Author",
     "accessibleNameRequired": true,
     "childrenArePresentational": false,
@@ -3050,7 +2922,6 @@
       "aria-dropeffect",
       "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3068,6 +2939,7 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [
+      "group",
       "treeitem"
     ],
     "nameFromSource": "Author",
@@ -3088,8 +2960,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -3102,7 +2973,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3117,9 +2987,11 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [
+      "group",
       "menuitem",
+      "menuitemradio",
       "menuitemcheckbox",
-      "menuitemradio"
+      "separator"
     ],
     "nameFromSource": "Author",
     "accessibleNameRequired": false,
@@ -3146,15 +3018,14 @@
       "aria-activedescendant",
       "aria-atomic",
       "aria-braillelabel",
-      "aria-colcount",
       "aria-brailleroledescription",
+      "aria-colcount",
       "aria-controls",
       "aria-describedby",
       "aria-description",
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3173,7 +3044,11 @@
     "prohibitedStates": [],
     "prohibitedProperties": [],
     "requiredContextRoles": [],
-    "requiredOwnedElements": [],
+    "requiredOwnedElements": [
+      "caption",
+      "row",
+      "rowgroup"
+    ],
     "nameFromSource": "Author",
     "accessibleNameRequired": true,
     "childrenArePresentational": false,
@@ -3188,10 +3063,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3203,7 +3076,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3232,10 +3104,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3247,7 +3117,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3276,10 +3145,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3291,7 +3158,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3320,10 +3186,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3335,7 +3199,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3364,10 +3227,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3379,7 +3240,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3408,10 +3268,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3421,9 +3279,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-live",
       "aria-owns",
@@ -3433,7 +3289,11 @@
     "requiredStates": [],
     "requiredProperties": [],
     "prohibitedStates": [],
-    "prohibitedProperties": [],
+    "prohibitedProperties": [
+      "aria-braillelabel",
+      "aria-label",
+      "aria-labelledby"
+    ],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
     "nameFromSource": "Prohibited",
@@ -3450,10 +3310,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3465,7 +3323,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3494,10 +3351,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3509,7 +3364,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3538,10 +3392,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3553,7 +3405,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3582,10 +3433,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3597,7 +3446,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3626,10 +3474,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3641,7 +3487,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3676,8 +3521,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3688,9 +3532,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3712,9 +3554,9 @@
       "listbox"
     ],
     "requiredOwnedElements": [],
-    "nameFromSource": null,
-    "accessibleNameRequired": false,
-    "childrenArePresentational": false,
+    "nameFromSource": "AuthorContent",
+    "accessibleNameRequired": true,
+    "childrenArePresentational": true,
     "implicitValueForRole": {}
   },
   "TreeItem": {
@@ -3729,9 +3571,9 @@
       "aria-checked",
       "aria-current",
       "aria-disabled",
+      "aria-expanded",
       "aria-grabbed",
       "aria-hidden",
-      "aria-invalid",
       "aria-selected"
     ],
     "supportedProperties": [
@@ -3759,7 +3601,10 @@
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [],
-    "requiredContextRoles": [],
+    "requiredContextRoles": [
+      "group",
+      "tree"
+    ],
     "requiredOwnedElements": [],
     "nameFromSource": "AuthorContent",
     "accessibleNameRequired": true,
@@ -3775,10 +3620,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3790,7 +3633,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3824,23 +3666,20 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
       "aria-atomic",
       "aria-braillelabel",
-      "aria-colcount",
       "aria-brailleroledescription",
+      "aria-colcount",
       "aria-controls",
       "aria-describedby",
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3857,7 +3696,9 @@
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [
-      "row"
+      "caption",
+      "row",
+      "rowgroup"
     ],
     "nameFromSource": "Author",
     "accessibleNameRequired": true,
@@ -3873,10 +3714,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3888,7 +3727,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -3899,8 +3737,11 @@
       "aria-roledescription"
     ],
     "requiredStates": [],
-    "requiredProperties": [],
-    "prohibitedStates": [],
+    "requiredProperties": [
+      "aria-level"
+    ],
+    "prohibitedStates": [
+    ],
     "prohibitedProperties": [],
     "requiredContextRoles": [],
     "requiredOwnedElements": [],
@@ -3923,7 +3764,6 @@
       "aria-expanded",
       "aria-grabbed",
       "aria-hidden",
-      "aria-invalid",
       "aria-selected"
     ],
     "supportedProperties": [
@@ -3956,7 +3796,7 @@
     ],
     "requiredOwnedElements": [],
     "nameFromSource": "AuthorContent",
-    "accessibleNameRequired": false,
+    "accessibleNameRequired": true,
     "childrenArePresentational": true,
     "implicitValueForRole": {
       "aria-selected": "false"
@@ -3972,10 +3812,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -3987,7 +3825,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4020,7 +3857,7 @@
       "aria-expanded",
       "aria-grabbed",
       "aria-hidden",
-      "aria-invalid"
+      "aria-pressed"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4031,7 +3868,6 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
       "aria-haspopup",
       "aria-keyshortcuts",
@@ -4039,7 +3875,6 @@
       "aria-labelledby",
       "aria-live",
       "aria-owns",
-      "aria-pressed",
       "aria-relevant",
       "aria-roledescription"
     ],
@@ -4066,8 +3901,7 @@
       "aria-disabled",
       "aria-expanded",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4079,7 +3913,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-errormessage",
       "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
@@ -4112,8 +3945,7 @@
       "aria-disabled",
       "aria-expanded",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4161,9 +3993,9 @@
       "aria-busy",
       "aria-current",
       "aria-disabled",
+      "aria-expanded",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4174,7 +4006,6 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
       "aria-haspopup",
       "aria-keyshortcuts",
@@ -4212,12 +4043,10 @@
     ],
     "supportedStates": [
       "aria-busy",
-      "aria-checked",
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4240,7 +4069,9 @@
       "aria-roledescription",
       "aria-setsize"
     ],
-    "requiredStates": [],
+    "requiredStates": [
+      "aria-checked"
+    ],
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [],
@@ -4279,8 +4110,8 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
+      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4291,7 +4122,9 @@
       "aria-required",
       "aria-roledescription"
     ],
-    "requiredStates": [],
+    "requiredStates": [
+      "aria-checked"
+    ],
     "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [],
@@ -4313,14 +4146,15 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
       "aria-atomic",
-      "aria-braillelabel",
       "aria-autocomplete",
+      "aria-braillelabel",
+      "aria-brailleroledescription",
+      "aria-controls",
       "aria-describedby",
       "aria-description",
       "aria-details",
@@ -4341,10 +4175,7 @@
     "requiredStates": [
       "aria-expanded"
     ],
-    "requiredProperties": [
-      "aria-brailleroledescription",
-      "aria-controls"
-    ],
+    "requiredProperties": [],
     "prohibitedStates": [],
     "prohibitedProperties": [],
     "requiredContextRoles": [],
@@ -4367,8 +4198,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4379,9 +4209,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4422,8 +4250,8 @@
     "supportedProperties": [
       "aria-activedescendant",
       "aria-atomic",
-      "aria-braillelabel",
       "aria-autocomplete",
+      "aria-braillelabel",
       "aria-brailleroledescription",
       "aria-controls",
       "aria-describedby",
@@ -4482,7 +4310,6 @@
       "aria-dropeffect",
       "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4522,8 +4349,8 @@
     "supportedProperties": [
       "aria-activedescendant",
       "aria-atomic",
-      "aria-braillelabel",
       "aria-autocomplete",
+      "aria-braillelabel",
       "aria-brailleroledescription",
       "aria-controls",
       "aria-describedby",
@@ -4567,8 +4394,7 @@
       "aria-current",
       "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -4581,7 +4407,6 @@
       "aria-details",
       "aria-dropeffect",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4616,10 +4441,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4630,9 +4453,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4661,10 +4482,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-activedescendant",
@@ -4676,9 +4495,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",
@@ -4707,10 +4524,8 @@
     "supportedStates": [
       "aria-busy",
       "aria-current",
-      "aria-disabled",
       "aria-grabbed",
-      "aria-hidden",
-      "aria-invalid"
+      "aria-hidden"
     ],
     "supportedProperties": [
       "aria-atomic",
@@ -4721,9 +4536,7 @@
       "aria-description",
       "aria-details",
       "aria-dropeffect",
-      "aria-errormessage",
       "aria-flowto",
-      "aria-haspopup",
       "aria-keyshortcuts",
       "aria-label",
       "aria-labelledby",


### PR DESCRIPTION
So I did a complete audit (manually) of our `AriaRoles.json` file against every single one of the **Characteristics** tables in the ARIA spec — at, for example, https://w3c.github.io/aria/#application — and patched the  `AriaRoles.json` file to match the current data in the spec.

When I started on it, I had optimistically imagined I was only going to find a small number of differences between the file and the spec. But I ended up finding a lot more than a few.

Most of the changes are to match the **Supported States and Properties** and **Inherited States and Properties** data — but some changes are to match the **Name From** data and **Accessible Name Required** data.

I also intentionally removed all states and properties the **Characteristics** tables list as _“deprecated on this role in ARIA 1.2”._

The rationale for dropping the deprecated states and properties is just that developers shouldn’t be using those — and so we don’t need or want to be tracking data for them in our `AriaRoles.json` file. It’s just a waste of time all around.

---

In more detail:

- The **Characteristics** tables in the spec don’t state UA requirements for implementors but instead state document/authoring-conformance requirements.

- So the corresponding data in the `AriaRoles.json` file — because it’s just based on the **Characteristics** tables in the spec — has no affect on any of the actual application behavior of Ladybird as far as handling of web content.

- Instead that data in the `AriaRoles.json` file is used only in our devtools — for the convenience of web developers,so that they can view the information at point-of-use within devtools, rather than needing to go look at the spec.

Given all that, we don’t want or need to be exposing information about deprecated states and properties to developers in our devtools — because it’s pointless, confusing, non-convenient, and counter-productive to developers to be exposing information to them about stuff that they’re not meant to be using anyway.
