### PR TITLE
LibWeb: Prevent crash when loading module in worker

### DIFF
--- a/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
+++ b/Libraries/LibWeb/HTML/Scripting/Fetching.cpp
@@ -317,7 +317,7 @@ ScriptFetchOptions get_descendant_script_fetch_options(ScriptFetchOptions const&
 String resolve_a_module_integrity_metadata(const URL::URL& url, EnvironmentSettingsObject& settings_object)
 {
     // 1. Let map be settingsObject's global object's import map.
-    auto map = as<Window>(settings_object.global_object()).import_map();
+    auto map = as<UniversalGlobalScopeMixin>(settings_object.global_object()).import_map();
 
     // 2. If map's integrity[url] does not exist, then return the empty string.
     // 3. Return map's integrity[url].

--- a/Libraries/LibWeb/HTML/UniversalGlobalScope.h
+++ b/Libraries/LibWeb/HTML/UniversalGlobalScope.h
@@ -45,6 +45,10 @@ public:
 
     void notify_about_rejected_promises(Badge<EventLoop>);
 
+    ImportMap& import_map() { return m_import_map; }
+    ImportMap const& import_map() const { return m_import_map; }
+    void set_import_map(ImportMap const& import_map) { m_import_map = import_map; }
+
 protected:
     void visit_edges(GC::Cell::Visitor&);
 
@@ -61,6 +65,10 @@ private:
     // https://html.spec.whatwg.org/multipage/webappapis.html#outstanding-rejected-promises-weak-set
     // The outstanding rejected promises weak set must not create strong references to any of its members, and implementations are free to limit its size, e.g. by removing old entries from it when new ones are added.
     Vector<GC::Ptr<JS::Promise>> m_outstanding_rejected_promises_weak_set;
+
+    // https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-import-map
+    // A global object has an import map, initially an empty import map.
+    ImportMap m_import_map;
 };
 
 }

--- a/Libraries/LibWeb/HTML/Window.h
+++ b/Libraries/LibWeb/HTML/Window.h
@@ -114,10 +114,6 @@ public:
 
     GC::Ptr<Navigable> navigable() const;
 
-    ImportMap& import_map() { return m_import_map; }
-    ImportMap const& import_map() const { return m_import_map; }
-    void set_import_map(ImportMap const& import_map) { m_import_map = import_map; }
-
     void append_resolved_module(SpecifierResolution resolution) { m_resolved_module_set.append(move(resolution)); }
     Vector<SpecifierResolution> const& resolved_module_set() const { return m_resolved_module_set; }
 
@@ -287,10 +283,6 @@ private:
     GC::Ptr<DOM::Document> m_associated_document;
 
     GC::Ptr<DOM::Event> m_current_event;
-
-    // https://html.spec.whatwg.org/multipage/webappapis.html#concept-global-import-map
-    // A global object has an import map, initially an empty import map.
-    ImportMap m_import_map;
 
     // https://html.spec.whatwg.org/multipage/webappapis.html#resolved-module-set
     // A global object has a resolved module set, a set of specifier resolution records, initially empty.

--- a/Tests/LibWeb/Text/input/Worker/worker.mjs
+++ b/Tests/LibWeb/Text/input/Worker/worker.mjs
@@ -1,3 +1,5 @@
+import "./worker.mjs";
+
 self.onmessage = ({ data }) => {
     self.postMessage(`Worker responding to: ${data}`);
 };


### PR DESCRIPTION
The import map is defined for all global objects, not just the window.

This also adds an import to the `Worker-module.html` test which causes the worker to crash and the test to time out without this change (although it is currently skipped due to being flaky on CI, you'll need to change `TestConfig.ini` to run it yourself).

This fix allows https://treecalcul.us/live/ to run without its worker crashing (although it's too slow to finish without timing out, maybe a potential js perf target?)