### PR TITLE
LibWeb: Implement HTMLInputElement type=url constraint validation

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -15,6 +15,7 @@
 #include <LibJS/Runtime/Date.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/RegExpObject.h>
+#include <LibURL/Parser.h>
 #include <LibWeb/Bindings/HTMLInputElementPrototype.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/CSS/ComputedProperties.h>
@@ -3044,12 +3045,15 @@ bool HTMLInputElement::suffering_from_being_missing() const
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#suffering-from-a-type-mismatch
 bool HTMLInputElement::suffering_from_a_type_mismatch() const
 {
+    auto input = value();
     switch (type_state()) {
     case TypeAttributeState::URL:
         // https://html.spec.whatwg.org/multipage/input.html#url-state-(type%3Durl)%3Asuffering-from-a-type-mismatch
         // While the value of the element is neither the empty string nor a valid absolute URL, the element is suffering from a type mismatch.
-        // FIXME: Implement this.
-        break;
+        // AD-HOC: https://github.com/whatwg/html/issues/11083 and https://github.com/web-platform-tests/wpt/pull/51011
+        //         We intentionally don't check if the value is a "valid absolute URL", because that's not what other
+        //         engines actually do. So we instead just implement what matches the behavior in existing engines.
+        return !input.is_empty() && !URL::Parser::basic_parse(input).has_value();
     case TypeAttributeState::Email:
         // https://html.spec.whatwg.org/multipage/input.html#email-state-(type%3Demail)%3Asuffering-from-a-type-mismatch
         // While the value of the element is neither the empty string nor a single valid email address, the element is suffering from a type mismatch.

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 130 tests
 
-112 Pass
-18 Fail
+114 Pass
+16 Fail
 Pass	[INPUT in TEXT status] no constraint
 Pass	[INPUT in TEXT status] no constraint (in a form)
 Pass	[INPUT in TEXT status] not suffering from being too long
@@ -42,8 +42,8 @@ Pass	[INPUT in URL status] suffering from being too long
 Pass	[INPUT in URL status] suffering from being too long (in a form)
 Pass	[INPUT in URL status] suffering from a pattern mismatch
 Pass	[INPUT in URL status] suffering from a pattern mismatch (in a form)
-Fail	[INPUT in URL status] suffering from a type mismatch
-Fail	[INPUT in URL status] suffering from a type mismatch (in a form)
+Pass	[INPUT in URL status] suffering from a type mismatch
+Pass	[INPUT in URL status] suffering from a type mismatch (in a form)
 Pass	[INPUT in URL status] suffering from being missing
 Pass	[INPUT in URL status] suffering from being missing (in a form)
 Pass	[INPUT in EMAIL status] no constraint

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-typeMismatch.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-typeMismatch.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 11 tests
 
-7 Pass
-4 Fail
+8 Pass
+3 Fail
 Pass	[INPUT in EMAIL status] The value is empty
 Pass	[INPUT in EMAIL status] The value is a valid email address
 Pass	[INPUT in EMAIL status] The value is a valid email address with some white spaces.
@@ -14,4 +14,4 @@ Fail	[INPUT in EMAIL status] The value contains invalid separator
 Pass	[INPUT in URL status] The value is empty
 Pass	[INPUT in URL status] The value is a valid url
 Pass	[INPUT in URL status] The value is a valid url with some white spaces.
-Fail	[INPUT in URL status] The value is not an url
+Pass	[INPUT in URL status] The value is not an url


### PR DESCRIPTION
This change implements `HTMLInputElement` `type=url` constraint validation in such a way as to match the behavior in other existing engines — which is, however, very different from what the spec currently requires.

See https://github.com/whatwg/html/issues/11083 and see the additional test cases at https://github.com/web-platform-tests/wpt/pull/51011/files — and see Anne’s comment at https://github.com/web-platform-tests/wpt/pull/51011#issuecomment-2689983961.

For the record here: If we were to strictly implement the spec requirements as currently written, we’d end up reporting validation errors for a lot of cases that all other existing engines don’t report validation errors for. So, from a user point of view, it’d look to users as if our behavior is broken.

This therefore seems like a case where we’re better off just doing what other existing engines do.
