### PR TITLE
LibRegex: Treat the UnicodeSets flag as Unicode

### DIFF
--- a/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
+++ b/Libraries/LibJS/Tests/builtins/RegExp/RegExp.js
@@ -72,3 +72,8 @@ test("regexp that always matches stops matching if it's past the end of the stri
     expect("whf".match(re)).toEqual(["", "", "", ""]);
     expect(re.lastIndex).toBe(0);
 });
+
+test("v flag should enable unicode mode", () => {
+    const re = new RegExp("a\\u{10FFFF}", "v");
+    expect(re.test("a\u{10FFFF}")).toBe(true);
+});

--- a/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Libraries/LibRegex/RegexMatcher.cpp
@@ -160,7 +160,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
     input.start_offset = m_pattern->start_offset;
     size_t lines_to_skip = 0;
 
-    bool unicode = input.regex_options.has_flag_set(AllFlags::Unicode);
+    bool unicode = input.regex_options.has_flag_set(AllFlags::Unicode) || input.regex_options.has_flag_set(AllFlags::UnicodeSets);
     for (auto const& view : views)
         const_cast<RegexStringView&>(view).set_unicode(unicode);
 

--- a/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Libraries/LibRegex/RegexOptimizer.cpp
@@ -627,7 +627,7 @@ bool Regex<Parser>::attempt_rewrite_entire_match_as_substring_search(BasicBlockL
 
     auto& bytecode = parser_result.bytecode;
 
-    auto is_unicode = parser_result.options.has_flag_set(AllFlags::Unicode);
+    auto is_unicode = parser_result.options.has_flag_set(AllFlags::Unicode) || parser_result.options.has_flag_set(AllFlags::UnicodeSets);
 
     // We have a single basic block, let's see if it's a series of character or string compares.
     StringBuilder final_string;


### PR DESCRIPTION
Fixes /.../v not being interpreted as a unicode pattern.