### PR TITLE
LibWeb: Bucket hover rules using RuleCache

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -110,6 +110,21 @@ struct OwnFontFaceKey {
     int slope { 0 };
 };
 
+struct RuleCache {
+    HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
+    HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
+    HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
+    HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
+    Array<Vector<MatchingRule>, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)> rules_by_pseudo_element;
+    Vector<MatchingRule> root_rules;
+    Vector<MatchingRule> other_rules;
+
+    HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
+
+    void add_rule(MatchingRule const&, Optional<Selector::PseudoElement::Type>, bool contains_root_pseudo_class);
+    void for_each_matching_rules(DOM::Element const&, Optional<Selector::PseudoElement::Type>, Function<IterationDecision(Vector<MatchingRule> const&)> callback) const;
+};
+
 class FontLoader;
 
 class StyleComputer {
@@ -257,18 +272,6 @@ private:
 
     struct SelectorInsights {
         bool has_has_selectors { false };
-    };
-
-    struct RuleCache {
-        HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
-        HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
-        HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
-        HashMap<FlyString, Vector<MatchingRule>, AK::ASCIICaseInsensitiveFlyStringTraits> rules_by_attribute_name;
-        Array<Vector<MatchingRule>, to_underlying(CSS::Selector::PseudoElement::Type::KnownPseudoElementCount)> rules_by_pseudo_element;
-        Vector<MatchingRule> root_rules;
-        Vector<MatchingRule> other_rules;
-
-        HashMap<FlyString, NonnullRefPtr<Animations::KeyframeEffect::KeyFrameSet>> rules_by_animation_keyframes;
     };
 
     struct RuleCaches {

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -161,7 +161,7 @@ public:
     [[nodiscard]] GC::Ref<ComputedProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> = {}) const;
     [[nodiscard]] GC::Ptr<ComputedProperties> compute_pseudo_element_style_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type>) const;
 
-    Vector<MatchingRule> const& get_hover_rules() const;
+    RuleCache const& get_hover_rules() const;
     [[nodiscard]] Vector<MatchingRule const*> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement::Type>, bool& did_match_any_hover_rules, FlyString const& qualified_layer_name = {}) const;
 
     InvalidationSet invalidation_set_for_properties(Vector<InvalidationSet::Property> const&) const;
@@ -284,14 +284,14 @@ private:
         HashMap<GC::Ref<DOM::ShadowRoot const>, NonnullOwnPtr<RuleCaches>> for_shadow_roots;
     };
 
-    void make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&, Vector<MatchingRule>& hover_rules);
+    void make_rule_cache_for_cascade_origin(CascadeOrigin, SelectorInsights&);
 
     [[nodiscard]] RuleCache const* rule_cache_for_cascade_origin(CascadeOrigin, FlyString const& qualified_layer_name, GC::Ptr<DOM::ShadowRoot const>) const;
 
     static void collect_selector_insights(Selector const&, SelectorInsights&);
 
     OwnPtr<SelectorInsights> m_selector_insights;
-    Vector<MatchingRule> m_hover_rules;
+    OwnPtr<RuleCache> m_hover_rule_cache;
     OwnPtr<StyleInvalidationData> m_style_invalidation_data;
     OwnPtr<RuleCachesForDocumentAndShadowRoots> m_author_rule_cache;
     OwnPtr<RuleCachesForDocumentAndShadowRoots> m_user_rule_cache;


### PR DESCRIPTION
Analysis of selectors on modern websites shows that the `:hover`
pseudo-class is mostly used in the subject position within relatively
simple selectors like `.a:hover`. This suggests that we could greatly
benefit from segregating them by id/class/tag name, this way reducing
number of selectors tested during hover style invalidation.

With this change, hover invalidation on Discord goes down from 70ms to
3ms on my machine. I also tested GMail and GitHub where this change
shows nice 2x-3x speedup.