### PR TITLE
LibWeb: Make binary search find values in cahce, preventing a crash.

### DIFF
--- a/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/EasingStyleValue.cpp
@@ -279,9 +279,9 @@ double EasingStyleValue::CubicBezier::evaluate_at(double input_progress, bool) c
 
     size_t nearby_index = 0;
     if (auto found = binary_search(m_cached_x_samples, x, &nearby_index, [](auto x, auto& sample) {
-            if (x - sample.x >= NumericLimits<double>::epsilon())
+            if (x - sample.x > NumericLimits<double>::epsilon())
                 return 1;
-            if (x - sample.x <= NumericLimits<double>::epsilon())
+            if (x - sample.x < -NumericLimits<double>::epsilon())
                 return -1;
             return 0;
         }))
@@ -299,9 +299,9 @@ double EasingStyleValue::CubicBezier::evaluate_at(double input_progress, bool) c
         }
 
         if (auto found = binary_search(m_cached_x_samples, x, &nearby_index, [](auto x, auto& sample) {
-                if (x - sample.x >= NumericLimits<double>::epsilon())
+                if (x - sample.x > NumericLimits<double>::epsilon())
                     return 1;
-                if (x - sample.x <= NumericLimits<double>::epsilon())
+                if (x - sample.x < -NumericLimits<double>::epsilon())
                     return -1;
                 return 0;
             }))


### PR DESCRIPTION
Comparisons in the binary searches which look for cached cubic bezier curve values were incorrecly comparing against epsilon.

This patch allows the binary searches to find exact matches, which prevents a crash when the animation is set to play backwards.

This fixes the bug shown in #3628, wherein the page will crash if an animation with a cubic bezier curve easing function has animation-direction: reverse;