### PR TITLE
LibWeb: Don't begin link element fetch until browsing-context connected

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -73,7 +73,8 @@ void HTMLLinkElement::inserted()
         // The appropriate times to fetch and process this type of link are:
         //  - When the external resource link is created on a link element that is already browsing-context connected.
         //  - When the external resource link's link element becomes browsing-context connected.
-        fetch_and_process_linked_resource();
+        if (is_browsing_context_connected())
+            fetch_and_process_linked_resource();
     }
 
     // FIXME: Follow spec for fetching and processing these attributes as well


### PR DESCRIPTION
Note that "becomes browsing-context connected" is defined as:

> When the insertion steps are invoked with it as the argument and it is
> now browsing-context connected.

This fixes an issue where WPT editing tests would clone the entire DOM thousands of times and re-fetch all the linked CSS files once per clone.