### PR TITLE
LibDevTools+LibWebView: Avoid dependence on LibWebView from LibDevTools

### DIFF
--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -108,7 +108,7 @@ void PageStyleActor::inspect_dom_node(StringView node_actor, Callback&& callback
 
     devtools().delegate().inspect_dom_node(
         tab->description(), dom_node->id, dom_node->pseudo_element,
-        [weak_self = make_weak_ptr<PageStyleActor>(), block_token = move(block_token), callback = forward<Callback>(callback)](ErrorOr<WebView::ViewImplementation::DOMNodeProperties> properties) mutable {
+        [weak_self = make_weak_ptr<PageStyleActor>(), block_token = move(block_token), callback = forward<Callback>(callback)](ErrorOr<DOMNodeProperties> properties) mutable {
             if (properties.is_error()) {
                 dbgln_if(DEVTOOLS_DEBUG, "Unable to inspect DOM node: {}", properties.error());
                 return;

--- a/Libraries/LibDevTools/Actors/PageStyleActor.h
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.h
@@ -6,10 +6,16 @@
 
 #pragma once
 
+#include <AK/JsonObject.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
 
 namespace DevTools {
+
+struct DOMNodeProperties {
+    JsonObject computed_style;
+    JsonObject node_box_sizing;
+};
 
 class PageStyleActor final : public Actor {
 public:

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -11,11 +11,11 @@
 #include <AK/JsonValue.h>
 #include <AK/Vector.h>
 #include <LibDevTools/Actors/CSSPropertiesActor.h>
+#include <LibDevTools/Actors/PageStyleActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Forward.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Forward.h>
-#include <LibWebView/ViewImplementation.h>
 
 namespace DevTools {
 
@@ -29,7 +29,7 @@ public:
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }
 
-    using OnDOMNodeInspectionComplete = Function<void(ErrorOr<WebView::ViewImplementation::DOMNodeProperties>)>;
+    using OnDOMNodeInspectionComplete = Function<void(ErrorOr<DOMNodeProperties>)>;
     virtual void inspect_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>, OnDOMNodeInspectionComplete) const { }
     virtual void clear_inspected_dom_node(TabDescription const&) const { }
 

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -389,7 +389,11 @@ void Application::inspect_dom_node(DevTools::TabDescription const& description, 
 
     view->on_received_dom_node_properties = [&view = *view, on_complete = move(on_complete)](ViewImplementation::DOMNodeProperties properties) {
         view.on_received_dom_node_properties = nullptr;
-        on_complete(move(properties));
+
+        on_complete(DevTools::DOMNodeProperties {
+            .computed_style = move(properties.computed_style),
+            .node_box_sizing = move(properties.node_box_sizing),
+        });
     };
 
     view->inspect_dom_node(node_id, pseudo_element);


### PR DESCRIPTION
LibDevTools was implicitly including generated IPC endpoints from LibWebView. This is not a dependency declared in the CMakeLists.txt. So updates to the IPC file might not have caused the endpoint header to be regenerated by the time LibDevTools is compiled, resulting in a build error.

This patch removes that implicit dependency entirely.