### PR TITLE
LibDevTools: Support highlighting and inspecting DOM nodes

### DIFF
--- a/Documentation/DevTools.md
+++ b/Documentation/DevTools.md
@@ -223,16 +223,17 @@ this point that the server fetches the DOM tree from the WebContent process. The
 for the application to asynchronously provide this information. The inspector actor's message queue is blocked until we
 receive the DOM tree (or encounter an error). The server will reply with information about the document element.
 
-Next, the client asks for a page style actor and a highlighter actor. The page style actor is currently stubbed to reply
-with some fields expected by the client. The highlighter actor is also currently stubbed, but this actor seems like what
-will be used to paint an overlay onto the inspected node.
+Next, the client asks for a page style actor and a highlighter actor. The page style actor is what will provide layout
+and style information about a particular node. The highlighter actor's responsibility varies depending on the type of
+highlighter that is requested. Here, the client asks for a viewport resize highlighter, which we currently do not
+support.
 
 ```jsonc
 >> {"type":"getWalker","options":{"showAllAnonymousContent":false},"to":"server0-inspector7"}
 >> {"type":"getPageStyle","to":"server0-inspector7"}
 >> {"type":"getHighlighterByType","typeName":"ViewportSizeOnResizeHighlighter","to":"server0-inspector7"}
 
-<< {"from":"server0-inspector7","walker":{"actor":"server0-walker14","root":{"actor":"server0-walker14-node0","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"#document","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":false,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":true,"nodeName":"#document","nodeType":9,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{}}}}
+<< {"from":"server0-inspector7","walker":{"actor":"server0-walker14","root":{"actor":"server0-node15","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"#document","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":false,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":true,"nodeName":"#document","nodeType":9,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{}}}}
 << {"from":"server0-inspector7","pageStyle":{"actor":"server0-page-style12","traits":{"fontStyleLevel4":true,"fontWeightLevel4":true,"fontStretchLevel4":true,"fontVariations":true}}}
 << {"from":"server0-inspector7","highlighter":{"actor":"server0-highlighter13"}}
 ```
@@ -245,12 +246,12 @@ context as the frame itself:
 << {"from":"server0-watcher5","browsingContextID":1}
 ```
 
-The client then instructs the highlighter actor to "show" the inspector actor, to which the server currently replies
-with an ack:
+The client then instructs the viewport resize highlighter actor to "show" the inspector actor, to which the server
+currently replies with a nack:
 
 ```jsonc
 >> {"type":"show","node":"server0-inspector7","to":"server0-highlighter13"}
-<< {"from":"server0-highlighter13","value":true}
+<< {"from":"server0-highlighter13","value":false}
 ```
 
 Then client then starts to ask for DOM node information. It begins by issuing a query selector request for the `<body>`
@@ -262,16 +263,16 @@ parent is not the parent from which the search started. Each serialized DOM node
 display name, tag name, attributes, etc.
 
 ```jsonc
->> {"type":"querySelector","node":"server0-walker14-node0","selector":"body","to":"server0-walker14"}
-<< {"from":"server0-walker14","node":{"actor":"server0-walker14-node17","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"body","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"BODY","nodeType":1,"nodeValue":null,"numChildren":10,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node1"},"newParents":[{"actor":"server0-walker14-node1","attrs":[{"name":"lang","value":"en"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"html","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HTML","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node0"}]}
+>> {"type":"querySelector","node":"server0-node15","selector":"body","to":"server0-walker14"}
+<< {"from":"server0-walker14","node":{"actor":"server0-node32","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"body","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"BODY","nodeType":1,"nodeValue":null,"numChildren":10,"shadowRootMode":null,"traits":{},"parent":"server0-node16"},"newParents":[{"actor":"server0-node16","attrs":[{"name":"lang","value":"en"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"html","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HTML","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node15"}]}
 
->> {"type":"children","node":"server0-walker14-node1","maxNodes":100,"center":"server0-walker14-node17","to":"server0-walker14"}
->> {"type":"children","node":"server0-walker14-node0","maxNodes":100,"center":"server0-walker14-node1","to":"server0-walker14"}
->> {"type":"children","node":"server0-walker14-node17","maxNodes":100,"to":"server0-walker14"}
+>> {"type":"children","node":"server0-node16","maxNodes":100,"center":"server0-node32","to":"server0-walker14"}
+>> {"type":"children","node":"server0-node15","maxNodes":100,"center":"server0-node16","to":"server0-walker14"}
+>> {"type":"children","node":"server0-node32","maxNodes":100,"to":"server0-walker14"}
 
-<< {"from":"server0-walker14","hasFirst":true,"hasLast":true,"nodes":[{"actor":"server0-walker14-node2","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"head","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":false,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HEAD","nodeType":1,"nodeValue":null,"numChildren":13,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node1"},{"actor":"server0-walker14-node17","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"body","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"BODY","nodeType":1,"nodeValue":null,"numChildren":10,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node1"}]}
-<< {"from":"server0-walker14","hasFirst":true,"hasLast":true,"nodes":[{"actor":"server0-walker14-node1","attrs":[{"name":"lang","value":"en"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"html","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HTML","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node0"}]}
-<< {"from":"server0-walker14","hasFirst":true,"hasLast":true,"nodes":[{"actor":"server0-walker14-node18","attrs":[{"name":"class","value":"p-[20px] bg-[#000] relative"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"header","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HEADER","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node38","attrs":[{"name":"class","value":"bg-[#000] relative flex flex-col items-center pt-[80px] px-5 pb-0 lg:flex-row lg:pt-0 lg:min-h-[892px]"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node55","attrs":[{"name":"id","value":"about"},{"name":"class","value":"text-[#fff] bg-[#000] pt-12 lg:pt-0 px-4"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node71","attrs":[{"name":"class","value":"why"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node112","attrs":[{"name":"class","value":"news"},{"name":"id","value":"news"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node174","attrs":[{"name":"id","value":"gi"},{"name":"class","value":"gi"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node197","attrs":[{"name":"class","value":"relative mb-24 px-5 lg:mb-28"},{"name":"id","value":"sponsors"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":3,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node322","attrs":[{"name":"class","value":"relative z-10 -top-4 text-[#fff] bg-[url('/assets/img/blurp.webp')] bg-center bg-cover mb-12 flex justify-center"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node341","attrs":[{"name":"id","value":"faq"},{"name":"class","value":"faq"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"},{"actor":"server0-walker14-node495","attrs":[{"name":"class","value":"bg-[#000] py-0 md:px-20"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"footer","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"FOOTER","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-walker14-node17"}]}
+<< {"from":"server0-walker14","hasFirst":true,"hasLast":true,"nodes":[{"actor":"server0-node17","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"head","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":false,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HEAD","nodeType":1,"nodeValue":null,"numChildren":13,"shadowRootMode":null,"traits":{},"parent":"server0-node16"},{"actor":"server0-node32","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"body","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"BODY","nodeType":1,"nodeValue":null,"numChildren":10,"shadowRootMode":null,"traits":{},"parent":"server0-node16"}]}
+<< {"from":"server0-walker14","hasFirst":true,"hasLast":true,"nodes":[{"actor":"server0-node16","attrs":[{"name":"lang","value":"en"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"html","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HTML","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node15"}]}
+<< {"from":"server0-walker14","hasFirst":true,"hasLast":true,"nodes":[{"actor":"server0-node33","attrs":[{"name":"class","value":"p-[20px] bg-[#000] relative"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"header","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"HEADER","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node53","attrs":[{"name":"class","value":"bg-[#000] relative flex flex-col items-center pt-[80px] px-5 pb-0 lg:flex-row lg:pt-0 lg:min-h-[892px]"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node70","attrs":[{"name":"id","value":"about"},{"name":"class","value":"text-[#fff] bg-[#000] pt-12 lg:pt-0 px-4"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node86","attrs":[{"name":"class","value":"why"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node127","attrs":[{"name":"class","value":"news"},{"name":"id","value":"news"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node189","attrs":[{"name":"id","value":"gi"},{"name":"class","value":"gi"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":2,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node212","attrs":[{"name":"class","value":"relative mb-24 px-5 lg:mb-28"},{"name":"id","value":"sponsors"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":3,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node337","attrs":[{"name":"class","value":"relative z-10 -top-4 text-[#fff] bg-[url('/assets/img/blurp.webp')] bg-center bg-cover mb-12 flex justify-center"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node356","attrs":[{"name":"id","value":"faq"},{"name":"class","value":"faq"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"section","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"SECTION","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-node32"},{"actor":"server0-node510","attrs":[{"name":"class","value":"bg-[#000] py-0 md:px-20"}],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"footer","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":true,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":false,"nodeName":"FOOTER","nodeType":1,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{},"parent":"server0-node32"}]}
 ```
 
 The client then instructs the server to watch the root node. The server replies with information about the document
@@ -279,13 +280,134 @@ element again, followed by an empty message. We do not currently do anything mor
 
 ```jsonc
 >> {"type":"watchRootNode","to":"server0-walker14"}
-<< {"from":"server0-walker14","type":"root-available","node":{"actor":"server0-walker14-node0","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"#document","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":false,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":true,"nodeName":"#document","nodeType":9,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{}}}
+<< {"from":"server0-walker14","type":"root-available","node":{"actor":"server0-node15","attrs":[],"baseURI":"https://ladybird.org/","causesOverflow":false,"containerType":null,"displayName":"#document","displayType":"block","host":null,"isAfterPseudoElement":false,"isAnonymous":false,"isBeforePseudoElement":false,"isDirectShadowHostChild":null,"isDisplayed":false,"isInHTMLDocument":true,"isMarkerPseudoElement":false,"isNativeAnonymous":false,"isScrollable":false,"isShadowHost":false,"isShadowRoot":false,"isTopLevelDocument":true,"nodeName":"#document","nodeType":9,"nodeValue":null,"numChildren":1,"shadowRootMode":null,"traits":{}}}
 << {"from":"server0-walker14"}
 ```
 
 At this point, the DOM tree in the DevTools client is interactable. As the user interacts with the client, the client
 will send similar requests as the above to retrieve more DOM node information. The server will log an error for features
 we do not yet support.
+
+### Inspecting a DOM node
+
+After the DOM tree becomes interactable, the client will inspect a default node on the page (typically the `<body>`
+element). The client will immediately ask for the layout of the inspected node and for a layout inspector. The layout
+consists of the box model metrics for the node. The layout inspector is an actor that provides e.g. grid and flexbox
+information, but we currently just sub this out.
+
+```jsonc
+>> {"type":"getLayout","node":"server0-node31","autoMargins":true,"to":"server0-page-style12"}
+>> {"type":"getLayoutInspector","to":"server0-walker14"}
+
+<< {"from":"server0-page-style12","autoMargins":{},"width":1514,"height":10236.8125,"border-top-width":"0px","border-right-width":"0px","border-bottom-width":"0px","border-left-width":"0px","margin-top":"0px","margin-right":"0px","margin-bottom":"0px","margin-left":"0px","padding-top":"0px","padding-right":"0px","padding-bottom":"0px","padding-left":"0px","box-sizing":"border-box","display":"block","float":"none","line-height":"1.5","position":"static","z-index":"auto"}
+<< {"from":"server0-walker14","actor":{"actor":"server0-layout-inspector568"}}
+```
+
+The client then asks for a selector for the inspected node. The server replies with the display name of the node:
+
+```jsonc
+>> {"type":"getUniqueSelector","to":"server0-node32"}
+<< {"from":"server0-node32","value":"body"}
+```
+
+The client then asks for the applied style for the inspected node. This would be for the pane in the inspector tab which
+allows the user to toggle and edit styles on a live DOM node. We do not yet have support for this in LibWeb, so the
+server replies with an empty list:
+
+```jsonc
+>> {"type":"getApplied","node":"server0-node32","inherited":true,"matchedSelectors":true,"to":"server0-page-style12"}
+<< {"from":"server0-page-style12","entries":[]}
+```
+
+The client then asks the layout inspector for the inspect node's flexbox and grid information. As noted above, we have
+just stubbed this for now. The server replies with empty values:
+
+```jsonc
+>> {"type":"getCurrentFlexbox","node":"server0-node32","onlyLookAtParents":false,"to":"server0-layout-inspector568"}
+>> {"type":"getGrids","rootNode":"server0-node15","to":"server0-layout-inspector568"}
+
+<< {"from":"server0-layout-inspector568","flexbox":null}
+<< {"from":"server0-layout-inspector568","grids":[]}
+```
+
+The client then asks if the inspected node's box model metrics are editable, and for the node's "offset parent". We
+currently don't support such edits, and have stubbed the offset parent. The server again replies with empty values:
+
+```jsonc
+>> {"type":"isPositionEditable","node":"server0-node32","to":"server0-page-style12"}
+<< {"from":"server0-page-style12","value":false}
+
+>> {"type":"getOffsetParent","node":"server0-node32","to":"server0-walker14"}
+<< {"from":"server0-walker14","node":null}
+```
+
+If the user switches the inspector to the "Computed" pane, then the client will ask for the inspected node's computed
+style. The server collects the computed style from the WebContent process, and replies with that style:
+
+(For brevity, only the `color` property is included here, as the list of all styles is very large.)
+
+```jsonc
+>> {"type":"getComputed","node":"server0-node32","markMatched":true,"onlyMatched":true,"filter":"user","to":"server0-page-style12"}
+<< {"from":"server0-page-style12","computed":{"color":{"matched":true,"value":"canvastext"}}}
+```
+
+The user may select any other DOM node to inspect. As the mouse hovers over other DOM nodes, the client will ask (once)
+if the server supports highlighting DOM nodes. We do support this, and the server will reply:
+
+```jsonc
+>> {"type":"supportsHighlighters","to":"server0-inspector7"}
+<< {"from":"server0-inspector7","value":true}
+```
+
+The client will then asks for box model highlighter. This highlighter indicates when the WebContent process should
+render an overlay over a particular node, with information about that node's box model. The server will create this
+highlighter type, and reply:
+
+```jsonc
+>> {"type":"getHighlighterByType","typeName":"BoxModelHighlighter","to":"server0-inspector7"}
+<< {"from":"server0-inspector7","highlighter":{"actor":"server0-highlighter569"}}
+```
+
+When the user's mouse enters a DOM node, the client will instruct the server to show the box model overlay for that node:
+```jsonc
+>> {"type":"show","node":"server0-node16","to":"server0-highlighter569"}
+<< {"from":"server0-highlighter569","value":true}
+```
+
+When the user's mouse leaves a DOM node, the client will instruct the server to stop showing the box model overlay for
+that node:
+
+```jsonc
+>> {"type":"hide","to":"server0-highlighter569"}
+<< {"from":"server0-highlighter569"}
+```
+
+The above highlighter requests are repeated as the user's mouse is moved between nodes. When the user clicks on a DOM
+node, that node then becomes the inspected node, and the client will ask for the box model / computed style for that
+node.
+
+### Session termination
+
+When the user disconnects from the DevTools server, the client will send a few cleanup messages. We currently do not
+implement the first few that are sent:
+
+```jsonc
+>> {"type":"unwatchTargets","targetType":"frame","options":{},"to":"server0-watcher10"}
+<< {"from":"server0-watcher10","error":"unrecognizedPacketType","message":"Unrecognized packet type: 'unwatchTargets'"}
+
+>> {"type":"finalize","to":"server0-highlighter18"}
+>> {"type":"finalize","to":"server0-highlighter573"}
+<< {"from":"server0-highlighter18","error":"unrecognizedPacketType","message":"Unrecognized packet type: 'finalize'"}
+<< {"from":"server0-highlighter573","error":"unrecognizedPacketType","message":"Unrecognized packet type: 'finalize'"}
+```
+
+We do implement the request to detach the frame, at which point we clear any inspected DOM node information from the
+WebContent process:
+
+```jsonc
+>> {"type":"detach","to":"server0-frame14"}
+<< {"from":"server0-frame14"}
+```
 
 ## Known issues
 

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -35,6 +35,14 @@ void FrameActor::handle_message(StringView type, JsonObject const&)
     JsonObject response;
     response.set("from"sv, name());
 
+    if (type == "detach"sv) {
+        if (auto tab = m_tab.strong_ref())
+            tab->reset_selected_node();
+
+        send_message(move(response));
+        return;
+    }
+
     if (type == "listFrames"sv) {
         send_message(move(response));
         return;

--- a/Libraries/LibDevTools/Actors/HighlighterActor.h
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.h
@@ -15,14 +15,16 @@ class HighlighterActor final : public Actor {
 public:
     static constexpr auto base_name = "highlighter"sv;
 
-    static NonnullRefPtr<HighlighterActor> create(DevToolsServer&, String name);
+    static NonnullRefPtr<HighlighterActor> create(DevToolsServer&, String name, WeakPtr<InspectorActor>);
     virtual ~HighlighterActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
     JsonValue serialize_highlighter() const;
 
 private:
-    HighlighterActor(DevToolsServer&, String name);
+    HighlighterActor(DevToolsServer&, String name, WeakPtr<InspectorActor>);
+
+    WeakPtr<InspectorActor> m_inspector;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -36,7 +36,7 @@ void InspectorActor::handle_message(StringView type, JsonObject const& message)
 
     if (type == "getPageStyle"sv) {
         if (!m_page_style)
-            m_page_style = devtools().register_actor<PageStyleActor>();
+            m_page_style = devtools().register_actor<PageStyleActor>(*this);
 
         response.set("pageStyle"sv, m_page_style->serialize_style());
         send_message(move(response));

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -21,12 +21,16 @@ public:
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
+    static RefPtr<TabActor> tab_for(WeakPtr<InspectorActor> const&);
+    static RefPtr<WalkerActor> walker_for(WeakPtr<InspectorActor> const&);
+
 private:
     InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
     void received_dom_tree(JsonObject, BlockToken);
 
     WeakPtr<TabActor> m_tab;
+    WeakPtr<WalkerActor> m_walker;
     WeakPtr<PageStyleActor> m_page_style;
     HashMap<String, WeakPtr<HighlighterActor>> m_highlighters;
 };

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
 
@@ -27,7 +28,7 @@ private:
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<PageStyleActor> m_page_style;
-    WeakPtr<HighlighterActor> m_highlighter;
+    HashMap<String, WeakPtr<HighlighterActor>> m_highlighters;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/LayoutInspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/LayoutInspectorActor.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <LibDevTools/Actors/LayoutInspectorActor.h>
+
+namespace DevTools {
+
+NonnullRefPtr<LayoutInspectorActor> LayoutInspectorActor::create(DevToolsServer& devtools, String name)
+{
+    return adopt_ref(*new LayoutInspectorActor(devtools, move(name)));
+}
+
+LayoutInspectorActor::LayoutInspectorActor(DevToolsServer& devtools, String name)
+    : Actor(devtools, move(name))
+{
+}
+
+LayoutInspectorActor::~LayoutInspectorActor() = default;
+
+void LayoutInspectorActor::handle_message(StringView type, JsonObject const&)
+{
+    JsonObject response;
+    response.set("from"sv, name());
+
+    if (type == "getCurrentFlexbox"sv) {
+        response.set("flexbox"sv, JsonValue {});
+        send_message(move(response));
+        return;
+    }
+
+    if (type == "getGrids"sv) {
+        response.set("grids"sv, JsonArray {});
+        send_message(move(response));
+        return;
+    }
+
+    send_unrecognized_packet_type_error(type);
+}
+
+}

--- a/Libraries/LibDevTools/Actors/LayoutInspectorActor.h
+++ b/Libraries/LibDevTools/Actors/LayoutInspectorActor.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <LibDevTools/Actor.h>
+
+namespace DevTools {
+
+class LayoutInspectorActor final : public Actor {
+public:
+    static constexpr auto base_name = "layout-inspector"sv;
+
+    static NonnullRefPtr<LayoutInspectorActor> create(DevToolsServer&, String name);
+    virtual ~LayoutInspectorActor() override;
+
+    virtual void handle_message(StringView type, JsonObject const&) override;
+
+private:
+    LayoutInspectorActor(DevToolsServer&, String name);
+};
+
+}

--- a/Libraries/LibDevTools/Actors/NodeActor.cpp
+++ b/Libraries/LibDevTools/Actors/NodeActor.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonObject.h>
+#include <LibDevTools/Actors/NodeActor.h>
+#include <LibDevTools/Actors/WalkerActor.h>
+
+namespace DevTools {
+
+NonnullRefPtr<NodeActor> NodeActor::create(DevToolsServer& devtools, String name, WeakPtr<WalkerActor> walker)
+{
+    return adopt_ref(*new NodeActor(devtools, move(name), move(walker)));
+}
+
+NodeActor::NodeActor(DevToolsServer& devtools, String name, WeakPtr<WalkerActor> walker)
+    : Actor(devtools, move(name))
+    , m_walker(move(walker))
+{
+}
+
+NodeActor::~NodeActor() = default;
+
+void NodeActor::handle_message(StringView type, JsonObject const&)
+{
+    JsonObject response;
+    response.set("from"sv, name());
+
+    if (type == "getUniqueSelector"sv) {
+        if (auto walker = m_walker.strong_ref()) {
+            if (auto const& dom_node = walker->dom_node(name()); dom_node.has_value())
+                response.set("value"sv, dom_node->node.get_string("name"sv)->to_ascii_lowercase());
+        }
+
+        send_message(move(response));
+        return;
+    }
+
+    send_unrecognized_packet_type_error(type);
+}
+
+}

--- a/Libraries/LibDevTools/Actors/NodeActor.h
+++ b/Libraries/LibDevTools/Actors/NodeActor.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <LibDevTools/Actor.h>
+
+namespace DevTools {
+
+class NodeActor final : public Actor {
+public:
+    static constexpr auto base_name = "node"sv;
+
+    static NonnullRefPtr<NodeActor> create(DevToolsServer&, String name, WeakPtr<WalkerActor>);
+    virtual ~NodeActor() override;
+
+    virtual void handle_message(StringView type, JsonObject const&) override;
+
+private:
+    NodeActor(DevToolsServer&, String name, WeakPtr<WalkerActor>);
+
+    WeakPtr<WalkerActor> m_walker;
+};
+
+}

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -5,24 +5,76 @@
  */
 
 #include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <LibDevTools/Actors/InspectorActor.h>
 #include <LibDevTools/Actors/PageStyleActor.h>
+#include <LibDevTools/Actors/TabActor.h>
+#include <LibDevTools/Actors/WalkerActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
+#include <LibDevTools/DevToolsServer.h>
 
 namespace DevTools {
 
-NonnullRefPtr<PageStyleActor> PageStyleActor::create(DevToolsServer& devtools, String name)
+NonnullRefPtr<PageStyleActor> PageStyleActor::create(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector)
 {
-    return adopt_ref(*new PageStyleActor(devtools, move(name)));
+    return adopt_ref(*new PageStyleActor(devtools, move(name), move(inspector)));
 }
 
-PageStyleActor::PageStyleActor(DevToolsServer& devtools, String name)
+PageStyleActor::PageStyleActor(DevToolsServer& devtools, String name, WeakPtr<InspectorActor> inspector)
     : Actor(devtools, move(name))
+    , m_inspector(move(inspector))
 {
 }
 
 PageStyleActor::~PageStyleActor() = default;
 
-void PageStyleActor::handle_message(StringView type, JsonObject const&)
+void PageStyleActor::handle_message(StringView type, JsonObject const& message)
 {
+    JsonObject response;
+    response.set("from"sv, name());
+
+    if (type == "getApplied"sv) {
+        // FIXME: This provides information to the "styles" pane in the inspector tab, which allows toggling and editing
+        //        styles live. We do not yet support figuring out the list of styles that apply to a specific node.
+        response.set("entries"sv, JsonArray {});
+        send_message(move(response));
+        return;
+    }
+
+    if (type == "getComputed"sv) {
+        auto node = message.get_string("node"sv);
+        if (!node.has_value()) {
+            send_missing_parameter_error("node"sv);
+            return;
+        }
+
+        inspect_dom_node(*node, [](auto& self, auto const& properties, auto block_token) {
+            self.received_computed_style(properties.computed_style, move(block_token));
+        });
+
+        return;
+    }
+
+    if (type == "getLayout"sv) {
+        auto node = message.get_string("node"sv);
+        if (!node.has_value()) {
+            send_missing_parameter_error("node"sv);
+            return;
+        }
+
+        inspect_dom_node(*node, [](auto& self, auto const& properties, auto block_token) {
+            self.received_layout(properties.computed_style, properties.node_box_sizing, move(block_token));
+        });
+
+        return;
+    }
+
+    if (type == "isPositionEditable") {
+        response.set("value"sv, false);
+        send_message(move(response));
+        return;
+    }
+
     send_unrecognized_packet_type_error(type);
 }
 
@@ -38,6 +90,97 @@ JsonValue PageStyleActor::serialize_style() const
     style.set("actor"sv, name());
     style.set("traits"sv, move(traits));
     return style;
+}
+
+template<typename Callback>
+void PageStyleActor::inspect_dom_node(StringView node_actor, Callback&& callback)
+{
+    auto tab = InspectorActor::tab_for(m_inspector);
+    auto walker = InspectorActor::walker_for(m_inspector);
+    if (!tab || !walker)
+        return;
+
+    auto const& dom_node = walker->dom_node(node_actor);
+    if (!dom_node.has_value())
+        return;
+
+    auto block_token = block_responses();
+
+    devtools().delegate().inspect_dom_node(
+        tab->description(), dom_node->id, dom_node->pseudo_element,
+        [weak_self = make_weak_ptr<PageStyleActor>(), block_token = move(block_token), callback = forward<Callback>(callback)](ErrorOr<WebView::ViewImplementation::DOMNodeProperties> properties) mutable {
+            if (properties.is_error()) {
+                dbgln_if(DEVTOOLS_DEBUG, "Unable to inspect DOM node: {}", properties.error());
+                return;
+            }
+
+            if (auto self = weak_self.strong_ref())
+                callback(*self, properties.value(), move(block_token));
+        });
+}
+
+void PageStyleActor::received_layout(JsonObject const& computed_style, JsonObject const& node_box_sizing, BlockToken block_token)
+{
+    JsonObject message;
+    message.set("from"sv, name());
+    message.set("autoMargins"sv, JsonObject {});
+
+    auto pixel_value = [&](auto const& object, auto key) {
+        return object.get_double_with_precision_loss(key).value_or(0);
+    };
+    auto set_pixel_value_from = [&](auto const& object, auto object_key, auto message_key) {
+        message.set(message_key, MUST(String::formatted("{}px", pixel_value(object, object_key))));
+    };
+    auto set_computed_value_from = [&](auto const& object, auto key) {
+        message.set(key, object.get_string(key).value_or(String {}));
+    };
+
+    message.set("width"sv, pixel_value(node_box_sizing, "content_width"sv));
+    message.set("height"sv, pixel_value(node_box_sizing, "content_height"sv));
+
+    // FIXME: This response should also contain "top", "right", "bottom", and "left", but our box model metrics in
+    //        WebContent do not provide this information.
+
+    set_pixel_value_from(node_box_sizing, "border_top"sv, "border-top-width"sv);
+    set_pixel_value_from(node_box_sizing, "border_right"sv, "border-right-width"sv);
+    set_pixel_value_from(node_box_sizing, "border_bottom"sv, "border-bottom-width"sv);
+    set_pixel_value_from(node_box_sizing, "border_left"sv, "border-left-width"sv);
+
+    set_pixel_value_from(node_box_sizing, "margin_top"sv, "margin-top"sv);
+    set_pixel_value_from(node_box_sizing, "margin_right"sv, "margin-right"sv);
+    set_pixel_value_from(node_box_sizing, "margin_bottom"sv, "margin-bottom"sv);
+    set_pixel_value_from(node_box_sizing, "margin_left"sv, "margin-left"sv);
+
+    set_pixel_value_from(node_box_sizing, "padding_top"sv, "padding-top"sv);
+    set_pixel_value_from(node_box_sizing, "padding_right"sv, "padding-right"sv);
+    set_pixel_value_from(node_box_sizing, "padding_bottom"sv, "padding-bottom"sv);
+    set_pixel_value_from(node_box_sizing, "padding_left"sv, "padding-left"sv);
+
+    set_computed_value_from(computed_style, "box-sizing"sv);
+    set_computed_value_from(computed_style, "display"sv);
+    set_computed_value_from(computed_style, "float"sv);
+    set_computed_value_from(computed_style, "line-height"sv);
+    set_computed_value_from(computed_style, "position"sv);
+    set_computed_value_from(computed_style, "z-index"sv);
+
+    send_message(move(message), move(block_token));
+}
+
+void PageStyleActor::received_computed_style(JsonObject const& computed_style, BlockToken block_token)
+{
+    JsonObject computed;
+
+    computed_style.for_each_member([&](String const& name, JsonValue const& value) {
+        JsonObject property;
+        property.set("matched"sv, true);
+        property.set("value"sv, value);
+        computed.set(name, move(property));
+    });
+
+    JsonObject message;
+    message.set("from"sv, name());
+    message.set("computed"sv, move(computed));
+    send_message(move(message), move(block_token));
 }
 
 }

--- a/Libraries/LibDevTools/Actors/PageStyleActor.h
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.h
@@ -15,14 +15,22 @@ class PageStyleActor final : public Actor {
 public:
     static constexpr auto base_name = "page-style"sv;
 
-    static NonnullRefPtr<PageStyleActor> create(DevToolsServer&, String name);
+    static NonnullRefPtr<PageStyleActor> create(DevToolsServer&, String name, WeakPtr<InspectorActor>);
     virtual ~PageStyleActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
     JsonValue serialize_style() const;
 
 private:
-    PageStyleActor(DevToolsServer&, String name);
+    PageStyleActor(DevToolsServer&, String name, WeakPtr<InspectorActor>);
+
+    template<typename Callback>
+    void inspect_dom_node(StringView node_actor, Callback&&);
+
+    void received_layout(JsonObject const& computed_style, JsonObject const& node_box_sizing, BlockToken);
+    void received_computed_style(JsonObject const& computed_style, BlockToken);
+
+    WeakPtr<InspectorActor> m_inspector;
 };
 
 }

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -76,6 +76,7 @@ JsonObject TabActor::serialize_description() const
 void TabActor::reset_selected_node()
 {
     devtools().delegate().clear_highlighted_dom_node(description());
+    devtools().delegate().clear_inspected_dom_node(description());
 }
 
 }

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -7,6 +7,7 @@
 #include <AK/JsonObject.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WatcherActor.h>
+#include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
 
 namespace DevTools {
@@ -22,7 +23,10 @@ TabActor::TabActor(DevToolsServer& devtools, String name, TabDescription descrip
 {
 }
 
-TabActor::~TabActor() = default;
+TabActor::~TabActor()
+{
+    reset_selected_node();
+}
 
 void TabActor::handle_message(StringView type, JsonObject const&)
 {
@@ -67,6 +71,11 @@ JsonObject TabActor::serialize_description() const
     description.set("outerWindowID"sv, m_description.id);
     description.set("traits"sv, move(traits));
     return description;
+}
+
+void TabActor::reset_selected_node()
+{
+    devtools().delegate().clear_highlighted_dom_node(description());
 }
 
 }

--- a/Libraries/LibDevTools/Actors/TabActor.h
+++ b/Libraries/LibDevTools/Actors/TabActor.h
@@ -30,6 +30,8 @@ public:
     TabDescription const& description() const { return m_description; }
     JsonObject serialize_description() const;
 
+    void reset_selected_node();
+
 private:
     TabActor(DevToolsServer&, String name, TabDescription);
 

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -72,6 +72,12 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
         return;
     }
 
+    if (type == "getOffsetParent"sv) {
+        response.set("node"sv, JsonValue {});
+        send_message(move(response));
+        return;
+    }
+
     if (type == "querySelector"sv) {
         auto node = message.get_string("node"sv);
         if (!node.has_value()) {

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -6,8 +6,10 @@
 
 #include <AK/JsonArray.h>
 #include <AK/StringUtils.h>
+#include <LibDevTools/Actors/NodeActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
+#include <LibDevTools/DevToolsServer.h>
 #include <LibWeb/DOM/NodeType.h>
 
 namespace DevTools {
@@ -276,11 +278,12 @@ Optional<JsonObject const&> WalkerActor::find_node_by_selector(JsonObject const&
 
 void WalkerActor::populate_dom_tree_cache(JsonObject& node, JsonObject const* parent)
 {
+    auto& node_actor = devtools().register_actor<NodeActor>(*this);
+
     m_dom_node_to_parent_map.set(&node, parent);
 
-    auto actor = MUST(String::formatted("{}-node{}", name(), m_dom_node_count++));
-    m_actor_to_dom_node_map.set(actor, &node);
-    node.set("actor"sv, actor);
+    m_actor_to_dom_node_map.set(node_actor.name(), &node);
+    node.set("actor"sv, node_actor.name());
 
     auto children = node.get_array("children"sv);
     if (!children.has_value())

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/JsonArray.h>
 #include <AK/StringUtils.h>
+#include <LibDevTools/Actors/LayoutInspectorActor.h>
 #include <LibDevTools/Actors/NodeActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
@@ -55,6 +56,18 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
         response.set("hasFirst"sv, !nodes.is_empty());
         response.set("hasLast"sv, !nodes.is_empty());
         response.set("nodes"sv, move(nodes));
+        send_message(move(response));
+        return;
+    }
+
+    if (type == "getLayoutInspector"sv) {
+        if (!m_layout_inspector)
+            m_layout_inspector = devtools().register_actor<LayoutInspectorActor>();
+
+        JsonObject actor;
+        actor.set("actor"sv, m_layout_inspector->name());
+
+        response.set("actor"sv, move(actor));
         send_message(move(response));
         return;
     }

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -44,6 +44,8 @@ private:
     void populate_dom_tree_cache(JsonObject& node, JsonObject const* parent = nullptr);
 
     WeakPtr<TabActor> m_tab;
+    WeakPtr<LayoutInspectorActor> m_layout_inspector;
+
     JsonObject m_dom_tree;
 
     HashMap<JsonObject const*, JsonObject const*> m_dom_node_to_parent_map;

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -48,7 +48,6 @@ private:
 
     HashMap<JsonObject const*, JsonObject const*> m_dom_node_to_parent_map;
     HashMap<String, JsonObject const*> m_actor_to_dom_node_map;
-    size_t m_dom_node_count { 0 };
 };
 
 }

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -11,6 +11,8 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <LibDevTools/Actor.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/Forward.h>
 
 namespace DevTools {
 
@@ -25,6 +27,13 @@ public:
 
     static bool is_suitable_for_dom_inspection(JsonValue const&);
     JsonValue serialize_root() const;
+
+    struct DOMNode {
+        JsonObject const& node;
+        Web::UniqueNodeID id { 0 };
+        Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element;
+    };
+    Optional<DOMNode> dom_node(StringView actor);
 
 private:
     WalkerActor(DevToolsServer&, String name, WeakPtr<TabActor>, JsonObject dom_tree);

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     Actors/FrameActor.cpp
     Actors/HighlighterActor.cpp
     Actors/InspectorActor.cpp
+    Actors/LayoutInspectorActor.cpp
     Actors/NodeActor.cpp
     Actors/PageStyleActor.cpp
     Actors/PreferenceActor.cpp

--- a/Libraries/LibDevTools/CMakeLists.txt
+++ b/Libraries/LibDevTools/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     Actors/FrameActor.cpp
     Actors/HighlighterActor.cpp
     Actors/InspectorActor.cpp
+    Actors/NodeActor.cpp
     Actors/PageStyleActor.cpp
     Actors/PreferenceActor.cpp
     Actors/ProcessActor.cpp

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -13,6 +13,8 @@
 #include <LibDevTools/Actors/CSSPropertiesActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Forward.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/Forward.h>
 
 namespace DevTools {
 
@@ -25,6 +27,9 @@ public:
 
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }
+
+    virtual void highlight_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const { }
+    virtual void clear_highlighted_dom_node(TabDescription const&) const { }
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -15,6 +15,7 @@
 #include <LibDevTools/Forward.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/ViewImplementation.h>
 
 namespace DevTools {
 
@@ -27,6 +28,10 @@ public:
 
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }
+
+    using OnDOMNodeInspectionComplete = Function<void(ErrorOr<WebView::ViewImplementation::DOMNodeProperties>)>;
+    virtual void inspect_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>, OnDOMNodeInspectionComplete) const { }
+    virtual void clear_inspected_dom_node(TabDescription const&) const { }
 
     virtual void highlight_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const { }
     virtual void clear_highlighted_dom_node(TabDescription const&) const { }

--- a/Libraries/LibDevTools/DevToolsServer.h
+++ b/Libraries/LibDevTools/DevToolsServer.h
@@ -32,16 +32,16 @@ public:
     ActorType& register_actor(Args&&... args)
     {
         String name;
+        auto id = m_actor_count++;
 
         if constexpr (IsSame<ActorType, RootActor>) {
             name = String::from_utf8_without_validation(ActorType::base_name.bytes());
         } else {
-            name = MUST(String::formatted("server{}-{}{}", m_server_id, ActorType::base_name, m_actor_count));
+            name = MUST(String::formatted("server{}-{}{}", m_server_id, ActorType::base_name, id));
         }
 
         auto actor = ActorType::create(*this, name, forward<Args>(args)...);
         m_actor_registry.set(name, actor);
-        ++m_actor_count;
 
         return actor;
     }

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -17,6 +17,7 @@ class DevToolsServer;
 class FrameActor;
 class HighlighterActor;
 class InspectorActor;
+class LayoutInspectorActor;
 class NodeActor;
 class PageStyleActor;
 class PreferenceActor;

--- a/Libraries/LibDevTools/Forward.h
+++ b/Libraries/LibDevTools/Forward.h
@@ -17,6 +17,7 @@ class DevToolsServer;
 class FrameActor;
 class HighlighterActor;
 class InspectorActor;
+class NodeActor;
 class PageStyleActor;
 class PreferenceActor;
 class ProcessActor;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -518,6 +518,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_style_sheets);
     visitor.visit(m_hovered_node);
     visitor.visit(m_inspected_node);
+    visitor.visit(m_highlighted_node);
     visitor.visit(m_active_favicon);
     visitor.visit(m_focused_element);
     visitor.visit(m_active_element);
@@ -1637,29 +1638,36 @@ Layout::Viewport* Document::layout_node()
     return static_cast<Layout::Viewport*>(Node::layout_node());
 }
 
-void Document::set_inspected_node(Node* node, Optional<CSS::Selector::PseudoElement::Type> pseudo_element)
+void Document::set_inspected_node(GC::Ptr<Node> node)
 {
-    if (m_inspected_node.ptr() == node && m_inspected_pseudo_element == pseudo_element)
+    m_inspected_node = node;
+}
+
+void Document::set_highlighted_node(GC::Ptr<Node> node, Optional<CSS::Selector::PseudoElement::Type> pseudo_element)
+{
+    if (m_highlighted_node == node && m_highlighted_pseudo_element == pseudo_element)
         return;
 
-    if (auto layout_node = inspected_layout_node(); layout_node && layout_node->first_paintable())
+    if (auto layout_node = highlighted_layout_node(); layout_node && layout_node->first_paintable())
         layout_node->first_paintable()->set_needs_display();
 
-    m_inspected_node = node;
-    m_inspected_pseudo_element = pseudo_element;
+    m_highlighted_node = node;
+    m_highlighted_pseudo_element = pseudo_element;
 
-    if (auto layout_node = inspected_layout_node(); layout_node && layout_node->first_paintable())
+    if (auto layout_node = highlighted_layout_node(); layout_node && layout_node->first_paintable())
         layout_node->first_paintable()->set_needs_display();
 }
 
-Layout::Node* Document::inspected_layout_node()
+GC::Ptr<Layout::Node> Document::highlighted_layout_node()
 {
-    if (!m_inspected_node)
+    if (!m_highlighted_node)
         return nullptr;
-    if (!m_inspected_pseudo_element.has_value() || !m_inspected_node->is_element())
-        return m_inspected_node->layout_node();
-    auto& element = static_cast<Element&>(*m_inspected_node);
-    return element.get_pseudo_element_node(m_inspected_pseudo_element.value());
+
+    if (!m_highlighted_pseudo_element.has_value() || !m_highlighted_node->is_element())
+        return m_highlighted_node->layout_node();
+
+    auto const& element = static_cast<Element const&>(*m_highlighted_node);
+    return element.get_pseudo_element_node(m_highlighted_pseudo_element.value());
 }
 
 static Node* find_common_ancestor(Node* a, Node* b)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -186,11 +186,13 @@ public:
     Node* hovered_node() { return m_hovered_node.ptr(); }
     Node const* hovered_node() const { return m_hovered_node.ptr(); }
 
-    void set_inspected_node(Node*, Optional<CSS::Selector::PseudoElement::Type>);
-    Node* inspected_node() { return m_inspected_node.ptr(); }
-    Node const* inspected_node() const { return m_inspected_node.ptr(); }
-    Layout::Node* inspected_layout_node();
-    Layout::Node const* inspected_layout_node() const { return const_cast<Document*>(this)->inspected_layout_node(); }
+    void set_inspected_node(GC::Ptr<Node>);
+    GC::Ptr<Node const> inspected_node() const { return m_inspected_node; }
+
+    void set_highlighted_node(GC::Ptr<Node>, Optional<CSS::Selector::PseudoElement::Type>);
+    GC::Ptr<Node const> highlighted_node() const { return m_highlighted_node; }
+    GC::Ptr<Layout::Node> highlighted_layout_node();
+    GC::Ptr<Layout::Node const> highlighted_layout_node() const { return const_cast<Document*>(this)->highlighted_layout_node(); }
 
     Element* document_element();
     Element const* document_element() const;
@@ -866,9 +868,6 @@ private:
     GC::Ref<Page> m_page;
     OwnPtr<CSS::StyleComputer> m_style_computer;
     GC::Ptr<CSS::StyleSheetList> m_style_sheets;
-    GC::Ptr<Node> m_hovered_node;
-    GC::Ptr<Node> m_inspected_node;
-    Optional<CSS::Selector::PseudoElement::Type> m_inspected_pseudo_element;
     GC::Ptr<Node> m_active_favicon;
     WeakPtr<HTML::BrowsingContext> m_browsing_context;
     URL::URL m_url;
@@ -876,6 +875,11 @@ private:
     GC::Ptr<HTML::Window> m_window;
 
     GC::Ptr<Layout::Viewport> m_layout_root;
+
+    GC::Ptr<Node> m_hovered_node;
+    GC::Ptr<Node> m_inspected_node;
+    GC::Ptr<Node> m_highlighted_node;
+    Optional<CSS::Selector::PseudoElement::Type> m_highlighted_pseudo_element;
 
     Optional<Color> m_normal_link_color;
     Optional<Color> m_active_link_color;

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -474,7 +474,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
         }
     }
 
-    if (phase == PaintPhase::Overlay && layout_node().document().inspected_layout_node() == &layout_node_with_style_and_box_metrics()) {
+    if (phase == PaintPhase::Overlay && layout_node().document().highlighted_layout_node() == &layout_node_with_style_and_box_metrics()) {
         auto content_rect = absolute_united_content_rect();
         auto margin_rect = united_rect_for_continuation_chain(*this, [](PaintableBox const& box) {
             auto margin_box = box.box_model().margin_box();
@@ -758,7 +758,7 @@ void paint_text_fragment(PaintContext& context, TextPaintable const& paintable, 
         auto fragment_absolute_rect = fragment.absolute_rect();
         auto fragment_absolute_device_rect = context.enclosing_device_rect(fragment_absolute_rect);
 
-        if (paintable.document().inspected_layout_node() == &paintable.layout_node())
+        if (paintable.document().highlighted_layout_node() == &paintable.layout_node())
             context.display_list_recorder().draw_rect(fragment_absolute_device_rect.to_type<int>(), Color::Magenta);
 
         auto text = paintable.text_for_rendering();

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -371,14 +371,9 @@ void Application::inspect_tab(DevTools::TabDescription const& description, DevTo
         return;
     }
 
-    view->on_received_dom_tree = [&view = *view, on_complete = move(on_complete)](String const& dom_tree) {
+    view->on_received_dom_tree = [&view = *view, on_complete = move(on_complete)](JsonObject dom_tree) {
         view.on_received_dom_tree = nullptr;
-
-        if (auto parsed_tree = JsonValue::from_string(dom_tree); parsed_tree.is_error()) {
-            on_complete(parsed_tree.release_error());
-        } else {
-            on_complete(parsed_tree.release_value());
-        }
+        on_complete(move(dom_tree));
     };
 
     view->inspect_dom_tree();

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -371,7 +371,7 @@ void Application::inspect_tab(DevTools::TabDescription const& description, DevTo
         return;
     }
 
-    view->on_received_dom_tree = [&view = *view, on_complete = move(on_complete)](ByteString const& dom_tree) {
+    view->on_received_dom_tree = [&view = *view, on_complete = move(on_complete)](String const& dom_tree) {
         view.on_received_dom_tree = nullptr;
 
         if (auto parsed_tree = JsonValue::from_string(dom_tree); parsed_tree.is_error()) {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -363,7 +363,7 @@ Vector<DevTools::CSSProperty> Application::css_property_list() const
     return property_list;
 }
 
-void Application::inspect_tab(DevTools::TabDescription const& description, DevTools::DevToolsDelegate::OnTabInspectionComplete on_complete) const
+void Application::inspect_tab(DevTools::TabDescription const& description, OnTabInspectionComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);
     if (!view.has_value()) {
@@ -377,6 +377,40 @@ void Application::inspect_tab(DevTools::TabDescription const& description, DevTo
     };
 
     view->inspect_dom_tree();
+}
+
+void Application::inspect_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element, OnDOMNodeInspectionComplete on_complete) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value()) {
+        on_complete(Error::from_string_literal("Unable to locate tab"));
+        return;
+    }
+
+    view->on_received_dom_node_properties = [&view = *view, on_complete = move(on_complete)](ViewImplementation::DOMNodeProperties properties) {
+        view.on_received_dom_node_properties = nullptr;
+        on_complete(move(properties));
+    };
+
+    view->inspect_dom_node(node_id, pseudo_element);
+}
+
+void Application::clear_inspected_dom_node(DevTools::TabDescription const& description) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->clear_inspected_dom_node();
+}
+
+void Application::highlight_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->highlight_dom_node(node_id, pseudo_element);
+}
+
+void Application::clear_highlighted_dom_node(DevTools::TabDescription const& description) const
+{
+    if (auto view = ViewImplementation::find_view_by_id(description.id); view.has_value())
+        view->clear_highlighted_dom_node();
 }
 
 }

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -91,7 +91,11 @@ private:
 
     virtual Vector<DevTools::TabDescription> tab_list() const override;
     virtual Vector<DevTools::CSSProperty> css_property_list() const override;
-    virtual void inspect_tab(DevTools::TabDescription const&, DevTools::DevToolsDelegate::OnTabInspectionComplete) const override;
+    virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
+    virtual void inspect_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>, OnDOMNodeInspectionComplete) const override;
+    virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override;
+    virtual void highlight_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const override;
+    virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override;
 
     static Application* s_the;
 

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -161,6 +161,7 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
     };
 
     m_inspector_web_view.on_inspector_selected_dom_node = [this](auto node_id, auto const& pseudo_element) {
+        m_content_web_view.highlight_dom_node(node_id, pseudo_element);
         m_content_web_view.inspect_dom_node(node_id, pseudo_element);
     };
 
@@ -306,6 +307,7 @@ void InspectorClient::select_default_node()
 
 void InspectorClient::clear_selection()
 {
+    m_content_web_view.clear_highlighted_dom_node();
     m_content_web_view.clear_inspected_dom_node();
 
     static constexpr auto script = "inspector.clearInspectedDOMNode();"sv;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -303,14 +303,19 @@ void ViewImplementation::inspect_dom_tree()
     client().async_inspect_dom_tree(page_id());
 }
 
-void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element)
-{
-    client().async_inspect_dom_node(page_id(), node_id, move(pseudo_element));
-}
-
 void ViewImplementation::inspect_accessibility_tree()
 {
     client().async_inspect_accessibility_tree(page_id());
+}
+
+void ViewImplementation::get_hovered_node_id()
+{
+    client().async_get_hovered_node_id(page_id());
+}
+
+void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element)
+{
+    client().async_inspect_dom_node(page_id(), node_id, move(pseudo_element));
 }
 
 void ViewImplementation::clear_inspected_dom_node()
@@ -318,9 +323,14 @@ void ViewImplementation::clear_inspected_dom_node()
     inspect_dom_node(0, {});
 }
 
-void ViewImplementation::get_hovered_node_id()
+void ViewImplementation::highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element)
 {
-    client().async_get_hovered_node_id(page_id());
+    client().async_highlight_dom_node(page_id(), node_id, move(pseudo_element));
+}
+
+void ViewImplementation::clear_highlighted_dom_node()
+{
+    highlight_dom_node(0, {});
 }
 
 void ViewImplementation::set_dom_node_text(Web::UniqueNodeID node_id, String text)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -200,9 +200,9 @@ public:
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;
     Function<void(URL::URL const&, URL::URL const&, String const&)> on_received_source;
-    Function<void(ByteString const&)> on_received_dom_tree;
+    Function<void(String const&)> on_received_dom_tree;
     Function<void(Optional<DOMNodeProperties>)> on_received_dom_node_properties;
-    Function<void(ByteString const&)> on_received_accessibility_tree;
+    Function<void(String const&)> on_received_accessibility_tree;
     Function<void(Vector<Web::CSS::StyleSheetIdentifier>)> on_received_style_sheet_list;
     Function<void(Web::CSS::StyleSheetIdentifier const&)> on_inspector_requested_style_sheet_source;
     Function<void(Web::CSS::StyleSheetIdentifier const&, URL::URL const&, String const&)> on_received_style_sheet_source;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -9,6 +9,8 @@
 
 #include <AK/Forward.h>
 #include <AK/Function.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
 #include <AK/LexicalPath.h>
 #include <AK/Queue.h>
 #include <AK/String.h>
@@ -35,12 +37,12 @@ public:
     virtual ~ViewImplementation();
 
     struct DOMNodeProperties {
-        String computed_style_json;
-        String resolved_style_json;
-        String custom_properties_json;
-        String node_box_sizing_json;
-        String aria_properties_state_json;
-        String fonts_json;
+        JsonObject computed_style;
+        JsonObject resolved_style;
+        JsonObject custom_properties;
+        JsonObject node_box_sizing;
+        JsonObject aria_properties_state;
+        JsonArray fonts;
     };
 
     static void for_each_view(Function<IterationDecision(ViewImplementation&)>);
@@ -200,9 +202,9 @@ public:
     Function<void()> on_request_accept_dialog;
     Function<void()> on_request_dismiss_dialog;
     Function<void(URL::URL const&, URL::URL const&, String const&)> on_received_source;
-    Function<void(String const&)> on_received_dom_tree;
-    Function<void(Optional<DOMNodeProperties>)> on_received_dom_node_properties;
-    Function<void(String const&)> on_received_accessibility_tree;
+    Function<void(JsonObject)> on_received_dom_tree;
+    Function<void(DOMNodeProperties)> on_received_dom_node_properties;
+    Function<void(JsonObject)> on_received_accessibility_tree;
     Function<void(Vector<Web::CSS::StyleSheetIdentifier>)> on_received_style_sheet_list;
     Function<void(Web::CSS::StyleSheetIdentifier const&)> on_inspector_requested_style_sheet_source;
     Function<void(Web::CSS::StyleSheetIdentifier const&, URL::URL const&, String const&)> on_received_style_sheet_source;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -103,10 +103,14 @@ public:
     void get_source();
 
     void inspect_dom_tree();
-    void inspect_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);
     void inspect_accessibility_tree();
-    void clear_inspected_dom_node();
     void get_hovered_node_id();
+
+    void inspect_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);
+    void clear_inspected_dom_node();
+
+    void highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);
+    void clear_highlighted_dom_node();
 
     void set_dom_node_text(Web::UniqueNodeID node_id, String text);
     void set_dom_node_tag(Web::UniqueNodeID node_id, String name);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -264,7 +264,7 @@ void WebContentClient::did_get_source(u64 page_id, URL::URL const& url, URL::URL
     }
 }
 
-void WebContentClient::did_inspect_dom_tree(u64 page_id, ByteString const& dom_tree)
+void WebContentClient::did_inspect_dom_tree(u64 page_id, String const& dom_tree)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_received_dom_tree)
@@ -272,7 +272,7 @@ void WebContentClient::did_inspect_dom_tree(u64 page_id, ByteString const& dom_t
     }
 }
 
-void WebContentClient::did_inspect_dom_node(u64 page_id, bool has_style, ByteString const& computed_style, ByteString const& resolved_style, ByteString const& custom_properties, ByteString const& node_box_sizing, ByteString const& aria_properties_state, ByteString const& fonts)
+void WebContentClient::did_inspect_dom_node(u64 page_id, bool has_style, String const& computed_style, String const& resolved_style, String const& custom_properties, String const& node_box_sizing, String const& aria_properties_state, String const& fonts)
 {
     auto view = view_for_page_id(page_id);
     if (!view.has_value() || !view->on_received_dom_node_properties)
@@ -282,19 +282,19 @@ void WebContentClient::did_inspect_dom_node(u64 page_id, bool has_style, ByteStr
 
     if (has_style) {
         properties = ViewImplementation::DOMNodeProperties {
-            .computed_style_json = MUST(String::from_byte_string(computed_style)),
-            .resolved_style_json = MUST(String::from_byte_string(resolved_style)),
-            .custom_properties_json = MUST(String::from_byte_string(custom_properties)),
-            .node_box_sizing_json = MUST(String::from_byte_string(node_box_sizing)),
-            .aria_properties_state_json = MUST(String::from_byte_string(aria_properties_state)),
-            .fonts_json = MUST(String::from_byte_string(fonts))
+            .computed_style_json = computed_style,
+            .resolved_style_json = resolved_style,
+            .custom_properties_json = custom_properties,
+            .node_box_sizing_json = node_box_sizing,
+            .aria_properties_state_json = aria_properties_state,
+            .fonts_json = fonts,
         };
     }
 
     view->on_received_dom_node_properties(move(properties));
 }
 
-void WebContentClient::did_inspect_accessibility_tree(u64 page_id, ByteString const& accessibility_tree)
+void WebContentClient::did_inspect_accessibility_tree(u64 page_id, String const& accessibility_tree)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
         if (view->on_received_accessibility_tree)

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -71,9 +71,9 @@ private:
     virtual void did_request_image_context_menu(u64 page_id, Gfx::IntPoint, URL::URL const&, ByteString const&, unsigned, Optional<Gfx::ShareableBitmap> const&) override;
     virtual void did_request_media_context_menu(u64 page_id, Gfx::IntPoint, ByteString const&, unsigned, Web::Page::MediaContextMenu const&) override;
     virtual void did_get_source(u64 page_id, URL::URL const&, URL::URL const&, String const&) override;
-    virtual void did_inspect_dom_tree(u64 page_id, ByteString const&) override;
-    virtual void did_inspect_dom_node(u64 page_id, bool has_style, ByteString const& computed_style, ByteString const& resolved_style, ByteString const& custom_properties, ByteString const& node_box_sizing, ByteString const& aria_properties_state, ByteString const& fonts) override;
-    virtual void did_inspect_accessibility_tree(u64 page_id, ByteString const&) override;
+    virtual void did_inspect_dom_tree(u64 page_id, String const&) override;
+    virtual void did_inspect_dom_node(u64 page_id, bool has_style, String const& computed_style, String const& resolved_style, String const& custom_properties, String const& node_box_sizing, String const& aria_properties_state, String const& fonts) override;
+    virtual void did_inspect_accessibility_tree(u64 page_id, String const&) override;
     virtual void did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID const& node_id) override;
     virtual void did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> const& node_id) override;
     virtual void did_get_dom_node_html(u64 page_id, String const& html) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -441,7 +441,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
 
     for (auto& navigable : Web::HTML::all_navigables()) {
         if (navigable->active_document() != nullptr) {
-            navigable->active_document()->set_inspected_node(nullptr, {});
+            navigable->active_document()->set_inspected_node(nullptr);
         }
     }
 
@@ -452,7 +452,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
         return;
     }
 
-    node->document().set_inspected_node(node, pseudo_element);
+    node->document().set_inspected_node(node);
 
     if (node->is_element()) {
         auto& element = as<Web::DOM::Element>(*node);
@@ -596,6 +596,25 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
     }
 
     async_did_inspect_dom_node(page_id, false, {}, {}, {}, {}, {}, {});
+}
+
+void ConnectionFromClient::highlight_dom_node(u64 page_id, Web::UniqueNodeID const& node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    for (auto& navigable : Web::HTML::all_navigables()) {
+        if (navigable->active_document() != nullptr) {
+            navigable->active_document()->set_highlighted_node(nullptr, {});
+        }
+    }
+
+    auto* node = Web::DOM::Node::from_unique_id(node_id);
+    if (!node || !node->layout_node())
+        return;
+
+    node->document().set_highlighted_node(node, pseudo_element);
 }
 
 void ConnectionFromClient::inspect_accessibility_tree(u64 page_id)

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -429,7 +429,7 @@ void ConnectionFromClient::inspect_dom_tree(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
         if (auto* doc = page->page().top_level_browsing_context().active_document())
-            async_did_inspect_dom_tree(page_id, doc->dump_dom_tree_as_json().to_byte_string());
+            async_did_inspect_dom_tree(page_id, doc->dump_dom_tree_as_json());
     }
 }
 
@@ -461,7 +461,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
             return;
         }
 
-        auto serialize_json = [](Web::CSS::ComputedProperties const& properties) -> ByteString {
+        auto serialize_json = [](Web::CSS::ComputedProperties const& properties) {
             StringBuilder builder;
 
             auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
@@ -470,10 +470,10 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
             });
             MUST(serializer.finish());
 
-            return builder.to_byte_string();
+            return MUST(builder.to_string());
         };
 
-        auto serialize_custom_properties_json = [](Web::DOM::Element const& element, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) -> ByteString {
+        auto serialize_custom_properties_json = [](Web::DOM::Element const& element, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) {
             StringBuilder builder;
             auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
             HashTable<FlyString> seen_properties;
@@ -497,11 +497,11 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
 
             MUST(serializer.finish());
 
-            return builder.to_byte_string();
+            return MUST(builder.to_string());
         };
-        auto serialize_node_box_sizing_json = [](Web::Layout::Node const* layout_node) -> ByteString {
+        auto serialize_node_box_sizing_json = [](Web::Layout::Node const* layout_node) {
             if (!layout_node || !layout_node->is_box() || !layout_node->first_paintable() || !layout_node->first_paintable()->is_paintable_box()) {
-                return "{}";
+                return "{}"_string;
             }
             auto const& paintable_box = as<Web::Painting::PaintableBox>(*layout_node->first_paintable());
             auto const& box_model = paintable_box.box_model();
@@ -523,13 +523,13 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
             MUST(serializer.add("content_height"sv, paintable_box.content_height().to_double()));
 
             MUST(serializer.finish());
-            return builder.to_byte_string();
+            return MUST(builder.to_string());
         };
 
-        auto serialize_aria_properties_state_json = [](Web::DOM::Element const& element) -> ByteString {
+        auto serialize_aria_properties_state_json = [](Web::DOM::Element const& element) {
             auto role_name = element.role_or_default();
             if (!role_name.has_value()) {
-                return "";
+                return "{}"_string;
             }
             auto aria_data = MUST(Web::ARIA::AriaData::build_data(element));
             auto role = MUST(Web::ARIA::RoleType::build_role_object(role_name.value(), element.is_focusable(), *aria_data));
@@ -538,10 +538,10 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
             auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
             MUST(role->serialize_as_json(serializer));
             MUST(serializer.finish());
-            return builder.to_byte_string();
+            return MUST(builder.to_string());
         };
 
-        auto serialize_fonts_json = [](Web::CSS::ComputedProperties const& properties) -> ByteString {
+        auto serialize_fonts_json = [](Web::CSS::ComputedProperties const& properties) {
             StringBuilder builder;
             auto serializer = MUST(JsonArraySerializer<>::try_create(builder));
 
@@ -555,7 +555,7 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
                 MUST(font_json_object.finish());
             });
             MUST(serializer.finish());
-            return builder.to_byte_string();
+            return MUST(builder.to_string());
         };
 
         if (pseudo_element.has_value()) {
@@ -567,9 +567,9 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
 
             auto pseudo_element_style = element.pseudo_element_computed_properties(pseudo_element.value());
 
-            ByteString computed_values;
-            ByteString fonts_json;
-            ByteString resolved_values;
+            String computed_values;
+            String fonts_json;
+            String resolved_values;
             if (pseudo_element_style) {
                 computed_values = serialize_json(*pseudo_element_style);
                 fonts_json = serialize_fonts_json(*pseudo_element_style);
@@ -578,18 +578,18 @@ void ConnectionFromClient::inspect_dom_node(u64 page_id, Web::UniqueNodeID const
                 dbgln("Inspected pseudo-element has no computed style.");
             }
 
-            ByteString custom_properties_json = serialize_custom_properties_json(element, pseudo_element);
-            ByteString node_box_sizing_json = serialize_node_box_sizing_json(pseudo_element_node.ptr());
-            async_did_inspect_dom_node(page_id, true, move(computed_values), move(resolved_values), move(custom_properties_json), move(node_box_sizing_json), {}, move(fonts_json));
+            auto custom_properties_json = serialize_custom_properties_json(element, pseudo_element);
+            auto node_box_sizing_json = serialize_node_box_sizing_json(pseudo_element_node.ptr());
+            async_did_inspect_dom_node(page_id, true, move(computed_values), move(resolved_values), move(custom_properties_json), move(node_box_sizing_json), "{}"_string, move(fonts_json));
             return;
         }
 
-        ByteString computed_values = serialize_json(*element.computed_properties());
-        ByteString resolved_values = serialize_json(element.resolved_css_values());
-        ByteString custom_properties_json = serialize_custom_properties_json(element, {});
-        ByteString node_box_sizing_json = serialize_node_box_sizing_json(element.layout_node());
-        ByteString aria_properties_state_json = serialize_aria_properties_state_json(element);
-        ByteString fonts_json = serialize_fonts_json(*element.computed_properties());
+        auto computed_values = serialize_json(*element.computed_properties());
+        auto resolved_values = serialize_json(element.resolved_css_values());
+        auto custom_properties_json = serialize_custom_properties_json(element, {});
+        auto node_box_sizing_json = serialize_node_box_sizing_json(element.layout_node());
+        auto aria_properties_state_json = serialize_aria_properties_state_json(element);
+        auto fonts_json = serialize_fonts_json(*element.computed_properties());
 
         async_did_inspect_dom_node(page_id, true, move(computed_values), move(resolved_values), move(custom_properties_json), move(node_box_sizing_json), move(aria_properties_state_json), move(fonts_json));
         return;
@@ -602,7 +602,7 @@ void ConnectionFromClient::inspect_accessibility_tree(u64 page_id)
 {
     if (auto page = this->page(page_id); page.has_value()) {
         if (auto* doc = page->page().top_level_browsing_context().active_document())
-            async_did_inspect_accessibility_tree(page_id, doc->dump_accessibility_tree_as_json().to_byte_string());
+            async_did_inspect_accessibility_tree(page_id, doc->dump_accessibility_tree_as_json());
     }
 }
 

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -76,6 +76,7 @@ private:
     virtual void get_source(u64 page_id) override;
     virtual void inspect_dom_tree(u64 page_id) override;
     virtual void inspect_dom_node(u64 page_id, Web::UniqueNodeID const& node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
+    virtual void highlight_dom_node(u64 page_id, Web::UniqueNodeID const& node_id, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspect_accessibility_tree(u64 page_id) override;
     virtual void get_hovered_node_id(u64 page_id) override;
 

--- a/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
+++ b/Services/WebContent/ConsoleGlobalEnvironmentExtensions.cpp
@@ -53,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleGlobalEnvironmentExtensions::$0_getter)
 {
     auto* console_global_object = TRY(get_console(vm));
     auto& window = *console_global_object->m_window_object;
-    auto* inspected_node = window.associated_document().inspected_node();
+    auto inspected_node = window.associated_document().inspected_node();
     if (!inspected_node)
         return JS::js_undefined();
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -47,9 +47,9 @@ endpoint WebContentClient
     did_request_dismiss_dialog(u64 page_id) =|
     did_get_source(u64 page_id, URL::URL url, URL::URL base_url, String source) =|
 
-    did_inspect_dom_tree(u64 page_id, ByteString dom_tree) =|
-    did_inspect_dom_node(u64 page_id, bool has_style, ByteString computed_style,  ByteString resolved_style,  ByteString custom_properties, ByteString node_box_sizing, ByteString aria_properties_state, ByteString fonts) =|
-    did_inspect_accessibility_tree(u64 page_id, ByteString accessibility_tree) =|
+    did_inspect_dom_tree(u64 page_id, String dom_tree) =|
+    did_inspect_dom_node(u64 page_id, bool has_style, String computed_style,  String resolved_style,  String custom_properties, String node_box_sizing, String aria_properties_state, String fonts) =|
+    did_inspect_accessibility_tree(u64 page_id, String accessibility_tree) =|
     did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) =|
     did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) =|
     did_get_dom_node_html(u64 page_id, String html) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -45,6 +45,7 @@ endpoint WebContentServer
     get_source(u64 page_id) =|
     inspect_dom_tree(u64 page_id) =|
     inspect_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) =|
+    highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) =|
     inspect_accessibility_tree(u64 page_id) =|
     get_hovered_node_id(u64 page_id) =|
     js_console_input(u64 page_id, ByteString js_source) =|

--- a/Tests/AK/TestJSON.cpp
+++ b/Tests/AK/TestJSON.cpp
@@ -615,3 +615,27 @@ TEST_CASE(json_value_as_integer)
     EXPECT(!very_large_value.is_integer<i32>());
     EXPECT(very_large_value.is_integer<i64>());
 }
+
+TEST_CASE(json_object_move_from_value)
+{
+    JsonArray array;
+    array.must_append(false);
+    array.must_append("string"sv);
+
+    JsonObject object;
+    object.set("foo"sv, "bar"sv);
+    object.set("baz"sv, move(array));
+
+    JsonValue value { move(object) };
+    object = move(value.as_object());
+
+    EXPECT(value.is_object());
+    EXPECT(value.as_object().is_empty());
+
+    EXPECT_EQ(object.size(), 2uz);
+    EXPECT_EQ(object.get_string("foo"sv), "bar"sv);
+
+    auto array2 = object.get_array("baz"sv);
+    EXPECT_EQ(array2->at(0).as_bool(), false);
+    EXPECT_EQ(array2->at(1).as_string(), "string"sv);
+}


### PR DESCRIPTION
This supports:
* Moving the mouse over DOM nodes in the inspector panel to render an overlay on the page with box model metrics
* Inspecting a DOM node to show its box model in the DevTools client
* Inspecting a DOM node to show its computed CSS style values in the DevTools client


https://github.com/user-attachments/assets/6cf6871b-fd62-4131-b669-5f7e2874b146

