### PR TITLE
LibJS: Fix parseFloat(-0) returning -0 instead of +0

### DIFF
--- a/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -247,8 +247,13 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::parse_float)
     auto string = vm.argument(0);
 
     // OPTIMIZATION: We can skip the number-to-string-to-number round trip when the value is already a number.
-    if (string.is_number())
+    if (string.is_number()) {
+        // Special case for negative zero - it should become positive zero
+        if (string.is_negative_zero())
+            return Value(0);
+
         return string;
+    }
 
     // 1. Let inputString be ? ToString(string).
     auto input_string = TRY(string.to_string(vm));

--- a/Libraries/LibJS/Tests/builtins/functions/parseFloat.js
+++ b/Libraries/LibJS/Tests/builtins/functions/parseFloat.js
@@ -1,6 +1,16 @@
+// This is necessary because we can't simply check if 0 is negative using equality,
+// since -0 === 0 evaluates to true.
+// test262 checks for negative zero in a similar way here:
+// https://github.com/tc39/test262/blob/main/test/built-ins/parseFloat/S15.1.2.3_A1_T2.js
+function isZeroNegative(x) {
+    const isZero = x === 0;
+    const isNegative = 1 / x === Number.NEGATIVE_INFINITY;
+
+    return isZero && isNegative;
+}
+
 test("parsing numbers", () => {
     [
-        [0, 0],
         [1, 1],
         [0.23, 0.23],
         [1.23, 1.23],
@@ -12,6 +22,16 @@ test("parsing numbers", () => {
         expect(parseFloat(+test[0])).toBe(test[1]);
         expect(parseFloat(-test[0])).toBe(-test[1]);
     });
+});
+
+test("parsing zero", () => {
+    expect(isZeroNegative(parseFloat("0"))).toBeFalse();
+    expect(isZeroNegative(parseFloat("+0"))).toBeFalse();
+    expect(isZeroNegative(parseFloat("-0"))).toBeTrue();
+
+    expect(isZeroNegative(parseFloat(0))).toBeFalse();
+    expect(isZeroNegative(parseFloat(+0))).toBeFalse();
+    expect(isZeroNegative(parseFloat(-0))).toBeFalse();
 });
 
 test("parsing strings", () => {


### PR DESCRIPTION
`parseFloat(-0)` should return +0, but optimization that skips the string conversion for number values was causing -0 to be returned as-is.

Summary:
        +2 ✅    -1 ❌    -1 💀   

Diff Tests:
    test/built-ins/decodeURIComponent/S15.1.3.2_A2.5_T1.js 💀 -> ✅
    test/built-ins/parseFloat/S15.1.2.3_A1_T2.js           ❌ -> ✅
    test/staging/sm/Date/dst-offset-caching-1-of-8.js      💀 -> ✅
    test/staging/sm/Date/dst-offset-caching-5-of-8.js      ✅ -> 💀