### PR TITLE
LibWeb: Apply `nowrap` attribute as presentational hint

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTableCellElement.cpp
@@ -47,6 +47,7 @@ bool HTMLTableCellElement::is_presentational_hint(FlyString const& name) const
         HTML::AttributeNames::background,
         HTML::AttributeNames::bgcolor,
         HTML::AttributeNames::height,
+        HTML::AttributeNames::nowrap,
         HTML::AttributeNames::valign,
         HTML::AttributeNames::width);
 }
@@ -91,6 +92,9 @@ void HTMLTableCellElement::apply_presentational_hints(GC::Ref<CSS::CascadedPrope
             // https://html.spec.whatwg.org/multipage/rendering.html#tables-2:encoding-parsing-and-serializing-a-url
             if (auto parsed_value = document().encoding_parse_url(value); parsed_value.has_value())
                 cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::BackgroundImage, CSS::ImageStyleValue::create(*parsed_value));
+            return;
+        } else if (name == HTML::AttributeNames::nowrap) {
+            cascaded_properties->set_property_from_presentational_hint(CSS::PropertyID::WhiteSpace, CSS::CSSKeywordValue::create(CSS::Keyword::Nowrap));
             return;
         }
     });

--- a/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width-ref.html
+++ b/Tests/LibWeb/Ref/expected/wpt-import/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width-ref.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://html.spec.whatwg.org/#tables-2">
+<link rel="help" href="https://bugs.chromium.org/p/chromium/issues/detail?id=821915">
+<link rel="match" href="../../../../../../expected/wpt-import/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width-ref.html">
+<title>A td element with the nowrap attribute should unconditionally apply white-space:nowrap</title>
+<style>
+table { border-spacing: 0; }
+td { width: 10px; padding: 0; }
+div { display: inline-block; background: green; width: 50px; height: 100px; }
+</style>
+<table>
+  <td nowrap>
+    <div></div><div></div>
+  </td>
+</table>


### PR DESCRIPTION
Fixes: https://wpt.live/html/rendering/non-replaced-elements/tables/table-cell-nowrap-with-fixed-width.html