### PR TITLE
LibWeb/CSS: Populate 'cached_x_samples' properly in 'CubicBezier::evaluate_at'

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
@@ -287,11 +287,11 @@ double EasingStyleValue::CubicBezier::evaluate_at(double input_progress, bool) c
         }))
         return found->y;
 
-    if (nearby_index == m_cached_x_samples.size() || nearby_index + 1 == m_cached_x_samples.size()) {
+    if (nearby_index + 1 >= m_cached_x_samples.size()) {
         // Produce more samples until we have enough.
         auto last_t = m_cached_x_samples.last().t;
         auto last_x = m_cached_x_samples.last().x;
-        while (last_x <= x && last_t < 1.0) {
+        while (last_x <= x || last_t < 1.0) {
             last_t += 1. / 60.;
             auto solution = solve(last_t);
             m_cached_x_samples.append(solution);

--- a/Tests/LibWeb/Text/expected/css/cubic-bezier-infinite-slope-reverse-crash.txt
+++ b/Tests/LibWeb/Text/expected/css/cubic-bezier-infinite-slope-reverse-crash.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/css/cubic-bezier-infinite-slope-reverse-crash.html
+++ b/Tests/LibWeb/Text/input/css/cubic-bezier-infinite-slope-reverse-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<style>
+    #foo {
+        animation-name: move;
+        animation-duration: 2s;
+        animation-timing-function: cubic-bezier(0.8, 0, 1, 1);
+        animation-iteration-count: 0.1;
+        animation-direction: reverse;
+    }
+
+    @keyframes move {}
+</style>
+<div id="foo"></div>
+<script src="../include.js"></script>
+<script>
+    asyncTest(async (done) => {
+        const foo = document.getElementById("foo");
+        const anim = foo.getAnimations()[0];
+        anim.onfinish = function () {
+            println("PASS! (Didn't crash)");
+            done();
+        };
+        anim.play();
+    });
+</script>


### PR DESCRIPTION
When we populate 'm_cached_x_samples' the last value might be less than 1.0, which leads to a crash when 'input_progress == 1' since the binary search populate 'nearby_index' with the index of the last element in 'm_cached_x_samples' and when we try to linearly interpolate between 'm_cached_x_samples[nearby_index]' and m_cached_x_samples[nearby_index + 2] we crash because of an index out of bounds assertion failure.

This change makes sure the loop responsible for populating 'm_cached_x_samples' reaches 'input_progress'.

This fixes the issue described in #3628