### PR TITLE
LibRegex: Ensure nullable quantifiers backtrack when input remains

### DIFF
--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -1118,6 +1118,10 @@ ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const& inp
         }
     }
 
+    if (state.string_position < input.view.length()) {
+        return ExecutionResult::Failed_ExecuteLowPrioForks;
+    }
+
     return ExecutionResult::Continue;
 }
 

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -986,6 +986,15 @@ TEST_CASE(extremely_long_fork_chain)
     EXPECT_EQ(result.success, true);
 }
 
+TEST_CASE(nullable_quantifiers)
+{
+    // clang-format off
+    Regex<ECMA262> re("(a?b?""?)*"); // Pattern (a?b??)* has to be concatenated to avoid "??)", which is a trigraph.
+    // clang-format on
+    auto result = re.match("ab"sv);
+    EXPECT_EQ(result.matches.at(0).view, "ab"sv);
+}
+
 TEST_CASE(theoretically_infinite_loop)
 {
     Array patterns {


### PR DESCRIPTION
This makes patterns like `/(a?b??)*/` correctly match the string.

Issue was originally found in test262: [https://github.com/tc39/test262/blob/9d8efae5c2c1848b9c3362c4aa81dd360ff8d3a7/test/built-ins/RegExp/nullable-quantifier.js](https://github.com/tc39/test262/blob/9d8efae5c2c1848b9c3362c4aa81dd360ff8d3a7/test/built-ins/RegExp/nullable-quantifier.js)