### PR TITLE
LibWeb: Fix some IDL generator errors

### DIFF
--- a/Libraries/LibIDL/IDLParser.cpp
+++ b/Libraries/LibIDL/IDLParser.cpp
@@ -295,6 +295,10 @@ NonnullRefPtr<Type const> Parser::parse_type()
         // Note: This case is handled above
     }
 
+    if (builder.is_empty()) {
+        report_parsing_error("Type can't be an empty string"sv, filename, input, lexer.tell());
+    }
+
     if (is_parameterized_type)
         return adopt_ref(*new ParameterizedType(builder.to_byte_string(), nullable, move(parameters)));
 


### PR DESCRIPTION
This fixes two errors in the IDL generator

- A minor one:
If you write something similar to this:
```
typedef (A or
         B or
// FIXME: C
// FIXME: D
         ) Something;
```
 
Or something where after the `or` there are only spaces (the comments are just for comparison).
You get this error: `Unimplemented type for idl_type_name_to_cpp_type: `

This error is really confusing, as the empty type isn't really visible. So it is better to report empty types in that scenario earlier.

Now you get a more reasonable error:

```
          ) Something;
         ^
<file>:<line> error: Type can't be an empty string
```

- And an actual one:
If you use the enum feature of the IDL, you also can specify strings that start with an invalid C++ identifier. An example would be #3788

```
enum OffscreenRenderingContextId { "2d", "bitmaprenderer", "webgl", "webgl2", "webgpu" };
```

here it generates invalid C++:
```cpp
enum class OffscreenRenderingContextId {
    2d,
    Bitmaprenderer,
    Webgl,
    Webgl2,
    Webgpu,
};
```


With this fix this new, valid C++ is generated:

```cpp
enum class OffscreenRenderingContextId {
    _2d,
    Bitmaprenderer,
    Webgl,
    Webgl2,
    Webgpu,
};
```



Note: the string names of the enums are still correct. e.g. in this example: 

```cpp
inline String idl_enum_to_string(OffscreenRenderingContextId value)
{
    switch (value) {

    case OffscreenRenderingContextId::_2d:
        return "2d"_string;
...
```


