### PR TITLE
LibWebSocket+RequestServer: Add a WebSocketImpl using libcurl 

### DIFF
--- a/Libraries/LibDNS/Resolver.h
+++ b/Libraries/LibDNS/Resolver.h
@@ -15,7 +15,7 @@
 #include <AK/TemporaryChange.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/Promise.h>
-#include <LibCore/SocketAddress.h>
+#include <LibCore/Socket.h>
 #include <LibCore/Timer.h>
 #include <LibDNS/Message.h>
 #include <LibThreading/MutexProtected.h>

--- a/Libraries/LibThreading/Mutex.h
+++ b/Libraries/LibThreading/Mutex.h
@@ -27,11 +27,12 @@ public:
         pthread_mutexattr_init(&attr);
         pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
         pthread_mutex_init(&m_mutex, &attr);
+        pthread_mutexattr_destroy(&attr);
     }
     ~Mutex()
     {
         VERIFY(m_lock_count == 0);
-        // FIXME: pthread_mutex_destroy() is not implemented.
+        pthread_mutex_destroy(&m_mutex);
     }
 
     void lock();

--- a/Libraries/LibWebSocket/CMakeLists.txt
+++ b/Libraries/LibWebSocket/CMakeLists.txt
@@ -6,4 +6,4 @@ set(SOURCES
 )
 
 serenity_lib(LibWebSocket websocket)
-target_link_libraries(LibWebSocket PRIVATE LibCore LibCrypto LibTLS LibURL)
+target_link_libraries(LibWebSocket PRIVATE LibCore LibCrypto LibTLS LibURL LibDNS)

--- a/Libraries/LibWebSocket/ConnectionInfo.h
+++ b/Libraries/LibWebSocket/ConnectionInfo.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibDNS/Resolver.h>
 #include <LibHTTP/HeaderMap.h>
 #include <LibURL/URL.h>
 
@@ -33,6 +34,9 @@ public:
     Optional<ByteString> const& root_certificates_path() const { return m_root_certificates_path; }
     void set_root_certificates_path(Optional<ByteString> root_certificates_path) { m_root_certificates_path = move(root_certificates_path); }
 
+    Optional<DNS::LookupResult const&> dns_result() const { return m_dns_result ? Optional<DNS::LookupResult const&>(*m_dns_result) : OptionalNone {}; }
+    void set_dns_result(NonnullRefPtr<DNS::LookupResult const> dns_result) { m_dns_result = move(dns_result); }
+
     // secure flag - defined in RFC 6455 Section 3
     bool is_secure() const;
 
@@ -46,6 +50,7 @@ private:
     Vector<ByteString> m_extensions {};
     HTTP::HeaderMap m_headers;
     Optional<ByteString> m_root_certificates_path;
+    RefPtr<DNS::LookupResult const> m_dns_result;
 };
 
 }

--- a/Libraries/LibWebSocket/Impl/WebSocketImpl.h
+++ b/Libraries/LibWebSocket/Impl/WebSocketImpl.h
@@ -27,6 +27,8 @@ public:
     virtual bool eof() = 0;
     virtual void discard_connection() = 0;
 
+    virtual bool handshake_complete_when_connected() const { return false; }
+
     Function<void()> on_connected;
     Function<void()> on_connection_error;
     Function<void()> on_ready_to_read;

--- a/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Libraries/LibWebSocket/WebSocket.cpp
@@ -42,9 +42,14 @@ void WebSocket::start()
     m_impl->on_connected = [this] {
         if (m_state != WebSocket::InternalState::EstablishingProtocolConnection)
             return;
-        set_state(WebSocket::InternalState::SendingClientHandshake);
-        send_client_handshake();
-        drain_read();
+        if (m_impl->handshake_complete_when_connected()) {
+            set_state(WebSocket::InternalState::Open);
+            notify_open();
+        } else {
+            set_state(WebSocket::InternalState::SendingClientHandshake);
+            send_client_handshake();
+            drain_read();
+        }
     };
     m_impl->on_ready_to_read = [this] {
         drain_read();

--- a/Services/RequestServer/CMakeLists.txt
+++ b/Services/RequestServer/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CMAKE_AUTOUIC OFF)
 
 set(SOURCES
     ConnectionFromClient.cpp
+    WebSocketImplCurl.cpp
 )
 
 if (ANDROID)

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -77,6 +77,8 @@ private:
     NonnullRefPtr<Resolver> m_resolver;
 };
 
+// FIXME: Find a good home for this
+ByteString build_curl_resolve_list(DNS::LookupResult const&, StringView host, u16 port);
 constexpr inline uintptr_t websocket_private_tag = 0x1;
 
 }

--- a/Services/RequestServer/ConnectionFromClient.h
+++ b/Services/RequestServer/ConnectionFromClient.h
@@ -77,4 +77,6 @@ private:
     NonnullRefPtr<Resolver> m_resolver;
 };
 
+constexpr inline uintptr_t websocket_private_tag = 0x1;
+
 }

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2025, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <RequestServer/WebSocketImplCurl.h>
+
+namespace RequestServer {
+
+NonnullRefPtr<WebSocketImplCurl> WebSocketImplCurl::create(CURLM* multi_handle)
+{
+    return adopt_ref(*new WebSocketImplCurl(multi_handle));
+}
+
+WebSocketImplCurl::WebSocketImplCurl(CURLM* multi_handle)
+    : m_multi_handle(multi_handle)
+{
+}
+
+WebSocketImplCurl::~WebSocketImplCurl()
+{
+    if (m_read_notifier)
+        m_read_notifier->close();
+    if (m_error_notifier)
+        m_error_notifier->close();
+
+    if (m_easy_handle) {
+        curl_multi_remove_handle(m_multi_handle, m_easy_handle);
+        curl_easy_cleanup(m_easy_handle);
+    }
+
+    for (auto* list : m_curl_string_lists) {
+        curl_slist_free_all(list);
+    }
+}
+
+void WebSocketImplCurl::connect(WebSocket::ConnectionInfo const& info)
+{
+    VERIFY(!m_easy_handle);
+    VERIFY(on_connected);
+    VERIFY(on_connection_error);
+    VERIFY(on_ready_to_read);
+
+    m_easy_handle = curl_easy_init();
+    VERIFY(m_easy_handle); // FIXME: Allow failure, and return ENOMEM
+
+    auto set_option = [this](auto option, auto value) -> bool {
+        auto result = curl_easy_setopt(m_easy_handle, option, value);
+        if (result == CURLE_OK)
+            return true;
+        dbgln("WebSocketImplCurl::connect: Failed to set curl option {}={}: {}", to_underlying(option), value, curl_easy_strerror(result));
+        return false;
+    };
+
+    set_option(CURLOPT_PRIVATE, reinterpret_cast<uintptr_t>(this) | websocket_private_tag);
+    set_option(CURLOPT_WS_OPTIONS, CURLWS_RAW_MODE);
+    set_option(CURLOPT_CONNECT_ONLY, 2); // WebSocket mode
+
+    // FIXME: Add a header function to validate the Sec-WebSocket headers that curl currently doesn't validate
+
+    auto const& url = info.url();
+    set_option(CURLOPT_URL, url.to_byte_string().characters());
+    set_option(CURLOPT_PORT, url.port_or_default());
+
+    if (auto root_certs = info.root_certificates_path(); root_certs.has_value())
+        set_option(CURLOPT_CAINFO, root_certs->characters());
+
+    auto const origin_header = ByteString::formatted("Origin: {}", info.origin());
+    curl_slist* curl_headers = curl_slist_append(nullptr, origin_header.characters());
+
+    for (auto const& [name, value] : info.headers().headers()) {
+        // curl will discard headers with empty values unless we pass the header name followed by a semicolon.
+        ByteString header_string;
+        if (value.is_empty())
+            header_string = ByteString::formatted("{};", name);
+        else
+            header_string = ByteString::formatted("{}: {}", name, value);
+        curl_headers = curl_slist_append(curl_headers, header_string.characters());
+    }
+
+    if (auto const& protocols = info.protocols(); !protocols.is_empty()) {
+        StringBuilder protocol_builder;
+        protocol_builder.append("Sec-WebSocket-Protocol: "sv);
+        protocol_builder.append(ByteString::join(","sv, protocols));
+        curl_headers = curl_slist_append(curl_headers, protocol_builder.to_byte_string().characters());
+    }
+
+    if (auto const& extensions = info.extensions(); !extensions.is_empty()) {
+        StringBuilder protocol_builder;
+        protocol_builder.append("Sec-WebSocket-Extensions: "sv);
+        protocol_builder.append(ByteString::join(","sv, extensions));
+        curl_headers = curl_slist_append(curl_headers, protocol_builder.to_byte_string().characters());
+    }
+
+    set_option(CURLOPT_HTTPHEADER, curl_headers);
+    m_curl_string_lists.append(curl_headers);
+
+    CURLMcode const err = curl_multi_add_handle(m_multi_handle, m_easy_handle);
+    VERIFY(err == CURLM_OK);
+}
+
+bool WebSocketImplCurl::can_read_line()
+{
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<ByteBuffer> WebSocketImplCurl::read(int max_size)
+{
+    auto buffer = TRY(ByteBuffer::create_uninitialized(max_size));
+    auto const read_bytes = TRY(m_read_buffer.read_some(buffer));
+    return buffer.slice(0, read_bytes.size());
+}
+
+ErrorOr<ByteString> WebSocketImplCurl::read_line(size_t)
+{
+    VERIFY_NOT_REACHED();
+}
+
+bool WebSocketImplCurl::send(ReadonlyBytes bytes)
+{
+    size_t sent = 0;
+    CURLcode result = CURLE_OK;
+    do {
+        sent = 0;
+        result = curl_easy_send(m_easy_handle, bytes.data(), bytes.size(), &sent);
+        bytes = bytes.slice(sent);
+    } while (bytes.size() > 0 && (result == CURLE_OK || result == CURLE_AGAIN));
+
+    return result == CURLE_OK;
+}
+
+bool WebSocketImplCurl::eof()
+{
+    return m_read_buffer.is_eof();
+}
+
+void WebSocketImplCurl::discard_connection()
+{
+    if (m_read_notifier) {
+        m_read_notifier->close();
+        m_read_notifier = nullptr;
+    }
+    if (m_error_notifier) {
+        m_error_notifier->close();
+        m_error_notifier = nullptr;
+    }
+    if (m_easy_handle) {
+        curl_multi_remove_handle(m_multi_handle, m_easy_handle);
+        curl_easy_cleanup(m_easy_handle);
+        m_easy_handle = nullptr;
+    }
+}
+
+void WebSocketImplCurl::did_connect()
+{
+    curl_socket_t socket_fd = CURL_SOCKET_BAD;
+    auto res = curl_easy_getinfo(m_easy_handle, CURLINFO_ACTIVESOCKET, &socket_fd);
+    VERIFY(res == CURLE_OK && socket_fd != CURL_SOCKET_BAD);
+
+    m_read_notifier = Core::Notifier::construct(socket_fd, Core::Notifier::Type::Read);
+    m_read_notifier->on_activation = [this] {
+        u8 buffer[65536];
+        size_t nread = 0;
+        CURLcode const result = curl_easy_recv(m_easy_handle, buffer, sizeof(buffer), &nread);
+        if (result == CURLE_AGAIN)
+            return;
+
+        if (result != CURLE_OK) {
+            dbgln("Failed to read from WebSocket: {}", curl_easy_strerror(result));
+            on_connection_error();
+        }
+
+        if (auto const err = m_read_buffer.write_until_depleted({ buffer, nread }); err.is_error())
+            on_connection_error();
+
+        on_ready_to_read();
+    };
+    m_error_notifier = Core::Notifier::construct(socket_fd, Core::Notifier::Type::Error | Core::Notifier::Type::HangUp);
+    m_error_notifier->on_activation = [this] {
+        on_connection_error();
+    };
+
+    on_connected();
+}
+
+}

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "ConnectionFromClient.h"
+
 #include <RequestServer/WebSocketImplCurl.h>
 
 namespace RequestServer {
@@ -95,6 +97,12 @@ void WebSocketImplCurl::connect(WebSocket::ConnectionInfo const& info)
 
     set_option(CURLOPT_HTTPHEADER, curl_headers);
     m_curl_string_lists.append(curl_headers);
+
+    if (auto const& dns_info = info.dns_result(); dns_info.has_value()) {
+        auto* resolve_list = curl_slist_append(nullptr, build_curl_resolve_list(*dns_info, url.serialized_host(), url.port_or_default()).characters());
+        set_option(CURLOPT_RESOLVE, resolve_list);
+        m_curl_string_lists.append(resolve_list);
+    }
 
     CURLMcode const err = curl_multi_add_handle(m_multi_handle, m_easy_handle);
     VERIFY(err == CURLM_OK);

--- a/Services/RequestServer/WebSocketImplCurl.h
+++ b/Services/RequestServer/WebSocketImplCurl.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/MemoryStream.h>
+#include <LibCore/Forward.h>
+#include <LibWebSocket/Impl/WebSocketImpl.h>
+#include <curl/curl.h>
+
+namespace RequestServer {
+
+class WebSocketImplCurl final : public WebSocket::WebSocketImpl {
+public:
+    virtual ~WebSocketImplCurl() override;
+
+    static NonnullRefPtr<WebSocketImplCurl> create(CURLM*);
+
+    virtual void connect(WebSocket::ConnectionInfo const&) override;
+    virtual bool can_read_line() override;
+    virtual ErrorOr<ByteString> read_line(size_t) override;
+    virtual ErrorOr<ByteBuffer> read(int max_size) override;
+    virtual bool send(ReadonlyBytes) override;
+    virtual bool eof() override;
+    virtual void discard_connection() override;
+
+    virtual bool handshake_complete_when_connected() const override { return true; }
+
+    void did_connect();
+
+private:
+    explicit WebSocketImplCurl(CURLM*);
+
+    CURLM* m_multi_handle { nullptr };
+    CURL* m_easy_handle { nullptr };
+    RefPtr<Core::Notifier> m_read_notifier;
+    RefPtr<Core::Notifier> m_error_notifier;
+    Vector<curl_slist*> m_curl_string_lists;
+    AllocatingMemoryStream m_read_buffer;
+};
+
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -9,7 +9,9 @@
       "name": "curl",
       "features": [
         "brotli",
-        "http2"
+        "http2",
+        "ssl",
+        "websockets"
       ]
     },
     {


### PR DESCRIPTION
This results in the following diff on the `websockets` WPTs, as a bonus to the future cleanups I plan for LibWebSocket:

`master` (e1119023e9fca17dab51b35c7e63f25c2f87e63a)

```
Ran 758 tests finished in 676.1 seconds.
  • 216 ran as expected. 0 tests skipped.
  • 5 tests crashed unexpectedly
  • 45 tests had errors unexpectedly
  • 370 tests timed out unexpectedly
  • 283 tests had unexpected subtest results
```
  
This Branch:

```
Ran 758 tests finished in 591.9 seconds.
  • 244 ran as expected. 0 tests skipped.
  • 5 tests crashed unexpectedly
  • 45 tests had errors unexpectedly
  • 313 tests timed out unexpectedly
  • 256 tests had unexpected subtest results
```

Timeouts and unexpected subtest results -> as expected :D