### PR TITLE
LibWeb: Flip on checkValidity() for HTMLTextAreaElement

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -247,8 +247,7 @@ bool HTMLTextAreaElement::will_validate()
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
 bool HTMLTextAreaElement::check_validity()
 {
-    dbgln("(STUBBED) HTMLTextAreaElement::check_validity(). Called on: {}", debug_description());
-    return true;
+    return check_validity_steps();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-reportvalidity

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 130 tests
 
-75 Pass
-55 Fail
+76 Pass
+54 Fail
 Pass	[INPUT in TEXT status] no constraint
 Pass	[INPUT in TEXT status] no constraint (in a form)
 Pass	[INPUT in TEXT status] not suffering from being too long
@@ -132,5 +132,5 @@ Fail	[select]  suffering from being missing
 Pass	[select]  suffering from being missing (in a form)
 Pass	[textarea]  no constraint
 Pass	[textarea]  no constraint (in a form)
-Fail	[textarea]  suffering from being missing
+Pass	[textarea]  suffering from being missing
 Pass	[textarea]  suffering from being missing (in a form)


### PR DESCRIPTION
This is a simple change that just un-stubs our implementation of the `checkValidity()` method for `HTMLTextAreaElement`.
