### PR TITLE
LibDevTools: Implement DOM mutations and DOM editing requests

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -58,6 +58,7 @@ void FrameActor::handle_message(StringView type, JsonObject const&)
 
     if (type == "detach"sv) {
         if (auto tab = m_tab.strong_ref()) {
+            devtools().delegate().stop_listening_for_dom_mutations(tab->description());
             devtools().delegate().stop_listening_for_console_messages(tab->description());
             tab->reset_selected_node();
         }

--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -42,7 +42,7 @@ void HighlighterActor::handle_message(StringView type, JsonObject const& message
         response.set("value"sv, false);
 
         if (auto dom_node = WalkerActor::dom_node_for(InspectorActor::walker_for(m_inspector), *node); dom_node.has_value()) {
-            devtools().delegate().highlight_dom_node(dom_node->tab->description(), dom_node->id, dom_node->pseudo_element);
+            devtools().delegate().highlight_dom_node(dom_node->tab->description(), dom_node->identifier.id, dom_node->identifier.pseudo_element);
             response.set("value"sv, true);
         }
 

--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -39,15 +39,11 @@ void HighlighterActor::handle_message(StringView type, JsonObject const& message
             return;
         }
 
-        auto tab = InspectorActor::tab_for(m_inspector);
-        auto walker = InspectorActor::walker_for(m_inspector);
         response.set("value"sv, false);
 
-        if (tab && walker) {
-            if (auto const& dom_node = walker->dom_node(*node); dom_node.has_value()) {
-                devtools().delegate().highlight_dom_node(tab->description(), dom_node->id, dom_node->pseudo_element);
-                response.set("value"sv, true);
-            }
+        if (auto dom_node = WalkerActor::dom_node_for(InspectorActor::walker_for(m_inspector), *node); dom_node.has_value()) {
+            devtools().delegate().highlight_dom_node(dom_node->tab->description(), dom_node->id, dom_node->pseudo_element);
+            response.set("value"sv, true);
         }
 
         send_message(move(response));

--- a/Libraries/LibDevTools/Actors/NodeActor.cpp
+++ b/Libraries/LibDevTools/Actors/NodeActor.cpp
@@ -5,13 +5,62 @@
  */
 
 #include <AK/JsonObject.h>
+#include <AK/Optional.h>
+#include <AK/Variant.h>
 #include <LibDevTools/Actors/NodeActor.h>
 #include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
 #include <LibDevTools/DevToolsDelegate.h>
 #include <LibDevTools/DevToolsServer.h>
+#include <LibWebView/Attribute.h>
 
 namespace DevTools {
+
+struct AttributeModification {
+    Optional<String> attribute_to_replace;
+    Vector<WebView::Attribute> replacement_attributes;
+};
+static AttributeModification parse_attribute_modification(JsonArray const& modifications)
+{
+    if (modifications.is_empty())
+        return {};
+
+    Optional<String> attribute_to_replace;
+    Vector<WebView::Attribute> replacement_attributes;
+
+    auto parse_modification = [&](JsonValue const& modification) -> Variant<Empty, String, WebView::Attribute> {
+        if (!modification.is_object())
+            return {};
+
+        auto name = modification.as_object().get_string("attributeName"sv);
+        if (!name.has_value())
+            return {};
+
+        auto value = modification.as_object().get_string("newValue"sv);
+        if (!value.has_value())
+            return *name;
+
+        return WebView::Attribute { *name, *value };
+    };
+
+    auto modification = parse_modification(modifications.at(0));
+    if (modification.has<Empty>())
+        return {};
+
+    modification.visit(
+        [&](String& name) { attribute_to_replace = move(name); },
+        [&](WebView::Attribute& attribute) { replacement_attributes.append(move(attribute)); },
+        [](Empty) { VERIFY_NOT_REACHED(); });
+
+    for (auto i = 1uz; i < modifications.size(); ++i) {
+        auto modification = parse_modification(modifications.at(i));
+
+        if (auto* attribute = modification.get_pointer<WebView::Attribute>())
+            replacement_attributes.empend(move(attribute->name), move(attribute->value));
+    }
+
+    return AttributeModification { move(attribute_to_replace), move(replacement_attributes) };
+}
 
 NodeIdentifier NodeIdentifier::for_node(JsonObject const& node)
 {
@@ -54,6 +103,40 @@ void NodeActor::handle_message(StringView type, JsonObject const& message)
             response.set("value"sv, dom_node->node.get_string("name"sv)->to_ascii_lowercase());
 
         send_message(move(response));
+        return;
+    }
+
+    if (type == "modifyAttributes"sv) {
+        auto modifications = message.get_array("modifications"sv);
+        if (!modifications.has_value()) {
+            send_missing_parameter_error("modifications"sv);
+            return;
+        }
+
+        auto [attribute_to_replace, replacement_attributes] = parse_attribute_modification(*modifications);
+        if (!attribute_to_replace.has_value() && replacement_attributes.is_empty())
+            return;
+
+        if (auto dom_node = WalkerActor::dom_node_for(m_walker, name()); dom_node.has_value()) {
+            auto block_token = block_responses();
+
+            auto on_complete = [weak_self = make_weak_ptr<NodeActor>(), block_token = move(block_token)](ErrorOr<Web::UniqueNodeID> node_id) mutable {
+                if (node_id.is_error()) {
+                    dbgln_if(DEVTOOLS_DEBUG, "Unable to edit DOM node: {}", node_id.error());
+                    return;
+                }
+
+                if (auto self = weak_self.strong_ref())
+                    self->finished_editing_dom_node(move(block_token));
+            };
+
+            if (attribute_to_replace.has_value()) {
+                devtools().delegate().replace_dom_node_attribute(dom_node->tab->description(), dom_node->identifier.id, attribute_to_replace.release_value(), move(replacement_attributes), move(on_complete));
+            } else {
+                devtools().delegate().add_dom_node_attributes(dom_node->tab->description(), dom_node->identifier.id, move(replacement_attributes), move(on_complete));
+            }
+        }
+
         return;
     }
 

--- a/Libraries/LibDevTools/Actors/NodeActor.cpp
+++ b/Libraries/LibDevTools/Actors/NodeActor.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/JsonObject.h>
 #include <LibDevTools/Actors/NodeActor.h>
+#include <LibDevTools/Actors/TabActor.h>
 #include <LibDevTools/Actors/WalkerActor.h>
 
 namespace DevTools {
@@ -29,10 +30,8 @@ void NodeActor::handle_message(StringView type, JsonObject const&)
     response.set("from"sv, name());
 
     if (type == "getUniqueSelector"sv) {
-        if (auto walker = m_walker.strong_ref()) {
-            if (auto const& dom_node = walker->dom_node(name()); dom_node.has_value())
-                response.set("value"sv, dom_node->node.get_string("name"sv)->to_ascii_lowercase());
-        }
+        if (auto dom_node = WalkerActor::dom_node_for(m_walker, name()); dom_node.has_value())
+            response.set("value"sv, dom_node->node.get_string("name"sv)->to_ascii_lowercase());
 
         send_message(move(response));
         return;

--- a/Libraries/LibDevTools/Actors/NodeActor.h
+++ b/Libraries/LibDevTools/Actors/NodeActor.h
@@ -8,20 +8,35 @@
 
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
+#include <LibWeb/CSS/Selector.h>
+#include <LibWeb/Forward.h>
 
 namespace DevTools {
+
+struct NodeIdentifier {
+    static NodeIdentifier for_node(JsonObject const& node);
+
+    bool operator==(NodeIdentifier const&) const = default;
+
+    Web::UniqueNodeID id { 0 };
+    Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element;
+};
 
 class NodeActor final : public Actor {
 public:
     static constexpr auto base_name = "node"sv;
 
-    static NonnullRefPtr<NodeActor> create(DevToolsServer&, String name, WeakPtr<WalkerActor>);
+    static NonnullRefPtr<NodeActor> create(DevToolsServer&, String name, NodeIdentifier, WeakPtr<WalkerActor>);
     virtual ~NodeActor() override;
 
     virtual void handle_message(StringView type, JsonObject const&) override;
 
+    NodeIdentifier const& node_identifier() const { return m_node_identifier; }
+
 private:
-    NodeActor(DevToolsServer&, String name, WeakPtr<WalkerActor>);
+    NodeActor(DevToolsServer&, String name, NodeIdentifier, WeakPtr<WalkerActor>);
+
+    NodeIdentifier m_node_identifier;
 
     WeakPtr<WalkerActor> m_walker;
 };

--- a/Libraries/LibDevTools/Actors/NodeActor.h
+++ b/Libraries/LibDevTools/Actors/NodeActor.h
@@ -36,6 +36,8 @@ public:
 private:
     NodeActor(DevToolsServer&, String name, NodeIdentifier, WeakPtr<WalkerActor>);
 
+    void finished_editing_dom_node(BlockToken);
+
     NodeIdentifier m_node_identifier;
 
     WeakPtr<WalkerActor> m_walker;

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -95,19 +95,14 @@ JsonValue PageStyleActor::serialize_style() const
 template<typename Callback>
 void PageStyleActor::inspect_dom_node(StringView node_actor, Callback&& callback)
 {
-    auto tab = InspectorActor::tab_for(m_inspector);
-    auto walker = InspectorActor::walker_for(m_inspector);
-    if (!tab || !walker)
-        return;
-
-    auto const& dom_node = walker->dom_node(node_actor);
+    auto dom_node = WalkerActor::dom_node_for(InspectorActor::walker_for(m_inspector), node_actor);
     if (!dom_node.has_value())
         return;
 
     auto block_token = block_responses();
 
     devtools().delegate().inspect_dom_node(
-        tab->description(), dom_node->id, dom_node->pseudo_element,
+        dom_node->tab->description(), dom_node->id, dom_node->pseudo_element,
         [weak_self = make_weak_ptr<PageStyleActor>(), block_token = move(block_token), callback = forward<Callback>(callback)](ErrorOr<DOMNodeProperties> properties) mutable {
             if (properties.is_error()) {
                 dbgln_if(DEVTOOLS_DEBUG, "Unable to inspect DOM node: {}", properties.error());

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -102,7 +102,7 @@ void PageStyleActor::inspect_dom_node(StringView node_actor, Callback&& callback
     auto block_token = block_responses();
 
     devtools().delegate().inspect_dom_node(
-        dom_node->tab->description(), dom_node->id, dom_node->pseudo_element,
+        dom_node->tab->description(), dom_node->identifier.id, dom_node->identifier.pseudo_element,
         [weak_self = make_weak_ptr<PageStyleActor>(), block_token = move(block_token), callback = forward<Callback>(callback)](ErrorOr<DOMNodeProperties> properties) mutable {
             if (properties.is_error()) {
                 dbgln_if(DEVTOOLS_DEBUG, "Unable to inspect DOM node: {}", properties.error());

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -249,8 +249,19 @@ JsonValue WalkerActor::serialize_node(JsonObject const& node) const
     return serialized;
 }
 
+Optional<WalkerActor::DOMNode> WalkerActor::dom_node_for(WeakPtr<WalkerActor> const& weak_walker, StringView actor)
+{
+    if (auto walker = weak_walker.strong_ref())
+        return walker->dom_node(actor);
+    return {};
+}
+
 Optional<WalkerActor::DOMNode> WalkerActor::dom_node(StringView actor)
 {
+    auto tab = m_tab.strong_ref();
+    if (!tab)
+        return {};
+
     auto maybe_dom_node = m_actor_to_dom_node_map.get(actor);
     if (!maybe_dom_node.has_value() || !maybe_dom_node.value())
         return {};
@@ -268,7 +279,7 @@ Optional<WalkerActor::DOMNode> WalkerActor::dom_node(StringView actor)
     else
         node_id = dom_node.get_integer<Web::UniqueNodeID::Type>("id"sv).value();
 
-    return DOMNode { .node = dom_node, .id = node_id, .pseudo_element = pseudo_element };
+    return DOMNode { .node = dom_node, .id = node_id, .pseudo_element = pseudo_element, .tab = tab.release_nonnull() };
 }
 
 Optional<JsonObject const&> WalkerActor::find_node_by_selector(JsonObject const& node, StringView selector)

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -13,6 +13,7 @@
 #include <LibDevTools/Actor.h>
 #include <LibDevTools/Actors/NodeActor.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/Forward.h>
 
 namespace DevTools {
 
@@ -42,6 +43,11 @@ private:
     JsonValue serialize_node(JsonObject const&) const;
     Optional<JsonObject const&> find_node_by_selector(JsonObject const& node, StringView selector);
 
+    void new_dom_node_mutation(WebView::Mutation);
+    JsonValue serialize_mutations();
+
+    bool replace_node_in_tree(JsonObject replacement);
+
     void populate_dom_tree_cache();
     void populate_dom_tree_cache(JsonObject& node, JsonObject const* parent);
 
@@ -51,6 +57,9 @@ private:
     WeakPtr<LayoutInspectorActor> m_layout_inspector;
 
     JsonObject m_dom_tree;
+
+    Vector<WebView::Mutation> m_dom_node_mutations;
+    bool m_has_new_mutations_since_last_mutations_request { false };
 
     HashMap<JsonObject const*, JsonObject const*> m_dom_node_to_parent_map;
     HashMap<String, JsonObject const*> m_actor_to_dom_node_map;

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -32,7 +32,9 @@ public:
         JsonObject const& node;
         Web::UniqueNodeID id { 0 };
         Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element;
+        NonnullRefPtr<TabActor> tab;
     };
+    static Optional<DOMNode> dom_node_for(WeakPtr<WalkerActor> const&, StringView actor);
     Optional<DOMNode> dom_node(StringView actor);
 
 private:

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -43,6 +43,10 @@ private:
     JsonValue serialize_node(JsonObject const&) const;
     Optional<JsonObject const&> find_node_by_selector(JsonObject const& node, StringView selector);
 
+    Optional<JsonObject const&> previous_sibling_for_node(JsonObject const& node);
+    Optional<JsonObject const&> next_sibling_for_node(JsonObject const& node);
+    Optional<JsonObject const&> remove_node(JsonObject const& node);
+
     void new_dom_node_mutation(WebView::Mutation);
     JsonValue serialize_mutations();
 

--- a/Libraries/LibDevTools/Actors/WalkerActor.h
+++ b/Libraries/LibDevTools/Actors/WalkerActor.h
@@ -11,7 +11,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <LibDevTools/Actor.h>
-#include <LibWeb/CSS/Selector.h>
+#include <LibDevTools/Actors/NodeActor.h>
 #include <LibWeb/Forward.h>
 
 namespace DevTools {
@@ -30,8 +30,7 @@ public:
 
     struct DOMNode {
         JsonObject const& node;
-        Web::UniqueNodeID id { 0 };
-        Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element;
+        NodeIdentifier identifier;
         NonnullRefPtr<TabActor> tab;
     };
     static Optional<DOMNode> dom_node_for(WeakPtr<WalkerActor> const&, StringView actor);
@@ -43,7 +42,10 @@ private:
     JsonValue serialize_node(JsonObject const&) const;
     Optional<JsonObject const&> find_node_by_selector(JsonObject const& node, StringView selector);
 
-    void populate_dom_tree_cache(JsonObject& node, JsonObject const* parent = nullptr);
+    void populate_dom_tree_cache();
+    void populate_dom_tree_cache(JsonObject& node, JsonObject const* parent);
+
+    NodeActor const& actor_for_node(JsonObject const& node);
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<LayoutInspectorActor> m_layout_inspector;
@@ -52,6 +54,7 @@ private:
 
     HashMap<JsonObject const*, JsonObject const*> m_dom_node_to_parent_map;
     HashMap<String, JsonObject const*> m_actor_to_dom_node_map;
+    HashMap<Web::UniqueNodeID, String> m_dom_node_id_to_actor_map;
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -46,6 +46,7 @@ public:
     virtual void set_dom_node_tag(TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const { }
     virtual void add_dom_node_attributes(TabDescription const&, Web::UniqueNodeID, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
     virtual void replace_dom_node_attribute(TabDescription const&, Web::UniqueNodeID, String, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
+    virtual void remove_dom_node(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
 
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void evaluate_javascript(TabDescription const&, String, OnScriptEvaluationComplete) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -43,6 +43,8 @@ public:
 
     using OnDOMNodeEditComplete = Function<void(ErrorOr<Web::UniqueNodeID>)>;
     virtual void set_dom_node_text(TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const { }
+    virtual void add_dom_node_attributes(TabDescription const&, Web::UniqueNodeID, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
+    virtual void replace_dom_node_attribute(TabDescription const&, Web::UniqueNodeID, String, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
 
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void evaluate_javascript(TabDescription const&, String, OnScriptEvaluationComplete) const { }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -41,6 +41,9 @@ public:
     virtual void listen_for_dom_mutations(TabDescription const&, OnDOMMutationReceived) const { }
     virtual void stop_listening_for_dom_mutations(TabDescription const&) const { }
 
+    using OnDOMNodeEditComplete = Function<void(ErrorOr<Web::UniqueNodeID>)>;
+    virtual void set_dom_node_text(TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const { }
+
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void evaluate_javascript(TabDescription const&, String, OnScriptEvaluationComplete) const { }
 

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -47,6 +47,7 @@ public:
     virtual void add_dom_node_attributes(TabDescription const&, Web::UniqueNodeID, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
     virtual void replace_dom_node_attribute(TabDescription const&, Web::UniqueNodeID, String, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
     virtual void create_child_element(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
+    virtual void clone_dom_node(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
     virtual void remove_dom_node(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
 
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -37,6 +37,10 @@ public:
     virtual void highlight_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const { }
     virtual void clear_highlighted_dom_node(TabDescription const&) const { }
 
+    using OnDOMMutationReceived = Function<void(WebView::Mutation)>;
+    virtual void listen_for_dom_mutations(TabDescription const&, OnDOMMutationReceived) const { }
+    virtual void stop_listening_for_dom_mutations(TabDescription const&) const { }
+
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void evaluate_javascript(TabDescription const&, String, OnScriptEvaluationComplete) const { }
 

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -43,6 +43,7 @@ public:
 
     using OnDOMNodeEditComplete = Function<void(ErrorOr<Web::UniqueNodeID>)>;
     virtual void set_dom_node_text(TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const { }
+    virtual void set_dom_node_tag(TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const { }
     virtual void add_dom_node_attributes(TabDescription const&, Web::UniqueNodeID, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
     virtual void replace_dom_node_attribute(TabDescription const&, Web::UniqueNodeID, String, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
 

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -46,6 +46,7 @@ public:
     virtual void set_dom_node_tag(TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const { }
     virtual void add_dom_node_attributes(TabDescription const&, Web::UniqueNodeID, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
     virtual void replace_dom_node_attribute(TabDescription const&, Web::UniqueNodeID, String, Vector<WebView::Attribute>, OnDOMNodeEditComplete) const { }
+    virtual void create_child_element(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
     virtual void remove_dom_node(TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const { }
 
     using OnScriptEvaluationComplete = Function<void(ErrorOr<JsonValue>)>;

--- a/Libraries/LibWeb/DOM/Node.cpp
+++ b/Libraries/LibWeb/DOM/Node.cpp
@@ -2292,7 +2292,7 @@ void Node::queue_mutation_record(FlyString const& type, Optional<FlyString> cons
             string_attribute_name = attribute_name->to_string();
         Optional<String> string_attribute_namespace;
         if (attribute_namespace.has_value())
-            string_attribute_name = attribute_namespace->to_string();
+            string_attribute_namespace = attribute_namespace->to_string();
 
         // 1. Let record be a new MutationRecord object with its type set to type, target set to target, attributeName set to name, attributeNamespace set to namespace, oldValue set to mappedOldValue,
         //    addedNodes set to addedNodes, removedNodes set to removedNodes, previousSibling set to previousSibling, and nextSibling set to nextSibling.

--- a/Libraries/LibWeb/DOM/Node.h
+++ b/Libraries/LibWeb/DOM/Node.h
@@ -355,7 +355,7 @@ public:
 
     void add_registered_observer(RegisteredObserver&);
 
-    void queue_mutation_record(FlyString const& type, Optional<FlyString> const& attribute_name, Optional<FlyString> const& attribute_namespace, Optional<String> const& old_value, Vector<GC::Root<Node>> added_nodes, Vector<GC::Root<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling) const;
+    void queue_mutation_record(FlyString const& type, Optional<FlyString> const& attribute_name, Optional<FlyString> const& attribute_namespace, Optional<String> const& old_value, Vector<GC::Root<Node>> added_nodes, Vector<GC::Root<Node>> removed_nodes, Node* previous_sibling, Node* next_sibling);
 
     // https://dom.spec.whatwg.org/#concept-shadow-including-inclusive-descendant
     template<typename Callback>

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -222,6 +222,9 @@ public:
     FindInPageResult find_in_page_previous_match();
     Optional<FindInPageQuery> last_find_in_page_query() const { return m_last_find_in_page_query; }
 
+    bool listen_for_dom_mutations() const { return m_listen_for_dom_mutations; }
+    void set_listen_for_dom_mutations(bool listen_for_dom_mutations) { m_listen_for_dom_mutations = listen_for_dom_mutations; }
+
 private:
     explicit Page(GC::Ref<PageClient>);
     virtual void visit_edges(Visitor&) override;
@@ -287,9 +290,12 @@ private:
     // Spec Note: This value also impacts the navigation processing model.
     // FIXME: Actually support pdf viewing
     bool m_pdf_viewer_supported { false };
+
     size_t m_find_in_page_match_index { 0 };
     Optional<FindInPageQuery> m_last_find_in_page_query;
     URL::URL m_last_find_in_page_url;
+
+    bool m_listen_for_dom_mutations { false };
 };
 
 struct PaintOptions {
@@ -396,6 +402,8 @@ public:
     virtual void page_did_change_audio_play_state(HTML::AudioPlayState) { }
 
     virtual IPC::File request_worker_agent() { return IPC::File {}; }
+
+    virtual void page_did_mutate_dom([[maybe_unused]] FlyString const& type, [[maybe_unused]] DOM::Node const& target, [[maybe_unused]] DOM::NodeList& added_nodes, [[maybe_unused]] DOM::NodeList& removed_nodes, [[maybe_unused]] GC::Ptr<DOM::Node> previous_sibling, [[maybe_unused]] GC::Ptr<DOM::Node> next_sibling, [[maybe_unused]] Optional<String> const& attribute_name) { }
 
     virtual void inspector_did_load() { }
     virtual void inspector_did_select_dom_node([[maybe_unused]] UniqueNodeID node_id, [[maybe_unused]] Optional<CSS::Selector::PseudoElement::Type> const& pseudo_element) { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -493,6 +493,13 @@ void Application::create_child_element(DevTools::TabDescription const& descripti
     });
 }
 
+void Application::clone_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, OnDOMNodeEditComplete on_complete) const
+{
+    edit_dom_node(description, move(on_complete), [&](auto& view) {
+        view.clone_dom_node(node_id);
+    });
+}
+
 void Application::remove_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, OnDOMNodeEditComplete on_complete) const
 {
     edit_dom_node(description, move(on_complete), [&](auto& view) {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -465,6 +465,20 @@ void Application::set_dom_node_text(DevTools::TabDescription const& description,
     });
 }
 
+void Application::add_dom_node_attributes(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, Vector<Attribute> replacement_attributes, OnDOMNodeEditComplete on_complete) const
+{
+    edit_dom_node(description, move(on_complete), [&](auto& view) {
+        view.add_dom_node_attributes(node_id, move(replacement_attributes));
+    });
+}
+
+void Application::replace_dom_node_attribute(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, String name, Vector<Attribute> replacement_attributes, OnDOMNodeEditComplete on_complete) const
+{
+    edit_dom_node(description, move(on_complete), [&](auto& view) {
+        view.replace_dom_node_attribute(node_id, move(name), move(replacement_attributes));
+    });
+}
+
 void Application::evaluate_javascript(DevTools::TabDescription const& description, String script, OnScriptEvaluationComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -465,6 +465,13 @@ void Application::set_dom_node_text(DevTools::TabDescription const& description,
     });
 }
 
+void Application::set_dom_node_tag(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, String value, OnDOMNodeEditComplete on_complete) const
+{
+    edit_dom_node(description, move(on_complete), [&](auto& view) {
+        view.set_dom_node_tag(node_id, move(value));
+    });
+}
+
 void Application::add_dom_node_attributes(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, Vector<Attribute> replacement_attributes, OnDOMNodeEditComplete on_complete) const
 {
     edit_dom_node(description, move(on_complete), [&](auto& view) {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -417,6 +417,26 @@ void Application::clear_highlighted_dom_node(DevTools::TabDescription const& des
         view->clear_highlighted_dom_node();
 }
 
+void Application::listen_for_dom_mutations(DevTools::TabDescription const& description, OnDOMMutationReceived on_dom_mutation_received) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->on_dom_mutation_received = move(on_dom_mutation_received);
+    view->set_listen_for_dom_mutations(true);
+}
+
+void Application::stop_listening_for_dom_mutations(DevTools::TabDescription const& description) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->on_dom_mutation_received = nullptr;
+    view->set_listen_for_dom_mutations(false);
+}
+
 void Application::evaluate_javascript(DevTools::TabDescription const& description, String script, OnScriptEvaluationComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -486,6 +486,13 @@ void Application::replace_dom_node_attribute(DevTools::TabDescription const& des
     });
 }
 
+void Application::create_child_element(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, OnDOMNodeEditComplete on_complete) const
+{
+    edit_dom_node(description, move(on_complete), [&](auto& view) {
+        view.create_child_element(node_id);
+    });
+}
+
 void Application::remove_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, OnDOMNodeEditComplete on_complete) const
 {
     edit_dom_node(description, move(on_complete), [&](auto& view) {

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -486,6 +486,13 @@ void Application::replace_dom_node_attribute(DevTools::TabDescription const& des
     });
 }
 
+void Application::remove_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, OnDOMNodeEditComplete on_complete) const
+{
+    edit_dom_node(description, move(on_complete), [&](auto& view) {
+        view.remove_dom_node(node_id);
+    });
+}
+
 void Application::evaluate_javascript(DevTools::TabDescription const& description, String script, OnScriptEvaluationComplete on_complete) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -98,6 +98,7 @@ private:
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override;
     virtual void listen_for_dom_mutations(DevTools::TabDescription const&, OnDOMMutationReceived) const override;
     virtual void stop_listening_for_dom_mutations(DevTools::TabDescription const&) const override;
+    virtual void set_dom_node_text(DevTools::TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;
     virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -103,6 +103,7 @@ private:
     virtual void add_dom_node_attributes(DevTools::TabDescription const&, Web::UniqueNodeID, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void replace_dom_node_attribute(DevTools::TabDescription const&, Web::UniqueNodeID, String, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void create_child_element(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const override;
+    virtual void clone_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const override;
     virtual void remove_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -99,6 +99,8 @@ private:
     virtual void listen_for_dom_mutations(DevTools::TabDescription const&, OnDOMMutationReceived) const override;
     virtual void stop_listening_for_dom_mutations(DevTools::TabDescription const&) const override;
     virtual void set_dom_node_text(DevTools::TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const override;
+    virtual void add_dom_node_attributes(DevTools::TabDescription const&, Web::UniqueNodeID, Vector<Attribute>, OnDOMNodeEditComplete) const override;
+    virtual void replace_dom_node_attribute(DevTools::TabDescription const&, Web::UniqueNodeID, String, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;
     virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -102,6 +102,7 @@ private:
     virtual void set_dom_node_tag(DevTools::TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const override;
     virtual void add_dom_node_attributes(DevTools::TabDescription const&, Web::UniqueNodeID, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void replace_dom_node_attribute(DevTools::TabDescription const&, Web::UniqueNodeID, String, Vector<Attribute>, OnDOMNodeEditComplete) const override;
+    virtual void remove_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;
     virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -102,6 +102,7 @@ private:
     virtual void set_dom_node_tag(DevTools::TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const override;
     virtual void add_dom_node_attributes(DevTools::TabDescription const&, Web::UniqueNodeID, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void replace_dom_node_attribute(DevTools::TabDescription const&, Web::UniqueNodeID, String, Vector<Attribute>, OnDOMNodeEditComplete) const override;
+    virtual void create_child_element(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const override;
     virtual void remove_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, OnDOMNodeEditComplete) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -99,6 +99,7 @@ private:
     virtual void listen_for_dom_mutations(DevTools::TabDescription const&, OnDOMMutationReceived) const override;
     virtual void stop_listening_for_dom_mutations(DevTools::TabDescription const&) const override;
     virtual void set_dom_node_text(DevTools::TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const override;
+    virtual void set_dom_node_tag(DevTools::TabDescription const&, Web::UniqueNodeID, String, OnDOMNodeEditComplete) const override;
     virtual void add_dom_node_attributes(DevTools::TabDescription const&, Web::UniqueNodeID, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void replace_dom_node_attribute(DevTools::TabDescription const&, Web::UniqueNodeID, String, Vector<Attribute>, OnDOMNodeEditComplete) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -96,6 +96,8 @@ private:
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override;
     virtual void highlight_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const override;
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override;
+    virtual void listen_for_dom_mutations(DevTools::TabDescription const&, OnDOMMutationReceived) const override;
+    virtual void stop_listening_for_dom_mutations(DevTools::TabDescription const&) const override;
     virtual void evaluate_javascript(DevTools::TabDescription const&, String, OnScriptEvaluationComplete) const override;
     virtual void listen_for_console_messages(DevTools::TabDescription const&, OnConsoleMessageAvailable, OnReceivedConsoleMessages) const override;
     virtual void stop_listening_for_console_messages(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     Database.cpp
     HelperProcess.cpp
     InspectorClient.cpp
+    Mutation.cpp
     Plugins/FontPlugin.cpp
     Plugins/ImageCodecPlugin.cpp
     Process.cpp

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -21,6 +21,7 @@ class WebContentClient;
 struct Attribute;
 struct ConsoleOutput;
 struct CookieStorageKey;
+struct Mutation;
 struct ProcessHandle;
 struct SearchEngine;
 

--- a/Libraries/LibWebView/Mutation.cpp
+++ b/Libraries/LibWebView/Mutation.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/Mutation.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::AttributeMutation const& mutation)
+{
+    TRY(encoder.encode(mutation.attribute_name));
+    TRY(encoder.encode(mutation.new_value));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::AttributeMutation> IPC::decode(Decoder& decoder)
+{
+    auto attribute_name = TRY(decoder.decode<String>());
+    auto new_value = TRY(decoder.decode<Optional<String>>());
+
+    return WebView::AttributeMutation { move(attribute_name), move(new_value) };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::CharacterDataMutation const& mutation)
+{
+    TRY(encoder.encode(mutation.new_value));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::CharacterDataMutation> IPC::decode(Decoder& decoder)
+{
+    auto new_value = TRY(decoder.decode<String>());
+
+    return WebView::CharacterDataMutation { move(new_value) };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::ChildListMutation const& mutation)
+{
+    TRY(encoder.encode(mutation.added));
+    TRY(encoder.encode(mutation.removed));
+    TRY(encoder.encode(mutation.target_child_count));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::ChildListMutation> IPC::decode(Decoder& decoder)
+{
+    auto added = TRY(decoder.decode<Vector<Web::UniqueNodeID>>());
+    auto removed = TRY(decoder.decode<Vector<Web::UniqueNodeID>>());
+    auto target_child_count = TRY(decoder.decode<size_t>());
+
+    return WebView::ChildListMutation { move(added), move(removed), target_child_count };
+}
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::Mutation const& mutation)
+{
+    TRY(encoder.encode(mutation.type));
+    TRY(encoder.encode(mutation.target));
+    TRY(encoder.encode(mutation.serialized_target));
+    TRY(encoder.encode(mutation.mutation));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::Mutation> IPC::decode(Decoder& decoder)
+{
+    auto type = TRY(decoder.decode<String>());
+    auto target = TRY(decoder.decode<Web::UniqueNodeID>());
+    auto serialized_target = TRY(decoder.decode<String>());
+    auto mutation = TRY(decoder.decode<WebView::Mutation::Type>());
+
+    return WebView::Mutation { move(type), target, move(serialized_target), move(mutation) };
+}

--- a/Libraries/LibWebView/Mutation.h
+++ b/Libraries/LibWebView/Mutation.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibIPC/Forward.h>
+#include <LibWeb/Forward.h>
+
+namespace WebView {
+
+struct AttributeMutation {
+    String attribute_name;
+    Optional<String> new_value;
+};
+
+struct CharacterDataMutation {
+    String new_value;
+};
+
+struct ChildListMutation {
+    Vector<Web::UniqueNodeID> added;
+    Vector<Web::UniqueNodeID> removed;
+    size_t target_child_count { 0 };
+};
+
+struct Mutation {
+    using Type = Variant<AttributeMutation, CharacterDataMutation, ChildListMutation>;
+
+    String type;
+    Web::UniqueNodeID target { 0 };
+    String serialized_target;
+    Type mutation;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::AttributeMutation const&);
+
+template<>
+ErrorOr<WebView::AttributeMutation> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::CharacterDataMutation const&);
+
+template<>
+ErrorOr<WebView::CharacterDataMutation> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::ChildListMutation const&);
+
+template<>
+ErrorOr<WebView::ChildListMutation> decode(Decoder&);
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::Mutation const&);
+
+template<>
+ErrorOr<WebView::Mutation> decode(Decoder&);
+
+}

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -333,6 +333,11 @@ void ViewImplementation::clear_highlighted_dom_node()
     highlight_dom_node(0, {});
 }
 
+void ViewImplementation::set_listen_for_dom_mutations(bool listen_for_dom_mutations)
+{
+    client().async_set_listen_for_dom_mutations(page_id(), listen_for_dom_mutations);
+}
+
 void ViewImplementation::set_dom_node_text(Web::UniqueNodeID node_id, String text)
 {
     client().async_set_dom_node_text(page_id(), node_id, move(text));

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -112,6 +112,7 @@ public:
     void highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);
     void clear_highlighted_dom_node();
 
+    void set_listen_for_dom_mutations(bool);
     void set_dom_node_text(Web::UniqueNodeID node_id, String text);
     void set_dom_node_tag(Web::UniqueNodeID node_id, String name);
     void add_dom_node_attributes(Web::UniqueNodeID node_id, Vector<Attribute> attributes);
@@ -213,6 +214,7 @@ public:
     Function<void(Web::CSS::StyleSheetIdentifier const&)> on_inspector_requested_style_sheet_source;
     Function<void(Web::CSS::StyleSheetIdentifier const&, URL::URL const&, String const&)> on_received_style_sheet_source;
     Function<void(Web::UniqueNodeID)> on_received_hovered_node_id;
+    Function<void(Mutation)> on_dom_mutation_received;
     Function<void(Optional<Web::UniqueNodeID> const& node_id)> on_finshed_editing_dom_node;
     Function<void(String const&)> on_received_dom_node_html;
     Function<void(JsonValue)> on_received_js_console_result;

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -341,6 +341,14 @@ void WebContentClient::did_finish_editing_dom_node(u64 page_id, Optional<Web::Un
     }
 }
 
+void WebContentClient::did_mutate_dom(u64 page_id, Mutation const& mutation)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value()) {
+        if (view->on_dom_mutation_received)
+            view->on_dom_mutation_received(move(const_cast<Mutation&>(mutation)));
+    }
+}
+
 void WebContentClient::did_get_dom_node_html(u64 page_id, String const& html)
 {
     if (auto view = view_for_page_id(page_id); view.has_value()) {

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -76,6 +76,7 @@ private:
     virtual void did_inspect_accessibility_tree(u64 page_id, String const&) override;
     virtual void did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID const& node_id) override;
     virtual void did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> const& node_id) override;
+    virtual void did_mutate_dom(u64 page_id, Mutation const&) override;
     virtual void did_get_dom_node_html(u64 page_id, String const& html) override;
     virtual void did_take_screenshot(u64 page_id, Gfx::ShareableBitmap const& screenshot) override;
     virtual void did_get_internal_page_info(u64 page_id, PageInfoType, String const&) override;

--- a/Services/WebContent/ConnectionFromClient.cpp
+++ b/Services/WebContent/ConnectionFromClient.cpp
@@ -663,6 +663,15 @@ void ConnectionFromClient::request_style_sheet_source(u64 page_id, Web::CSS::Sty
     }
 }
 
+void ConnectionFromClient::set_listen_for_dom_mutations(u64 page_id, bool listen_for_dom_mutations)
+{
+    auto page = this->page(page_id);
+    if (!page.has_value())
+        return;
+
+    page->page().set_listen_for_dom_mutations(listen_for_dom_mutations);
+}
+
 void ConnectionFromClient::set_dom_node_text(u64 page_id, Web::UniqueNodeID const& node_id, String const& text)
 {
     auto* dom_node = Web::DOM::Node::from_unique_id(node_id);

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -83,6 +83,7 @@ private:
     virtual void list_style_sheets(u64 page_id) override;
     virtual void request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier const& identifier) override;
 
+    virtual void set_listen_for_dom_mutations(u64 page_id, bool) override;
     virtual void set_dom_node_text(u64 page_id, Web::UniqueNodeID const& node_id, String const& text) override;
     virtual void set_dom_node_tag(u64 page_id, Web::UniqueNodeID const& node_id, String const& name) override;
     virtual void add_dom_node_attributes(u64 page_id, Web::UniqueNodeID const& node_id, Vector<WebView::Attribute> const& attributes) override;

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -173,6 +173,7 @@ private:
     virtual void page_did_change_audio_play_state(Web::HTML::AudioPlayState) override;
     virtual void page_did_allocate_backing_stores(i32 front_bitmap_id, Gfx::ShareableBitmap front_bitmap, i32 back_bitmap_id, Gfx::ShareableBitmap back_bitmap) override;
     virtual IPC::File request_worker_agent() override;
+    virtual void page_did_mutate_dom(FlyString const& type, Web::DOM::Node const& target, Web::DOM::NodeList& added_nodes, Web::DOM::NodeList& removed_nodes, GC::Ptr<Web::DOM::Node> previous_sibling, GC::Ptr<Web::DOM::Node> next_sibling, Optional<String> const& attribute_name) override;
     virtual void inspector_did_load() override;
     virtual void inspector_did_select_dom_node(Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type> const& pseudo_element) override;
     virtual void inspector_did_set_dom_node_text(Web::UniqueNodeID, String const& text) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -17,6 +17,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ConsoleOutput.h>
+#include <LibWebView/Mutation.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/ProcessHandle.h>
 
@@ -54,6 +55,7 @@ endpoint WebContentClient
     did_inspect_accessibility_tree(u64 page_id, String accessibility_tree) =|
     did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) =|
     did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) =|
+    did_mutate_dom(u64 page_id, WebView::Mutation mutation) =|
     did_get_dom_node_html(u64 page_id, String html) =|
 
     inspector_did_list_style_sheets(u64 page_id, Vector<Web::CSS::StyleSheetIdentifier> style_sheets) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -56,6 +56,7 @@ endpoint WebContentServer
     list_style_sheets(u64 page_id) =|
     request_style_sheet_source(u64 page_id, Web::CSS::StyleSheetIdentifier identifier) =|
 
+    set_listen_for_dom_mutations(u64 page_id, bool listen_for_dom_mutations) =|
     set_dom_node_text(u64 page_id, Web::UniqueNodeID node_id, String text) =|
     set_dom_node_tag(u64 page_id, Web::UniqueNodeID node_id, String name) =|
     add_dom_node_attributes(u64 page_id, Web::UniqueNodeID node_id, Vector<WebView::Attribute> attributes) =|


### PR DESCRIPTION
This first implements propagating DOM mutations from WebContent to LibDevTools. The DevTools protocol for mutations more or less mimics the `MutationObserver` API exactly.

Then this implements a handful of DOM editing requests.


https://github.com/user-attachments/assets/53456d68-82de-4a4d-af58-88b9524678f7

Yes, this is peak web design 🙃 