### PR TITLE
LibRegex: Allow duplicate named capture groups in separate alternatives

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -598,6 +598,7 @@ TEST_CASE(ECMA262_parse)
         { "(?<a>a)(?<a>b)"sv, regex::Error::DuplicateNamedCapture },
         { "(?<a>a)(?<b>b)(?<a>c)"sv, regex::Error::DuplicateNamedCapture },
         { "(?<a>(?<a>a))"sv, regex::Error::DuplicateNamedCapture },
+        { "(?:(?<x>a)|(?<y>a)(?<x>b))(?:(?<z>c)|(?<z>d))"sv }, // Duplicate named capturing groups in separate alternatives should parse correctly
         { "(?<1a>a)"sv, regex::Error::InvalidNameForCaptureGroup },
         { "(?<\\a>a)"sv, regex::Error::InvalidNameForCaptureGroup },
         { "(?<\ta>a)"sv, regex::Error::InvalidNameForCaptureGroup },


### PR DESCRIPTION
Instead of tracking duplicate named capture groups across the entire expression, we now track them within each alternative. This allows us to match things correctly when we have duplicate named groups. 
We can pass a couple more tests by ensuring the groups are in the correct order, but I haven’t figured that out yet :^)

Summary:
        +10 ✅    -10 ❌ 

Diff Tests:
    test/annexB/built-ins/RegExp/prototype/compile/duplicate-named-capturing-groups-syntax.js ❌ -> ✅
    test/built-ins/RegExp/duplicate-named-capturing-groups-syntax.js                          ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-match-indices.js                       ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-matchall.js                            ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-replace.js                             ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-replaceall.js                          ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-search.js                              ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-split.js                               ❌ -> ✅
    test/built-ins/RegExp/named-groups/duplicate-names-test.js                                ❌ -> ✅
    test/staging/built-ins/RegExp/named-groups/duplicate-named-groups-search.js               ❌ -> ✅