### PR TITLE
LibTLS: Improve error handling

### DIFF
--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -18,13 +18,13 @@ namespace TLS {
 ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(ByteString const& host, u16 port, Options options)
 {
     auto tcp_socket = TRY(Core::TCPSocket::connect(host, port));
-    return connect_internal(move(tcp_socket), host, options);
+    return connect_internal(move(tcp_socket), host, move(options));
 }
 
-ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(Core::SocketAddress address, ByteString const& host, Options options)
+ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(Core::SocketAddress const& address, ByteString const& host, Options options)
 {
     auto tcp_socket = TRY(Core::TCPSocket::connect(address));
-    return connect_internal(move(tcp_socket), host, options);
+    return connect_internal(move(tcp_socket), host, move(options));
 }
 
 static void wait_for_activity(int sock, bool read)

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -59,7 +59,7 @@ public:
     virtual ErrorOr<void> set_blocking(bool block) override;
     virtual ErrorOr<void> set_close_on_exec(bool enabled) override;
 
-    static ErrorOr<NonnullOwnPtr<TLSv12>> connect(Core::SocketAddress, ByteString const& host, Options = {});
+    static ErrorOr<NonnullOwnPtr<TLSv12>> connect(Core::SocketAddress const&, ByteString const& host, Options = {});
     static ErrorOr<NonnullOwnPtr<TLSv12>> connect(ByteString const& host, u16 port, Options = {});
 
     ~TLSv12() override;

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -69,6 +69,8 @@ private:
 
     static ErrorOr<NonnullOwnPtr<TLSv12>> connect_internal(NonnullOwnPtr<Core::TCPSocket>, ByteString const&, Options);
 
+    void handle_fatal_error();
+
     SSL_CTX* m_ssl_ctx { nullptr };
     SSL* m_ssl { nullptr };
     BIO* m_bio { nullptr };

--- a/Libraries/LibTLS/TLSv12.h
+++ b/Libraries/LibTLS/TLSv12.h
@@ -33,6 +33,7 @@ struct Options {
     }
 
     OPTION_WITH_DEFAULTS(Optional<ByteString>, root_certificates_path, )
+    OPTION_WITH_DEFAULTS(bool, blocking, true)
 };
 
 class TLSv12 final : public Core::Socket {
@@ -67,8 +68,6 @@ private:
     explicit TLSv12(NonnullOwnPtr<Core::TCPSocket>, SSL_CTX*, SSL*, BIO*);
 
     static ErrorOr<NonnullOwnPtr<TLSv12>> connect_internal(NonnullOwnPtr<Core::TCPSocket>, ByteString const&, Options);
-
-    void wait_for_activity(bool);
 
     SSL_CTX* m_ssl_ctx { nullptr };
     SSL* m_ssl { nullptr };

--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -52,6 +52,8 @@ static NonnullRefPtr<Resolver> default_resolver()
 
         if (g_dns_info.use_dns_over_tls) {
             TLS::Options options;
+            options.set_blocking(false);
+
             if (!g_default_certificate_path.is_empty())
                 options.set_root_certificates_path(g_default_certificate_path);
 


### PR DESCRIPTION
This PR contains various improvements to the error handling capabilities of the OpenSSL backend `TLSv12` implementation. Notably, it enforces the underlying socket to be initialized as blocking or non-blocking before the SSL handshake occurs and checks for fatal errors when the `on_ready_to_read` callback is called from the underlying socket.

