### PR TITLE
LibWeb: Reduce number of recompiled files when changing certain LibWeb headers

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/Animations/PseudoElementParsing.h>
 #include <LibWeb/Bindings/KeyframeEffectPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontStyleMapping.h>
 #include <LibGfx/Font/FontWeight.h>
 #include <LibWeb/CSS/CSSStyleValue.h>

--- a/Libraries/LibWeb/CSS/Interpolation.cpp
+++ b/Libraries/LibWeb/CSS/Interpolation.cpp
@@ -9,6 +9,7 @@
 
 #include "Interpolation.h"
 #include <LibWeb/CSS/PropertyID.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/AngleStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CSSColorValue.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>

--- a/Libraries/LibWeb/CSS/Length.cpp
+++ b/Libraries/LibWeb/CSS/Length.cpp
@@ -12,6 +12,7 @@
 #include <LibGfx/Rect.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Percentage.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -9,6 +9,7 @@
 #include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/NonnullRefPtr.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h>

--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -37,6 +37,7 @@
 #include <LibWeb/CSS/CSSNestedDeclarations.h>
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSTransition.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Interpolation.h>
 #include <LibWeb/CSS/InvalidationSet.h>
 #include <LibWeb/CSS/Parser/Parser.h>

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -11,13 +11,13 @@
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <LibGfx/Font/Typeface.h>
+#include <LibGfx/FontCascadeList.h>
 #include <LibWeb/Animations/KeyframeEffect.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSKeyframesRule.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/CascadeOrigin.h>
 #include <LibWeb/CSS/CascadedProperties.h>
-#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleInvalidationData.h>
 #include <LibWeb/Forward.h>

--- a/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ConicGradientStyleValue.cpp
@@ -10,6 +10,7 @@
 #include "ConicGradientStyleValue.h"
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/LinearGradientStyleValue.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "LinearGradientStyleValue.h"
+#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/RadialGradientStyleValue.cpp
@@ -10,6 +10,7 @@
 #include "RadialGradientStyleValue.h"
 #include <LibWeb/CSS/StyleValues/PositionStyleValue.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::CSS {
 

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -35,6 +35,7 @@
 #include <LibWeb/CSS/CSSAnimation.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSTransition.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/FontFaceSet.h>
 #include <LibWeb/CSS/MediaQueryList.h>
 #include <LibWeb/CSS/MediaQueryListEvent.h>

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -14,7 +14,6 @@
 #include <LibWeb/Bindings/Intrinsics.h>
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/CSS/CascadedProperties.h>
-#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/CountersSet.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleInvalidation.h>

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -14,6 +14,7 @@
 #include <LibRegex/Regex.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
 #include <LibWeb/Bindings/NodePrototype.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CDATASection.h>
 #include <LibWeb/DOM/Comment.h>

--- a/Libraries/LibWeb/Dump.cpp
+++ b/Libraries/LibWeb/Dump.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/CSS/CSSStyleRule.h>
 #include <LibWeb/CSS/CSSStyleSheet.h>
 #include <LibWeb/CSS/CSSSupportsRule.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/PseudoClass.h>
 #include <LibWeb/DOM/Comment.h>

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Forward.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Path.h>
+#include <LibGfx/TextLayout.h>
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/HTML/Canvas/CanvasCompositing.h>
 #include <LibWeb/HTML/Canvas/CanvasDrawImage.h>
@@ -31,8 +32,6 @@
 #include <LibWeb/HTML/Canvas/CanvasTextDrawingStyles.h>
 #include <LibWeb/HTML/Canvas/CanvasTransform.h>
 #include <LibWeb/HTML/CanvasGradient.h>
-#include <LibWeb/Layout/InlineNode.h>
-#include <LibWeb/Layout/LineBox.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 namespace Web::HTML {

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/HTMLAudioElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/HTML/AudioTrack.h>
 #include <LibWeb/HTML/AudioTrackList.h>

--- a/Libraries/LibWeb/HTML/HTMLBRElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLBRElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/HTMLBRElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLBRElement.h>

--- a/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLCanvasElement.cpp
@@ -12,6 +12,7 @@
 #include <LibGfx/ImageFormats/PNGWriter.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLCanvasElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>

--- a/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/ExceptionOrUtils.h>
 #include <LibWeb/Bindings/HTMLElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/EditingHostManager.h>

--- a/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/HTMLFrameElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>

--- a/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLFrameSetElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Bindings/HTMLFrameSetElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLFrameSetElement.h>

--- a/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLHtmlElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Bindings/HTMLHtmlElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/Node.h>

--- a/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -7,6 +7,7 @@
 
 #include <LibURL/Origin.h>
 #include <LibWeb/Bindings/HTMLIFrameElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>

--- a/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -9,6 +9,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/ARIA/Roles.h>
 #include <LibWeb/Bindings/HTMLImageElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibWeb/Bindings/HTMLInputElementPrototype.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>

--- a/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLMeterElement.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibWeb/Bindings/HTMLMeterElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>

--- a/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/Bindings/HTMLObjectElementPrototype.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -9,6 +9,7 @@
 
 #include <LibWeb/Bindings/HTMLSelectElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -8,6 +8,7 @@
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/Bindings/HTMLVideoElementPrototype.h>
 #include <LibWeb/Bindings/Intrinsics.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Fetching/Fetching.h>

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -23,7 +23,6 @@
 #include <LibWeb/HTML/TokenizedFeatures.h>
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/Page/EventHandler.h>
-#include <LibWeb/Painting/DisplayList.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/XHR/FormDataEntry.h>
 

--- a/Libraries/LibWeb/Layout/Node.cpp
+++ b/Libraries/LibWeb/Layout/Node.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Demangle.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleValues/AbstractImageStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BackgroundRepeatStyleValue.h>
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
@@ -30,6 +31,7 @@
 #include <LibWeb/Layout/TableWrapper.h>
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Page/Page.h>
 #include <LibWeb/SVG/SVGForeignObjectElement.h>
 
 namespace Web::Layout {

--- a/Libraries/LibWeb/Layout/Node.h
+++ b/Libraries/LibWeb/Layout/Node.h
@@ -10,9 +10,6 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
 #include <LibJS/Heap/Cell.h>
-#include <LibWeb/CSS/ComputedProperties.h>
-#include <LibWeb/CSS/ComputedValues.h>
-#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/ImageStyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Forward.h>

--- a/Libraries/LibWeb/Layout/TextNode.h
+++ b/Libraries/LibWeb/Layout/TextNode.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Utf8View.h>
+#include <LibGfx/TextLayout.h>
 #include <LibUnicode/Segmenter.h>
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/Layout/Node.h>

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/Optional.h>
 #include <AK/TemporaryChange.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>

--- a/Libraries/LibWeb/Painting/AudioPaintable.cpp
+++ b/Libraries/LibWeb/Painting/AudioPaintable.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Layout/AudioBox.h>
 #include <LibWeb/Painting/AudioPaintable.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::Painting {
 

--- a/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/Layout/TextNode.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintableBox.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 
 namespace Web::Painting {
 

--- a/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
+++ b/Libraries/LibWeb/Painting/BorderRadiusCornerClipper.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintContext.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
+++ b/Libraries/LibWeb/Painting/CheckBoxPaintable.cpp
@@ -12,6 +12,7 @@
 #include <LibWeb/Layout/CheckBox.h>
 #include <LibWeb/Layout/Label.h>
 #include <LibWeb/Painting/CheckBoxPaintable.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/InputColors.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
+++ b/Libraries/LibWeb/Painting/ClippableAndScrollable.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Painting/ClippableAndScrollable.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintContext.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/FieldSetPaintable.cpp
+++ b/Libraries/LibWeb/Painting/FieldSetPaintable.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Layout/LegendBox.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/FieldSetPaintable.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/HTMLImageElement.h>
 #include <LibWeb/HTML/ImageRequest.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/ImagePaintable.h>
 #include <LibWeb/Platform/FontPlugin.h>
 

--- a/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGC/Heap.h>
 #include <LibWeb/Layout/ListItemMarkerBox.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/MarkerPaintable.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/MediaPaintable.cpp
+++ b/Libraries/LibWeb/Painting/MediaPaintable.cpp
@@ -13,6 +13,7 @@
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Page/EventHandler.h>
 #include <LibWeb/Page/Page.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/MediaPaintable.h>
 #include <LibWeb/UIEvents/MouseButton.h>
 

--- a/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
+++ b/Libraries/LibWeb/Painting/NavigableContainerViewportPaintable.cpp
@@ -9,6 +9,7 @@
 #include <LibWeb/Layout/NavigableContainerViewport.h>
 #include <LibWeb/Layout/Viewport.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/NavigableContainerViewportPaintable.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 

--- a/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Libraries/LibWeb/Painting/PaintContext.h
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include <AK/Vector.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/Rect.h>
-#include <LibWeb/Painting/DisplayListRecorder.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web {

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -9,7 +9,7 @@
 #include <AK/NonnullOwnPtr.h>
 #include <LibGC/Root.h>
 #include <LibWeb/InvalidateDisplayList.h>
-#include <LibWeb/Layout/LineBox.h>
+#include <LibWeb/PixelUnits.h>
 #include <LibWeb/TraversalDecision.h>
 #include <LibWeb/TreeNode.h>
 

--- a/Libraries/LibWeb/Painting/Paintable.h
+++ b/Libraries/LibWeb/Painting/Paintable.h
@@ -8,6 +8,8 @@
 
 #include <AK/NonnullOwnPtr.h>
 #include <LibGC/Root.h>
+#include <LibWeb/CSS/ComputedValues.h>
+#include <LibWeb/Forward.h>
 #include <LibWeb/InvalidateDisplayList.h>
 #include <LibWeb/PixelUnits.h>
 #include <LibWeb/TraversalDecision.h>

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -19,6 +19,7 @@
 #include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Painting/BackgroundPainting.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/SVGPaintable.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>

--- a/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Libraries/LibWeb/Painting/PaintableBox.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibWeb/CSS/StyleValues/GridTrackSizeListStyleValue.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Layout/Box.h>

--- a/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <LibGfx/TextLayout.h>
 #include <LibWeb/Layout/Node.h>
+#include <LibWeb/Painting/ShadowData.h>
 #include <LibWeb/PixelUnits.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
+++ b/Libraries/LibWeb/Painting/RadioButtonPaintable.cpp
@@ -10,6 +10,7 @@
 #include <LibWeb/HTML/HTMLInputElement.h>
 #include <LibWeb/Layout/Label.h>
 #include <LibWeb/Layout/RadioButton.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/InputColors.h>
 #include <LibWeb/Painting/RadioButtonPaintable.h>
 

--- a/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGForeignObjectPaintable.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibWeb/Layout/SVGForeignObjectBox.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/SVGMaskable.h>

--- a/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
+++ b/Libraries/LibWeb/Painting/SVGGraphicsPaintable.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibWeb/Layout/SVGGraphicsBox.h>
 #include <LibWeb/Painting/SVGMaskable.h>
 #include <LibWeb/Painting/SVGPaintable.h>

--- a/Libraries/LibWeb/Painting/SVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPaintable.cpp
@@ -6,6 +6,7 @@
 
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Layout/SVGSVGBox.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/SVGPaintable.h>
 #include <LibWeb/SVG/SVGMaskElement.h>
 

--- a/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGPathPaintable.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <LibGfx/Quad.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/SVGPathPaintable.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
 

--- a/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
+++ b/Libraries/LibWeb/Painting/SVGSVGPaintable.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibWeb/Layout/ImageBox.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
 #include <LibWeb/Painting/StackingContext.h>
 

--- a/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -8,6 +8,7 @@
 
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintBoxShadowParams.h>
 #include <LibWeb/Painting/PaintContext.h>
 #include <LibWeb/Painting/PaintableBox.h>

--- a/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/ReplacedBox.h>
 #include <LibWeb/Layout/Viewport.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/SVGSVGPaintable.h>
 #include <LibWeb/Painting/StackingContext.h>

--- a/Libraries/LibWeb/Painting/TableBordersPainting.cpp
+++ b/Libraries/LibWeb/Painting/TableBordersPainting.cpp
@@ -8,6 +8,7 @@
 #include <AK/QuickSort.h>
 #include <AK/Traits.h>
 #include <LibWeb/Layout/TableFormattingContext.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/TableBordersPainting.h>
 

--- a/Libraries/LibWeb/Painting/VideoPaintable.cpp
+++ b/Libraries/LibWeb/Painting/VideoPaintable.cpp
@@ -11,6 +11,7 @@
 #include <LibWeb/HTML/VideoTrackList.h>
 #include <LibWeb/Layout/VideoBox.h>
 #include <LibWeb/Painting/BorderRadiusCornerClipper.h>
+#include <LibWeb/Painting/DisplayListRecorder.h>
 #include <LibWeb/Painting/VideoPaintable.h>
 
 namespace Web::Painting {

--- a/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
+++ b/Libraries/LibWeb/SVG/SVGDecodedImageData.cpp
@@ -6,6 +6,7 @@
 
 #include <LibGfx/Bitmap.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/HTML/BrowsingContext.h>

--- a/Libraries/LibWeb/SVG/SVGImageElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGImageElement.cpp
@@ -7,6 +7,7 @@
 #include "SVGImageElement.h"
 #include <LibCore/Timer.h>
 #include <LibGC/Heap.h>
+#include <LibGfx/ImmutableBitmap.h>
 #include <LibWeb/Bindings/SVGImageElementPrototype.h>
 #include <LibWeb/DOM/DocumentObserver.h>
 #include <LibWeb/DOM/Event.h>

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -21,6 +21,7 @@
 #include <LibUnicode/TimeZone.h>
 #include <LibWeb/ARIA/RoleType.h>
 #include <LibWeb/Bindings/MainThreadVM.h>
+#include <LibWeb/CSS/ComputedProperties.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Attr.h>
 #include <LibWeb/DOM/CharacterData.h>


### PR DESCRIPTION
A lot of header files force recompilation of a large amount of `.cpp`  files. For the headers mentioned below, this was entirely incidental and can easily be avoided by being a bit more deliberate with include directive placement. The changes in this PR are a mixture of removing unused include directives, preferring forward declarations over full headers, and replacing transitive includes with ones in the files where they are actually needed.

| Header                         | Before | After |
|--------------------------------|--------|-------|
| CSS/ComputedProperties.h       | 1113   | 49    |
| CSS/ComputedValues.h           | 1127   | 209   |
| Painting/Command.h             | 1030   | 61    |
| Painting/DisplayList.h         | 1030   | 60    |
| Painting/DisplayListRecorder.h | 557    | 59    |