### PR TITLE
Make font-family:monospace default to 13px in magical ways

### DIFF
--- a/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1881,8 +1881,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
             }
         }
         return font_size_in_px;
-    };
-    Length::FontMetrics font_metrics { parent_font_size(), font_pixel_metrics };
+    }();
 
     if (font_size.is_keyword()) {
         auto const keyword = font_size.to_keyword();
@@ -1926,7 +1925,7 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
                     return scale;
                 return 1.0 / scale;
             };
-            font_size_in_px = parent_font_size().scale_by(math_scaling_factor());
+            font_size_in_px = parent_font_size.scale_by(math_scaling_factor());
         } else {
             // https://w3c.github.io/csswg-drafts/css-fonts/#valdef-font-size-relative-size
             // TODO: If the parent element has a keyword font size in the absolute size keyword mapping table,
@@ -1942,20 +1941,20 @@ RefPtr<Gfx::FontCascadeList const> StyleComputer::compute_font_for_style_values(
     } else {
         Length::ResolutionContext const length_resolution_context {
             .viewport_rect = viewport_rect(),
-            .font_metrics = font_metrics,
+            .font_metrics = Length::FontMetrics { parent_font_size, font_pixel_metrics },
             .root_font_metrics = m_root_element_font_metrics,
         };
 
         Optional<Length> maybe_length;
         if (font_size.is_percentage()) {
             // Percentages refer to parent element's font size
-            maybe_length = Length::make_px(CSSPixels::nearest_value_for(font_size.as_percentage().percentage().as_fraction() * parent_font_size().to_double()));
+            maybe_length = Length::make_px(CSSPixels::nearest_value_for(font_size.as_percentage().percentage().as_fraction() * parent_font_size.to_double()));
 
         } else if (font_size.is_length()) {
             maybe_length = font_size.as_length().length();
         } else if (font_size.is_calculated()) {
             maybe_length = font_size.as_calculated().resolve_length({
-                .percentage_basis = Length::make_px(parent_font_size()),
+                .percentage_basis = Length::make_px(parent_font_size),
                 .length_resolution_context = length_resolution_context,
             });
         }

--- a/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Libraries/LibWeb/CSS/StyleComputer.h
@@ -183,6 +183,8 @@ public:
     static CSSPixelFraction absolute_size_mapping(Keyword);
     RefPtr<Gfx::FontCascadeList const> compute_font_for_style_values(DOM::Element const* element, Optional<CSS::Selector::PseudoElement::Type> pseudo_element, CSSStyleValue const& font_family, CSSStyleValue const& font_size, CSSStyleValue const& font_style, CSSStyleValue const& font_weight, CSSStyleValue const& font_stretch, int math_depth = 0) const;
 
+    [[nodiscard]] RefPtr<CSSStyleValue> recascade_font_size_if_needed(DOM::Element&, Optional<CSS::Selector::PseudoElement::Type> pseudo_element, CascadedProperties&) const;
+
     void set_viewport_rect(Badge<DOM::Document>, CSSPixelRect const& viewport_rect) { m_viewport_rect = viewport_rect; }
 
     enum class AnimationRefresh {

--- a/Libraries/LibWeb/Layout/LineBuilder.cpp
+++ b/Libraries/LibWeb/Layout/LineBuilder.cpp
@@ -286,10 +286,6 @@ void LineBuilder::update_last_line()
 
             auto alphabetic_baseline = m_current_block_offset + line_box_baseline - fragment.baseline() + effective_box_top_offset;
 
-            // NOTE: Plain inline text content is always on the alphabetic baseline.
-            if (!fragment.is_atomic_inline())
-                return alphabetic_baseline;
-
             switch (vertical_align) {
             case CSS::VerticalAlign::Baseline:
                 return alphabetic_baseline;

--- a/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -81,8 +81,11 @@ static Layout::Node& insertion_parent_for_inline_node(Layout::NodeWithStyle& lay
     if (layout_parent.display().is_inline_outside() && layout_parent.display().is_flow_inside())
         return layout_parent;
 
-    if (layout_parent.display().is_flex_inside() || layout_parent.display().is_grid_inside())
+    if (layout_parent.display().is_flex_inside()
+        || layout_parent.display().is_grid_inside()
+        || layout_parent.display().is_table_cell()) {
         return last_child_creating_anonymous_wrapper_if_needed(layout_parent);
+    }
 
     if (!has_in_flow_block_children(layout_parent) || layout_parent.children_are_inline())
         return layout_parent;

--- a/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/forced-break-stops-non-whitespace-sequence.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,16) content-size 784x19 children: not-inline
-      BlockContainer <pre> at (9,17) content-size 782x17 children: inline
+    BlockContainer <body> at (8,13) content-size 784x16 children: not-inline
+      BlockContainer <pre> at (9,14) content-size 782x14 children: inline
         InlineNode <span>
-          frag 0 from TextNode start: 0, length: 1, rect: [9,17 8x17] baseline: 13.296875
+          frag 0 from TextNode start: 0, length: 1, rect: [9,14 6.5x14] baseline: 10.890625
               " "
           TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,16 784x19]
-      PaintableWithLines (BlockContainer<PRE>) [8,16 784x19]
+    PaintableWithLines (BlockContainer<BODY>) [8,13 784x16]
+      PaintableWithLines (BlockContainer<PRE>) [8,13 784x16]
         PaintableWithLines (InlineNode<SPAN>)
           TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
+++ b/Tests/LibWeb/Layout/expected/block-and-inline/relpos-inline-element-js-offsets.txt
@@ -1,6 +1,6 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x152 children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x140 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x17 children: inline
         InlineNode <span>
           frag 0 from TextNode start: 0, length: 5, rect: [8,8 36.40625x17] baseline: 13.296875
@@ -15,27 +15,27 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   "friends"
               TextNode <#text>
         TextNode <#text>
-      BlockContainer <div> at (8,25) content-size 784x135 children: not-inline
+      BlockContainer <div> at (8,25) content-size 784x123 children: not-inline
         BlockContainer <(anonymous)> at (8,25) content-size 784x68 children: inline
           BreakNode <br>
           BreakNode <br>
           BreakNode <br>
           BreakNode <br>
-        BlockContainer <pre#out> at (8,109) content-size 784x51 children: inline
-          frag 0 from TextNode start: 0, length: 10, rect: [8,109 72.203125x17] baseline: 13.296875
+        BlockContainer <pre#out> at (8,106) content-size 784x42 children: inline
+          frag 0 from TextNode start: 0, length: 10, rect: [8,106 58.640625x14] baseline: 10.890625
               "well: 8, 8"
-          frag 1 from TextNode start: 11, length: 13, rect: [8,126 95.359375x17] baseline: 13.296875
+          frag 1 from TextNode start: 11, length: 13, rect: [8,120 77.46875x14] baseline: 10.890625
               "hello: 44, 33"
-          frag 2 from TextNode start: 25, length: 15, rect: [8,143 112.953125x17] baseline: 13.296875
+          frag 2 from TextNode start: 25, length: 15, rect: [8,134 91.78125x14] baseline: 10.890625
               "friends: 44, 25"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,176) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,161) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x152]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x140]
       PaintableWithLines (BlockContainer(anonymous)) [8,8 784x17]
         PaintableWithLines (InlineNode<SPAN>)
           TextPaintable (TextNode<#text>)
@@ -43,8 +43,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             TextPaintable (TextNode<#text>)
             PaintableWithLines (InlineNode<I>)
               TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer<DIV>) [8,25 784x135]
+      PaintableWithLines (BlockContainer<DIV>) [8,25 784x123]
         PaintableWithLines (BlockContainer(anonymous)) [8,25 784x68]
-        PaintableWithLines (BlockContainer<PRE>#out) [8,109 784x51]
+        PaintableWithLines (BlockContainer<PRE>#out) [8,106 784x42]
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,176 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,161 784x0]

--- a/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
+++ b/Tests/LibWeb/Layout/expected/css-table-cell-verticalalign-text-top.txt
@@ -13,10 +13,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 204x100 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 200x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 15, rect: [10,10 129.296875x17] baseline: 13.296875
-                    "Text at the top"
-                TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 200x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (10,10) content-size 200x17 children: inline
+                  frag 0 from TextNode start: 0, length: 15, rect: [10,10 129.296875x17] baseline: 13.296875
+                      "Text at the top"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,5 +35,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 204x100]
             PaintableBox (Box<TR>) [8,8 204x100]
               PaintableWithLines (BlockContainer<TD>) [8,8 204x100]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [10,10 200x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,108 784x0]

--- a/Tests/LibWeb/Layout/expected/font-family-monospace-quirk.txt
+++ b/Tests/LibWeb/Layout/expected/font-family-monospace-quirk.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x235 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x219 children: not-inline
+      BlockContainer <(anonymous)> at (8,8) content-size 784x35 children: inline
+        frag 0 from TextNode start: 0, length: 3, rect: [8,8 55.40625x35] baseline: 27.09375
+            "abc"
+        TextNode <#text>
+      BlockContainer <main> at (8,43) content-size 784x184 children: not-inline
+        BlockContainer <(anonymous)> at (8,43) content-size 784x70 children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,43 92.0625x70] baseline: 54.1875
+              "def"
+          TextNode <#text>
+        BlockContainer <article> at (8,113) content-size 784x114 children: not-inline
+          BlockContainer <(anonymous)> at (8,113) content-size 784x57 children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [8,113 69.625x57] baseline: 44.09375
+                "ghi"
+            TextNode <#text>
+          BlockContainer <div> at (8,170) content-size 784x57 children: inline
+            frag 0 from TextNode start: 0, length: 3, rect: [8,170 59.828125x57] baseline: 44.09375
+                "jkl"
+            TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x235]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x219]
+      PaintableWithLines (BlockContainer(anonymous)) [8,8 784x35]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer<MAIN>) [8,43 784x184]
+        PaintableWithLines (BlockContainer(anonymous)) [8,43 784x70]
+          TextPaintable (TextNode<#text>)
+        PaintableWithLines (BlockContainer<ARTICLE>) [8,113 784x114]
+          PaintableWithLines (BlockContainer(anonymous)) [8,113 784x57]
+            TextPaintable (TextNode<#text>)
+          PaintableWithLines (BlockContainer<DIV>) [8,170 784x57]
+            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
+++ b/Tests/LibWeb/Layout/expected/grid/floating-table-wrapper-width.txt
@@ -11,14 +11,16 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <table.middle> at (15.34375,9) content-size 154.796875x25 table-box [TFC] children: not-inline
               Box <tbody> at (17.34375,11) content-size 150.796875x21 table-row-group children: not-inline
                 Box <tr> at (17.34375,11) content-size 150.796875x21 table-row children: not-inline
-                  BlockContainer <td> at (19.34375,13) content-size 69.59375x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x17] baseline: 13.296875
-                        "2"
-                    TextNode <#text>
-                  BlockContainer <td> at (94.9375,13) content-size 71.203125x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x17] baseline: 13.296875
-                        "3"
-                    TextNode <#text>
+                  BlockContainer <td> at (19.34375,13) content-size 69.59375x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (19.34375,13) content-size 69.59375x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [19.34375,13 8.8125x17] baseline: 13.296875
+                          "2"
+                      TextNode <#text>
+                  BlockContainer <td> at (94.9375,13) content-size 71.203125x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (94.9375,13) content-size 71.203125x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [94.9375,13 9.09375x17] baseline: 13.296875
+                          "3"
+                      TextNode <#text>
           BlockContainer <div.right> at (171.140625,8) content-size 7.75x17 floating [BFC] children: inline
             frag 0 from TextNode start: 0, length: 1, rect: [171.140625,8 7.75x17] baseline: 13.296875
                 "4"
@@ -38,9 +40,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableBox (Box<TBODY>) [17.34375,11 150.796875x21]
                 PaintableBox (Box<TR>) [17.34375,11 150.796875x21]
                   PaintableWithLines (BlockContainer<TD>) [17.34375,11 73.59375x21]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [19.34375,13 69.59375x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [92.9375,11 75.203125x21]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [94.9375,13 71.203125x17]
+                      TextPaintable (TextNode<#text>)
           PaintableWithLines (BlockContainer<DIV>.right) [171.140625,8 7.75x17]
             TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,35 784x0]

--- a/Tests/LibWeb/Layout/expected/pre.txt
+++ b/Tests/LibWeb/Layout/expected/pre.txt
@@ -2,7 +2,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x17 children: inline
       InlineNode <pre>
-        frag 0 from TextNode start: 0, length: 3, rect: [9,8 19.875x17] baseline: 13.296875
+        frag 0 from TextNode start: 0, length: 3, rect: [9,10 16.15625x14] baseline: 10.890625
             " | "
         TextNode <#text>
       TextNode <#text>

--- a/Tests/LibWeb/Layout/expected/tab-size-chars-should-vertically-align.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-chars-should-vertically-align.txt
@@ -1,52 +1,52 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x84 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x68 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x17 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,21 60x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [68,8 82.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x72 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x56 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x14 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,18 48x0] baseline: 0
+        frag 1 from TextNode start: 0, length: 2, rect: [56,8 15.59375x14] baseline: 10.890625
             "	A"
-        BlockContainer <span#s1> at (8,21) content-size 60x0 inline-block [BFC] children: not-inline
+        BlockContainer <span#s1> at (8,18) content-size 48x0 inline-block [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,22) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,25) content-size 784x17 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,38 70x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [78,25 72.265625x17] baseline: 13.296875
+      BlockContainer <div> at (8,22) content-size 784x14 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,32 56x0] baseline: 0
+        frag 1 from TextNode start: 0, length: 2, rect: [64,22 59.59375x14] baseline: 10.890625
             "	A"
-        BlockContainer <span#s2> at (8,38) content-size 70x0 inline-block [BFC] children: not-inline
+        BlockContainer <span#s2> at (8,32) content-size 56x0 inline-block [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,42) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,36) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,42) content-size 784x17 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,55 73x0] baseline: 0
-        frag 1 from TextNode start: 0, length: 2, rect: [81,42 69.265625x17] baseline: 13.296875
+      BlockContainer <div> at (8,36) content-size 784x14 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,46 58.40625x0] baseline: 0
+        frag 1 from TextNode start: 0, length: 2, rect: [66.40625,36 57.1875x14] baseline: 10.890625
             "	A"
-        BlockContainer <span#s3> at (8,55) content-size 73x0 inline-block [BFC] children: not-inline
+        BlockContainer <span#s3> at (8,46) content-size 58.40625x0 inline-block [BFC] children: not-inline
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,50) content-size 784x0 children: inline
         TextNode <#text>
-      BlockContainer <div> at (8,59) content-size 784x17 children: inline
-        frag 0 from TextNode start: 0, length: 9, rect: [8,59 78.265625x17] baseline: 13.296875
+      BlockContainer <div> at (8,50) content-size 784x14 children: inline
+        frag 0 from TextNode start: 0, length: 9, rect: [8,50 63.59375x14] baseline: 10.890625
             "        A"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,76) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,64) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x84]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x68]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
-        PaintableWithLines (BlockContainer<SPAN>#s1) [8,21 60x0]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x72]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x56]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x14]
+        PaintableWithLines (BlockContainer<SPAN>#s1) [8,18 48x0]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,25 784x17]
-        PaintableWithLines (BlockContainer<SPAN>#s2) [8,38 70x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,22 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,22 784x14]
+        PaintableWithLines (BlockContainer<SPAN>#s2) [8,32 56x0]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,42 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,42 784x17]
-        PaintableWithLines (BlockContainer<SPAN>#s3) [8,55 73x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,36 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,36 784x14]
+        PaintableWithLines (BlockContainer<SPAN>#s3) [8,46 58.40625x0]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,59 784x0]
-      PaintableWithLines (BlockContainer<DIV>) [8,59 784x17]
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,50 784x14]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,76 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,64 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-letter-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-letter-spacing.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 1, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x30 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x14 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x14 children: inline
+        frag 0 from TextNode start: 1, length: 1, rect: [8,8 11.59375x14] baseline: 10.890625
             "A"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,22) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x14]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x14]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,22 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-text-wrap.txt
@@ -1,33 +1,33 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x67 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x51 children: not-inline
-      BlockContainer <div> at (8,8) content-size 100x51 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 114.265625x17] baseline: 13.296875
-        frag 1 from BlockContainer start: 0, length: 0, rect: [8,25 123.609375x17] baseline: 13.296875
-        frag 2 from BlockContainer start: 0, length: 0, rect: [8,42 133.921875x17] baseline: 13.296875
-        BlockContainer <span> at (8,8) content-size 114.265625x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 2, rect: [8,8 114.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x58 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x42 children: not-inline
+      BlockContainer <div> at (8,8) content-size 100x42 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [8,8 111.59375x14] baseline: 10.890625
+        frag 1 from BlockContainer start: 0, length: 0, rect: [8,22 119.1875x14] baseline: 10.890625
+        frag 2 from BlockContainer start: 0, length: 0, rect: [8,36 127.5625x14] baseline: 10.890625
+        BlockContainer <span> at (8,8) content-size 111.59375x14 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 2, rect: [8,8 111.59375x14] baseline: 10.890625
               "	A"
           TextNode <#text>
-        BlockContainer <span> at (8,25) content-size 123.609375x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 3, rect: [8,25 123.609375x17] baseline: 13.296875
+        BlockContainer <span> at (8,22) content-size 119.1875x14 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 3, rect: [8,22 119.1875x14] baseline: 10.890625
               "	AB"
           TextNode <#text>
-        BlockContainer <span> at (8,42) content-size 133.921875x17 inline-block [BFC] children: inline
-          frag 0 from TextNode start: 0, length: 4, rect: [8,42 133.921875x17] baseline: 13.296875
+        BlockContainer <span> at (8,36) content-size 127.5625x14 inline-block [BFC] children: inline
+          frag 0 from TextNode start: 0, length: 4, rect: [8,36 127.5625x14] baseline: 10.890625
               "	ABC"
           TextNode <#text>
-      BlockContainer <(anonymous)> at (8,59) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,50) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x67]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x51]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 100x51] overflow: [8,8 133.921875x51]
-        PaintableWithLines (BlockContainer<SPAN>) [8,8 114.265625x17]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x58]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x42]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 100x42] overflow: [8,8 127.5625x42]
+        PaintableWithLines (BlockContainer<SPAN>) [8,8 111.59375x14]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<SPAN>) [8,25 123.609375x17]
+        PaintableWithLines (BlockContainer<SPAN>) [8,22 119.1875x14]
           TextPaintable (TextNode<#text>)
-        PaintableWithLines (BlockContainer<SPAN>) [8,42 133.921875x17]
+        PaintableWithLines (BlockContainer<SPAN>) [8,36 127.5625x14]
           TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,59 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,50 784x0]

--- a/Tests/LibWeb/Layout/expected/tab-size-word-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/tab-size-word-spacing.txt
@@ -1,16 +1,16 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
-  BlockContainer <html> at (0,0) content-size 800x33 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x17 children: not-inline
-      BlockContainer <div> at (8,8) content-size 784x17 children: inline
-        frag 0 from TextNode start: 1, length: 1, rect: [8,8 14.265625x17] baseline: 13.296875
+  BlockContainer <html> at (0,0) content-size 800x30 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x14 children: not-inline
+      BlockContainer <div> at (8,8) content-size 784x14 children: inline
+        frag 0 from TextNode start: 1, length: 1, rect: [8,8 11.59375x14] baseline: 10.890625
             "A"
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,25) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,22) content-size 784x0 children: inline
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
-  PaintableWithLines (BlockContainer<HTML>) [0,0 800x33]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x17]
-      PaintableWithLines (BlockContainer<DIV>) [8,8 784x17]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x30]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x14]
+      PaintableWithLines (BlockContainer<DIV>) [8,8 784x14]
         TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,25 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,22 784x0]

--- a/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table-fixup-with-rowspan.txt
@@ -5,19 +5,22 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 27.90625x46 table-box [TFC] children: not-inline
           Box <tbody> at (10,10) content-size 23.90625x42 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 23.90625x19 table-row children: not-inline
-              BlockContainer <td> at (11,11) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
-              BlockContainer <td> at (24.09375,22.5) content-size 8.8125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [24.09375,22.5 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
+              BlockContainer <td> at (24.09375,22.5) content-size 8.8125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (24.09375,22.5) content-size 8.8125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [24.09375,22.5 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
             Box <tr> at (10,31) content-size 23.90625x19 table-row children: not-inline
-              BlockContainer <td> at (11,32) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [11,32 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,32 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
             Box <tr> at (10,52) content-size 23.90625x0 table-row children: not-inline
               BlockContainer <(anonymous)> at (10,52) content-size 11.09375x0 table-cell [BFC] children: not-inline
       BlockContainer <(anonymous)> at (8,54) content-size 784x0 children: inline
@@ -31,12 +34,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 23.90625x42]
             PaintableBox (Box<TR>) [10,10 23.90625x19]
               PaintableWithLines (BlockContainer<TD>) [10,10 11.09375x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 9.09375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [23.09375,10 10.8125x42]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [24.09375,22.5 8.8125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,31 23.90625x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 11.09375x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,52 23.90625x0]
               PaintableWithLines (BlockContainer(anonymous)) [10,52 11.09375x0]
       PaintableWithLines (BlockContainer(anonymous)) [8,54 784x0]

--- a/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
+++ b/Tests/LibWeb/Layout/expected/table/align-top-and-bottom.txt
@@ -9,22 +9,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 198.328125x49 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,25) content-size 32.078125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x17] baseline: 13.296875
-                    "Top"
-                TextNode <#text>
+              BlockContainer <td> at (25,25) content-size 32.078125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (25,25) content-size 32.078125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [25,25 32.078125x17] baseline: 13.296875
+                      "Top"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (89.078125,74) content-size 55.984375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [89.078125,74 55.984375x17] baseline: 13.296875
-                    "Bottom"
-                TextNode <#text>
+              BlockContainer <td> at (89.078125,74) content-size 55.984375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (89.078125,74) content-size 55.984375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [89.078125,74 55.984375x17] baseline: 13.296875
+                      "Bottom"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (177.0625,25) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (177.0625,25) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (177.0625,25) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,25 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,10 +35,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,58) content-size 198.328125x49 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (177.0625,74) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [177.0625,74 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (177.0625,74) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (177.0625,74) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [177.0625,74 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -49,11 +53,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 198.328125x98]
             PaintableBox (Box<TR>) [9,9 198.328125x49]
               PaintableWithLines (BlockContainer<TD>) [9,9 64.078125x98]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [25,25 32.078125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [73.078125,9 87.984375x98]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [89.078125,74 55.984375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [161.0625,9 46.265625x49]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [177.0625,25 14.265625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,58 198.328125x49]
               PaintableWithLines (BlockContainer<TD>) [161.0625,58 46.265625x49]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [177.0625,74 14.265625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/auto-height.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-height.txt
@@ -5,18 +5,20 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (11,11) content-size 29.15625x19 [BFC] children: not-inline
           Box <(anonymous)> at (11,11) content-size 29.15625x19 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,11) content-size 29.15625x19 table-row children: not-inline
-              BlockContainer <span> at (12,12) content-size 27.15625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x17] baseline: 13.296875
-                    "foo"
-                TextNode <#text>
+              BlockContainer <span> at (12,12) content-size 27.15625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (12,12) content-size 27.15625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 27.15625x17] baseline: 13.296875
+                      "foo"
+                  TextNode <#text>
       BlockContainer <div> at (11,32) content-size 778x19 children: not-inline
         TableWrapper <(anonymous)> at (11,32) content-size 29.640625x19 [BFC] children: not-inline
           Box <(anonymous)> at (11,32) content-size 29.640625x19 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,32) content-size 29.640625x19 table-row children: not-inline
-              BlockContainer <span> at (12,33) content-size 27.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [12,33 27.640625x17] baseline: 13.296875
-                    "bar"
-                TextNode <#text>
+              BlockContainer <span> at (12,33) content-size 27.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (12,33) content-size 27.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [12,33 27.640625x17] baseline: 13.296875
+                      "bar"
+                  TextNode <#text>
       BlockContainer <(anonymous)> at (10,52) content-size 780x0 children: inline
         TextNode <#text>
 
@@ -28,11 +30,13 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box(anonymous)) [11,11 29.15625x19]
             PaintableBox (Box(anonymous)) [11,11 29.15625x19]
               PaintableWithLines (BlockContainer<SPAN>) [11,11 29.15625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [12,12 27.15625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>) [10,31 780x21]
         PaintableWithLines (TableWrapper(anonymous)) [11,32 29.640625x19]
           PaintableBox (Box(anonymous)) [11,32 29.640625x19]
             PaintableBox (Box(anonymous)) [11,32 29.640625x19]
               PaintableWithLines (BlockContainer<SPAN>) [11,32 29.640625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [12,33 27.640625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [10,52 780x0]

--- a/Tests/LibWeb/Layout/expected/table/auto-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/auto-margins.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (235.265625,8) content-size 329.46875x17 [BFC] children: not-inline
           Box <div.box> at (235.265625,8) content-size 329.46875x17 table-box [TFC] children: not-inline
             Box <(anonymous)> at (235.265625,8) content-size 329.46875x17 table-row children: not-inline
-              BlockContainer <div.cell> at (235.265625,8) content-size 329.46875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x17] baseline: 13.296875
-                    "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
-                TextNode <#text>
+              BlockContainer <div.cell> at (235.265625,8) content-size 329.46875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (235.265625,8) content-size 329.46875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 34, rect: [235.265625,8 329.46875x17] baseline: 13.296875
+                      "DaTa DisplaYiNg CSS WeBpaGE ScReEn"
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -18,4 +19,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<DIV>.box) [235.265625,8 329.46875x17]
             PaintableBox (Box(anonymous)) [235.265625,8 329.46875x17]
               PaintableWithLines (BlockContainer<DIV>.cell) [235.265625,8 329.46875x17]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [235.265625,8 329.46875x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
+++ b/Tests/LibWeb/Layout/expected/table/avoid-div-by-zero-in-table-measures.txt
@@ -11,10 +11,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 2x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 0x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 0x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 0x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -25,9 +26,10 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
     PaintableWithLines (BlockContainer<BODY>) [8,8 784x23]
-      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x23] overflow: [8,8 17.265625x23]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 6x23]
         PaintableBox (Box<TABLE>) [8,8 6x23]
           PaintableBox (Box<TBODY>) [10,10 2x19]
             PaintableBox (Box<TR>) [10,10 2x19]
-              PaintableWithLines (BlockContainer<TD>) [10,10 2x19] overflow: [10,10 15.265625x20]
-                TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer<TD>) [10,10 2x19]
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 0x17] overflow: [11,11 14.265625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/basic.txt
+++ b/Tests/LibWeb/Layout/expected/table/basic.txt
@@ -22,10 +22,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,29) content-size 95.171875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,30) content-size 93.171875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [11,30 73.65625x17] baseline: 13.296875
-                    "Head Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,30) content-size 93.171875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,30) content-size 93.171875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,30 73.65625x17] baseline: 13.296875
+                      "Head Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,10 +39,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,50) content-size 95.171875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,51) content-size 93.171875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [11,51 70.234375x17] baseline: 13.296875
-                    "Body Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,51) content-size 93.171875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,51) content-size 93.171875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,51 70.234375x17] baseline: 13.296875
+                      "Body Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -54,10 +56,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,71) content-size 95.171875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,72) content-size 93.171875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 11, rect: [11,72 93.171875x17] baseline: 13.296875
-                    "Footer Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,72) content-size 93.171875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,72) content-size 93.171875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 11, rect: [11,72 93.171875x17] baseline: 13.296875
+                      "Footer Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -80,13 +83,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [10,29 95.171875x19]
             PaintableBox (Box<TR>) [10,29 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,29 95.171875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,30 93.171875x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>) [10,50 95.171875x19]
             PaintableBox (Box<TR>) [10,50 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,50 95.171875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,51 93.171875x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TFOOT>) [10,71 95.171875x19]
             PaintableBox (Box<TR>) [10,71 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,71 95.171875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,72 93.171875x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,109 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute-overridden-by-css.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (18,18) content-size 22.265625x25 table-box [TFC] children: not-inline
           Box <tbody> at (20,20) content-size 18.265625x21 table-row-group children: not-inline
             Box <tr> at (20,20) content-size 18.265625x21 table-row children: not-inline
-              BlockContainer <td> at (22,22) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (22,22) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (22,22) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [22,22 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -18,4 +19,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [20,20 18.265625x21]
             PaintableBox (Box<TR>) [20,20 18.265625x21]
               PaintableWithLines (BlockContainer<TD>) [20,20 18.265625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [22,22 14.265625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-attribute.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-attribute.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (13,13) content-size 22.265625x25 table-box [TFC] children: not-inline
           Box <tbody> at (15,15) content-size 18.265625x21 table-row-group children: not-inline
             Box <tr> at (15,15) content-size 18.265625x21 table-row children: not-inline
-              BlockContainer <td> at (17,17) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (17,17) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (17,17) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,17 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -18,4 +19,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [15,15 18.265625x21]
             PaintableBox (Box<TR>) [15,15 18.265625x21]
               PaintableWithLines (BlockContainer<TD>) [15,15 18.265625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [17,17 14.265625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-collapse-is-inherited.txt
@@ -6,7 +6,7 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       BlockContainer <(anonymous)> at (8,8) content-size 784x0 children: inline
         TextNode <#text>
       BlockContainer <div.horizontal> at (8,8) content-size 784x197 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 161.90625x195] baseline: 13.796875
+        frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 161.90625x195] baseline: 14.296875
         TextNode <#text>
         BlockContainer <table> at (9,9) content-size 161.90625x195 inline-block [BFC] children: not-inline
           BlockContainer <(anonymous)> at (9,9) content-size 161.90625x0 children: inline
@@ -19,22 +19,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,9) content-size 161.90625x39 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,20) content-size 14.265625x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x17] baseline: 13.296875
-                        "A"
-                    TextNode <#text>
+                  BlockContainer <td> at (30,20) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (30,20) content-size 14.265625x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [30,20 14.265625x17] baseline: 13.296875
+                          "A"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,20) content-size 12.546875x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [87.859375,20 9.34375x17] baseline: 13.296875
-                        "B"
-                    TextNode <#text>
+                  BlockContainer <td> at (86.265625,20) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (86.265625,20) content-size 12.546875x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [87.859375,20 9.34375x17] baseline: 13.296875
+                          "B"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,20) content-size 9.09375x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [142.1875,20 6.34375x17] baseline: 13.296875
-                        "1"
-                    TextNode <#text>
+                  BlockContainer <td> at (140.8125,20) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (140.8125,20) content-size 9.09375x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [142.1875,20 6.34375x17] baseline: 13.296875
+                          "1"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,22 +45,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,48) content-size 161.90625x39 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,59) content-size 14.265625x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [31.96875,59 10.3125x17] baseline: 13.296875
-                        "C"
-                    TextNode <#text>
+                  BlockContainer <td> at (30,59) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (30,59) content-size 14.265625x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [31.96875,59 10.3125x17] baseline: 13.296875
+                          "C"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,59) content-size 12.546875x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [86.96875,59 11.140625x17] baseline: 13.296875
-                        "D"
-                    TextNode <#text>
+                  BlockContainer <td> at (86.265625,59) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (86.265625,59) content-size 12.546875x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.96875,59 11.140625x17] baseline: 13.296875
+                          "D"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,59) content-size 9.09375x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [140.953125,59 8.8125x17] baseline: 13.296875
-                        "2"
-                    TextNode <#text>
+                  BlockContainer <td> at (140.8125,59) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (140.8125,59) content-size 9.09375x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [140.953125,59 8.8125x17] baseline: 13.296875
+                          "2"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,22 +71,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,87) content-size 161.90625x39 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,98) content-size 14.265625x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [31.203125,98 11.859375x17] baseline: 13.296875
-                        "E"
-                    TextNode <#text>
+                  BlockContainer <td> at (30,98) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (30,98) content-size 14.265625x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [31.203125,98 11.859375x17] baseline: 13.296875
+                          "E"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,98) content-size 12.546875x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [86.265625,98 12.546875x17] baseline: 13.296875
-                        "F"
-                    TextNode <#text>
+                  BlockContainer <td> at (86.265625,98) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (86.265625,98) content-size 12.546875x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.265625,98 12.546875x17] baseline: 13.296875
+                          "F"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,98) content-size 9.09375x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [140.8125,98 9.09375x17] baseline: 13.296875
-                        "3"
-                    TextNode <#text>
+                  BlockContainer <td> at (140.8125,98) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (140.8125,98) content-size 9.09375x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [140.8125,98 9.09375x17] baseline: 13.296875
+                          "3"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -88,22 +97,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,126) content-size 161.90625x39 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,137) content-size 14.265625x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [30.515625,137 13.234375x17] baseline: 13.296875
-                        "G"
-                    TextNode <#text>
+                  BlockContainer <td> at (30,137) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (30,137) content-size 14.265625x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [30.515625,137 13.234375x17] baseline: 13.296875
+                          "G"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,137) content-size 12.546875x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [86.421875,137 12.234375x17] baseline: 13.296875
-                        "H"
-                    TextNode <#text>
+                  BlockContainer <td> at (86.265625,137) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (86.265625,137) content-size 12.546875x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [86.421875,137 12.234375x17] baseline: 13.296875
+                          "H"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,137) content-size 9.09375x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [141.484375,137 7.75x17] baseline: 13.296875
-                        "4"
-                    TextNode <#text>
+                  BlockContainer <td> at (140.8125,137) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (140.8125,137) content-size 9.09375x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [141.484375,137 7.75x17] baseline: 13.296875
+                          "4"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
@@ -111,22 +123,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                 Box <tr> at (9,165) content-size 161.90625x39 table-row children: not-inline
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (30,176) content-size 14.265625x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [34.828125,176 4.59375x17] baseline: 13.296875
-                        "I"
-                    TextNode <#text>
+                  BlockContainer <td> at (30,176) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (30,176) content-size 14.265625x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [34.828125,176 4.59375x17] baseline: 13.296875
+                          "I"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (86.265625,176) content-size 12.546875x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [88.078125,176 8.90625x17] baseline: 13.296875
-                        "J"
-                    TextNode <#text>
+                  BlockContainer <td> at (86.265625,176) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (86.265625,176) content-size 12.546875x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [88.078125,176 8.90625x17] baseline: 13.296875
+                          "J"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> (not painted) children: inline
                     TextNode <#text>
-                  BlockContainer <td> at (140.8125,176) content-size 9.09375x17 table-cell [BFC] children: inline
-                    frag 0 from TextNode start: 0, length: 1, rect: [141.125,176 8.453125x17] baseline: 13.296875
-                        "5"
-                    TextNode <#text>
+                  BlockContainer <td> at (140.8125,176) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                    BlockContainer <(anonymous)> at (140.8125,176) content-size 9.09375x17 children: inline
+                      frag 0 from TextNode start: 0, length: 1, rect: [141.125,176 8.453125x17] baseline: 13.296875
+                          "5"
+                      TextNode <#text>
                   BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
                     TextNode <#text>
                 BlockContainer <(anonymous)> at (9,9) content-size 0x0 children: inline
@@ -150,39 +165,54 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableBox (Box<TBODY>) [9,9 161.90625x195]
                 PaintableBox (Box<TR>) [9,9 161.90625x39]
                   PaintableWithLines (BlockContainer<TD>) [9,9 56.265625x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [30,20 14.265625x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,9 54.546875x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,20 12.546875x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,9 51.09375x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,20 9.09375x17]
+                      TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,48 161.90625x39]
                   PaintableWithLines (BlockContainer<TD>) [9,48 56.265625x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [30,59 14.265625x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,48 54.546875x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,59 12.546875x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,48 51.09375x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,59 9.09375x17]
+                      TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,87 161.90625x39]
                   PaintableWithLines (BlockContainer<TD>) [9,87 56.265625x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [30,98 14.265625x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,87 54.546875x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,98 12.546875x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,87 51.09375x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,98 9.09375x17]
+                      TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,126 161.90625x39]
                   PaintableWithLines (BlockContainer<TD>) [9,126 56.265625x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [30,137 14.265625x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,126 54.546875x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,137 12.546875x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,126 51.09375x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,137 9.09375x17]
+                      TextPaintable (TextNode<#text>)
                 PaintableBox (Box<TR>) [9,165 161.90625x39]
                   PaintableWithLines (BlockContainer<TD>) [9,165 56.265625x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [30,176 14.265625x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [65.265625,165 54.546875x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [86.265625,176 12.546875x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer<TD>) [119.8125,165 51.09375x39]
-                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (BlockContainer(anonymous)) [140.8125,176 9.09375x17]
+                      TextPaintable (TextNode<#text>)
                   PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
                 PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]
               PaintableWithLines (BlockContainer(anonymous)) [9,9 0x0]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-cell.txt
@@ -11,22 +11,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 172.671875x43 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,21) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (29,21) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (29,21) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [29,21 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td.td-thick-border> at (89.265625,21) content-size 9.859375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td.td-thick-border> at (89.265625,21) content-size 9.859375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (89.265625,21) content-size 9.859375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [89.265625,21 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (145.125,20) content-size 14.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (145.125,20) content-size 14.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (145.125,20) content-size 14.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,20 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,22 +37,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,51) content-size 172.671875x43 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,64) content-size 16.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [29,64 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (29,64) content-size 16.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (29,64) content-size 16.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [29,64 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,65) content-size 11.859375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,65) content-size 11.859375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,65) content-size 11.859375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,65 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td.td-thick-border> at (145.125,64) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [145.125,64 12.546875x17] baseline: 13.296875
-                    "F"
-                TextNode <#text>
+              BlockContainer <td.td-thick-border> at (145.125,64) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (145.125,64) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [145.125,64 12.546875x17] baseline: 13.296875
+                      "F"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,15 +71,21 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 172.671875x86]
             PaintableBox (Box<TR>) [8,8 172.671875x43]
               PaintableWithLines (BlockContainer<TD>) [8,8 58.265625x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [29,21 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>.td-thick-border) [66.265625,8 55.859375x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [89.265625,21 9.859375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [122.125,8 58.546875x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [145.125,20 14.546875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,51 172.671875x43]
               PaintableWithLines (BlockContainer<TD>) [8,51 58.265625x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [29,64 16.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,51 55.859375x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,65 11.859375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>.td-thick-border) [122.125,51 58.546875x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [145.125,64 12.546875x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-col.txt
@@ -19,10 +19,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 60.265625x41 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,21) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (31,21) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,21) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -30,10 +31,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,49) content-size 60.265625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,60) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,60 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (31,60) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,60) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,60 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,10 +43,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,88) content-size 60.265625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,99) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,99 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (31,99) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,99) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,99 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -52,10 +55,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,127) content-size 60.265625x41 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,138) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,138 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (31,138) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,138) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,138 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -75,14 +79,18 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 60.265625x160]
             PaintableBox (Box<TR>) [8,8 60.265625x41]
               PaintableWithLines (BlockContainer<TD>) [8,8 60.265625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,21 14.265625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,49 60.265625x39]
               PaintableWithLines (BlockContainer<TD>) [8,49 60.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,60 14.265625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,88 60.265625x39]
               PaintableWithLines (BlockContainer<TD>) [8,88 60.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,99 14.265625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,127 60.265625x41]
               PaintableWithLines (BlockContainer<TD>) [8,127 60.265625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,138 14.265625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,168 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-row.txt
@@ -11,16 +11,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr.td-thick-border> at (8,8) content-size 114.8125x43 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,21) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (31,21) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,21) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,21 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,21) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,21) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,21) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,21 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -28,16 +30,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,51) content-size 114.8125x43 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29,64) content-size 16.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [29,64 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (29,64) content-size 16.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (29,64) content-size 16.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [29,64 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,64) content-size 14.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,64 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,64) content-size 14.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,64) content-size 14.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,64 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,16 +49,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr.td-thick-border> at (8,94) content-size 114.8125x43 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,107) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,107 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (31,107) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,107) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,107 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,107) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,107 12.546875x17] baseline: 13.296875
-                    "F"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,107) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,107) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,107 12.546875x17] baseline: 13.296875
+                      "F"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -70,16 +76,22 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 114.8125x129]
             PaintableBox (Box<TR>.td-thick-border) [8,8 114.8125x43]
               PaintableWithLines (BlockContainer<TD>) [8,8 58.265625x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,21 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,8 56.546875x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,21 12.546875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,51 114.8125x43]
               PaintableWithLines (BlockContainer<TD>) [8,51 58.265625x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [29,64 16.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,51 56.546875x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,64 14.546875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>.td-thick-border) [8,94 114.8125x43]
               PaintableWithLines (BlockContainer<TD>) [8,94 58.265625x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,107 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,94 56.546875x43]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,107 12.546875x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolution-with-rowgroup.txt
@@ -9,16 +9,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (8,8) content-size 113.40625x41 table-row children: not-inline
-              BlockContainer <td> at (29,19) content-size 16.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x17] baseline: 13.296875
-                    "0"
-                TextNode <#text>
+              BlockContainer <td> at (29,19) content-size 16.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (29,19) content-size 16.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [29,19 9.59375x17] baseline: 13.296875
+                      "0"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,19) content-size 13.140625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,19) content-size 13.140625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,19) content-size 13.140625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,19 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -29,16 +31,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,49) content-size 113.40625x41 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,62) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,62 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (31,62) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,62) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,62 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,62) content-size 11.140625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,62 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,62) content-size 11.140625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,62) content-size 11.140625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,62 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -46,16 +50,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,90) content-size 113.40625x41 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (31,101) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [31,101 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (31,101) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (31,101) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [31,101 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.265625,101) content-size 11.140625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.265625,101 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (87.265625,101) content-size 11.140625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.265625,101) content-size 11.140625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.265625,101 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -71,17 +77,23 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [8,8 113.40625x41]
             PaintableBox (Box<TR>) [8,8 113.40625x41]
               PaintableWithLines (BlockContainer<TD>) [8,8 58.265625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [29,19 16.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,8 55.140625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,19 13.140625x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>.thick-border) [8,49 113.40625x82]
             PaintableBox (Box<TR>) [8,49 113.40625x41]
               PaintableWithLines (BlockContainer<TD>) [8,49 58.265625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,62 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,49 55.140625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,62 11.140625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,90 113.40625x41]
               PaintableWithLines (BlockContainer<TD>) [8,90 58.265625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [31,101 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [66.265625,90 55.140625x41]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.265625,101 11.140625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-conflict-resolutions-with-more-cells-than-cols.txt
@@ -19,28 +19,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 53.0625x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,9) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [9,9 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (9,9) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (9,9) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [9,9 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25.265625,9) content-size 9.34375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [25.265625,9 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (25.265625,9) content-size 9.34375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (25.265625,9) content-size 9.34375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [25.265625,9 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (36.609375,9) content-size 10.3125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [36.609375,9 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (36.609375,9) content-size 10.3125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (36.609375,9) content-size 10.3125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [36.609375,9 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (48.921875,9) content-size 11.140625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [48.921875,9 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (48.921875,9) content-size 11.140625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (48.921875,9) content-size 11.140625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [48.921875,9 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -59,11 +63,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 53.0625x19]
             PaintableBox (Box<TR>) [8,8 53.0625x19]
               PaintableWithLines (BlockContainer<TD>) [8,8 16.265625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [9,9 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [24.265625,8 11.34375x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [25.265625,9 9.34375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [35.609375,8 12.3125x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [36.609375,9 10.3125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [47.921875,8 13.140625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [48.921875,9 11.140625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,27 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-and-borders-table-width.txt
@@ -9,16 +9,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (33,23) content-size 93.609375x47 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (48,38) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (48,38) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (48,38) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [48,38 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (102.265625,38) content-size 9.34375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (102.265625,38) content-size 9.34375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (102.265625,38) content-size 9.34375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [102.265625,38 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,6 +34,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [33,23 93.609375x47]
             PaintableBox (Box<TR>) [33,23 93.609375x47]
               PaintableWithLines (BlockContainer<TD>) [33,23 44.265625x47]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [48,38 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [87.265625,23 39.34375x47]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [102.265625,38 9.34375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-colspan.txt
@@ -15,22 +15,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,19) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,30) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,30) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,30) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,16 +41,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,68) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,79) content-size 88.8125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [89.25,79 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (50,79) content-size 88.8125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,79) content-size 88.8125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [89.25,79 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,79) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,22 +60,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,117) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,128) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
-                    "F"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,128) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
+                      "F"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,128) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -78,22 +86,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,166) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50.515625,177 13.234375x17] baseline: 13.296875
-                    "G"
-                TextNode <#text>
+              BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,177) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,177 13.234375x17] baseline: 13.296875
+                      "G"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.421875,177 12.234375x17] baseline: 13.296875
-                    "H"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,177) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,177 12.234375x17] baseline: 13.296875
+                      "H"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [201.484375,177 7.75x17] baseline: 13.296875
-                    "4"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,177) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,177 7.75x17] baseline: 13.296875
+                      "4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -101,22 +112,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,215) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [54.828125,226 4.59375x17] baseline: 13.296875
-                    "I"
-                TextNode <#text>
+              BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,226) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,226 4.59375x17] baseline: 13.296875
+                      "I"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [128.078125,226 8.90625x17] baseline: 13.296875
-                    "J"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,226) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,226 8.90625x17] baseline: 13.296875
+                      "J"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [201.125,226 8.453125x17] baseline: 13.296875
-                    "5"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,226) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,226 8.453125x17] baseline: 13.296875
+                      "5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -136,35 +150,49 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [29,19 201.90625x235]
             PaintableBox (Box<TR>) [29,19 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,30 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,30 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,30 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,68 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,68 130.8125x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,79 88.8125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,68 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,79 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,117 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,117 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,128 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,117 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,128 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,117 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,128 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,166 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,166 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,177 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,166 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,177 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,166 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,177 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,215 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,215 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,226 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,215 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,226 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,215 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,226 9.09375x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,265 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-rowspan.txt
@@ -15,22 +15,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,19) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,54.5) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50,54.5 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (50,54.5) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,54.5) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,54.5 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,30) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,30) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,16 +41,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,68) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.96875,79 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,79) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,79 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,79) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,22 +60,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,117) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,128) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
-                    "F"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,128) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
+                      "F"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,128) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -78,22 +86,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,166) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50.515625,177 13.234375x17] baseline: 13.296875
-                    "G"
-                TextNode <#text>
+              BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,177) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,177 13.234375x17] baseline: 13.296875
+                      "G"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.421875,177 12.234375x17] baseline: 13.296875
-                    "H"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,177) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,177 12.234375x17] baseline: 13.296875
+                      "H"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [201.484375,177 7.75x17] baseline: 13.296875
-                    "4"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,177) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,177 7.75x17] baseline: 13.296875
+                      "4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -101,22 +112,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,215) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [54.828125,226 4.59375x17] baseline: 13.296875
-                    "I"
-                TextNode <#text>
+              BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,226) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,226 4.59375x17] baseline: 13.296875
+                      "I"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [128.078125,226 8.90625x17] baseline: 13.296875
-                    "J"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,226) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,226 8.90625x17] baseline: 13.296875
+                      "J"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [201.125,226 8.453125x17] baseline: 13.296875
-                    "5"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,226) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,226 8.453125x17] baseline: 13.296875
+                      "5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -136,35 +150,49 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [29,19 201.90625x235]
             PaintableBox (Box<TR>) [29,19 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x88]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,54.5 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,30 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,30 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,68 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [105.265625,68 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,79 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,68 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,79 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,117 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,117 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,128 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,117 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,128 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,117 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,128 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,166 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,166 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,177 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,166 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,177 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,166 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,177 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,215 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,215 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,226 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,215 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,226 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,215 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,226 9.09375x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,265 784x0]

--- a/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing-with-percentage-width.txt
@@ -16,10 +16,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (127.59375,10) content-size 474.234375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (128.59375,11) content-size 472.234375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (128.59375,11) content-size 472.234375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (128.59375,11) content-size 472.234375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.59375,11 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,6 +43,7 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [127.59375,10 474.234375x19]
             PaintableBox (Box<TR>) [127.59375,10 474.234375x19]
               PaintableWithLines (BlockContainer<TD>) [127.59375,10 474.234375x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [128.59375,11 472.234375x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer<DIV>.right) [603.828125,8 188.15625x17]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/border-spacing.txt
+++ b/Tests/LibWeb/Layout/expected/table/border-spacing.txt
@@ -15,22 +15,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,19) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (50,30) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,30) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50,30 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,30) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,30) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [127.859375,30 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,30) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,30) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [202.1875,30 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,22 +41,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,68) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,79) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [51.96875,79 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (50,79) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,79) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.96875,79 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.96875,79 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,79) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,79) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.96875,79 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,79) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,79) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.953125,79 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -61,22 +67,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,117) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (50,128) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,128) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.203125,128 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
-                    "F"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,128) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,128) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.265625,128 12.546875x17] baseline: 13.296875
+                      "F"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,128) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,128) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.8125,128 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -84,22 +93,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,166) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50.515625,177 13.234375x17] baseline: 13.296875
-                    "G"
-                TextNode <#text>
+              BlockContainer <td> at (50,177) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,177) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.515625,177 13.234375x17] baseline: 13.296875
+                      "G"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [126.421875,177 12.234375x17] baseline: 13.296875
-                    "H"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,177) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,177) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [126.421875,177 12.234375x17] baseline: 13.296875
+                      "H"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [201.484375,177 7.75x17] baseline: 13.296875
-                    "4"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,177) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,177) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.484375,177 7.75x17] baseline: 13.296875
+                      "4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -107,22 +119,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (29,215) content-size 201.90625x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [54.828125,226 4.59375x17] baseline: 13.296875
-                    "I"
-                TextNode <#text>
+              BlockContainer <td> at (50,226) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (50,226) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [54.828125,226 4.59375x17] baseline: 13.296875
+                      "I"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [128.078125,226 8.90625x17] baseline: 13.296875
-                    "J"
-                TextNode <#text>
+              BlockContainer <td> at (126.265625,226) content-size 12.546875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (126.265625,226) content-size 12.546875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [128.078125,226 8.90625x17] baseline: 13.296875
+                      "J"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [201.125,226 8.453125x17] baseline: 13.296875
-                    "5"
-                TextNode <#text>
+              BlockContainer <td> at (200.8125,226) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (200.8125,226) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [201.125,226 8.453125x17] baseline: 13.296875
+                      "5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -142,37 +157,52 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [29,19 201.90625x235]
             PaintableBox (Box<TR>) [29,19 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,19 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,30 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,19 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,30 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,19 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,30 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,68 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,68 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,79 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,68 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,79 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,68 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,79 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,117 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,117 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,128 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,117 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,128 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,117 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,128 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,166 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,166 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,177 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,166 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,177 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,166 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,177 9.09375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [29,215 201.90625x39]
               PaintableWithLines (BlockContainer<TD>) [29,215 56.265625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [50,226 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [105.265625,215 54.546875x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [126.265625,226 12.546875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [179.8125,215 51.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [200.8125,226 9.09375x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,265 784x0]

--- a/Tests/LibWeb/Layout/expected/table/borders.txt
+++ b/Tests/LibWeb/Layout/expected/table/borders.txt
@@ -9,16 +9,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 168.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 82.015625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x17] baseline: 13.296875
-                    "Firstname"
-                TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 82.015625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,13) content-size 82.015625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,13 82.015625x17] baseline: 13.296875
+                      "Firstname"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,13) content-size 76.28125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x17] baseline: 13.296875
-                    "Lastname"
-                TextNode <#text>
+              BlockContainer <td> at (101.015625,13) content-size 76.28125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (101.015625,13) content-size 76.28125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [101.015625,13 76.28125x17] baseline: 13.296875
+                      "Lastname"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -26,16 +28,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,34) content-size 168.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,36) content-size 82.015625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [13,36 44.65625x17] baseline: 13.296875
-                    "Peter"
-                TextNode <#text>
+              BlockContainer <td> at (13,36) content-size 82.015625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,36) content-size 82.015625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [13,36 44.65625x17] baseline: 13.296875
+                      "Peter"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,36) content-size 76.28125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [101.015625,36 53.671875x17] baseline: 13.296875
-                    "Griffin"
-                TextNode <#text>
+              BlockContainer <td> at (101.015625,36) content-size 76.28125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (101.015625,36) content-size 76.28125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,36 53.671875x17] baseline: 13.296875
+                      "Griffin"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,16 +47,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,57) content-size 168.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,59) content-size 82.015625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [13,59 35.125x17] baseline: 13.296875
-                    "Lois"
-                TextNode <#text>
+              BlockContainer <td> at (13,59) content-size 82.015625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,59) content-size 82.015625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [13,59 35.125x17] baseline: 13.296875
+                      "Lois"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (101.015625,59) content-size 76.28125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59 53.671875x17] baseline: 13.296875
-                    "Griffin"
-                TextNode <#text>
+              BlockContainer <td> at (101.015625,59) content-size 76.28125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (101.015625,59) content-size 76.28125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [101.015625,59 53.671875x17] baseline: 13.296875
+                      "Griffin"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -68,16 +74,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,81) content-size 164.296875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,82) content-size 82.015625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [9,82 82.015625x17] baseline: 13.296875
-                    "Firstname"
-                TextNode <#text>
+              BlockContainer <td> at (9,82) content-size 82.015625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (9,82) content-size 82.015625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [9,82 82.015625x17] baseline: 13.296875
+                      "Firstname"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,82) content-size 76.28125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [95.015625,82 76.28125x17] baseline: 13.296875
-                    "Lastname"
-                TextNode <#text>
+              BlockContainer <td> at (95.015625,82) content-size 76.28125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (95.015625,82) content-size 76.28125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [95.015625,82 76.28125x17] baseline: 13.296875
+                      "Lastname"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -85,16 +93,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,101) content-size 164.296875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,103) content-size 82.015625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [9,103 44.65625x17] baseline: 13.296875
-                    "Peter"
-                TextNode <#text>
+              BlockContainer <td> at (9,103) content-size 82.015625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (9,103) content-size 82.015625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [9,103 44.65625x17] baseline: 13.296875
+                      "Peter"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,103) content-size 76.28125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [95.015625,103 53.671875x17] baseline: 13.296875
-                    "Griffin"
-                TextNode <#text>
+              BlockContainer <td> at (95.015625,103) content-size 76.28125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (95.015625,103) content-size 76.28125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,103 53.671875x17] baseline: 13.296875
+                      "Griffin"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -102,16 +112,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,122) content-size 164.296875x20 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (9,124) content-size 82.015625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [9,124 35.125x17] baseline: 13.296875
-                    "Lois"
-                TextNode <#text>
+              BlockContainer <td> at (9,124) content-size 82.015625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (9,124) content-size 82.015625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [9,124 35.125x17] baseline: 13.296875
+                      "Lois"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (95.015625,124) content-size 76.28125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [95.015625,124 53.671875x17] baseline: 13.296875
-                    "Griffin"
-                TextNode <#text>
+              BlockContainer <td> at (95.015625,124) content-size 76.28125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (95.015625,124) content-size 76.28125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [95.015625,124 53.671875x17] baseline: 13.296875
+                      "Griffin"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -126,16 +138,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.border-black> at (8,142) content-size 160.296875x18 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,142) content-size 82.015625x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 9, rect: [8,142 82.015625x17] baseline: 13.296875
-                  "Firstname"
-              TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (8,142) content-size 82.015625x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,142) content-size 82.015625x17 children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [8,142 82.015625x17] baseline: 13.296875
+                    "Firstname"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,142) content-size 76.28125x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 8, rect: [92.015625,142 76.28125x17] baseline: 13.296875
-                  "Lastname"
-              TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (92.015625,142) content-size 76.28125x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (92.015625,142) content-size 76.28125x17 children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [92.015625,142 76.28125x17] baseline: 13.296875
+                    "Lastname"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -143,16 +157,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.border-black> at (8,160) content-size 160.296875x19 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,161) content-size 82.015625x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 5, rect: [8,161 44.65625x17] baseline: 13.296875
-                  "Peter"
-              TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (8,161) content-size 82.015625x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,161) content-size 82.015625x17 children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [8,161 44.65625x17] baseline: 13.296875
+                    "Peter"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,161) content-size 76.28125x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 7, rect: [92.015625,161 53.671875x17] baseline: 13.296875
-                  "Griffin"
-              TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (92.015625,161) content-size 76.28125x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (92.015625,161) content-size 76.28125x17 children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,161 53.671875x17] baseline: 13.296875
+                    "Griffin"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -160,16 +176,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.border-black> at (8,179) content-size 160.296875x18 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (8,180) content-size 82.015625x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 4, rect: [8,180 35.125x17] baseline: 13.296875
-                  "Lois"
-              TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (8,180) content-size 82.015625x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,180) content-size 82.015625x17 children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [8,180 35.125x17] baseline: 13.296875
+                    "Lois"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.border-black> at (92.015625,180) content-size 76.28125x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 7, rect: [92.015625,180 53.671875x17] baseline: 13.296875
-                  "Griffin"
-              TextNode <#text>
+            BlockContainer <div.table-cell.border-black> at (92.015625,180) content-size 76.28125x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (92.015625,180) content-size 76.28125x17 children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [92.015625,180 53.671875x17] baseline: 13.296875
+                    "Griffin"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -184,16 +202,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.thick-border-black> at (8,197) content-size 168.296875x22 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,197) content-size 82.015625x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 9, rect: [8,197 82.015625x17] baseline: 13.296875
-                  "Firstname"
-              TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (8,197) content-size 82.015625x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,197) content-size 82.015625x17 children: inline
+                frag 0 from TextNode start: 0, length: 9, rect: [8,197 82.015625x17] baseline: 13.296875
+                    "Firstname"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,197) content-size 76.28125x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 8, rect: [100.015625,197 76.28125x17] baseline: 13.296875
-                  "Lastname"
-              TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,197) content-size 76.28125x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (100.015625,197) content-size 76.28125x17 children: inline
+                frag 0 from TextNode start: 0, length: 8, rect: [100.015625,197 76.28125x17] baseline: 13.296875
+                    "Lastname"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -201,16 +221,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.thick-border-black> at (8,219) content-size 168.296875x27 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,224) content-size 82.015625x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 5, rect: [8,224 44.65625x17] baseline: 13.296875
-                  "Peter"
-              TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (8,224) content-size 82.015625x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,224) content-size 82.015625x17 children: inline
+                frag 0 from TextNode start: 0, length: 5, rect: [8,224 44.65625x17] baseline: 13.296875
+                    "Peter"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,224) content-size 76.28125x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 7, rect: [100.015625,224 53.671875x17] baseline: 13.296875
-                  "Griffin"
-              TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,224) content-size 76.28125x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (100.015625,224) content-size 76.28125x17 children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,224 53.671875x17] baseline: 13.296875
+                    "Griffin"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -218,16 +240,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <div.table-row.thick-border-black> at (8,246) content-size 168.296875x22 table-row children: not-inline
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (8,251) content-size 82.015625x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 4, rect: [8,251 35.125x17] baseline: 13.296875
-                  "Lois"
-              TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (8,251) content-size 82.015625x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,251) content-size 82.015625x17 children: inline
+                frag 0 from TextNode start: 0, length: 4, rect: [8,251 35.125x17] baseline: 13.296875
+                    "Lois"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
-            BlockContainer <div.table-cell.thick-border-black> at (100.015625,251) content-size 76.28125x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 7, rect: [100.015625,251 53.671875x17] baseline: 13.296875
-                  "Griffin"
-              TextNode <#text>
+            BlockContainer <div.table-cell.thick-border-black> at (100.015625,251) content-size 76.28125x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (100.015625,251) content-size 76.28125x17 children: inline
+                frag 0 from TextNode start: 0, length: 7, rect: [100.015625,251 53.671875x17] baseline: 13.296875
+                    "Griffin"
+                TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
           BlockContainer <(anonymous)> (not painted) children: inline
@@ -243,72 +267,96 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 168.296875x67]
             PaintableBox (Box<TR>) [11,11 168.296875x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 86.015625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,13 82.015625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,11 80.28125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [101.015625,13 76.28125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [11,34 168.296875x21]
               PaintableWithLines (BlockContainer<TD>) [11,34 86.015625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,36 82.015625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,34 80.28125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [101.015625,36 76.28125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [11,57 168.296875x21]
               PaintableWithLines (BlockContainer<TD>) [11,57 86.015625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,59 82.015625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [99.015625,57 80.28125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [101.015625,59 76.28125x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,81 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,81 164.296875x61]
         PaintableBox (Box<TABLE>.table-border-black) [8,81 164.296875x61]
           PaintableBox (Box<TBODY>) [8,81 164.296875x61]
             PaintableBox (Box<TR>) [8,81 164.296875x20]
               PaintableWithLines (BlockContainer<TD>) [8,81 85.015625x20]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [9,82 82.015625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [93.015625,81 79.28125x20]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [95.015625,82 76.28125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,101 164.296875x21]
               PaintableWithLines (BlockContainer<TD>) [8,101 85.015625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [9,103 82.015625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [93.015625,101 79.28125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [95.015625,103 76.28125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,122 164.296875x20]
               PaintableWithLines (BlockContainer<TD>) [8,122 85.015625x20]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [9,124 82.015625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [93.015625,122 79.28125x20]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [95.015625,124 76.28125x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,142 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,142 160.296875x55]
         PaintableBox (Box<DIV>.table.border-black) [8,142 160.296875x55]
           PaintableBox (Box<DIV>.table-row.border-black) [8,142 160.296875x18]
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,142 83.015625x18]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,142 82.015625x17]
+                TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [91.015625,142 77.28125x18]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [92.015625,142 76.28125x17]
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.border-black) [8,160 160.296875x19]
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,160 83.015625x19]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,161 82.015625x17]
+                TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [91.015625,160 77.28125x19]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [92.015625,161 76.28125x17]
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.border-black) [8,179 160.296875x18]
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [8,179 83.015625x18]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,180 82.015625x17]
+                TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.border-black) [91.015625,179 77.28125x18]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [92.015625,180 76.28125x17]
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,197 784x0]
       PaintableWithLines (TableWrapper(anonymous)) [8,197 168.296875x71]
         PaintableBox (Box<DIV>.table.thick-border-black) [8,197 168.296875x71]
           PaintableBox (Box<DIV>.table-row.thick-border-black) [8,197 168.296875x22]
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,197 87.015625x22]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,197 82.015625x17]
+                TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,197 81.28125x22]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [100.015625,197 76.28125x17]
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.thick-border-black) [8,219 168.296875x27]
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,219 87.015625x27]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,224 82.015625x17]
+                TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,219 81.28125x27]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [100.015625,224 76.28125x17]
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.table-row.thick-border-black) [8,246 168.296875x22]
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [8,246 87.015625x22]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,251 82.015625x17]
+                TextPaintable (TextNode<#text>)
             PaintableWithLines (BlockContainer<DIV>.table-cell.thick-border-black) [95.015625,246 81.28125x22]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [100.015625,251 76.28125x17]
+                TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,268 784x0]

--- a/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
+++ b/Tests/LibWeb/Layout/expected/table/bottom-caption.txt
@@ -19,10 +19,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 95.171875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 93.171875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x17] baseline: 13.296875
-                    "Head Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 93.171875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 93.171875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,11 73.65625x17] baseline: 13.296875
+                      "Head Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -35,10 +36,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,31) content-size 95.171875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 93.171875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [11,32 70.234375x17] baseline: 13.296875
-                    "Body Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 93.171875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 93.171875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [11,32 70.234375x17] baseline: 13.296875
+                      "Body Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -51,10 +53,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,52) content-size 95.171875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,53) content-size 93.171875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 11, rect: [11,53 93.171875x17] baseline: 13.296875
-                    "Footer Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,53) content-size 93.171875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,53) content-size 93.171875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 11, rect: [11,53 93.171875x17] baseline: 13.296875
+                      "Footer Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -75,13 +78,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [10,10 95.171875x19]
             PaintableBox (Box<TR>) [10,10 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,10 95.171875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 93.171875x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>) [10,31 95.171875x19]
             PaintableBox (Box<TR>) [10,31 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 95.171875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 93.171875x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TFOOT>) [10,52 95.171875x19]
             PaintableBox (Box<TR>) [10,52 95.171875x19]
               PaintableWithLines (BlockContainer<TD>) [10,52 95.171875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,53 93.171875x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,90 784x0]

--- a/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-auto-max-width-table-percentage-width.txt
@@ -14,22 +14,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               Box <tr> at (10,10) content-size 76x19 table-row children: not-inline
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (11,11) content-size 17.828125x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
+                BlockContainer <td> at (11,11) content-size 17.828125x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (11,11) content-size 17.828125x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [11,11 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (32.828125,11) content-size 11.828125x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x17] baseline: 13.296875
-                      "B"
-                  TextNode <#text>
+                BlockContainer <td> at (32.828125,11) content-size 11.828125x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (32.828125,11) content-size 11.828125x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [32.828125,11 9.34375x17] baseline: 13.296875
+                        "B"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
-                BlockContainer <td> at (48.65625,11) content-size 36.34375x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x17] baseline: 13.296875
-                      "C D"
-                  TextNode <#text>
+                BlockContainer <td> at (48.65625,11) content-size 36.34375x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (48.65625,11) content-size 36.34375x17 children: inline
+                    frag 0 from TextNode start: 0, length: 3, rect: [48.65625,11 29.453125x17] baseline: 13.296875
+                        "C D"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> (not painted) children: inline
                   TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
@@ -49,9 +52,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [10,10 76x19]
               PaintableBox (Box<TR>) [10,10 76x19]
                 PaintableWithLines (BlockContainer<TD>) [10,10 19.828125x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [11,11 17.828125x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [31.828125,10 13.828125x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [32.828125,11 11.828125x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [47.65625,10 38.34375x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [48.65625,11 36.34375x17]
+                    TextPaintable (TextNode<#text>)
         PaintableWithLines (BlockContainer(anonymous)) [8,31 80x0]

--- a/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/cell-relative-to-specified-table-width.txt
@@ -11,22 +11,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 780x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 300.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [154.1875,11 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 300.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 300.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [154.1875,11 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (315.640625,11) content-size 168.71875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [395.328125,11 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <th> at (315.640625,11) content-size 168.71875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (315.640625,11) content-size 168.71875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [395.328125,11 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (488.359375,11) content-size 300.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [623.953125,11 29.453125x17] baseline: 13.296875
-                    "C D"
-                TextNode <#text>
+              BlockContainer <th> at (488.359375,11) content-size 300.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (488.359375,11) content-size 300.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [623.953125,11 29.453125x17] baseline: 13.296875
+                      "C D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,22 +37,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,31) content-size 780x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 300.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [155.390625,32 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 300.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 300.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [155.390625,32 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (315.640625,32) content-size 168.71875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [393.71875,32 12.546875x17] baseline: 13.296875
-                    "F"
-                TextNode <#text>
+              BlockContainer <td> at (315.640625,32) content-size 168.71875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (315.640625,32) content-size 168.71875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [393.71875,32 12.546875x17] baseline: 13.296875
+                      "F"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (488.359375,32) content-size 300.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [632.0625,32 13.234375x17] baseline: 13.296875
-                    "G"
-                TextNode <#text>
+              BlockContainer <td> at (488.359375,32) content-size 300.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (488.359375,32) content-size 300.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [632.0625,32 13.234375x17] baseline: 13.296875
+                      "G"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,15 +71,21 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 780x40]
             PaintableBox (Box<TR>) [10,10 780x19]
               PaintableWithLines (BlockContainer<TH>) [10,10 302.640625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 300.640625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [314.640625,10 170.71875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [315.640625,11 168.71875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [487.359375,10 302.640625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [488.359375,11 300.640625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,31 780x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 302.640625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 300.640625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [314.640625,31 170.71875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [315.640625,32 168.71875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [487.359375,31 302.640625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [488.359375,32 300.640625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
+++ b/Tests/LibWeb/Layout/expected/table/clip-spans-to-table-end.txt
@@ -9,22 +9,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 93.359375x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,19) content-size 8.453125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (19,19) content-size 8.453125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (19,19) content-size 8.453125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [19,19 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,19) content-size 8.8125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (49.453125,19) content-size 8.8125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (49.453125,19) content-size 8.8125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [49.453125,19 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (80.265625,19) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (80.265625,19) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (80.265625,19) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [80.265625,19 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <(anonymous)> at (101.359375,27.5) content-size 0x0 table-cell [BFC] children: not-inline
@@ -33,16 +36,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,47) content-size 93.359375x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,58) content-size 8.453125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [19,58 7.75x17] baseline: 13.296875
-                    "4"
-                TextNode <#text>
+              BlockContainer <td> at (19,58) content-size 8.453125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (19,58) content-size 8.453125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [19,58 7.75x17] baseline: 13.296875
+                      "4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (49.453125,77.5) content-size 40.90625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [49.453125,77.5 24.046875x17] baseline: 13.296875
-                    "6-9"
-                TextNode <#text>
+              BlockContainer <td> at (49.453125,77.5) content-size 40.90625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (49.453125,77.5) content-size 40.90625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [49.453125,77.5 24.046875x17] baseline: 13.296875
+                      "6-9"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -50,10 +55,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,86) content-size 93.359375x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (19,97) content-size 8.453125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [19,97 8.453125x17] baseline: 13.296875
-                    "5"
-                TextNode <#text>
+              BlockContainer <td> at (19,97) content-size 8.453125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (19,97) content-size 8.453125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [19,97 8.453125x17] baseline: 13.296875
+                      "5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -67,17 +73,23 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 93.359375x117]
             PaintableBox (Box<TR>) [8,8 93.359375x39]
               PaintableWithLines (BlockContainer<TD>) [8,8 30.453125x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [19,19 8.453125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [38.453125,8 30.8125x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [49.453125,19 8.8125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [69.265625,8 31.09375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [80.265625,19 9.09375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer(anonymous)) [100.359375,8 1x39]
             PaintableBox (Box<TR>) [8,47 93.359375x39]
               PaintableWithLines (BlockContainer<TD>) [8,47 30.453125x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [19,58 8.453125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [38.453125,47 62.90625x78]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [49.453125,77.5 40.90625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [8,86 93.359375x39]
               PaintableWithLines (BlockContainer<TD>) [8,86 30.453125x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [19,97 8.453125x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-overflow-crash.txt
@@ -9,10 +9,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 23.90625x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 6.8125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 6.8125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 6.8125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,11 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <(anonymous)> at (20.8125,19.5) content-size 0x0 table-cell [BFC] children: not-inline
@@ -22,16 +23,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,31) content-size 23.90625x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 8.8125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [11,32 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 8.8125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 8.8125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11,32 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (23.8125,32) content-size 9.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [23.8125,32 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (23.8125,32) content-size 9.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (23.8125,32) content-size 9.09375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [23.8125,32 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -49,13 +52,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 23.90625x40]
             PaintableBox (Box<TR>) [10,10 23.90625x19]
               PaintableWithLines (BlockContainer<TD>) [10,10 8.8125x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 6.8125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer(anonymous)) [20.8125,10 0x19]
               PaintableWithLines (BlockContainer(anonymous)) [22.8125,10 11.09375x19]
             PaintableBox (Box<TR>) [10,31 23.90625x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 10.8125x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 8.8125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [22.8125,31 11.09375x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [23.8125,32 9.09375x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,52 784x17]
         TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-percentage-width.txt
@@ -9,22 +9,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 418x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 79.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [43.65625,11 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 79.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 79.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [43.65625,11 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.59375,11) content-size 157.328125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [168.578125,11 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (94.59375,11) content-size 157.328125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (94.59375,11) content-size 157.328125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [168.578125,11 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (255.921875,11) content-size 169.078125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [335.296875,11 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (255.921875,11) content-size 169.078125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (255.921875,11) content-size 169.078125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [335.296875,11 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,16 +35,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 418x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 79.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [45.21875,32 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 79.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 79.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [45.21875,32 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (94.59375,32) content-size 330.40625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [253.859375,32 11.859375x17] baseline: 13.296875
-                    "E"
-                TextNode <#text>
+              BlockContainer <td> at (94.59375,32) content-size 330.40625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (94.59375,32) content-size 330.40625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [253.859375,32 11.859375x17] baseline: 13.296875
+                      "E"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -55,13 +60,18 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 418x42]
             PaintableBox (Box<TR>) [9,9 418x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 83.59375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 79.59375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [92.59375,9 161.328125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [94.59375,11 157.328125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [253.921875,9 173.078125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [255.921875,11 169.078125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 418x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 83.59375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 79.59375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [92.59375,30 334.40625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [94.59375,32 330.40625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-weighted-width-distribution.txt
@@ -9,16 +9,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 208x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 180x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [93.859375,11 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 180x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 180x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [93.859375,11 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (195,11) content-size 20x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [200.328125,11 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (195,11) content-size 20x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (195,11) content-size 20x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [200.328125,11 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -26,10 +28,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 208x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 204x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [107.84375,32 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 204x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 204x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [107.84375,32 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,9 +46,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 208x42]
             PaintableBox (Box<TR>) [9,9 208x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 184x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 180x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [193,9 24x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [195,11 20x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 208x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 208x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 204x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-width-distribution.txt
@@ -13,16 +13,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 37.3125x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 17.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [12.640625,11 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 17.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 17.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [12.640625,11 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (32.5625,11) content-size 11.75x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [33.765625,11 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (32.5625,11) content-size 11.75x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (32.5625,11) content-size 11.75x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [33.765625,11 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -30,10 +32,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 37.3125x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 33.3125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [11,32 33.3125x17] baseline: 13.296875
-                    "CDE"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 33.3125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 33.3125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [11,32 33.3125x17] baseline: 13.296875
+                      "CDE"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -51,10 +54,13 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 37.3125x42]
             PaintableBox (Box<TR>) [9,9 37.3125x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 21.5625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 17.5625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [30.5625,9 15.75x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [32.5625,11 11.75x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 37.3125x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 37.3125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 33.3125x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]

--- a/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/colspan-with-trailing-characters.txt
@@ -13,22 +13,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
-                    "Header 1"
-                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
+                      "Header 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
-                    "Header 2"
-                TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,11) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
+                      "Header 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
-                    "Header 3"
-                TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,11) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
+                      "Header 3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,10 +39,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 223.359375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [101.75,32 41.84375x17] baseline: 13.296875
-                    "Cell 1"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 223.359375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 223.359375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [101.75,32 41.84375x17] baseline: 13.296875
+                      "Cell 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -47,10 +51,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,51) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,53) content-size 223.359375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [100.515625,53 44.3125x17] baseline: 13.296875
-                    "Cell 2"
-                TextNode <#text>
+              BlockContainer <td> at (11,53) content-size 223.359375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,53) content-size 223.359375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [100.515625,53 44.3125x17] baseline: 13.296875
+                      "Cell 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -58,22 +63,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,72) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [23.71875,74 44.59375x17] baseline: 13.296875
-                    "Cell 3"
-                TextNode <#text>
+              BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,74) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [23.71875,74 44.59375x17] baseline: 13.296875
+                      "Cell 3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [99.671875,74 43.25x17] baseline: 13.296875
-                    "Cell 4"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,74) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.671875,74 43.25x17] baseline: 13.296875
+                      "Cell 4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [175.984375,74 43.953125x17] baseline: 13.296875
-                    "Cell 5"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,74) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [175.984375,74 43.953125x17] baseline: 13.296875
+                      "Cell 5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -91,22 +99,30 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 227.359375x84]
             PaintableBox (Box<TR>) [9,9 227.359375x21]
               PaintableWithLines (BlockContainer<TH>) [9,9 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [83.046875,9 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,11 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [159.5625,9 76.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,11 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 227.359375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 223.359375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,51 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,51 227.359375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,53 223.359375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,72 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,72 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,74 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,72 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,74 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,72 76.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,74 72.796875x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,94 784x0]

--- a/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
+++ b/Tests/LibWeb/Layout/expected/table/columns-width-distribution-1.txt
@@ -9,20 +9,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 778x104 table-row children: not-inline
               BlockContainer <td.mbox-image> at (12,38) content-size 50x50 table-cell [BFC] children: not-inline
                 BlockContainer <div.mbox-image-div> at (12,38) content-size 50x50 children: not-inline
-              BlockContainer <td.mbox-text> at (66,12) content-size 722x102 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17] baseline: 13.296875
-                    "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
-                frag 1 from TextNode start: 86, length: 84, rect: [66,29 695.5625x17] baseline: 13.296875
-                    "against the wall. They receive a call from their assistant who expresses frustration"
-                frag 2 from TextNode start: 171, length: 85, rect: [66,46 703.125x17] baseline: 13.296875
-                    "over a packed waiting room and the lawyer's lack of clients. The lawyer then looks at"
-                frag 3 from TextNode start: 257, length: 81, rect: [66,63 695.90625x17] baseline: 13.296875
-                    "some papers from a large envelope, which turn out to be divorce papers from their"
-                frag 4 from TextNode start: 339, length: 84, rect: [66,80 670.515625x17] baseline: 13.296875
-                    "significant other. Finally, the lawyer instructs their assistant to send in the next"
-                frag 5 from TextNode start: 424, length: 7, rect: [66,97 47.21875x17] baseline: 13.296875
-                    "client."
-                TextNode <#text>
+              BlockContainer <td.mbox-text> at (66,12) content-size 722x102 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (66,12) content-size 722x102 children: inline
+                  frag 0 from TextNode start: 1, length: 84, rect: [66,12 689.640625x17] baseline: 13.296875
+                      "In a scene set in a lawyer's office, the lawyer sits alone and bounces a rubber ball"
+                  frag 1 from TextNode start: 86, length: 84, rect: [66,29 695.5625x17] baseline: 13.296875
+                      "against the wall. They receive a call from their assistant who expresses frustration"
+                  frag 2 from TextNode start: 171, length: 85, rect: [66,46 703.125x17] baseline: 13.296875
+                      "over a packed waiting room and the lawyer's lack of clients. The lawyer then looks at"
+                  frag 3 from TextNode start: 257, length: 81, rect: [66,63 695.90625x17] baseline: 13.296875
+                      "some papers from a large envelope, which turn out to be divorce papers from their"
+                  frag 4 from TextNode start: 339, length: 84, rect: [66,80 670.515625x17] baseline: 13.296875
+                      "significant other. Finally, the lawyer instructs their assistant to send in the next"
+                  frag 5 from TextNode start: 424, length: 7, rect: [66,97 47.21875x17] baseline: 13.296875
+                      "client."
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -34,4 +35,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
               PaintableWithLines (BlockContainer<TD>.mbox-image) [11,11 52x104]
                 PaintableWithLines (BlockContainer<DIV>.mbox-image-div) [12,38 50x50]
               PaintableWithLines (BlockContainer<TD>.mbox-text) [65,11 724x104]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [66,12 722x102]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width-all-columns.txt
@@ -9,28 +9,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 62.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 62.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 62.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (77.4375,11) content-size 62.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (77.4375,11) content-size 62.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (77.4375,11) content-size 62.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [77.4375,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (143.875,11) content-size 128.890625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (143.875,11) content-size 128.890625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (143.875,11) content-size 128.890625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [143.875,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (276.765625,11) content-size 328.234375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (276.765625,11) content-size 328.234375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (276.765625,11) content-size 328.234375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [276.765625,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,28 +42,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 598x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 62.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 62.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 62.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (77.4375,32) content-size 62.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [77.4375,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (77.4375,32) content-size 62.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (77.4375,32) content-size 62.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [77.4375,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (143.875,32) content-size 128.890625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [143.875,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (143.875,32) content-size 128.890625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (143.875,32) content-size 128.890625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [143.875,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (276.765625,32) content-size 328.234375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [276.765625,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (276.765625,32) content-size 328.234375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (276.765625,32) content-size 328.234375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [276.765625,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -73,19 +81,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x42]
             PaintableBox (Box<TR>) [9,9 598x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 66.4375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 62.4375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [75.4375,9 66.4375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [77.4375,11 62.4375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [141.875,9 132.890625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [143.875,11 128.890625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [274.765625,9 332.234375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [276.765625,11 328.234375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 598x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 66.4375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 62.4375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [75.4375,30 66.4375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [77.4375,32 62.4375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [141.875,30 132.890625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [143.875,32 128.890625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [274.765625,30 332.234375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [276.765625,32 328.234375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-percentage-width.txt
@@ -9,28 +9,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 597.96875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 95.65625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 95.65625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 95.65625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (110.65625,11) content-size 95.65625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (110.65625,11) content-size 95.65625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (110.65625,11) content-size 95.65625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (210.3125,11) content-size 95.65625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (210.3125,11) content-size 95.65625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (210.3125,11) content-size 95.65625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (309.96875,11) content-size 295x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (309.96875,11) content-size 295x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (309.96875,11) content-size 295x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,28 +42,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 597.96875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 95.65625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 95.65625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 95.65625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (110.65625,32) content-size 95.65625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [110.65625,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (110.65625,32) content-size 95.65625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (110.65625,32) content-size 95.65625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [110.65625,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (210.3125,32) content-size 95.65625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [210.3125,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (210.3125,32) content-size 95.65625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (210.3125,32) content-size 95.65625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [210.3125,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (309.96875,32) content-size 295x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [309.96875,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (309.96875,32) content-size 295x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (309.96875,32) content-size 295x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [309.96875,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -73,19 +81,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 597.96875x42]
             PaintableBox (Box<TR>) [9,9 597.96875x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 99.65625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 95.65625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [108.65625,9 99.65625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [110.65625,11 95.65625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [208.3125,9 99.65625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [210.3125,11 95.65625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [307.96875,9 299x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [309.96875,11 295x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 597.96875x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 99.65625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 95.65625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [108.65625,30 99.65625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [110.65625,32 95.65625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [208.3125,30 99.65625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [210.3125,32 95.65625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [307.96875,30 299x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [309.96875,32 295x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width-all-columns.txt
@@ -9,28 +9,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 58.578125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 58.578125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 58.578125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (73.578125,11) content-size 58.578125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [73.578125,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (73.578125,11) content-size 58.578125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (73.578125,11) content-size 58.578125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [73.578125,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (136.15625,11) content-size 116.53125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [136.15625,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (136.15625,11) content-size 116.53125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (136.15625,11) content-size 116.53125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [136.15625,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (256.6875,11) content-size 348.3125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (256.6875,11) content-size 348.3125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (256.6875,11) content-size 348.3125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [256.6875,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,28 +42,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 598x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 58.578125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 58.578125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 58.578125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (73.578125,32) content-size 58.578125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [73.578125,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (73.578125,32) content-size 58.578125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (73.578125,32) content-size 58.578125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [73.578125,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (136.15625,32) content-size 116.53125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [136.15625,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (136.15625,32) content-size 116.53125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (136.15625,32) content-size 116.53125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [136.15625,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (256.6875,32) content-size 348.3125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [256.6875,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (256.6875,32) content-size 348.3125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (256.6875,32) content-size 348.3125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [256.6875,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -73,19 +81,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x42]
             PaintableBox (Box<TR>) [9,9 598x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 62.578125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 58.578125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [71.578125,9 62.578125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [73.578125,11 58.578125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [134.15625,9 120.53125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [136.15625,11 116.53125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [254.6875,9 352.3125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [256.6875,11 348.3125x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 598x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 62.578125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 58.578125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [71.578125,30 62.578125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [73.578125,32 58.578125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [134.15625,30 120.53125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [136.15625,32 116.53125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [254.6875,30 352.3125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [256.6875,32 348.3125x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout-pixel-width.txt
@@ -9,30 +9,34 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x38 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,19.5) content-size 94x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,19.5 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,19.5) content-size 94x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,19.5) content-size 94x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,19.5 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (109,19.5) content-size 94x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [109,19.5 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (109,19.5) content-size 94x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (109,19.5) content-size 94x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [109,19.5 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (207,11) content-size 94x34 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x17] baseline: 13.296875
-                    "A table"
-                frag 1 from TextNode start: 8, length: 4, rect: [207,28 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (207,11) content-size 94x34 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (207,11) content-size 94x34 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [207,11 60.890625x17] baseline: 13.296875
+                      "A table"
+                  frag 1 from TextNode start: 8, length: 4, rect: [207,28 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (305,19.5) content-size 300x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [305,19.5 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (305,19.5) content-size 300x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (305,19.5) content-size 300x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [305,19.5 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -40,30 +44,34 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,47) content-size 598x38 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,57.5) content-size 94x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,57.5 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,57.5) content-size 94x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,57.5) content-size 94x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,57.5 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (109,57.5) content-size 94x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [109,57.5 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (109,57.5) content-size 94x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (109,57.5) content-size 94x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [109,57.5 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (207,49) content-size 94x34 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [207,49 60.890625x17] baseline: 13.296875
-                    "A table"
-                frag 1 from TextNode start: 8, length: 4, rect: [207,66 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (207,49) content-size 94x34 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (207,49) content-size 94x34 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [207,49 60.890625x17] baseline: 13.296875
+                      "A table"
+                  frag 1 from TextNode start: 8, length: 4, rect: [207,66 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (305,57.5) content-size 300x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [305,57.5 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (305,57.5) content-size 300x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (305,57.5) content-size 300x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [305,57.5 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -77,19 +85,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x76]
             PaintableBox (Box<TR>) [9,9 598x38]
               PaintableWithLines (BlockContainer<TD>) [9,9 98x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,19.5 94x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [107,9 98x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [109,19.5 94x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [205,9 98x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [207,11 94x34]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [303,9 304x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [305,19.5 300x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,47 598x38]
               PaintableWithLines (BlockContainer<TD>) [9,47 98x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,57.5 94x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [107,47 98x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [109,57.5 94x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [205,47 98x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [207,49 94x34]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [303,47 304x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [305,57.5 300x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-layout.txt
@@ -9,28 +9,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 598x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (160.5,11) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [160.5,11 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (160.5,11) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (160.5,11) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [160.5,11 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (310,11) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [310,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (310,11) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (310,11) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [310,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (459.5,11) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (459.5,11) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (459.5,11) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [459.5,11 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,28 +42,32 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 598x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (160.5,32) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [160.5,32 26.078125x17] baseline: 13.296875
-                    "cell"
-                TextNode <#text>
+              BlockContainer <td> at (160.5,32) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (160.5,32) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [160.5,32 26.078125x17] baseline: 13.296875
+                      "cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (310,32) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [310,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (310,32) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (310,32) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [310,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (459.5,32) content-size 145.5x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [459.5,32 94.96875x17] baseline: 13.296875
-                    "A table cell"
-                TextNode <#text>
+              BlockContainer <td> at (459.5,32) content-size 145.5x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (459.5,32) content-size 145.5x17 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [459.5,32 94.96875x17] baseline: 13.296875
+                      "A table cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -73,19 +81,27 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 598x42]
             PaintableBox (Box<TR>) [9,9 598x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 145.5x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [158.5,9 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [160.5,11 145.5x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [308,9 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [310,11 145.5x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [457.5,9 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [459.5,11 145.5x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 598x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 145.5x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [158.5,30 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [160.5,32 145.5x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [308,30 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [310,32 145.5x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [457.5,30 149.5x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [459.5,32 145.5x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
+++ b/Tests/LibWeb/Layout/expected/table/fixed-margins.txt
@@ -5,12 +5,13 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (108,8) content-size 584x34 [BFC] children: not-inline
           Box <div.box> at (108,8) content-size 584x34 table-box [TFC] children: not-inline
             Box <(anonymous)> at (108,8) content-size 584x34 table-row children: not-inline
-              BlockContainer <div.cell> at (108,8) content-size 584x34 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x17] baseline: 13.296875
-                    "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"
-                frag 1 from TextNode start: 59, length: 40, rect: [108,25 399.9375x17] baseline: 13.296875
-                    "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
-                TextNode <#text>
+              BlockContainer <div.cell> at (108,8) content-size 584x34 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (108,8) content-size 584x34 children: inline
+                  frag 0 from TextNode start: 0, length: 58, rect: [108,8 569.859375x17] baseline: 13.296875
+                      "DaTa DisplaYiNg CSS WeBpaGE ScReEn OF aR AddITioN COmmOnLY"
+                  frag 1 from TextNode start: 59, length: 40, rect: [108,25 399.9375x17] baseline: 13.296875
+                      "To AdJuSt PRiCiNG sTYLiNG ceLL oF TAbLeS"
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -20,4 +21,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<DIV>.box) [108,8 584x34]
             PaintableBox (Box(anonymous)) [108,8 584x34]
               PaintableWithLines (BlockContainer<DIV>.cell) [108,8 584x34]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [108,8 584x34]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
+++ b/Tests/LibWeb/Layout/expected/table/in-auto-height-flex-item.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         TableWrapper <(anonymous)> at (11,11) content-size 41.78125x19 [BFC] children: not-inline
           Box <(anonymous)> at (11,11) content-size 41.78125x19 table-box [TFC] children: not-inline
             Box <(anonymous)> at (11,11) content-size 41.78125x19 table-row children: not-inline
-              BlockContainer <div.cell> at (12,12) content-size 39.78125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17] baseline: 13.296875
-                    "Hello"
-                TextNode <#text>
+              BlockContainer <div.cell> at (12,12) content-size 39.78125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (12,12) content-size 39.78125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [12,12 39.78125x17] baseline: 13.296875
+                      "Hello"
+                  TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x41]
@@ -18,4 +19,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box(anonymous)) [11,11 41.78125x19]
             PaintableBox (Box(anonymous)) [11,11 41.78125x19]
               PaintableWithLines (BlockContainer<DIV>.cell) [11,11 41.78125x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [12,12 39.78125x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/inline-table-width.txt
@@ -1,29 +1,33 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
     BlockContainer <body> at (8,8) content-size 784x46 children: inline
-      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44] baseline: 13.796875
+      frag 0 from BlockContainer start: 0, length: 0, rect: [9,9 135.984375x44] baseline: 14.296875
       BlockContainer <table> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
         TableWrapper <(anonymous)> at (9,9) content-size 135.984375x44 inline-block [BFC] children: not-inline
           Box <(anonymous)> at (9,9) content-size 135.984375x44 inline-table table-box [TFC] children: not-inline
             Box <tbody> at (11,11) content-size 131.984375x40 table-row-group children: not-inline
               Box <tr> at (11,11) content-size 131.984375x19 table-row children: not-inline
-                BlockContainer <td> at (12,12) content-size 87.90625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x17] baseline: 13.296875
-                      "ID"
-                  TextNode <#text>
-                BlockContainer <td> at (103.90625,12) content-size 38.078125x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17] baseline: 13.296875
-                      "null"
-                  TextNode <#text>
+                BlockContainer <td> at (12,12) content-size 87.90625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (12,12) content-size 87.90625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 2, rect: [12,12 15.734375x17] baseline: 13.296875
+                        "ID"
+                    TextNode <#text>
+                BlockContainer <td> at (103.90625,12) content-size 38.078125x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (103.90625,12) content-size 38.078125x17 children: inline
+                    frag 0 from TextNode start: 0, length: 4, rect: [103.90625,12 27.84375x17] baseline: 13.296875
+                        "null"
+                    TextNode <#text>
               Box <tr> at (11,32) content-size 131.984375x19 table-row children: not-inline
-                BlockContainer <td> at (12,33) content-size 87.90625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 11, rect: [12,33 87.90625x17] baseline: 13.296875
-                      "Is Selected"
-                  TextNode <#text>
-                BlockContainer <td> at (103.90625,33) content-size 38.078125x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 5, rect: [103.90625,33 38.078125x17] baseline: 13.296875
-                      "false"
-                  TextNode <#text>
+                BlockContainer <td> at (12,33) content-size 87.90625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (12,33) content-size 87.90625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 11, rect: [12,33 87.90625x17] baseline: 13.296875
+                        "Is Selected"
+                    TextNode <#text>
+                BlockContainer <td> at (103.90625,33) content-size 38.078125x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (103.90625,33) content-size 38.078125x17 children: inline
+                    frag 0 from TextNode start: 0, length: 5, rect: [103.90625,33 38.078125x17] baseline: 13.296875
+                        "false"
+                    TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -34,11 +38,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [11,11 131.984375x40]
               PaintableBox (Box<TR>) [11,11 131.984375x19]
                 PaintableWithLines (BlockContainer<TD>) [11,11 89.90625x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [12,12 87.90625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,11 40.078125x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [103.90625,12 38.078125x17]
+                    TextPaintable (TextNode<#text>)
               PaintableBox (Box<TR>) [11,32 131.984375x19]
                 PaintableWithLines (BlockContainer<TD>) [11,32 89.90625x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [12,33 87.90625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [102.90625,32 40.078125x19]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [103.90625,33 38.078125x17]
+                    TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
+++ b/Tests/LibWeb/Layout/expected/table/keyword-value-does-not-constrain-column.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (8,8) content-size 37.609375x23 table-box [TFC] children: not-inline
           Box <tbody> at (10,10) content-size 33.609375x19 table-row-group children: not-inline
             Box <tr> at (10,10) content-size 33.609375x19 table-row children: not-inline
-              BlockContainer <td.ab> at (11,11) content-size 31.609375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x17] baseline: 13.296875
-                    "A B"
-                TextNode <#text>
+              BlockContainer <td.ab> at (11,11) content-size 31.609375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 31.609375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [11,11 31.609375x17] baseline: 13.296875
+                      "A B"
+                  TextNode <#text>
       BlockContainer <(anonymous)> at (8,31) content-size 784x0 children: inline
         TextNode <#text>
 
@@ -20,5 +21,6 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 33.609375x19]
             PaintableBox (Box<TR>) [10,10 33.609375x19]
               PaintableWithLines (BlockContainer<TD>.ab) [10,10 33.609375x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 31.609375x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,31 784x0]

--- a/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/line-breaking-in-cells.txt
@@ -11,26 +11,29 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 61x38 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,18.5) content-size 14.296875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [10,18.5 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (10,18.5) content-size 14.296875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (10,18.5) content-size 14.296875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [10,18.5 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (28.296875,10) content-size 20.40625x34 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x17] baseline: 13.296875
-                    "B"
-                frag 1 from TextNode start: 0, length: 1, rect: [28.296875,27 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
-                BreakNode <br>
-                TextNode <#text>
+              BlockContainer <td> at (28.296875,10) content-size 20.40625x34 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (28.296875,10) content-size 20.40625x34 children: inline
+                  frag 0 from TextNode start: 1, length: 1, rect: [28.296875,10 9.34375x17] baseline: 13.296875
+                      "B"
+                  frag 1 from TextNode start: 0, length: 1, rect: [28.296875,27 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
+                  BreakNode <br>
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (52.703125,18.5) content-size 14.296875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 1, length: 1, rect: [52.703125,18.5 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (52.703125,18.5) content-size 14.296875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (52.703125,18.5) content-size 14.296875x17 children: inline
+                  frag 0 from TextNode start: 1, length: 1, rect: [52.703125,18.5 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -46,9 +49,12 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 61x38]
             PaintableBox (Box<TR>) [8,8 61x38]
               PaintableWithLines (BlockContainer<TD>) [8,8 18.296875x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [10,18.5 14.296875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [26.296875,8 24.40625x38]
-                TextPaintable (TextNode<#text>)
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [28.296875,10 20.40625x34]
+                  TextPaintable (TextNode<#text>)
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [50.703125,8 18.296875x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [52.703125,18.5 14.296875x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/long-caption-increases-width.txt
@@ -21,16 +21,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (12,44) content-size 55.046875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,46) content-size 21.25x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [14,46 20.609375x17] baseline: 13.296875
-                    "A1"
-                TextNode <#text>
+              BlockContainer <td> at (14,46) content-size 21.25x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (14,46) content-size 21.25x17 children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,46 20.609375x17] baseline: 13.296875
+                      "A1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,46) content-size 23.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [41.25,46 23.078125x17] baseline: 13.296875
-                    "A2"
-                TextNode <#text>
+              BlockContainer <td> at (41.25,46) content-size 23.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (41.25,46) content-size 23.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,46 23.078125x17] baseline: 13.296875
+                      "A2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,16 +45,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (12,67) content-size 55.046875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,69) content-size 21.25x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [14,69 15.6875x17] baseline: 13.296875
-                    "B1"
-                TextNode <#text>
+              BlockContainer <td> at (14,69) content-size 21.25x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (14,69) content-size 21.25x17 children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,69 15.6875x17] baseline: 13.296875
+                      "B1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,69) content-size 23.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [41.25,69 18.15625x17] baseline: 13.296875
-                    "B2"
-                TextNode <#text>
+              BlockContainer <td> at (41.25,69) content-size 23.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (41.25,69) content-size 23.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,69 18.15625x17] baseline: 13.296875
+                      "B2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -65,16 +69,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (12,90) content-size 55.046875x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (14,92) content-size 21.25x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [14,92 18.890625x17] baseline: 13.296875
-                    "F1"
-                TextNode <#text>
+              BlockContainer <td> at (14,92) content-size 21.25x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (14,92) content-size 21.25x17 children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [14,92 18.890625x17] baseline: 13.296875
+                      "F1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (41.25,92) content-size 23.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 2, rect: [41.25,92 21.359375x17] baseline: 13.296875
-                    "F2"
-                TextNode <#text>
+              BlockContainer <td> at (41.25,92) content-size 23.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (41.25,92) content-size 23.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 2, rect: [41.25,92 21.359375x17] baseline: 13.296875
+                      "F2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -95,19 +101,25 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<THEAD>) [12,44 55.046875x21]
             PaintableBox (Box<TR>) [12,44 55.046875x21]
               PaintableWithLines (BlockContainer<TD>) [12,44 25.25x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [14,46 21.25x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,44 27.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [41.25,46 23.796875x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TBODY>) [12,67 55.046875x21]
             PaintableBox (Box<TR>) [12,67 55.046875x21]
               PaintableWithLines (BlockContainer<TD>) [12,67 25.25x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [14,69 21.25x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,67 27.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [41.25,69 23.796875x17]
+                  TextPaintable (TextNode<#text>)
           PaintableBox (Box<TFOOT>) [12,90 55.046875x21]
             PaintableBox (Box<TR>) [12,90 55.046875x21]
               PaintableWithLines (BlockContainer<TD>) [12,90 25.25x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [14,92 21.25x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [39.25,90 27.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [41.25,92 23.796875x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,149 784x0]

--- a/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells-with-span.txt
@@ -6,26 +6,30 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table> at (9,9) content-size 98x117 table-box [TFC] children: not-inline
             Box <tbody> at (9,9) content-size 98x117 table-row-group children: not-inline
               Box <tr> at (9,9) content-size 98x39 table-row children: not-inline
-                BlockContainer <td> at (20,20) content-size 30.5625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
-                BlockContainer <td> at (72.5625,20) content-size 23.4375x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17] baseline: 13.296875
-                      "B"
-                  TextNode <#text>
+                BlockContainer <td> at (20,20) content-size 30.5625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (20,20) content-size 30.5625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
+                BlockContainer <td> at (72.5625,20) content-size 23.4375x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (72.5625,20) content-size 23.4375x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17] baseline: 13.296875
+                        "B"
+                    TextNode <#text>
               Box <tr> at (9,48) content-size 98x39 table-row children: not-inline
-                BlockContainer <td> at (20,59) content-size 30.5625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
+                BlockContainer <td> at (20,59) content-size 30.5625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (20,59) content-size 30.5625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,68) content-size 21.71875x0 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (84.28125,67.5) content-size 21.71875x0 table-cell [BFC] children: not-inline
               Box <tr> at (9,87) content-size 98x39 table-row children: not-inline
-                BlockContainer <td> at (20,98) content-size 30.5625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
+                BlockContainer <td> at (20,98) content-size 30.5625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (20,98) content-size 30.5625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,106) content-size 21.71875x0 table-cell [BFC] children: not-inline
                 BlockContainer <(anonymous)> at (84.28125,106) content-size 21.71875x0 table-cell [BFC] children: not-inline
 
@@ -38,16 +42,20 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [9,9 98x117]
               PaintableBox (Box<TR>) [9,9 98x39]
                 PaintableWithLines (BlockContainer<TD>) [9,9 52.5625x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [20,20 30.5625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [61.5625,9 45.4375x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [72.5625,20 23.4375x17]
+                    TextPaintable (TextNode<#text>)
               PaintableBox (Box<TR>) [9,48 98x39]
                 PaintableWithLines (BlockContainer<TD>) [9,48 52.5625x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [20,59 30.5625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,48 22.71875x39]
                 PaintableWithLines (BlockContainer(anonymous)) [84.28125,48 22.71875x39]
               PaintableBox (Box<TR>) [9,87 98x39]
                 PaintableWithLines (BlockContainer<TD>) [9,87 52.5625x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [20,98 30.5625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,87 22.71875x39]
                 PaintableWithLines (BlockContainer(anonymous)) [84.28125,87 22.71875x39]

--- a/Tests/LibWeb/Layout/expected/table/missing-cells.txt
+++ b/Tests/LibWeb/Layout/expected/table/missing-cells.txt
@@ -6,25 +6,29 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table> at (9,9) content-size 98x117 table-box [TFC] children: not-inline
             Box <tbody> at (9,9) content-size 98x117 table-row-group children: not-inline
               Box <tr> at (9,9) content-size 98x39 table-row children: not-inline
-                BlockContainer <td> at (20,20) content-size 30.5625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
-                BlockContainer <td> at (72.5625,20) content-size 23.4375x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17] baseline: 13.296875
-                      "B"
-                  TextNode <#text>
+                BlockContainer <td> at (20,20) content-size 30.5625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (20,20) content-size 30.5625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [20,20 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
+                BlockContainer <td> at (72.5625,20) content-size 23.4375x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (72.5625,20) content-size 23.4375x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [72.5625,20 9.34375x17] baseline: 13.296875
+                        "B"
+                    TextNode <#text>
               Box <tr> at (9,48) content-size 98x39 table-row children: not-inline
-                BlockContainer <td> at (20,59) content-size 30.5625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
+                BlockContainer <td> at (20,59) content-size 30.5625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (20,59) content-size 30.5625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [20,59 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,68) content-size 43.4375x0 table-cell [BFC] children: not-inline
               Box <tr> at (9,87) content-size 98x39 table-row children: not-inline
-                BlockContainer <td> at (20,98) content-size 30.5625x17 table-cell [BFC] children: inline
-                  frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17] baseline: 13.296875
-                      "A"
-                  TextNode <#text>
+                BlockContainer <td> at (20,98) content-size 30.5625x17 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (20,98) content-size 30.5625x17 children: inline
+                    frag 0 from TextNode start: 0, length: 1, rect: [20,98 14.265625x17] baseline: 13.296875
+                        "A"
+                    TextNode <#text>
                 BlockContainer <(anonymous)> at (62.5625,106) content-size 43.4375x0 table-cell [BFC] children: not-inline
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
@@ -36,14 +40,18 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [9,9 98x117]
               PaintableBox (Box<TR>) [9,9 98x39]
                 PaintableWithLines (BlockContainer<TD>) [9,9 52.5625x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [20,20 30.5625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer<TD>) [61.5625,9 45.4375x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [72.5625,20 23.4375x17]
+                    TextPaintable (TextNode<#text>)
               PaintableBox (Box<TR>) [9,48 98x39]
                 PaintableWithLines (BlockContainer<TD>) [9,48 52.5625x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [20,59 30.5625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,48 45.4375x39]
               PaintableBox (Box<TR>) [9,87 98x39]
                 PaintableWithLines (BlockContainer<TD>) [9,87 52.5625x39]
-                  TextPaintable (TextNode<#text>)
+                  PaintableWithLines (BlockContainer(anonymous)) [20,98 30.5625x17]
+                    TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [61.5625,87 45.4375x39]

--- a/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
+++ b/Tests/LibWeb/Layout/expected/table/multi-line-cell.txt
@@ -7,19 +7,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           Box <tbody> at (11,11) content-size 75.4375x61 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 75.4375x21 table-row children: not-inline
-              BlockContainer <td> at (13,13) content-size 71.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x17] baseline: 13.296875
-                    "*"
-                TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 71.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,13) content-size 71.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 7.9375x17] baseline: 13.296875
+                      "*"
+                  TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (11,34) content-size 75.4375x38 table-row children: not-inline
-              BlockContainer <td> at (13,36) content-size 71.4375x34 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 9, rect: [13,36 71.4375x17] baseline: 13.296875
-                    "*********"
-                frag 1 from TextNode start: 10, length: 8, rect: [13,53 63.5625x17] baseline: 13.296875
-                    "***** **"
-                TextNode <#text>
+              BlockContainer <td> at (13,36) content-size 71.4375x34 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,36) content-size 71.4375x34 children: inline
+                  frag 0 from TextNode start: 0, length: 9, rect: [13,36 71.4375x17] baseline: 13.296875
+                      "*********"
+                  frag 1 from TextNode start: 10, length: 8, rect: [13,53 63.5625x17] baseline: 13.296875
+                      "***** **"
+                  TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,75) content-size 784x0 children: inline
@@ -33,8 +35,10 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 75.4375x61]
             PaintableBox (Box<TR>) [11,11 75.4375x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 75.4375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,13 71.4375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [11,34 75.4375x38]
               PaintableWithLines (BlockContainer<TD>) [11,34 75.4375x38]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,36 71.4375x34]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,75 784x0]

--- a/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-alignment.txt
@@ -10,10 +10,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (159.890625,13) content-size 43.109375x202 table-box [TFC] children: not-inline
                     Box <tbody> at (161.890625,15) content-size 39.109375x198 table-row-group children: not-inline
                       Box <tr> at (161.890625,15) content-size 39.109375x198 table-row children: not-inline
-                        BlockContainer <td> at (162.890625,105.5) content-size 37.109375x17 table-cell [BFC] children: inline
-                          frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105.5 37.109375x17] baseline: 13.296875
-                              "right"
-                          TextNode <#text>
+                        BlockContainer <td> at (162.890625,105.5) content-size 37.109375x17 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (162.890625,105.5) content-size 37.109375x17 children: inline
+                            frag 0 from TextNode start: 0, length: 5, rect: [162.890625,105.5 37.109375x17] baseline: 13.296875
+                                "right"
+                            TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x228]
@@ -28,4 +29,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [161.890625,15 39.109375x198]
                       PaintableBox (Box<TR>) [161.890625,15 39.109375x198]
                         PaintableWithLines (BlockContainer<TD>) [161.890625,15 39.109375x198]
-                          TextPaintable (TextNode<#text>)
+                          PaintableWithLines (BlockContainer(anonymous)) [162.890625,105.5 37.109375x17]
+                            TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
+++ b/Tests/LibWeb/Layout/expected/table/nested-table-box-width.txt
@@ -15,10 +15,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (15,15) content-size 101.828125x54 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,33.5) content-size 11.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x17] baseline: 13.296875
-                    "X"
-                TextNode <#text>
+              BlockContainer <td> at (25,33.5) content-size 11.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (25,33.5) content-size 11.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [25,33.5 11.5625x17] baseline: 13.296875
+                      "X"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (58.5625,25) content-size 48.265625x90 table-cell [BFC] children: not-inline
@@ -34,10 +35,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (65.5625,32) content-size 34.265625x37 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (75.5625,42) content-size 14.265625x17 table-cell [BFC] children: inline
-                          frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x17] baseline: 13.296875
-                              "A"
-                          TextNode <#text>
+                        BlockContainer <td> at (75.5625,42) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (75.5625,42) content-size 14.265625x17 children: inline
+                            frag 0 from TextNode start: 0, length: 1, rect: [75.5625,42 14.265625x17] baseline: 13.296875
+                                "A"
+                            TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,10 +47,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (65.5625,71) content-size 34.265625x37 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (75.5625,81) content-size 14.265625x17 table-cell [BFC] children: inline
-                          frag 0 from TextNode start: 0, length: 1, rect: [75.5625,81 9.34375x17] baseline: 13.296875
-                              "B"
-                          TextNode <#text>
+                        BlockContainer <td> at (75.5625,81) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (75.5625,81) content-size 14.265625x17 children: inline
+                            frag 0 from TextNode start: 0, length: 1, rect: [75.5625,81 9.34375x17] baseline: 13.296875
+                                "B"
+                            TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -64,10 +67,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (15,71) content-size 101.828125x54 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (25,89.5) content-size 11.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [25,89.5 11.09375x17] baseline: 13.296875
-                    "Y"
-                TextNode <#text>
+              BlockContainer <td> at (25,89.5) content-size 11.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (25,89.5) content-size 11.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [25,89.5 11.09375x17] baseline: 13.296875
+                      "Y"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -87,7 +91,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [15,15 101.828125x110]
             PaintableBox (Box<TR>) [15,15 101.828125x54]
               PaintableWithLines (BlockContainer<TD>) [15,15 31.5625x54]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [25,33.5 11.5625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [48.5625,15 68.265625x110]
                 PaintableWithLines (BlockContainer(anonymous)) [58.5625,25 48.265625x0]
                 PaintableWithLines (TableWrapper(anonymous)) [58.5625,25 48.265625x90]
@@ -95,12 +100,15 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [65.5625,32 34.265625x76]
                       PaintableBox (Box<TR>) [65.5625,32 34.265625x37]
                         PaintableWithLines (BlockContainer<TD>) [65.5625,32 34.265625x37]
-                          TextPaintable (TextNode<#text>)
+                          PaintableWithLines (BlockContainer(anonymous)) [75.5625,42 14.265625x17]
+                            TextPaintable (TextNode<#text>)
                       PaintableBox (Box<TR>) [65.5625,71 34.265625x37]
                         PaintableWithLines (BlockContainer<TD>) [65.5625,71 34.265625x37]
-                          TextPaintable (TextNode<#text>)
+                          PaintableWithLines (BlockContainer(anonymous)) [75.5625,81 14.265625x17]
+                            TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [58.5625,115 48.265625x0]
             PaintableBox (Box<TR>) [15,71 101.828125x54]
               PaintableWithLines (BlockContainer<TD>) [15,71 31.5625x54]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [25,89.5 11.5625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,132 784x0]

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-columns.txt
@@ -11,22 +11,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 92x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,11) content-size 14.40625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [11.0625,11 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 14.40625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 14.40625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [11.0625,11 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (29.40625,11) content-size 51.1875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [50.328125,11 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (29.40625,11) content-size 51.1875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (29.40625,11) content-size 51.1875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [50.328125,11 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (84.59375,11) content-size 14.40625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [86.640625,11 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (84.59375,11) content-size 14.40625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (84.59375,11) content-size 14.40625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [86.640625,11 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,8 +45,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 92x21]
             PaintableBox (Box<TR>) [9,9 92x21]
               PaintableWithLines (BlockContainer<TD>) [9,9 18.40625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 14.40625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [27.40625,9 55.1875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [29.40625,11 51.1875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [82.59375,9 18.40625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [84.59375,11 14.40625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-for-nested-table-is-like-auto.txt
@@ -12,10 +12,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <table.inner> at (12,12) content-size 192x23 table-box [TFC] children: not-inline
                         Box <tbody> at (14,14) content-size 188x19 table-row-group children: not-inline
                           Box <tr> at (14,14) content-size 188x19 table-row children: not-inline
-                            BlockContainer <td> at (15,15) content-size 186x17 table-cell [BFC] children: inline
-                              frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x17] baseline: 13.296875
-                                  "A A"
-                              TextNode <#text>
+                            BlockContainer <td> at (15,15) content-size 186x17 table-cell [BFC] children: not-inline
+                              BlockContainer <(anonymous)> at (15,15) content-size 186x17 children: inline
+                                frag 0 from TextNode start: 0, length: 3, rect: [15,15 36.53125x17] baseline: 13.296875
+                                    "A A"
+                                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -32,4 +33,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                         PaintableBox (Box<TBODY>) [14,14 188x19]
                           PaintableBox (Box<TR>) [14,14 188x19]
                             PaintableWithLines (BlockContainer<TD>) [14,14 188x19]
-                              TextPaintable (TextNode<#text>)
+                              PaintableWithLines (BlockContainer(anonymous)) [15,15 186x17]
+                                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/percentage-width-max-width-columns.txt
@@ -9,22 +9,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 119x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 31.703125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x17] baseline: 13.296875
-                    "A B"
-                TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 31.703125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (10,10) content-size 31.703125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [10,10 31.609375x17] baseline: 13.296875
+                      "A B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (45.703125,10) content-size 43.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [45.703125,10 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (45.703125,10) content-size 43.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (45.703125,10) content-size 43.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [45.703125,10 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (93.296875,10) content-size 31.703125x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x17] baseline: 13.296875
-                    "D"
-                TextNode <#text>
+              BlockContainer <td> at (93.296875,10) content-size 31.703125x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (93.296875,10) content-size 31.703125x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [93.296875,10 11.140625x17] baseline: 13.296875
+                      "D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,8 +41,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 119x21]
             PaintableBox (Box<TR>) [8,8 119x21]
               PaintableWithLines (BlockContainer<TD>) [8,8 35.703125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [10,10 31.703125x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [43.703125,8 47.59375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [45.703125,10 43.59375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [91.296875,8 35.703125x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [93.296875,10 31.703125x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-outer-size-with-computed-size.txt
@@ -12,13 +12,14 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
               BlockContainer <td> at (11,14.75) content-size 0x0 table-cell [BFC] children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (16,12) content-size 37.21875x17 table-cell [BFC] children: inline
-                TextNode <#text>
-                InlineNode <a>
-                  frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x17] baseline: 13.296875
-                      "Test"
+              BlockContainer <td> at (16,12) content-size 37.21875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (16,12) content-size 37.21875x17 children: inline
                   TextNode <#text>
-                TextNode <#text>
+                  InlineNode <a>
+                    frag 0 from TextNode start: 0, length: 4, rect: [16,12 37.21875x17] baseline: 13.296875
+                        "Test"
+                    TextNode <#text>
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -41,7 +42,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TR>) [10,10 45.21875x9.5]
               PaintableWithLines (BlockContainer<TD>) [10,10 2x9.5]
               PaintableWithLines (BlockContainer<TD>) [14,10 41.21875x21]
-                PaintableWithLines (InlineNode<A>)
-                  TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [16,12 37.21875x17]
+                  PaintableWithLines (InlineNode<A>)
+                    TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,21.5 45.21875x9.5]
               PaintableWithLines (BlockContainer<TD>) [10,21.5 2x9.5]

--- a/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
+++ b/Tests/LibWeb/Layout/expected/table/row-span-and-nested-tables.txt
@@ -15,10 +15,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 69.828125x53.5 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,29.25) content-size 11.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [17,29.25 11.5625x17] baseline: 13.296875
-                    "X"
-                TextNode <#text>
+              BlockContainer <td> at (17,29.25) content-size 11.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (17,29.25) content-size 11.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,29.25 11.5625x17] baseline: 13.296875
+                      "X"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
               BlockContainer <td> at (42.5625,17) content-size 32.265625x97 table-cell [BFC] children: not-inline
@@ -34,10 +35,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (45.5625,20) content-size 26.265625x29 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,26) content-size 14.265625x17 table-cell [BFC] children: inline
-                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x17] baseline: 13.296875
-                              "A"
-                          TextNode <#text>
+                        BlockContainer <td> at (51.5625,26) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (51.5625,26) content-size 14.265625x17 children: inline
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,26 14.265625x17] baseline: 13.296875
+                                "A"
+                            TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -45,10 +47,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (45.5625,51) content-size 26.265625x29 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,57) content-size 14.265625x17 table-cell [BFC] children: inline
-                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,57 9.34375x17] baseline: 13.296875
-                              "B"
-                          TextNode <#text>
+                        BlockContainer <td> at (51.5625,57) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (51.5625,57) content-size 14.265625x17 children: inline
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,57 9.34375x17] baseline: 13.296875
+                                "B"
+                            TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -56,10 +59,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                       Box <tr> at (45.5625,82) content-size 26.265625x29 table-row children: not-inline
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
-                        BlockContainer <td> at (51.5625,88) content-size 14.265625x17 table-cell [BFC] children: inline
-                          frag 0 from TextNode start: 0, length: 1, rect: [51.5625,88 10.3125x17] baseline: 13.296875
-                              "C"
-                          TextNode <#text>
+                        BlockContainer <td> at (51.5625,88) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (51.5625,88) content-size 14.265625x17 children: inline
+                            frag 0 from TextNode start: 0, length: 1, rect: [51.5625,88 10.3125x17] baseline: 13.296875
+                                "C"
+                            TextNode <#text>
                         BlockContainer <(anonymous)> (not painted) children: inline
                           TextNode <#text>
                       BlockContainer <(anonymous)> (not painted) children: inline
@@ -75,10 +79,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,66.5) content-size 69.828125x53.5 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (17,84.75) content-size 11.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [17,84.75 11.09375x17] baseline: 13.296875
-                    "Y"
-                TextNode <#text>
+              BlockContainer <td> at (17,84.75) content-size 11.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (17,84.75) content-size 11.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [17,84.75 11.09375x17] baseline: 13.296875
+                      "Y"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -98,7 +103,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 69.828125x109]
             PaintableBox (Box<TR>) [11,11 69.828125x53.5]
               PaintableWithLines (BlockContainer<TD>) [11,11 23.5625x53.5]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [17,29.25 11.5625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36.5625,11 44.265625x109]
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,17 32.265625x0]
                 PaintableWithLines (TableWrapper(anonymous)) [42.5625,17 32.265625x97]
@@ -106,15 +112,19 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [45.5625,20 26.265625x91]
                       PaintableBox (Box<TR>) [45.5625,20 26.265625x29]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,20 26.265625x29]
-                          TextPaintable (TextNode<#text>)
+                          PaintableWithLines (BlockContainer(anonymous)) [51.5625,26 14.265625x17]
+                            TextPaintable (TextNode<#text>)
                       PaintableBox (Box<TR>) [45.5625,51 26.265625x29]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,51 26.265625x29]
-                          TextPaintable (TextNode<#text>)
+                          PaintableWithLines (BlockContainer(anonymous)) [51.5625,57 14.265625x17]
+                            TextPaintable (TextNode<#text>)
                       PaintableBox (Box<TR>) [45.5625,82 26.265625x29]
                         PaintableWithLines (BlockContainer<TD>) [45.5625,82 26.265625x29]
-                          TextPaintable (TextNode<#text>)
+                          PaintableWithLines (BlockContainer(anonymous)) [51.5625,88 14.265625x17]
+                            TextPaintable (TextNode<#text>)
                 PaintableWithLines (BlockContainer(anonymous)) [42.5625,114 32.265625x0]
             PaintableBox (Box<TR>) [11,66.5 69.828125x53.5]
               PaintableWithLines (BlockContainer<TD>) [11,66.5 23.5625x53.5]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [17,84.75 11.5625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,123 784x0]

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-3.txt
@@ -4,15 +4,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
           Box <div.row.a> at (8,8) content-size 200x150 table-row children: not-inline
-            BlockContainer <div.cell> at (8,8) content-size 200x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
-                  "a"
-              TextNode <#text>
+            BlockContainer <div.cell> at (8,8) content-size 200x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,8) content-size 200x17 children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
+                    "a"
+                TextNode <#text>
           Box <div.row.b> at (8,158) content-size 200x150 table-row children: not-inline
-            BlockContainer <div.cell> at (8,158) content-size 200x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x17] baseline: 13.296875
-                  "b"
-              TextNode <#text>
+            BlockContainer <div.cell> at (8,158) content-size 200x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,158) content-size 200x17 children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,158 9.46875x17] baseline: 13.296875
+                    "b"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -21,7 +23,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<DIV>.table) [8,8 200x300]
           PaintableBox (Box<DIV>.row.a) [8,8 200x150]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x150]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,8 200x17]
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.row.b) [8,158 200x150]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,158 200x150]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,158 200x17]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
+++ b/Tests/LibWeb/Layout/expected/table/rows-height-distribution-4.txt
@@ -4,15 +4,17 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
       TableWrapper <(anonymous)> at (8,8) content-size 200x300 [BFC] children: not-inline
         Box <div.table> at (8,8) content-size 200x300 table-box [TFC] children: not-inline
           Box <div.row.a> at (8,8) content-size 200x100 table-row children: not-inline
-            BlockContainer <div.cell> at (8,8) content-size 200x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
-                  "a"
-              TextNode <#text>
+            BlockContainer <div.cell> at (8,8) content-size 200x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,8) content-size 200x17 children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,8 9.34375x17] baseline: 13.296875
+                    "a"
+                TextNode <#text>
           Box <div.row.b> at (8,108) content-size 200x200 table-row children: not-inline
-            BlockContainer <div.cell> at (8,108) content-size 200x17 table-cell [BFC] children: inline
-              frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x17] baseline: 13.296875
-                  "b"
-              TextNode <#text>
+            BlockContainer <div.cell> at (8,108) content-size 200x17 table-cell [BFC] children: not-inline
+              BlockContainer <(anonymous)> at (8,108) content-size 200x17 children: inline
+                frag 0 from TextNode start: 0, length: 1, rect: [8,108 9.46875x17] baseline: 13.296875
+                    "b"
+                TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
@@ -21,7 +23,9 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
         PaintableBox (Box<DIV>.table) [8,8 200x300]
           PaintableBox (Box<DIV>.row.a) [8,8 200x100]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,8 200x100]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,8 200x17]
+                TextPaintable (TextNode<#text>)
           PaintableBox (Box<DIV>.row.b) [8,108 200x200]
             PaintableWithLines (BlockContainer<DIV>.cell) [8,108 200x200]
-              TextPaintable (TextNode<#text>)
+              PaintableWithLines (BlockContainer(anonymous)) [8,108 200x17]
+                TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan-with-trailing-characters.txt
@@ -13,22 +13,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
-                    "Header 1"
-                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
+                      "Header 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
-                    "Header 2"
-                TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,11) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
+                      "Header 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
-                    "Header 3"
-                TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,11) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
+                      "Header 3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,22 +39,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,30) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,32) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [25.09375,32 41.84375x17] baseline: 13.296875
-                    "Cell 1"
-                TextNode <#text>
+              BlockContainer <td> at (11,32) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,32) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [25.09375,32 41.84375x17] baseline: 13.296875
+                      "Cell 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,32) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [99.140625,32 44.3125x17] baseline: 13.296875
-                    "Cell 2"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,32) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,32) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.140625,32 44.3125x17] baseline: 13.296875
+                      "Cell 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,42.5) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [175.65625,42.5 44.59375x17] baseline: 13.296875
-                    "Cell 3"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,42.5) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,42.5) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [175.65625,42.5 44.59375x17] baseline: 13.296875
+                      "Cell 3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -59,16 +65,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,51) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,53) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [24.390625,53 43.25x17] baseline: 13.296875
-                    "Cell 4"
-                TextNode <#text>
+              BlockContainer <td> at (11,53) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,53) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [24.390625,53 43.25x17] baseline: 13.296875
+                      "Cell 4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [99.328125,53 43.953125x17] baseline: 13.296875
-                    "Cell 5"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,53) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.328125,53 43.953125x17] baseline: 13.296875
+                      "Cell 5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -76,22 +84,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,72) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [23.90625,74 44.234375x17] baseline: 13.296875
-                    "Cell 6"
-                TextNode <#text>
+              BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,74) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [23.90625,74 44.234375x17] baseline: 13.296875
+                      "Cell 6"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [99.1875,74 44.21875x17] baseline: 13.296875
-                    "Cell 7"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,74) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [99.1875,74 44.21875x17] baseline: 13.296875
+                      "Cell 7"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [175.46875,74 44.984375x17] baseline: 13.296875
-                    "Cell 8"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,74) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [175.46875,74 44.984375x17] baseline: 13.296875
+                      "Cell 8"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -99,22 +110,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,93) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,95) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [23.859375,95 44.328125x17] baseline: 13.296875
-                    "Cell 9"
-                TextNode <#text>
+              BlockContainer <td> at (11,95) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,95) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [23.859375,95 44.328125x17] baseline: 13.296875
+                      "Cell 9"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,95) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [95.578125,95 51.4375x17] baseline: 13.296875
-                    "Cell 10"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,95) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,95) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [95.578125,95 51.4375x17] baseline: 13.296875
+                      "Cell 10"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,105.5) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [173.859375,105.5 48.1875x17] baseline: 13.296875
-                    "Cell 11"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,105.5) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,105.5) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [173.859375,105.5 48.1875x17] baseline: 13.296875
+                      "Cell 11"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -122,16 +136,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,114) content-size 227.359375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,116) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [20.6875,116 50.65625x17] baseline: 13.296875
-                    "Cell 12"
-                TextNode <#text>
+              BlockContainer <td> at (11,116) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,116) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [20.6875,116 50.65625x17] baseline: 13.296875
+                      "Cell 12"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,116) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 7, rect: [95.828125,116 50.9375x17] baseline: 13.296875
-                    "Cell 13"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,116) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,116) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 7, rect: [95.828125,116 50.9375x17] baseline: 13.296875
+                      "Cell 13"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -149,40 +165,56 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 227.359375x126]
             PaintableBox (Box<TR>) [9,9 227.359375x21]
               PaintableWithLines (BlockContainer<TH>) [9,9 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [83.046875,9 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,11 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [159.5625,9 76.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,11 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,30 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,30 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,32 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,30 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,32 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,30 76.796875x42]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,42.5 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,51 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,51 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,53 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,51 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,53 72.515625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,72 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,72 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,74 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,72 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,74 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,72 76.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,74 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,93 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,93 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,95 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,93 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,95 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.5625,93 76.796875x42]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,105.5 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,114 227.359375x21]
               PaintableWithLines (BlockContainer<TD>) [9,114 74.046875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,116 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.046875,114 76.515625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,116 72.515625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,136 784x0]

--- a/Tests/LibWeb/Layout/expected/table/rowspan.txt
+++ b/Tests/LibWeb/Layout/expected/table/rowspan.txt
@@ -13,22 +13,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,10) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
-                    "Header 1"
-                TextNode <#text>
+              BlockContainer <th> at (11,11) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [11,11 70.046875x17] baseline: 13.296875
+                      "Header 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
-                    "Header 2"
-                TextNode <#text>
+              BlockContainer <th> at (85.046875,11) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,11) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [85.046875,11 72.515625x17] baseline: 13.296875
+                      "Header 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
-                    "Header 3"
-                TextNode <#text>
+              BlockContainer <th> at (161.5625,11) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,11) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 8, rect: [161.5625,11 72.796875x17] baseline: 13.296875
+                      "Header 3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -36,22 +39,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,31) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,42.5) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [11,42.5 49.609375x17] baseline: 13.296875
-                    "Row 1"
-                TextNode <#text>
+              BlockContainer <td> at (11,42.5) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,42.5) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [11,42.5 49.609375x17] baseline: 13.296875
+                      "Row 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,32) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,32 41.84375x17] baseline: 13.296875
-                    "Cell 1"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,32) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,32) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,32 41.84375x17] baseline: 13.296875
+                      "Cell 1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,32) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,32 44.3125x17] baseline: 13.296875
-                    "Cell 2"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,32) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,32) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,32 44.3125x17] baseline: 13.296875
+                      "Cell 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -59,16 +65,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,52) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,53 44.59375x17] baseline: 13.296875
-                    "Cell 3"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,53) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,53) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,53 44.59375x17] baseline: 13.296875
+                      "Cell 3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,53) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,53 43.25x17] baseline: 13.296875
-                    "Cell 4"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,53) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,53) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,53 43.25x17] baseline: 13.296875
+                      "Cell 4"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -76,22 +84,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,73) content-size 225.359375x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 5, rect: [11,74 52.078125x17] baseline: 13.296875
-                    "Row 2"
-                TextNode <#text>
+              BlockContainer <td> at (11,74) content-size 70.046875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,74) content-size 70.046875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [11,74 52.078125x17] baseline: 13.296875
+                      "Row 2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [85.046875,74 43.953125x17] baseline: 13.296875
-                    "Cell 5"
-                TextNode <#text>
+              BlockContainer <td> at (85.046875,74) content-size 72.515625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.046875,74) content-size 72.515625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [85.046875,74 43.953125x17] baseline: 13.296875
+                      "Cell 5"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [161.5625,74 44.234375x17] baseline: 13.296875
-                    "Cell 6"
-                TextNode <#text>
+              BlockContainer <td> at (161.5625,74) content-size 72.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (161.5625,74) content-size 72.796875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [161.5625,74 44.234375x17] baseline: 13.296875
+                      "Cell 6"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -109,28 +120,39 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [10,10 225.359375x82]
             PaintableBox (Box<TR>) [10,10 225.359375x19]
               PaintableWithLines (BlockContainer<TH>) [10,10 72.046875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [84.046875,10 74.515625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,11 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TH>) [160.5625,10 74.796875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,11 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,31 225.359375x19]
               PaintableWithLines (BlockContainer<TD>) [10,31 72.046875x40]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,42.5 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [84.046875,31 74.515625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,32 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,31 74.796875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,32 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,52 225.359375x19]
               PaintableWithLines (BlockContainer<TD>) [84.046875,52 74.515625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,53 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,52 74.796875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,53 72.796875x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [10,73 225.359375x19]
               PaintableWithLines (BlockContainer<TD>) [10,73 72.046875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,74 70.046875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [84.046875,73 74.515625x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.046875,74 72.515625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [160.5625,73 74.796875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [161.5625,74 72.796875x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,94 784x0]

--- a/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
+++ b/Tests/LibWeb/Layout/expected/table/style-invalidation-propagation-to-table-wrapper.txt
@@ -6,8 +6,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
           Box <table> at (204,8) content-size 392x104 table-box [TFC] children: not-inline
             Box <tbody> at (206,10) content-size 388x100 table-row-group children: not-inline
               Box <tr> at (206,10) content-size 388x100 table-row children: not-inline
-                BlockContainer <td> at (207,60) content-size 386x0 table-cell [BFC] children: inline
-                  TextNode <#text>
+                BlockContainer <td> at (207,60) content-size 386x0 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (207,60) content-size 386x0 children: inline
+                    TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x120]
@@ -18,3 +19,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
             PaintableBox (Box<TBODY>) [206,10 388x100]
               PaintableBox (Box<TR>) [206,10 388x100]
                 PaintableWithLines (BlockContainer<TD>) [206,10 388x100]
+                  PaintableWithLines (BlockContainer(anonymous)) [207,60 386x0]

--- a/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
+++ b/Tests/LibWeb/Layout/expected/table/sum-of-percentage-column-widths-less-than-100.txt
@@ -9,22 +9,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 95.984375x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 19x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 19x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,13) content-size 19x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (38,13) content-size 41.984375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (38,13) content-size 41.984375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (38,13) content-size 41.984375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [38,13 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (85.984375,13) content-size 19x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (85.984375,13) content-size 19x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (85.984375,13) content-size 19x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [85.984375,13 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -38,8 +41,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 95.984375x21]
             PaintableBox (Box<TR>) [11,11 95.984375x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 23x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,13 19x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [36,11 45.984375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [38,13 41.984375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [83.984375,11 23x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [85.984375,13 19x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center-with-margin.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (109,101) content-size 87.34375x202 table-box [TFC] children: not-inline
           Box <tbody> at (111,103) content-size 83.34375x198 table-row-group children: not-inline
             Box <tr> at (111,103) content-size 83.34375x198 table-row children: not-inline
-              BlockContainer <td> at (112,193.5) content-size 81.34375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 10, rect: [112,193.5 81.34375x17] baseline: 13.296875
-                    "off-center"
-                TextNode <#text>
+              BlockContainer <td> at (112,193.5) content-size 81.34375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (112,193.5) content-size 81.34375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 10, rect: [112,193.5 81.34375x17] baseline: 13.296875
+                      "off-center"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -20,4 +21,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [111,103 83.34375x198]
             PaintableBox (Box<TR>) [111,103 83.34375x198]
               PaintableWithLines (BlockContainer<TD>) [111,103 83.34375x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [112,193.5 81.34375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-align-center.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-align-center.txt
@@ -5,10 +5,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (371.1875,9) content-size 57.625x202 table-box [TFC] children: not-inline
           Box <tbody> at (373.1875,11) content-size 53.625x198 table-row-group children: not-inline
             Box <tr> at (373.1875,11) content-size 53.625x198 table-row children: not-inline
-              BlockContainer <td> at (374.1875,101.5) content-size 51.625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101.5 51.625x17] baseline: 13.296875
-                    "center"
-                TextNode <#text>
+              BlockContainer <td> at (374.1875,101.5) content-size 51.625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (374.1875,101.5) content-size 51.625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [374.1875,101.5 51.625x17] baseline: 13.296875
+                      "center"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -20,4 +21,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [373.1875,11 53.625x198]
             PaintableBox (Box<TR>) [373.1875,11 53.625x198]
               PaintableWithLines (BlockContainer<TD>) [373.1875,11 53.625x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [374.1875,101.5 51.625x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-cellpadding.txt
@@ -5,18 +5,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 496.1875x202 table-box [TFC] children: not-inline
           Box <tbody> at (11,11) content-size 492.1875x198 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 492.1875x198 table-row children: not-inline
-              BlockContainer <td> at (71,71) content-size 26.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x17] baseline: 13.296875
-                    "top"
-                TextNode <#text>
-              BlockContainer <td> at (219.640625,101.5) content-size 45.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101.5 45.4375x17] baseline: 13.296875
-                    "middle"
-                TextNode <#text>
-              BlockContainer <td> at (387.078125,132) content-size 56.109375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [387.078125,132 56.109375x17] baseline: 13.296875
-                    "bottom"
-                TextNode <#text>
+              BlockContainer <td> at (71,71) content-size 26.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (71,71) content-size 26.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [71,71 26.640625x17] baseline: 13.296875
+                      "top"
+                  TextNode <#text>
+              BlockContainer <td> at (219.640625,101.5) content-size 45.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (219.640625,101.5) content-size 45.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [219.640625,101.5 45.4375x17] baseline: 13.296875
+                      "middle"
+                  TextNode <#text>
+              BlockContainer <td> at (387.078125,132) content-size 56.109375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (387.078125,132) content-size 56.109375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [387.078125,132 56.109375x17] baseline: 13.296875
+                      "bottom"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -28,8 +31,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 492.1875x198]
             PaintableBox (Box<TR>) [11,11 492.1875x198]
               PaintableWithLines (BlockContainer<TD>) [11,11 146.640625x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [71,71 26.640625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [159.640625,11 165.4375x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [219.640625,101.5 45.4375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [327.078125,11 176.109375x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [387.078125,132 56.109375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
+++ b/Tests/LibWeb/Layout/expected/table/table-formation-with-rowspan-in-the-middle.txt
@@ -9,22 +9,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,9) content-size 101.421875x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,20) content-size 9.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x17] baseline: 13.296875
-                    "0"
-                TextNode <#text>
+              BlockContainer <td> at (20,20) content-size 9.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (20,20) content-size 9.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,20 9.59375x17] baseline: 13.296875
+                      "0"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (51.59375,39.5) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [51.59375,39.5 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (51.59375,39.5) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (51.59375,39.5) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,39.5 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.859375,59) content-size 11.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.859375,59 11.5625x17] baseline: 13.296875
-                    "X"
-                TextNode <#text>
+              BlockContainer <td> at (87.859375,59) content-size 11.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.859375,59) content-size 11.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,59 11.5625x17] baseline: 13.296875
+                      "X"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,10 +35,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,48) content-size 101.421875x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,59) content-size 9.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [20,59 6.34375x17] baseline: 13.296875
-                    "1"
-                TextNode <#text>
+              BlockContainer <td> at (20,59) content-size 9.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (20,59) content-size 9.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,59 6.34375x17] baseline: 13.296875
+                      "1"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -43,16 +47,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,87) content-size 101.421875x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,98) content-size 9.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [20,98 8.8125x17] baseline: 13.296875
-                    "2"
-                TextNode <#text>
+              BlockContainer <td> at (20,98) content-size 9.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (20,98) content-size 9.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,98 8.8125x17] baseline: 13.296875
+                      "2"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (51.59375,117.5) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [51.59375,117.5 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (51.59375,117.5) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (51.59375,117.5) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [51.59375,117.5 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -60,16 +66,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (9,126) content-size 101.421875x39 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (20,137) content-size 9.59375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [20,137 9.09375x17] baseline: 13.296875
-                    "3"
-                TextNode <#text>
+              BlockContainer <td> at (20,137) content-size 9.59375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (20,137) content-size 9.59375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [20,137 9.09375x17] baseline: 13.296875
+                      "3"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (87.859375,137) content-size 11.5625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [87.859375,137 10.3125x17] baseline: 13.296875
-                    "C"
-                TextNode <#text>
+              BlockContainer <td> at (87.859375,137) content-size 11.5625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (87.859375,137) content-size 11.5625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [87.859375,137 10.3125x17] baseline: 13.296875
+                      "C"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -85,22 +93,30 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 101.421875x156]
             PaintableBox (Box<TR>) [9,9 101.421875x39]
               PaintableWithLines (BlockContainer<TD>) [9,9 31.59375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [20,20 9.59375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [40.59375,9 36.265625x78]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [51.59375,39.5 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [76.859375,9 33.5625x117]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.859375,59 11.5625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,48 101.421875x39]
               PaintableWithLines (BlockContainer<TD>) [9,48 31.59375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [20,59 9.59375x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,87 101.421875x39]
               PaintableWithLines (BlockContainer<TD>) [9,87 31.59375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [20,98 9.59375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [40.59375,87 36.265625x78]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [51.59375,117.5 14.265625x17]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,126 101.421875x39]
               PaintableWithLines (BlockContainer<TD>) [9,126 31.59375x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [20,137 9.59375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [76.859375,126 33.5625x39]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [87.859375,137 11.5625x17]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,166 784x0]

--- a/Tests/LibWeb/Layout/expected/table/td-valign.txt
+++ b/Tests/LibWeb/Layout/expected/table/td-valign.txt
@@ -5,18 +5,21 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
         Box <table> at (9,9) content-size 142.1875x202 table-box [TFC] children: not-inline
           Box <tbody> at (11,11) content-size 138.1875x198 table-row-group children: not-inline
             Box <tr> at (11,11) content-size 138.1875x198 table-row children: not-inline
-              BlockContainer <td> at (12,12) content-size 26.640625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x17] baseline: 13.296875
-                    "top"
-                TextNode <#text>
-              BlockContainer <td> at (42.640625,101.5) content-size 45.4375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101.5 45.4375x17] baseline: 13.296875
-                    "middle"
-                TextNode <#text>
-              BlockContainer <td> at (92.078125,191) content-size 56.109375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 6, rect: [92.078125,191 56.109375x17] baseline: 13.296875
-                    "bottom"
-                TextNode <#text>
+              BlockContainer <td> at (12,12) content-size 26.640625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (12,12) content-size 26.640625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 3, rect: [12,12 26.640625x17] baseline: 13.296875
+                      "top"
+                  TextNode <#text>
+              BlockContainer <td> at (42.640625,101.5) content-size 45.4375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (42.640625,101.5) content-size 45.4375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [42.640625,101.5 45.4375x17] baseline: 13.296875
+                      "middle"
+                  TextNode <#text>
+              BlockContainer <td> at (92.078125,191) content-size 56.109375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (92.078125,191) content-size 56.109375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 6, rect: [92.078125,191 56.109375x17] baseline: 13.296875
+                      "bottom"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
 
@@ -28,8 +31,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 138.1875x198]
             PaintableBox (Box<TR>) [11,11 138.1875x198]
               PaintableWithLines (BlockContainer<TD>) [11,11 28.640625x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [12,12 26.640625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [41.640625,11 47.4375x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [42.640625,101.5 45.4375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [91.078125,11 58.109375x198]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [92.078125,191 56.109375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
+++ b/Tests/LibWeb/Layout/expected/table/top-caption-with-padding.txt
@@ -15,10 +15,11 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (10,37) content-size 56.46875x19 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (11,38) content-size 54.46875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 4, rect: [11,38 27.5x17] baseline: 13.296875
-                    "Cell"
-                TextNode <#text>
+              BlockContainer <td> at (11,38) content-size 54.46875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,38) content-size 54.46875x17 children: inline
+                  frag 0 from TextNode start: 0, length: 4, rect: [11,38 27.5x17] baseline: 13.296875
+                      "Cell"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -34,4 +35,5 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600] overflow: [0,-2 800x602]
           PaintableBox (Box<TBODY>) [10,37 56.46875x19]
             PaintableBox (Box<TR>) [10,37 56.46875x19]
               PaintableWithLines (BlockContainer<TD>) [10,37 56.46875x19]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,38 54.46875x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-baseline.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-baseline.txt
@@ -7,25 +7,29 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             TextNode <#text>
           Box <tbody> at (9,9) content-size 613.65625x96 table-row-group children: not-inline
             Box <tr> at (9,9) content-size 613.65625x48 table-row children: not-inline
-              BlockContainer <td> at (11,11) content-size 349.90625x44 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 13, rect: [11,11 273.984375x44] baseline: 34
-                    "Text baseline"
-                TextNode <#text>
-              BlockContainer <td.small-text> at (364.90625,36.5) content-size 255.75x11 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [364.90625,36.5 62.28125x11] baseline: 8.5
-                    "Smaller text"
-                TextNode <#text>
+              BlockContainer <td> at (11,11) content-size 349.90625x44 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,11) content-size 349.90625x44 children: inline
+                  frag 0 from TextNode start: 0, length: 13, rect: [11,11 273.984375x44] baseline: 34
+                      "Text baseline"
+                  TextNode <#text>
+              BlockContainer <td.small-text> at (364.90625,36.5) content-size 255.75x11 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (364.90625,36.5) content-size 255.75x11 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [364.90625,36.5 62.28125x11] baseline: 8.5
+                      "Smaller text"
+                  TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
             Box <tr> at (9,57) content-size 613.65625x48 table-row children: not-inline
-              BlockContainer <td> at (11,59) content-size 349.90625x44 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 16, rect: [11,59 349.90625x44] baseline: 34
-                    "Another baseline"
-                TextNode <#text>
-              BlockContainer <td> at (364.90625,59) content-size 255.75x44 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 12, rect: [364.90625,59 255.75x44] baseline: 34
-                    "Regular text"
-                TextNode <#text>
+              BlockContainer <td> at (11,59) content-size 349.90625x44 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,59) content-size 349.90625x44 children: inline
+                  frag 0 from TextNode start: 0, length: 16, rect: [11,59 349.90625x44] baseline: 34
+                      "Another baseline"
+                  TextNode <#text>
+              BlockContainer <td> at (364.90625,59) content-size 255.75x44 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (364.90625,59) content-size 255.75x44 children: inline
+                  frag 0 from TextNode start: 0, length: 12, rect: [364.90625,59 255.75x44] baseline: 34
+                      "Regular text"
+                  TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
               TextNode <#text>
       BlockContainer <(anonymous)> at (8,106) content-size 784x0 children: inline
@@ -39,12 +43,16 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [9,9 613.65625x96]
             PaintableBox (Box<TR>) [9,9 613.65625x48]
               PaintableWithLines (BlockContainer<TD>) [9,9 353.90625x48]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,11 349.90625x44]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>.small-text) [362.90625,9 259.75x48]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [364.90625,36.5 255.75x11]
+                  TextPaintable (TextNode<#text>)
             PaintableBox (Box<TR>) [9,57 613.65625x48]
               PaintableWithLines (BlockContainer<TD>) [9,57 353.90625x48]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [11,59 349.90625x44]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [362.90625,57 259.75x48]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [364.90625,59 255.75x44]
+                  TextPaintable (TextNode<#text>)
       PaintableWithLines (BlockContainer(anonymous)) [8,106 784x0]

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-td-vs-div.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-td-vs-div.txt
@@ -1,0 +1,35 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x204 children: not-inline
+      TableWrapper <(anonymous)> at (8,8) content-size 42.84375x104 [BFC] children: not-inline
+        Box <table> at (8,8) content-size 42.84375x104 table-box [TFC] children: not-inline
+          Box <tbody> at (10,10) content-size 38.84375x100 table-row-group children: not-inline
+            Box <tr> at (10,10) content-size 38.84375x100 table-row children: not-inline
+              BlockContainer <td> at (11,51.5) content-size 36.84375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (11,51.5) content-size 36.84375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 5, rect: [11,51.5 36.84375x17] baseline: 13.296875
+                      "hello"
+                  TextNode <#text>
+      BlockContainer <(anonymous)> at (8,112) content-size 784x0 children: inline
+        TextNode <#text>
+      BlockContainer <div> at (8,112) content-size 784x100 children: inline
+        frag 0 from TextNode start: 0, length: 5, rect: [8,112 36.84375x17] baseline: 13.296875
+            "hello"
+        TextNode <#text>
+      BlockContainer <(anonymous)> at (8,212) content-size 784x0 children: inline
+        TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x204]
+      PaintableWithLines (TableWrapper(anonymous)) [8,8 42.84375x104]
+        PaintableBox (Box<TABLE>) [8,8 42.84375x104]
+          PaintableBox (Box<TBODY>) [10,10 38.84375x100]
+            PaintableBox (Box<TR>) [10,10 38.84375x100]
+              PaintableWithLines (BlockContainer<TD>) [10,10 38.84375x100]
+                PaintableWithLines (BlockContainer(anonymous)) [11,51.5 36.84375x17]
+                  TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,112 784x0]
+      PaintableWithLines (BlockContainer<DIV>) [8,112 784x100]
+        TextPaintable (TextNode<#text>)
+      PaintableWithLines (BlockContainer(anonymous)) [8,212 784x0]

--- a/Tests/LibWeb/Layout/expected/table/vertical-align-middle-vs-top.txt
+++ b/Tests/LibWeb/Layout/expected/table/vertical-align-middle-vs-top.txt
@@ -1,0 +1,31 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x129 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 784x113 children: not-inline
+      BlockContainer <main> at (8,8) content-size 784x113 children: not-inline
+        TableWrapper <(anonymous)> at (8,8) content-size 346.5x113 [BFC] children: not-inline
+          Box <table> at (8,8) content-size 346.5x113 table-box [TFC] children: not-inline
+            Box <tbody> at (10,10) content-size 342.5x109 table-row-group children: not-inline
+              Box <tr> at (10,10) content-size 342.5x109 table-row children: not-inline
+                BlockContainer <td> at (10,10) content-size 342.5x109 table-cell [BFC] children: not-inline
+                  BlockContainer <(anonymous)> at (10,10) content-size 342.5x109 children: inline
+                    frag 0 from TextNode start: 0, length: 3, rect: [10,10 169.734375x109] baseline: 84.484375
+                        "foo"
+                    TextNode <#text>
+                    InlineNode <span>
+                      frag 0 from TextNode start: 0, length: 3, rect: [179.734375,10 172.765625x109] baseline: 84.484375
+                          "bar"
+                      TextNode <#text>
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x129]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x113]
+      PaintableWithLines (BlockContainer<MAIN>) [8,8 784x113]
+        PaintableWithLines (TableWrapper(anonymous)) [8,8 346.5x113]
+          PaintableBox (Box<TABLE>) [8,8 346.5x113]
+            PaintableBox (Box<TBODY>) [10,10 342.5x109]
+              PaintableBox (Box<TR>) [10,10 342.5x109]
+                PaintableWithLines (BlockContainer<TD>) [10,10 342.5x109]
+                  PaintableWithLines (BlockContainer(anonymous)) [10,10 342.5x109]
+                    TextPaintable (TextNode<#text>)
+                    PaintableWithLines (InlineNode<SPAN>)
+                      TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-increased-size-on-col.txt
@@ -14,16 +14,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 414x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 46x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 46x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,13) content-size 46x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (65,13) content-size 358x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (65,13) content-size 358x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (65,13) content-size 358x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [65,13 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -37,6 +39,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 414x21]
             PaintableBox (Box<TR>) [11,11 414x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 50x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,13 46x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [63,11 362x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [65,13 358x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns-size-on-col.txt
@@ -14,16 +14,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 414x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,13) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (33.265625,13) content-size 389.734375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (33.265625,13) content-size 389.734375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (33.265625,13) content-size 389.734375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -37,6 +39,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 414x21]
             PaintableBox (Box<TR>) [11,11 414x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,13 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [33.265625,13 389.734375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-and-constrained-columns.txt
@@ -9,16 +9,18 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (11,11) content-size 414x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (13,13) content-size 14.265625x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (13,13) content-size 14.265625x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [13,13 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (33.265625,13) content-size 389.734375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (33.265625,13) content-size 389.734375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (33.265625,13) content-size 389.734375x17 children: inline
+                  frag 0 from TextNode start: 0, length: 1, rect: [33.265625,13 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -32,6 +34,8 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [11,11 414x21]
             PaintableBox (Box<TR>) [11,11 414x21]
               PaintableWithLines (BlockContainer<TD>) [11,11 18.265625x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [13,13 14.265625x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [31.265625,11 393.734375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [33.265625,13 389.734375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
+++ b/Tests/LibWeb/Layout/expected/table/width-distribution-of-max-width-increment.txt
@@ -11,22 +11,25 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
             Box <tr> at (8,8) content-size 784x21 table-row children: not-inline
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (10,10) content-size 216.09375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x17] baseline: 13.296875
-                    "A"
-                TextNode <#text>
+              BlockContainer <td> at (10,10) content-size 216.09375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (10,10) content-size 216.09375x17 children: inline
+                  frag 0 from TextNode start: 1, length: 1, rect: [10,10 14.265625x17] baseline: 13.296875
+                      "A"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (230.09375,10) content-size 156.796875x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 1, length: 1, rect: [230.09375,10 9.34375x17] baseline: 13.296875
-                    "B"
-                TextNode <#text>
+              BlockContainer <td> at (230.09375,10) content-size 156.796875x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (230.09375,10) content-size 156.796875x17 children: inline
+                  frag 0 from TextNode start: 1, length: 1, rect: [230.09375,10 9.34375x17] baseline: 13.296875
+                      "B"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
-              BlockContainer <td> at (390.890625,10) content-size 399.109375x17 table-cell [BFC] children: inline
-                frag 0 from TextNode start: 1, length: 3, rect: [390.890625,10 29.453125x17] baseline: 13.296875
-                    "C D"
-                TextNode <#text>
+              BlockContainer <td> at (390.890625,10) content-size 399.109375x17 table-cell [BFC] children: not-inline
+                BlockContainer <(anonymous)> at (390.890625,10) content-size 399.109375x17 children: inline
+                  frag 0 from TextNode start: 1, length: 3, rect: [390.890625,10 29.453125x17] baseline: 13.296875
+                      "C D"
+                  TextNode <#text>
               BlockContainer <(anonymous)> (not painted) children: inline
                 TextNode <#text>
             BlockContainer <(anonymous)> (not painted) children: inline
@@ -42,8 +45,11 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
           PaintableBox (Box<TBODY>) [8,8 784x21]
             PaintableBox (Box<TR>) [8,8 784x21]
               PaintableWithLines (BlockContainer<TD>) [8,8 220.09375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [10,10 216.09375x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [228.09375,8 160.796875x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [230.09375,10 156.796875x17]
+                  TextPaintable (TextNode<#text>)
               PaintableWithLines (BlockContainer<TD>) [388.890625,8 403.109375x21]
-                TextPaintable (TextNode<#text>)
+                PaintableWithLines (BlockContainer(anonymous)) [390.890625,10 399.109375x17]
+                  TextPaintable (TextNode<#text>)

--- a/Tests/LibWeb/Layout/expected/textarea-reset.txt
+++ b/Tests/LibWeb/Layout/expected/textarea-reset.txt
@@ -1,26 +1,26 @@
 Viewport <#document> at (0,0) content-size 800x600 children: not-inline
   BlockContainer <html> at (0,0) content-size 800x600 [BFC] children: not-inline
-    BlockContainer <body> at (8,8) content-size 784x34 children: not-inline
-      BlockContainer <form#form> at (8,8) content-size 784x34 children: inline
-        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 194x28] baseline: 16.296875
+    BlockContainer <body> at (8,8) content-size 784x28 children: not-inline
+      BlockContainer <form#form> at (8,8) content-size 784x28 children: inline
+        frag 0 from BlockContainer start: 0, length: 0, rect: [11,11 154x22] baseline: 13.890625
         TextNode <#text>
-        BlockContainer <textarea#textarea> at (11,11) content-size 194x28 inline-block [BFC] children: not-inline
-          BlockContainer <div> at (11,11) content-size 194x17 children: not-inline
-            BlockContainer <div> at (11,11) content-size 194x17 children: inline
-              frag 0 from TextNode start: 0, length: 14, rect: [11,11 108.453125x17] baseline: 13.296875
+        BlockContainer <textarea#textarea> at (11,11) content-size 154x22 inline-block [BFC] children: not-inline
+          BlockContainer <div> at (11,11) content-size 154x14 children: not-inline
+            BlockContainer <div> at (11,11) content-size 154x14 children: inline
+              frag 0 from TextNode start: 0, length: 14, rect: [11,11 88.109375x14] baseline: 10.890625
                   "Original value"
               TextNode <#text>
         TextNode <#text>
-      BlockContainer <(anonymous)> at (8,58) content-size 784x0 children: inline
+      BlockContainer <(anonymous)> at (8,52) content-size 784x0 children: inline
         TextNode <#text>
         TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x600]
-    PaintableWithLines (BlockContainer<BODY>) [8,8 784x34]
-      PaintableWithLines (BlockContainer<FORM>#form) [8,8 784x34]
-        PaintableWithLines (BlockContainer<TEXTAREA>#textarea) [8,8 200x34]
-          PaintableWithLines (BlockContainer<DIV>) [11,11 194x17]
-            PaintableWithLines (BlockContainer<DIV>) [11,11 194x17]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 784x28]
+      PaintableWithLines (BlockContainer<FORM>#form) [8,8 784x28]
+        PaintableWithLines (BlockContainer<TEXTAREA>#textarea) [8,8 160x28]
+          PaintableWithLines (BlockContainer<DIV>) [11,11 154x14]
+            PaintableWithLines (BlockContainer<DIV>) [11,11 154x14]
               TextPaintable (TextNode<#text>)
-      PaintableWithLines (BlockContainer(anonymous)) [8,58 784x0]
+      PaintableWithLines (BlockContainer(anonymous)) [8,52 784x0]

--- a/Tests/LibWeb/Layout/expected/zero_percent_width_nested_table.txt
+++ b/Tests/LibWeb/Layout/expected/zero_percent_width_nested_table.txt
@@ -10,8 +10,9 @@ Viewport <#document> at (0,0) content-size 800x600 children: not-inline
                   Box <table> at (11,11) content-size 6x6 table-box [TFC] children: not-inline
                     Box <tbody> at (13,13) content-size 2x2 table-row-group children: not-inline
                       Box <tr> at (13,13) content-size 2x2 table-row children: not-inline
-                        BlockContainer <td> at (14,14) content-size 0x0 table-cell [BFC] children: inline
-                          TextNode <#text>
+                        BlockContainer <td> at (14,14) content-size 0x0 table-cell [BFC] children: not-inline
+                          BlockContainer <(anonymous)> at (14,14) content-size 0x0 children: inline
+                            TextNode <#text>
 
 ViewportPaintable (Viewport<#document>) [0,0 800x600]
   PaintableWithLines (BlockContainer<HTML>) [0,0 800x28]
@@ -26,3 +27,4 @@ ViewportPaintable (Viewport<#document>) [0,0 800x600]
                     PaintableBox (Box<TBODY>) [13,13 2x2]
                       PaintableBox (Box<TR>) [13,13 2x2]
                         PaintableWithLines (BlockContainer<TD>) [13,13 2x2]
+                          PaintableWithLines (BlockContainer(anonymous)) [14,14 0x0]

--- a/Tests/LibWeb/Layout/input/font-family-monospace-quirk.html
+++ b/Tests/LibWeb/Layout/input/font-family-monospace-quirk.html
@@ -1,0 +1,7 @@
+<!doctype html><style>
+    html { font-size: medium; }
+    body { font-size: 200%; }
+    main { font-size: 2em; }
+    article { font-family: monospace; }
+    div { }
+</style><body>abc<main>def<article>ghi<div>jkl

--- a/Tests/LibWeb/Layout/input/table/vertical-align-middle-td-vs-div.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-middle-td-vs-div.html
@@ -1,0 +1,11 @@
+<style>
+* {
+    outline: 1px solid black;
+}
+td, div {
+    height: 100px;
+    vertical-align: middle;
+}
+</style>
+<table><tr><td>hello</td></tr></table>
+<div>hello</div>

--- a/Tests/LibWeb/Layout/input/table/vertical-align-middle-vs-top.html
+++ b/Tests/LibWeb/Layout/input/table/vertical-align-middle-vs-top.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html><style>
+* {
+    outline: 1px solid black;
+}
+body {
+    font-family: monospace;
+    font-size: 100px;
+}
+.green {
+    color: green;
+}
+.red {
+    color: red;
+}
+table {
+    padding: 0;
+    margin: 0;
+    border: none;
+}
+tr {
+    padding: 0;
+    margin: 0;
+    border: none;
+}
+td {
+    padding: 0;
+    margin: 0;
+    border: none;
+    vertical-align: middle;
+}
+span {
+    vertical-align: top;
+    background: orange;
+}
+</style><body><main><table><tr><td>foo<span>bar

--- a/Tests/LibWeb/Text/expected/DOM/Offset-of-empty-inline-element.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Offset-of-empty-inline-element.txt
@@ -1,2 +1,2 @@
-Top: 16
+Top: 13
 Left: 8

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-print-all.txt
@@ -135,7 +135,7 @@ grid-row-start: auto
 grid-template-areas: none
 grid-template-columns: auto
 grid-template-rows: auto
-height: 2329px
+height: 1918px
 inline-size: auto
 inset-block-end: auto
 inset-block-start: auto
@@ -146,9 +146,9 @@ justify-content: normal
 justify-items: legacy
 justify-self: auto
 left: auto
-margin-block-end: 16px
+margin-block-end: 13px
 margin-block-start: 8px
-margin-bottom: 16px
+margin-bottom: 13px
 margin-inline-end: 8px
 margin-inline-start: 8px
 margin-left: 8px


### PR DESCRIPTION
For mysterious historical reasons, `font-family: monospace` needs to cause `font-size` to be re-cascaded as if the default `medium` font size were `13px` all along, rather than the usual `16px`. This ignores the normal "inherited CSS values are based on computed values from the parent" stuff that applies everywhere else. We're in 1990s compatibility territory now!

Implementing this quirk incidentally revealed that `vertical-align` was implemented very incorrectly for `display: table-cell` boxes (aka `td` elements). This had to be fixed by wrapping inline children of table cells in anonymous block boxes. That allowed us to remove an incorrect workaround in line layout as well.

All in all, this should allow us to run and pass a lot more WPT tests in the `/css/CSS2/tables` directory :)

For a lot more information, see this blog post:
https://manishearth.github.io/blog/2017/08/10/font-size-an-unexpectedly-complex-css-property/