### PR TITLE
LibJS+LibWebView: Treat trivia tokens as comments

### DIFF
--- a/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -78,7 +78,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         Syntax::TextDocumentSpan span;
         span.range.set_start(start);
         span.range.set_end({ position.line(), position.column() });
-        auto type = is_trivia ? TokenType::Invalid : token.type();
+        auto type = is_trivia ? TokenType::Trivia : token.type();
         span.attributes = style_for_token_type(palette, type);
         span.is_skippable = is_trivia;
         span.data = static_cast<u64>(type);

--- a/Libraries/LibJS/Token.h
+++ b/Libraries/LibJS/Token.h
@@ -145,6 +145,7 @@ constexpr u32 const ZERO_WIDTH_JOINER { 0x200D };
     __ENUMERATE_JS_TOKEN(Throw, ControlKeyword)                 \
     __ENUMERATE_JS_TOKEN(Tilde, Operator)                       \
     __ENUMERATE_JS_TOKEN(TripleDot, Operator)                   \
+    __ENUMERATE_JS_TOKEN(Trivia, Trivia)                        \
     __ENUMERATE_JS_TOKEN(Try, ControlKeyword)                   \
     __ENUMERATE_JS_TOKEN(Typeof, Keyword)                       \
     __ENUMERATE_JS_TOKEN(UnsignedShiftRight, Operator)          \
@@ -168,6 +169,7 @@ constexpr size_t cs_num_of_js_tokens = static_cast<size_t>(TokenType::_COUNT_OF_
 
 enum class TokenCategory {
     Invalid,
+    Trivia,
     Number,
     String,
     Punctuation,

--- a/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Libraries/LibWebView/SourceHighlighter.cpp
@@ -205,6 +205,8 @@ StringView SourceHighlighterClient::class_for_token(u64 token_type) const
         switch (category) {
         case JS::TokenCategory::Invalid:
             return "invalid"sv;
+        case JS::TokenCategory::Trivia:
+            return "comment"sv;
         case JS::TokenCategory::Number:
             return "number"sv;
         case JS::TokenCategory::String:


### PR DESCRIPTION
Trivia is whatever whitespace and comments appear before a token. Previously this was always given a TokenCategory of Invalid, so it would be displayed as an error in the view-source page, with red wiggly underlines. Instead, treat it as what it actually is: whitespace and comments!

![image](https://github.com/user-attachments/assets/c5159c75-baaf-42b8-8bdd-102b522dd99c)
