### PR TITLE
LibWeb: Use partial layout tree rebuild in element's style invalidation

### DIFF
--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -787,6 +787,9 @@ void Node::insert_before(GC::Ref<Node> node, GC::Ptr<Node> child, bool suppress_
     }
 
     if (is_connected()) {
+        if (layout_node() && layout_node()->display().is_contents() && parent_element()) {
+            parent_element()->set_needs_layout_tree_update(true);
+        }
         set_needs_layout_tree_update(true);
     }
 


### PR DESCRIPTION
This allows us to avoid a full layout tree rebuild after change of "display" property, which happens frequently in practice. It also allows us to avoid a full rebuild after DOM node insertion, since previously, computing styles for newly inserted nodes would trigger a complete layout tree rebuild.