### PR TITLE
LibWeb/CSS: Prevent empty <li> elements from collapsing

### DIFF
--- a/Libraries/LibWeb/CSS/Default.css
+++ b/Libraries/LibWeb/CSS/Default.css
@@ -504,6 +504,10 @@ li {
     text-align: match-parent;
 }
 
+li:empty::before {
+    content: "\00a0";
+}
+
 dir, dl, menu, ol, ul {
     margin-block-start: 1em;
     margin-block-end: 1em;


### PR DESCRIPTION
- Fixes #3762.
- Added a CSS rule to inject a non-breaking space into empty list items.
- This ensures proper spacing in lists even when no content is present.
