### PR TITLE
LibWeb: Don't close websocket if already closed in `make_disappear()` AO

### DIFF
--- a/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -411,6 +411,10 @@ void WebSocket::make_disappear()
     // -> Otherwise
     //    - Do nothing.
     // NOTE: All of these are handled by the WebSocket Protocol when calling close()
+    auto ready_state = this->ready_state();
+    if (ready_state == Requests::WebSocket::ReadyState::Closing || ready_state == Requests::WebSocket::ReadyState::Closed)
+        return;
+
     m_websocket->close(1001);
 }
 


### PR DESCRIPTION
This fixes the WPT regressions seen in: https://wpt.fyi/results/websockets?diff&filter=ADC&run_id=5114993798545408&run_id=5116882309087232