### PR TITLE
LibWeb: Ensure EventHandler visits its mouse selection target

### DIFF
--- a/Libraries/LibWeb/DOM/EditingHostManager.h
+++ b/Libraries/LibWeb/DOM/EditingHostManager.h
@@ -14,7 +14,8 @@
 
 namespace Web::DOM {
 
-class EditingHostManager : public JS::Cell
+class EditingHostManager
+    : public JS::Cell
     , public InputEventsTarget {
     GC_CELL(EditingHostManager, JS::Cell);
     GC_DECLARE_ALLOCATOR(EditingHostManager);
@@ -44,6 +45,8 @@ public:
 
 private:
     EditingHostManager(GC::Ref<Document>);
+
+    virtual GC::Ref<JS::Cell> as_cell() override { return *this; }
 
     GC::Ref<Document> m_document;
     GC::Ptr<DOM::Node> m_active_contenteditable_element;

--- a/Libraries/LibWeb/DOM/InputEventsTarget.h
+++ b/Libraries/LibWeb/DOM/InputEventsTarget.h
@@ -15,6 +15,8 @@ class InputEventsTarget {
 public:
     virtual ~InputEventsTarget() = default;
 
+    virtual GC::Ref<JS::Cell> as_cell() = 0;
+
     virtual void handle_insert(String const&) = 0;
     virtual void handle_return_key() = 0;
 

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -969,4 +969,9 @@ GC::Ptr<DOM::Position> FormAssociatedTextControlElement::cursor_position() const
     return nullptr;
 }
 
+GC::Ref<JS::Cell> FormAssociatedTextControlElement::as_cell()
+{
+    return form_associated_element_to_html_element();
+}
+
 }

--- a/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -160,7 +160,8 @@ enum class SelectionSource {
     DOM,
 };
 
-class FormAssociatedTextControlElement : public FormAssociatedElement
+class FormAssociatedTextControlElement
+    : public FormAssociatedElement
     , public InputEventsTarget {
 public:
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-textarea/input-relevant-value
@@ -231,6 +232,8 @@ protected:
     void relevant_value_was_changed();
 
 private:
+    virtual GC::Ref<JS::Cell> as_cell() override;
+
     void collapse_selection_to_offset(size_t);
     void selection_was_changed();
 

--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1375,6 +1375,9 @@ void EventHandler::visit_edges(JS::Cell::Visitor& visitor) const
 {
     m_drag_and_drop_event_handler->visit_edges(visitor);
     visitor.visit(m_mouse_event_tracking_paintable);
+
+    if (m_mouse_selection_target)
+        visitor.visit(m_mouse_selection_target->as_cell());
 }
 
 Unicode::Segmenter& EventHandler::word_segmenter()

--- a/Tests/LibWeb/Text/expected/UIEvents/gc-mouse-selection-target.txt
+++ b/Tests/LibWeb/Text/expected/UIEvents/gc-mouse-selection-target.txt
@@ -1,0 +1,1 @@
+PASS (didn't crash)

--- a/Tests/LibWeb/Text/input/UIEvents/gc-mouse-selection-target.html
+++ b/Tests/LibWeb/Text/input/UIEvents/gc-mouse-selection-target.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<iframe id="iframe"></iframe>
+<script src="../include.js"></script>
+<script>
+    const runTest = () => {
+        return new Promise(resolve => {
+            let iframe = document.getElementById("iframe");
+
+            iframe.onload = () => {
+                internals.movePointerTo(20, 40);
+                internals.mouseDown(20, 40);
+                internals.movePointerTo(60, 40);
+
+                iframe.onload = () => {
+                    setTimeout(() => {
+                        internals.movePointerTo(20, 40);
+                        resolve();
+                    });
+                };
+
+                iframe.src = "data:text/html,<p contenteditable>Text 2</p>";
+            };
+
+            iframe.src = "data:text/html,<p contenteditable>Text 1</p>";
+        });
+    };
+
+    asyncTest(async done => {
+        for (let i = 0; i < 10; ++i) {
+            await runTest();
+            internals.gc();
+        }
+
+        println("PASS (didn't crash)");
+        done();
+    });
+</script>


### PR DESCRIPTION
We hold a raw pointer to the mouse selection target, which is a mixin-style class inherited only by `JS::Cell` classes. By not visiting this object, we sometime had a dangling reference to it after it had been garbage collected.

Fixes a crash seen in CI:
https://github.com/LadybirdBrowser/ladybird/actions/runs/13554607471/job/37886019271?pr=3710#step:17:2763

```
LibWeb/Page/EventHandler.cpp:775:66: runtime error: member call on address 0x7f6c672f3808 which does not point to an object of type 'InputEventsTarget'
```