### PR TITLE
LibWebView: add fallback mechanism for monospace font

### DIFF
--- a/Libraries/LibWebView/Plugins/FontPlugin.cpp
+++ b/Libraries/LibWebView/Plugins/FontPlugin.cpp
@@ -46,6 +46,28 @@ FontPlugin::FontPlugin(bool is_layout_test_mode, Gfx::SystemFontProvider* font_p
 
     auto default_fixed_width_font_name = generic_font_name(Web::Platform::GenericFont::UiMonospace);
     m_default_fixed_width_font = Gfx::FontDatabase::the().get(default_fixed_width_font_name, 12.0, 400, Gfx::FontWidth::Normal, 0);
+
+    if (!m_default_fixed_width_font) {
+        // Try fallback monospace fonts.
+        for (auto const& fallback : { "Courier New"_fly_string, "Courier"_fly_string, "FreeMono"_fly_string, "Liberation Mono"_fly_string }) {
+            m_default_fixed_width_font = Gfx::FontDatabase::the().get(fallback, 12.0, 400, Gfx::FontWidth::Normal, 0);
+            if (m_default_fixed_width_font)
+                break;
+        }
+        
+        // If still no font found, try to get any monospace font to avoid crashing.
+        if (!m_default_fixed_width_font) {
+            auto& database = Gfx::FontDatabase::the();
+            for (auto const& font_name : database.font_families()) {
+                auto font = database.get(font_name, 12.0, 400, Gfx::FontWidth::Normal, 0);
+                if (font && font->is_fixed_width()) {
+                    m_default_fixed_width_font = move(font);
+                    break;
+                }
+            }
+        }
+    }
+
     VERIFY(m_default_fixed_width_font);
 }
 

--- a/Tests/LibWebView/CMakeLists.txt
+++ b/Tests/LibWebView/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(TEST_SOURCES
     TestWebViewURL.cpp
+    TestFontPlugin.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibWebView/TestFontPlugin.cpp
+++ b/Tests/LibWebView/TestFontPlugin.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024, Oleg Luganskiy <oleg.lgnsk@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGfx/Font/FontDatabase.h>
+#include <LibGfx/Font/PathFontProvider.h>
+#include <LibTest/TestCase.h>
+#include <LibWeb/Platform/FontPlugin.h>
+#include <LibWebView/Plugins/FontPlugin.h>
+
+// Mock font provider that simulates missing fonts
+class MockFontProvider : public Gfx::PathFontProvider {
+public:
+    MockFontProvider() = default;
+    virtual ~MockFontProvider() override = default;
+
+    void set_available_fonts(Vector<FlyString> fonts)
+    {
+        m_available_fonts = move(fonts);
+    }
+
+    virtual RefPtr<Gfx::Font> get_by_name(FlyString const& name, float point_size, unsigned weight, Gfx::FontWidth width, unsigned flags) override
+    {
+        // Only return a font if it's in our available fonts list.
+        if (m_available_fonts.contains_slow(name))
+            return Gfx::PathFontProvider::get_by_name(name, point_size, weight, width, flags);
+        return {};
+    }
+
+private:
+    Vector<FlyString> m_available_fonts;
+};
+
+TEST_CASE(font_plugin_handles_missing_monospace_font)
+{
+    // Create a mock font provider with no available fonts.
+    auto mock_provider = make<MockFontProvider>();
+    mock_provider->set_available_fonts({});
+
+    // Create the font plugin with mock provider.
+    // This should not crash despite no fonts being available.
+    auto font_plugin = WebView::FontPlugin(false, mock_provider.ptr());
+    
+    // Verify a valid default fixed-width font.
+    auto& default_fixed_width_font = font_plugin.default_fixed_width_font();
+    EXPECT(default_fixed_width_font.is_fixed_width());
+}
+
+TEST_CASE(font_plugin_uses_fallback_when_primary_font_missing)
+{
+    // Create a mock font provider with some fonts but not the primary monospace font.
+    auto mock_provider = make<MockFontProvider>();
+    
+    // Add some fallback fonts but not the primary one that would be returned by fontconfig.
+    Vector<FlyString> available_fonts = {
+        "Courier New"_fly_string,
+        "Liberation Mono"_fly_string
+    };
+    mock_provider->set_available_fonts(move(available_fonts));
+    
+    // Load the fonts into the provider.
+    for (auto const& path : Core::StandardPaths::font_directories().release_value_but_fixme_should_propagate_errors())
+        mock_provider->load_all_fonts_from_uri(MUST(String::formatted("file://{}", path)));
+
+    // Create the font plugin with mock provider.
+    auto font_plugin = WebView::FontPlugin(false, mock_provider.ptr());
+    
+    // Verify a valid default fixed-width font.
+    auto& default_fixed_width_font = font_plugin.default_fixed_width_font();
+    EXPECT(default_fixed_width_font.is_fixed_width());
+    
+    // The font name should be one of fallback fonts.
+    auto font_name = default_fixed_width_font.family();
+    EXPECT(font_name == "Courier New"_fly_string || font_name == "Liberation Mono"_fly_string);
+}
+
+TEST_CASE(font_plugin_uses_primary_font_when_available)
+{
+    // Mock font provider with the primary monospace font available.
+    auto mock_provider = make<MockFontProvider>();
+    
+    // JetBrainsMono is available.
+    Vector<FlyString> available_fonts = {
+        "JetBrainsMono Nerd Font"_fly_string
+    };
+    mock_provider->set_available_fonts(move(available_fonts));
+    
+    // Load the fonts into the provider.
+    for (auto const& path : Core::StandardPaths::font_directories().release_value_but_fixme_should_propagate_errors())
+        mock_provider->load_all_fonts_from_uri(MUST(String::formatted("file://{}", path)));
+
+    // Create the font plugin with mock provider.
+    auto font_plugin = WebView::FontPlugin(false, mock_provider.ptr());
+    
+    // Verify a valid default fixed-width font.
+    auto& default_fixed_width_font = font_plugin.default_fixed_width_font();
+    EXPECT(default_fixed_width_font.is_fixed_width());
+    
+    // The font name should be primary font.
+    EXPECT_EQ(default_fixed_width_font.family(), "JetBrainsMono Nerd Font"_fly_string);
+}


### PR DESCRIPTION
## FontPlugin: add fallback mechanism for `monospace` font

### Problem
Ladybird crashes when trying to resolve the `UiMonospace` font on systems where the default `monospace` font is `JetBrainsMono Nerd Font`. The WebContent process fails with:
```sh
VERIFICATION FAILED: m_default_font at /build/source/Libraries/LibWebView/Plugins/FontPlugin.cpp:47
```

The crash occurs because `generic_font_name(Web::Platform::GenericFont::UiMonospace)` returns a font name that cannot be successfully loaded by the FontDatabase, and the subsequent VERIFY assertion fails.

### Solution
This PR adds a fallback mechanism to the `FontPlugin` constructor that attempts to find a suitable `monospace` font when the primary font resolution fails. Instead of immediately failing with a VERIFY assertion, the code now:

1. First tries to use the font returned by `fontconfig`
2. If that fails, tries a list of common `monospace` fonts
3. If that still fails, attempts to find any `monospace` font in the database
4. Only triggers the `VERIFY` assertion if all fallback attempts fail

### Testing
```sh
ctest --test-dir Build/release -R TestFontPlugin
// or
./Meta/ladybird.sh test LibWebView
```

### Related Issues
Fixes #3832