### PR TITLE
LibWeb: Block rendering until linked stylesheets are loaded

### DIFF
--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021-2023, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
  * Copyright (c) 2025, Jelle Raaijmakers <jelle@ladybird.org>
@@ -812,6 +812,8 @@ public:
     [[nodiscard]] bool is_render_blocked() const;
     // https://html.spec.whatwg.org/multipage/dom.html#allows-adding-render-blocking-elements
     [[nodiscard]] bool allows_adding_render_blocking_elements() const;
+
+    [[nodiscard]] bool is_render_blocking_element(GC::Ref<Element>) const;
 
     void add_render_blocking_element(GC::Ref<Element>);
     void remove_render_blocking_element(GC::Ref<Element>);

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2023, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2018-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, the SerenityOS developers.
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2023, Srikavin Ramkumar <me@srikavin.me>
@@ -43,6 +43,8 @@ public:
 
     static WebIDL::ExceptionOr<void> load_fallback_favicon_if_needed(GC::Ref<DOM::Document>);
 
+    void set_parser_document(Badge<HTMLParser>, GC::Ref<DOM::Document>);
+
 private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 
@@ -58,6 +60,7 @@ private:
 
     // ^HTMLElement
     virtual void visit_edges(Cell::Visitor&) override;
+    virtual bool is_implicitly_potentially_render_blocking() const override;
 
     struct LinkProcessingOptions {
         // href (default the empty string)
@@ -152,6 +155,8 @@ private:
     bool m_explicitly_enabled { false };
 
     Optional<String> m_mime_type;
+
+    WeakPtr<DOM::Document> m_parser_document;
 };
 
 }

--- a/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2024, Andreas Kling <andreas@ladybird.org>
+ * Copyright (c) 2020-2025, Andreas Kling <andreas@ladybird.org>
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
  * Copyright (c) 2023-2024, Shannon Booth <shannon@serenityos.org>
  *
@@ -30,6 +30,7 @@
 #include <LibWeb/HTML/HTMLFormElement.h>
 #include <LibWeb/HTML/HTMLHeadElement.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
+#include <LibWeb/HTML/HTMLLinkElement.h>
 #include <LibWeb/HTML/HTMLScriptElement.h>
 #include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
@@ -780,6 +781,12 @@ GC::Ref<DOM::Element> HTMLParser::create_element_for(HTMLToken const& token, Opt
 
     // 9. Let element be the result of creating an element given document, localName, given namespace, null, is, and willExecuteScript.
     auto element = create_element(*document, local_name, namespace_, {}, is_value, will_execute_script).release_value_but_fixme_should_propagate_errors();
+
+    // AD-HOC: Let <link> elements know which document they were originally parsed for.
+    //         This is used for the render-blocking logic.
+    if (local_name == HTML::TagNames::link && namespace_ == Namespace::HTML) {
+        as<HTMLLinkElement>(*element).set_parser_document({}, document);
+    }
 
     // 10. Append each attribute in the given token to element.
     token.for_each_attribute([&](auto const& attribute) {


### PR DESCRIPTION
This commit implements the main "render blocking" behavior for link elements, drastically reducing the amount of FOUC (flash of unstyled content) we subject our users to.

The document will now block rendering until linked style sheets referenced by parser-created link elements have loaded (or failed).

Note that we don't yet extend the blocking period until "critical subresources" such as imported style sheets have been downloaded as well.

Before/after demo:

https://github.com/user-attachments/assets/227ef968-bc61-450d-bebc-6ebf0d08f343

