### PR TITLE
CodeGenerators: Fix clang-18 crash by specifying types explicitly

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -111,7 +111,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& enums_data, Core::File& f
 namespace Web::CSS {
 )~~~");
 
-    enums_data.for_each_member([&](auto& name, auto& value) -> void {
+    enums_data.for_each_member([&](String const& name, JsonValue const& value) {
         VERIFY(value.is_array());
         auto& members = value.as_array();
 


### PR DESCRIPTION
clang 18.1.8 was crashing during the build without this change.

Filed a bug report here:
https://github.com/llvm/llvm-project/issues/128359