### PR TITLE
LibWeb/CSS: Allow whitespace inside fit-content() function

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/ValueParsing.cpp
@@ -2556,8 +2556,6 @@ RefPtr<FitContentStyleValue> Parser::parse_fit_content_value(TokenStream<Compone
     auto const& function = component_value.function();
     if (function.name != "fit-content"sv)
         return nullptr;
-    if (function.value.size() != 1)
-        return nullptr;
     TokenStream argument_tokens { function.value };
     argument_tokens.discard_whitespace();
     auto maybe_length = parse_length_percentage(argument_tokens);

--- a/Tests/LibWeb/Text/expected/css/fit-content-parsing-with-whitespace.txt
+++ b/Tests/LibWeb/Text/expected/css/fit-content-parsing-with-whitespace.txt
@@ -1,0 +1,4 @@
+"fit-content(10%)" became "fit-content(10%)"
+"fit-content(       10%)" became "fit-content(10%)"
+"fit-content(10%  )" became "fit-content(10%)"
+"fit-content(   10%  )" became "fit-content(10%)"

--- a/Tests/LibWeb/Text/input/css/fit-content-parsing-with-whitespace.html
+++ b/Tests/LibWeb/Text/input/css/fit-content-parsing-with-whitespace.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="target"></div>
+<script>
+    test(() => {
+        let inputs = [
+            "fit-content(10%)",
+            "fit-content(       10%)",
+            "fit-content(10%  )",
+            "fit-content(   10%  )",
+        ];
+        let target = document.getElementById('target');
+        for (let input of inputs) {
+            target.style.width = '';
+            target.style.width = input;
+            println(`"${input}" became "${target.style.width}"`);
+        }
+    });
+</script>


### PR DESCRIPTION
I think I explained this poorly in https://github.com/LadybirdBrowser/ladybird/pull/3706#discussion_r1972060343 :sweat_smile: Note to self: Don't code-review in a rush.

Weirdly, WPT doesn't seem to test this, so I added a test myself. Without the change, the last 3 results print out "".