### PR TITLE
LibUnicode: Specify ICU 76 in LibUnicode/CMakeLists.txt

### DIFF
--- a/Libraries/LibUnicode/CMakeLists.txt
+++ b/Libraries/LibUnicode/CMakeLists.txt
@@ -23,5 +23,5 @@ set(GENERATED_SOURCES ${CURRENT_LIB_GENERATED})
 
 serenity_lib(LibUnicode unicode)
 
-find_package(ICU 74 REQUIRED COMPONENTS data i18n uc)
+find_package(ICU 76 REQUIRED COMPONENTS data i18n uc)
 target_link_libraries(LibUnicode PRIVATE ICU::i18n ICU::uc ICU::data)


### PR DESCRIPTION
We upgraded to ICU 76 in 6a564376fc011167c90a4bd79b408f9a52684e0c. This CMakeLists.txt should have been updated to match.