### PR TITLE
vcpkg: Explicitly use OpenSSL backend with curl

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -10,7 +10,7 @@
       "features": [
         "brotli",
         "http2",
-        "ssl",
+        "openssl",
         "websockets"
       ]
     },


### PR DESCRIPTION
The generic `ssl` feature selects Secure Transport on macOS, which is a deprecated library and support for it in curl is also deprecated and scheduled for removal after May 2025: https://daniel.haxx.se/blog/tag/securetransport/

Secure Transport is replaced by Network Framework, but as per the blog post above, there's no foreseeable future of curl supporting it.

With this information, we now explicitly use OpenSSL as the backend for curl, inline with the default choice for Linux.

This gives us some key benefits:
- A maintained and current TLS library
- TLS 1.0 and 1.1 is disabled by default
- TLS 1.3 is now available
- Modern cipher suites
- Removal of TLS_EMPTY_RENEGOTIATION_INFO_SCSV extension
- Opportunity to support HTTP/3 with nghttp3 and OpenSSL's QUIC support
- More extensions, key exchanges, EC point formats, etc.

<details>
<summary>Before:</summary>

![screenshot-2025-02-28-14-48-09](https://github.com/user-attachments/assets/cd1dd685-b81e-4e9f-a531-4f85a8ab84fa)

</details>

<details>
<summary>After:</summary>

![screenshot-2025-02-28-14-47-11](https://github.com/user-attachments/assets/f1afd6f4-109e-4b72-900a-341b6cdff16f)

</details>