### PR TITLE
LibWeb: Allow null for optional, nullable, no default value union types

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/BindingsGenerator/IDLGenerators.cpp
@@ -1586,9 +1586,10 @@ static void generate_to_cpp(SourceGenerator& generator, ParameterType& parameter
 )~~~");
             } else {
                 if (!optional_default_value.has_value()) {
+                    union_generator.set("nullish_or_undefined", union_type.is_nullable() ? "nullish" : "undefined");
                     union_generator.append(R"~~~(
     Optional<@union_type@> @cpp_name@;
-    if (!@js_name@@js_suffix@.is_undefined())
+    if (!@js_name@@js_suffix@.is_@nullish_or_undefined@())
         @cpp_name@ = TRY(@js_name@@js_suffix@_to_variant(@js_name@@js_suffix@));
 )~~~");
                 } else {

--- a/Tests/LibWeb/Text/expected/Fetch/request-constructor-does-not-throw-on-null-body-with-get-or-head-request.txt
+++ b/Tests/LibWeb/Text/expected/Fetch/request-constructor-does-not-throw-on-null-body-with-get-or-head-request.txt
@@ -1,0 +1,4 @@
+Successfully created GET request with body set to null
+Successfully created HEAD request with body set to null
+Successfully started GET fetch with body set to null
+Successfully started HEAD fetch with body set to null

--- a/Tests/LibWeb/Text/input/Fetch/request-constructor-does-not-throw-on-null-body-with-get-or-head-request.html
+++ b/Tests/LibWeb/Text/input/Fetch/request-constructor-does-not-throw-on-null-body-with-get-or-head-request.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        try {
+            const dataUrl = "data:,hello";
+            new Request(dataUrl, { method: "GET", body: null });
+            println("Successfully created GET request with body set to null");
+            new Request(dataUrl, { method: "HEAD", body: null });
+            println("Successfully created HEAD request with body set to null");
+            await fetch(dataUrl, { method: "GET", body: null });
+            println("Successfully started GET fetch with body set to null");
+            await fetch(dataUrl, { method: "HEAD", body: null });
+            println("Successfully started HEAD fetch with body set to null");
+        } catch (e) {
+            println(`Unexpected throw: ${e}`);
+        }
+
+        done();
+    });
+</script>


### PR DESCRIPTION
For these types, it would previously only accept `undefined` for the `null` state.

Fixes GET requests in the Turbo library always failing: https://github.com/hotwired/turbo/blob/9e057f284a60a9597446b258d562cebd55be71d7/src/http/fetch_request.js#L219-L220 https://github.com/hotwired/turbo/blob/9e057f284a60a9597446b258d562cebd55be71d7/src/http/fetch_request.js#L51-L64

This was found on https://www.fangamer.com/.