### PR TITLE
Tests: Use own websocket echo server instead of websocket.org

### DIFF
--- a/Tests/LibWeb/Text/input/WebSocket/WebSocket-gc.html
+++ b/Tests/LibWeb/Text/input/WebSocket/WebSocket-gc.html
@@ -2,7 +2,7 @@
 <script>
     asyncTest((done) => {
         {
-            const ws = new WebSocket('wss://echo.websocket.org');
+            const ws = new WebSocket('wss://websocket-echo.app.ladybird.org');
 
             ws.onopen = () => {
             };

--- a/Tests/LibWeb/Text/input/WebSocket/echo.html
+++ b/Tests/LibWeb/Text/input/WebSocket/echo.html
@@ -1,7 +1,7 @@
 <script src="../include.js"></script>
 <script>
     asyncTest((done) => {
-        const ws = new WebSocket('wss://echo.websocket.org');
+        const ws = new WebSocket('wss://websocket-echo.app.ladybird.org');
 
         let messageCount = 0;
 


### PR DESCRIPTION
The public one at echo.websocket.org tends to be slow at times, frequently causing timeouts. Ideally we would run a local websocket server but for now we can make do with a self-hosted alternative.