### PR TITLE
LibWeb: Invalidate style (and rule cache) on MediaList changes

### DIFF
--- a/Libraries/LibWeb/CSS/MediaList.h
+++ b/Libraries/LibWeb/CSS/MediaList.h
@@ -36,11 +36,15 @@ public:
     bool evaluate(HTML::Window const&);
     bool matches() const;
 
+    void set_associated_style_sheet(GC::Ref<StyleSheet> style_sheet) { m_associated_style_sheet = style_sheet; }
+
 private:
     MediaList(JS::Realm&, Vector<NonnullRefPtr<MediaQuery>>&&);
 
     virtual void initialize(JS::Realm&) override;
+    virtual void visit_edges(Visitor&) override;
 
+    GC::Ptr<StyleSheet> m_associated_style_sheet;
     Vector<NonnullRefPtr<MediaQuery>> m_media;
 };
 

--- a/Libraries/LibWeb/CSS/StyleSheet.cpp
+++ b/Libraries/LibWeb/CSS/StyleSheet.cpp
@@ -16,6 +16,7 @@ StyleSheet::StyleSheet(JS::Realm& realm, MediaList& media)
     : PlatformObject(realm)
     , m_media(media)
 {
+    m_media->set_associated_style_sheet(*this);
 }
 
 void StyleSheet::visit_edges(Cell::Visitor& visitor)

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -68,6 +68,9 @@ enum class ShouldComputeRole {
     X(HTMLOptionElementSelectedChange)              \
     X(HTMLSelectElementSetIsOpen)                   \
     X(Hover)                                        \
+    X(MediaListSetMediaText)                        \
+    X(MediaListAppendMedium)                        \
+    X(MediaListDeleteMedium)                        \
     X(MediaQueryChangedMatchState)                  \
     X(NavigableSetViewportSize)                     \
     X(NodeInsertBefore)                             \

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/Bindings/HTMLLinkElementPrototype.h>
 #include <LibWeb/Bindings/PrincipalHostDefined.h>
 #include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/DOMTokenList.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
@@ -123,6 +124,18 @@ GC::Ref<DOM::DOMTokenList> HTMLLinkElement::sizes()
     if (!m_sizes)
         m_sizes = DOM::DOMTokenList::create(*this, HTML::AttributeNames::sizes);
     return *m_sizes;
+}
+
+void HTMLLinkElement::set_media(String media)
+{
+    (void)set_attribute(HTML::AttributeNames::media, media);
+    if (auto sheet = m_loaded_style_sheet)
+        sheet->set_media(media);
+}
+
+String HTMLLinkElement::media() const
+{
+    return attribute(HTML::AttributeNames::media).value_or(String {});
 }
 
 bool HTMLLinkElement::has_loaded_icon() const

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -45,6 +45,9 @@ public:
 
     void set_parser_document(Badge<HTMLParser>, GC::Ref<DOM::Document>);
 
+    void set_media(String);
+    String media() const;
+
 private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -42,7 +42,7 @@ interface HTMLLinkElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString rel;
     [CEReactions, Reflect, Enumerated=PotentialDestination] attribute DOMString as;
     [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
-    [CEReactions, Reflect] attribute DOMString media;
+    [CEReactions] attribute DOMString media;
     [CEReactions, Reflect] attribute DOMString integrity;
     [CEReactions, Reflect] attribute DOMString hreflang;
     [CEReactions, Reflect] attribute DOMString type;

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <LibWeb/Bindings/HTMLStyleElementPrototype.h>
+#include <LibWeb/CSS/StyleComputer.h>
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
 
 namespace Web::HTML {
@@ -75,6 +77,18 @@ void HTMLStyleElement::set_disabled(bool disabled)
     // 2. If the given value is true, set this's associated CSS style sheet's disabled flag.
     //    Otherwise, unset this's associated CSS style sheet's disabled flag.
     sheet()->set_disabled(disabled);
+}
+
+String HTMLStyleElement::media() const
+{
+    return attribute(HTML::AttributeNames::media).value_or(String {});
+}
+
+void HTMLStyleElement::set_media(String media)
+{
+    (void)set_attribute(HTML::AttributeNames::media, media);
+    if (auto sheet = m_style_element_utils.sheet())
+        sheet->set_media(media);
 }
 
 // https://www.w3.org/TR/cssom/#dom-linkstyle-sheet

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -26,6 +26,9 @@ public:
     bool disabled();
     void set_disabled(bool disabled);
 
+    [[nodiscard]] String media() const;
+    void set_media(String);
+
     CSS::CSSStyleSheet* sheet();
     CSS::CSSStyleSheet const* sheet() const;
 

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.idl
@@ -8,7 +8,7 @@ interface HTMLStyleElement : HTMLElement {
     [HTMLConstructor] constructor();
 
     attribute boolean disabled;
-    [Reflect, CEReactions] attribute DOMString media;
+    [CEReactions] attribute DOMString media;
     [FIXME, SameObject, PutForwards=value] readonly attribute DOMTokenList blocking;
 
     // Obsolete

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/document-metadata/the-style-element/style_media.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/document-metadata/the-style-element/style_media.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	The style information must be applied to the environment specified by the media attribute

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/document-metadata/the-style-element/style_media.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/document-metadata/the-style-element/style_media.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Test: The style information must be applied to the environment specified by the media attribute</title>
+    <link rel="author" title="Intel" href="http://www.intel.com/">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-style-media">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-style-element">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+    <style>
+      #test {
+        width: 100px;
+      }
+    </style>
+    <style id="style">
+      #test {
+        width: 50px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="log"></div>
+    <div id="test"></div>
+    <script>
+      test(function() {
+        var testElement = document.getElementById("test");
+        var style = document.getElementById("style");
+        var width1, width2;
+
+        width1 = window.getComputedStyle(testElement)["width"];
+        assert_equals(width1, "50px", "The style should be applied.");
+
+        style.media = "print";
+        width2 = window.getComputedStyle(testElement)["width"];
+        assert_equals(width2, "100px", "The style should not be applied.");
+      }, "The style information must be applied to the environment specified by the media attribute");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This makes dynamic changes to a style sheet's media attribute actually take effect immediately.