### PR TITLE
LibWeb: Don't prepare script when src attribute is removed

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -64,6 +64,11 @@ void HTMLScriptElement::attribute_changed(FlyString const& name, Optional<String
         if (namespace_.has_value())
             return;
 
+        // AD-HOC: This ensures that prepare_script() is not called when the src attribute is removed.
+        //         See: https://github.com/whatwg/html/pull/10188/files#r1685905457 for more information.
+        if (!value.has_value())
+            return;
+
         // 2. If localName is src, then run the script HTML element post-connection steps, given element.
         post_connection();
     } else if (name == HTML::AttributeNames::async) {

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/remove-src-attr-prepare-a-script.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/scripting-1/the-script-element/remove-src-attr-prepare-a-script.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Removing the `src` content attribute does not 'prepare' the script

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/remove-src-attr-prepare-a-script.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/scripting-1/the-script-element/remove-src-attr-prepare-a-script.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<meta charset=utf-8>
+<link rel=help href=https://github.com/whatwg/html/pull/10188/files#r1685905457>
+<title>Remove src attribute does not "prepare the script"</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<body>
+<script>
+test(() => {
+  // Flags that the script element in this test will change, if it incorrectly
+  // executes.
+  window.didExecute = false;
+  window.innerTextExecuted = false;
+
+  const script = document.createElement('script');
+  // Invalid type, so the script won't execute upon insertion.
+  script.type = 'invalid';
+  script.src = 'resources/flag-setter.js';
+  script.innerText = 'window.innerTextExecuted = true';
+  document.body.append(script);
+  assert_false(window.didExecute);
+  assert_false(window.innerTextExecuted);
+
+  // Make script valid, but don't immediately execute it.
+  script.type = '';
+
+  // Removing the `src` content attribute does not trigger the "prepare a
+  // script" algorithm on the script.
+  script.removeAttribute('src');
+  assert_false(window.didExecute);
+  assert_false(window.innerTextExecuted);
+}, "Removing the `src` content attribute does not 'prepare' the script");
+</script>
+</body>


### PR DESCRIPTION
Fixes: https://wpt.live/html/semantics/scripting-1/the-script-element/remove-src-attr-prepare-a-script.html