### PR TITLE
LibWeb+LibWebView+WebContent: Begin implementing simple site isolation

### DIFF
--- a/Libraries/LibURL/Host.cpp
+++ b/Libraries/LibURL/Host.cpp
@@ -220,7 +220,7 @@ Optional<String> Host::registrable_domain() const
     // 3. Let registrableDomain be the registrable domain determined by running the Public Suffix List algorithm with host as domain. [PSL]
     // NOTE: The spec algorithm for the public suffix returns "*" by default, but get_public_suffix() returns an empty Optional.
     //       Remove the `value_or()` if and when we update it.
-    auto registrable_domain = get_public_suffix(host_string).value_or("*"_string);
+    auto registrable_domain = get_registrable_domain(host_string).value_or("*"_string);
 
     // 4. Assert: registrableDomain is an ASCII string that does not end with ".".
     VERIFY(all_of(registrable_domain.code_points(), is_ascii));

--- a/Libraries/LibURL/URL.h
+++ b/Libraries/LibURL/URL.h
@@ -203,6 +203,7 @@ URL create_with_data(StringView mime_type, StringView payload, bool is_base64 = 
 
 bool is_public_suffix(StringView host);
 Optional<String> get_public_suffix(StringView host);
+Optional<String> get_registrable_domain(StringView host);
 
 inline URL about_blank() { return URL::about("blank"_string); }
 inline URL about_srcdoc() { return URL::about("srcdoc"_string); }

--- a/Libraries/LibWeb/HTML/Navigable.cpp
+++ b/Libraries/LibWeb/HTML/Navigable.cpp
@@ -1351,6 +1351,12 @@ WebIDL::ExceptionOr<void> Navigable::navigate(NavigateParams params)
     auto& active_document = *this->active_document();
     auto& realm = active_document.realm();
 
+    // AD-HOC: If we are not able to continue in this process, request a new process from the UI.
+    if (!active_document.page().client().is_url_suitable_for_same_process_navigation(active_document.url(), params.url)) {
+        active_document.page().client().request_new_process_for_navigation(params.url);
+        return {};
+    }
+
     // 2. Let sourceSnapshotParams be the result of snapshotting source snapshot params given sourceDocument.
     auto source_snapshot_params = source_document->snapshot_source_snapshot_params();
 

--- a/Libraries/LibWeb/Page/Page.h
+++ b/Libraries/LibWeb/Page/Page.h
@@ -321,6 +321,8 @@ public:
     virtual Page& page() = 0;
     virtual Page const& page() const = 0;
     virtual bool is_connection_open() const = 0;
+    virtual bool is_url_suitable_for_same_process_navigation([[maybe_unused]] URL::URL const& current_url, [[maybe_unused]] URL::URL const& target_url) const { return true; }
+    virtual void request_new_process_for_navigation(URL::URL const&) { }
     virtual Gfx::Palette palette() const = 0;
     virtual DevicePixelRect screen_rect() const = 0;
     virtual double device_pixels_per_css_pixel() const = 0;

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -45,6 +45,7 @@ public:
 
     Core::EventLoop& event_loop() { return m_event_loop; }
 
+    ErrorOr<NonnullRefPtr<WebContentClient>> launch_web_content_process(ViewImplementation&);
     ErrorOr<void> launch_services();
 
     void add_child_process(Process&&);
@@ -85,6 +86,7 @@ protected:
 private:
     void initialize(Main::Arguments const& arguments, URL::URL new_tab_page_url);
 
+    void launch_spare_web_content_process();
     ErrorOr<void> launch_request_server();
     ErrorOr<void> launch_image_decoder_server();
     ErrorOr<void> launch_devtools_server();
@@ -117,6 +119,9 @@ private:
 
     RefPtr<Requests::RequestClient> m_request_server_client;
     RefPtr<ImageDecoderClient::Client> m_image_decoder_client;
+
+    RefPtr<WebContentClient> m_spare_web_content_process;
+    bool m_has_queued_task_to_launch_spare_web_content_process { false };
 
     RefPtr<Database> m_database;
     OwnPtr<CookieJar> m_cookie_jar;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     ProcessHandle.cpp
     ProcessManager.cpp
     SearchEngine.cpp
+    SiteIsolation.cpp
     SourceHighlighter.cpp
     URL.cpp
     UserAgent.cpp

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -10,6 +10,7 @@
 
 namespace WebView {
 
+class Application;
 class CookieJar;
 class Database;
 class InspectorClient;

--- a/Libraries/LibWebView/HelperProcess.h
+++ b/Libraries/LibWebView/HelperProcess.h
@@ -21,6 +21,10 @@ ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_process(
     IPC::File image_decoder_socket,
     Optional<IPC::File> request_server_socket = {});
 
+ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_spare_web_content_process(
+    IPC::File image_decoder_socket,
+    Optional<IPC::File> request_server_socket = {});
+
 ErrorOr<NonnullRefPtr<ImageDecoderClient::Client>> launch_image_decoder_process();
 ErrorOr<NonnullRefPtr<Web::HTML::WebWorkerClient>> launch_web_worker_process();
 ErrorOr<NonnullRefPtr<Requests::RequestClient>> launch_request_server_process();

--- a/Libraries/LibWebView/SiteIsolation.cpp
+++ b/Libraries/LibWebView/SiteIsolation.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibURL/URL.h>
+#include <LibWeb/Fetch/Infrastructure/URL.h>
+#include <LibWeb/HTML/BrowsingContext.h>
+#include <LibWebView/SiteIsolation.h>
+
+namespace WebView {
+
+bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url)
+{
+    // Allow navigating from about:blank to any site.
+    if (Web::HTML::url_matches_about_blank(current_url))
+        return true;
+
+    // Allow cross-scheme non-HTTP(S) navigation. Disallow cross-scheme HTTP(s) navigation.
+    auto current_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(current_url.scheme());
+    auto target_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme());
+
+    if (!current_url_is_http || !target_url_is_http)
+        return !current_url_is_http && !target_url_is_http;
+
+    // Disallow cross-site HTTP(S) navigation.
+    return current_url.origin().is_same_site(target_url.origin());
+}
+
+}

--- a/Libraries/LibWebView/SiteIsolation.h
+++ b/Libraries/LibWebView/SiteIsolation.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibURL/Forward.h>
+
+namespace WebView {
+
+[[nodiscard]] bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url);
+
+}

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/Infra/Strings.h>
 #include <LibWebView/Application.h>
 #include <LibWebView/HelperProcess.h>
+#include <LibWebView/SiteIsolation.h>
 #include <LibWebView/UserAgent.h>
 #include <LibWebView/ViewImplementation.h>
 
@@ -87,6 +88,21 @@ u64 ViewImplementation::page_id() const
 {
     VERIFY(m_client_state.client);
     return m_client_state.page_index;
+}
+
+void ViewImplementation::create_new_process_for_cross_site_navigation(URL::URL const& url)
+{
+    if (m_client_state.client)
+        client().async_close_server();
+
+    initialize_client();
+    VERIFY(m_client_state.client);
+
+    // Don't keep a stale backup bitmap around.
+    m_backup_bitmap = nullptr;
+    handle_resize();
+
+    load(url);
 }
 
 void ViewImplementation::server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size)

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -568,11 +568,8 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     if (create_new_client == CreateNewClient::Yes) {
         m_client_state = {};
 
-        // FIXME: Fail to open the tab, rather than crashing the whole application if these fail.
-        auto request_server_socket = connect_new_request_server_client().release_value_but_fixme_should_propagate_errors();
-        auto image_decoder_socket = connect_new_image_decoder_client().release_value_but_fixme_should_propagate_errors();
-
-        m_client_state.client = launch_web_content_process(*this, AK::move(image_decoder_socket), AK::move(request_server_socket)).release_value_but_fixme_should_propagate_errors();
+        // FIXME: Fail to open the tab, rather than crashing the whole application if this fails.
+        m_client_state.client = Application::the().launch_web_content_process(*this).release_value_but_fixme_should_propagate_errors();
     } else {
         m_client_state.client->register_view(m_client_state.page_index, *this);
     }

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -58,6 +58,8 @@ public:
 
     String const& handle() const { return m_client_state.client_handle; }
 
+    void create_new_process_for_cross_site_navigation(URL::URL const&);
+
     void server_did_paint(Badge<WebContentClient>, i32 bitmap_id, Gfx::IntSize size);
 
     void set_window_position(Gfx::IntPoint);

--- a/Libraries/LibWebView/WebContentClient.cpp
+++ b/Libraries/LibWebView/WebContentClient.cpp
@@ -62,6 +62,12 @@ void WebContentClient::did_paint(u64 page_id, Gfx::IntRect rect, i32 bitmap_id)
         view->server_did_paint({}, bitmap_id, rect.size());
 }
 
+void WebContentClient::did_request_new_process_for_navigation(u64 page_id, URL::URL url)
+{
+    if (auto view = view_for_page_id(page_id); view.has_value())
+        view->create_new_process_for_cross_site_navigation(url);
+}
+
 void WebContentClient::did_start_loading(u64 page_id, URL::URL url, bool is_redirect)
 {
     if (auto process = WebView::Application::the().find_process(m_process_handle.pid); process.has_value())

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -52,6 +52,7 @@ private:
     virtual void die() override;
 
     virtual void did_paint(u64 page_id, Gfx::IntRect, i32) override;
+    virtual void did_request_new_process_for_navigation(u64 page_id, URL::URL url) override;
     virtual void did_finish_loading(u64 page_id, URL::URL) override;
     virtual void did_request_refresh(u64 page_id) override;
     virtual void did_request_cursor_change(u64 page_id, Gfx::Cursor) override;

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -16,6 +16,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/HTML/WebViewHints.h>
 #include <LibWeb/Page/EventResult.h>
+#include <LibWebView/Forward.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentServerEndpoint.h>
 
@@ -38,14 +39,17 @@ public:
 
     static size_t client_count() { return s_clients.size(); }
 
+    explicit WebContentClient(IPC::Transport);
     WebContentClient(IPC::Transport, ViewImplementation&);
     ~WebContentClient();
 
+    void assign_view(Badge<Application>, ViewImplementation&);
     void register_view(u64 page_id, ViewImplementation&);
     void unregister_view(u64 page_id);
 
     Function<void()> on_web_content_process_crash;
 
+    pid_t pid() const { return m_process_handle.pid; }
     void set_pid(pid_t pid) { m_process_handle.pid = pid; }
 
 private:

--- a/Services/WebContent/PageClient.cpp
+++ b/Services/WebContent/PageClient.cpp
@@ -29,6 +29,7 @@
 #include <LibWeb/Painting/PaintableBox.h>
 #include <LibWeb/Painting/ViewportPaintable.h>
 #include <LibWebView/Attribute.h>
+#include <LibWebView/SiteIsolation.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/DevToolsConsoleClient.h>
 #include <WebContent/InspectorConsoleClient.h>
@@ -132,6 +133,16 @@ void PageClient::setup_palette()
 bool PageClient::is_connection_open() const
 {
     return client().is_open();
+}
+
+bool PageClient::is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url) const
+{
+    return WebView::is_url_suitable_for_same_process_navigation(current_url, target_url);
+}
+
+void PageClient::request_new_process_for_navigation(URL::URL const& url)
+{
+    client().async_did_request_new_process_for_navigation(m_id, url);
 }
 
 Gfx::Palette PageClient::palette() const

--- a/Services/WebContent/PageClient.h
+++ b/Services/WebContent/PageClient.h
@@ -111,6 +111,8 @@ private:
 
     // ^PageClient
     virtual bool is_connection_open() const override;
+    virtual bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url) const override;
+    virtual void request_new_process_for_navigation(URL::URL const&) override;
     virtual Gfx::Palette palette() const override;
     virtual Web::DevicePixelRect screen_rect() const override { return m_screen_rect; }
     virtual Web::CSS::PreferredColorScheme preferred_color_scheme() const override { return m_preferred_color_scheme; }

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -23,6 +23,7 @@
 
 endpoint WebContentClient
 {
+    did_request_new_process_for_navigation(u64 page_id, URL::URL url) =|
     did_start_loading(u64 page_id, URL::URL url, bool is_redirect) =|
     did_finish_loading(u64 page_id, URL::URL url) =|
     did_request_refresh(u64 page_id) =|

--- a/Tests/LibURL/TestURL.cpp
+++ b/Tests/LibURL/TestURL.cpp
@@ -558,3 +558,52 @@ TEST_CASE(invalid_domain_code_points)
         EXPECT(!url.has_value());
     }
 }
+
+TEST_CASE(get_registrable_domain)
+{
+    {
+        auto domain = URL::get_registrable_domain({});
+        EXPECT(!domain.has_value());
+    }
+    {
+        auto domain = URL::get_registrable_domain("foobar"sv);
+        EXPECT(!domain.has_value());
+    }
+    {
+        auto domain = URL::get_registrable_domain("com"sv);
+        EXPECT(!domain.has_value());
+    }
+    {
+        auto domain = URL::get_registrable_domain(".com"sv);
+        EXPECT(!domain.has_value());
+    }
+    {
+        auto domain = URL::get_registrable_domain("example.com"sv);
+        VERIFY(domain.has_value());
+        EXPECT_EQ(*domain, "example.com"sv);
+    }
+    {
+        auto domain = URL::get_registrable_domain(".example.com"sv);
+        VERIFY(domain.has_value());
+        EXPECT_EQ(*domain, "example.com"sv);
+    }
+    {
+        auto domain = URL::get_registrable_domain("www.example.com"sv);
+        VERIFY(domain.has_value());
+        EXPECT_EQ(*domain, "example.com"sv);
+    }
+    {
+        auto domain = URL::get_registrable_domain("sub.www.example.com"sv);
+        VERIFY(domain.has_value());
+        EXPECT_EQ(*domain, "example.com"sv);
+    }
+    {
+        auto domain = URL::get_registrable_domain("github.io"sv);
+        EXPECT(!domain.has_value());
+    }
+    {
+        auto domain = URL::get_registrable_domain("ladybird.github.io"sv);
+        VERIFY(domain.has_value());
+        EXPECT_EQ(*domain, "ladybird.github.io"sv);
+    }
+}


### PR DESCRIPTION
Site isolation is a common technique to reduce the chance that malicious sites can access data from other sites. When the user navigates, we now check if the target site is the same as the current site. If not, we instruct the UI to perform the navigation in a new WebContent process.

The phrase "site" here is defined as the public suffix of the URL plus one level. This means that navigating from "www.example.com" to "sub.example.com" remains in the same process.

As an easy optimization, this also creates a spare WebContent process to be used whenever a new process is created.


https://github.com/user-attachments/assets/e35398b0-0934-45be-8974-31818adf9b80

