### PR TITLE
LibWeb: Fix moving through tabs with keyboard shortcuts

### DIFF
--- a/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Libraries/LibWeb/Page/EventHandler.cpp
@@ -1148,10 +1148,12 @@ EventResult EventHandler::handle_keydown(UIEvents::KeyCode key, u32 modifiers, u
 
     GC::Ref<DOM::Document> document = *m_navigable->active_document();
 
-    if (key == UIEvents::KeyCode::Key_Tab) {
-        if (modifiers & UIEvents::KeyModifier::Mod_Shift)
-            return focus_previous_element() ? EventResult::Handled : EventResult::Dropped;
-        return focus_next_element() ? EventResult::Handled : EventResult::Dropped;
+    if (!(modifiers & UIEvents::KeyModifier::Mod_Ctrl)) {
+        if (key == UIEvents::KeyCode::Key_Tab) {
+            if (modifiers & UIEvents::KeyModifier::Mod_Shift)
+                return focus_previous_element() ? EventResult::Handled : EventResult::Dropped;
+            return focus_next_element() ? EventResult::Handled : EventResult::Dropped;
+        }
     }
 
     // https://html.spec.whatwg.org/multipage/interaction.html#close-requests


### PR DESCRIPTION
Previously, despite CTRL being held, the webpage elements such as checkboxes (if existing) could 'hijack' the CTRL+TAB keypress which disabled moving to the next tab.

Now, if CTRL is held, TAB and SHIFT+TAB keypresses are ignored, so that the default Qt's next/previous tab movements are applied.

Before:
[before.webm](https://github.com/user-attachments/assets/3b54cb6b-d112-4889-b788-4a7eee73fee9)

After:
[after.webm](https://github.com/user-attachments/assets/2ddc3e93-77f7-4d4f-9b5f-eb8eb0088e6b)
