### PR TITLE
AK: Remove fast_u32_xxx apis from Memory.h

### DIFF
--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -10,32 +10,6 @@
 #include <AK/Types.h>
 #include <string.h>
 
-ALWAYS_INLINE void fast_u32_copy(u32* dest, u32 const* src, size_t count)
-{
-#if ARCH(X86_64)
-    asm volatile(
-        "rep movsl\n"
-        : "+S"(src), "+D"(dest), "+c"(count)::"memory");
-#else
-    __builtin_memcpy(dest, src, count * 4);
-#endif
-}
-
-ALWAYS_INLINE void fast_u32_fill(u32* dest, u32 value, size_t count)
-{
-#if ARCH(X86_64)
-    asm volatile(
-        "rep stosl\n"
-        : "=D"(dest), "=c"(count)
-        : "D"(dest), "c"(count), "a"(value)
-        : "memory");
-#else
-    for (auto* p = dest; p < (dest + count); ++p) {
-        *p = value;
-    }
-#endif
-}
-
 namespace AK {
 
 inline void secure_zero(void* ptr, size_t size)

--- a/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/GIFLoader.cpp
@@ -127,8 +127,12 @@ static void clear_rect(Bitmap& bitmap, IntRect const& rect, Color color)
     ARGB32* dst = bitmap.scanline(intersection_rect.top()) + intersection_rect.left();
     size_t const dst_skip = bitmap.pitch() / sizeof(ARGB32);
 
+    auto const value = color.value();
+    auto const width = intersection_rect.width();
     for (int i = intersection_rect.height() - 1; i >= 0; --i) {
-        fast_u32_fill(dst, color.value(), intersection_rect.width());
+        for (ARGB32* p = dst; p < (dst + width); ++p) {
+            *p = value;
+        }
         dst += dst_skip;
     }
 }


### PR DESCRIPTION
This commit removes the fast_u32_fill and fast_u32_copy, as they were only used in one place, and are not optimal.