### PR TITLE
LibWeb: Limit sibling style invalidation by max distance

### DIFF
--- a/Libraries/LibWeb/CSS/Selector.h
+++ b/Libraries/LibWeb/CSS/Selector.h
@@ -271,12 +271,15 @@ public:
     bool can_use_fast_matches() const { return m_can_use_fast_matches; }
     bool can_use_ancestor_filter() const { return m_can_use_ancestor_filter; }
 
+    size_t sibling_invalidation_distance() const;
+
 private:
     explicit Selector(Vector<CompoundSelector>&&);
 
     Vector<CompoundSelector> m_compound_selectors;
     mutable Optional<u32> m_specificity;
     Optional<Selector::PseudoElement> m_pseudo_element;
+    mutable Optional<size_t> m_sibling_invalidation_distance;
     bool m_can_use_fast_matches { false };
     bool m_can_use_ancestor_filter { false };
     bool m_contains_the_nesting_selector { false };

--- a/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -978,7 +978,9 @@ bool matches(CSS::Selector const& selector, int component_list_index, DOM::Eleme
     }
     case CSS::Selector::Combinator::NextSibling:
         if (context.collect_per_element_selector_involvement_metadata) {
-            const_cast<DOM::Element&>(element).set_affected_by_sibling_combinator(true);
+            const_cast<DOM::Element&>(element).set_affected_by_direct_sibling_combinator(true);
+            auto new_sibling_invalidation_distance = max(selector.sibling_invalidation_distance(), element.sibling_invalidation_distance());
+            const_cast<DOM::Element&>(element).set_sibling_invalidation_distance(new_sibling_invalidation_distance);
         }
         VERIFY(component_list_index != 0);
         if (auto* sibling = element.previous_element_sibling())
@@ -986,7 +988,7 @@ bool matches(CSS::Selector const& selector, int component_list_index, DOM::Eleme
         return false;
     case CSS::Selector::Combinator::SubsequentSibling:
         if (context.collect_per_element_selector_involvement_metadata) {
-            const_cast<DOM::Element&>(element).set_affected_by_sibling_combinator(true);
+            const_cast<DOM::Element&>(element).set_affected_by_indirect_sibling_combinator(true);
         }
         VERIFY(component_list_index != 0);
         for (auto* sibling = element.previous_element_sibling(); sibling; sibling = sibling->previous_element_sibling()) {

--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -509,9 +509,11 @@ CSS::RequiredInvalidationAfterStyleChange Element::recompute_style()
     m_affected_by_has_pseudo_class_in_subject_position = false;
     m_affected_by_has_pseudo_class_in_non_subject_position = false;
     m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator = false;
-    m_affected_by_sibling_combinator = false;
+    m_affected_by_direct_sibling_combinator = false;
+    m_affected_by_indirect_sibling_combinator = false;
     m_affected_by_first_or_last_child_pseudo_class = false;
     m_affected_by_nth_child_pseudo_class = false;
+    m_sibling_invalidation_distance = 0;
 
     auto& style_computer = document().style_computer();
     auto new_computed_properties = style_computer.compute_style(*this);

--- a/Libraries/LibWeb/DOM/Element.h
+++ b/Libraries/LibWeb/DOM/Element.h
@@ -437,8 +437,11 @@ public:
     bool affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator() const { return m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator; }
     void set_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator(bool value) { m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator = value; }
 
-    bool affected_by_sibling_combinator() const { return m_affected_by_sibling_combinator; }
-    void set_affected_by_sibling_combinator(bool value) { m_affected_by_sibling_combinator = value; }
+    bool affected_by_direct_sibling_combinator() const { return m_affected_by_direct_sibling_combinator; }
+    void set_affected_by_direct_sibling_combinator(bool value) { m_affected_by_direct_sibling_combinator = value; }
+
+    bool affected_by_indirect_sibling_combinator() const { return m_affected_by_indirect_sibling_combinator; }
+    void set_affected_by_indirect_sibling_combinator(bool value) { m_affected_by_indirect_sibling_combinator = value; }
 
     bool affected_by_first_or_last_child_pseudo_class() const { return m_affected_by_first_or_last_child_pseudo_class; }
     void set_affected_by_first_or_last_child_pseudo_class(bool value) { m_affected_by_first_or_last_child_pseudo_class = value; }
@@ -446,9 +449,12 @@ public:
     bool affected_by_nth_child_pseudo_class() const { return m_affected_by_nth_child_pseudo_class; }
     void set_affected_by_nth_child_pseudo_class(bool value) { m_affected_by_nth_child_pseudo_class = value; }
 
+    size_t sibling_invalidation_distance() const { return m_sibling_invalidation_distance; }
+    void set_sibling_invalidation_distance(size_t value) { m_sibling_invalidation_distance = value; }
+
     bool style_affected_by_structural_changes() const
     {
-        return affected_by_sibling_combinator() || affected_by_first_or_last_child_pseudo_class() || affected_by_nth_child_pseudo_class();
+        return affected_by_direct_sibling_combinator() || affected_by_indirect_sibling_combinator() || affected_by_first_or_last_child_pseudo_class() || affected_by_nth_child_pseudo_class();
     }
 
     size_t number_of_owned_list_items() const;
@@ -547,10 +553,13 @@ private:
     bool m_style_uses_css_custom_properties { false };
     bool m_affected_by_has_pseudo_class_in_subject_position : 1 { false };
     bool m_affected_by_has_pseudo_class_in_non_subject_position : 1 { false };
-    bool m_affected_by_sibling_combinator : 1 { false };
+    bool m_affected_by_direct_sibling_combinator : 1 { false };
+    bool m_affected_by_indirect_sibling_combinator : 1 { false };
     bool m_affected_by_first_or_last_child_pseudo_class : 1 { false };
     bool m_affected_by_nth_child_pseudo_class : 1 { false };
     bool m_affected_by_has_pseudo_class_with_relative_selector_that_has_sibling_combinator : 1 { false };
+
+    size_t m_sibling_invalidation_distance { 0 };
 
     OwnPtr<CSS::CountersSet> m_counters_set;
 


### PR DESCRIPTION
If an element is affected only by selectors using the direct sibling combinator `+`, we can calculate the maximum invalidation distance and use it to limit style invalidation. For example, the selector `.a + .b + .c` has a maximum invalidation distance of 2, meaning we can skip invalidating any element affected by this selector if it's more than two siblings away from the element that triggered the style invalidation.

This change results in visible performance improvement when hovering PR list on GitHub.