### PR TITLE
LibWeb: allow loading stylesheets without a mime

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -397,7 +397,7 @@ void HTMLLinkElement::process_stylesheet_resource(bool success, Fetch::Infrastru
             mime_type_string = extracted_mime_type->essence();
     }
 
-    if (mime_type_string != "text/css"sv) {
+    if (mime_type_string.has_value() && mime_type_string != "text/css"sv) {
         success = false;
     }
 


### PR DESCRIPTION
I am not sure if this is 100% correct, but it's another quirk I found.

If you go to https://animetitties.cc (don't worry about the name, it's my website, sfw) it doesn't load the stylesheet, because I didn't add a mime to the stylesheet:
```html
<link rel="stylesheet" href="/css/main.css" as="style">
```

Both firefox and chromium do load it regardless, so I made Ladybird load css stylesheets if the mime is empty.

It does indeed fix the rendering on at least my website.

Tests still pass, but should I add another test for this edge case?