### PR TITLE
LibWeb: Don't invalidate style of finished animations

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1520,8 +1520,6 @@ void Document::update_animated_style_if_needed()
     if (!m_needs_animated_style_update)
         return;
 
-    invalidate_display_list();
-
     for (auto& timeline : m_associated_animation_timelines) {
         for (auto& animation : timeline->associated_animations()) {
             if (animation->is_finished())

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1529,6 +1529,8 @@ void Document::update_animated_style_if_needed()
         }
 
         for (auto& animation : timeline->associated_animations()) {
+            if (animation->is_finished())
+                continue;
             if (auto effect = animation->effect())
                 effect->update_computed_properties();
         }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -1524,15 +1524,13 @@ void Document::update_animated_style_if_needed()
 
     for (auto& timeline : m_associated_animation_timelines) {
         for (auto& animation : timeline->associated_animations()) {
-            if (auto effect = animation->effect(); effect && effect->target())
-                effect->target()->reset_animated_css_properties();
-        }
-
-        for (auto& animation : timeline->associated_animations()) {
             if (animation->is_finished())
                 continue;
-            if (auto effect = animation->effect())
+            if (auto effect = animation->effect()) {
+                if (auto* target = effect->target())
+                    target->reset_animated_css_properties();
                 effect->update_computed_properties();
+            }
         }
     }
     m_needs_animated_style_update = false;


### PR DESCRIPTION
Removes lots of completely unnecessary work, especially when animated property affects layout.