### PR TITLE
Clangd: disable complain about unqualified move

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,5 +1,6 @@
 CompileFlags:
   CompilationDatabase: Build/release
+  Add: -Wno-unqualified-std-cast-call
 
 Diagnostics:
   UnusedIncludes: None


### PR DESCRIPTION
Editors using the output of clangd reports [usage](https://github.com/search?q=repo%3ALadybirdBrowser%2Fladybird%20move%28&type=code) of the `move` (instead of `std:move`) function as an error. ([clang PR](https://reviews.llvm.org/D119670)). since this is (for better or worse) a common practice on this project, it would be wise to make clang stop complaining about that.

[ref issue on duckdb](https://github.com/duckdb/duckdb/issues/5750)
[ref PR on duckdb](https://github.com/duckdb/duckdb/pull/5751)