### PR TITLE
RequestServer: Enable support for the zstd Content-Encoding

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -425,7 +425,7 @@ void ConnectionFromClient::start_request(i32 request_id, ByteString const& metho
             if (!g_default_certificate_path.is_empty())
                 set_option(CURLOPT_CAINFO, g_default_certificate_path.characters());
 
-            set_option(CURLOPT_ACCEPT_ENCODING, "gzip, deflate, br");
+            set_option(CURLOPT_ACCEPT_ENCODING, "gzip, deflate, br, zstd");
             set_option(CURLOPT_URL, url.to_string().to_byte_string().characters());
             set_option(CURLOPT_PORT, url.port_or_default());
             set_option(CURLOPT_CONNECTTIMEOUT, s_connect_timeout_seconds);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,7 +11,8 @@
         "brotli",
         "http2",
         "openssl",
-        "websockets"
+        "websockets",
+        "zstd"
       ]
     },
     {


### PR DESCRIPTION
This is done by enabling the zstd feature with the curl package, then reporting that we support zstd in Accept-Encoding.

This is used on https://www.facebook.com/.