### PR TITLE
LibWeb: Use type attribute to determine `HTMLLinkElement` mime type

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -150,6 +150,8 @@ private:
     unsigned m_relationship { 0 };
     // https://html.spec.whatwg.org/multipage/semantics.html#explicitly-enabled
     bool m_explicitly_enabled { false };
+
+    Optional<String> m_mime_type;
 };
 
 }

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/semantics/document-metadata/the-link-element/link-type-attribute-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/semantics/document-metadata/the-link-element/link-type-attribute-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>You should see a green rectangle below</p>
+<div style="width:100px;height:100px;background-color:green"></div>

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/process-stylesheet-linked-resource-ascii-case-insensitive-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/process-stylesheet-linked-resource-ascii-case-insensitive-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<style>
+p:after { font-weight: bold; }
+p:after { content: "PASS"; color: green; }
+</style>
+<p>text/css treated as CSS?
+<p>TeXt/CsS treated as CSS?
+<p>text/cſs ignored?

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/link-type-attribute.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/document-metadata/the-link-element/link-type-attribute.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<link rel=match href=../../../../../../expected/wpt-import/html/semantics/document-metadata/the-link-element/link-type-attribute-ref.html>
+<link rel="stylesheet" type="application/javascript" href="data:text/css,div { background-color: red !important; }">
+<link rel="stylesheet" type="ABCtext/css" href="data:text/css,div { background-color: red !important; }">
+<link rel="stylesheet" type="text/cssDEF" href="data:text/css,div { background-color: red !important; }">
+<link rel="stylesheet" type="text/invalid" href="data:text/css,div { background-color: red !important; }">
+<link rel="stylesheet" type="invalid" href="data:text/css,div { background-color: red !important; }">
+<p>You should see a green rectangle below</p>
+<div style="width:100px;height:100px;background-color:green"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/process-stylesheet-linked-resource-ascii-case-insensitive.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/process-stylesheet-linked-resource-ascii-case-insensitive.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet:process-the-linked-resource">
+<link rel="help" href="https://html.spec.whatwg.org/#content-type">
+<link rel="help" href="https://mimesniff.spec.whatwg.org/#mime-type-representation">
+<link rel="match" href="../../../../../../../expected/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/process-stylesheet-linked-resource-ascii-case-insensitive-ref.html">
+<meta name="assert" content="link@type values for stylesheet resources are ASCII case-insensitive">
+<link rel="stylesheet" href="support/process-stylesheet-linked-resource-ascii-case-insensitive.css">
+<link rel="stylesheet" href="support/process-stylesheet-linked-resource-ascii-case-insensitive-lower.css" type="text/css">
+<link rel="stylesheet" href="support/process-stylesheet-linked-resource-ascii-case-insensitive-mixed.css" type="TeXt/CsS">
+<link rel="stylesheet" href="support/process-stylesheet-linked-resource-ascii-case-insensitive-other.css" type="text/cſs">
+<p id="z-lower">text/css treated as CSS?
+<p id="z-mixed">TeXt/CsS treated as CSS?
+<p id="z-other">text/cſs ignored?

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive-lower.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive-lower.css
@@ -1,0 +1,1 @@
+#z-lower:after { content: "PASS"; color: green; }

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive-mixed.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive-mixed.css
@@ -1,0 +1,1 @@
+#z-mixed:after { content: "PASS"; color: green; }

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive-other.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive-other.css
@@ -1,0 +1,1 @@
+#z-other:after { content: "FAIL"; color: red; }

--- a/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive.css
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/semantics/links/linktypes/link-type-stylesheet/support/process-stylesheet-linked-resource-ascii-case-insensitive.css
@@ -1,0 +1,3 @@
+p:after { font-weight: bold; }
+p:after { content: "FAIL"; color: red; }
+#z-other:after { content: "PASS"; color: green; }


### PR DESCRIPTION
Previously, the type attribute was ignored on link elements.