### PR TITLE
LibWeb: Fire error event if `HTMLTrackElement` src is empty on load

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTrackElement.cpp
@@ -235,7 +235,6 @@ void HTMLTrackElement::start_the_track_processing_model_parallel_steps(JS::Realm
         // 4. Fetch request.
         m_fetch_algorithms = Fetch::Infrastructure::FetchAlgorithms::create(vm(), move(fetch_algorithms_input));
         m_fetch_controller = MUST(Fetch::Fetching::fetch(realm, request, *m_fetch_algorithms));
-        return;
     } else {
         fire_error_event();
         return;

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/media-elements/track/track-element/src-empty-string.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/embedded-content/media-elements/track/track-element/src-empty-string.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	Setting HTMLTrackElement.src to the empty string fires 'error' and sets readyState to ERROR

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/media-elements/track/track-element/src-empty-string.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/embedded-content/media-elements/track/track-element/src-empty-string.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<title>Setting HTMLTrackElement.src to the empty string fires 'error' and sets readyState to ERROR</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/media.html#sourcing-out-of-band-text-tracks">
+<script src="../../../../../../resources/testharness.js"></script>
+<script src="../../../../../../resources/testharnessreport.js"></script>
+<video></video>
+<script>
+async_test(t => {
+  let track = document.createElement("track");
+  track.src = '';
+  track.default = true;
+  track.onerror = t.step_func_done(() => {
+    assert_equals(track.readyState, HTMLTrackElement.ERROR);
+  });
+  track.onload = t.unreached_func('fired load');
+
+  assert_equals(track.readyState, HTMLTrackElement.NONE);
+
+  document.querySelector('video').appendChild(track);
+});
+</script>


### PR DESCRIPTION
Previously, we would hang while waiting for the track to load if the `src` attribute was not present or empty.

I've also removed an incorrect early return after the track element fetch request starts, which prevented subsequent algorithm steps from running.

Fixes: #3740