### PR TITLE
LibWeb: Treat media query with an invalid media type as invalid

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/MediaParsing.cpp
@@ -112,6 +112,10 @@ NonnullRefPtr<MediaQuery> Parser::parse_media_query(TokenStream<ComponentValue>&
 
     // `<media-type>`
     if (auto media_type = parse_media_type(tokens); media_type.has_value()) {
+        // https://drafts.csswg.org/mediaqueries-4/#error-handling
+        // An unknown <media-type> must be treated as not matching.
+        if (media_type.value() == MediaQuery::MediaType::Unknown)
+            return invalid_media_query();
         media_query->m_media_type = media_type.value();
         tokens.discard_whitespace();
     } else {

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-invalid-media-type-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-invalid-media-type-001.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html>
+	<head>
+		<title>Test: syntax error handling in Media Queries</title>
+		<link rel="author" title="Florian Rivoal" href="http://florian.rivoal.net/">
+		<link rel="help" href="https://drafts.csswg.org/mediaqueries4/#error-handling">
+		<link rel="match" href="../../../../expected/wpt-import/css/reference/ref-filled-green-100px-square.xht">
+		<meta name="assert" content="'and' is an invalid media type">
+		<meta name="flags" content="invalid">
+		<style>
+			div {
+				width: 100px;
+				height: 100px;
+			}
+			@media all {
+				div { background-color: green; }
+			}
+			@media not and {
+				div { background-color: red; }
+			}
+			@media and {
+				div { background-color: red; }
+			}
+	</style>
+	</head>
+	<body>
+		<p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+		<div></div>
+	</body>
+</html>
+


### PR DESCRIPTION
This fixes 7 WPT tests in the `css/mediaqueries` directory.