### PR TITLE
LibDevTools: Implement basic support for console logging

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -126,7 +126,7 @@ template<typename T, typename ValueT>
 concept IterableContainerOf = IterableContainer<T> && requires {
     {
         *declval<T>().begin()
-    } -> SameAs<ValueT>;
+    } -> SameAs<ValueT&>;
 };
 
 template<typename Func, typename... Args>

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -38,10 +38,17 @@ public:
     }
 
     template<IterableContainerOf<JsonValue> ContainerT>
-    JsonArray(ContainerT const& source)
+    JsonArray(ContainerT&& source)
     {
         for (auto& value : source)
             m_values.append(move(value));
+    }
+
+    template<IterableContainerOf<JsonValue> ContainerT>
+    JsonArray(ContainerT const& source)
+    {
+        for (auto const& value : source)
+            m_values.append(value);
     }
 
     JsonArray& operator=(JsonArray const& other)

--- a/Documentation/DevTools.md
+++ b/Documentation/DevTools.md
@@ -425,6 +425,13 @@ ID is then sent once the script is complete:
 << {"from":"server0-console8","type":"evaluationResult","timestamp":1740417141889,"resultID":"server0-console8-3","input":"1+1","result":2,"exception":null,"exceptionMessage":null,"helperResult":null}
 ```
 
+Anytime console messages are evaluated by the page (`console.log`, `console.warn`, etc.), the server will independently
+notify the client without any prompt. The same grip serialization used for console results is used here.
+
+```jsonc
+<< {"from":"server0-frame10","type":"resources-available-array","array":[["console-message",[{"level":"log","filename":"<eval>","line_number":1,"column_number":1,"time_stamp":1741096175644,"arguments":["hello!"]}]]]}
+```
+
 ### Session termination
 
 When the user disconnects from the DevTools server, the client will send a few cleanup messages. We currently do not

--- a/Libraries/LibDevTools/Actors/FrameActor.h
+++ b/Libraries/LibDevTools/Actors/FrameActor.h
@@ -7,7 +7,10 @@
 #pragma once
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibDevTools/Actor.h>
+#include <LibWebView/Forward.h>
 
 namespace DevTools {
 
@@ -26,12 +29,20 @@ public:
 private:
     FrameActor(DevToolsServer&, String name, WeakPtr<TabActor>, WeakPtr<CSSPropertiesActor>, WeakPtr<ConsoleActor>, WeakPtr<InspectorActor>, WeakPtr<ThreadActor>);
 
+    void console_message_available(i32 message_index);
+    void console_messages_received(i32 start_index, Vector<WebView::ConsoleOutput>);
+    void request_console_messages();
+
     WeakPtr<TabActor> m_tab;
 
     WeakPtr<CSSPropertiesActor> m_css_properties;
     WeakPtr<ConsoleActor> m_console;
     WeakPtr<InspectorActor> m_inspector;
     WeakPtr<ThreadActor> m_thread;
+
+    i32 m_highest_notified_message_index { -1 };
+    i32 m_highest_received_message_index { -1 };
+    bool m_waiting_for_messages { false };
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -16,6 +16,7 @@
 #include <LibDevTools/Forward.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/Forward.h>
 
 namespace DevTools {
 
@@ -38,6 +39,12 @@ public:
 
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void evaluate_javascript(TabDescription const&, String, OnScriptEvaluationComplete) const { }
+
+    using OnConsoleMessageAvailable = Function<void(i32 message_id)>;
+    using OnReceivedConsoleMessages = Function<void(i32 start_index, Vector<WebView::ConsoleOutput>)>;
+    virtual void listen_for_console_messages(TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const { }
+    virtual void stop_listening_for_console_messages(TabDescription const&) const { }
+    virtual void request_console_messages(TabDescription const&, i32) const { }
 };
 
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -433,4 +433,34 @@ void Application::evaluate_javascript(DevTools::TabDescription const& descriptio
     view->js_console_input(move(script));
 }
 
+void Application::listen_for_console_messages(DevTools::TabDescription const& description, OnConsoleMessageAvailable on_console_message_available, OnReceivedConsoleMessages on_received_console_output) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->on_console_message_available = move(on_console_message_available);
+    view->on_received_unstyled_console_messages = move(on_received_console_output);
+    view->js_console_request_messages(0);
+}
+
+void Application::stop_listening_for_console_messages(DevTools::TabDescription const& description) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->on_console_message_available = nullptr;
+    view->on_received_unstyled_console_messages = nullptr;
+}
+
+void Application::request_console_messages(DevTools::TabDescription const& description, i32 start_index) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->js_console_request_messages(start_index);
+}
+
 }

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -97,6 +97,9 @@ private:
     virtual void highlight_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const override;
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
+    virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;
+    virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;
+    virtual void request_console_messages(DevTools::TabDescription const&, i32) const override;
 
     static Application* s_the;
 

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     Application.cpp
     Attribute.cpp
     ChromeProcess.cpp
+    ConsoleOutput.cpp
     CookieJar.cpp
     Database.cpp
     HelperProcess.cpp

--- a/Libraries/LibWebView/ConsoleOutput.cpp
+++ b/Libraries/LibWebView/ConsoleOutput.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/ConsoleOutput.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::ConsoleOutput const& console_output)
+{
+    TRY(encoder.encode(console_output.level));
+    TRY(encoder.encode(console_output.timestamp));
+    TRY(encoder.encode(console_output.arguments));
+
+    return {};
+}
+
+template<>
+ErrorOr<WebView::ConsoleOutput> IPC::decode(Decoder& decoder)
+{
+    auto level = TRY(decoder.decode<JS::Console::LogLevel>());
+    auto timestamp = TRY(decoder.decode<UnixDateTime>());
+    auto arguments = TRY(decoder.decode<Vector<JsonValue>>());
+
+    return WebView::ConsoleOutput { level, timestamp, move(arguments) };
+}

--- a/Libraries/LibWebView/ConsoleOutput.h
+++ b/Libraries/LibWebView/ConsoleOutput.h
@@ -9,6 +9,7 @@
 #include <AK/JsonValue.h>
 #include <AK/Time.h>
 #include <AK/Vector.h>
+#include <LibIPC/Forward.h>
 #include <LibJS/Console.h>
 
 namespace WebView {
@@ -18,5 +19,15 @@ struct ConsoleOutput {
     UnixDateTime timestamp;
     Vector<JsonValue> arguments;
 };
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::ConsoleOutput const&);
+
+template<>
+ErrorOr<WebView::ConsoleOutput> decode(Decoder&);
 
 }

--- a/Libraries/LibWebView/ConsoleOutput.h
+++ b/Libraries/LibWebView/ConsoleOutput.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <AK/Time.h>
+#include <AK/Vector.h>
+#include <LibJS/Console.h>
+
+namespace WebView {
+
+struct ConsoleOutput {
+    JS::Console::LogLevel level;
+    UnixDateTime timestamp;
+    Vector<JsonValue> arguments;
+};
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -19,6 +19,7 @@ class ViewImplementation;
 class WebContentClient;
 
 struct Attribute;
+struct ConsoleOutput;
 struct CookieStorageKey;
 struct ProcessHandle;
 struct SearchEngine;

--- a/Libraries/LibWebView/InspectorClient.cpp
+++ b/Libraries/LibWebView/InspectorClient.cpp
@@ -118,12 +118,12 @@ InspectorClient::InspectorClient(ViewImplementation& content_web_view, ViewImple
             m_content_web_view.on_insert_clipboard_entry(html, "unspecified"_string, "text/plain"_string);
     };
 
-    m_content_web_view.on_received_console_message = [this](auto message_index) {
-        handle_console_message(message_index);
+    m_content_web_view.on_console_message_available = [this](auto message_index) {
+        console_message_available(message_index);
     };
 
-    m_content_web_view.on_received_console_messages = [this](auto start_index, auto const& message_types, auto const& messages) {
-        handle_console_messages(start_index, message_types, messages);
+    m_content_web_view.on_received_styled_console_messages = [this](auto start_index, auto const& message_types, auto const& messages) {
+        console_messages_received(start_index, message_types, messages);
     };
 
     m_inspector_web_view.enable_inspector_prototype();
@@ -257,8 +257,8 @@ InspectorClient::~InspectorClient()
 {
     m_content_web_view.on_finshed_editing_dom_node = nullptr;
     m_content_web_view.on_received_accessibility_tree = nullptr;
-    m_content_web_view.on_received_console_message = nullptr;
-    m_content_web_view.on_received_console_messages = nullptr;
+    m_content_web_view.on_console_message_available = nullptr;
+    m_content_web_view.on_received_styled_console_messages = nullptr;
     m_content_web_view.on_received_dom_node_html = nullptr;
     m_content_web_view.on_received_dom_node_properties = nullptr;
     m_content_web_view.on_received_dom_tree = nullptr;
@@ -700,7 +700,7 @@ void InspectorClient::request_console_messages()
     m_waiting_for_messages = true;
 }
 
-void InspectorClient::handle_console_message(i32 message_index)
+void InspectorClient::console_message_available(i32 message_index)
 {
     if (message_index <= m_highest_received_message_index) {
         dbgln("Notified about console message we already have");
@@ -717,7 +717,7 @@ void InspectorClient::handle_console_message(i32 message_index)
         request_console_messages();
 }
 
-void InspectorClient::handle_console_messages(i32 start_index, ReadonlySpan<String> message_types, ReadonlySpan<String> messages)
+void InspectorClient::console_messages_received(i32 start_index, ReadonlySpan<String> message_types, ReadonlySpan<String> messages)
 {
     auto end_index = start_index + static_cast<i32>(message_types.size()) - 1;
     if (end_index <= m_highest_received_message_index) {

--- a/Libraries/LibWebView/InspectorClient.h
+++ b/Libraries/LibWebView/InspectorClient.h
@@ -57,8 +57,8 @@ private:
     void load_cookies();
 
     void request_console_messages();
-    void handle_console_message(i32 message_index);
-    void handle_console_messages(i32 start_index, ReadonlySpan<String> message_types, ReadonlySpan<String> messages);
+    void console_message_available(i32 message_index);
+    void console_messages_received(i32 start_index, ReadonlySpan<String> message_types, ReadonlySpan<String> messages);
 
     void append_console_source(StringView);
     void append_console_message(StringView);

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -216,8 +216,8 @@ public:
     Function<void(Optional<Web::UniqueNodeID> const& node_id)> on_finshed_editing_dom_node;
     Function<void(String const&)> on_received_dom_node_html;
     Function<void(JsonValue)> on_received_js_console_result;
-    Function<void(i32 message_id)> on_received_console_message;
-    Function<void(i32 start_index, Vector<String> const& message_types, Vector<String> const& messages)> on_received_console_messages;
+    Function<void(i32 message_id)> on_console_message_available;
+    Function<void(i32 start_index, Vector<String> const& message_types, Vector<String> const& messages)> on_received_styled_console_messages;
     Function<void(i32 count_waiting)> on_resource_status_change;
     Function<void()> on_restore_window;
     Function<void(Gfx::IntPoint)> on_reposition_window;

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -218,6 +218,7 @@ public:
     Function<void(JsonValue)> on_received_js_console_result;
     Function<void(i32 message_id)> on_console_message_available;
     Function<void(i32 start_index, Vector<String> const& message_types, Vector<String> const& messages)> on_received_styled_console_messages;
+    Function<void(i32 start_index, Vector<ConsoleOutput>)> on_received_unstyled_console_messages;
     Function<void(i32 count_waiting)> on_resource_status_change;
     Function<void()> on_restore_window;
     Function<void(Gfx::IntPoint)> on_reposition_window;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -385,6 +385,14 @@ void WebContentClient::did_get_styled_js_console_messages(u64 page_id, i32 start
     }
 }
 
+void WebContentClient::did_get_unstyled_js_console_messages(u64 page_id, i32 start_index, Vector<ConsoleOutput> const& console_output)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_received_unstyled_console_messages)
+            view->on_received_unstyled_console_messages(start_index, move(const_cast<Vector<ConsoleOutput>&>(console_output)));
+    }
+}
+
 void WebContentClient::did_request_alert(u64 page_id, String const& message)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -372,16 +372,16 @@ void WebContentClient::did_execute_js_console_input(u64 page_id, JsonValue const
 void WebContentClient::did_output_js_console_message(u64 page_id, i32 message_index)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_received_console_message)
-            view->on_received_console_message(message_index);
+        if (view->on_console_message_available)
+            view->on_console_message_available(message_index);
     }
 }
 
-void WebContentClient::did_get_js_console_messages(u64 page_id, i32 start_index, Vector<String> const& message_types, Vector<String> const& messages)
+void WebContentClient::did_get_styled_js_console_messages(u64 page_id, i32 start_index, Vector<String> const& message_types, Vector<String> const& messages)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {
-        if (view->on_received_console_messages)
-            view->on_received_console_messages(start_index, message_types, messages);
+        if (view->on_received_styled_console_messages)
+            view->on_received_styled_console_messages(start_index, message_types, messages);
     }
 }
 

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -81,7 +81,7 @@ private:
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, String const&) override;
     virtual void did_execute_js_console_input(u64 page_id, JsonValue const&) override;
     virtual void did_output_js_console_message(u64 page_id, i32 message_index) override;
-    virtual void did_get_js_console_messages(u64 page_id, i32 start_index, Vector<String> const& message_types, Vector<String> const& messages) override;
+    virtual void did_get_styled_js_console_messages(u64 page_id, i32 start_index, Vector<String> const& message_types, Vector<String> const& messages) override;
     virtual void did_change_favicon(u64 page_id, Gfx::ShareableBitmap const&) override;
     virtual void did_request_alert(u64 page_id, String const&) override;
     virtual void did_request_confirm(u64 page_id, String const&) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -82,6 +82,7 @@ private:
     virtual void did_execute_js_console_input(u64 page_id, JsonValue const&) override;
     virtual void did_output_js_console_message(u64 page_id, i32 message_index) override;
     virtual void did_get_styled_js_console_messages(u64 page_id, i32 start_index, Vector<String> const& message_types, Vector<String> const& messages) override;
+    virtual void did_get_unstyled_js_console_messages(u64 page_id, i32 start_index, Vector<ConsoleOutput> const&) override;
     virtual void did_change_favicon(u64 page_id, Gfx::ShareableBitmap const&) override;
     virtual void did_request_alert(u64 page_id, String const&) override;
     virtual void did_request_confirm(u64 page_id, String const&) override;

--- a/Services/WebContent/DevToolsConsoleClient.h
+++ b/Services/WebContent/DevToolsConsoleClient.h
@@ -6,9 +6,12 @@
 
 #pragma once
 
+#include <AK/Time.h>
+#include <LibIPC/Forward.h>
 #include <LibJS/Console.h>
 #include <LibJS/Forward.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/ConsoleOutput.h>
 #include <WebContent/Forward.h>
 #include <WebContent/WebContentConsoleClient.h>
 
@@ -32,6 +35,8 @@ private:
 
     virtual void send_messages(i32 start_index) override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel, PrinterArguments) override;
+
+    Vector<WebView::ConsoleOutput> m_console_output;
 };
 
 }

--- a/Services/WebContent/DevToolsConsoleClient.h
+++ b/Services/WebContent/DevToolsConsoleClient.h
@@ -27,9 +27,11 @@ private:
 
     virtual void handle_result(JS::Value) override;
     virtual void report_exception(JS::Error const&, bool) override;
-    virtual void send_messages(i32 start_index) override;
+    virtual void end_group() override { }
+    virtual void clear() override { }
 
-    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, PrinterArguments) override;
+    virtual void send_messages(i32 start_index) override;
+    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel, PrinterArguments) override;
 };
 
 }

--- a/Services/WebContent/InspectorConsoleClient.cpp
+++ b/Services/WebContent/InspectorConsoleClient.cpp
@@ -110,7 +110,7 @@ void InspectorConsoleClient::send_messages(i32 start_index)
         messages.append(message.data);
     }
 
-    m_client->did_get_js_console_messages(start_index, move(message_types), move(messages));
+    m_client->did_get_styled_js_console_messages(start_index, move(message_types), move(messages));
 }
 
 // 2.3. Printer(logLevel, args[, options]), https://console.spec.whatwg.org/#printer

--- a/Services/WebContent/InspectorConsoleClient.h
+++ b/Services/WebContent/InspectorConsoleClient.h
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/Vector.h>
 #include <LibWeb/Forward.h>
 #include <WebContent/Forward.h>
 #include <WebContent/WebContentConsoleClient.h>
@@ -28,8 +30,14 @@ private:
 
     virtual void handle_result(JS::Value) override;
     virtual void report_exception(JS::Error const&, bool) override;
-    virtual void send_messages(i32 start_index) override;
 
+    void begin_group(String const& label, bool start_expanded);
+    virtual void end_group() override;
+    virtual void clear() override;
+
+    void print_html(String const& line);
+
+    virtual void send_messages(i32 start_index) override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, PrinterArguments) override;
 
     virtual void add_css_style_to_current_message(StringView style) override
@@ -38,6 +46,19 @@ private:
         m_current_message_style.append(';');
     }
 
+    struct ConsoleOutput {
+        enum class Type {
+            HTML,
+            Clear,
+            BeginGroup,
+            BeginGroupCollapsed,
+            EndGroup,
+        };
+        Type type;
+        String data;
+    };
+
+    Vector<ConsoleOutput> m_message_log;
     StringBuilder m_current_message_style;
 };
 

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -805,9 +805,9 @@ void PageClient::console_peer_did_misbehave(char const* reason)
     client().did_misbehave(reason);
 }
 
-void PageClient::did_get_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages)
+void PageClient::did_get_styled_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages)
 {
-    client().async_did_get_js_console_messages(m_id, start_index, move(message_types), move(messages));
+    client().async_did_get_styled_js_console_messages(m_id, start_index, move(message_types), move(messages));
 }
 
 static void gather_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>& results, Web::CSS::CSSStyleSheet& sheet)

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -810,6 +810,11 @@ void PageClient::did_get_styled_js_console_messages(i32 start_index, Vector<Stri
     client().async_did_get_styled_js_console_messages(m_id, start_index, move(message_types), move(messages));
 }
 
+void PageClient::did_get_unstyled_js_console_messages(i32 start_index, Vector<WebView::ConsoleOutput> console_output)
+{
+    client().async_did_get_unstyled_js_console_messages(m_id, start_index, move(console_output));
+}
+
 static void gather_style_sheets(Vector<Web::CSS::StyleSheetIdentifier>& results, Web::CSS::CSSStyleSheet& sheet)
 {
     Web::CSS::StyleSheetIdentifier identifier {};

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -90,7 +90,7 @@ public:
     void js_console_request_messages(i32 start_index);
     void did_output_js_console_message(i32 message_index);
     void console_peer_did_misbehave(char const* reason);
-    void did_get_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages);
+    void did_get_styled_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages);
 
     Vector<Web::CSS::StyleSheetIdentifier> list_style_sheets() const;
 

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -14,6 +14,7 @@
 #include <LibWeb/HTML/FileFilter.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWeb/PixelUnits.h>
+#include <LibWebView/Forward.h>
 #include <WebContent/BackingStoreManager.h>
 #include <WebContent/Forward.h>
 
@@ -91,6 +92,7 @@ public:
     void did_output_js_console_message(i32 message_index);
     void console_peer_did_misbehave(char const* reason);
     void did_get_styled_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages);
+    void did_get_unstyled_js_console_messages(i32 start_index, Vector<WebView::ConsoleOutput> console_output);
 
     Vector<Web::CSS::StyleSheetIdentifier> list_style_sheets() const;
 

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -16,8 +16,9 @@
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/Page.h>
 #include <LibWebView/Attribute.h>
-#include <LibWebView/ProcessHandle.h>
+#include <LibWebView/ConsoleOutput.h>
 #include <LibWebView/PageInfo.h>
+#include <LibWebView/ProcessHandle.h>
 
 endpoint WebContentClient
 {
@@ -95,6 +96,7 @@ endpoint WebContentClient
     did_execute_js_console_input(u64 page_id, JsonValue result) =|
     did_output_js_console_message(u64 page_id, i32 message_index) =|
     did_get_styled_js_console_messages(u64 page_id, i32 start_index, Vector<String> message_types, Vector<String> messages) =|
+    did_get_unstyled_js_console_messages(u64 page_id, i32 start_index, Vector<WebView::ConsoleOutput> console_output) =|
 
     did_finish_text_test(u64 page_id, String text) =|
     did_set_test_timeout(u64 page_id, double milliseconds) =|

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -94,7 +94,7 @@ endpoint WebContentClient
 
     did_execute_js_console_input(u64 page_id, JsonValue result) =|
     did_output_js_console_message(u64 page_id, i32 message_index) =|
-    did_get_js_console_messages(u64 page_id, i32 start_index, Vector<String> message_types, Vector<String> messages) =|
+    did_get_styled_js_console_messages(u64 page_id, i32 start_index, Vector<String> message_types, Vector<String> messages) =|
 
     did_finish_text_test(u64 page_id, String text) =|
     did_set_test_timeout(u64 page_id, double milliseconds) =|

--- a/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Services/WebContent/WebContentConsoleClient.cpp
@@ -54,33 +54,4 @@ void WebContentConsoleClient::handle_input(StringView js_source)
     }
 }
 
-void WebContentConsoleClient::print_html(String const& line)
-{
-    m_message_log.append({ .type = ConsoleOutput::Type::HTML, .data = line });
-    m_client->did_output_js_console_message(m_message_log.size() - 1);
-}
-
-void WebContentConsoleClient::clear()
-{
-    clear_output();
-}
-
-void WebContentConsoleClient::clear_output()
-{
-    m_message_log.append({ .type = ConsoleOutput::Type::Clear, .data = String {} });
-    m_client->did_output_js_console_message(m_message_log.size() - 1);
-}
-
-void WebContentConsoleClient::begin_group(String const& label, bool start_expanded)
-{
-    m_message_log.append({ .type = start_expanded ? ConsoleOutput::Type::BeginGroup : ConsoleOutput::Type::BeginGroupCollapsed, .data = label });
-    m_client->did_output_js_console_message(m_message_log.size() - 1);
-}
-
-void WebContentConsoleClient::end_group()
-{
-    m_message_log.append({ .type = ConsoleOutput::Type::EndGroup, .data = String {} });
-    m_client->did_output_js_console_message(m_message_log.size() - 1);
-}
-
 }

--- a/Services/WebContent/WebContentConsoleClient.h
+++ b/Services/WebContent/WebContentConsoleClient.h
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <AK/Vector.h>
 #include <LibJS/Console.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Value.h>
@@ -34,30 +33,9 @@ protected:
 
     virtual void visit_edges(JS::Cell::Visitor&) override;
 
-    void print_html(String const& line);
-
-    virtual void clear() override;
-    void clear_output();
-
-    void begin_group(String const& label, bool start_expanded);
-    virtual void end_group() override;
-
     GC::Ref<JS::Realm> m_realm;
     GC::Ref<PageClient> m_client;
     GC::Ref<ConsoleGlobalEnvironmentExtensions> m_console_global_environment_extensions;
-
-    struct ConsoleOutput {
-        enum class Type {
-            HTML,
-            Clear,
-            BeginGroup,
-            BeginGroupCollapsed,
-            EndGroup,
-        };
-        Type type;
-        String data;
-    };
-    Vector<ConsoleOutput> m_message_log;
 };
 
 }


### PR DESCRIPTION
This implements support for basic usage of `console.log` and friends. It does not implement `console.assert`, `console.trace`, `console.group`, etc.

![console](https://github.com/user-attachments/assets/672a8468-054c-42a1-940e-786ab382c738)
