### PR TITLE
LibWeb: Respect margin boxes when center-aligning flex items

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -1476,7 +1476,9 @@ void FlexFormattingContext::align_all_flex_items_along_the_cross_axis()
                 item.cross_offset = half_line_size - item.cross_size.value() - item.margins.cross_after - item.borders.cross_after - item.padding.cross_after;
                 break;
             case CSS::AlignItems::Center:
-                item.cross_offset = -(item.cross_size.value() / 2);
+                // https://drafts.csswg.org/css-flexbox/#align-items-property
+                // The flex item’s margin box is centered in the cross axis within the line
+                item.cross_offset = (-item.cross_size.value() + item.margins.cross_before + item.borders.cross_before + item.padding.cross_before - item.margins.cross_after - item.borders.cross_after - item.padding.cross_after) / 2;
                 break;
             default:
                 break;

--- a/Tests/LibWeb/Layout/expected/flex/align-center-margin.txt
+++ b/Tests/LibWeb/Layout/expected/flex/align-center-margin.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x216 [BFC] children: not-inline
+    Box <body> at (8,8) content-size 784x200 flex-container(row) [FFC] children: not-inline
+      BlockContainer <div> at (8,58) content-size 100x100 flex-item [BFC] children: not-inline
+      BlockContainer <span> at (108,108) content-size 100x100 flex-item [BFC] children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x216]
+    PaintableBox (Box<BODY>) [8,8 784x200]
+      PaintableWithLines (BlockContainer<DIV>) [8,58 100x100]
+      PaintableWithLines (BlockContainer<SPAN>) [108,108 100x100]

--- a/Tests/LibWeb/Layout/input/flex/align-center-margin.html
+++ b/Tests/LibWeb/Layout/input/flex/align-center-margin.html
@@ -1,0 +1,17 @@
+<!doctype html><style>
+    body {
+      display: flex;
+      align-items: center;
+    }
+    div {
+      width: 100px;
+      height: 100px;
+      background-color: red;
+    }
+    span {
+      margin-top: 100px;
+      width: 100px;
+      height: 100px;
+      background-color: blue;
+    }
+</style><body><div></div><span></span>


### PR DESCRIPTION
This closes #3473