### PR TITLE
LibWeb/CSP: Preparatory work for enforcing policies

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -47,6 +47,9 @@
 #include <LibWeb/CSS/SystemColor.h>
 #include <LibWeb/CSS/TransitionEvent.h>
 #include <LibWeb/CSS/VisualViewport.h>
+#include <LibWeb/ContentSecurityPolicy/Directives/Directive.h>
+#include <LibWeb/ContentSecurityPolicy/Policy.h>
+#include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/AdoptedStyleSheets.h>
 #include <LibWeb/DOM/Attr.h>
@@ -379,7 +382,8 @@ WebIDL::ExceptionOr<GC::Ref<Document>> Document::create_and_initialize(Type type
     // 10. Set window's associated Document to document.
     window->set_associated_document(*document);
 
-    // FIXME: 11. Run CSP initialization for a Document given document.
+    // 11. Run CSP initialization for a Document given document.
+    document->run_csp_initialization();
 
     // 12. If navigationParams's request is non-null, then:
     if (navigation_params.request) {
@@ -6363,6 +6367,20 @@ Document::StepsToFireBeforeunloadResult Document::steps_to_fire_beforeunload(boo
 
     // 8. Return (unloadPromptShown, unloadPromptCanceled).
     return { unload_prompt_shown, unload_prompt_canceled };
+}
+
+// https://w3c.github.io/webappsec-csp/#run-document-csp-initialization
+void Document::run_csp_initialization() const
+{
+    // 1. For each policy of document’s policy container's CSP list:
+    for (auto policy : policy_container()->csp_list->policies()) {
+        // 1. For each directive of policy:
+        for (auto directive : policy->directives()) {
+            // 1. Execute directive’s initialization algorithm on document, and assert: its returned value is "Allowed".
+            auto result = directive->initialization(GC::Ref { *this }, policy);
+            VERIFY(result == ContentSecurityPolicy::Directives::Directive::Result::Allowed);
+        }
+    }
 }
 
 WebIDL::CallbackType* Document::onreadystatechange()

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -872,6 +872,8 @@ private:
         }
     }
 
+    void run_csp_initialization() const;
+
     GC::Ref<Page> m_page;
     OwnPtr<CSS::StyleComputer> m_style_computer;
     GC::Ptr<CSS::StyleSheetList> m_style_sheets;

--- a/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -120,10 +120,10 @@ private:
 
     ErrorOr<void> mutate_action_url(URL::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, String encoding, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
     ErrorOr<void> submit_as_entity_body(URL::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, EncodingTypeAttributeState encoding_type, String encoding, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
-    void get_action_url(URL::URL parsed_action, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
+    void get_action_url(URL::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
     ErrorOr<void> mail_with_headers(URL::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, String encoding, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
     ErrorOr<void> mail_as_body(URL::URL parsed_action, Vector<XHR::FormDataEntry> entry_list, EncodingTypeAttributeState encoding_type, String encoding, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
-    void plan_to_navigate_to(URL::URL url, Variant<Empty, String, POSTResource> post_resource, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
+    void plan_to_navigate_to(URL::URL url, Variant<Empty, String, POSTResource> post_resource, Vector<XHR::FormDataEntry> entry_list, GC::Ref<Navigable> target_navigable, Bindings::NavigationHistoryBehavior history_handling, UserNavigationInvolvement user_involvement);
 
     FormAssociatedElement* default_button();
     size_t number_of_fields_blocking_implicit_submission() const;

--- a/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLOrSVGElement.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/HTML/Focus.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/HTML/HTMLOrSVGElement.h>
@@ -100,12 +101,12 @@ void HTMLOrSVGElement<ElementBase>::inserted()
     if (!element.shadow_including_root().is_browsing_context_connected())
         return;
 
-    // FIXME: 1. Let CSP list be element's shadow-including root's policy container's CSP list.
-    [[maybe_unused]] auto policy_container = element.shadow_including_root().document().policy_container();
+    // 1. Let CSP list be element's shadow-including root's policy container's CSP list.
+    auto csp_list = element.shadow_including_root().document().policy_container()->csp_list;
 
-    // FIXME: 2. If CSP list contains a header-delivered Content Security Policy, and element has a
-    //           nonce content attribute whose value is not the empty string, then:
-    if (true && element.has_attribute(HTML::AttributeNames::nonce)) {
+    // 2. If CSP list contains a header-delivered Content Security Policy, and element has a
+    //    nonce content attribute whose value is not the empty string, then:
+    if (csp_list->contains_header_delivered_policy() && element.has_attribute(HTML::AttributeNames::nonce)) {
         // 2.1. Let nonce be element's [[CryptographicNonce]].
         auto nonce = m_cryptographic_nonce;
 

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <LibWeb/CSS/SystemColor.h>
+#include <LibWeb/ContentSecurityPolicy/PolicyList.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentLoading.h>
@@ -992,8 +993,11 @@ static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation
             entry->document_state()->set_resource(Empty {});
         }
 
-        // FIXME 9. Set responsePolicyContainer to the result of creating a policy container from a fetch response given response and request's reserved client.
-        // FIXME 10. Set finalSandboxFlags to the union of targetSnapshotParams's sandboxing flags and responsePolicyContainer's CSP list's CSP-derived sandboxing flags.
+        // 9. Set responsePolicyContainer to the result of creating a policy container from a fetch response given response and request's reserved client.
+        response_policy_container = create_a_policy_container_from_a_fetch_response(realm, *response_holder->response(), request->reserved_client());
+
+        // 10. Set finalSandboxFlags to the union of targetSnapshotParams's sandboxing flags and responsePolicyContainer's CSP list's CSP-derived sandboxing flags.
+        final_sandbox_flags = target_snapshot_params.sandboxing_flags | response_policy_container->csp_list->csp_derived_sandboxing_flags();
 
         // 11. Set responseOrigin to the result of determining the origin given response's URL, finalSandboxFlags, and entry's document state's initiator origin.
         response_origin = determine_the_origin(response_holder->response()->url(), final_sandbox_flags, entry->document_state()->initiator_origin());

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -781,7 +781,7 @@ static GC::Ref<NavigationParams> create_navigation_params_from_a_srcdoc_resource
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#create-navigation-params-by-fetching
-static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation_params_by_fetching(GC::Ptr<SessionHistoryEntry> entry, GC::Ptr<Navigable> navigable, SourceSnapshotParams const& source_snapshot_params, TargetSnapshotParams const& target_snapshot_params, CSPNavigationType csp_navigation_type, UserNavigationInvolvement user_involvement, Optional<String> navigation_id)
+static WebIDL::ExceptionOr<Navigable::NavigationParamsVariant> create_navigation_params_by_fetching(GC::Ptr<SessionHistoryEntry> entry, GC::Ptr<Navigable> navigable, SourceSnapshotParams const& source_snapshot_params, TargetSnapshotParams const& target_snapshot_params, ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type, UserNavigationInvolvement user_involvement, Optional<String> navigation_id)
 {
     auto& vm = navigable->vm();
     VERIFY(navigable->active_window());
@@ -1164,7 +1164,7 @@ WebIDL::ExceptionOr<void> Navigable::populate_session_history_entry_document(
     UserNavigationInvolvement user_involvement,
     Optional<String> navigation_id,
     Navigable::NavigationParamsVariant navigation_params,
-    CSPNavigationType csp_navigation_type,
+    ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type,
     bool allow_POST,
     GC::Ptr<GC::Function<void()>> completion_steps)
 {
@@ -1420,7 +1420,7 @@ void Navigable::begin_navigation(NavigateParams params)
     auto& vm = this->vm();
 
     // 1. Let cspNavigationType be "form-submission" if formDataEntryList is non-null; otherwise "other".
-    auto csp_navigation_type = form_data_entry_list.has_value() ? CSPNavigationType::FormSubmission : CSPNavigationType::Other;
+    auto csp_navigation_type = form_data_entry_list.has_value() ? ContentSecurityPolicy::Directives::Directive::NavigationType::FormSubmission : ContentSecurityPolicy::Directives::Directive::NavigationType::Other;
 
     // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
     auto source_snapshot_params = source_document->snapshot_source_snapshot_params();
@@ -1865,7 +1865,7 @@ GC::Ptr<DOM::Document> Navigable::evaluate_javascript_url(URL::URL const& url, U
 }
 
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate-to-a-javascript:-url
-void Navigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHandlingBehavior history_handling, GC::Ref<SourceSnapshotParams>, URL::Origin const& initiator_origin, UserNavigationInvolvement user_involvement, CSPNavigationType csp_navigation_type, String navigation_id)
+void Navigable::navigate_to_a_javascript_url(URL::URL const& url, HistoryHandlingBehavior history_handling, GC::Ref<SourceSnapshotParams>, URL::Origin const& initiator_origin, UserNavigationInvolvement user_involvement, ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type, String navigation_id)
 {
     // 1. Assert: historyHandling is "replace".
     VERIFY(history_handling == HistoryHandlingBehavior::Replace);

--- a/Libraries/LibWeb/HTML/Navigable.h
+++ b/Libraries/LibWeb/HTML/Navigable.h
@@ -28,11 +28,6 @@
 
 namespace Web::HTML {
 
-enum class CSPNavigationType {
-    Other,
-    FormSubmission,
-};
-
 // https://html.spec.whatwg.org/multipage/browsing-the-web.html#target-snapshot-params
 struct TargetSnapshotParams {
     SandboxingFlagSet sandboxing_flags {};
@@ -130,7 +125,7 @@ public:
         UserNavigationInvolvement user_involvement,
         Optional<String> navigation_id = {},
         NavigationParamsVariant navigation_params = Navigable::NullOrError {},
-        CSPNavigationType csp_navigation_type = CSPNavigationType::Other,
+        ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type = ContentSecurityPolicy::Directives::Directive::NavigationType::Other,
         bool allow_POST = false,
         GC::Ptr<GC::Function<void()>> completion_steps = {});
 
@@ -204,7 +199,7 @@ protected:
 private:
     void begin_navigation(NavigateParams);
     void navigate_to_a_fragment(URL::URL const&, HistoryHandlingBehavior, UserNavigationInvolvement, GC::Ptr<DOM::Element> source_element, Optional<SerializationRecord> navigation_api_state, String navigation_id);
-    void navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, GC::Ref<SourceSnapshotParams>, URL::Origin const& initiator_origin, UserNavigationInvolvement, CSPNavigationType csp_navigation_type, String navigation_id);
+    void navigate_to_a_javascript_url(URL::URL const&, HistoryHandlingBehavior, GC::Ref<SourceSnapshotParams>, URL::Origin const& initiator_origin, UserNavigationInvolvement, ContentSecurityPolicy::Directives::Directive::NavigationType csp_navigation_type, String navigation_id);
 
     void reset_cursor_blink_cycle();
 

--- a/Libraries/LibWeb/HTML/PolicyContainers.cpp
+++ b/Libraries/LibWeb/HTML/PolicyContainers.cpp
@@ -9,6 +9,7 @@
 #include <LibURL/URL.h>
 #include <LibWeb/ContentSecurityPolicy/Policy.h>
 #include <LibWeb/ContentSecurityPolicy/PolicyList.h>
+#include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
 #include <LibWeb/Fetch/Infrastructure/URL.h>
 #include <LibWeb/HTML/PolicyContainers.h>
 #include <LibWeb/HTML/SerializedPolicyContainer.h>
@@ -32,6 +33,29 @@ bool url_requires_storing_the_policy_container_in_history(URL::URL const& url)
     // 2. If url is local, then return true.
     // 3. Return false.
     return Fetch::Infrastructure::is_local_url(url);
+}
+
+// https://html.spec.whatwg.org/multipage/browsers.html#creating-a-policy-container-from-a-fetch-response
+GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(JS::Realm& realm, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment>)
+{
+    // FIXME: 1. If response's URL's scheme is "blob", then return a clone of response's URL's blob URL entry's
+    //           environment's policy container.
+
+    // 2. Let result be a new policy container.
+    GC::Ref<PolicyContainer> result = realm.create<PolicyContainer>(realm);
+
+    // 3. Set result's CSP list to the result of parsing a response's Content Security Policies given response.
+    result->csp_list = ContentSecurityPolicy::Policy::parse_a_responses_content_security_policies(realm, response);
+
+    // FIXME: 4. If environment is non-null, then set result's embedder policy to the result of obtaining an embedder
+    //           policy given response and environment. Otherwise, set it to "unsafe-none".
+
+    // FIXME: 5. Set result's referrer policy to the result of parsing the `Referrer-Policy` header given response.
+    //           [REFERRERPOLICY]
+    //        Doing this currently makes Fetch fail the policy != ReferrerPolicy::EmptyString verification.
+
+    // 6. Return result.
+    return result;
 }
 
 GC::Ref<PolicyContainer> create_a_policy_container_from_serialized_policy_container(JS::Realm& realm, SerializedPolicyContainer const& serialized_policy_container)

--- a/Libraries/LibWeb/HTML/PolicyContainers.h
+++ b/Libraries/LibWeb/HTML/PolicyContainers.h
@@ -50,6 +50,9 @@ private:
 // https://html.spec.whatwg.org/multipage/browsers.html#requires-storing-the-policy-container-in-history
 [[nodiscard]] bool url_requires_storing_the_policy_container_in_history(URL::URL const& url);
 
+// https://html.spec.whatwg.org/multipage/browsers.html#creating-a-policy-container-from-a-fetch-response
+[[nodiscard]] GC::Ref<PolicyContainer> create_a_policy_container_from_a_fetch_response(JS::Realm&, GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ptr<Environment> environment);
+
 [[nodiscard]] GC::Ref<PolicyContainer> create_a_policy_container_from_serialized_policy_container(JS::Realm&, SerializedPolicyContainer const&);
 
 }

--- a/Libraries/LibWeb/HTML/TraversableNavigable.cpp
+++ b/Libraries/LibWeb/HTML/TraversableNavigable.cpp
@@ -655,7 +655,7 @@ TraversableNavigable::HistoryStepResult TraversableNavigable::apply_the_history_
                 //    queue a global task on the navigation and traversal task source given navigable's active window to
                 //    run afterDocumentPopulated.
                 Platform::EventLoopPlugin::the().deferred_invoke(GC::create_function(this->heap(), [populated_target_entry, potentially_target_specific_source_snapshot_params, target_snapshot_params, this, allow_POST, navigable, after_document_populated = GC::create_function(this->heap(), move(after_document_populated)), user_involvement] {
-                    navigable->populate_session_history_entry_document(populated_target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, user_involvement, {}, Navigable::NullOrError {}, CSPNavigationType::Other, allow_POST, GC::create_function(this->heap(), [this, after_document_populated, populated_target_entry]() mutable {
+                    navigable->populate_session_history_entry_document(populated_target_entry, *potentially_target_specific_source_snapshot_params, target_snapshot_params, user_involvement, {}, Navigable::NullOrError {}, ContentSecurityPolicy::Directives::Directive::NavigationType::Other, allow_POST, GC::create_function(this->heap(), [this, after_document_populated, populated_target_entry]() mutable {
                                  VERIFY(active_window());
                                  queue_global_task(Task::Source::NavigationAndTraversal, *active_window(), GC::create_function(this->heap(), [after_document_populated, populated_target_entry]() mutable {
                                      after_document_populated->function()(true, populated_target_entry);

--- a/Libraries/LibWeb/HTML/WorkerGlobalScope.h
+++ b/Libraries/LibWeb/HTML/WorkerGlobalScope.h
@@ -97,6 +97,9 @@ public:
 
     bool is_closing() const { return m_closing; }
 
+    void initialize_policy_container(GC::Ref<Fetch::Infrastructure::Response const> response, GC::Ref<EnvironmentSettingsObject> environment);
+    [[nodiscard]] ContentSecurityPolicy::Directives::Directive::Result run_csp_initialization() const;
+
 protected:
     explicit WorkerGlobalScope(JS::Realm&, GC::Ref<Web::Page>);
 

--- a/Tests/LibWeb/Text/expected/HTML/HTMLOrSVGElement-nonce.txt
+++ b/Tests/LibWeb/Text/expected/HTML/HTMLOrSVGElement-nonce.txt
@@ -5,7 +5,7 @@ nonce: "456" attribute: 456;
 nonce: "null" attribute: 456;
 insertion
 nonce: "foo" attribute: foo;
-nonce: "foo" attribute: ;
+nonce: "foo" attribute: foo;
 cloning
 nonce: "bar" attribute: bar;
 nonce: "bar" attribute: bar;


### PR DESCRIPTION
Part 3 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

Namely:
- Only stash the nonce attribute's value if there is a CSP header
- Parse CSP from navigation/worker response
- Determine the correct CSP navigation type for form submission