### PR TITLE
LibWeb: Implement string->number for type=datetime-local input elements

### DIFF
--- a/Libraries/LibWeb/HTML/Dates.h
+++ b/Libraries/LibWeb/HTML/Dates.h
@@ -40,7 +40,20 @@ struct YearMonthDay {
     u32 day;
 };
 
+struct HourMinuteSecond {
+    i32 hour;
+    i32 minute;
+    i32 second;
+};
+
+struct DateAndTime {
+    YearMonthDay date;
+    HourMinuteSecond time;
+};
+
 Optional<YearMonthDay> parse_a_date_string(StringView);
+
+Optional<DateAndTime> parse_a_local_date_and_time_string(StringView);
 
 i32 number_of_months_since_unix_epoch(YearAndMonth);
 

--- a/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -2136,6 +2136,24 @@ static Optional<double> convert_date_string_to_number(StringView input)
     return date_time.milliseconds_since_epoch();
 }
 
+// https://html.spec.whatwg.org/multipage/input.html#local-date-and-time-state-(type=datetime-local):parse-a-local-date-and-time-string-2
+static Optional<double> convert_local_date_and_time_string_to_number(StringView input)
+{
+    // The algorithm to convert a string to a number, given a string input, is as follows: If parsing a date and time
+    // from input results in an error, then return an error; otherwise, return the number of milliseconds elapsed from
+    // midnight on the morning of 1970-01-01 (the time represented by the value "1970-01-01T00:00:00.0") to the parsed
+    // local date and time, ignoring leap seconds.
+    auto maybe_date_and_time = parse_a_local_date_and_time_string(input);
+    if (!maybe_date_and_time.has_value())
+        return {};
+    auto date_and_time = maybe_date_and_time.value();
+    auto date = date_and_time.date;
+    auto time = date_and_time.time;
+
+    auto date_time = UnixDateTime::from_unix_time_parts(date.year, date.month, date.day, time.hour, time.minute, time.second, 0);
+    return date_time.milliseconds_since_epoch();
+}
+
 // https://html.spec.whatwg.org/multipage/input.html#time-state-(type=time):concept-input-value-string-number
 Optional<double> HTMLInputElement::convert_time_string_to_number(StringView input) const
 {
@@ -2171,7 +2189,9 @@ Optional<double> HTMLInputElement::convert_string_to_number(StringView input) co
     if (type_state() == TypeAttributeState::Time)
         return convert_time_string_to_number(input);
 
-    dbgln("HTMLInputElement::convert_string_to_number() not implemented for input type {}", type());
+    if (type_state() == TypeAttributeState::LocalDateAndTime)
+        return convert_local_date_and_time_string_to_number(input);
+
     return {};
 }
 

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-checkValidity.txt
@@ -2,8 +2,7 @@ Harness status: OK
 
 Found 132 tests
 
-126 Pass
-6 Fail
+132 Pass
 Pass	[INPUT in TEXT status] no constraint
 Pass	[INPUT in TEXT status] no constraint (in a form)
 Pass	[INPUT in TEXT status] not suffering from being too long
@@ -58,12 +57,12 @@ Pass	[INPUT in EMAIL status] suffering from being missing
 Pass	[INPUT in EMAIL status] suffering from being missing (in a form)
 Pass	[INPUT in DATETIME-LOCAL status] no constraint
 Pass	[INPUT in DATETIME-LOCAL status] no constraint (in a form)
-Fail	[INPUT in DATETIME-LOCAL status] suffering from an overflow
-Fail	[INPUT in DATETIME-LOCAL status] suffering from an overflow (in a form)
-Fail	[INPUT in DATETIME-LOCAL status] suffering from an underflow
-Fail	[INPUT in DATETIME-LOCAL status] suffering from an underflow (in a form)
-Fail	[INPUT in DATETIME-LOCAL status] suffering from a step mismatch
-Fail	[INPUT in DATETIME-LOCAL status] suffering from a step mismatch (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an overflow
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an overflow (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an underflow
+Pass	[INPUT in DATETIME-LOCAL status] suffering from an underflow (in a form)
+Pass	[INPUT in DATETIME-LOCAL status] suffering from a step mismatch
+Pass	[INPUT in DATETIME-LOCAL status] suffering from a step mismatch (in a form)
 Pass	[INPUT in DATETIME-LOCAL status] suffering from being missing
 Pass	[INPUT in DATETIME-LOCAL status] suffering from being missing (in a form)
 Pass	[INPUT in DATE status] no constraint

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeOverflow.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeOverflow.txt
@@ -2,19 +2,19 @@ Harness status: OK
 
 Found 49 tests
 
-41 Pass
-8 Fail
+43 Pass
+6 Fail
 Pass	[INPUT in DATETIME-LOCAL status] The max attribute is not set
 Pass	[INPUT in DATETIME-LOCAL status] Value is empty string
 Pass	[INPUT in DATETIME-LOCAL status] The max attribute is an invalid local date time string
 Pass	[INPUT in DATETIME-LOCAL status] The max attribute is greater than the value attribute
 Pass	[INPUT in DATETIME-LOCAL status] The value is an invalid local date time string(hour is greater than 23)
 Pass	[INPUT in DATETIME-LOCAL status] The value if an invalid local date time string(year is two digits)
-Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max
+Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max
 Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 1 digit)
 Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 2 digits)
 Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(with millisecond in 3 digits)
-Fail	[INPUT in DATETIME-LOCAL status] The value is greater than max(Year is 10000 should be valid)
+Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max(Year is 10000 should be valid)
 Pass	[INPUT in DATE status] The max attribute is not set
 Pass	[INPUT in DATE status] Value is empty string
 Pass	[INPUT in DATE status] The max attribute is an invalid date

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeUnderflow.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/constraints/form-validation-validity-rangeUnderflow.txt
@@ -2,19 +2,19 @@ Harness status: OK
 
 Found 47 tests
 
-39 Pass
-8 Fail
+41 Pass
+6 Fail
 Pass	[INPUT in DATETIME-LOCAL status] The min attribute is not set
 Pass	[INPUT in DATETIME-LOCAL status] Value is empty string
 Pass	[INPUT in DATETIME-LOCAL status] The min attribute is an invalid local date time string
 Pass	[INPUT in DATETIME-LOCAL status] The min attribute is less than the value attribute
 Pass	[INPUT in DATETIME-LOCAL status] The value is an invalid local date time string(hour is greater than 23)
 Pass	[INPUT in DATETIME-LOCAL status] The value is an invalid local date time string(year is two digits)
-Fail	[INPUT in DATETIME-LOCAL status] The value is less than min
+Pass	[INPUT in DATETIME-LOCAL status] The value is less than min
 Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 1 digit)
 Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 2 digits)
 Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(with millisecond in 3 digits)
-Fail	[INPUT in DATETIME-LOCAL status] The value is less than min(Year is 10000 should be valid)
+Pass	[INPUT in DATETIME-LOCAL status] The value is less than min(Year is 10000 should be valid)
 Pass	[INPUT in DATETIME-LOCAL status] The value is greater than max
 Pass	[INPUT in DATE status] The min attribute is not set
 Pass	[INPUT in DATE status] Value is empty string


### PR DESCRIPTION
This gets us passing 100% of the subtests in the test at https://wpt.fyi/results/html/semantics/forms/constraints/form-validation-checkValidity.html?product=ladybird
