### PR TITLE
LibWeb: Implement more steps of HTMLDialogElement

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -94,6 +94,7 @@
 #include <LibWeb/HTML/HTMLAreaElement.h>
 #include <LibWeb/HTML/HTMLBaseElement.h>
 #include <LibWeb/HTML/HTMLBodyElement.h>
+#include <LibWeb/HTML/HTMLDialogElement.h>
 #include <LibWeb/HTML/HTMLDocument.h>
 #include <LibWeb/HTML/HTMLEmbedElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
@@ -591,6 +592,7 @@ void Document::visit_edges(Cell::Visitor& visitor)
     visitor.visit(m_session_storage_holder);
     visitor.visit(m_render_blocking_elements);
     visitor.visit(m_policy_container);
+    visitor.visit(m_open_dialogs);
 }
 
 // https://w3c.github.io/selection-api/#dom-document-getselection
@@ -6349,6 +6351,16 @@ WebIDL::CallbackType* Document::onvisibilitychange()
 void Document::set_onvisibilitychange(WebIDL::CallbackType* value)
 {
     set_event_handler_attribute(HTML::EventNames::visibilitychange, value);
+}
+
+void Document::add_to_open_dialogs_list(GC::Ref<HTML::HTMLDialogElement> dialog)
+{
+    m_open_dialogs.append(dialog);
+}
+
+void Document::remove_from_open_dialogs_list(HTML::HTMLDialogElement& dialog)
+{
+    m_open_dialogs.remove_first_matching([&](auto& entry) { return entry.ptr() == &dialog; });
 }
 
 }

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -57,6 +57,7 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/DocumentFragment.h>
 #include <LibWeb/DOM/DocumentObserver.h>
+#include <LibWeb/DOM/DocumentOrShadowRoot.h>
 #include <LibWeb/DOM/DocumentType.h>
 #include <LibWeb/DOM/EditingHostManager.h>
 #include <LibWeb/DOM/Element.h>
@@ -2383,44 +2384,9 @@ String const& Document::compat_mode() const
     return css1_compat;
 }
 
-// https://html.spec.whatwg.org/multipage/interaction.html#dom-documentorshadowroot-activeelement
 void Document::update_active_element()
 {
-    // 1. Let candidate be the DOM anchor of the focused area of this DocumentOrShadowRoot's node document.
-    Node* candidate = focused_element();
-
-    // 2. Set candidate to the result of retargeting candidate against this DocumentOrShadowRoot.
-    candidate = as<Node>(retarget(candidate, this));
-
-    // 3. If candidate's root is not this DocumentOrShadowRoot, then return null.
-    if (&candidate->root() != this) {
-        set_active_element(nullptr);
-        return;
-    }
-
-    // 4. If candidate is not a Document object, then return candidate.
-    if (!is<Document>(candidate)) {
-        set_active_element(as<Element>(candidate));
-        return;
-    }
-
-    auto* candidate_document = static_cast<Document*>(candidate);
-
-    // 5. If candidate has a body element, then return that body element.
-    if (candidate_document->body()) {
-        set_active_element(candidate_document->body());
-        return;
-    }
-
-    // 6. If candidate's document element is non-null, then return that document element.
-    if (candidate_document->document_element()) {
-        set_active_element(candidate_document->document_element());
-        return;
-    }
-
-    // 7. Return null.
-    set_active_element(nullptr);
-    return;
+    set_active_element(calculate_active_element(*this));
 }
 
 void Document::set_focused_element(Element* element)

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -823,6 +823,10 @@ public:
         m_pending_nodes_for_style_invalidation_due_to_presence_of_has.set(node.make_weak_ptr<Node>());
     }
 
+    Vector<GC::Ref<HTML::HTMLDialogElement>> const& open_dialogs() const { return m_open_dialogs; }
+    void add_to_open_dialogs_list(GC::Ref<HTML::HTMLDialogElement> dialog);
+    void remove_from_open_dialogs_list(HTML::HTMLDialogElement& dialog);
+
 protected:
     virtual void initialize(JS::Realm&) override;
     virtual void visit_edges(Cell::Visitor&) override;
@@ -1174,6 +1178,10 @@ private:
     HashTable<GC::Ref<Element>> m_render_blocking_elements;
 
     HashTable<WeakPtr<Node>> m_pending_nodes_for_style_invalidation_due_to_presence_of_has;
+
+    // https://html.spec.whatwg.org/multipage/dom.html#open-dialogs-list
+    // Each Document has an open dialogs list, which is a list of dialog elements, initially empty.
+    Vector<GC::Ref<HTML::HTMLDialogElement>> m_open_dialogs;
 };
 
 template<>

--- a/Libraries/LibWeb/DOM/Document.idl
+++ b/Libraries/LibWeb/DOM/Document.idl
@@ -72,7 +72,6 @@ interface Document : Node {
 
     readonly attribute USVString referrer;
 
-    readonly attribute Element? activeElement;
 
     Element? getElementById(DOMString id);
     NodeList getElementsByName([FlyString] DOMString name);

--- a/Libraries/LibWeb/DOM/DocumentOrShadowRoot.h
+++ b/Libraries/LibWeb/DOM/DocumentOrShadowRoot.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, circl <circl.lastname@gmail.com>
+ * Copyright (c) 2025, Feng Yu <f3n67u@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/Utils.h>
+
+namespace Web::DOM {
+
+template<typename T>
+concept DocumentOrShadowRoot = OneOf<T, Document, ShadowRoot>;
+
+// https://html.spec.whatwg.org/multipage/interaction.html#dom-documentorshadowroot-activeelement
+template<DocumentOrShadowRoot T>
+Element* calculate_active_element(T& self)
+{
+    // 1. Let candidate be the DOM anchor of the focused area of this DocumentOrShadowRoot's node document.
+    Node* candidate = self.document().focused_element();
+
+    // 2. Set candidate to the result of retargeting candidate against this DocumentOrShadowRoot.
+    candidate = as<Node>(retarget(candidate, &self));
+
+    // 3. If candidate's root is not this DocumentOrShadowRoot, then return null.
+    if (&candidate->root() != &self)
+        return nullptr;
+
+    // 4. If candidate is not a Document object, then return candidate.
+    if (!is<Document>(candidate))
+        return as<Element>(candidate);
+
+    auto* candidate_document = static_cast<Document*>(candidate);
+
+    // 5. If candidate has a body element, then return that body element.
+    if (candidate_document->body())
+        return candidate_document->body();
+
+    // 6. If candidate's document element is non-null, then return that document element.
+    if (candidate_document->document_element())
+        return candidate_document->document_element();
+
+    // 7. Return null.
+    return nullptr;
+}
+
+}

--- a/Libraries/LibWeb/DOM/DocumentOrShadowRoot.idl
+++ b/Libraries/LibWeb/DOM/DocumentOrShadowRoot.idl
@@ -2,6 +2,9 @@
 
 // https://dom.spec.whatwg.org/#documentorshadowroot
 interface mixin DocumentOrShadowRoot {
+    // https://html.spec.whatwg.org/multipage/interaction.html#dom-documentorshadowroot-activeelement
+    readonly attribute Element? activeElement;
+
     // https://w3c.github.io/csswg-drafts/cssom/#extensions-to-the-document-or-shadow-root-interface
     [SameObject, ImplementedAs=style_sheets_for_bindings] readonly attribute StyleSheetList styleSheets;
     attribute any adoptedStyleSheets;

--- a/Libraries/LibWeb/DOM/ShadowRoot.cpp
+++ b/Libraries/LibWeb/DOM/ShadowRoot.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/Bindings/ShadowRootPrototype.h>
 #include <LibWeb/DOM/AdoptedStyleSheets.h>
 #include <LibWeb/DOM/Document.h>
+#include <LibWeb/DOM/DocumentOrShadowRoot.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/HTML/HTMLTemplateElement.h>
@@ -117,6 +118,11 @@ WebIDL::ExceptionOr<void> ShadowRoot::set_html_unsafe(StringView html)
     TRY(unsafely_set_html(*this->host(), html));
 
     return {};
+}
+
+Element* ShadowRoot::active_element()
+{
+    return calculate_active_element(*this);
 }
 
 CSS::StyleSheetList& ShadowRoot::style_sheets()

--- a/Libraries/LibWeb/DOM/ShadowRoot.h
+++ b/Libraries/LibWeb/DOM/ShadowRoot.h
@@ -50,6 +50,8 @@ public:
 
     WebIDL::ExceptionOr<String> get_html(GetHTMLOptions const&) const;
 
+    Element* active_element();
+
     CSS::StyleSheetList& style_sheets();
     CSS::StyleSheetList const& style_sheets() const;
 

--- a/Libraries/LibWeb/HTML/HTMLDialogElement.h
+++ b/Libraries/LibWeb/HTML/HTMLDialogElement.h
@@ -59,6 +59,9 @@ private:
 
     // https://html.spec.whatwg.org/multipage/interactive-elements.html#dialog-toggle-task-tracker
     Optional<ToggleTaskTracker> m_dialog_toggle_task_tracker;
+
+    // https://html.spec.whatwg.org/multipage/interactive-elements.html#previously-focused-element
+    GC::Ptr<Element> m_previously_focused_element;
 };
 
 }

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+3 Pass
+2 Fail
+Pass	Focus should not be restored if the currently focused element is not inside the dialog.
+Pass	Focus restore should not occur when the focused element is in a shadowroot outside of the dialog.
+Pass	Focus restore should occur when the focused element is in a shadowroot inside the dialog.
+Fail	Focus restore should occur when the focused element is slotted into a dialog.
+Fail	Focus restore should always occur for modal dialogs.

--- a/Tests/LibWeb/Text/expected/wpt-import/shadow-dom/focus/DocumentOrShadowRoot-activeElement.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/shadow-dom/focus/DocumentOrShadowRoot-activeElement.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	activeElement on document & shadow root when focused element is in the shadow tree
+Pass	activeElement on document & shadow root when focused element is in the document
+Pass	activeElement on document & shadow root when focused element is slotted
+Pass	activeElement on a neighboring host when focused element is in another shadow tree
+Pass	activeElement when focused element is in a nested shadow tree
+Pass	activeElement when focused element is in a parent shadow tree

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://github.com/whatwg/html/issues/8904">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<button id=b1>button 1</button>
+<button id=b2>button 2</button>
+<div id=host>
+  <template shadowrootmode=open>
+    <button>button in shadowroot outside dialog</button>
+  </template>
+</div>
+<dialog id=mydialog>
+  <button id=b3>button in dialog</button>
+  <div id=dialoghost>
+    <template shadowrootmode=open>
+      <button>button in shadowroot in dialog</button>
+    </template>
+  </div>
+</dialog>
+
+<div id=host2>
+  <template shadowrootmode=open>
+    <dialog>
+      <slot></slot>
+    </dialog>
+  </template>
+  <button id=host2button>button</button>
+</div>
+
+<dialog id=mydialog2>hello world</dialog>
+
+<script>
+test(() => {
+  b1.focus();
+  mydialog.show();
+  b2.focus();
+  mydialog.close();
+  assert_equals(document.activeElement, b2);
+}, 'Focus should not be restored if the currently focused element is not inside the dialog.');
+
+test(() => {
+  const shadowbutton = host.shadowRoot.querySelector('button');
+  b2.focus();
+  mydialog.show();
+  shadowbutton.focus();
+  mydialog.close();
+  assert_equals(document.activeElement, host, 'document.activeElement should point at the shadow host.');
+  assert_equals(host.shadowRoot.activeElement, shadowbutton, 'The button in the shadowroot should remain focused.');
+}, 'Focus restore should not occur when the focused element is in a shadowroot outside of the dialog.');
+
+test(() => {
+  const shadowbutton = dialoghost.shadowRoot.querySelector('button');
+  b2.focus();
+  mydialog.show();
+  shadowbutton.focus();
+  mydialog.close();
+  assert_equals(document.activeElement, b2);
+}, 'Focus restore should occur when the focused element is in a shadowroot inside the dialog.');
+
+test(() => {
+  const dialog = host2.shadowRoot.querySelector('dialog');
+  b2.focus();
+  dialog.show();
+  host2button.focus();
+  dialog.close();
+  assert_equals(document.activeElement, b2);
+}, 'Focus restore should occur when the focused element is slotted into a dialog.');
+
+test(() => {
+  b1.focus();
+  const dialog = document.getElementById('mydialog2');
+  dialog.showModal();
+  dialog.blur();
+  assert_equals(document.activeElement, document.body,
+    'Focus should return to the body when calling dialog.blur().');
+  dialog.close();
+  assert_equals(document.activeElement, b1,
+    'Focus should be restored to the previously focused element.');
+}, 'Focus restore should always occur for modal dialogs.');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/shadow-dom/focus/DocumentOrShadowRoot-activeElement.html
+++ b/Tests/LibWeb/Text/input/wpt-import/shadow-dom/focus/DocumentOrShadowRoot-activeElement.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>HTML Test: DocumentOrShadowRoot.activeElement</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<script src="../../resources/testdriver.js"></script>
+<script src="../../resources/testdriver-vendor.js"></script>
+<body>
+<script>
+function createChildAndFocus(focusParent) {
+  const focused = document.createElement("div");
+  focused.tabIndex = 0;
+  focusParent.appendChild(focused);
+  focused.focus();
+  return focused;
+}
+
+test(() => {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  document.body.appendChild(host);
+
+  const focused = createChildAndFocus(shadowRoot);
+  assert_equals(document.activeElement, host);
+  assert_equals(shadowRoot.activeElement, focused);
+}, "activeElement on document & shadow root when focused element is in the shadow tree");
+
+test(() => {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  document.body.appendChild(host);
+
+  const focused = createChildAndFocus(document.body);
+  assert_equals(document.activeElement, focused);
+  assert_equals(shadowRoot.activeElement, null);
+}, "activeElement on document & shadow root when focused element is in the document");
+
+test(() => {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  shadowRoot.appendChild(document.createElement("slot"));
+  document.body.appendChild(host);
+
+  // Child of |host|, will be slotted to the slot in |shadowRoot|.
+  const focused = createChildAndFocus(host);
+  assert_equals(document.activeElement, focused);
+  assert_equals(shadowRoot.activeElement, null);
+}, "activeElement on document & shadow root when focused element is slotted");
+
+test(() => {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  document.body.appendChild(host);
+  const neighborHost = document.createElement("div");
+  const neighborShadowRoot = neighborHost.attachShadow({ mode: "open" });
+  document.body.appendChild(neighborHost);
+
+  const focused = createChildAndFocus(shadowRoot);
+  assert_equals(document.activeElement, host);
+  assert_equals(shadowRoot.activeElement, focused);
+  assert_equals(neighborShadowRoot.activeElement, null);
+}, "activeElement on a neighboring host when focused element is in another shadow tree");
+
+test(() => {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  document.body.appendChild(host);
+  const nestedHost = document.createElement("div");
+  const nestedShadowRoot = nestedHost.attachShadow({ mode: "open" });
+  shadowRoot.appendChild(nestedHost);
+
+  const focused = createChildAndFocus(nestedShadowRoot);
+  assert_equals(document.activeElement, host);
+  assert_equals(shadowRoot.activeElement, nestedHost);
+  assert_equals(nestedShadowRoot.activeElement, focused);
+}, "activeElement when focused element is in a nested shadow tree");
+
+test(() => {
+  const host = document.createElement("div");
+  const shadowRoot = host.attachShadow({ mode: "open" });
+  document.body.appendChild(host);
+  const nestedHost = document.createElement("div");
+  const nestedShadowRoot = nestedHost.attachShadow({ mode: "open" });
+  shadowRoot.appendChild(nestedHost);
+
+  const focused = createChildAndFocus(shadowRoot);
+  assert_equals(document.activeElement, host);
+  assert_equals(shadowRoot.activeElement, focused);
+  assert_equals(nestedShadowRoot.activeElement, null);
+}, "activeElement when focused element is in a parent shadow tree");
+</script>
+</body>


### PR DESCRIPTION
Implement more steps of `HTMLDialogElement::show()`, `HTMLDialogElement::show_a_modal_dialog()` and `HTMLDialogElement::close_the_dialog()` methods.

Added activeElement attribute in ShadowRoot because wpt test `html/semantics/interactive-elements/the-dialog-element/dialog-focus-previous-outside.html` rely on this feature.