### PR TITLE
LibWeb: Use class for border painting

### DIFF
--- a/Libraries/LibGfx/Forward.h
+++ b/Libraries/LibGfx/Forward.h
@@ -62,6 +62,7 @@ using FloatQuad = Quad<float>;
 
 enum class BitmapFormat;
 enum class ColorRole;
+enum class LineStyle;
 enum class TextAlignment;
 
 }

--- a/Libraries/LibWeb/Painting/BorderPainting.h
+++ b/Libraries/LibWeb/Painting/BorderPainting.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <LibGfx/Forward.h>
+#include <LibGfx/Path.h>
 #include <LibWeb/CSS/ComputedValues.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/BorderRadiiData.h>
@@ -22,12 +23,38 @@ enum class BorderEdge {
     Left,
 };
 
+class BorderPainter final {
+public:
+    explicit BorderPainter(
+        DisplayListRecorder& painter,
+        DevicePixelRect const& border_rect,
+        CornerRadii const& corner_radii,
+        BordersDataDevicePixels const& borders_data)
+        : m_painter(painter)
+        , m_border_rect(border_rect)
+        , m_corner_radii(corner_radii)
+        , m_borders_data(borders_data)
+    {
+    }
+
+    void paint_border(BorderEdge, DevicePixelRect const&, CornerRadius const&, CornerRadius const&, bool);
+    void paint_simple_border(BorderEdge, DevicePixelRect const&, BorderDataDevicePixels const&, Gfx::LineStyle);
+    void paint_joined_border(BorderEdge, DevicePixelRect const&, BorderDataDevicePixels const&, CornerRadius const&, CornerRadius const&, bool);
+
+    BorderDataDevicePixels border_data_for_edge(BorderEdge) const;
+    Gfx::Color border_color_for_edge(BorderEdge) const;
+
+private:
+    DisplayListRecorder& m_painter;
+    DevicePixelRect const m_border_rect;
+    CornerRadii const m_corner_radii;
+    BordersDataDevicePixels const m_borders_data;
+    Gfx::Path m_path;
+};
+
 // Returns OptionalNone if there is no outline to paint.
 Optional<BordersData> borders_data_for_outline(Layout::Node const&, Color outline_color, CSS::OutlineStyle outline_style, CSSPixels outline_width);
 
-void paint_border(DisplayListRecorder& painter, BorderEdge edge, DevicePixelRect const& rect, CornerRadius const& radius, CornerRadius const& opposite_radius, BordersDataDevicePixels const& borders_data, Gfx::Path&, bool last);
 void paint_all_borders(DisplayListRecorder& painter, DevicePixelRect const& border_rect, CornerRadii const& corner_radii, BordersDataDevicePixels const&);
-
-Gfx::Color border_color(BorderEdge edge, BordersDataDevicePixels const& borders_data);
 
 }


### PR DESCRIPTION
When painting the more complex borders (double, groove, ridge) joined border slopes become more complex to calculate. These borders will require two paints for their inner and outer parts. The border that is joined to it may also have to calculate its slope differently for the inner or outer parts.

For example, if a double border edge is joined to a standard solid edge, the solid border joint must be calculated relative to the outer part of the double border to achieve a smooth corner without gaps.

The current implementation will struggle to do this without having access to some state. To go stepwise toward addressing this complexity the `paint_all_borders` function is treated as a facade around the new class.