### PR TITLE
LibURL: Add U+005E (^) to path percent encoding list

### DIFF
--- a/Libraries/LibURL/URL.cpp
+++ b/Libraries/LibURL/URL.cpp
@@ -428,9 +428,9 @@ bool code_point_is_in_percent_encode_set(u32 code_point, PercentEncodeSet set)
     case PercentEncodeSet::SpecialQuery:
         return code_point_is_in_percent_encode_set(code_point, PercentEncodeSet::Query) || code_point == '\'';
     case PercentEncodeSet::Path:
-        return code_point_is_in_percent_encode_set(code_point, PercentEncodeSet::Query) || "?`{}"sv.contains(static_cast<char>(code_point));
+        return code_point_is_in_percent_encode_set(code_point, PercentEncodeSet::Query) || "?^`{}"sv.contains(static_cast<char>(code_point));
     case PercentEncodeSet::Userinfo:
-        return code_point_is_in_percent_encode_set(code_point, PercentEncodeSet::Path) || "/:;=@[\\]^|"sv.contains(static_cast<char>(code_point));
+        return code_point_is_in_percent_encode_set(code_point, PercentEncodeSet::Path) || "/:;=@[\\]|"sv.contains(static_cast<char>(code_point));
     case PercentEncodeSet::Component:
         return code_point_is_in_percent_encode_set(code_point, PercentEncodeSet::Userinfo) || "$%&+,"sv.contains(static_cast<char>(code_point));
     case PercentEncodeSet::ApplicationXWWWFormUrlencoded:


### PR DESCRIPTION
* Passes wpt tests which were failing after https://github.com/whatwg/url/commit/9bc33c39d4a6cd6a936ea7620b5a69f606ec0d4c.
* ex: http://wpt.live/url/url-constructor.any.worker.html?exclude=(file|javascript|mailto)