### PR TITLE
LibWeb: Skip quick selector rejection using ancestor filter if possible

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Libraries/LibWeb/CSS/Selector.cpp
@@ -154,6 +154,7 @@ void Selector::collect_ancestor_hashes()
     for (ssize_t compound_selector_index = static_cast<ssize_t>(m_compound_selectors.size()) - 2; compound_selector_index >= 0; --compound_selector_index) {
         auto const& compound_selector = m_compound_selectors[compound_selector_index];
         if (last_combinator == Combinator::Descendant || last_combinator == Combinator::ImmediateChild) {
+            m_can_use_ancestor_filter = true;
             for (auto const& simple_selector : compound_selector.simple_selectors) {
                 switch (simple_selector.type) {
                 case SimpleSelector::Type::Id:

--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -269,6 +269,7 @@ public:
     auto const& ancestor_hashes() const { return m_ancestor_hashes; }
 
     bool can_use_fast_matches() const { return m_can_use_fast_matches; }
+    bool can_use_ancestor_filter() const { return m_can_use_ancestor_filter; }
 
 private:
     explicit Selector(Vector<CompoundSelector>&&);
@@ -277,6 +278,7 @@ private:
     mutable Optional<u32> m_specificity;
     Optional<Selector::PseudoElement> m_pseudo_element;
     bool m_can_use_fast_matches { false };
+    bool m_can_use_ancestor_filter { false };
     bool m_contains_the_nesting_selector { false };
     bool m_contains_hover_pseudo_class { false };
 

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -503,7 +503,8 @@ Vector<MatchingRule const*> StyleComputer::collect_matching_rules(DOM::Element c
         if (!rule_is_relevant_for_current_scope)
             return;
 
-        if (should_reject_with_ancestor_filter(rule_to_run.selector))
+        auto const& selector = rule_to_run.selector;
+        if (selector.can_use_ancestor_filter() && should_reject_with_ancestor_filter(selector))
             return;
 
         rules_to_run.unchecked_append(rule_to_run);

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1741,7 +1741,7 @@ void Document::invalidate_style_for_elements_affected_by_hover_change(Node& old_
             return false;
 
         auto const& selector = rule.selector;
-        if (style_computer.should_reject_with_ancestor_filter(selector))
+        if (selector.can_use_ancestor_filter() && style_computer.should_reject_with_ancestor_filter(selector))
             return false;
 
         SelectorEngine::MatchContext context;


### PR DESCRIPTION
If selector does not have any descendant combinators then we know for sure it won't be filtered out by ancestor filter, which means there is no need to check for it.

This change makes hover style invalidation go faster on Discord where with this change we spend 4-5% in `should_reject_with_ancestor_filter()` instead of 20%.