### PR TITLE
LibWeb: Assign sticky insets to Layout::InlineNode

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -73,6 +73,7 @@ struct LayoutState {
 
     struct UsedValues {
         NodeWithStyle const& node() const { return *m_node; }
+        NodeWithStyle& node() { return const_cast<NodeWithStyle&>(*m_node); }
         void set_node(NodeWithStyle&, UsedValues const* containing_block_used_values);
 
         UsedValues const* containing_block_used_values() const { return m_containing_block_used_values; }

--- a/Tests/LibWeb/Crash/Layout/display-inline-with-position-sticky.html
+++ b/Tests/LibWeb/Crash/Layout/display-inline-with-position-sticky.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+
+<head>
+    <style>
+        .container {
+            width: 80%;
+            margin: auto;
+        }
+
+        .sticky-inline {
+            display: inline;
+            position: sticky;
+            top: 10px;
+            background: yellow;
+            padding: 5px;
+            font-weight: bold;
+        }
+
+        .content {
+            margin-top: 20px;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <p>
+            This is an example of an inline box with <span class="sticky-inline">position: sticky</span>.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum euismod, nulla id consequat facilisis,
+            libero risus placerat lacus, sed fermentum nisl nunc non sapien. Vivamus scelerisque feugiat dui, ac
+            venenatis ligula ultricies vel. Duis id nunc in felis feugiat cursus. Pellentesque habitant morbi tristique
+            senectus et netus et malesuada fames ac turpis egestas.
+            Curabitur at felis ac massa aliquet dictum. Ut auctor ligula non ante interdum, a euismod dui tristique. Nam
+            consequat, massa ut ultrices fermentum, lacus libero vulputate nulla, sit amet vehicula erat odio a metus.
+            Nulla vitae lectus sed erat scelerisque sodales.
+        </p>
+        <p>
+            This is an example of an inline box with <span class="sticky-inline">position: sticky</span>.
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum euismod, nulla id consequat facilisis,
+            libero risus placerat lacus, sed fermentum nisl nunc non sapien. Vivamus scelerisque feugiat dui, ac
+            venenatis ligula ultricies vel. Duis id nunc in felis feugiat cursus. Pellentesque habitant morbi tristique
+            senectus et netus et malesuada fames ac turpis egestas.
+            Curabitur at felis ac massa aliquet dictum. Ut auctor ligula non ante interdum, a euismod dui tristique. Nam
+            consequat, massa ut ultrices fermentum, lacus libero vulputate nulla, sit amet vehicula erat odio a metus.
+            Nulla vitae lectus sed erat scelerisque sodales.
+        </p>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Before this change we were ignoring boxes with `display: inline` while assigning sticky insets. This was not correct because inline boxes are allowed to have sticky positioning.

Fixes:
https://github.com/LadybirdBrowser/ladybird/issues/3718 https://github.com/LadybirdBrowser/ladybird/issues/3507 https://github.com/LadybirdBrowser/ladybird/issues/3133

We don't match behavior of other engines when inline node is splitted between multiple lines, but still better than crashing

![CleanShot 2025-02-27 at 17 10 32](https://github.com/user-attachments/assets/e302f268-56c9-49b8-96bd-36c508bbfceb)



