### PR TITLE
LibGfx: Fix _ITERATOR_DEBUG_LEVEL mismatch when linking WOFF2 on Windows

### DIFF
--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -105,15 +105,15 @@ endif()
 # Third-party
 find_package(PkgConfig)
 
-pkg_check_modules(WOFF2 REQUIRED IMPORTED_TARGET libwoff2dec)
 find_package(JPEG REQUIRED)
 find_package(PNG REQUIRED)
 find_package(LIBAVIF REQUIRED)
 find_package(WebP REQUIRED)
 find_package(harfbuzz REQUIRED)
+find_package(WOFF2 REQUIRED)
 
-target_link_libraries(LibGfx PRIVATE PkgConfig::WOFF2 JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
-            WebP::webpdemux WebP::libwebpmux skia harfbuzz)
+target_link_libraries(LibGfx PRIVATE JPEG::JPEG PNG::PNG avif WebP::webp WebP::webpdecoder
+            WebP::webpdemux WebP::libwebpmux skia harfbuzz WOFF2::WOFF2)
 
 if (NOT ANDROID)
     pkg_check_modules(Jxl REQUIRED IMPORTED_TARGET libjxl)

--- a/Meta/CMake/FindWOFF2.cmake
+++ b/Meta/CMake/FindWOFF2.cmake
@@ -1,0 +1,21 @@
+include(FindPackageHandleStandardArgs)
+
+find_path(WOFF2_INCLUDE_DIR woff2/decode.h)
+
+if (CMAKE_BUILD_TYPE MATCHES "Debug|RelWithDebInfo")
+    set(LIBRARY_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/debug/lib")
+else()
+    set(LIBRARY_DIR "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/lib")
+endif()
+
+set(WOFF2_LIBRARY "${LIBRARY_DIR}/woff2dec.lib")
+
+find_package_handle_standard_args(WOFF2 DEFAULT_MSG WOFF2_LIBRARY WOFF2_INCLUDE_DIR)
+
+if (WOFF2_FOUND AND NOT TARGET WOFF2::WOFF2)
+    add_library(WOFF2::WOFF2 UNKNOWN IMPORTED)
+    set_target_properties(WOFF2::WOFF2 PROPERTIES
+        IMPORTED_LOCATION "${WOFF2_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${WOFF2_INCLUDE_DIR}")
+    target_link_libraries(WOFF2::WOFF2 INTERFACE "${LIBRARY_DIR}/woff2common.lib" "${LIBRARY_DIR}/brotlidec.lib")
+endif()


### PR DESCRIPTION
[Discord discussion.](https://discord.com/channels/1247070541085671459/1306918361732616212/1342094839524884491)

Turns out this error shows up only when building with `windows_msbuild` preset. `windows_ninja` preset builds LibGfx without errors.