### PR TITLE
LibWeb: Parse CSS fit-content(<length-percentage>) values

### DIFF
--- a/Libraries/LibWeb/CSS/CSSNumericType.cpp
+++ b/Libraries/LibWeb/CSS/CSSNumericType.cpp
@@ -38,6 +38,7 @@ Optional<CSSNumericType::BaseType> CSSNumericType::base_type_from_value_type(Val
     case ValueType::CustomIdent:
     case ValueType::EasingFunction:
     case ValueType::FilterValueList:
+    case ValueType::FitContent:
     case ValueType::Image:
     case ValueType::Integer:
     case ValueType::Number:

--- a/Libraries/LibWeb/CSS/CSSStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2024, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022-2023, MacDue <macdue@dueutil.tech>
@@ -30,6 +30,7 @@
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/FitContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FlexStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FrequencyStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h>
@@ -173,6 +174,12 @@ FilterValueListStyleValue const& CSSStyleValue::as_filter_value_list() const
 {
     VERIFY(is_filter_value_list());
     return static_cast<FilterValueListStyleValue const&>(*this);
+}
+
+FitContentStyleValue const& CSSStyleValue::as_fit_content() const
+{
+    VERIFY(is_fit_content());
+    return static_cast<FitContentStyleValue const&>(*this);
 }
 
 FlexStyleValue const& CSSStyleValue::as_flex() const

--- a/Libraries/LibWeb/CSS/CSSStyleValue.h
+++ b/Libraries/LibWeb/CSS/CSSStyleValue.h
@@ -106,6 +106,7 @@ public:
         Easing,
         Edge,
         FilterValueList,
+        FitContent,
         Flex,
         FontVariant,
         Frequency,
@@ -215,6 +216,10 @@ public:
     bool is_filter_value_list() const { return type() == Type::FilterValueList; }
     FilterValueListStyleValue const& as_filter_value_list() const;
     FilterValueListStyleValue& as_filter_value_list() { return const_cast<FilterValueListStyleValue&>(const_cast<CSSStyleValue const&>(*this).as_filter_value_list()); }
+
+    [[nodiscard]] bool is_fit_content() const { return type() == Type::FitContent; }
+    [[nodiscard]] FitContentStyleValue const& as_fit_content() const;
+    [[nodiscard]] FitContentStyleValue& as_fit_content() { return const_cast<FitContentStyleValue&>(const_cast<CSSStyleValue const&>(*this).as_fit_content()); }
 
     bool is_flex() const { return type() == Type::Flex; }
     FlexStyleValue const& as_flex() const;

--- a/Libraries/LibWeb/CSS/ComputedProperties.cpp
+++ b/Libraries/LibWeb/CSS/ComputedProperties.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -19,6 +19,7 @@
 #include <LibWeb/CSS/StyleValues/CounterStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CustomIdentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/DisplayStyleValue.h>
+#include <LibWeb/CSS/StyleValues/FitContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTemplateAreaStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridTrackPlacementStyleValue.h>
@@ -158,13 +159,15 @@ Size ComputedProperties::size_value(PropertyID id) const
             return Size::make_min_content();
         case Keyword::MaxContent:
             return Size::make_max_content();
-        case Keyword::FitContent:
-            return Size::make_fit_content();
         case Keyword::None:
             return Size::make_none();
         default:
             VERIFY_NOT_REACHED();
         }
+    }
+    if (value.is_fit_content()) {
+        auto& fit_content = value.as_fit_content();
+        return Size::make_fit_content(fit_content.length_percentage());
     }
 
     if (value.is_calculated())

--- a/Libraries/LibWeb/CSS/Keywords.json
+++ b/Libraries/LibWeb/CSS/Keywords.json
@@ -175,7 +175,6 @@
   "fill",
   "fill-box",
   "fine",
-  "fit-content",
   "fixed",
   "flex",
   "flex-end",

--- a/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -264,7 +264,7 @@ private:
     Optional<Gfx::UnicodeRange> parse_unicode_range(StringView);
     Vector<Gfx::UnicodeRange> parse_unicode_ranges(TokenStream<ComponentValue>&);
     Optional<GridSize> parse_grid_size(ComponentValue const&);
-    Optional<GridFitContent> parse_fit_content(Vector<ComponentValue> const&);
+    Optional<GridFitContent> parse_grid_fit_content(Vector<ComponentValue> const&);
     Optional<GridMinMax> parse_min_max(Vector<ComponentValue> const&);
     Optional<GridRepeat> parse_repeat(Vector<ComponentValue> const&);
     Optional<ExplicitGridTrack> parse_track_sizing_function(ComponentValue const&);
@@ -274,6 +274,8 @@ private:
 
     Optional<ShapeRadius> parse_shape_radius(TokenStream<ComponentValue>&);
     RefPtr<CSSStyleValue> parse_basic_shape_value(TokenStream<ComponentValue>&);
+
+    RefPtr<FitContentStyleValue> parse_fit_content_value(TokenStream<ComponentValue>&);
 
     template<typename TElement>
     Optional<Vector<TElement>> parse_color_stop_list(TokenStream<ComponentValue>& tokens, auto parse_position);

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2020-2021, the SerenityOS developers.
  * Copyright (c) 2021-2025, Sam Atkins <sam@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
@@ -31,6 +31,7 @@
 #include <LibWeb/CSS/StyleValues/EasingStyleValue.h>
 #include <LibWeb/CSS/StyleValues/EdgeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FilterValueListStyleValue.h>
+#include <LibWeb/CSS/StyleValues/FitContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FlexStyleValue.h>
 #include <LibWeb/CSS/StyleValues/FrequencyStyleValue.h>
 #include <LibWeb/CSS/StyleValues/GridAutoFlowStyleValue.h>
@@ -299,6 +300,12 @@ Optional<Parser::PropertyAndValue> Parser::parse_css_value_for_properties(Readon
             if (value->is_frequency() && property_accepts_frequency(*property, value->as_frequency().frequency()))
                 return PropertyAndValue { *property, value };
         }
+    }
+
+    if (auto property = any_property_accepts_type(property_ids, ValueType::FitContent); property.has_value()) {
+        auto context_guard = push_temporary_value_parsing_context(*property);
+        if (auto value = parse_fit_content_value(tokens))
+            return PropertyAndValue { *property, value };
     }
 
     if (auto property = any_property_accepts_type(property_ids, ValueType::Length); property.has_value()) {

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -1131,13 +1131,13 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto",
       "content",
-      "fit-content",
       "max-content",
       "min-content"
     ],
@@ -1614,12 +1614,12 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto",
-      "fit-content",
       "max-content",
       "min-content"
     ],
@@ -2032,11 +2032,11 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
-      "fit-content",
       "max-content",
       "min-content",
       "none"
@@ -2058,11 +2058,11 @@
     "inherited": false,
     "initial": "none",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
-      "fit-content",
       "max-content",
       "min-content",
       "none"
@@ -2084,12 +2084,12 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto",
-      "fit-content",
       "max-content",
       "min-content"
     ],
@@ -2110,12 +2110,12 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto",
-      "fit-content",
       "max-content",
       "min-content"
     ],
@@ -2936,12 +2936,12 @@
     "inherited": false,
     "initial": "auto",
     "valid-types": [
+      "fit-content",
       "length [0,∞]",
       "percentage [0,∞]"
     ],
     "valid-identifiers": [
       "auto",
-      "fit-content",
       "max-content",
       "min-content"
     ],

--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2021-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022-2025, Sam Atkins <sam@ladybird.org>
  *
@@ -16,6 +16,7 @@
 #include <LibWeb/CSS/StyleValues/BackgroundSizeStyleValue.h>
 #include <LibWeb/CSS/StyleValues/CSSColorValue.h>
 #include <LibWeb/CSS/StyleValues/CSSKeywordValue.h>
+#include <LibWeb/CSS/StyleValues/FitContentStyleValue.h>
 #include <LibWeb/CSS/StyleValues/LengthStyleValue.h>
 #include <LibWeb/CSS/StyleValues/NumberStyleValue.h>
 #include <LibWeb/CSS/StyleValues/PercentageStyleValue.h>
@@ -96,9 +97,8 @@ static NonnullRefPtr<CSSStyleValue const> style_value_for_size(Size const& size)
         return CSSKeywordValue::create(Keyword::MinContent);
     if (size.is_max_content())
         return CSSKeywordValue::create(Keyword::MaxContent);
-    // FIXME: Support fit-content(<length>)
     if (size.is_fit_content())
-        return CSSKeywordValue::create(Keyword::FitContent);
+        return FitContentStyleValue::create(size.fit_content_available_space());
     TODO();
 }
 

--- a/Libraries/LibWeb/CSS/Size.cpp
+++ b/Libraries/LibWeb/CSS/Size.cpp
@@ -54,7 +54,7 @@ Size Size::make_max_content()
     return Size { Type::MaxContent, Length::make_auto() };
 }
 
-Size Size::make_fit_content(Length available_space)
+Size Size::make_fit_content(LengthPercentage available_space)
 {
     return Size { Type::FitContent, move(available_space) };
 }
@@ -77,6 +77,10 @@ bool Size::contains_percentage() const
     case Type::MinContent:
     case Type::MaxContent:
     case Type::None:
+        return false;
+    case Type::FitContent:
+        // FIXME: This should return m_length_percentage.contains_percentage()
+        //        but we have to update a lot of code to handle this.
         return false;
     default:
         return m_length_percentage.contains_percentage();

--- a/Libraries/LibWeb/CSS/Size.h
+++ b/Libraries/LibWeb/CSS/Size.h
@@ -32,7 +32,7 @@ public:
     static Size make_calculated(NonnullRefPtr<CalculatedStyleValue>);
     static Size make_min_content();
     static Size make_max_content();
-    static Size make_fit_content(Length available_space);
+    static Size make_fit_content(LengthPercentage available_space);
     static Size make_fit_content();
     static Size make_none();
 
@@ -67,10 +67,10 @@ public:
         return m_length_percentage.percentage();
     }
 
-    CSS::Length const& fit_content_available_space() const
+    CSS::LengthPercentage const& fit_content_available_space() const
     {
         VERIFY(is_fit_content());
-        return m_length_percentage.length();
+        return m_length_percentage;
     }
 
     String to_string() const;

--- a/Libraries/LibWeb/CSS/StyleValues/FitContentStyleValue.h
+++ b/Libraries/LibWeb/CSS/StyleValues/FitContentStyleValue.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025, Andreas Kling <andreas@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/CSS/CSSStyleValue.h>
+#include <LibWeb/CSS/PercentageOr.h>
+
+namespace Web::CSS {
+
+class FitContentStyleValue final : public CSSStyleValue {
+public:
+    static ValueComparingNonnullRefPtr<FitContentStyleValue> create()
+    {
+        return adopt_ref(*new (nothrow) FitContentStyleValue(LengthPercentage { Length::make_auto() }));
+    }
+    static ValueComparingNonnullRefPtr<FitContentStyleValue> create(LengthPercentage length_percentage)
+    {
+        return adopt_ref(*new (nothrow) FitContentStyleValue(move(length_percentage)));
+    }
+    virtual ~FitContentStyleValue() override = default;
+
+    virtual String to_string(SerializationMode) const override
+    {
+        if (m_length_percentage.is_auto())
+            return "fit-content"_string;
+        return MUST(String::formatted("fit-content({})", m_length_percentage.to_string()));
+    }
+
+    bool equals(CSSStyleValue const& other) const override
+    {
+        if (type() != other.type())
+            return false;
+        return m_length_percentage == other.as_fit_content().m_length_percentage;
+    }
+
+    [[nodiscard]] LengthPercentage const& length_percentage() const { return m_length_percentage; }
+
+private:
+    FitContentStyleValue(LengthPercentage length_percentage)
+        : CSSStyleValue(Type::FitContent)
+        , m_length_percentage(move(length_percentage))
+    {
+    }
+
+    LengthPercentage m_length_percentage;
+};
+
+}

--- a/Libraries/LibWeb/Forward.h
+++ b/Libraries/LibWeb/Forward.h
@@ -176,6 +176,7 @@ class EdgeStyleValue;
 class ElementInlineCSSStyleDeclaration;
 class ExplicitGridTrack;
 class FilterValueListStyleValue;
+class FitContentStyleValue;
 class Flex;
 class FlexOrCalculated;
 class FlexStyleValue;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -30,6 +30,7 @@ static bool type_name_is_enum(StringView type_name)
         "custom-ident"sv,
         "easing-function"sv,
         "flex"sv,
+        "fit-content"sv,
         "frequency"sv,
         "image"sv,
         "integer"sv,
@@ -230,6 +231,7 @@ enum class ValueType {
     CustomIdent,
     EasingFunction,
     FilterValueList,
+    FitContent,
     Flex,
     Frequency,
     Image,
@@ -801,6 +803,8 @@ bool property_accepts_type(PropertyID property_id, ValueType value_type)
                     property_generator.appendln("        case ValueType::CustomIdent:");
                 } else if (type_name == "easing-function") {
                     property_generator.appendln("        case ValueType::EasingFunction:");
+                } else if (type_name == "fit-content") {
+                    property_generator.appendln("        case ValueType::FitContent:");
                 } else if (type_name == "flex") {
                     property_generator.appendln("        case ValueType::Flex:");
                 } else if (type_name == "frequency") {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/height-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/height-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 10 tests
 
-6 Pass
-4 Fail
+8 Pass
+2 Fail
 Pass	e.style['height'] = "auto" should set the property value
 Pass	e.style['height'] = "min-content" should set the property value
 Pass	e.style['height'] = "max-content" should set the property value
@@ -11,6 +11,6 @@ Pass	e.style['height'] = "0" should set the property value
 Pass	e.style['height'] = "10%" should set the property value
 Pass	e.style['height'] = "0.5em" should set the property value
 Fail	e.style['height'] = "calc(10% - 0.5em)" should set the property value
-Fail	e.style['height'] = "fit-content(10%)" should set the property value
-Fail	e.style['height'] = "fit-content(0.5em)" should set the property value
+Pass	e.style['height'] = "fit-content(10%)" should set the property value
+Pass	e.style['height'] = "fit-content(0.5em)" should set the property value
 Fail	e.style['height'] = "fit-content(calc(10% - 0.5em))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-height-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-height-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 12 tests
 
-6 Pass
-6 Fail
+9 Pass
+3 Fail
 Pass	Property max-height value 'none'
 Pass	Property max-height value 'min-content'
 Pass	Property max-height value 'max-content'
@@ -12,7 +12,7 @@ Pass	Property max-height value '20%'
 Pass	Property max-height value 'calc(10% + 40px)'
 Fail	Property max-height value 'calc(10px - 0.5em)'
 Fail	Property max-height value 'calc(10px + 0.5em)'
-Fail	Property max-height value 'fit-content(10px)'
-Fail	Property max-height value 'fit-content(20%)'
-Fail	Property max-height value 'fit-content(calc(10% + 40px))'
+Pass	Property max-height value 'fit-content(10px)'
+Pass	Property max-height value 'fit-content(20%)'
+Pass	Property max-height value 'fit-content(calc(10% + 40px))'
 Fail	Property max-height value 'fit-content(calc(10px + 0.5em))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-height-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-height-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 10 tests
 
-6 Pass
-4 Fail
+8 Pass
+2 Fail
 Pass	e.style['max-height'] = "none" should set the property value
 Pass	e.style['max-height'] = "min-content" should set the property value
 Pass	e.style['max-height'] = "max-content" should set the property value
@@ -11,6 +11,6 @@ Pass	e.style['max-height'] = "0" should set the property value
 Pass	e.style['max-height'] = "10%" should set the property value
 Pass	e.style['max-height'] = "0.5em" should set the property value
 Fail	e.style['max-height'] = "calc(10% - 0.5em)" should set the property value
-Fail	e.style['max-height'] = "fit-content(10%)" should set the property value
-Fail	e.style['max-height'] = "fit-content(0.5em)" should set the property value
+Pass	e.style['max-height'] = "fit-content(10%)" should set the property value
+Pass	e.style['max-height'] = "fit-content(0.5em)" should set the property value
 Fail	e.style['max-height'] = "fit-content(calc(10% - 0.5em))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-width-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-width-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 12 tests
 
-6 Pass
-6 Fail
+9 Pass
+3 Fail
 Pass	Property max-width value 'none'
 Pass	Property max-width value 'min-content'
 Pass	Property max-width value 'max-content'
@@ -12,7 +12,7 @@ Pass	Property max-width value '20%'
 Pass	Property max-width value 'calc(10% + 40px)'
 Fail	Property max-width value 'calc(10px - 0.5em)'
 Fail	Property max-width value 'calc(10px + 0.5em)'
-Fail	Property max-width value 'fit-content(10px)'
-Fail	Property max-width value 'fit-content(20%)'
-Fail	Property max-width value 'fit-content(calc(10% + 40px))'
+Pass	Property max-width value 'fit-content(10px)'
+Pass	Property max-width value 'fit-content(20%)'
+Pass	Property max-width value 'fit-content(calc(10% + 40px))'
 Fail	Property max-width value 'fit-content(calc(10px + 0.5em))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-width-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/max-width-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 10 tests
 
-6 Pass
-4 Fail
+8 Pass
+2 Fail
 Pass	e.style['max-width'] = "none" should set the property value
 Pass	e.style['max-width'] = "min-content" should set the property value
 Pass	e.style['max-width'] = "max-content" should set the property value
@@ -11,6 +11,6 @@ Pass	e.style['max-width'] = "0" should set the property value
 Pass	e.style['max-width'] = "10%" should set the property value
 Pass	e.style['max-width'] = "0.5em" should set the property value
 Fail	e.style['max-width'] = "calc(10% - 0.5em)" should set the property value
-Fail	e.style['max-width'] = "fit-content(10%)" should set the property value
-Fail	e.style['max-width'] = "fit-content(0.5em)" should set the property value
+Pass	e.style['max-width'] = "fit-content(10%)" should set the property value
+Pass	e.style['max-width'] = "fit-content(0.5em)" should set the property value
 Fail	e.style['max-width'] = "fit-content(calc(10% - 0.5em))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-height-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-height-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 11 tests
 
-5 Pass
-6 Fail
+8 Pass
+3 Fail
 Pass	Property min-height value 'min-content'
 Pass	Property min-height value 'max-content'
 Pass	Property min-height value '10px'
@@ -11,7 +11,7 @@ Pass	Property min-height value '20%'
 Pass	Property min-height value 'calc(10% + 40px)'
 Fail	Property min-height value 'calc(10px - 0.5em)'
 Fail	Property min-height value 'calc(10px + 0.5em)'
-Fail	Property min-height value 'fit-content(10px)'
-Fail	Property min-height value 'fit-content(20%)'
-Fail	Property min-height value 'fit-content(calc(10% + 40px))'
+Pass	Property min-height value 'fit-content(10px)'
+Pass	Property min-height value 'fit-content(20%)'
+Pass	Property min-height value 'fit-content(calc(10% + 40px))'
 Fail	Property min-height value 'fit-content(calc(10px + 0.5em))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-height-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-height-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 10 tests
 
-6 Pass
-4 Fail
+8 Pass
+2 Fail
 Pass	e.style['min-height'] = "auto" should set the property value
 Pass	e.style['min-height'] = "min-content" should set the property value
 Pass	e.style['min-height'] = "max-content" should set the property value
@@ -11,6 +11,6 @@ Pass	e.style['min-height'] = "0" should set the property value
 Pass	e.style['min-height'] = "10%" should set the property value
 Pass	e.style['min-height'] = "0.5em" should set the property value
 Fail	e.style['min-height'] = "calc(10% - 0.5em)" should set the property value
-Fail	e.style['min-height'] = "fit-content(10%)" should set the property value
-Fail	e.style['min-height'] = "fit-content(0.5em)" should set the property value
+Pass	e.style['min-height'] = "fit-content(10%)" should set the property value
+Pass	e.style['min-height'] = "fit-content(0.5em)" should set the property value
 Fail	e.style['min-height'] = "fit-content(calc(10% - 0.5em))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-width-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-width-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 11 tests
 
-5 Pass
-6 Fail
+8 Pass
+3 Fail
 Pass	Property min-width value 'min-content'
 Pass	Property min-width value 'max-content'
 Pass	Property min-width value '10px'
@@ -11,7 +11,7 @@ Pass	Property min-width value '20%'
 Pass	Property min-width value 'calc(10% + 40px)'
 Fail	Property min-width value 'calc(10px - 0.5em)'
 Fail	Property min-width value 'calc(10px + 0.5em)'
-Fail	Property min-width value 'fit-content(10px)'
-Fail	Property min-width value 'fit-content(20%)'
-Fail	Property min-width value 'fit-content(calc(10% + 40px))'
+Pass	Property min-width value 'fit-content(10px)'
+Pass	Property min-width value 'fit-content(20%)'
+Pass	Property min-width value 'fit-content(calc(10% + 40px))'
 Fail	Property min-width value 'fit-content(calc(10px + 0.5em))'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-width-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/min-width-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 10 tests
 
-6 Pass
-4 Fail
+8 Pass
+2 Fail
 Pass	e.style['min-width'] = "auto" should set the property value
 Pass	e.style['min-width'] = "min-content" should set the property value
 Pass	e.style['min-width'] = "max-content" should set the property value
@@ -11,6 +11,6 @@ Pass	e.style['min-width'] = "0" should set the property value
 Pass	e.style['min-width'] = "10%" should set the property value
 Pass	e.style['min-width'] = "0.5em" should set the property value
 Fail	e.style['min-width'] = "calc(10% - 0.5em)" should set the property value
-Fail	e.style['min-width'] = "fit-content(10%)" should set the property value
-Fail	e.style['min-width'] = "fit-content(0.5em)" should set the property value
+Pass	e.style['min-width'] = "fit-content(10%)" should set the property value
+Pass	e.style['min-width'] = "fit-content(0.5em)" should set the property value
 Fail	e.style['min-width'] = "fit-content(calc(10% - 0.5em))" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/width-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-sizing/parsing/width-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 10 tests
 
-6 Pass
-4 Fail
+8 Pass
+2 Fail
 Pass	e.style['width'] = "auto" should set the property value
 Pass	e.style['width'] = "min-content" should set the property value
 Pass	e.style['width'] = "max-content" should set the property value
@@ -11,6 +11,6 @@ Pass	e.style['width'] = "0" should set the property value
 Pass	e.style['width'] = "10%" should set the property value
 Pass	e.style['width'] = "0.5em" should set the property value
 Fail	e.style['width'] = "calc(10% - 0.5em)" should set the property value
-Fail	e.style['width'] = "fit-content(10%)" should set the property value
-Fail	e.style['width'] = "fit-content(0.5em)" should set the property value
+Pass	e.style['width'] = "fit-content(10%)" should set the property value
+Pass	e.style['width'] = "fit-content(0.5em)" should set the property value
 Fail	e.style['width'] = "fit-content(calc(10% - 0.5em))" should set the property value


### PR DESCRIPTION
Before this change, we only parsed fit-content as a standalone keyword, but CSS-SIZING-3 added it as a function as well. I don't know of anything else in CSS that is overloaded like this, so it ends up looking a little awkward in the implementation.

Note that a lot of code had already been prepped for fit-content values to have an argument, we just weren't parsing it.