### PR TITLE
LibURL+LibWeb+UI: Remove the implicit URL constructors

### DIFF
--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
  * Copyright (c) 2024, Sam Atkins <sam@ladybird.org>
+ * Copyright (c) 2023-2025, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,18 +21,6 @@
 #endif
 
 namespace URL {
-
-// FIXME: It could make sense to force users of URL to use URL::Parser::basic_parse() explicitly instead of using a constructor.
-URL::URL(StringView string)
-    : URL(Parser::basic_parse(string).value_or(URL {}))
-{
-    if constexpr (URL_PARSER_DEBUG) {
-        if (m_data->valid)
-            dbgln("URL constructor: Parsed URL to be '{}'.", serialize());
-        else
-            dbgln("URL constructor: Parsed URL to be invalid.");
-    }
-}
 
 Optional<URL> URL::complete_url(StringView relative_url) const
 {

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Max Wipfli <mail@maxwipfli.ch>
- * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
+ * Copyright (c) 2023-2025, Shannon Booth <shannon@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -77,15 +77,6 @@ class URL {
 
 public:
     URL() = default;
-    URL(StringView);
-    URL(ByteString const& string)
-        : URL(string.view())
-    {
-    }
-    URL(String const& string)
-        : URL(string.bytes_as_string_view())
-    {
-    }
 
     bool is_valid() const { return m_data->valid; }
 

--- a/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.cpp
@@ -518,7 +518,9 @@ void HTMLHyperlinkElementUtils::follow_the_hyperlink(Optional<String> hyperlink_
     // FIXME: 12. If subject's link types includes the noreferrer keyword, then set referrerPolicy to "no-referrer".
 
     // 13. Navigate targetNavigable to urlString using subject's node document, with referrerPolicy set to referrerPolicy and userInvolvement set to userInvolvement.
-    MUST(target_navigable->navigate({ .url = url_string, .source_document = hyperlink_element_utils_document(), .referrer_policy = referrer_policy, .user_involvement = user_involvement }));
+    auto url = URL::Parser::basic_parse(url_string);
+    VERIFY(url.has_value());
+    MUST(target_navigable->navigate({ .url = url.release_value(), .source_document = hyperlink_element_utils_document(), .referrer_policy = referrer_policy, .user_involvement = user_involvement }));
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -134,7 +134,7 @@ private:
 
     void handle_successful_fetch(URL::URL const&, StringView mime_type, ImageRequest&, ByteBuffer, bool maybe_omit_events, URL::URL const& previous_url);
     void handle_failed_fetch();
-    void add_callbacks_to_image_request(GC::Ref<ImageRequest>, bool maybe_omit_events, URL::URL const& url_string, URL::URL const& previous_url);
+    void add_callbacks_to_image_request(GC::Ref<ImageRequest>, bool maybe_omit_events, URL::URL const& url_string, String const& previous_url);
 
     void animate();
 

--- a/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibURL/Parser.h>
 #include <LibWeb/Bindings/HTMLTrackElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/DOM/Document.h>
@@ -184,7 +185,9 @@ void HTMLTrackElement::start_the_track_processing_model_parallel_steps(JS::Realm
     if (!url.is_empty()) {
         // 1. Let request be the result of creating a potential-CORS request given URL, "track", and corsAttributeState,
         // and with the same-origin fallback flag set.
-        auto request = create_potential_CORS_request(realm.vm(), url, Fetch::Infrastructure::Request::Destination::Track, cors_attribute_state, SameOriginFallbackFlag::Yes);
+        auto parsed_url = URL::Parser::basic_parse(url);
+        VERIFY(parsed_url.has_value());
+        auto request = create_potential_CORS_request(realm.vm(), parsed_url.release_value(), Fetch::Infrastructure::Request::Destination::Track, cors_attribute_state, SameOriginFallbackFlag::Yes);
 
         // 2. Set request's client to the track element's node document's relevant settings object.
         request->set_client(&document().relevant_settings_object());

--- a/Libraries/LibWeb/HTML/ImageRequest.cpp
+++ b/Libraries/LibWeb/HTML/ImageRequest.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/HashTable.h>
 #include <LibGfx/Bitmap.h>
+#include <LibURL/Parser.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>
 #include <LibWeb/Fetch/Infrastructure/FetchAlgorithms.h>
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
@@ -67,16 +68,11 @@ void ImageRequest::set_state(State state)
     m_state = state;
 }
 
-URL::URL const& ImageRequest::current_url() const
-{
-    return m_current_url;
-}
-
-void ImageRequest::set_current_url(JS::Realm& realm, URL::URL url)
+void ImageRequest::set_current_url(JS::Realm& realm, String url)
 {
     m_current_url = move(url);
-    if (m_current_url.is_valid())
-        m_shared_resource_request = SharedResourceRequest::get_or_create(realm, m_page, m_current_url);
+    if (auto url = URL::Parser::basic_parse(m_current_url); url.has_value())
+        m_shared_resource_request = SharedResourceRequest::get_or_create(realm, m_page, url.release_value());
 }
 
 // https://html.spec.whatwg.org/multipage/images.html#abort-the-image-request

--- a/Libraries/LibWeb/HTML/ImageRequest.h
+++ b/Libraries/LibWeb/HTML/ImageRequest.h
@@ -39,8 +39,8 @@ public:
     State state() const;
     void set_state(State);
 
-    URL::URL const& current_url() const;
-    void set_current_url(JS::Realm&, URL::URL);
+    String const& current_url() const { return m_current_url; }
+    void set_current_url(JS::Realm&, String);
 
     [[nodiscard]] GC::Ptr<DecodedImageData> image_data() const;
     void set_image_data(GC::Ptr<DecodedImageData>);
@@ -72,7 +72,7 @@ private:
 
     // https://html.spec.whatwg.org/multipage/images.html#img-req-url
     // An image request's current URL is initially the empty string.
-    URL::URL m_current_url;
+    String m_current_url;
 
     // https://html.spec.whatwg.org/multipage/images.html#img-req-data
     GC::Ptr<DecodedImageData> m_image_data;

--- a/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -10,9 +10,11 @@
 #include <LibCore/Directory.h>
 #include <LibCore/MimeData.h>
 #include <LibCore/Resource.h>
+#include <LibGC/Function.h>
 #include <LibHTTP/HttpResponse.h>
 #include <LibRequests/Request.h>
 #include <LibRequests/RequestClient.h>
+#include <LibURL/Parser.h>
 #include <LibWeb/Cookie/Cookie.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
@@ -320,7 +322,9 @@ void ResourceLoader::load(LoadRequest& request, GC::Root<SuccessCallback> succes
 
         // When resource URI is a directory use file directory loader to generate response
         if (resource.value()->is_directory()) {
-            respond_directory_page(request, resource.value()->file_url(), success_callback, error_callback);
+            auto url = URL::Parser::basic_parse(resource.value()->file_url());
+            VERIFY(url.has_value());
+            respond_directory_page(request, url.release_value(), success_callback, error_callback);
             return;
         }
 

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -15,6 +15,7 @@
 #include <LibCore/File.h>
 #include <LibCore/Resource.h>
 #include <LibJS/MarkupGenerator.h>
+#include <LibURL/Parser.h>
 #include <LibWeb/Infra/Strings.h>
 #include <LibWeb/Namespace.h>
 #include <LibWebView/Application.h>
@@ -97,8 +98,8 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
         m_inspector_web_view.run_javascript(builder.string_view());
     };
 
-    m_content_web_view.on_received_style_sheet_source = [this](Web::CSS::StyleSheetIdentifier const& identifier, auto const& base_url, String const& source) {
-        auto html = highlight_source(identifier.url.value_or({}), base_url, source, Syntax::Language::CSS, HighlightOutputMode::SourceOnly);
+    m_content_web_view.on_received_style_sheet_source = [this](Web::CSS::StyleSheetIdentifier const& identifier, URL::URL const& base_url, String const& source) {
+        auto html = highlight_source(URL::Parser::basic_parse(identifier.url.value_or({})), base_url, source, Syntax::Language::CSS, HighlightOutputMode::SourceOnly);
         auto script = MUST(String::formatted("inspector.setStyleSheetSource({}, \"{}\");",
             style_sheet_identifier_to_json(identifier),
             MUST(encode_base64(html.bytes()))));

--- a/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Libraries/LibWebView/SourceHighlighter.cpp
@@ -147,7 +147,7 @@ void SourceHighlighterClient::highlighter_did_set_folding_regions(Vector<Syntax:
     document().set_folding_regions(move(folding_regions));
 }
 
-String highlight_source(URL::URL const& url, URL::URL const& base_url, String const& source, Syntax::Language language, HighlightOutputMode mode)
+String highlight_source(Optional<URL::URL> const& url, URL::URL const& base_url, String const& source, Syntax::Language language, HighlightOutputMode mode)
 {
     SourceHighlighterClient highlighter_client { source, language };
     return highlighter_client.to_html_string(url, base_url, mode);
@@ -266,7 +266,7 @@ StringView SourceHighlighterClient::class_for_token(u64 token_type) const
     }
 }
 
-String SourceHighlighterClient::to_html_string(URL::URL const& url, URL::URL const& base_url, HighlightOutputMode mode) const
+String SourceHighlighterClient::to_html_string(Optional<URL::URL> const& url, URL::URL const& base_url, HighlightOutputMode mode) const
 {
     StringBuilder builder;
 
@@ -300,7 +300,11 @@ String SourceHighlighterClient::to_html_string(URL::URL const& url, URL::URL con
 <head>
     <meta name="color-scheme" content="dark light">)~~~"sv);
 
-        builder.appendff("<title>View Source - {}</title>", escape_html_entities(url.serialize_for_display()));
+        if (url.has_value())
+            builder.appendff("<title>View Source - {}</title>", escape_html_entities(url->serialize_for_display()));
+        else
+            builder.append("<title>View Source</title>"sv);
+
         builder.appendff("<style type=\"text/css\">{}</style>", HTML_HIGHLIGHTER_STYLE);
         builder.append(R"~~~(
 </head>

--- a/Libraries/LibWebView/SourceHighlighter.h
+++ b/Libraries/LibWebView/SourceHighlighter.h
@@ -52,7 +52,7 @@ public:
     SourceHighlighterClient(String const& source, Syntax::Language);
     virtual ~SourceHighlighterClient() = default;
 
-    String to_html_string(URL::URL const& url, URL::URL const& base_url, HighlightOutputMode) const;
+    String to_html_string(Optional<URL::URL> const&, URL::URL const& base_url, HighlightOutputMode) const;
 
 private:
     // ^ Syntax::HighlighterClient
@@ -75,7 +75,7 @@ private:
     OwnPtr<Syntax::Highlighter> m_highlighter;
 };
 
-String highlight_source(URL::URL const& url, URL::URL const& base_url, String const& source, Syntax::Language, HighlightOutputMode);
+String highlight_source(Optional<URL::URL> const&, URL::URL const& base_url, String const& source, Syntax::Language, HighlightOutputMode);
 
 constexpr inline StringView HTML_HIGHLIGHTER_STYLE = R"~~~(
     @media (prefers-color-scheme: dark) {

--- a/Meta/Lagom/Fuzzers/FuzzURL.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzURL.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibURL/URL.h>
+#include <LibURL/Parser.h>
 
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
     auto string_view = StringView(data, size);
-    auto url = URL::URL(string_view);
+    auto url = URL::Parser::basic_parse(string_view);
+    (void)url;
     return 0;
 }

--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -9,6 +9,7 @@
 #include <Interface/LadybirdWebViewBridge.h>
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibGfx/ShareableBitmap.h>
+#include <LibURL/Parser.h>
 #include <LibURL/URL.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/Application.h>
@@ -1129,8 +1130,10 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
 {
     auto* delegate = (ApplicationDelegate*)[NSApp delegate];
 
-    auto url = MUST(String::formatted([delegate searchEngine].query_url, URL::percent_encode(*m_context_menu_search_text)));
-    [self.observer onCreateNewTab:url activateTab:Web::HTML::ActivateTab::Yes];
+    auto url_string = MUST(String::formatted([delegate searchEngine].query_url, URL::percent_encode(*m_context_menu_search_text)));
+    auto url = URL::Parser::basic_parse(url_string);
+    VERIFY(url.has_value());
+    [self.observer onCreateNewTab:url.release_value() activateTab:Web::HTML::ActivateTab::Yes];
 }
 
 - (void)takeVisibleScreenshot:(id)sender

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -7,6 +7,7 @@
 #include <AK/Enumerate.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibMain/Main.h>
+#include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/ChromeProcess.h>
 #include <LibWebView/EventLoop/EventLoopImplementationMacOS.h>
@@ -49,7 +50,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Application* application = [Application sharedApplication];
 
     Core::EventLoopManager::install(*new WebView::EventLoopManagerMacOS);
-    [application setupWebViewApplication:arguments newTabPageURL:Browser::default_new_tab_url];
+    auto url = URL::Parser::basic_parse(Browser::default_new_tab_url);
+    VERIFY(url.has_value());
+    [application setupWebViewApplication:arguments newTabPageURL:url.release_value()];
 
     WebView::platform_init();
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -596,7 +596,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     auto* about_action = new QAction("&About Ladybird", this);
     help_menu->addAction(about_action);
     QObject::connect(about_action, &QAction::triggered, this, [this] {
-        new_tab_from_url("about:version"sv, Web::HTML::ActivateTab::Yes);
+        new_tab_from_url(URL::about_version(), Web::HTML::ActivateTab::Yes);
     });
 
     m_hamburger_menu->addSeparator();
@@ -609,7 +609,9 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
     QObject::connect(quit_action, &QAction::triggered, this, &QMainWindow::close);
 
     QObject::connect(m_new_tab_action, &QAction::triggered, this, [this] {
-        auto& tab = new_tab_from_url(ak_url_from_qstring(Settings::the()->new_tab_page()), Web::HTML::ActivateTab::Yes);
+        auto url = ak_url_from_qstring(Settings::the()->new_tab_page());
+        VERIFY(url.has_value());
+        auto& tab = new_tab_from_url(url.release_value(), Web::HTML::ActivateTab::Yes);
         tab.set_url_is_hidden(true);
         tab.focus_location_editor();
     });

--- a/UI/Qt/SettingsDialog.cpp
+++ b/UI/Qt/SettingsDialog.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibURL/Parser.h>
 #include <LibURL/URL.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/SearchEngine.h>
@@ -50,11 +51,11 @@ SettingsDialog::SettingsDialog(QMainWindow* window)
     m_new_tab_page->setText(Settings::the()->new_tab_page());
     QObject::connect(m_new_tab_page, &QLineEdit::textChanged, this, [this] {
         auto url_string = ak_string_from_qstring(m_new_tab_page->text());
-        m_new_tab_page->setStyleSheet(URL::URL(url_string).is_valid() ? "" : "border: 1px solid red;");
+        m_new_tab_page->setStyleSheet(URL::Parser::basic_parse(url_string).has_value() ? "" : "border: 1px solid red;");
     });
     QObject::connect(m_new_tab_page, &QLineEdit::editingFinished, this, [this] {
         auto url_string = ak_string_from_qstring(m_new_tab_page->text());
-        if (URL::URL(url_string).is_valid())
+        if (URL::Parser::basic_parse(url_string).has_value())
             Settings::the()->set_new_tab_page(m_new_tab_page->text());
     });
     QObject::connect(m_new_tab_page, &QLineEdit::returnPressed, this, [this] {

--- a/UI/Qt/StringUtils.cpp
+++ b/UI/Qt/StringUtils.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibURL/Parser.h>
 #include <UI/Qt/StringUtils.h>
 
 AK::ByteString ak_byte_string_from_qstring(QString const& qstring)
@@ -23,13 +24,13 @@ QString qstring_from_ak_string(StringView ak_string)
     return QString::fromUtf8(ak_string.characters_without_null_termination(), static_cast<qsizetype>(ak_string.length()));
 }
 
-URL::URL ak_url_from_qstring(QString const& qstring)
+Optional<URL::URL> ak_url_from_qstring(QString const& qstring)
 {
     auto utf8_data = qstring.toUtf8();
-    return URL::URL(StringView(utf8_data.data(), utf8_data.size()));
+    return URL::Parser::basic_parse(StringView(utf8_data.data(), utf8_data.size()));
 }
 
 URL::URL ak_url_from_qurl(QUrl const& qurl)
 {
-    return ak_url_from_qstring(qurl.toString());
+    return ak_url_from_qstring(qurl.toString()).value();
 }

--- a/UI/Qt/StringUtils.h
+++ b/UI/Qt/StringUtils.h
@@ -8,6 +8,7 @@
 
 #include <AK/ByteString.h>
 #include <AK/Error.h>
+#include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibURL/URL.h>
@@ -18,5 +19,5 @@
 AK::ByteString ak_byte_string_from_qstring(QString const&);
 String ak_string_from_qstring(QString const&);
 QString qstring_from_ak_string(StringView);
-URL::URL ak_url_from_qstring(QString const&);
+Optional<URL::URL> ak_url_from_qstring(QString const&);
 URL::URL ak_url_from_qurl(QUrl const&);

--- a/UI/Qt/Tab.cpp
+++ b/UI/Qt/Tab.cpp
@@ -8,6 +8,7 @@
 
 #include <AK/TemporaryChange.h>
 #include <LibGfx/ImageFormats/BMPWriter.h>
+#include <LibURL/Parser.h>
 #include <LibWeb/HTML/SelectedFile.h>
 #include <LibWebView/SearchEngine.h>
 #include <LibWebView/SourceHighlighter.h>
@@ -466,8 +467,10 @@ Tab::Tab(BrowserWindow* window, RefPtr<WebView::WebContentClient> parent_client,
     auto* search_selected_text_action = new QAction("&Search for <query>", this);
     search_selected_text_action->setIcon(load_icon_from_uri("resource://icons/16x16/find.png"sv));
     QObject::connect(search_selected_text_action, &QAction::triggered, this, [this]() {
-        auto url = MUST(String::formatted(Settings::the()->search_engine().query_url, URL::percent_encode(*m_page_context_menu_search_text)));
-        m_window->new_tab_from_url(URL::URL(url), Web::HTML::ActivateTab::Yes);
+        auto url_string = MUST(String::formatted(Settings::the()->search_engine().query_url, URL::percent_encode(*m_page_context_menu_search_text)));
+        auto url = URL::Parser::basic_parse(url_string);
+        VERIFY(url.has_value());
+        m_window->new_tab_from_url(url.release_value(), Web::HTML::ActivateTab::Yes);
     });
 
     auto take_screenshot = [this](auto type) {

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -73,7 +73,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::EventLoopManager::install(*new WebView::EventLoopManagerQt);
 
-    auto app = Ladybird::Application::create(arguments, ak_url_from_qstring(Ladybird::Settings::the()->new_tab_page()));
+    auto url = ak_url_from_qstring(Ladybird::Settings::the()->new_tab_page());
+    VERIFY(url.has_value());
+    auto app = Ladybird::Application::create(arguments, url.release_value());
 
     static_cast<WebView::EventLoopImplementationQt&>(Core::EventLoop::current().impl()).set_main_loop();
     TRY(handle_attached_debugger());


### PR DESCRIPTION
All URLs are now either constucted through the URL Parser or by
default constructing a URL, and setting each of the fields of that
URL manually. This makes it much more difficult to create invalid
URLs to enable removing it's valid state.