### PR TITLE
LibWeb: Don't drop layout tree in CSS animation invalidation

### DIFF
--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -963,8 +963,15 @@ void KeyframeEffect::update_computed_properties()
 
     if (invalidation.relayout)
         target->set_needs_layout_update(DOM::SetNeedsLayoutReason::KeyframeEffect);
-    if (invalidation.rebuild_layout_tree)
-        document.invalidate_layout_tree(DOM::InvalidateLayoutTreeReason::KeyframeEffect);
+    if (invalidation.rebuild_layout_tree) {
+        // We mark layout tree for rebuild starting from parent element to correctly invalidate
+        // "display" property change to/from "contents" value.
+        if (auto* parent_element = target->parent_element()) {
+            parent_element->set_needs_layout_tree_update(true);
+        } else {
+            target->set_needs_layout_tree_update(true);
+        }
+    }
     if (invalidation.repaint) {
         document.set_needs_display();
         document.set_needs_to_resolve_paint_only_properties();

--- a/Libraries/LibWeb/Animations/KeyframeEffect.cpp
+++ b/Libraries/LibWeb/Animations/KeyframeEffect.cpp
@@ -923,6 +923,13 @@ void KeyframeEffect::update_computed_properties()
     if (!target || !target->is_connected())
         return;
 
+    if (target->has_inclusive_ancestor_with_display_none()) {
+        // FIXME: Reaching this point means we failed to cancel animation for an element that started
+        //        being nested in "display: none".
+        //        For now this hack is needed to avoid lots of unnecessary work.
+        return;
+    }
+
     GC::Ptr<CSS::ComputedProperties> style = {};
     if (!pseudo_element_type().has_value())
         style = target->computed_properties();

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -55,7 +55,6 @@ enum class QuirksMode {
     X(DocumentRequestAnElementToBeRemovedFromTheTopLayer) \
     X(HTMLInputElementSrcAttributeChange)                 \
     X(HTMLObjectElement)                                  \
-    X(KeyframeEffect)                                     \
     X(SVGGraphicsElementTransformAttributeChange)         \
     X(ShadowRootSetInnerHTML)
 


### PR DESCRIPTION
It's possible to do a partial tree rebuild instead.