### PR TITLE
Tests: Add a bunch of input-element tests (tests only, no code)

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/date.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/date.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 6 tests
+
+6 Pass
+Pass	date type support on input element
+Pass	The value attribute, if specified and not empty, must have a value that is a valid date string.
+Pass	The min attribute must be reflected verbatim by the min property.
+Pass	The max attribute must be reflected verbatim by the max property.
+Pass	User agents must not allow the user to set the value to a non-empty string that is not a valid date string.
+Pass	Number of days

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime-local-trailing-zeros.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime-local-trailing-zeros.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Fail
+Fail	Verifies that trailing zeros in the milliseconds portion of the date strings are removed.

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime-local.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime-local.txt
@@ -1,0 +1,23 @@
+Harness status: OK
+
+Found 17 tests
+
+16 Pass
+1 Fail
+Pass	empty value
+Pass	datetime-local input value set to 2014-01-01T11:11:11.111 without min/max
+Pass	datetime-local input value set to 2014-01-01 11:11:11.111 without min/max
+Pass	datetime-local input value set to 2014-01-01 11:11 without min/max
+Fail	datetime-local input value set to 2014-01-01 00:00:00.000 without min/max
+Pass	datetime-local input value set to 2014-01-0 11:11 without min/max
+Pass	datetime-local input value set to 2014-01-01 11:1 without min/max
+Pass	invalid datetime-local input value 1
+Pass	invalid datetime-local input value 2
+Pass	invalid datetime-local input value 3
+Pass	invalid datetime-local input value 4
+Pass	invalid datetime-local input value 5
+Pass	invalid datetime-local input value 6
+Pass	Value >= min attribute
+Pass	Value < min attribute
+Pass	Value <= max attribute
+Pass	Value > max attribute

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime-weekmonth.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime-weekmonth.txt
@@ -1,0 +1,19 @@
+Harness status: OK
+
+Found 14 tests
+
+14 Pass
+Pass	month type support on input element
+Pass	[month] The value must be a value that is a valid global date and time string
+Pass	[month] The min attribute must have a value that is a valid global date and time string
+Pass	[month] The max attribute must have a value that is a valid global date and time string
+Pass	[month] The step attribute must be expressed in seconds
+Pass	[month] stepUp method support on input 'month' element
+Pass	[month] stepDown method support on input 'month' element
+Pass	week type support on input element
+Pass	[week] The value must be a value that is a valid global date and time string
+Pass	[week] The min attribute must have a value that is a valid global date and time string
+Pass	[week] The max attribute must have a value that is a valid global date and time string
+Pass	[week] The step attribute must be expressed in seconds
+Pass	[week] stepUp method support on input 'week' element
+Pass	[week] stepDown method support on input 'week' element

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/datetime.txt
@@ -1,0 +1,26 @@
+Harness status: OK
+
+Found 21 tests
+
+21 Pass
+Pass	date type support on input element
+Pass	[date] The value must be a valid global date and time string
+Pass	[date] The min attribute must have a value that is a valid global date and time string
+Pass	[date] The max attribute must have a value that is a valid global date and time string
+Pass	[date] The step attribute must be expressed in seconds
+Pass	[date] stepUp method support on input 'date' element
+Pass	[date] stepDown method support on input 'date' element
+Pass	[time] time type support on input element
+Pass	[time] The value must be a valid global date and time string
+Pass	[time] The min attribute must have a value that is a valid global date and time string
+Pass	[time] The max attribute must have a value that is a valid global date and time string
+Pass	[time] The step attribute must be expressed in seconds
+Pass	[time] stepUp method support on input 'time' element
+Pass	[time] stepDown method support on input 'time' element
+Pass	datetime-local type support on input element
+Pass	[datetime-local] The must be a valid local date and time string
+Pass	[datetime-local] The min attribute must have a value that is a valid local date and time string
+Pass	[datetime-local] The max attribute must have a value that is a valid local date and time string
+Pass	[datetime-local] The step attribute must be expressed in seconds
+Pass	[datetime-local] stepUp method support on input 'datetime-local' element
+Pass	[datetime-local] stepDown method support on input 'datetime-local' element

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/email.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/email.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 8 tests
+
+5 Pass
+3 Fail
+Pass	single_email doesn't have the multiple attribute
+Pass	value should be sanitized: strip line breaks
+Pass	Email address validity
+Fail	When the multiple attribute is removed, the user agent must run the value sanitization algorithm
+Pass	multiple_email has the multiple attribute
+Fail	run the value sanitization algorithm after setting a new value
+Pass	valid value is a set of valid email addresses separated by a single ','
+Fail	When the multiple attribute is set, the user agent must run the value sanitization algorithm

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/files.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/files.txt
@@ -1,0 +1,30 @@
+Harness status: OK
+
+Found 24 tests
+
+23 Pass
+1 Fail
+Pass	files for input type=hidden
+Pass	files for input type=text
+Pass	files for input type=search
+Pass	files for input type=tel
+Pass	files for input type=url
+Pass	files for input type=email
+Pass	files for input type=password
+Pass	files for input type=date
+Pass	files for input type=month
+Pass	files for input type=week
+Pass	files for input type=time
+Pass	files for input type=datetime-local
+Pass	files for input type=number
+Pass	files for input type=range
+Pass	files for input type=color
+Pass	files for input type=checkbox
+Pass	files for input type=radio
+Pass	files for input type=submit
+Pass	files for input type=image
+Pass	files for input type=reset
+Pass	files for input type=button
+Pass	files for input type=file
+Pass	setting <input type=file>.files
+Fail	setting <input type=file>.files from DataTransfer

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/input-stepdown-02.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/input-stepdown-02.txt
@@ -1,0 +1,12 @@
+Harness status: OK
+
+Found 6 tests
+
+5 Pass
+1 Fail
+Pass	stepDown() on input with no initial or min values
+Fail	stepDown() on input with no initial value and positive min value
+Pass	stepDown() on input with no initial value and negative min value
+Pass	stepDown() on input with initial value equal to min value
+Pass	stepDown() on input with initial value less than min value
+Pass	stepDown() on input with initial value greater than min value

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/number.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/number.txt
@@ -1,0 +1,38 @@
+Harness status: OK
+
+Found 33 tests
+
+33 Pass
+Pass	empty value
+Pass	value = 11
+Pass	value = 11.12
+Pass	value = -11111
+Pass	value = -11111.123
+Pass	value = 1e2
+Pass	value = 1E2
+Pass	value = 1e+2
+Pass	value = 1e-2
+Pass	value is not a valid floating-point number: 1d+2
+Pass	value not a valid floating-point number: random string
+Pass	Value >= min attribute
+Pass	Value < min attribute
+Pass	Value <= max attribute
+Pass	Value > max attribute
+Pass	value with a leading '.'
+Pass	value ending with '.'
+Pass	value = -0
+Pass	 value = Infinity
+Pass	value = -Infinity
+Pass	value = NaN
+Pass	value = 2^53+1
+Pass	value >= Number.MAX_VALUE
+Pass	value = 1e
+Pass	value = +1
+Pass	value = '+'
+Pass	value = '-'
+Pass	value with a leading tab
+Pass	value with a leading newline
+Pass	value with a leading form feed
+Pass	value with a leading carriage return
+Pass	value with a leading space
+Pass	value = 1trailing junk

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/password.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/password.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	Value returns the current value for password
+Pass	Setting value changes the current value for password, but not the value content attribute
+Pass	Value sanitization algorithm should strip line breaks for password
+Pass	sanitization algorithm doesn't strip leading and trailing whitespaces
+Pass	sanitization algorithm strips line breaks

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/range.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/range.txt
@@ -1,0 +1,31 @@
+Harness status: OK
+
+Found 25 tests
+
+15 Pass
+10 Fail
+Pass	range type support on input element
+Pass	range overflow styles
+Pass	min attribute support on input element
+Pass	max attribute support on input element
+Pass	Illegal value of min attribute
+Pass	Illegal value of max attribute
+Fail	Converting an illegal string to the default value
+Pass	Illegal value of step attribute
+Fail	the value is set to min when a smaller value than min attribute is given
+Fail	the value is set to max when a larger value than max attribute is given
+Pass	default value of min attribute in input type=range
+Pass	default value of max attribute in input type=range
+Fail	default value when min and max attributes are given (= min plus half the difference between min and max)
+Fail	default value with step control when both min and max attributes are given
+Fail	default value when both min and max attributes are given, while min > max
+Fail	The default step scale factor is 1, unless min attribute has non-integer value
+Fail	Step scale factor behavior when min attribute has integer value but max attribute is non-integer 
+Fail	Solving the step mismatch
+Pass	Performing stepUp()
+Pass	Performing stepDown()
+Fail	Performing stepUp() beyond the value of the max attribute
+Pass	Performing stepDown() beyond the value of the min attribute
+Pass	Input should be reset to the default value when value attribute has whitespace
+Pass	Multiply value by ten raised to the exponentth power with `e`
+Pass	Multiply value by ten raised to the exponentth power with `E`

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/required_attribute.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/required_attribute.txt
@@ -1,0 +1,6 @@
+Harness status: OK
+
+Found 1 tests
+
+1 Pass
+Pass	required attribute support on input element

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/time.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/time.txt
@@ -1,0 +1,38 @@
+Harness status: OK
+
+Found 32 tests
+
+30 Pass
+2 Fail
+Pass	time element of default time value
+Pass	step attribute on default value check
+Pass	max  attribute on default value check
+Pass	min  attribute on default value check
+Pass	type attribute support on input element
+Pass	max attribute support on input element
+Pass	min attribute support on input element
+Pass	step attribute support on input element
+Pass	stepUp function support on input Element
+Pass	stepDown function support on input Element
+Pass	stepUp step value empty on default step value 
+Pass	stepDown step value empty default step value
+Pass	stepUp on step value minus
+Pass	stepDown on step value minus
+Pass	stepUp on step value zero 
+Pass	stepDown on step value zero 
+Pass	stepUp on step value 24 hour
+Pass	stepDown on step value 24 hour 
+Pass	stepUp on step value hour  
+Pass	stepDown on step value hour 
+Pass	stepUp on step value second 
+Pass	stepDown on step value second 
+Fail	stepUp on step value with fractional seconds
+Pass	stepDown on step value with fractional seconds
+Pass	stepUp argument 2 times
+Pass	stepDown argument 2 times
+Pass	stepUp stop because it exceeds the maximum value
+Pass	stepDown stop so lower than the minimum value
+Fail	stop at border on stepUp
+Pass	stop at border on stepDown
+Pass	 empty value of stepUp
+Pass	set value on not time format value

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/url.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/url.txt
@@ -1,0 +1,9 @@
+Harness status: OK
+
+Found 4 tests
+
+4 Pass
+Pass	url type supported on input element
+Pass	The value must not be set with "LF" (U+000A) or "CR" (U+000D)
+Pass	The value sanitization algorithm is as follows: Strip line breaks from the value
+Pass	The value sanitization algorithm is as follows: Strip leading and trailing whitespace from the value.

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/week.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/forms/the-input-element/week.txt
@@ -1,0 +1,21 @@
+Harness status: OK
+
+Found 16 tests
+
+16 Pass
+Pass	empty value
+Pass	Valid value: Value should be 2014-W52
+Pass	2014 has 52 weeks: Value should be empty
+Pass	2015 has 53 weeks: Value should be 2015-W53
+Pass	Invalid value: year only
+Pass	Invalid value: no week number
+Pass	Invalid value: no '-' (U+002D)
+Pass	Invalid value: yearless week
+Pass	Invalid value: should be capital letter 'W'
+Pass	Invalid value: incorrect with '-' at the end
+Pass	Invalid value: value should be two parts
+Pass	Invalid value: yearless week and no '-' (U+002D)
+Pass	Value >= min attribute
+Pass	Value < min attribute
+Pass	Value <= max attribute
+Pass	Value > max attribute

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/date.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/date.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Inputs Date</title>
+    <link rel="author" title="Morishita Hiromitsu" href="mailto:hero@asterisk-works.jp">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#date-state-(type=date)">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dates-and-times">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+    <h1>Inputs Date</h1>
+    <div style="display: none">
+      <input id="valid" type="date" value="2011-11-01" min="2011-01-01" max="2011-12-31" />
+      <input id="too_small_value" type="date" value="1999-01-31" min="2011-01-01" max="2011-12-31"/>
+      <input id="too_large_value" type="date" value="2099-01-31" min="2011-01-01" max="2011-12-31"/>
+      <input id="invalid_min" type="date" value="2011-01-01" min="1999-1" max="2011-12-31"/>
+      <input id="invalid_max" type="date" value="2011-01-01" min="2011-01-01" max="2011-13-162-777"/>
+      <input id="min_larger_than_max" type="date" value="2011-01-01" min="2099-01-01" max="2011-12-31"/>
+      <input id="invalid_value" type="date" value="invalid-date" min="2011-01-01" max="2011-12-31"/>
+    </div>
+
+    <div id="log"></div>
+
+    <script type="text/javascript">
+      test(function() {
+        assert_equals(document.getElementById("valid").type, "date")
+      }, "date type support on input element");
+
+      test(function() {
+        assert_equals(document.getElementById("valid").value, "2011-11-01");
+        assert_equals(document.getElementById("too_small_value").value, "1999-01-31");
+        assert_equals(document.getElementById("too_large_value").value, "2099-01-31");
+      }, "The value attribute, if specified and not empty, must have a value that is a valid date string.");
+
+      test(function() {
+        assert_equals(document.getElementById("valid").min, "2011-01-01");
+        assert_equals(document.getElementById("invalid_min").min, "1999-1");
+      }, "The min attribute must be reflected verbatim by the min property.");
+
+      test(function() {
+        assert_equals(document.getElementById("valid").max, "2011-12-31");
+        assert_equals(document.getElementById("min_larger_than_max").max, "2011-12-31");
+        assert_equals(document.getElementById("invalid_max").max, "2011-13-162-777");
+      }, "The max attribute must be reflected verbatim by the max property.");
+
+      test(function() {
+        assert_equals(document.getElementById("invalid_value").value, "");
+      }, "User agents must not allow the user to set the value to a non-empty string that is not a valid date string.");
+      test(function() {
+        var numDays = [
+          // the number of days in month month of year year is: 31 if month is 1, 3, 5, 7, 8, 10, or 12;
+          {value: "2014-01-31", expected: "2014-01-31", testname: "January has 31 days"},
+          {value: "2014-01-32", expected: "", testname: "January has 31 days"},
+          {value: "2014-03-31", expected: "2014-03-31", testname: "March has 31 days"},
+          {value: "2014-03-32", expected: "", testname: "March has 31 days"},
+          {value: "2014-05-31", expected: "2014-05-31", testname: "May has 31 days"},
+          {value: "2014-05-32", expected: "", testname: "May has 31 days"},
+          {value: "2014-07-31", expected: "2014-07-31", testname: "July has 31 days"},
+          {value: "2014-07-32", expected: "", testname: "July has 31 days"},
+          {value: "2014-08-31", expected: "2014-08-31", testname: "August has 31 days"},
+          {value: "2014-08-32", expected: "", testname: "August has 31 days"},
+          {value: "2014-10-31", expected: "2014-10-31", testname: "October has 31 days"},
+          {value: "2014-10-32", expected: "", testname: "October has 31 days"},
+          {value: "2014-12-31", expected: "2014-12-31", testname: "December has 31 days"},
+          {value: "2014-12-32", expected: "", testname: "December has 31 days"},
+          // the number of days in month month of year year is: 30 if month is 4, 6, 9, or 11;
+          {value: "2014-04-30", expected: "2014-04-30", testname: "April has 30 days"},
+          {value: "2014-04-31", expected: "", testname: "April has 30 days"},
+          {value: "2014-06-30", expected: "2014-06-30", testname: "June has 30 days"},
+          {value: "2014-06-31", expected: "", testname: "June has 30 days"},
+          {value: "2014-09-30", expected: "2014-09-30", testname: "September has 30 days"},
+          {value: "2014-09-31", expected: "", testname: "September has 30 days"},
+          {value: "2014-11-30", expected: "2014-11-30", testname: "November has 30 days"},
+          {value: "2014-11-31", expected: "", testname: "November has 30 days"},
+          // leap years
+          {value: "2014-02-28", expected: "2014-02-28", testname: "2014 is not a leap year: February has 28 days"},
+          {value: "2014-02-29", expected: "", testname: "2014 is not a leap year: February has 28 days: value should be empty"},
+          {value: "2016-02-29", expected: "2016-02-29", testname: "2016 is a leap year: February has 29 days"}
+        ];
+        for (var i = 0; i < numDays.length; i++) {
+          var input = document.createElement("input");
+          input.type = "date";
+          input.value = numDays[i].value;
+          assert_equals(input.value, numDays[i].expected, numDays[i].testname);
+        }
+      }, "Number of days");
+    </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime-local-trailing-zeros.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime-local-trailing-zeros.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<link rel=help href="https://html.spec.whatwg.org/multipage/multipage/common-microsyntaxes.html#local-dates-and-times">
+<link rel=help href="https://html.spec.whatwg.org/multipage/multipage/states-of-the-type-attribute.html#local-date-and-time-state-(type=datetime-local)">
+
+<input id=input type=datetime-local value="2022-04-19T12:34:56.010">
+
+<script>
+test(() => {
+  assert_equals(input.value, '2022-04-19T12:34:56.01');
+}, 'Verifies that trailing zeros in the milliseconds portion of the date strings are removed.');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime-local.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime-local.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Form input type=datetime-local</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/multipage/common-microsyntaxes.html#local-dates-and-times">
+<link rel=help href="https://html.spec.whatwg.org/multipage/multipage/states-of-the-type-attribute.html#local-date-and-time-state-(type=datetime-local)">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  var datetimeLocal = [
+    {value: "", expected: "", testname: "empty value"},
+    {value: "2014-01-01T11:11:11.111", expected: "2014-01-01T11:11:11.111", testname: "datetime-local input value set to 2014-01-01T11:11:11.111 without min/max"},
+    {value: "2014-01-01 11:11:11.111", expected: "2014-01-01T11:11:11.111", testname: "datetime-local input value set to 2014-01-01 11:11:11.111 without min/max"},
+    {value: "2014-01-01 11:11", expected: "2014-01-01T11:11", testname: "datetime-local input value set to 2014-01-01 11:11 without min/max"},
+    {value: "2014-01-01 00:00:00.000", expected: "2014-01-01T00:00", testname: "datetime-local input value set to 2014-01-01 00:00:00.000 without min/max"},
+    {value: "2014-01-0 11:11", expected: "", testname: "datetime-local input value set to 2014-01-0 11:11 without min/max"},
+    {value: "2014-01-01 11:1", expected: "", testname: "datetime-local input value set to 2014-01-01 11:1 without min/max"},
+    {value: "2014-01-01 11:1d1", expected: "", testname: "invalid datetime-local input value 1"},
+    {value: "2014-01-01H11:11", expected: "", testname: "invalid datetime-local input value 2"},
+    {value: "2014-01-01 11:11:", expected: "", testname: "invalid datetime-local input value 3"},
+    {value: "2014-01-01 11-11", expected: "", testname: "invalid datetime-local input value 4"},
+    {value: "2014-01-01 11:11:123", expected: "", testname: "invalid datetime-local input value 5"},
+    {value: "2014-01-01 11:11:12.1234", expected: "", testname: "invalid datetime-local input value 6"},
+    {value: "2014-01-01 11:12", attributes: { min: "2014-01-01 11:11" }, expected: "2014-01-01T11:12", testname: "Value >= min attribute"},
+    {value: "2014-01-01 11:10", attributes: { min: "2014-01-01 11:11" }, expected: "2014-01-01T11:10", testname: "Value < min attribute"},
+    {value: "2014-01-01 11:10", attributes: { max: "2014-01-01 11:11" }, expected: "2014-01-01T11:10", testname: "Value <= max attribute"},
+    {value: "2014-01-01 11:12", attributes: { max: "2014-01-01 11:11" }, expected: "2014-01-01T11:12", testname: "Value > max attribute"}
+  ];
+  for (var i = 0; i < datetimeLocal.length; i++) {
+    var w = datetimeLocal[i];
+    test(function() {
+      var input = document.createElement("input");
+      input.type = "datetime-local";
+      input.value = w.value;
+      for(var attr in w.attributes) {
+        input[attr] = w.attributes[attr];
+      }
+      assert_equals(input.value, w.expected);
+    }, w.testname);
+  }
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime-weekmonth.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime-weekmonth.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Date and Time Inputs</title>
+    <meta name=viewport content="width=device-width, maximum-scale=1.0, user-scalable=no" />
+    <link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
+    <link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-input-element">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-type">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-value">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-min">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-max">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-step">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-stepup">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-stepdown">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+
+      <h1>Date and Time Inputs</h1>
+      <div style="display: none">
+        <input type="month" value="2011-01" min="2011-01" max="2011-12" step="2" />
+        <input type="week" value="2011-W40" min="2011-W20" max="2011-W50" step="2" />
+    </div>
+
+    <div id="log">
+    </div>
+
+  <script type="text/javascript">
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].type, "month")}, "month type support on input element");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].value, "2011-01")}, "[month] The value must be a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].min, "2011-01")}, "[month] The min attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].max, "2011-12")}, "[month] The max attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].step, "2")}, "[month] The step attribute must be expressed in seconds");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[0].stepUp) == "function")}, "[month] stepUp method support on input 'month' element");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[0].stepDown) == "function")}, "[month] stepDown method support on input 'month' element");
+
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].type, "week")}, "week type support on input element");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].value, "2011-W40")}, "[week] The value must be a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].min, "2011-W20")}, "[week] The min attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].max, "2011-W50")}, "[week] The max attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].step, "2")}, "[week] The step attribute must be expressed in seconds");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[1].stepUp) == "function")}, "[week] stepUp method support on input 'week' element");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[1].stepDown) == "function")}, "[week] stepDown method support on input 'week' element");
+
+  </script>
+
+  </body>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/datetime.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Date and Time Inputs</title>
+    <meta name=viewport content="width=device-width, maximum-scale=1.0, user-scalable=no" />
+    <link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
+    <link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-input-element">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-type">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-value">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-min">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-max">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-step">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-stepup">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-stepdown">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+  </head>
+  <body>
+
+      <h1>Date and Time Inputs</h1>
+      <div style="display: none">
+        <input type="date" value="2011-12-01" min="2011-12-01" max="2011-12-31" step="5" />
+        <input type="time" value= "12:00" min="11:30" max="14:00" step="600" />
+        <input type="datetime-local" value="2011-12-01T12:00" min="2011-12-01T12:00" max="2011-12-31T22:00" step="7200" />
+    </div>
+
+    <div id="log">
+    </div>
+
+  <script type="text/javascript">
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].type, "date")}, "date type support on input element");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].value, "2011-12-01")}, "[date] The value must be a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].min, "2011-12-01")}, "[date] The min attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].max, "2011-12-31")}, "[date] The max attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].step, "5")}, "[date] The step attribute must be expressed in seconds");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[0].stepUp) == "function")}, "[date] stepUp method support on input 'date' element");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[0].stepDown) == "function")}, "[date] stepDown method support on input 'date' element");
+
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].type, "time")}, "[time] time type support on input element");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].value, "12:00")}, "[time] The value must be a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].min, "11:30")}, "[time] The min attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].max, "14:00")}, "[time] The max attribute must have a value that is a valid global date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[1].step, "600")}, "[time] The step attribute must be expressed in seconds");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[1].stepUp) == "function")}, "[time] stepUp method support on input 'time' element");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[1].stepDown) == "function")}, "[time] stepDown method support on input 'time' element");
+
+    test(function() {assert_equals(document.getElementsByTagName("input")[2].type, "datetime-local")}, "datetime-local type support on input element");
+    test(function() {assert_equals(document.getElementsByTagName("input")[2].value, "2011-12-01T12:00")}, "[datetime-local] The must be a valid local date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[2].min, "2011-12-01T12:00")}, "[datetime-local] The min attribute must have a value that is a valid local date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[2].max, "2011-12-31T22:00")}, "[datetime-local] The max attribute must have a value that is a valid local date and time string");
+    test(function() {assert_equals(document.getElementsByTagName("input")[2].step, "7200")}, "[datetime-local] The step attribute must be expressed in seconds");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[2].stepUp) == "function")}, "[datetime-local] stepUp method support on input 'datetime-local' element");
+    test(function() {assert_true(typeof(document.getElementsByTagName("input")[2].stepDown) == "function")}, "[datetime-local] stepDown method support on input 'datetime-local' element");
+
+  </script>
+
+  </body>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/email.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/email.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<title>Input Email</title>
+<link rel="author" title="Kazuki Kanamori" href="mailto:yogurito@gmail.com">
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#e-mail-state-(type=email)">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<input type="email" id="single_email" value="user@example.com"/>
+<input type="email" id="multiple_email" value="user1@example.com, user2@test.com" multiple/>
+<div id="log"></div>
+
+<script type="text/javascript">
+  var single = document.getElementById('single_email'),
+      mult = document.getElementById('multiple_email');
+
+  test(function(){
+    assert_false(single.multiple);
+  }, "single_email doesn't have the multiple attribute");
+
+  test(function(){
+    single.value = 'user2@example.com\u000A';
+    assert_equals(single.value, 'user2@example.com');
+    single.value = 'user3@example.com\u000D';
+    assert_equals(single.value, 'user3@example.com');
+  }, 'value should be sanitized: strip line breaks');
+
+  test(function(){
+    single.value = 'user4@example.com';
+    assert_true(single.validity.valid);
+    single.value = 'example.com';
+    assert_false(single.validity.valid);
+  }, 'Email address validity');
+
+  test(function(){
+    single.setAttribute('multiple', true);
+    single.value = '  user@example.com  , user2@example.com  ';
+    assert_equals(single.value, 'user@example.com,user2@example.com');
+    single.removeAttribute('multiple');
+    assert_equals(single.value, 'user@example.com,user2@example.com');
+  }, 'When the multiple attribute is removed, the user agent must run the value sanitization algorithm');
+
+  test(function(){
+    assert_true(mult.multiple);
+  }, "multiple_email has the multiple attribute");
+
+  test(function(){
+    mult.value = '  user1@example.com  , user2@test.com, user3@test.com  ';
+    assert_equals(mult.value, 'user1@example.com,user2@test.com,user3@test.com');
+  }, "run the value sanitization algorithm after setting a new value");
+
+  test(function(){
+    mult.value = 'user1@example.com,user2@test.com,user3@test.com';
+    assert_true(mult.validity.valid);
+
+    mult.value = 'u,ser1@example.com,user2@test.com,user3@test.com';
+    assert_false(mult.validity.valid);
+  }, "valid value is a set of valid email addresses separated by a single ','");
+
+  test(function(){
+    mult.removeAttribute('multiple');
+    mult.value = 'user1@example.com , user2@example.com';
+    assert_equals(mult.value, 'user1@example.com , user2@example.com');
+    mult.setAttribute('multiple', true);
+    assert_equals(mult.value, 'user1@example.com,user2@example.com');
+  }, 'When the multiple attribute is set, the user agent must run the value sanitization algorithm');
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/files.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/files.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>HTMLInputElement#files</title>
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id=log></div>
+<script>
+var types = [
+  "hidden",
+  "text",
+  "search",
+  "tel",
+  "url",
+  "email",
+  "password",
+  "date",
+  "month",
+  "week",
+  "time",
+  "datetime-local",
+  "number",
+  "range",
+  "color",
+  "checkbox",
+  "radio",
+  "submit",
+  "image",
+  "reset",
+  "button",
+];
+
+types.forEach(function(type) {
+  test(function() {
+    const input = document.createElement("input"),
+          input2 = document.createElement("input");
+    input.type = type;
+    input2.type = "file";
+    assert_equals(input.files, null, "files should be null");
+
+    input.files = input2.files;
+    assert_equals(input.files, null, "files should remain null as it cannot be set when it does not apply");
+  }, "files for input type=" + type);
+});
+
+test(function() {
+  var input = document.createElement("input");
+  input.type = "file";
+  assert_not_equals(input.files, null);
+  assert_true(input.files instanceof FileList, "files should be a FileList");
+  var files = input.files;
+  assert_equals(input.files, files, "files should return the same object");
+}, "files for input type=file");
+
+test(() => {
+  const i1 = document.createElement("input"),
+        i2 = document.createElement("input");
+  i1.type = "file";
+  i2.type = "file";
+
+  const files = i2.files;
+  i1.files = i2.files;
+  assert_equals(i1.files, files, "FileList should not be copied");
+  assert_equals(i2.files, files, "FileList can be shared across input elements");
+
+  i1.files = null;
+  assert_equals(i1.files, files, "files cannot be set to null");
+
+  assert_throws_js(TypeError, () => i1.files = [], "files cannot be set to an array");
+  assert_throws_js(TypeError, () => i1.files = [new File([], "x")], "files cannot be set to an array (even when it contains File objects)");
+}, "setting <input type=file>.files");
+
+test(() => {
+  const i = document.createElement("input");
+  i.type = "file";
+
+  let dt = new DataTransfer();
+
+  const files = dt.files;
+  i.files = files;
+  assert_equals(i.files, files, "FileList should not be copied");
+  assert_equals(dt.files, files, "FileList can be shared across input / DataTransfer");
+}, "setting <input type=file>.files from DataTransfer");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/input-stepdown-02.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/input-stepdown-02.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML>
+<title>Input Step Down</title>
+
+<link rel="help" href="https://html.spec.whatwg.org/multipage/input.html#dom-input-stepup">
+
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+
+<input type='number' id='input'>
+
+<script>
+  const input = document.getElementById("input");
+
+  function testStepDown(initialValue, minValue, expectedValue) {
+    input.value = initialValue;
+    input.min = minValue;
+
+    input.stepDown();
+
+    assert_equals(input.value, expectedValue);
+  }
+
+  const tests = [
+    { initialValue: '', minValue: '', expectedValue: '-1', description: 'stepDown() on input with no initial or min values' },
+    { initialValue: '', minValue: '7', expectedValue: '7', description: 'stepDown() on input with no initial value and positive min value' },
+    { initialValue: '', minValue: '-7', expectedValue: '-1', description: 'stepDown() on input with no initial value and negative min value' },
+    { initialValue: '7', minValue: '7', expectedValue: '7', description: 'stepDown() on input with initial value equal to min value' },
+    { initialValue: '3', minValue: '7', expectedValue: '3', description: 'stepDown() on input with initial value less than min value' },
+    { initialValue: '10', minValue: '7', expectedValue: '9', description: 'stepDown() on input with initial value greater than min value' },
+  ];
+
+  for(const t of tests) {
+    test(()=>{
+      testStepDown(
+        t.initialValue,
+        t.minValue,
+        t.expectedValue
+      );
+    },
+    t.description);
+  }
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/number.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/number.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Form input type=number</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#number-state-(type=number)">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  var numbers = [
+    {value: "", expected: "", testname: "empty value"},
+    {value: "11", expected: "11", testname: "value = 11"},
+    {value: "11.12", expected: "11.12", testname: "value = 11.12"},
+    {value: "-11111", expected: "-11111", testname: "value = -11111"},
+    {value: "-11111.123", expected: "-11111.123", testname: "value = -11111.123"},
+    {value: "1e2", expected: "1e2", testname: "value = 1e2"},
+    {value: "1E2", expected: "1E2", testname: "value = 1E2"},
+    {value: "1e+2", expected: "1e+2", testname: "value = 1e+2"},
+    {value: "1e-2", expected: "1e-2", testname: "value = 1e-2"},
+    {value: "1d+2", expected: "", testname: "value is not a valid floating-point number: 1d+2"},
+    {value: "foobar", expected: "", testname: "value not a valid floating-point number: random string"},
+    {value: "11", attributes: { min: "10" }, expected: "11", testname: "Value >= min attribute"},
+    {value: "9", attributes: { min: "10" }, expected: "9", testname: "Value < min attribute"},
+    {value: "19", attributes: { max: "20" }, expected: "19", testname: "Value <= max attribute"},
+    {value: "21", attributes: { max: "20" }, expected: "21", testname: "Value > max attribute"},
+    {value: ".1", expected: ".1", testname: "value with a leading '.'"},
+    {value: "1.", expected: "", testname: "value ending with '.'"},
+    {value: "-0", expected: "-0", testname: "value = -0"},
+    {value: "Infinity", expected: "", testname: " value = Infinity"},
+    {value: "-Infinity", expected: "", testname: "value = -Infinity"},
+    {value: "NaN", expected: "", testname: "value = NaN"},
+    {value: "9007199254740993", expected: "9007199254740993", testname: "value = 2^53+1"},
+    {value: "2e308", expected: "", testname: "value >= Number.MAX_VALUE"},
+    {value: "1e", expected: "", testname: "value = 1e"},
+    {value: "+1", expected: "", testname: "value = +1"},
+    {value: "+", expected: "", testname: "value = '+'"},
+    {value: "-", expected: "", testname: "value = '-'"},
+    {value: "\t1", expected: "", testname: "value with a leading tab"},
+    {value: "\n1", expected: "", testname: "value with a leading newline"},
+    {value: "\f1", expected: "", testname: "value with a leading form feed"},
+    {value: "\r1", expected: "", testname: "value with a leading carriage return"},
+    {value: " 1", expected: "", testname: "value with a leading space"},
+    {value: "1trailing junk", expected: "", testname: "value = 1trailing junk"}
+  ];
+  for (var i = 0; i < numbers.length; i++) {
+    var w = numbers[i];
+    test(function() {
+      var input = document.createElement("input");
+      input.type = "number";
+      input.value = w.value;
+      for(var attr in w.attributes) {
+        input[attr] = w.attributes[attr];
+      }
+      assert_equals(input.value, w.expected);
+    }, w.testname);
+  }
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/password.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/password.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Password input element</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<link rel="help" href="https://html.spec.whatwg.org/multipage/#password-state-%28type=password%29">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<div style="display: none">
+<input id="password" type="password" />
+<input id=password2 type=password value="password">
+<input id="password_with_value" type="password" value="foobar" />
+</div>
+<script type="text/javascript">
+    setup(function() {
+      window.password = document.getElementById("password");
+    });
+
+    test(function() {
+      assert_equals(password.value, "");
+      assert_equals(document.getElementById("password_with_value").value, "foobar");
+    }, "Value returns the current value for password");
+
+    test(function() {
+      password.value = "A";
+      assert_equals(password.value, "A");
+      assert_equals(password.getAttribute("value"), null);
+      password.value = "B";
+      assert_equals(password.value, "B");
+      assert_equals(password.getAttribute("value"), null);
+    }, "Setting value changes the current value for password, but not the value content attribute");
+
+    test(function() {
+      // Any LF (\n) must be stripped.
+      password.value = "\nAB";
+      assert_equals(password.value, "AB");
+      password.value = "A\nB";
+      assert_equals(password.value, "AB");
+      password.value = "AB\n";
+      assert_equals(password.value, "AB");
+
+      // Any CR (\r) must be stripped.
+      password.value = "\rAB";
+      assert_equals(password.value, "AB");
+      password.value = "A\rB";
+      assert_equals(password.value, "AB");
+      password.value = "AB\r";
+      assert_equals(password.value, "AB");
+
+      // Any combinations of LF CR must be stripped.
+      password.value = "\r\nAB";
+      assert_equals(password.value, "AB");
+      password.value = "A\r\nB";
+      assert_equals(password.value, "AB");
+      password.value = "AB\r\n";
+      assert_equals(password.value, "AB");
+      password.value = "\r\nA\n\rB\r\n";
+      assert_equals(password.value, "AB");
+    }, "Value sanitization algorithm should strip line breaks for password");
+
+  var pass = document.getElementById('password2');
+
+  test(function(){
+    assert_equals(pass.value, "password");
+    pass.value = "  pass  word  ";
+    assert_equals(pass.value, "  pass  word  ");
+  }, "sanitization algorithm doesn't strip leading and trailing whitespaces");
+
+  test(function(){
+    pass.value = "pass\u000Aword";
+    assert_equals(pass.value, "password");
+    pass.value = "\u000Apassword\u000A";
+    assert_equals(pass.value, "password");
+    pass.value = "pass\u000Dword";
+    assert_equals(pass.value, "password");
+    pass.value = "\u000Dpassword\u000D";
+    assert_equals(pass.value, "password");
+  }, "sanitization algorithm strips line breaks");
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/range.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/range.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <title>Input Range</title>
+    <meta name=viewport content="width=device-width, maximum-scale=1.0, user-scalable=no" />
+    <link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
+    <link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
+    <link rel="author" title="Tomoyuki SHIMIZU" href="mailto:tomoyuki.labs@gmail.com">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-input-element">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-type">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-min">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-max">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#range-state-(type=range)">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-stepup">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#dom-input-stepdown">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#best-representation-of-the-number-as-a-floating-point-number">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+
+
+    <h1>Input Range</h1>
+    <div style="display:none">
+      <input type="range" id="range_basic" min=0 max=5 />
+      <input type="range" id="value_smaller_than_min" min=0 max=5 value=-10 />
+      <input type="range" id="value_larger_than_max" min=0 max=5 value=7 />
+      <input type="range" id="empty_attributes" />
+      <input type="range" id="value_not_specified" min=2 max=6 />
+      <input type="range" id="control_step_mismatch" min=0 max=7 step=2 />
+      <input type="range" id="max_smaller_than_min" min=2 max=-3 />
+      <input type="range" id="default_step_scale_factor_1" min=5 max=12.6 value=6.7 />
+      <input type="range" id="default_step_scale_factor_2" min=5.3 max=12 value=6.7 />
+      <input type="range" id="float_step_scale_factor" min=5.3 max=12 step=0.5 value=6.7 />
+      <input type="range" id="stepup" min=3 max=14 value=6 step=3 />
+      <input type="range" id="stepdown" min=3 max=11 value=9 step=3 />
+      <input type="range" id="stepup_beyond_max" min=3 max=14 value=9 step=3 />
+      <input type="range" id="stepdown_beyond_min" min=3 max=11 value=6 step=3 />
+      <input type="range" id="illegal_min_and_max" min="ab" max="f" />
+      <input type="range" id="illegal_value_and_step" min=0 max=5 value="ppp" step="xyz" />
+      <input type="range" id="should_skip_whitespace" value=" 123"/>
+      <input type="range" id="exponent_value1" value=""/>
+      <input type="range" id="exponent_value2" value=""/>
+    </div>
+
+    <div id="log">
+    </div>
+
+    <script type="text/javascript">
+
+      test(
+        function() {
+          assert_equals(document.getElementById('range_basic').type, "range");
+        },
+        "range type support on input element"
+      );
+
+      test(function() {
+        assert_equals(getComputedStyle(document.getElementById('range_basic')).overflow, "visible");
+      }, "range overflow styles");
+
+      test(
+        function() {
+          assert_equals(document.getElementById('range_basic').min, "0")
+        },
+        "min attribute support on input element"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('range_basic').max, "5")
+        },
+        "max attribute support on input element"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('illegal_min_and_max').min, "ab")
+        },
+        "Illegal value of min attribute"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('illegal_min_and_max').max, "f")
+        },
+        "Illegal value of max attribute"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('illegal_value_and_step').value, "3")
+        },
+        "Converting an illegal string to the default value"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('illegal_value_and_step').step, "xyz")
+        },
+        "Illegal value of step attribute"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('value_smaller_than_min').value, "0")
+        },
+        "the value is set to min when a smaller value than min attribute is given"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('value_larger_than_max').value, "5")
+        },
+        "the value is set to max when a larger value than max attribute is given"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('empty_attributes').min, "")
+        },
+        "default value of min attribute in input type=range"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('empty_attributes').max, "")
+        },
+        "default value of max attribute in input type=range"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('value_not_specified').value, "4")
+        },
+        "default value when min and max attributes are given (= min plus half the difference between min and max)"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('control_step_mismatch').value, "4")
+        },
+        "default value with step control when both min and max attributes are given"
+      );
+
+      // Chrome would result in different value out of the range between min and max. Why?
+      test(
+        function() {
+          assert_equals(document.getElementById('max_smaller_than_min').value, "2")
+        },
+        "default value when both min and max attributes are given, while min > max"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('default_step_scale_factor_1').value, "7")
+        },
+        "The default step scale factor is 1, unless min attribute has non-integer value"
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('default_step_scale_factor_2').value, "6.3")
+        },
+        "Step scale factor behavior when min attribute has integer value but max attribute is non-integer "
+      );
+
+      test(
+        function() {
+          assert_equals(document.getElementById('float_step_scale_factor').value, "6.8")
+        },
+        "Solving the step mismatch"
+      );
+
+      // Firefox Nightly (24.0a1) would result in the possible maximum value in this range... (i.e. 12)
+      test(
+        function() {
+          var e = document.getElementById('stepup');
+          e.stepUp();
+          assert_equals(e.value, "9")
+        },
+        "Performing stepUp()"
+      );
+
+      // Firefox Nightly (24.0a1) would result in the possible minimum value in this range... (i.e. 3)
+      test(
+        function() {
+          var e = document.getElementById('stepdown');
+          e.stepDown();
+          assert_equals(e.value, "6")
+        },
+        "Performing stepDown()"
+      );
+
+      // Chrome and Opera would throw DOM Exception 11 (InvalidStateError)
+      // Firefox Nightly gives the correct result
+      test(
+        function() {
+          var e = document.getElementById('stepup_beyond_max');
+          e.stepUp(2);
+          assert_equals(e.value, "12")
+        },
+        "Performing stepUp() beyond the value of the max attribute"
+      );
+
+      // Chrome and Opera would throw DOM Exception 11 (InvalidStateError)
+      // Firefox Nightly gives the correct result
+      test(
+        function() {
+          var e = document.getElementById('stepdown_beyond_min');
+          e.stepDown(2);
+          assert_equals(e.value, "3")
+        }, "Performing stepDown() beyond the value of the min attribute"
+      );
+
+      test(
+        function() {
+          var e = document.getElementById('should_skip_whitespace');
+          assert_equals(e.value, "50")
+        }, "Input should be reset to the default value when value attribute has whitespace"
+      );
+
+      test(
+        function() {
+          var e = document.getElementById('exponent_value1');
+          e.value = 1e2;
+          assert_equals(e.value, "100")
+        }, "Multiply value by ten raised to the exponentth power with `e`"
+      );
+
+      test(
+        function() {
+          var e = document.getElementById('exponent_value2');
+          e.value = 1E2;
+          assert_equals(e.value, "100")
+        }, "Multiply value by ten raised to the exponentth power with `E`"
+      );
+
+    </script>
+
+  </body>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/required_attribute.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/required_attribute.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <title>Required Attribute</title>
+    <meta name=viewport content="width=device-width, maximum-scale=1.0, user-scalable=no" />
+    <link rel="author" title="Fabrice Clari" href="mailto:f.clari@inno-group.com">
+    <link rel="author" title="Dimitri Bocquet" href="mailto:Dimitri.Bocquet@mosquito-fp7.eu">
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#attr-input-required">
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+
+
+      <h1>Required Attribute</h1>
+      <div style="display: none">
+      <input type="text" required="required" />
+    </div>
+
+    <div id="log">
+    </div>
+
+  <script type="text/javascript">
+
+
+    test(function() {assert_equals(document.getElementsByTagName("input")[0].getAttribute("required"), "required")}, "required attribute support on input element");
+
+  </script>
+
+  </body>
+
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/time.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/time.html
@@ -1,0 +1,357 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <title>Input Time</title>
+     <meta name=viewport content="width=device-width, maximum-scale=1.0, user-scalable=no" />
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-input-element">
+   <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+  </head>
+
+  <body>
+      <h1>Input Time</h1>
+      <div style="display:none;">
+              <input type="time "id="chkDefaultValue" />
+              <input type="time" id="chkStep" />
+              <input type="time" id="chkSetValueTest" />
+              <input type="time" id="chkSupportAttribute" min="01:01:01.001" max="12:12:12.012" step="600" />
+      </div>
+    <div id="log">
+    </div>
+
+  <script type="text/javascript">
+
+/* check default value */
+test(function(){ assert_equals(document.getElementById("chkDefaultValue").value, "");
+}, "time element of default time value");
+test(function(){assert_equals(document.getElementById('chkStep').step, "");
+}, "step attribute on default value check");
+test(function(){assert_equals(document.getElementById('chkDefaultValue').max, "");
+}, "max  attribute on default value check")
+test(function(){assert_equals(document.getElementById('chkDefaultValue').max, "");
+}, "min  attribute on default value check")
+
+/* simple attribute test*/
+test(function(){assert_equals(document.getElementById("chkSupportAttribute").type,"time");}
+  , "type attribute support on input element");
+test(function(){assert_equals(document.getElementById('chkSupportAttribute').min, "01:01:01.001")}
+  , "max attribute support on input element");
+test(function(){assert_equals(document.getElementById('chkSupportAttribute').max, "12:12:12.012")}
+  , "min attribute support on input element");
+test(function(){assert_equals(document.getElementById("chkSupportAttribute").step, "600")}
+  , "step attribute support on input element");
+
+/* check step up and down */
+var _StepTest = document.getElementById("chkStep");
+test(function(){ assert_true(typeof(_StepTest.stepUp) ==="function" ) }   , "stepUp function support on input Element");
+test(function(){ assert_true(typeof(_StepTest.stepDown) ==="function" ) } , "stepDown function support on input Element");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:01",
+      "12:01:00",
+      "12:01:00.0",
+      "12:01:00.00",
+      "12:01:00.000"],
+    "a valid time string representing 1 minute after noon");
+} , "stepUp step value empty on default step value ");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:59",
+      "11:59:00",
+      "11:59:00.0",
+      "11:59:00.00",
+      "11:59:00.000"],
+    "a valid time string representing 1 minute before noon");
+}, "stepDown step value empty default step value");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "-600";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:01",
+      "12:01:00",
+      "12:01:00.0",
+      "12:01:00.00",
+      "12:01:00.000"],
+    "a valid time string representing 1 minute after noon");
+},"stepUp on step value minus");
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "-600";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:59",
+      "11:59:00",
+      "11:59:00.0",
+      "11:59:00.00",
+      "11:59:00.000"],
+    "a valid time string representing 1 minute before noon");
+},"stepDown on step value minus");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "0";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:01",
+      "12:01:00",
+      "12:01:00.0",
+      "12:01:00.00",
+      "12:01:00.000"],
+    "a valid time string representing 1 minute after noon");
+} , "stepUp on step value zero ");
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "0";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:59",
+      "11:59:00",
+      "11:59:00.0",
+      "11:59:00.00",
+      "11:59:00.000"],
+    "a valid time string representing 1 minute before noon");
+} , "stepDown on step value zero ");
+
+test(function(){
+  _StepTest.value = "00:00";
+  _StepTest.step = "86399";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "23:59:59",
+      "23:59:59.0",
+      "23:59:59.00",
+      "23:59:59.000"],
+    "a valid time string representing 1 second before midnight");
+} , "stepUp on step value 24 hour");
+test(function(){
+  _StepTest.value = "23:59:59";
+  _StepTest.step = "86399";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "00:00",
+      "00:00:00",
+      "00:00:00.0",
+      "00:00:00.00",
+      "00:00:00.000"],
+    "a valid time string representing midnight");
+} , "stepDown on step value 24 hour ");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "3600";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "13:00",
+      "13:00:00",
+      "13:00:00.0",
+      "13:00:00.00",
+      "13:00:00.000"],
+    "a valid time string representing 1pm");
+} , "stepUp on step value hour  ");
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "3600";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:00",
+      "11:00:00",
+      "11:00:00.0",
+      "11:00:00.00",
+      "11:00:00.000"],
+    "a valid time string representing 11am");
+} , "stepDown on step value hour ");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "1";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:00:01",
+      "12:00:01.0",
+      "12:00:01.00",
+      "12:00:01.000"],
+    "a valid time string representing 1 second after noon");
+} , "stepUp on step value second ");
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "1";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "11:59:59",
+      "11:59:59.0",
+      "11:59:59.00",
+      "11:59:59.000"],
+    "a valid time string representing 1 second before noon");
+} , "stepDown on step value second ");
+
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "0.001";
+  _StepTest.stepUp();
+  assert_equals(_StepTest.value, "12:00:00.001");
+} , "stepUp on step value with fractional seconds");
+test(function(){
+  _StepTest.value = "12:00";
+  _StepTest.step = "0.001";
+  _StepTest.stepDown();
+  assert_equals(_StepTest.value, "11:59:59.999");
+} , "stepDown on step value with fractional seconds");
+
+test(function(){
+  _StepTest.value = "13:00:00";
+  _StepTest.step = "1";
+  _StepTest.stepUp(2);
+  assert_in_array(
+    _StepTest.value,
+    [
+      "13:00:02",
+      "13:00:02.0",
+      "13:00:02.00",
+      "13:00:02.000"],
+    "a valid time string representing 2 seconds after 1pm");
+}, "stepUp argument 2 times");
+test(function(){
+  _StepTest.value = "13:00:00";
+  _StepTest.step = "1";
+  _StepTest.stepDown(2);
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:59:58",
+      "12:59:58.0",
+      "12:59:58.00",
+      "12:59:58.000"],
+    "a valid time string representing 2 seconds before 1pm");
+}, "stepDown argument 2 times");
+
+test(function(){
+  _StepTest.max = "15:00";
+  this.add_cleanup(function() { _StepTest.max = ""; });
+  _StepTest.value = "15:00";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "15:00",
+      "15:00:00",
+      "15:00:00.0",
+      "15:00:00.00",
+      "15:00:00.000"],
+    "a valid time string representing 3pm");
+} , "stepUp stop because it exceeds the maximum value");
+test(function(){
+  _StepTest.min = "13:00";
+  this.add_cleanup(function() { _StepTest.min = ""; });
+  _StepTest.value = "13:00";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "13:00",
+      "13:00:00",
+      "13:00:00.0",
+      "13:00:00.00",
+      "13:00:00.000"],
+    "a valid time string representing 1pm");
+} , "stepDown stop so lower than the minimum value");
+
+test(function(){
+  // Set min value to ensure that 15:01 - base is a multiple of 2 min (i.e., a
+  // valid value).
+  _StepTest.min = "14:01";
+  _StepTest.max = "15:01";
+  this.add_cleanup(function() { _StepTest.min = _StepTest.max = ""; });
+  _StepTest.value = "15:00";
+  _StepTest.step = "120";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "15:01",
+      "15:01:00",
+      "15:01:00.0",
+      "15:01:00.00",
+      "15:01:00.000"],
+    "a valid time string representing 1 minute after 3pm");
+} , "stop at border on stepUp");
+test(function(){
+  _StepTest.min = "12:59";
+  this.add_cleanup(function() { _StepTest.min = ""; });
+  _StepTest.value = "13:00";
+  _StepTest.step = "120";
+  _StepTest.stepDown();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "12:59",
+      "12:59:00",
+      "12:59:00.0",
+      "12:59:00.00",
+      "12:59:00.000"],
+    "a valid time string representing 1 minute before 2pm");
+} , "stop at border on stepDown");
+
+test(function(){
+  _StepTest.value = "";
+  _StepTest.step = "60";
+  _StepTest.stepUp();
+  assert_in_array(
+    _StepTest.value,
+    [
+      "00:01",
+      "00:01:00",
+      "00:01:00.0",
+      "00:01:00.00",
+      "00:01:00.000"],
+    "a valid time string representing 1 minute after midnight");
+} , " empty value of stepUp");
+
+
+/* set value test */
+test(function(){
+  var _time = document.getElementById("chkSetValueTest");
+  _time.value = "12:00:00.000";
+  assert_equals(_time.value, "12:00:00.000");
+  _time.value = "hh:mi:ss.sss";
+  assert_equals(_time.value, "");
+}, "set value on not time format value");
+
+
+  </script>
+  </body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/url.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/url.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Input url</title>
+  <link rel="author" title="Hyeonseok Shin" href="mailto:hyeonseok@gmail.com">
+  <link rel="help" href="https://html.spec.whatwg.org/multipage/#url-state-%28type=url%29">
+  <script src="../../../../resources/testharness.js"></script>
+  <script src="../../../../resources/testharnessreport.js"></script>
+</head>
+<body>
+  <h1>Input url</h1>
+  <div style="display: none">
+  <input type="url" id="type_support" />
+  <input type="url" id="set_value_LF" />
+  <input type="url" id="set_value_CR" />
+  <input type="url" id="set_value_CRLF" />
+  <input type="url" id="value_with_CRLF" value="a&#x000D;&#x000A;a" />
+  <input type="url" id="value_with_leading_trailing_white_space" value=" aa " />
+  <input type="url" id="value_with_leading_trailing_inner_white_space" value=" a a " />
+  </div>
+  <div id="log">
+  </div>
+
+  <script type="text/javascript">
+    test(function(){
+      var element = document.getElementById('type_support');
+      assert_equals(element.type, 'url');
+    }, 'url type supported on input element');
+
+    test(function(){
+      var element = document.getElementById('set_value_LF');
+      element.value = 'a\u000Aa';
+      assert_equals(element.value, 'aa');
+
+      element = document.getElementById('set_value_CR');
+      element.value = 'a\u000Da';
+      assert_equals(element.value, 'aa');
+
+      element = document.getElementById('set_value_CRLF');
+      element.value = 'a\u000D\u000Aa';
+      assert_equals(element.value, 'aa');
+    }, 'The value must not be set with "LF" (U+000A) or "CR" (U+000D)');
+
+    test(function(){
+      var element = document.getElementById('value_with_CRLF');
+      assert_equals(element.value, 'aa');
+    }, 'The value sanitization algorithm is as follows: Strip line breaks from the value');
+
+    test(function(){
+      var element = document.getElementById('value_with_leading_trailing_white_space');
+      assert_equals(element.value, 'aa');
+
+      element = document.getElementById('value_with_leading_trailing_inner_white_space');
+      assert_equals(element.value, 'a a');
+    }, 'The value sanitization algorithm is as follows: Strip leading and trailing whitespace from the value.');
+  </script>
+
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/week.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/forms/the-input-element/week.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<meta charset=utf-8>
+<title>Form input type=week</title>
+<link rel="author" title="Denis Ah-Kang" href="mailto:denis@w3.org">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#weeks">
+<link rel=help href="https://html.spec.whatwg.org/multipage/#week-state-(type=week)">
+<script src="../../../../resources/testharness.js"></script>
+<script src="../../../../resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  var weeks = [
+    {value: "", expected: "", testname: "empty value"},
+    {value: "2014-W52", expected: "2014-W52", testname: "Valid value: Value should be 2014-W52"},
+    {value: "2014-W53", expected: "", testname: "2014 has 52 weeks: Value should be empty"},
+    {value: "2015-W53", expected: "2015-W53", testname: "2015 has 53 weeks: Value should be 2015-W53"},
+    {value: "2014", expected: "", testname: "Invalid value: year only"},
+    {value: "2014W", expected: "", testname: "Invalid value: no week number"},
+    {value: "2014W52", expected: "", testname: "Invalid value: no '-' (U+002D)"},
+    {value: "-W52", expected: "", testname: "Invalid value: yearless week"},
+    {value: "2017-w52", expected: "", testname: "Invalid value: should be capital letter 'W'"},
+    {value: "2017-W52-", expected: "", testname: "Invalid value: incorrect with '-' at the end"},
+    {value: "2017-W52-12", expected: "", testname: "Invalid value: value should be two parts"},
+    {value: "W52", expected: "", testname: "Invalid value: yearless week and no '-' (U+002D)"},
+    {value: "2014-W03", attributes: { min: "2014-W02" }, expected: "2014-W03", testname: "Value >= min attribute"},
+    {value: "2014-W01", attributes: { min: "2014-W02" }, expected: "2014-W01", testname: "Value < min attribute"},
+    {value: "2014-W10", attributes: { max: "2014-W11" }, expected: "2014-W10", testname: "Value <= max attribute"},
+    {value: "2014-W12", attributes: { max: "2014-W11" }, expected: "2014-W12", testname: "Value > max attribute"}
+  ];
+  for (var i = 0; i < weeks.length; i++) {
+    var w = weeks[i];
+    test(function() {
+      var input = document.createElement("input");
+      input.type = "week";
+      input.value = w.value;
+      for(var attr in w.attributes) {
+        input[attr] = w.attributes[attr];
+      }
+      assert_equals(input.value, w.expected);
+    }, w.testname);
+  }
+</script>


### PR DESCRIPTION
Importing these tests now because they are for input-element types that have requirements related to the constraint-validation API — which we’ve been implementing recently.

This commit only imports tests, without any changes to our code.
