### PR TITLE
LibWeb/CSS: Move custom-ident blacklists into Properties.json

### DIFF
--- a/Documentation/CSSGeneratedFiles.md
+++ b/Documentation/CSSGeneratedFiles.md
@@ -72,6 +72,7 @@ The `valid-types` array lists the names of CSS value types, as defined in the la
 [CSS Values and Units spec](https://www.w3.org/TR/css-values/), without the `<>` around them.
 For numeric types, we use the [bracketed range notation](https://www.w3.org/TR/css-values-4/#css-bracketed-range-notation),
 for example `width` can take any non-negative length, so it has `"length [0,∞]"` in its `valid-types` array.
+For `<custom-ident>`s, the excluded identifiers are placed within `![]`, for example `"custom-ident ![all,none]"`.
 
 ## Keywords.json
 

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1602,12 +1602,8 @@ MixBlendMode ComputedProperties::mix_blend_mode() const
 Optional<FlyString> ComputedProperties::view_transition_name() const
 {
     auto const& value = property(PropertyID::ViewTransitionName);
-    if (value.is_custom_ident()) {
-        auto ident = value.as_custom_ident().custom_ident();
-        if (ident == "none"_fly_string)
-            return {};
-        return ident;
-    }
+    if (value.is_custom_ident())
+        return value.as_custom_ident().custom_ident();
     return {};
 }
 

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -404,7 +404,6 @@ private:
     RefPtr<CSSStyleValue> parse_transition_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_translate_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_scale_value(TokenStream<ComponentValue>&);
-    RefPtr<CSSStyleValue> parse_view_transition_name_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_grid_track_size_list(TokenStream<ComponentValue>&, bool allow_separate_line_name_blocks = false);
     RefPtr<CSSStyleValue> parse_grid_auto_track_sizes(TokenStream<ComponentValue>&);
     RefPtr<GridAutoFlowStyleValue> parse_grid_auto_flow_value(TokenStream<ComponentValue>&);

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -293,7 +293,7 @@ private:
     Optional<PropertyAndValue> parse_css_value_for_properties(ReadonlySpan<PropertyID>, TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_builtin_value(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_calculated_value(ComponentValue const&);
-    RefPtr<CustomIdentStyleValue> parse_custom_ident_value(TokenStream<ComponentValue>&, std::initializer_list<StringView> blacklist);
+    RefPtr<CustomIdentStyleValue> parse_custom_ident_value(TokenStream<ComponentValue>&, ReadonlySpan<StringView> blacklist);
     // NOTE: Implemented in generated code. (GenerateCSSMathFunctions.cpp)
     RefPtr<CalculationNode> parse_math_function(Function const&, CalculationContext const&);
     RefPtr<CalculationNode> parse_a_calc_function_node(Function const&, CalculationContext const&);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -839,7 +839,7 @@ RefPtr<CSSStyleValue> Parser::parse_color_scheme_value(TokenStream<ComponentValu
 
         // The 'normal', 'light', 'dark', and 'only' keywords are not valid <custom-ident>s in this property.
         // Note: only 'normal' is blacklisted here because 'light' and 'dark' aren't parsed differently and 'only' is checked for afterwards
-        auto ident = parse_custom_ident_value(tokens, { "normal"sv });
+        auto ident = parse_custom_ident_value(tokens, { { "normal"sv } });
         if (!ident)
             return {};
 
@@ -4452,7 +4452,7 @@ RefPtr<CSSStyleValue> Parser::parse_view_transition_name_value(TokenStream<Compo
 
         // The values 'none' and 'auto' are excluded from <custom-ident> here.
         // Note: Only auto is excluded here since none isn't parsed differently.
-        auto ident = parse_custom_ident_value(tokens, { "auto"sv });
+        auto ident = parse_custom_ident_value(tokens, { { "auto"sv } });
         if (!ident)
             return {};
 

--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -1796,7 +1796,7 @@ RefPtr<CSSStyleValue> Parser::parse_counter_value(TokenStream<ComponentValue>& t
         auto transaction = tokens.begin_transaction();
         tokens.discard_whitespace();
 
-        auto counter_name = parse_custom_ident_value(tokens, { "none"sv });
+        auto counter_name = parse_custom_ident_value(tokens, { { "none"sv } });
         if (!counter_name)
             return {};
 
@@ -1817,7 +1817,7 @@ RefPtr<CSSStyleValue> Parser::parse_counter_value(TokenStream<ComponentValue>& t
         auto transaction = tokens.begin_transaction();
         tokens.discard_whitespace();
 
-        auto counter_style_name = parse_custom_ident_value(tokens, { "none"sv });
+        auto counter_style_name = parse_custom_ident_value(tokens, { { "none"sv } });
         if (!counter_style_name)
             return {};
 
@@ -2812,7 +2812,7 @@ RefPtr<CSSStyleValue> Parser::parse_builtin_value(TokenStream<ComponentValue>& t
 }
 
 // https://www.w3.org/TR/css-values-4/#custom-idents
-RefPtr<CustomIdentStyleValue> Parser::parse_custom_ident_value(TokenStream<ComponentValue>& tokens, std::initializer_list<StringView> blacklist)
+RefPtr<CustomIdentStyleValue> Parser::parse_custom_ident_value(TokenStream<ComponentValue>& tokens, ReadonlySpan<StringView> blacklist)
 {
     auto transaction = tokens.begin_transaction();
     tokens.discard_whitespace();
@@ -3096,7 +3096,7 @@ RefPtr<GridTrackPlacementStyleValue> Parser::parse_grid_track_placement(TokenStr
     };
     auto parse_custom_ident = [this](auto& tokens) {
         // The <custom-ident> additionally excludes the keywords span and auto.
-        return parse_custom_ident_value(tokens, { "span"sv, "auto"sv });
+        return parse_custom_ident_value(tokens, { { "span"sv, "auto"sv } });
     };
 
     auto transaction = tokens.begin_transaction();

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -247,7 +247,7 @@
     "initial": "none",
     "valid-types": [
       "string",
-      "custom-ident"
+      "custom-ident ![none]"
     ],
     "valid-identifiers": [
       "none"
@@ -880,7 +880,15 @@
     "affects-layout": false,
     "animation-type": "discrete",
     "inherited": true,
-    "initial": "normal"
+    "initial": "normal",
+    "valid-types": [
+      "custom-ident ![normal,light,dark,only]"
+    ],
+    "valid-identifiers": [
+      "normal",
+      "light",
+      "dark"
+    ]
   },
   "column-count": {
     "animation-type": "by-computed-value",
@@ -975,7 +983,7 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
-      "custom-ident",
+      "custom-ident ![none]",
       "integer [-∞,∞]"
     ],
     "valid-identifiers": [
@@ -987,7 +995,7 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
-      "custom-ident",
+      "custom-ident ![none]",
       "integer [-∞,∞]"
     ],
     "valid-identifiers": [
@@ -999,7 +1007,7 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
-      "custom-ident",
+      "custom-ident ![none]",
       "integer [-∞,∞]"
     ],
     "valid-identifiers": [
@@ -2841,7 +2849,7 @@
     "initial": "all",
     "valid-types": [
       "string",
-      "custom-ident"
+      "custom-ident ![all,none]"
     ],
     "valid-identifiers": [
       "all",
@@ -2902,7 +2910,7 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
-      "custom-ident"
+      "custom-ident ![auto,none]"
     ],
     "valid-identifiers": [
       "none"

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -2848,7 +2848,6 @@
     "inherited": false,
     "initial": "all",
     "valid-types": [
-      "string",
       "custom-ident ![all,none]"
     ],
     "valid-identifiers": [


### PR DESCRIPTION
This eliminates the need for bespoke `view-transition-name` parsing code. This isn't the case for any other properties, but does mean that parsing `animation-name` is less reliant on the order we attempt parsing different types.