### PR TITLE
Nix: Fix error 'Function called without required argument "prettier"'

### DIFF
--- a/Toolchain/Nix/shell.nix
+++ b/Toolchain/Nix/shell.nix
@@ -4,7 +4,7 @@
   ccache,
   clang-tools,
   pre-commit,
-  prettier,
+  nodePackages,
   ladybird,
   ...
 }:
@@ -17,7 +17,7 @@ mkShell {
     ccache
     clang-tools
     pre-commit
-    prettier
+    nodePackages.prettier
   ];
 
   # Fix for: https://github.com/LadybirdBrowser/ladybird/issues/371#issuecomment-2616415434


### PR DESCRIPTION
Fixes: #3896
The package prettier doesn't exist and is instead called nodePackages.prettier