### PR TITLE
AK/LibCore/LibFileSystem: Use AK/Windows.h instead of windows.h [NFC]

### DIFF
--- a/AK/Error.cpp
+++ b/AK/Error.cpp
@@ -10,9 +10,7 @@
 #ifdef AK_OS_WINDOWS
 #    include <AK/ByteString.h>
 #    include <AK/HashMap.h>
-#    include <windows.h>
-// Comment to prevent clang-format from including windows.h too late
-#    include <winbase.h>
+#    include <AK/Windows.h>
 #endif
 
 namespace AK {

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -19,9 +19,7 @@
 #    include <pthread.h>
 #    include <pthread_np.h>
 #elif defined(AK_OS_WINDOWS)
-#    include <Windows.h>
-// NOTE: Prevent clang-format from re-ordering this header order
-#    include <Processthreadsapi.h>
+#    include <AK/Windows.h>
 #endif
 
 namespace AK {

--- a/Libraries/LibCore/ProcessWindows.cpp
+++ b/Libraries/LibCore/ProcessWindows.cpp
@@ -10,8 +10,8 @@
 
 #include <AK/String.h>
 #include <AK/Utf16View.h>
+#include <AK/Windows.h>
 #include <LibCore/Process.h>
-#include <windows.h>
 
 namespace Core {
 

--- a/Libraries/LibFileSystem/FileSystem.cpp
+++ b/Libraries/LibFileSystem/FileSystem.cpp
@@ -16,7 +16,7 @@
 #elif defined(AK_OS_LINUX)
 #    include <linux/fs.h>
 #elif defined(AK_OS_WINDOWS)
-#    include <windows.h>
+#    include <AK/Windows.h>
 #endif
 
 // On Linux distros that use glibc `basename` is defined as a macro that expands to `__xpg_basename`, so we undefine it


### PR DESCRIPTION
This pr changes the remaining includes of windows.h to AK/Windows.h for consistency. In these files probably there wouldn't be future issues with redefinitions that AK/Windows.h avoids, but it doesn't hurt to make it more consistent. Also removes an unnecessary include. (processthreadsapi.h is already included in windows.h)