### PR TITLE
LibWeb: Don't handle scroll if no axes are accepted

### DIFF
--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -954,7 +954,8 @@ Paintable::DispatchEventOfSameName PaintableBox::handle_mousemove(Badge<EventHan
 
 bool PaintableBox::handle_mousewheel(Badge<EventHandler>, CSSPixelPoint, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
 {
-    if (!could_be_scrolled_by_wheel_event()) {
+    // if none of the axes we scrolled with can be accepted by this element, don't handle scroll.
+    if ((!wheel_delta_x || !could_be_scrolled_by_wheel_event(ScrollDirection::Horizontal)) && (!wheel_delta_y || !could_be_scrolled_by_wheel_event(ScrollDirection::Vertical))) {
         return false;
     }
 


### PR DESCRIPTION
In some cases, we might be hovering directly on an element scrollable e.g. horizontally, but we are scrolling vertically. In these cases, we need to delegate the scroll to the parent instead of stalling the user's scroll.

I found this on https://tidal.com. If you scroll a tiny bit down, you see a horizontal scroll element. Hovering on it prevents the user from scrolling further down.

I've tested this fix on tidal.com and it seems to work just fine. My mouse's horizontal scroll scrolls the horizontal element, while the vertical scrolls the webpage.