### PR TITLE
LibGfx+LibWeb: Move EXIF orientation to rendering and implement image-orientation

### DIFF
--- a/Libraries/LibGfx/Bitmap.h
+++ b/Libraries/LibGfx/Bitmap.h
@@ -12,6 +12,7 @@
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImageOrientation.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/ScalingMode.h>
 
@@ -53,12 +54,12 @@ struct BackingStore;
 
 class Bitmap : public AtomicRefCounted<Bitmap> {
 public:
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create(BitmapFormat, IntSize);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create(BitmapFormat, AlphaType, IntSize);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_shareable(BitmapFormat, AlphaType, IntSize);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, AlphaType, IntSize, size_t pitch, void*, Function<void()>&& destruction_callback = {});
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_with_raw_data(BitmapFormat, AlphaType, ReadonlyBytes, IntSize);
-    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_with_anonymous_buffer(BitmapFormat, AlphaType, Core::AnonymousBuffer, IntSize);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create(BitmapFormat, IntSize, ExifOrientation = ExifOrientation::Default);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create(BitmapFormat, AlphaType, IntSize, ExifOrientation = ExifOrientation::Default);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_shareable(BitmapFormat, AlphaType, IntSize, ExifOrientation = ExifOrientation::Default);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_wrapper(BitmapFormat, AlphaType, IntSize, size_t pitch, void*, Function<void()>&& destruction_callback = {}, ExifOrientation = ExifOrientation::Default);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_with_raw_data(BitmapFormat, AlphaType, ReadonlyBytes, IntSize, ExifOrientation = ExifOrientation::Default);
+    [[nodiscard]] static ErrorOr<NonnullRefPtr<Bitmap>> create_with_anonymous_buffer(BitmapFormat, AlphaType, Core::AnonymousBuffer, IntSize, ExifOrientation = ExifOrientation::Default);
 
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> clone() const;
 
@@ -87,10 +88,11 @@ public:
     [[nodiscard]] RawPixel const* end() const;
     [[nodiscard]] size_t data_size() const;
 
-    [[nodiscard]] IntRect rect() const { return { {}, m_size }; }
-    [[nodiscard]] IntSize size() const { return m_size; }
-    [[nodiscard]] int width() const { return m_size.width(); }
-    [[nodiscard]] int height() const { return m_size.height(); }
+    [[nodiscard]] IntRect rect() const;
+    [[nodiscard]] IntSize size() const;
+    [[nodiscard]] int width() const;
+    [[nodiscard]] int height() const;
+    [[nodiscard]] ExifOrientation exif_orientation() const { return m_exif_orientation; }
 
     [[nodiscard]] size_t pitch() const { return m_pitch; }
 
@@ -138,9 +140,9 @@ public:
     void set_alpha_type_destructive(AlphaType);
 
 private:
-    Bitmap(BitmapFormat, AlphaType, IntSize, BackingStore const&);
-    Bitmap(BitmapFormat, AlphaType, IntSize, size_t pitch, void*, Function<void()>&& destruction_callback);
-    Bitmap(BitmapFormat, AlphaType, Core::AnonymousBuffer, IntSize);
+    Bitmap(BitmapFormat, AlphaType, IntSize, BackingStore const&, ExifOrientation);
+    Bitmap(BitmapFormat, AlphaType, IntSize, size_t pitch, void*, Function<void()>&& destruction_callback, ExifOrientation);
+    Bitmap(BitmapFormat, AlphaType, Core::AnonymousBuffer, IntSize, ExifOrientation);
 
     enum class InitializeBackingStore {
         No,
@@ -155,6 +157,7 @@ private:
     AlphaType m_alpha_type { AlphaType::Premultiplied };
     Core::AnonymousBuffer m_buffer;
     Function<void()> m_destruction_callback;
+    ExifOrientation m_exif_orientation;
 };
 
 ALWAYS_INLINE u8* Bitmap::unchecked_scanline_u8(int y)

--- a/Libraries/LibGfx/CMakeLists.txt
+++ b/Libraries/LibGfx/CMakeLists.txt
@@ -41,6 +41,7 @@ set(SOURCES
     ImageFormats/WebPWriter.cpp
     ImageFormats/WebPWriterLossless.cpp
     ImmutableBitmap.cpp
+    ImageOrientation.cpp
     PaintStyle.cpp
     Painter.cpp
     PainterSkia.cpp

--- a/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
+++ b/Libraries/LibGfx/ImageFormats/PNGLoader.cpp
@@ -10,6 +10,7 @@
 #include <LibGfx/ImageFormats/PNGLoader.h>
 #include <LibGfx/ImageFormats/TIFFLoader.h>
 #include <LibGfx/ImageFormats/TIFFMetadata.h>
+#include <LibGfx/ImageOrientation.h>
 #include <LibGfx/ImmutableBitmap.h>
 #include <LibGfx/Painter.h>
 #include <png.h>
@@ -48,8 +49,6 @@ struct PNGLoadingContext {
 
         frame_count = TRY(read_frames(png_ptr, info_ptr));
 
-        if (exif_metadata)
-            TRY(apply_exif_orientation());
         return {};
     }
 };
@@ -221,36 +220,13 @@ ErrorOr<void> PNGImageDecoderPlugin::initialize()
     return {};
 }
 
-ErrorOr<void> PNGLoadingContext::apply_exif_orientation()
-{
-    auto orientation = exif_metadata->orientation().value_or(TIFF::Orientation::Default);
-    if (orientation == TIFF::Orientation::Default)
-        return {};
-
-    for (auto& img_frame_descriptor : frame_descriptors) {
-        auto& img = img_frame_descriptor.image;
-        auto oriented_bmp = TRY(ExifOrientedBitmap::create(orientation, img->size(), img->format()));
-
-        for (int y = 0; y < img->size().height(); ++y) {
-            for (int x = 0; x < img->size().width(); ++x) {
-                auto pixel = img->get_pixel(x, y);
-                oriented_bmp.set_pixel(x, y, pixel.value());
-            }
-        }
-
-        img_frame_descriptor.image = oriented_bmp.bitmap();
-    }
-
-    size = ExifOrientedBitmap::oriented_size(size, orientation);
-
-    return {};
-}
-
 ErrorOr<size_t> PNGLoadingContext::read_frames(png_structp png_ptr, png_infop info_ptr)
 {
+    auto exif_orientation = exif_metadata ? static_cast<ExifOrientation>(exif_metadata->orientation().value()) : ExifOrientation::Default;
+
     Vector<u8*> row_pointers;
     auto decode_frame = [&](IntSize frame_size) -> ErrorOr<NonnullRefPtr<Bitmap>> {
-        auto frame_bitmap = TRY(Bitmap::create(BitmapFormat::BGRA8888, AlphaType::Unpremultiplied, frame_size));
+        auto frame_bitmap = TRY(Bitmap::create(BitmapFormat::BGRA8888, AlphaType::Unpremultiplied, frame_size, exif_orientation));
 
         row_pointers.resize_and_keep_capacity(frame_size.height());
         for (auto i = 0; i < frame_size.height(); ++i)

--- a/Libraries/LibGfx/ImageOrientation.cpp
+++ b/Libraries/LibGfx/ImageOrientation.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, Tuur Martens <tuurmartens4@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/ImageOrientation.h>
+
+namespace Gfx {
+
+bool is_valid_exif_orientation(u32 orientation)
+{
+    switch (static_cast<Gfx::ExifOrientation>(orientation)) {
+    case Gfx::ExifOrientation::Default:
+    case Gfx::ExifOrientation::FlipHorizontally:
+    case Gfx::ExifOrientation::Rotate180:
+    case Gfx::ExifOrientation::FlipVertically:
+    case Gfx::ExifOrientation::Rotate90ClockwiseThenFlipHorizontally:
+    case Gfx::ExifOrientation::Rotate90Clockwise:
+    case Gfx::ExifOrientation::FlipHorizontallyThenRotate90Clockwise:
+    case Gfx::ExifOrientation::Rotate90CounterClockwise:
+        return true;
+    default:
+        return false;
+    }
+}
+
+bool exif_orientation_affects_image_size(Gfx::ExifOrientation orientation)
+{
+    switch (orientation) {
+    case Gfx::ExifOrientation::Rotate90Clockwise:
+    case Gfx::ExifOrientation::Rotate90CounterClockwise:
+    case Gfx::ExifOrientation::FlipHorizontallyThenRotate90Clockwise:
+    case Gfx::ExifOrientation::Rotate90ClockwiseThenFlipHorizontally:
+        return true;
+    default:
+        return false;
+    }
+}
+
+}

--- a/Libraries/LibGfx/ImageOrientation.h
+++ b/Libraries/LibGfx/ImageOrientation.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025, Tuur Martens <tuurmartens4@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <AK/Types.h>
+#include <LibGfx/AffineTransform.h>
+#include <LibGfx/Rect.h>
+
+namespace Gfx {
+
+enum class ExifOrientation : u8 {
+    Default = 1,
+    FlipHorizontally = 2,
+    Rotate180 = 3,
+    FlipVertically = 4,
+    Rotate90ClockwiseThenFlipHorizontally = 5,
+    Rotate90Clockwise = 6,
+    FlipHorizontallyThenRotate90Clockwise = 7,
+    Rotate90CounterClockwise = 8,
+};
+
+[[nodiscard]] bool is_valid_exif_orientation(u32 orientation);
+
+template<typename T>
+[[nodiscard]] Gfx::AffineTransform compute_exif_orientation_matrix(Gfx::ExifOrientation orientation, Gfx::Rect<T> const& dst_rect)
+{
+    Gfx::AffineTransform matrix;
+
+    switch (orientation) {
+    case Gfx::ExifOrientation::Default:
+        return matrix;
+    case Gfx::ExifOrientation::FlipHorizontally:
+        matrix.set_translation(dst_rect.width() / 2, 0);
+        matrix.set_scale(-1, 1);
+        matrix.translate(-dst_rect.width() / 2.f, 0);
+        break;
+    case Gfx::ExifOrientation::Rotate180:
+        matrix.set_translation(dst_rect.width(), dst_rect.height());
+        matrix.rotate_radians(AK::Pi<float>);
+        break;
+    case Gfx::ExifOrientation::FlipVertically:
+        matrix.set_translation(0, dst_rect.height() / 2);
+        matrix.set_scale(1, -1);
+        matrix.translate(0, -dst_rect.height() / 2);
+        break;
+    case Gfx::ExifOrientation::Rotate90ClockwiseThenFlipHorizontally:
+        matrix.set_translation(dst_rect.height(), 0);
+        matrix.rotate_radians(-AK::Pi<float> / 2.f);
+        matrix.translate(0, -dst_rect.height());
+        matrix.scale(-1, 1);
+        break;
+    case Gfx::ExifOrientation::Rotate90Clockwise:
+        matrix.set_translation(dst_rect.width(), 0);
+        matrix.rotate_radians(AK::Pi<float> / 2.f);
+        break;
+    case Gfx::ExifOrientation::FlipHorizontallyThenRotate90Clockwise:
+        // We translate by the dst_rect.height(), which will be the new dst_rect.width() of the image.
+        matrix.set_translation(dst_rect.width(), 0);
+        matrix.rotate_radians(AK::Pi<float> / 2.f);
+        // We translate by the old dst_rect.height() to move the image back to the origin.
+        matrix.translate(dst_rect.height(), 0);
+        matrix.scale(-1, 1);
+        break;
+    case Gfx::ExifOrientation::Rotate90CounterClockwise:
+        matrix.translate(0, dst_rect.height());
+        matrix.rotate_radians(-AK::Pi<float> / 2.f);
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    return matrix;
+}
+
+template<typename T>
+[[nodiscard]] Size<T> exif_oriented_size(Size<T> const& size, Gfx::ExifOrientation orientation)
+{
+    switch (orientation) {
+    case Gfx::ExifOrientation::Default:
+    case Gfx::ExifOrientation::FlipHorizontally:
+    case Gfx::ExifOrientation::Rotate180:
+    case Gfx::ExifOrientation::FlipVertically:
+        return size;
+    case Gfx::ExifOrientation::Rotate90ClockwiseThenFlipHorizontally:
+    case Gfx::ExifOrientation::Rotate90Clockwise:
+    case Gfx::ExifOrientation::FlipHorizontallyThenRotate90Clockwise:
+    case Gfx::ExifOrientation::Rotate90CounterClockwise:
+        return { size.height(), size.width() };
+    }
+    VERIFY_NOT_REACHED();
+}
+
+[[nodiscard]] bool exif_orientation_affects_image_size(Gfx::ExifOrientation orientation);
+
+}

--- a/Libraries/LibGfx/ImmutableBitmap.cpp
+++ b/Libraries/LibGfx/ImmutableBitmap.cpp
@@ -68,6 +68,14 @@ IntSize ImmutableBitmap::size() const
     return { width(), height() };
 }
 
+ExifOrientation ImmutableBitmap::get_exif_orientation() const
+{
+    if (auto const bitmap = m_impl->bitmap)
+        return bitmap->exif_orientation();
+
+    return ExifOrientation::Default;
+}
+
 AlphaType ImmutableBitmap::alpha_type() const
 {
     // We assume premultiplied alpha type for opaque surfaces since that is Skia's preferred alpha type and the

--- a/Libraries/LibGfx/ImmutableBitmap.h
+++ b/Libraries/LibGfx/ImmutableBitmap.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/ColorSpace.h>
 #include <LibGfx/Forward.h>
+#include <LibGfx/ImageOrientation.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/YUVData.h>
 
@@ -73,6 +74,8 @@ public:
 
     // Returns nullptr for YUV-backed bitmaps
     RefPtr<Bitmap const> bitmap() const;
+
+    [[nodiscard]] ExifOrientation get_exif_orientation() const;
 
 private:
     friend class YUVData;

--- a/Libraries/LibGfx/SkiaUtils.cpp
+++ b/Libraries/LibGfx/SkiaUtils.cpp
@@ -15,6 +15,21 @@
 
 namespace Gfx {
 
+SkMatrix to_skia_matrix(AffineTransform const& affine_transform)
+{
+    SkScalar affine[6];
+    affine[0] = affine_transform.a();
+    affine[1] = affine_transform.b();
+    affine[2] = affine_transform.c();
+    affine[3] = affine_transform.d();
+    affine[4] = affine_transform.e();
+    affine[5] = affine_transform.f();
+
+    SkMatrix matrix;
+    matrix.setAffine(affine);
+    return matrix;
+}
+
 SkPath to_skia_path(Path const& path)
 {
     return static_cast<PathImplSkia const&>(path.impl()).sk_path();

--- a/Libraries/LibGfx/SkiaUtils.h
+++ b/Libraries/LibGfx/SkiaUtils.h
@@ -136,6 +136,8 @@ constexpr SkSamplingOptions to_skia_sampling_options(ScalingMode scaling_mode)
     VERIFY_NOT_REACHED();
 }
 
+[[nodiscard]] SkMatrix to_skia_matrix(AffineTransform const& affine_transform);
+
 SkPath to_skia_path(Path const& path);
 sk_sp<SkImageFilter> to_skia_image_filter(Gfx::Filter const& filter);
 sk_sp<SkBlender> to_skia_blender(Gfx::CompositingAndBlendingOperator compositing_and_blending_operator);

--- a/Libraries/LibWeb/CSS/Enums.json
+++ b/Libraries/LibWeb/CSS/Enums.json
@@ -446,6 +446,10 @@
     "increasing",
     "decreasing"
   ],
+  "image-orientation": [
+    "from-image",
+    "none"
+  ],
   "image-rendering": [
     "auto",
     "crisp-edges",

--- a/Libraries/LibWeb/CSS/ToGfxConversions.h
+++ b/Libraries/LibWeb/CSS/ToGfxConversions.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025, Tuur Martens <tuurmartens4@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <LibGfx/ImageOrientation.h>
+#include <LibWeb/CSS/Enums.h>
+
+namespace Web::CSS {
+
+[[nodiscard]]
+inline Gfx::ImageOrientation to_gfx_image_orientation(CSS::ImageOrientation css_value)
+{
+    switch (css_value) {
+    case CSS::ImageOrientation::None:
+        return Gfx::ImageOrientation::FromDecoded;
+    case CSS::ImageOrientation::FromImage:
+        return Gfx::ImageOrientation::FromExif;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+}

--- a/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -179,6 +179,13 @@ WebIDL::ExceptionOr<void> CanvasRenderingContext2D::draw_image_internal(CanvasIm
     //    to the source image and the destination rectangle must be clipped in the same proportion.
     auto clipped_source = source_rect.intersected(bitmap->rect().to_type<float>());
     auto clipped_destination = destination_rect;
+
+    if (bitmap->bitmap()) {
+        auto const exif_orientation = bitmap->get_exif_orientation();
+        auto const oriented_size = Gfx::exif_oriented_size(destination_rect.size(), exif_orientation);
+        destination_rect.set_size(oriented_size);
+    }
+
     if (clipped_source != source_rect) {
         clipped_destination.set_width(clipped_destination.width() * (clipped_source.width() / source_rect.width()));
         clipped_destination.set_height(clipped_destination.height() * (clipped_source.height() / source_rect.height()));

--- a/Libraries/LibWeb/Painting/DisplayListCommand.h
+++ b/Libraries/LibWeb/Painting/DisplayListCommand.h
@@ -9,6 +9,7 @@
 #include <AK/Forward.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Vector.h>
+#include <LibGfx/AffineTransform.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/CompositingAndBlendingOperator.h>
 #include <LibGfx/Forward.h>
@@ -78,6 +79,8 @@ struct DrawScaledImmutableBitmap {
     Gfx::IntRect clip_rect;
     NonnullRefPtr<Gfx::ImmutableBitmap const> bitmap;
     Gfx::ScalingMode scaling_mode;
+    Gfx::AffineTransform transformation_matrix;
+    bool rect_correction_necessary;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return clip_rect; }
     void dump(StringBuilder&) const;
@@ -93,9 +96,11 @@ struct DrawRepeatedImmutableBitmap {
 
     Gfx::IntRect dst_rect;
     Gfx::IntRect clip_rect;
+    Gfx::IntSize src_size;
     NonnullRefPtr<Gfx::ImmutableBitmap const> bitmap;
     Gfx::ScalingMode scaling_mode;
     Repeat repeat;
+    Gfx::AffineTransform transformation_matrix;
 
     [[nodiscard]] Gfx::IntRect bounding_rect() const { return clip_rect; }
     void dump(StringBuilder&) const;

--- a/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListPlayerSkia.cpp
@@ -59,20 +59,6 @@ static SkRRect to_skia_rrect(auto const& rect, CornerRadii const& corner_radii)
     return rrect;
 }
 
-static SkMatrix to_skia_matrix(Gfx::AffineTransform const& affine_transform)
-{
-    SkScalar affine[6];
-    affine[0] = affine_transform.a();
-    affine[1] = affine_transform.b();
-    affine[2] = affine_transform.c();
-    affine[3] = affine_transform.d();
-    affine[4] = affine_transform.e();
-    affine[5] = affine_transform.f();
-
-    SkMatrix matrix;
-    matrix.setAffine(affine);
-    return matrix;
-}
 static SkM44 to_skia_matrix4x4(Gfx::FloatMatrix4x4 const& matrix)
 {
     return SkM44(
@@ -154,14 +140,33 @@ void DisplayListPlayerSkia::draw_scaled_immutable_bitmap(DrawScaledImmutableBitm
     if (m_context && !command.bitmap->ensure_sk_image(*m_context))
         return;
 
-    auto dst_rect = to_skia_rect(command.dst_rect);
+    // Our dst_rect is already correctly rotated, but since we rotate our canvas, our dst_rect now applies to a rotated canvas.
+    // This means our once correct rect now needs to be rotated 90deg *again* for it to be correct.
+    // This is equivalent to swapping the width and height of the rect.
+    // Of course, we don't *always* rotate, so only perform this correction if we are rotating.
+    auto cmd_dst_rect = command.dst_rect;
+    if (command.rect_correction_necessary) {
+        cmd_dst_rect.set_size(cmd_dst_rect.height(), cmd_dst_rect.width());
+    }
+
+    auto dst_rect = to_skia_rect(cmd_dst_rect);
     auto clip_rect = to_skia_rect(command.clip_rect);
+
     auto& canvas = surface().canvas();
+    auto const skia_transformation_matrix { to_skia_matrix(command.transformation_matrix) };
+
+    canvas.save();
+    // We clip first so we don't transform the clip rect.
+    canvas.clipRect(clip_rect, true);
+
+    canvas.translate(dst_rect.x(), dst_rect.y());
+    canvas.concat(skia_transformation_matrix);
+    canvas.translate(-dst_rect.x(), -dst_rect.y());
+
     SkPaint paint;
     paint.setAntiAlias(true);
-    canvas.save();
-    canvas.clipRect(clip_rect, true);
     canvas.drawImageRect(command.bitmap->sk_image(), dst_rect, to_skia_sampling_options(command.scaling_mode), &paint);
+
     canvas.restore();
 }
 
@@ -172,9 +177,13 @@ void DisplayListPlayerSkia::draw_repeated_immutable_bitmap(DrawRepeatedImmutable
 
     SkMatrix matrix;
     auto dst_rect = command.dst_rect.to_type<float>();
-    auto src_size = command.bitmap->size().to_type<float>();
+    auto src_size = command.src_size.to_type<float>();
     matrix.setScale(dst_rect.width() / src_size.width(), dst_rect.height() / src_size.height());
+
+    auto const skia_transformation_matrix { Gfx::to_skia_matrix(command.transformation_matrix) };
+    matrix.postConcat(skia_transformation_matrix);
     matrix.postTranslate(dst_rect.x(), dst_rect.y());
+
     auto sampling_options = to_skia_sampling_options(command.scaling_mode);
 
     auto tile_mode_x = command.repeat.x ? SkTileMode::kRepeat : SkTileMode::kDecal;

--- a/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
+++ b/Libraries/LibWeb/Painting/DisplayListRecorder.cpp
@@ -181,22 +181,39 @@ void DisplayListRecorder::draw_scaled_immutable_bitmap(Gfx::IntRect const& dst_r
 {
     if (dst_rect.is_empty())
         return;
+
+    auto const exif_orientation = bitmap.get_exif_orientation();
+    auto const rect_correction_necessary = Gfx::exif_orientation_affects_image_size(exif_orientation);
+
+    auto const transformation_matrix = compute_exif_orientation_matrix(exif_orientation, dst_rect);
+
     APPEND(DrawScaledImmutableBitmap {
         .dst_rect = dst_rect,
         .clip_rect = clip_rect,
         .bitmap = bitmap,
         .scaling_mode = scaling_mode,
+        .transformation_matrix = transformation_matrix,
+        .rect_correction_necessary = rect_correction_necessary,
     });
 }
 
 void DisplayListRecorder::draw_repeated_immutable_bitmap(Gfx::IntRect dst_rect, Gfx::IntRect clip_rect, NonnullRefPtr<Gfx::ImmutableBitmap const> bitmap, Gfx::ScalingMode scaling_mode, bool repeat_x, bool repeat_y)
 {
+    if (dst_rect.is_empty())
+        return;
+
+    auto const exif_orientation = bitmap->get_exif_orientation();
+    auto const transformation_matrix = compute_exif_orientation_matrix(exif_orientation, dst_rect);
+    auto const size = bitmap->size();
+
     APPEND(DrawRepeatedImmutableBitmap {
         .dst_rect = dst_rect,
         .clip_rect = clip_rect,
+        .src_size = size,
         .bitmap = move(bitmap),
         .scaling_mode = scaling_mode,
         .repeat = { repeat_x, repeat_y },
+        .transformation_matrix = transformation_matrix,
     });
 }
 

--- a/Tests/LibGfx/TestImageDecoder.cpp
+++ b/Tests/LibGfx/TestImageDecoder.cpp
@@ -483,11 +483,11 @@ TEST_CASE(test_apng_idat_not_affecting_next_frame)
     EXPECT_EQ(frame.image->size(), Gfx::IntSize(100, 100));
 }
 
-TEST_CASE(test_exif)
+TEST_CASE(test_exif_decoding_png)
 {
-    auto file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("png/exif.png"sv)));
+    auto const file = TRY_OR_FAIL(Core::MappedFile::map(TEST_INPUT("png/exif.png"sv)));
     EXPECT(Gfx::PNGImageDecoderPlugin::sniff(file->bytes()));
-    auto plugin_decoder = TRY_OR_FAIL(Gfx::PNGImageDecoderPlugin::create(file->bytes()));
+    auto const plugin_decoder = TRY_OR_FAIL(Gfx::PNGImageDecoderPlugin::create(file->bytes()));
 
     auto frame = TRY_OR_FAIL(expect_single_frame_of_size(*plugin_decoder, { 200, 100 }));
     EXPECT(plugin_decoder->metadata().has_value());


### PR DESCRIPTION
This PR aims to implement support for EXIF orientation and the `image-orientation` CSS property.
Previous existing implementations for EXIF orientation performed orientation while decoding, which makes implementing the `image-orientation` property difficult.

This PR instead:
1. Adds the exif orientation as a member to the bitmap, allowing us to read it out while rendering.
2. Performs the exif orientations while rendering, leaving the bitmap data alone.

Adding support for other image formats should be as simple as passing the EXIF orientation to the bitmap once it is retrieved from the EXIF data in the decoder.

![output](https://github.com/user-attachments/assets/0c803cd4-5754-448c-a7ea-8906648b5f86)

See the following links for prior discussions.
https://github.com/LadybirdBrowser/ladybird/issues/2065
https://github.com/LadybirdBrowser/ladybird/pull/2122#issuecomment-2458172026