### PR TITLE
LibWeb: Handle interleaved table-row and table-row-group boxes

### DIFF
--- a/Libraries/LibWeb/Layout/TableGrid.cpp
+++ b/Libraries/LibWeb/Layout/TableGrid.cpp
@@ -75,15 +75,18 @@ TableGrid TableGrid::calculate_row_column_grid(Box const& box, Vector<Cell>& cel
         process_col_group(column_group_box);
     });
 
-    for_each_child_box_matching(box, is_table_row_group, [&](auto& row_group_box) {
-        for_each_child_box_matching(row_group_box, is_table_row, [&](auto& row_box) {
+    auto process_row_group = [&](auto& row_group) {
+        for_each_child_box_matching(row_group, is_table_row, [&](auto& row_box) {
             process_row(row_box);
             return IterationDecision::Continue;
         });
-    });
+    };
 
-    for_each_child_box_matching(box, is_table_row, [&](auto& row_box) {
-        process_row(row_box);
+    box.for_each_child_of_type<Box>([&](auto& child) {
+        if (is_table_row_group(child))
+            process_row_group(child);
+        else if (is_table_row(child))
+            process_row(child);
         return IterationDecision::Continue;
     });
 

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/tables/table-anonymous-objects-059.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/tables/table-anonymous-objects-059.xht
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+
+  <title>CSS Test: Auto-imported from Gecko test infer-first-row.html</title>
+  <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/tables/reference/no_red_3x3_monospace_table-ref.xht"/>
+</head>
+<body style="font-family: monospace">
+<p>There should be no red below, except for antialiasing issues.</p>
+<div style="position: relative; font-size: 2em;">
+<div style="position: relative; z-index: 1; color: red; padding: 1px;">
+
+    <span style="display:table">
+      <span style="display: table-cell">Row 1, Col 1</span>
+      <span style="display: table-cell">Row 1, Col 2</span>
+      <span style="display: table-cell">Row 1, Col 3</span>
+      <span style="display: table-row-group">
+        <span style="display: table-row">
+          <span style="display: table-cell">Row 22, Col 1</span>
+          <span style="display: table-cell">Row 22, Col 2</span>
+          <span style="display: table-cell">Row 22, Col 3</span>
+        </span>
+        <span style="display: table-row">
+          <span style="display: table-cell">Row 333, Col 1</span>
+          <span style="display: table-cell">Row 333, Col 2</span>
+          <span style="display: table-cell">Row 333, Col 3</span>
+        </span>
+      </span>
+    </span>
+  </div>
+<div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
+
+    <table cellpadding="0" cellspacing="0" style="margin: 0; padding: 0; border: none">
+      <tr>
+        <td>Row 1, Col 1</td>
+        <td>Row 1, Col 2</td>
+        <td>Row 1, Col 3</td>
+      </tr>
+      <tr>
+        <td>Row 22, Col 1</td>
+        <td>Row 22, Col 2</td>
+        <td>Row 22, Col 3</td>
+      </tr>
+      <tr>
+        <td>Row 333, Col 1</td>
+        <td>Row 333, Col 2</td>
+        <td>Row 333, Col 3</td>
+      </tr>
+    </table>
+  </div>
+</div>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/tables/table-anonymous-objects-060.xht
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/CSS2/tables/table-anonymous-objects-060.xht
@@ -1,0 +1,55 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+
+  <title>CSS Test: Auto-imported from Gecko test infer-first-row.html</title>
+  <link rel="author" title="Boris Zbarsky" href="mailto:bzbarsky@mit.edu"/>
+  <link rel="help" href="http://www.w3.org/TR/CSS21/tables.html#anonymous-boxes"/>
+  <link rel="match" href="../../../../../expected/wpt-import/css/CSS2/tables/reference/no_red_3x3_monospace_table-ref.xht"/>
+</head>
+<body style="font-family: monospace">
+<p>There should be no red below, except for antialiasing issues.</p>
+<div style="position: relative; font-size: 2em;">
+<div style="position: absolute; z-index: 2; top: 0; color: green; padding: 1px;">
+
+    <span style="display:table">
+      <span style="display: table-cell">Row 1, Col 1</span>
+      <span style="display: table-cell">Row 1, Col 2</span>
+      <span style="display: table-cell">Row 1, Col 3</span>
+      <span style="display: table-row-group">
+        <span style="display: table-row">
+          <span style="display: table-cell">Row 22, Col 1</span>
+          <span style="display: table-cell">Row 22, Col 2</span>
+          <span style="display: table-cell">Row 22, Col 3</span>
+        </span>
+        <span style="display: table-row">
+          <span style="display: table-cell">Row 333, Col 1</span>
+          <span style="display: table-cell">Row 333, Col 2</span>
+          <span style="display: table-cell">Row 333, Col 3</span>
+        </span>
+      </span>
+    </span>
+  </div>
+<div style="position: relative; z-index: 1; color: red; padding: 1px;">
+
+    <table cellpadding="0" cellspacing="0" style="margin: 0; padding: 0; border: none">
+      <tr>
+        <td>Row 1, Col 1</td>
+        <td>Row 1, Col 2</td>
+        <td>Row 1, Col 3</td>
+      </tr>
+      <tr>
+        <td>Row 22, Col 1</td>
+        <td>Row 22, Col 2</td>
+        <td>Row 22, Col 3</td>
+      </tr>
+      <tr>
+        <td>Row 333, Col 1</td>
+        <td>Row 333, Col 2</td>
+        <td>Row 333, Col 3</td>
+      </tr>
+    </table>
+  </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Before this change, we were always processing all row groups first, and then all rows. This led to incorrect table layouts when rows and row groups were encountered in anything but that order.