### PR TITLE
TLS connection - Function now returns success of failure indication, wait_for_activity is used in TLSv12 to wait for socket writeability, small improvements to code readability

### DIFF
--- a/Libraries/LibTLS/TLSv12.cpp
+++ b/Libraries/LibTLS/TLSv12.cpp
@@ -17,6 +17,10 @@ namespace TLS {
 
 ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(ByteString const& host, u16 port, Options options)
 {
+    if (port == 0) {
+        return Error::from_string_literal("Invalid port number");
+    }
+
     auto tcp_socket = TRY(Core::TCPSocket::connect(host, port));
     return connect_internal(move(tcp_socket), host, move(options));
 }


### PR DESCRIPTION
Utilised Std::Optional and Std::Chrono for improved readability. In particular, std::chrono works well in time-related operations. Maintained consistent naming conventions for variables, functions, and kept type safety with namespace. 