### PR TITLE
Documentation: Fix a typo on line 52 in Devtools.md

### DIFF
--- a/Documentation/DevTools.md
+++ b/Documentation/DevTools.md
@@ -49,7 +49,7 @@ waiting for a reply, to which the actor must then reply in order. Any requests t
 (such as fetching the serialized DOM tree from the WebContent process) must block the actor from sending replies for
 subsequent requests.
 
-To log communcation between the DevTools server and client, enable the `DEVTOOLS_DEBUG` flag:
+To log communication between the DevTools server and client, enable the `DEVTOOLS_DEBUG` flag:
 
 ```bash
 cmake -B Build/release -D DEVTOOLS_DEBUG=ON


### PR DESCRIPTION
Typo "communcation" replaced with communication on line 52.