### PR TITLE
LibMedia+LibWeb: Demux videos with FFmpeg and play audio with videos

### DIFF
--- a/Libraries/LibMedia/Audio/FFmpegLoader.cpp
+++ b/Libraries/LibMedia/Audio/FFmpegLoader.cpp
@@ -19,73 +19,7 @@ namespace Audio {
 
 static constexpr int BUFFER_MAX_PROBE_SIZE = 64 * KiB;
 
-FFmpegIOContext::FFmpegIOContext(AVIOContext* avio_context)
-    : m_avio_context(avio_context)
-{
-}
-
-FFmpegIOContext::~FFmpegIOContext()
-{
-    // NOTE: free the buffer inside the AVIO context, since it might be changed since its initial allocation
-    av_free(m_avio_context->buffer);
-    avio_context_free(&m_avio_context);
-}
-
-ErrorOr<NonnullOwnPtr<FFmpegIOContext>> FFmpegIOContext::create(AK::SeekableStream& stream)
-{
-    auto* avio_buffer = av_malloc(PAGE_SIZE);
-    if (avio_buffer == nullptr)
-        return Error::from_string_literal("Failed to allocate AVIO buffer");
-
-    // This AVIOContext explains to avformat how to interact with our stream
-    auto* avio_context = avio_alloc_context(
-        static_cast<unsigned char*>(avio_buffer),
-        PAGE_SIZE,
-        0,
-        &stream,
-        [](void* opaque, u8* buffer, int size) -> int {
-            auto& stream = *static_cast<SeekableStream*>(opaque);
-            AK::Bytes buffer_bytes { buffer, AK::min<size_t>(size, PAGE_SIZE) };
-            auto read_bytes_or_error = stream.read_some(buffer_bytes);
-            if (read_bytes_or_error.is_error()) {
-                if (read_bytes_or_error.error().code() == EOF)
-                    return AVERROR_EOF;
-                return AVERROR_UNKNOWN;
-            }
-            int number_of_bytes_read = read_bytes_or_error.value().size();
-            if (number_of_bytes_read == 0)
-                return AVERROR_EOF;
-            return number_of_bytes_read;
-        },
-        nullptr,
-        [](void* opaque, int64_t offset, int whence) -> int64_t {
-            whence &= ~AVSEEK_FORCE;
-
-            auto& stream = *static_cast<SeekableStream*>(opaque);
-            if (whence == AVSEEK_SIZE)
-                return static_cast<int64_t>(stream.size().value());
-
-            auto seek_mode_from_whence = [](int origin) -> SeekMode {
-                if (origin == SEEK_CUR)
-                    return SeekMode::FromCurrentPosition;
-                if (origin == SEEK_END)
-                    return SeekMode::FromEndPosition;
-                return SeekMode::SetPosition;
-            };
-            auto offset_or_error = stream.seek(offset, seek_mode_from_whence(whence));
-            if (offset_or_error.is_error())
-                return -EIO;
-            return 0;
-        });
-    if (avio_context == nullptr) {
-        av_free(avio_buffer);
-        return Error::from_string_literal("Failed to allocate AVIO context");
-    }
-
-    return make<FFmpegIOContext>(avio_context);
-}
-
-FFmpegLoaderPlugin::FFmpegLoaderPlugin(NonnullOwnPtr<SeekableStream> stream, NonnullOwnPtr<FFmpegIOContext> io_context)
+FFmpegLoaderPlugin::FFmpegLoaderPlugin(NonnullOwnPtr<SeekableStream> stream, NonnullOwnPtr<Media::FFmpeg::FFmpegIOContext> io_context)
     : LoaderPlugin(move(stream))
     , m_io_context(move(io_context))
 {
@@ -105,7 +39,7 @@ FFmpegLoaderPlugin::~FFmpegLoaderPlugin()
 
 ErrorOr<NonnullOwnPtr<LoaderPlugin>> FFmpegLoaderPlugin::create(NonnullOwnPtr<SeekableStream> stream)
 {
-    auto io_context = TRY(FFmpegIOContext::create(*stream));
+    auto io_context = TRY(Media::FFmpeg::FFmpegIOContext::create(*stream));
     auto loader = make<FFmpegLoaderPlugin>(move(stream), move(io_context));
     TRY(loader->initialize());
     return loader;
@@ -180,7 +114,7 @@ double FFmpegLoaderPlugin::time_base() const
 
 bool FFmpegLoaderPlugin::sniff(SeekableStream& stream)
 {
-    auto io_context = MUST(FFmpegIOContext::create(stream));
+    auto io_context = MUST(Media::FFmpeg::FFmpegIOContext::create(stream));
 #ifdef USE_CONSTIFIED_POINTERS
     AVInputFormat const* detected_format {};
 #else

--- a/Libraries/LibMedia/Audio/FFmpegLoader.h
+++ b/Libraries/LibMedia/Audio/FFmpegLoader.h
@@ -9,6 +9,7 @@
 #include "Loader.h"
 #include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
+#include <LibMedia/FFmpeg/FFmpegIOContext.h>
 
 extern "C" {
 #include <libavcodec/avcodec.h>
@@ -17,22 +18,9 @@ extern "C" {
 
 namespace Audio {
 
-class FFmpegIOContext {
-public:
-    explicit FFmpegIOContext(AVIOContext*);
-    ~FFmpegIOContext();
-
-    static ErrorOr<NonnullOwnPtr<FFmpegIOContext>> create(AK::SeekableStream& stream);
-
-    AVIOContext* avio_context() const { return m_avio_context; }
-
-private:
-    AVIOContext* m_avio_context { nullptr };
-};
-
 class FFmpegLoaderPlugin : public LoaderPlugin {
 public:
-    explicit FFmpegLoaderPlugin(NonnullOwnPtr<SeekableStream>, NonnullOwnPtr<FFmpegIOContext>);
+    explicit FFmpegLoaderPlugin(NonnullOwnPtr<SeekableStream>, NonnullOwnPtr<Media::FFmpeg::FFmpegIOContext>);
     virtual ~FFmpegLoaderPlugin();
 
     static bool sniff(SeekableStream& stream);
@@ -58,7 +46,7 @@ private:
     AVCodecContext* m_codec_context { nullptr };
     AVFormatContext* m_format_context { nullptr };
     AVFrame* m_frame { nullptr };
-    NonnullOwnPtr<FFmpegIOContext> m_io_context;
+    NonnullOwnPtr<Media::FFmpeg::FFmpegIOContext> m_io_context;
     int m_loaded_samples { 0 };
     AVPacket* m_packet { nullptr };
     int m_total_samples { 0 };

--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -22,6 +22,7 @@ target_link_libraries(LibMedia PRIVATE LibCore LibCrypto LibRIFF LibIPC LibGfx L
 if (NOT ANDROID)
     target_sources(LibMedia PRIVATE
             Audio/FFmpegLoader.cpp
+            FFmpeg/FFmpegIOContext.cpp
             FFmpeg/FFmpegVideoDecoder.cpp
     )
     target_link_libraries(LibMedia PRIVATE PkgConfig::AVCODEC PkgConfig::AVFORMAT PkgConfig::AVUTIL)

--- a/Libraries/LibMedia/CMakeLists.txt
+++ b/Libraries/LibMedia/CMakeLists.txt
@@ -22,13 +22,17 @@ target_link_libraries(LibMedia PRIVATE LibCore LibCrypto LibRIFF LibIPC LibGfx L
 if (NOT ANDROID)
     target_sources(LibMedia PRIVATE
             Audio/FFmpegLoader.cpp
+            FFmpeg/FFmpegDemuxer.cpp
             FFmpeg/FFmpegIOContext.cpp
             FFmpeg/FFmpegVideoDecoder.cpp
     )
     target_link_libraries(LibMedia PRIVATE PkgConfig::AVCODEC PkgConfig::AVFORMAT PkgConfig::AVUTIL)
 else()
     # FIXME: Need to figure out how to build or replace ffmpeg libs on Android and Windows
-    target_sources(LibMedia PRIVATE FFmpeg/FFmpegVideoDecoderStub.cpp)
+    target_sources(LibMedia PRIVATE
+            FFmpeg/FFmpegDemuxerStub.cpp
+            FFmpeg/FFmpegVideoDecoderStub.cpp
+    )
 endif()
 
 if (LADYBIRD_AUDIO_BACKEND STREQUAL "PULSE")

--- a/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
+++ b/Libraries/LibMedia/Containers/Matroska/MatroskaDemuxer.h
@@ -31,7 +31,7 @@ public:
 
     DecoderErrorOr<Optional<AK::Duration>> seek_to_most_recent_keyframe(Track track, AK::Duration timestamp, Optional<AK::Duration> earliest_available_sample = OptionalNone()) override;
 
-    DecoderErrorOr<AK::Duration> duration() override;
+    DecoderErrorOr<AK::Duration> duration(Track track) override;
 
     DecoderErrorOr<CodecID> get_codec_id_for_track(Track track) override;
 

--- a/Libraries/LibMedia/Demuxer.h
+++ b/Libraries/LibMedia/Demuxer.h
@@ -33,7 +33,7 @@ public:
     // in the case that the timestamp is closer to the current time than the nearest keyframe.
     virtual DecoderErrorOr<Optional<AK::Duration>> seek_to_most_recent_keyframe(Track track, AK::Duration timestamp, Optional<AK::Duration> earliest_available_sample = OptionalNone()) = 0;
 
-    virtual DecoderErrorOr<AK::Duration> duration() = 0;
+    virtual DecoderErrorOr<AK::Duration> duration(Track track) = 0;
 };
 
 }

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.cpp
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Math.h>
+#include <AK/Stream.h>
+#include <LibMedia/FFmpeg/FFmpegDemuxer.h>
+#include <LibMedia/FFmpeg/FFmpegHelpers.h>
+
+namespace Media::FFmpeg {
+
+FFmpegDemuxer::FFmpegDemuxer(NonnullOwnPtr<SeekableStream> stream, NonnullOwnPtr<Media::FFmpeg::FFmpegIOContext> io_context)
+    : m_stream(move(stream))
+    , m_io_context(move(io_context))
+{
+}
+
+FFmpegDemuxer::~FFmpegDemuxer()
+{
+    if (m_packet != nullptr)
+        av_packet_free(&m_packet);
+    if (m_codec_context != nullptr)
+        avcodec_free_context(&m_codec_context);
+    if (m_format_context != nullptr)
+        avformat_close_input(&m_format_context);
+}
+
+ErrorOr<NonnullOwnPtr<FFmpegDemuxer>> FFmpegDemuxer::create(NonnullOwnPtr<SeekableStream> stream)
+{
+    auto io_context = TRY(Media::FFmpeg::FFmpegIOContext::create(*stream));
+    auto demuxer = make<FFmpegDemuxer>(move(stream), move(io_context));
+
+    // Open the container
+    demuxer->m_format_context = avformat_alloc_context();
+    if (demuxer->m_format_context == nullptr)
+        return Error::from_string_literal("Failed to allocate format context");
+    demuxer->m_format_context->pb = demuxer->m_io_context->avio_context();
+    if (avformat_open_input(&demuxer->m_format_context, nullptr, nullptr, nullptr) < 0)
+        return Error::from_string_literal("Failed to open input for format parsing");
+
+    // Read stream info; doing this is required for headerless formats like MPEG
+    if (avformat_find_stream_info(demuxer->m_format_context, nullptr) < 0)
+        return Error::from_string_literal("Failed to find stream info");
+
+    demuxer->m_packet = av_packet_alloc();
+    if (demuxer->m_packet == nullptr)
+        return Error::from_string_literal("Failed to allocate packet");
+
+    return demuxer;
+}
+
+DecoderErrorOr<AK::Duration> FFmpegDemuxer::duration_of_track_in_milliseconds(Track const& track)
+{
+    VERIFY(track.identifier() < m_format_context->nb_streams);
+    auto* stream = m_format_context->streams[track.identifier()];
+
+    if (stream->duration >= 0) {
+        auto time_base = av_q2d(stream->time_base);
+        double duration_in_milliseconds = static_cast<double>(stream->duration) * time_base * 1000.0;
+        return AK::Duration::from_milliseconds(AK::round_to<int64_t>(duration_in_milliseconds));
+    }
+
+    // If the stream doesn't specify the duration, fallback to what the container says the duration is.
+    // If the container doesn't know the duration, then we're out of luck. Return an error.
+    if (m_format_context->duration < 0)
+        return DecoderError::format(DecoderErrorCategory::Unknown, "Negative stream duration");
+
+    double duration_in_milliseconds = (static_cast<double>(m_format_context->duration) / AV_TIME_BASE) * 1000.0;
+    return AK::Duration::from_milliseconds(AK::round_to<int64_t>(duration_in_milliseconds));
+}
+
+DecoderErrorOr<Vector<Track>> FFmpegDemuxer::get_tracks_for_type(TrackType type)
+{
+    AVMediaType media_type;
+
+    switch (type) {
+    case TrackType::Video:
+        media_type = AVMediaType::AVMEDIA_TYPE_VIDEO;
+        break;
+    case TrackType::Audio:
+        media_type = AVMediaType::AVMEDIA_TYPE_AUDIO;
+        break;
+    case TrackType::Subtitles:
+        media_type = AVMediaType::AVMEDIA_TYPE_SUBTITLE;
+        break;
+    }
+
+    // Find the best stream to play within the container
+    int best_stream_index = av_find_best_stream(m_format_context, media_type, -1, -1, nullptr, 0);
+    if (best_stream_index == AVERROR_STREAM_NOT_FOUND)
+        return DecoderError::format(DecoderErrorCategory::Unknown, "No stream for given type found in container");
+    if (best_stream_index == AVERROR_DECODER_NOT_FOUND)
+        return DecoderError::format(DecoderErrorCategory::Unknown, "No suitable decoder found for stream");
+    if (best_stream_index < 0)
+        return DecoderError::format(DecoderErrorCategory::Unknown, "Failed to find a stream for the given type");
+
+    auto* stream = m_format_context->streams[best_stream_index];
+
+    Track track(type, best_stream_index);
+
+    if (type == TrackType::Video) {
+        track.set_video_data({
+            .duration = TRY(duration_of_track_in_milliseconds(track)),
+            .pixel_width = static_cast<u64>(stream->codecpar->width),
+            .pixel_height = static_cast<u64>(stream->codecpar->height),
+        });
+    }
+
+    Vector<Track> tracks;
+    tracks.append(move(track));
+    return tracks;
+}
+
+DecoderErrorOr<Optional<AK::Duration>> FFmpegDemuxer::seek_to_most_recent_keyframe(Track track, AK::Duration timestamp, Optional<AK::Duration> earliest_available_sample)
+{
+    // FIXME: What do we do with this here?
+    (void)earliest_available_sample;
+
+    VERIFY(track.identifier() < m_format_context->nb_streams);
+    auto* stream = m_format_context->streams[track.identifier()];
+    auto time_base = av_q2d(stream->time_base);
+    auto time_in_seconds = static_cast<double>(timestamp.to_milliseconds()) / 1000.0 / time_base;
+    auto sample_timestamp = AK::round_to<int64_t>(time_in_seconds);
+
+    if (av_seek_frame(m_format_context, stream->index, sample_timestamp, AVSEEK_FLAG_BACKWARD) < 0)
+        return DecoderError::format(DecoderErrorCategory::Unknown, "Failed to seek");
+
+    return timestamp;
+}
+
+DecoderErrorOr<AK::Duration> FFmpegDemuxer::duration(Track track)
+{
+    return duration_of_track_in_milliseconds(track);
+}
+
+DecoderErrorOr<CodecID> FFmpegDemuxer::get_codec_id_for_track(Track track)
+{
+    VERIFY(track.identifier() < m_format_context->nb_streams);
+    auto* stream = m_format_context->streams[track.identifier()];
+    return media_codec_id_from_ffmpeg_codec_id(stream->codecpar->codec_id);
+}
+
+DecoderErrorOr<ReadonlyBytes> FFmpegDemuxer::get_codec_initialization_data_for_track(Track track)
+{
+    VERIFY(track.identifier() < m_format_context->nb_streams);
+    auto* stream = m_format_context->streams[track.identifier()];
+    return ReadonlyBytes { stream->codecpar->extradata, static_cast<size_t>(stream->codecpar->extradata_size) };
+}
+
+DecoderErrorOr<Sample> FFmpegDemuxer::get_next_sample_for_track(Track track)
+{
+    VERIFY(track.identifier() < m_format_context->nb_streams);
+    auto* stream = m_format_context->streams[track.identifier()];
+
+    for (;;) {
+        auto read_frame_error = av_read_frame(m_format_context, m_packet);
+        if (read_frame_error < 0) {
+            if (read_frame_error == AVERROR_EOF)
+                return DecoderError::format(DecoderErrorCategory::EndOfStream, "End of stream");
+
+            return DecoderError::format(DecoderErrorCategory::Unknown, "Failed to read frame");
+        }
+        if (m_packet->stream_index != stream->index) {
+            av_packet_unref(m_packet);
+            continue;
+        }
+
+        auto color_primaries = static_cast<ColorPrimaries>(stream->codecpar->color_primaries);
+        auto transfer_characteristics = static_cast<TransferCharacteristics>(stream->codecpar->color_trc);
+        auto matrix_coefficients = static_cast<MatrixCoefficients>(stream->codecpar->color_space);
+        auto color_range = [stream] {
+            switch (stream->codecpar->color_range) {
+            case AVColorRange::AVCOL_RANGE_MPEG:
+                return VideoFullRangeFlag::Studio;
+            case AVColorRange::AVCOL_RANGE_JPEG:
+                return VideoFullRangeFlag::Full;
+            default:
+                return VideoFullRangeFlag::Unspecified;
+            }
+        }();
+
+        auto time_base = av_q2d(stream->time_base);
+        double timestamp_in_milliseconds = static_cast<double>(m_packet->pts) * time_base * 1000.0;
+
+        // Copy the packet data so that we have a permanent reference to it whilst the Sample is alive, which allows us
+        // to wipe the packet afterwards.
+        auto packet_data = DECODER_TRY_ALLOC(ByteBuffer::copy(m_packet->data, m_packet->size));
+
+        auto sample = Sample(
+            AK::Duration::from_milliseconds(AK::round_to<int64_t>(timestamp_in_milliseconds)),
+            move(packet_data),
+            VideoSampleData(CodingIndependentCodePoints(color_primaries, transfer_characteristics, matrix_coefficients, color_range)));
+
+        // Wipe the packet now that the data is safe.
+        av_packet_unref(m_packet);
+        return sample;
+    }
+}
+
+}

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxer.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <LibMedia/Demuxer.h>
+#include <LibMedia/FFmpeg/FFmpegIOContext.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
+namespace Media::FFmpeg {
+
+class FFmpegDemuxer : public Demuxer {
+public:
+    static ErrorOr<NonnullOwnPtr<FFmpegDemuxer>> create(NonnullOwnPtr<SeekableStream> stream);
+
+    FFmpegDemuxer(NonnullOwnPtr<SeekableStream> stream, NonnullOwnPtr<Media::FFmpeg::FFmpegIOContext>);
+    virtual ~FFmpegDemuxer() override;
+
+    virtual DecoderErrorOr<Vector<Track>> get_tracks_for_type(TrackType type) override;
+
+    virtual DecoderErrorOr<Optional<AK::Duration>> seek_to_most_recent_keyframe(Track track, AK::Duration timestamp, Optional<AK::Duration> earliest_available_sample = OptionalNone()) override;
+
+    virtual DecoderErrorOr<AK::Duration> duration(Track track) override;
+
+    virtual DecoderErrorOr<CodecID> get_codec_id_for_track(Track track) override;
+
+    virtual DecoderErrorOr<ReadonlyBytes> get_codec_initialization_data_for_track(Track track) override;
+
+    virtual DecoderErrorOr<Sample> get_next_sample_for_track(Track track) override;
+
+private:
+    DecoderErrorOr<AK::Duration> duration_of_track_in_milliseconds(Track const& track);
+
+    NonnullOwnPtr<SeekableStream> m_stream;
+    AVCodecContext* m_codec_context { nullptr };
+    AVFormatContext* m_format_context { nullptr };
+    NonnullOwnPtr<Media::FFmpeg::FFmpegIOContext> m_io_context;
+    AVPacket* m_packet { nullptr };
+};
+
+}

--- a/Libraries/LibMedia/FFmpeg/FFmpegDemuxerStub.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegDemuxerStub.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2025, Luke Wilde <luke@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibMedia/FFmpeg/FFmpegDemuxer.h>
+
+namespace Media::FFmpeg {
+
+DecoderErrorOr<Vector<Track>> FFmpegDemuxer::get_tracks_for_type(TrackType type)
+{
+    (void)type;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+DecoderErrorOr<Optional<AK::Duration>> FFmpegDemuxer::seek_to_most_recent_keyframe(Track track, AK::Duration timestamp, Optional<AK::Duration> earliest_available_sample = OptionalNone())
+{
+    (void)track;
+    (void)timestamp;
+    (void)earliest_available_sample;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+DecoderErrorOr<AK::Duration> FFmpegDemuxer::duration()
+{
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+DecoderErrorOr<CodecID> FFmpegDemuxer::get_codec_id_for_track(Track track)
+{
+    (void)track;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+DecoderErrorOr<ReadonlyBytes> FFmpegDemuxer::get_codec_initialization_data_for_track(Track track)
+{
+    (void)track;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+DecoderErrorOr<Sample> FFmpegDemuxer::get_next_sample_for_track(Track track)
+{
+    (void)track;
+    return DecoderError::format(DecoderErrorCategory::NotImplemented, "FFmpeg not available on this platform");
+}
+
+}

--- a/Libraries/LibMedia/FFmpeg/FFmpegHelpers.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegHelpers.h
@@ -14,7 +14,7 @@ extern "C" {
 
 namespace Media::FFmpeg {
 
-static inline AVCodecID ffmpeg_codec_id_from_serenity_codec_id(CodecID codec)
+static inline AVCodecID ffmpeg_codec_id_from_media_codec_id(CodecID codec)
 {
     switch (codec) {
     case CodecID::VP8:
@@ -42,6 +42,37 @@ static inline AVCodecID ffmpeg_codec_id_from_serenity_codec_id(CodecID codec)
         return AV_CODEC_ID_OPUS;
     default:
         return AV_CODEC_ID_NONE;
+    }
+}
+
+static inline CodecID media_codec_id_from_ffmpeg_codec_id(AVCodecID codec)
+{
+    switch (codec) {
+    case AV_CODEC_ID_VP8:
+        return CodecID::VP8;
+    case AV_CODEC_ID_VP9:
+        return CodecID::VP9;
+    case AV_CODEC_ID_H261:
+        return CodecID::H261;
+    case AV_CODEC_ID_MPEG2VIDEO:
+        // FIXME: This could also map to CodecID::MPEG1
+        return CodecID::H262;
+    case AV_CODEC_ID_H263:
+        return CodecID::H263;
+    case AV_CODEC_ID_H264:
+        return CodecID::H264;
+    case AV_CODEC_ID_HEVC:
+        return CodecID::H265;
+    case AV_CODEC_ID_AV1:
+        return CodecID::AV1;
+    case AV_CODEC_ID_THEORA:
+        return CodecID::Theora;
+    case AV_CODEC_ID_VORBIS:
+        return CodecID::Vorbis;
+    case AV_CODEC_ID_OPUS:
+        return CodecID::Opus;
+    default:
+        return CodecID::Unknown;
     }
 }
 

--- a/Libraries/LibMedia/FFmpeg/FFmpegIOContext.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegIOContext.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Stream.h>
+#include <LibMedia/FFmpeg/FFmpegIOContext.h>
+
+namespace Media::FFmpeg {
+
+FFmpegIOContext::FFmpegIOContext(AVIOContext* avio_context)
+    : m_avio_context(avio_context)
+{
+}
+
+FFmpegIOContext::~FFmpegIOContext()
+{
+    // NOTE: free the buffer inside the AVIO context, since it might be changed since its initial allocation
+    av_free(m_avio_context->buffer);
+    avio_context_free(&m_avio_context);
+}
+
+ErrorOr<NonnullOwnPtr<FFmpegIOContext>> FFmpegIOContext::create(AK::SeekableStream& stream)
+{
+    auto* avio_buffer = av_malloc(PAGE_SIZE);
+    if (avio_buffer == nullptr)
+        return Error::from_string_literal("Failed to allocate AVIO buffer");
+
+    // This AVIOContext explains to avformat how to interact with our stream
+    auto* avio_context = avio_alloc_context(
+        static_cast<unsigned char*>(avio_buffer),
+        PAGE_SIZE,
+        0,
+        &stream,
+        [](void* opaque, u8* buffer, int size) -> int {
+            auto& stream = *static_cast<SeekableStream*>(opaque);
+            AK::Bytes buffer_bytes { buffer, AK::min<size_t>(size, PAGE_SIZE) };
+            auto read_bytes_or_error = stream.read_some(buffer_bytes);
+            if (read_bytes_or_error.is_error()) {
+                if (read_bytes_or_error.error().code() == EOF)
+                    return AVERROR_EOF;
+                return AVERROR_UNKNOWN;
+            }
+            int number_of_bytes_read = read_bytes_or_error.value().size();
+            if (number_of_bytes_read == 0)
+                return AVERROR_EOF;
+            return number_of_bytes_read;
+        },
+        nullptr,
+        [](void* opaque, int64_t offset, int whence) -> int64_t {
+            whence &= ~AVSEEK_FORCE;
+
+            auto& stream = *static_cast<SeekableStream*>(opaque);
+            if (whence == AVSEEK_SIZE)
+                return static_cast<int64_t>(stream.size().value());
+
+            auto seek_mode_from_whence = [](int origin) -> SeekMode {
+                if (origin == SEEK_CUR)
+                    return SeekMode::FromCurrentPosition;
+                if (origin == SEEK_END)
+                    return SeekMode::FromEndPosition;
+                return SeekMode::SetPosition;
+            };
+            auto offset_or_error = stream.seek(offset, seek_mode_from_whence(whence));
+            if (offset_or_error.is_error())
+                return -EIO;
+            return 0;
+        });
+    if (avio_context == nullptr) {
+        av_free(avio_buffer);
+        return Error::from_string_literal("Failed to allocate AVIO context");
+    }
+
+    return make<FFmpegIOContext>(avio_context);
+}
+
+}

--- a/Libraries/LibMedia/FFmpeg/FFmpegIOContext.h
+++ b/Libraries/LibMedia/FFmpeg/FFmpegIOContext.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Jelle Raaijmakers <jelle@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+
+extern "C" {
+#include <libavcodec/avcodec.h>
+#include <libavformat/avformat.h>
+}
+
+namespace Media::FFmpeg {
+
+class FFmpegIOContext {
+public:
+    explicit FFmpegIOContext(AVIOContext*);
+    ~FFmpegIOContext();
+
+    static ErrorOr<NonnullOwnPtr<FFmpegIOContext>> create(AK::SeekableStream& stream);
+
+    AVIOContext* avio_context() const { return m_avio_context; }
+
+private:
+    AVIOContext* m_avio_context { nullptr };
+};
+
+}

--- a/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
+++ b/Libraries/LibMedia/FFmpeg/FFmpegVideoDecoder.cpp
@@ -47,7 +47,7 @@ DecoderErrorOr<NonnullOwnPtr<FFmpegVideoDecoder>> FFmpegVideoDecoder::try_create
         }
     };
 
-    auto ff_codec_id = ffmpeg_codec_id_from_serenity_codec_id(codec_id);
+    auto ff_codec_id = ffmpeg_codec_id_from_media_codec_id(codec_id);
     auto const* codec = avcodec_find_decoder(ff_codec_id);
     if (!codec)
         return DecoderError::format(DecoderErrorCategory::NotImplemented, "Could not find FFmpeg decoder for codec {}", codec_id);

--- a/Libraries/LibMedia/PlaybackManager.h
+++ b/Libraries/LibMedia/PlaybackManager.h
@@ -110,10 +110,8 @@ public:
 
     static constexpr SeekMode DEFAULT_SEEK_MODE = SeekMode::Accurate;
 
-    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_file(StringView file);
-    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_mapped_file(NonnullOwnPtr<Core::MappedFile> file);
-
     static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_data(ReadonlyBytes data);
+    static DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> from_stream(NonnullOwnPtr<SeekableStream> stream);
 
     PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder, VideoFrameQueue&& frame_queue);
     ~PlaybackManager();

--- a/Libraries/LibMedia/Sample.h
+++ b/Libraries/LibMedia/Sample.h
@@ -17,7 +17,7 @@ class Sample final {
 public:
     using AuxiliaryData = Variant<VideoSampleData>;
 
-    Sample(AK::Duration timestamp, ReadonlyBytes data, AuxiliaryData auxiliary_data)
+    Sample(AK::Duration timestamp, ByteBuffer data, AuxiliaryData auxiliary_data)
         : m_timestamp(timestamp)
         , m_data(data)
         , m_auxiliary_data(auxiliary_data)
@@ -25,12 +25,12 @@ public:
     }
 
     AK::Duration timestamp() const { return m_timestamp; }
-    ReadonlyBytes const& data() const { return m_data; }
+    ByteBuffer const& data() const { return m_data; }
     AuxiliaryData const& auxiliary_data() const { return m_auxiliary_data; }
 
 private:
     AK::Duration m_timestamp;
-    ReadonlyBytes m_data;
+    ByteBuffer m_data;
     AuxiliaryData m_auxiliary_data;
 };
 

--- a/Libraries/LibWeb/HTML/AudioTrack.cpp
+++ b/Libraries/LibWeb/HTML/AudioTrack.cpp
@@ -60,12 +60,12 @@ void AudioTrack::initialize(JS::Realm& realm)
     m_id = String::number(id);
 }
 
-void AudioTrack::play(Badge<HTMLAudioElement>)
+void AudioTrack::play()
 {
     m_audio_plugin->resume_playback();
 }
 
-void AudioTrack::pause(Badge<HTMLAudioElement>)
+void AudioTrack::pause()
 {
     m_audio_plugin->pause_playback();
 }

--- a/Libraries/LibWeb/HTML/AudioTrack.h
+++ b/Libraries/LibWeb/HTML/AudioTrack.h
@@ -22,8 +22,8 @@ public:
 
     void set_audio_track_list(Badge<AudioTrackList>, GC::Ptr<AudioTrackList> audio_track_list) { m_audio_track_list = audio_track_list; }
 
-    void play(Badge<HTMLAudioElement>);
-    void pause(Badge<HTMLAudioElement>);
+    void play();
+    void pause();
 
     AK::Duration duration();
     void seek(double, MediaSeekMode);

--- a/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAudioElement.cpp
@@ -55,14 +55,14 @@ Layout::AudioBox const* HTMLAudioElement::layout_node() const
 void HTMLAudioElement::on_playing()
 {
     audio_tracks()->for_each_enabled_track([](auto& audio_track) {
-        audio_track.play({});
+        audio_track.play();
     });
 }
 
 void HTMLAudioElement::on_paused()
 {
     audio_tracks()->for_each_enabled_track([](auto& audio_track) {
-        audio_track.pause({});
+        audio_track.pause();
     });
 }
 

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.cpp
@@ -16,6 +16,7 @@
 #include <LibWeb/Fetch/Infrastructure/FetchController.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Requests.h>
 #include <LibWeb/Fetch/Infrastructure/HTTP/Responses.h>
+#include <LibWeb/HTML/AudioTrackList.h>
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/HTML/VideoTrack.h>
 #include <LibWeb/HTML/VideoTrackList.h>
@@ -130,18 +131,37 @@ void HTMLVideoElement::on_playing()
 {
     if (m_video_track)
         m_video_track->play_video({});
+
+    audio_tracks()->for_each_enabled_track([](auto& audio_track) {
+        audio_track.play();
+    });
 }
 
 void HTMLVideoElement::on_paused()
 {
     if (m_video_track)
         m_video_track->pause_video({});
+
+    audio_tracks()->for_each_enabled_track([](auto& audio_track) {
+        audio_track.pause();
+    });
 }
 
 void HTMLVideoElement::on_seek(double position, MediaSeekMode seek_mode)
 {
     if (m_video_track)
         m_video_track->seek(AK::Duration::from_milliseconds(position * 1000.0), seek_mode);
+
+    audio_tracks()->for_each_enabled_track([&](auto& audio_track) {
+        audio_track.seek(position, seek_mode);
+    });
+}
+
+void HTMLVideoElement::on_volume_change()
+{
+    audio_tracks()->for_each_enabled_track([&](auto& audio_track) {
+        audio_track.update_volume();
+    });
 }
 
 // https://html.spec.whatwg.org/multipage/media.html#attr-video-poster

--- a/Libraries/LibWeb/HTML/HTMLVideoElement.h
+++ b/Libraries/LibWeb/HTML/HTMLVideoElement.h
@@ -66,6 +66,7 @@ private:
     virtual void on_playing() override;
     virtual void on_paused() override;
     virtual void on_seek(double, MediaSeekMode) override;
+    virtual void on_volume_change() override;
 
     WebIDL::ExceptionOr<void> determine_element_poster_frame(Optional<String> const& poster);
 


### PR DESCRIPTION
This acts as a drop-in replacement for our MatroskaDemuxer, giving us access to containers other than Matroska, with the biggest one being MP4.

Alongside this, since we already demux the audio with FFmpeg and create audio tracks regardless of media type, we can just play the audio tracks with the video element! However, audio/video sync is _not_ perfect, but that's not the goal of this PR :^)

For example, with MediaSource disabled (i.e. removing Window from the Exposed attribute on MediaSource and ManagedMediaSource), we can watch 360p h.264 mp4 YouTube videos!

https://github.com/user-attachments/assets/00cafce6-34fe-428b-9476-77ca33b21812

Note that there some improvements we could make here, e.g. dropping the MatroskaDemuxer and passing FFmpeg packets around directly, but that can be done in the future.

There's also some work we've got to do with keeping the data alive whilst the FFmpeg context exists. GCing a media element is very likely to cause a UAF with the audio stream at the moment, because audio decoding and playing is ran in a different thread, and GCing the media element destroys the underlying data buffer without coordinating with the other thread.