### PR TITLE
LibWeb: Don't layout flex descendants in intrinsic layout mode

### DIFF
--- a/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -153,7 +153,7 @@ void FlexFormattingContext::run(AvailableSpace const& available_space)
     // 16. Align all flex lines (per align-content)
     align_all_flex_lines();
 
-    if (available_space.width.is_intrinsic_sizing_constraint() || available_space.height.is_intrinsic_sizing_constraint()) {
+    if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         // We're computing intrinsic size for the flex container.
         determine_intrinsic_size_of_flex_container();
     } else {

--- a/Libraries/LibWeb/Layout/GridFormattingContext.cpp
+++ b/Libraries/LibWeb/Layout/GridFormattingContext.cpp
@@ -2046,7 +2046,7 @@ void GridFormattingContext::run(AvailableSpace const& available_space)
         determine_grid_container_height();
     }
 
-    if (available_space.height.is_intrinsic_sizing_constraint() || available_space.width.is_intrinsic_sizing_constraint()) {
+    if (m_layout_mode == LayoutMode::IntrinsicSizing) {
         determine_intrinsic_size_of_grid_container(available_space);
         return;
     }


### PR DESCRIPTION
We already have a check to skip the layout of descendants if the
available size is intrinsic, but this is not sufficient in nested
intrinsic layout cases, where the available size might be definite even
though we are in intrinsic layout mode.