### PR TITLE
LibWeb: avoid setting invalid webpage title on update

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.cpp
@@ -4,11 +4,15 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibCore/Timer.h>
 #include <LibWeb/Bindings/HTMLTitleElementPrototype.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLTitleElement.h>
 #include <LibWeb/HTML/TraversableNavigable.h>
 #include <LibWeb/Page/Page.h>
+
+static constexpr u32 timer_throttle_ms = 5;
+static constexpr u32 timer_unconditional_update_ms = 15;
 
 namespace Web::HTML {
 
@@ -17,6 +21,9 @@ GC_DEFINE_ALLOCATOR(HTMLTitleElement);
 HTMLTitleElement::HTMLTitleElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
+    m_throttle_update_timer = Core::Timer::create_single_shot(timer_throttle_ms, [this] {
+        this->propagate_title_update();
+    });
 }
 
 HTMLTitleElement::~HTMLTitleElement() = default;
@@ -30,9 +37,10 @@ void HTMLTitleElement::initialize(JS::Realm& realm)
 void HTMLTitleElement::children_changed(ChildrenChangedMetadata const* metadata)
 {
     HTMLElement::children_changed(metadata);
+
     auto navigable = this->navigable();
     if (navigable && navigable->is_traversable()) {
-        navigable->traversable_navigable()->page().client().page_did_change_title(document().title().to_byte_string());
+        consider_propagate_title_update();
     }
 }
 
@@ -48,6 +56,37 @@ void HTMLTitleElement::set_text(String const& value)
 {
     // The text attribute's setter must string replace all with the given value within this title element.
     string_replace_all(value);
+}
+
+void HTMLTitleElement::consider_propagate_title_update()
+{
+    if (text().is_empty()) {
+        m_throttle_update_timer->start();
+        return;
+    }
+
+    i64 const time_now = MonotonicTime::now_coarse().milliseconds();
+
+    if (m_first_block_at_ms == 0) {
+        m_first_block_at_ms = time_now;
+    }
+
+    if (time_now - m_first_block_at_ms > timer_unconditional_update_ms) {
+        // we've exceeded the max ms without a title update, we'll propagate it immediately
+        propagate_title_update();
+        return;
+    }
+
+    // start a throttling timer. This is to not spam every update to the front-end.
+    // furthermore, the first update is removing the title, so it gives us an erroneous empty title.
+    m_throttle_update_timer->restart();
+}
+
+void HTMLTitleElement::propagate_title_update()
+{
+    m_first_block_at_ms = 0;
+    m_throttle_update_timer->stop();
+    navigable()->traversable_navigable()->page().client().page_did_change_title(document().title().to_byte_string());
 }
 
 }

--- a/Libraries/LibWeb/HTML/HTMLTitleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLTitleElement.h
@@ -25,6 +25,12 @@ private:
 
     virtual void initialize(JS::Realm&) override;
     virtual void children_changed(ChildrenChangedMetadata const*) override;
+
+    void consider_propagate_title_update();
+    void propagate_title_update();
+
+    i64 m_first_block_at_ms { 0 };
+    RefPtr<Core::Timer> m_throttle_update_timer;
 };
 
 }


### PR DESCRIPTION
When JS calls `document.title = ...`, we first remove the old title, and then apply the new one. However, this will cause the title to be sent twice to the Ladybird main process, first time with an empty string (removed) and then with the proper string (added).

Instead, skip the first update if replacing to avoid the window title flickering the site URL.

This does fix the problem on my end, although obviously I am not very familiar with your internal coding rules so feel free to criticize my approach.