### PR TITLE
Fix template keyword misuse causing Mac build failure

### DIFF
--- a/UI/AppKit/Interface/LadybirdWebView.mm
+++ b/UI/AppKit/Interface/LadybirdWebView.mm
@@ -450,7 +450,7 @@ static void copy_data_to_clipboard(StringView data, NSPasteboardType pasteboard_
         if (self == nil) {
             return;
         }
-        cursor.template visit(
+        cursor.visit(
             [](Gfx::ImageCursor const& image_cursor) {
                 auto* cursor_image = Ladybird::gfx_bitmap_to_ns_image(*image_cursor.bitmap.bitmap());
                 auto hotspot = Ladybird::gfx_point_to_ns_point(image_cursor.hotspot);


### PR DESCRIPTION
I tried building the project following the [build guide](https://github.com/LadybirdBrowser/ladybird/blob/master/Documentation/BuildInstructionsLadybird.md) to install all the dependencies for Mac and running:

```
CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ ./Meta/ladybird.sh run
```

That caused the build to fail with this message:

```
[2955/2963] Building CXX object UI/AppKit/CMakeFiles/ladybird_impl.dir/Interface/LadybirdWebView.mm.o
FAILED: UI/AppKit/CMakeFiles/ladybird_impl.dir/Interface/LadybirdWebView.mm.o
/opt/homebrew/bin/ccache /opt/homebrew/opt/llvm/bin/clang++  -I/Users/silvanocerza/workspace/ladybird -I/Users/silvanocerza/workspace/ladybird/Services -I/Users/silvanocerza/workspace/ladybird/Libraries -I/Users/silvanocerza/workspace/ladybird/Build/release/Lagom -I/Users/silvanocerza/workspace/ladybird/Build/release/Lagom/Services -I/Users/silvanocerza/workspace/ladybird/Build/release/Lagom/Libraries -I/Users/silvanocerza/workspace/ladybird/UI/AppKit -I/Users/silvanocerza/workspace/ladybird/Build/release/UI -isystem /Users/silvanocerza/workspace/ladybird/Build/release/vcpkg_installed/arm64-osx-dynamic/include -O2 -g -DNDEBUG -std=c++23 -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.2.sdk -mmacosx-version-min=15.0 -fcolor-diagnostics -Wall -Wextra -fno-exceptions -ffp-contract=off -Wcast-qual -Wformat=2 -Wimplicit-fallthrough -Wlogical-op -Wmissing-declarations -Wmissing-field-initializers -Wsuggest-override -Wno-invalid-offsetof -Wno-unknown-warning-option -Wno-unused-command-line-argument -Wpadded-bitfield -Werror -fconstexpr-steps=16777216 -Wmissing-prototypes -Wno-implicit-const-int-float-conversion -Wno-user-defined-literals -Wno-unqualified-std-cast-call -fstack-protector-strong -fstrict-flex-arrays=2 -Wno-maybe-uninitialized -Wno-shorten-64-to-32 -fsigned-char -ggnu-pubnames -fPIC -O2 -g1 -Wno-expansion-to-defined -fobjc-arc -Wno-deprecated-anon-enum-enum-conversion -MD -MT UI/AppKit/CMakeFiles/ladybird_impl.dir/Interface/LadybirdWebView.mm.o -MF UI/AppKit/CMakeFiles/ladybird_impl.dir/Interface/LadybirdWebView.mm.o.d -o UI/AppKit/CMakeFiles/ladybird_impl.dir/Interface/LadybirdWebView.mm.o -c /Users/silvanocerza/workspace/ladybird/UI/AppKit/Interface/LadybirdWebView.mm
/Users/silvanocerza/workspace/ladybird/UI/AppKit/Interface/LadybirdWebView.mm:453:25: error: a template argument list is expected after a name prefixed by the template keyword [-Wmissing-template-arg-list-after-template-kw]
  453 |         cursor.template visit(
      |                         ^
1 error generated.
[2960/2963] Building CXX object UI/AppKit/CMakeFiles/ladybird.dir/main.mm.o
ninja: build stopped: subcommand failed.
```

This PR fixes this. I also run the following command as instructed by @sideshowbarker and everything worked fine with no extra changes.
```
$ CC=$(brew --prefix llvm)/bin/clang CXX=$(brew --prefix llvm)/bin/clang++ \
    ./Meta/ladybird.sh run headless-browser --rebaseline \
    --run-tests "./Tests/LibWeb"
...
Done!
==========================================================
Pass: 3385, Fail: 0, Skipped: 269, Timeout: 0, Crashed: 0
==========================================================
```