### PR TITLE
LibWeb: Implement HTMLInputElement type=email constraint validation

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 130 tests
 
-114 Pass
-16 Fail
+116 Pass
+14 Fail
 Pass	[INPUT in TEXT status] no constraint
 Pass	[INPUT in TEXT status] no constraint (in a form)
 Pass	[INPUT in TEXT status] not suffering from being too long
@@ -52,8 +52,8 @@ Pass	[INPUT in EMAIL status] not suffering from being too long
 Pass	[INPUT in EMAIL status] not suffering from being too long (in a form)
 Pass	[INPUT in EMAIL status] suffering from a pattern mismatch
 Pass	[INPUT in EMAIL status] suffering from a pattern mismatch (in a form)
-Fail	[INPUT in EMAIL status] suffering from a type mismatch
-Fail	[INPUT in EMAIL status] suffering from a type mismatch (in a form)
+Pass	[INPUT in EMAIL status] suffering from a type mismatch
+Pass	[INPUT in EMAIL status] suffering from a type mismatch (in a form)
 Pass	[INPUT in EMAIL status] suffering from being missing
 Pass	[INPUT in EMAIL status] suffering from being missing (in a form)
 Pass	[INPUT in DATETIME-LOCAL status] no constraint

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-typeMismatch.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-typeMismatch.txt
@@ -2,15 +2,14 @@ Harness status: OK
 
 Found 11 tests
 
-8 Pass
-3 Fail
+11 Pass
 Pass	[INPUT in EMAIL status] The value is empty
 Pass	[INPUT in EMAIL status] The value is a valid email address
 Pass	[INPUT in EMAIL status] The value is a valid email address with some white spaces.
-Fail	[INPUT in EMAIL status] The value is not an email address
-Fail	[INPUT in EMAIL status] The value contains multiple email addresses
+Pass	[INPUT in EMAIL status] The value is not an email address
+Pass	[INPUT in EMAIL status] The value contains multiple email addresses
 Pass	[INPUT in EMAIL status] The value is valid email addresses
-Fail	[INPUT in EMAIL status] The value contains invalid separator
+Pass	[INPUT in EMAIL status] The value contains invalid separator
 Pass	[INPUT in URL status] The value is empty
 Pass	[INPUT in URL status] The value is a valid url
 Pass	[INPUT in URL status] The value is a valid url with some white spaces.


### PR DESCRIPTION
This change implements `HTMLInputElement` `type=email` constraint validation in conformance with the current spec requirements (which happens to also produce behavior that’s interoperable with other existing engines).
