### PR TITLE
LibWeb: Implement checkValidity() for HTMLSelectElement

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -702,6 +702,12 @@ bool HTMLSelectElement::will_validate()
     return is_candidate_for_constraint_validation();
 }
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-cva-checkvalidity
+bool HTMLSelectElement::check_validity()
+{
+    return check_validity_steps();
+}
+
 bool HTMLSelectElement::is_focusable() const
 {
     return enabled();

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -59,6 +59,7 @@ public:
     Vector<GC::Root<HTMLOptionElement>> list_of_options() const;
 
     bool will_validate();
+    bool check_validity();
 
     // ^EventTarget
     // https://html.spec.whatwg.org/multipage/interaction.html#the-tabindex-attribute:the-select-element

--- a/Libraries/LibWeb/HTML/HTMLSelectElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLSelectElement.idl
@@ -34,7 +34,7 @@ interface HTMLSelectElement : HTMLElement {
     readonly attribute boolean willValidate;
     readonly attribute ValidityState validity;
     [FIXME] readonly attribute DOMString validationMessage;
-    [FIXME] boolean checkValidity();
+    boolean checkValidity();
     [FIXME] boolean reportValidity();
     undefined setCustomValidity(DOMString error);
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 130 tests
 
-76 Pass
-54 Fail
+78 Pass
+52 Fail
 Pass	[INPUT in TEXT status] no constraint
 Pass	[INPUT in TEXT status] no constraint (in a form)
 Pass	[INPUT in TEXT status] not suffering from being too long
@@ -126,9 +126,9 @@ Pass	[INPUT in FILE status] no constraint
 Pass	[INPUT in FILE status] no constraint (in a form)
 Pass	[INPUT in FILE status] suffering from being missing
 Pass	[INPUT in FILE status] suffering from being missing (in a form)
-Fail	[select]  no constraint
+Pass	[select]  no constraint
 Pass	[select]  no constraint (in a form)
-Fail	[select]  suffering from being missing
+Pass	[select]  suffering from being missing
 Pass	[select]  suffering from being missing (in a form)
 Pass	[textarea]  no constraint
 Pass	[textarea]  no constraint (in a form)

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-validity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-select-element/select-validity.txt
@@ -2,10 +2,11 @@ Harness status: OK
 
 Found 6 tests
 
-6 Fail
-Fail	Placeholder label options within a select
-Fail	Placeholder label-like options within optgroup
+4 Pass
+2 Fail
+Pass	Placeholder label options within a select
+Pass	Placeholder label-like options within optgroup
 Fail	Validation on selects with display size set as more than one
 Fail	Validation on selects with multiple set
-Fail	Validation on selects with non-empty disabled option
-Fail	Remove and add back the placeholder label option
+Pass	Validation on selects with non-empty disabled option
+Pass	Remove and add back the placeholder label option


### PR DESCRIPTION
This change adds an implementation of the `checkValidity()` method for `HTMLSelectElement`.

(We already have an implementation of the only check that’s required to be run when `checkValidity()` is called — a “suffering from being missing” check.)
