### PR TITLE
LibGC: Visit the edges of the cells that must survive garbage collection

### DIFF
--- a/Tests/LibWeb/Text/expected/WebSocket/WebSocket-gc.txt
+++ b/Tests/LibWeb/Text/expected/WebSocket/WebSocket-gc.txt
@@ -1,0 +1,1 @@
+PASS! (Didn't crash)

--- a/Tests/LibWeb/Text/input/WebSocket/WebSocket-gc.html
+++ b/Tests/LibWeb/Text/input/WebSocket/WebSocket-gc.html
@@ -1,0 +1,21 @@
+<script src="../include.js"></script>
+<script>
+    asyncTest((done) => {
+        {
+            const ws = new WebSocket('wss://echo.websocket.org');
+
+            ws.onopen = () => {
+            };
+            ws.onmessage = () => {
+            };
+            ws.onerror = () => {
+            };
+        }
+
+        setTimeout(() => {
+            internals.gc();
+            println("PASS! (Didn't crash)");
+            done();
+        }, 0);
+    });
+</script>


### PR DESCRIPTION
Previously, we would only keep the cell that must survive alive, but none of it's edges.

This cropped up with a GC UAF in must_survive_garbage_collection of WebSocket in .NET's SignalR frontend implementation, where an out-of-scope WebSocket had it's underlying EventTarget properties garbage collected, and must_survive_garbage_collection read from the destroyed EventTarget properties.

See: https://github.com/dotnet/aspnetcore/blob/main/src/SignalR/clients/ts/signalr/src/WebSocketTransport.ts#L81
Found on https://www.formula1.com/ during a live session.