### PR TITLE
LibWeb: Implement the WebSocket garbage collection rules and close them on document unload

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -3905,8 +3905,11 @@ void Document::run_unloading_cleanup_steps()
     // 1. Let window be document's relevant global object.
     auto& window = as<HTML::WindowOrWorkerGlobalScopeMixin>(HTML::relevant_global_object(*this));
 
-    // FIXME: 2. For each WebSocket object webSocket whose relevant global object is window, make disappear webSocket.
-    //            If this affected any WebSocket objects, then set document's salvageable state to false.
+    // 2. For each WebSocket object webSocket whose relevant global object is window, make disappear webSocket.
+    //    If this affected any WebSocket objects, then set document's salvageable state to false.
+    auto affected_any_web_sockets = window.make_disappear_all_web_sockets();
+    if (affected_any_web_sockets == HTML::WindowOrWorkerGlobalScopeMixin::AffectedAnyWebSockets::Yes)
+        m_salvageable = false;
 
     // FIXME: 3. For each WebTransport object transport whose relevant global object is window, run the context cleanup steps given transport.
 

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.cpp
@@ -44,6 +44,7 @@
 #include <LibWeb/WebIDL/DOMException.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 #include <LibWeb/WebIDL/Types.h>
+#include <LibWeb/WebSockets/WebSocket.h>
 
 namespace Web::HTML {
 
@@ -636,6 +637,28 @@ void WindowOrWorkerGlobalScopeMixin::forcibly_close_all_event_sources()
 {
     for (auto event_source : m_registered_event_sources)
         event_source->forcibly_close();
+}
+
+void WindowOrWorkerGlobalScopeMixin::register_web_socket(Badge<WebSockets::WebSocket>, GC::Ref<WebSockets::WebSocket> web_socket)
+{
+    m_registered_web_sockets.append(web_socket);
+}
+
+void WindowOrWorkerGlobalScopeMixin::unregister_web_socket(Badge<WebSockets::WebSocket>, GC::Ref<WebSockets::WebSocket> web_socket)
+{
+    m_registered_web_sockets.remove(web_socket);
+}
+
+WindowOrWorkerGlobalScopeMixin::AffectedAnyWebSockets WindowOrWorkerGlobalScopeMixin::make_disappear_all_web_sockets()
+{
+    auto affected_any_web_sockets = AffectedAnyWebSockets::No;
+
+    for (auto& web_socket : m_registered_web_sockets) {
+        web_socket.make_disappear();
+        affected_any_web_sockets = AffectedAnyWebSockets::Yes;
+    }
+
+    return affected_any_web_sockets;
 }
 
 // https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#run-steps-after-a-timeout

--- a/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WindowOrWorkerGlobalScope.h
@@ -18,6 +18,7 @@
 #include <LibWeb/HTML/ImageBitmap.h>
 #include <LibWeb/PerformanceTimeline/PerformanceEntry.h>
 #include <LibWeb/PerformanceTimeline/PerformanceEntryTuple.h>
+#include <LibWeb/WebSockets/WebSocket.h>
 
 namespace Web::HTML {
 
@@ -62,6 +63,15 @@ public:
     void register_event_source(Badge<EventSource>, GC::Ref<EventSource>);
     void unregister_event_source(Badge<EventSource>, GC::Ref<EventSource>);
     void forcibly_close_all_event_sources();
+
+    void register_web_socket(Badge<WebSockets::WebSocket>, GC::Ref<WebSockets::WebSocket>);
+    void unregister_web_socket(Badge<WebSockets::WebSocket>, GC::Ref<WebSockets::WebSocket>);
+
+    enum class AffectedAnyWebSockets {
+        No,
+        Yes,
+    };
+    AffectedAnyWebSockets make_disappear_all_web_sockets();
 
     void run_steps_after_a_timeout(i32 timeout, Function<void()> completion_step);
 
@@ -123,6 +133,8 @@ private:
     GC::Ptr<Crypto::Crypto> m_crypto;
 
     bool m_error_reporting_mode { false };
+
+    WebSockets::WebSocket::List m_registered_web_sockets;
 };
 
 }

--- a/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -15,7 +15,6 @@
 #include <LibWeb/Bindings/PlatformObject.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/Window.h>
 #include <LibWeb/WebIDL/ExceptionOr.h>
 
 #define ENUMERATE_WEBSOCKET_EVENT_HANDLERS(E) \
@@ -55,6 +54,8 @@ public:
     WebIDL::ExceptionOr<void> close(Optional<u16> code, Optional<String> reason);
     WebIDL::ExceptionOr<void> send(Variant<GC::Root<WebIDL::BufferSource>, GC::Root<FileAPI::Blob>, String> const& data);
 
+    void make_disappear();
+
 private:
     void on_open();
     void on_message(ByteBuffer message, bool is_text);
@@ -72,6 +73,11 @@ private:
     URL::URL m_url;
     String m_binary_type { "blob"_string };
     RefPtr<Requests::WebSocket> m_websocket;
+
+    IntrusiveListNode<WebSocket> m_list_node;
+
+public:
+    using List = IntrusiveList<&WebSocket::m_list_node>;
 };
 
 }

--- a/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -64,6 +64,8 @@ private:
     WebSocket(JS::Realm&);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void finalize() override;
+    virtual bool must_survive_garbage_collection() const override;
 
     ErrorOr<void> establish_web_socket_connection(URL::URL const& url_record, Vector<String> const& protocols, HTML::EnvironmentSettingsObject& client);
 


### PR DESCRIPTION
From the "LibWeb: Close WebSockets when document is unloaded" commit:

Previously, they would stay open for the entire WebContent lifetime,
or until the server closed the connection. This was particularly
noticeable on collaborative websites/games such as
https://jigsawpuzzles.io/, where the user using Ladybird would stick
around even after they had navigated away.