### PR TITLE
LibXML: Associate prefixed elements with the correct namespace

### DIFF
--- a/Libraries/LibWeb/XML/XMLDocumentBuilder.h
+++ b/Libraries/LibWeb/XML/XMLDocumentBuilder.h
@@ -38,15 +38,21 @@ private:
     virtual void comment(StringView data) override;
     virtual void document_end() override;
 
+    Optional<FlyString> namespace_for_element(XML::Name const& element_name);
+
     GC::Ref<DOM::Document> m_document;
     GC::Ptr<DOM::Node> m_current_node;
     XMLScriptingSupport m_scripting_support { XMLScriptingSupport::Enabled };
     bool m_has_error { false };
     StringBuilder text_builder;
-    Optional<FlyString> m_namespace;
+
+    struct NamespaceAndPrefix {
+        FlyString ns;
+        Optional<ByteString> prefix;
+    };
 
     struct NamespaceStackEntry {
-        Optional<FlyString> ns;
+        Vector<NamespaceAndPrefix, 2> namespaces;
         size_t depth;
     };
     Vector<NamespaceStackEntry, 2> m_namespace_stack;

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Document-constructor-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Document-constructor-svg.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	new Document(): interfaces
+Pass	new Document(): children
+Pass	new Document(): metadata
+Pass	new Document(): characterSet aliases

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElement-null-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElement-null-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Null test

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-dynamic-add-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-dynamic-add-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Dynamic Adding of Elements

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-dynamic-remove-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-dynamic-remove-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Dynamic Removal of Elements

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-nochild-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-nochild-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	childElementCount

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-childElementCount-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	childElementCount

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-entity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-entity.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Entity References

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-namespace-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-namespace-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	firstElementChild with namespaces

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-firstElementChild-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	firstElementChild

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-lastElementChild-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-lastElementChild-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	lastElementChild

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-nextElementSibling-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-nextElementSibling-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	nextElementSibling

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-previousElementSibling-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-previousElementSibling-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	previousElementSibling

--- a/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-siblingElement-null-svg.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/dom/nodes/Element-siblingElement-null-svg.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Null test

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Document-constructor-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Document-constructor-svg.svg
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="windows-1252"?>
+<!-- Using windows-1252 to ensure that new Document() doesn't inherit utf-8
+     from the parent document. -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:html="http://www.w3.org/1999/xhtml"
+  width="100%" height="100%" viewBox="0 0 800 600">
+<title>Document constructor</title>
+<html:script src="../../resources/testharness.js"></html:script>
+<html:script src="../../resources/testharnessreport.js"></html:script>
+<html:script><![CDATA[
+test(function() {
+  var doc = new Document();
+  assert_true(doc instanceof Node, "Should be a Node");
+  assert_true(doc instanceof Document, "Should be a Document");
+  assert_false(doc instanceof XMLDocument, "Should not be an XMLDocument");
+  assert_equals(Object.getPrototypeOf(doc), Document.prototype,
+                "Document should be the primary interface");
+}, "new Document(): interfaces")
+
+test(function() {
+  var doc = new Document();
+  assert_equals(doc.firstChild, null, "firstChild");
+  assert_equals(doc.lastChild, null, "lastChild");
+  assert_equals(doc.doctype, null, "doctype");
+  assert_equals(doc.documentElement, null, "documentElement");
+  assert_array_equals(doc.childNodes, [], "childNodes");
+}, "new Document(): children")
+
+test(function() {
+  var doc = new Document();
+  assert_equals(doc.URL, "about:blank");
+  assert_equals(doc.documentURI, "about:blank");
+  assert_equals(doc.compatMode, "CSS1Compat");
+  assert_equals(doc.characterSet, "UTF-8");
+  assert_equals(doc.contentType, "application/xml");
+  assert_equals(doc.createElement("DIV").localName, "DIV");
+}, "new Document(): metadata")
+
+test(function() {
+  var doc = new Document();
+  assert_equals(doc.characterSet, "UTF-8", "characterSet");
+  assert_equals(doc.charset, "UTF-8", "charset");
+  assert_equals(doc.inputEncoding, "UTF-8", "inputEncoding");
+}, "new Document(): characterSet aliases")
+]]></html:script>
+</svg>
+

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElement-null-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElement-null-svg.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>Null test</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of firstElementChild and lastChildElement returning null</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle" font-weight="bold">Test</text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl")
+  assert_equals(parentEl.firstElementChild, null)
+  assert_equals(parentEl.lastElementChild, null)
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-dynamic-add-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-dynamic-add-svg.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>Dynamic Adding of Elements</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of Dynamic Adding of Elements</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of this test is
+<tspan id="first_element_child" font-weight="bold">unknown.</tspan></text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var newChild = document.createElementNS("http://www.w3.org/2000/svg", "tspan");
+  parentEl.appendChild(newChild);
+  assert_equals(parentEl.childElementCount, 2)
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-dynamic-remove-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-dynamic-remove-svg.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>Dynamic Removal of Elements</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of Dynamic Removal of Elements</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of this test is
+<tspan id="first_element_child" font-weight="bold">unknown.</tspan><tspan id="last_element_child"> </tspan></text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var lec = parentEl.lastElementChild;
+  parentEl.removeChild(lec);
+  assert_equals(parentEl.childElementCount, 1)
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-nochild-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-nochild-svg.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>childElementCount</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of childElementCount with No Child Element Nodes</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle" font-weight="bold">Test</text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl")
+  assert_equals(parentEl.childElementCount, 0)
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-childElementCount-svg.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>childElementCount</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of childElementCount</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of <tspan id="first_element_child"><tspan>this</tspan> <tspan>test</tspan></tspan> is
+<tspan id="middle_element_child" font-weight="bold">unknown.</tspan>
+
+
+
+<tspan id="last_element_child" style="display:none;">fnord</tspan> </text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl")
+  assert_true("childElementCount" in parentEl)
+  assert_equals(parentEl.childElementCount, 3)
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-entity.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-entity.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"
+[
+<!ENTITY tree "<tspan id='first_element_child' font-weight='bold'>unknown.</tspan>">
+]>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>Entity References</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of Entity References</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of this test is &tree;</text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl")
+  var fec = parentEl.firstElementChild;
+  assert_true(!!fec)
+  assert_equals(fec.nodeType, 1)
+  assert_equals(fec.getAttribute("id"), "first_element_child")
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-namespace-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-namespace-svg.svg
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     xmlns:pickle="http://ns.example.org/pickle"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>firstElementChild with namespaces</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of firstElementChild with namespaces</text>
+<g id="parentEl">
+  <pickle:dill id="first_element_child"/>
+</g>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var fec = parentEl.firstElementChild;
+  assert_true(!!fec)
+  assert_equals(fec.nodeType, 1)
+  assert_equals(fec.getAttribute("id"), "first_element_child")
+  assert_equals(fec.localName, "dill")
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-firstElementChild-svg.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>firstElementChild</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of firstElementChild</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of this test is
+<tspan id="first_element_child" font-weight="bold">unknown.</tspan></text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var fec = parentEl.firstElementChild;
+  assert_true(!!fec)
+  assert_equals(fec.nodeType, 1)
+  assert_equals(fec.getAttribute("id"), "first_element_child")
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-lastElementChild-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-lastElementChild-svg.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>lastElementChild</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of lastElementChild</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of <tspan id="first_element_child">this test</tspan> is <tspan id="last_element_child" font-weight="bold">not</tspan> known.</text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var lec = parentEl.lastElementChild;
+  assert_true(!!lec)
+  assert_equals(lec.nodeType, 1)
+  assert_equals(lec.getAttribute("id"), "last_element_child")
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-nextElementSibling-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-nextElementSibling-svg.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>nextElementSibling</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of nextElementSibling</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of <tspan id="first_element_child">this test</tspan> is <tspan id="last_element_child" font-weight="bold">unknown.</tspan></text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var fec = document.getElementById("first_element_child");
+  var nes = fec.nextElementSibling;
+  assert_true(!!nes)
+  assert_equals(nes.nodeType, 1)
+  assert_equals(nes.getAttribute("id"), "last_element_child")
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-previousElementSibling-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-previousElementSibling-svg.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>previousElementSibling</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of previousElementSibling</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of <tspan id="first_element_child">this test</tspan> is
+<tspan id="middle_element_child" font-weight="bold">unknown.</tspan>
+
+
+
+<tspan id="last_element_child" display="none">fnord</tspan> </text>
+
+<h:script><![CDATA[
+test(function() {
+  var parentEl = document.getElementById("parentEl");
+  var lec = document.getElementById("last_element_child");
+  var pes = lec.previousElementSibling;
+  assert_true(!!pes)
+  assert_equals(pes.nodeType, 1)
+  assert_equals(pes.getAttribute("id"), "middle_element_child")
+})
+]]></h:script>
+</svg>

--- a/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-siblingElement-null-svg.svg
+++ b/Tests/LibWeb/Text/input/wpt-import/dom/nodes/Element-siblingElement-null-svg.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     version="1.1"
+     width="100%" height="100%" viewBox="0 0 400 400">
+<title>Null test</title>
+<h:script src="../../resources/testharness.js"/>
+<h:script src="../../resources/testharnessreport.js"/>
+
+<text x="200" y="40" font-size="25" fill="black" text-anchor="middle">Test of previousElementSibling and nextElementSibling returning null</text>
+<text id="parentEl" x="200" y="70" font-size="20" fill="black" text-anchor="middle">The result of this test is <tspan id="first_element_child" font-weight="bold">unknown.</tspan></text>
+
+<h:script><![CDATA[
+test(function() {
+  var fec = document.getElementById("first_element_child");
+  assert_equals(fec.previousElementSibling, null)
+  assert_equals(fec.nextElementSibling, null)
+})
+]]></h:script>
+</svg>


### PR DESCRIPTION
Previously, any xmlns attributes with an associated prefix were ignored.

For example, the following source:
```xml
<?xml version="1.0"?>
<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml">
    <h:script src="this-should-load.js" />
</svg>
```

wouldn't previously load because we would incorrectly assume that the prefixed script tag was an `SVGScriptElement` - and these don't have a `src` attribute.

WPT SVG tests rely on this working correctly, so previously all WPT SVG tests that used `testharness.js` would fail.

Here are the results of running: `./Meta/WPT.sh run $(./Meta/WPT.sh list-tests | grep '.svg$')`

Before:
```
Ran 577 tests finished in 41.2 seconds.
  • 135 ran as expected. 0 tests skipped.
  • 2 tests crashed unexpectedly
  • 200 tests had errors unexpectedly
  • 201 tests failed unexpectedly
  • 25 tests timed out unexpectedly
  • 17 tests had unexpected subtest results
```

After:
```
Ran 577 tests finished in 42.3 seconds.
  • 223 ran as expected. 0 tests skipped.
  • 2 tests crashed unexpectedly
  • 202 tests failed unexpectedly
  • 25 tests timed out unexpectedly
  • 131 tests had unexpected subtest results
```

This gives us at least 798 additional subtest passes :^)