### PR TITLE
LibWeb: Treat CSS at-rule names as case-insensitive

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -1227,7 +1227,7 @@ Token Tokenizer::consume_a_token()
         // If the next 3 input code points would start an ident sequence, consume an ident sequence, create
         // an <at-keyword-token> with its value set to the returned value, and return it.
         if (would_start_an_ident_sequence(peek_triplet())) {
-            auto name = consume_an_ident_sequence();
+            auto name = consume_an_ident_sequence().to_ascii_lowercase();
             return create_value_token(Token::Type::AtKeyword, move(name), input_since(start_byte_offset));
         }
 

--- a/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/reference/ref-green-background.xht
+++ b/Tests/LibWeb/Ref/expected/wpt-import/css/CSS2/reference/ref-green-background.xht
@@ -1,0 +1,16 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>CSS Reftest Reference</title>
+<link rel="author" title="Ms2ger" href="mailto:Ms2ger@gmail.com"/>
+<style type="text/css">
+p {
+  color: white;
+  background: green;
+}
+</style>
+</head>
+<body>
+<p>This should have a green background.</p>
+</body>
+</html>

--- a/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-case-insensitive-001.html
+++ b/Tests/LibWeb/Ref/input/wpt-import/css/mediaqueries/mq-case-insensitive-001.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<meta charset="utf-8">
+<html>
+ <head>
+  <title>Test: ASCII-case-insensitivity of media queries</title>
+  <link rel="author" title="Gerald Squelart" href="mailto:gerald@mozilla.com">
+  <link rel="help" href="http://www.w3.org/TR/CSS21/syndata.html#characters">
+  <link rel="help" href="https://drafts.csswg.org/mediaqueries-4/#mq-syntax">
+  <link rel="help" href="https://drafts.csswg.org/css-syntax/#rule-defs">
+  <link rel="match" href="../../../../expected/wpt-import/css/reference/ref-filled-green-100px-square.xht">
+  <style type="text/css">
+
+  div {
+   width: 100px;
+   height: 100px;
+  }
+
+  @media all and (height) and (min-width:0) and (orientation:landscape) {
+   div { background-color: red; }
+  }
+  @media all and (height) and (min-width:0) and (orientation:portrait) {
+   div { background-color: red; }
+  }
+
+  @MeDIa aLL and (Height) and (mIN-Width:0cM) and (orienTAtion:LandScape) {
+   div { background-color: green; }
+  }
+  @MeDIa All and (heiGHt) and (Min-widtH:0MM) and (Orientation:porTrait) {
+   div { background-color: green; }
+  }
+
+  /* In some languages Non-ASCII 'İ' (Latin capital I with dot above) may be
+     lowercased to ASCII 'i'; This would make "heİght" compare the same as
+     "height", which would be incorrect. */
+  @media all and (heİght) {
+   div { background-color: red; }
+  }
+
+  </style>
+ </head>
+ <body>
+  <p>Test passes if there is a filled green square and <strong>no red</strong>.</p>
+  <div></div>
+ </body>
+</html>


### PR DESCRIPTION
Fixes 2 WPT tests that I could find. 

I'm not sure if it would be better to convert name to lower case at some earlier point during parsing.