### PR TITLE
LibWeb/CSS: Reject invalid grid track placement property values

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -3977,8 +3977,11 @@ RefPtr<CSSStyleValue> Parser::parse_grid_track_placement_shorthand_value(Propert
 
     Vector<ComponentValue> track_start_placement_tokens;
     while (true) {
-        if (current_token->is_delim('/'))
+        if (current_token->is_delim('/')) {
+            if (!tokens.has_next_token())
+                return nullptr;
             break;
+        }
         track_start_placement_tokens.append(current_token);
         if (!tokens.has_next_token())
             break;

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-invalid.txt
@@ -2,15 +2,14 @@ Harness status: OK
 
 Found 25 tests
 
-21 Pass
-4 Fail
+25 Pass
 Pass	e.style['grid-area'] = "'string'" should not set the property value
 Pass	e.style['grid-row'] = "1.0" should not set the property value
 Pass	e.style['grid-column'] = "1 2" should not set the property value
 Pass	e.style['grid-row-start'] = "+-3" should not set the property value
 Pass	e.style['grid-column-start'] = "0" should not set the property value
-Fail	e.style['grid-row-end'] = "span" should not set the property value
-Fail	e.style['grid-column-end'] = "sPaN" should not set the property value
+Pass	e.style['grid-row-end'] = "span" should not set the property value
+Pass	e.style['grid-column-end'] = "sPaN" should not set the property value
 Pass	e.style['grid-column-end'] = "\"1st\"" should not set the property value
 Pass	e.style['grid-column-end'] = "1st" should not set the property value
 Pass	e.style['grid-column-start'] = "auto 1" should not set the property value
@@ -19,8 +18,8 @@ Pass	e.style['grid-area'] = "auto / initial" should not set the property value
 Pass	e.style['grid-row'] = "auto / inherit" should not set the property value
 Pass	e.style['grid-column'] = "auto / unset" should not set the property value
 Pass	e.style['grid-area'] = "auto / auto / auto / auto / auto" should not set the property value
-Fail	e.style['grid-row'] = "1 / 2 / 3" should not set the property value
-Fail	e.style['grid-column'] = "a / b / c" should not set the property value
+Pass	e.style['grid-row'] = "1 / 2 / 3" should not set the property value
+Pass	e.style['grid-column'] = "a / b / c" should not set the property value
 Pass	e.style['grid-row-end'] = "span 1 / span 2" should not set the property value
 Pass	e.style['grid-area'] = "auto 2 auto 4" should not set the property value
 Pass	e.style['grid-row'] = "33 -A0 auto" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-column-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-column-invalid.txt
@@ -2,36 +2,35 @@ Harness status: OK
 
 Found 31 tests
 
-1 Pass
-30 Fail
+31 Pass
 Pass	e.style['grid-column'] = "4 5" should not set the property value
-Fail	e.style['grid-column'] = "4 /" should not set the property value
-Fail	e.style['grid-column'] = "5 5" should not set the property value
-Fail	e.style['grid-column'] = "5 / /" should not set the property value
-Fail	e.style['grid-column'] = "0 / 5" should not set the property value
-Fail	e.style['grid-column'] = "6 / 0" should not set the property value
-Fail	e.style['grid-column'] = "0" should not set the property value
-Fail	e.style['grid-column'] = "span" should not set the property value
-Fail	e.style['grid-column'] = "span / span" should not set the property value
-Fail	e.style['grid-column'] = "span span / span span" should not set the property value
-Fail	e.style['grid-column'] = "5 5 / span 2" should not set the property value
-Fail	e.style['grid-column'] = "5 first last / span 2" should not set the property value
-Fail	e.style['grid-column'] = "5 / first last 2" should not set the property value
-Fail	e.style['grid-column'] = "first last / span 2" should not set the property value
-Fail	e.style['grid-column'] = "5 / first last" should not set the property value
-Fail	e.style['grid-column'] = "5 5 span / 2" should not set the property value
-Fail	e.style['grid-column'] = "span 3 5 / 1" should not set the property value
-Fail	e.style['grid-column'] = "span last first / 1" should not set the property value
-Fail	e.style['grid-column'] = "2 / span last first" should not set the property value
-Fail	e.style['grid-column'] = "span 1 last first / 1" should not set the property value
-Fail	e.style['grid-column'] = "2 / span last 3 first" should not set the property value
-Fail	e.style['grid-column'] = "1 span 2 first / 1" should not set the property value
-Fail	e.style['grid-column'] = "2 / 3 span 3 first" should not set the property value
-Fail	e.style['grid-column'] = "span -1 / -2" should not set the property value
-Fail	e.style['grid-column'] = "-1 / -2 span" should not set the property value
-Fail	e.style['grid-column'] = "0 span / 0" should not set the property value
-Fail	e.style['grid-column'] = "0 / span 0" should not set the property value
-Fail	e.style['grid-column'] = "span -3 'first' / 3 last" should not set the property value
-Fail	e.style['grid-column'] = "first span 1 / last" should not set the property value
-Fail	e.style['grid-column'] = "3 first / 2 span last" should not set the property value
-Fail	e.style['grid-column'] = "3 / 1 span 2" should not set the property value
+Pass	e.style['grid-column'] = "4 /" should not set the property value
+Pass	e.style['grid-column'] = "5 5" should not set the property value
+Pass	e.style['grid-column'] = "5 / /" should not set the property value
+Pass	e.style['grid-column'] = "0 / 5" should not set the property value
+Pass	e.style['grid-column'] = "6 / 0" should not set the property value
+Pass	e.style['grid-column'] = "0" should not set the property value
+Pass	e.style['grid-column'] = "span" should not set the property value
+Pass	e.style['grid-column'] = "span / span" should not set the property value
+Pass	e.style['grid-column'] = "span span / span span" should not set the property value
+Pass	e.style['grid-column'] = "5 5 / span 2" should not set the property value
+Pass	e.style['grid-column'] = "5 first last / span 2" should not set the property value
+Pass	e.style['grid-column'] = "5 / first last 2" should not set the property value
+Pass	e.style['grid-column'] = "first last / span 2" should not set the property value
+Pass	e.style['grid-column'] = "5 / first last" should not set the property value
+Pass	e.style['grid-column'] = "5 5 span / 2" should not set the property value
+Pass	e.style['grid-column'] = "span 3 5 / 1" should not set the property value
+Pass	e.style['grid-column'] = "span last first / 1" should not set the property value
+Pass	e.style['grid-column'] = "2 / span last first" should not set the property value
+Pass	e.style['grid-column'] = "span 1 last first / 1" should not set the property value
+Pass	e.style['grid-column'] = "2 / span last 3 first" should not set the property value
+Pass	e.style['grid-column'] = "1 span 2 first / 1" should not set the property value
+Pass	e.style['grid-column'] = "2 / 3 span 3 first" should not set the property value
+Pass	e.style['grid-column'] = "span -1 / -2" should not set the property value
+Pass	e.style['grid-column'] = "-1 / -2 span" should not set the property value
+Pass	e.style['grid-column'] = "0 span / 0" should not set the property value
+Pass	e.style['grid-column'] = "0 / span 0" should not set the property value
+Pass	e.style['grid-column'] = "span -3 'first' / 3 last" should not set the property value
+Pass	e.style['grid-column'] = "first span 1 / last" should not set the property value
+Pass	e.style['grid-column'] = "3 first / 2 span last" should not set the property value
+Pass	e.style['grid-column'] = "3 / 1 span 2" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-row-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-row-invalid.txt
@@ -2,36 +2,35 @@ Harness status: OK
 
 Found 31 tests
 
-1 Pass
-30 Fail
+31 Pass
 Pass	e.style['grid-row'] = "5 8" should not set the property value
-Fail	e.style['grid-row'] = "5 /" should not set the property value
-Fail	e.style['grid-row'] = "8 auto" should not set the property value
-Fail	e.style['grid-row'] = "8 / /" should not set the property value
-Fail	e.style['grid-row'] = "0 / 6" should not set the property value
-Fail	e.style['grid-row'] = "8 / 0" should not set the property value
-Fail	e.style['grid-row'] = "0" should not set the property value
-Fail	e.style['grid-row'] = "span" should not set the property value
-Fail	e.style['grid-row'] = "span / span" should not set the property value
-Fail	e.style['grid-row'] = "span span / span span" should not set the property value
-Fail	e.style['grid-row'] = "4 4 / 3 span" should not set the property value
-Fail	e.style['grid-row'] = "first 4 last / 3 span" should not set the property value
-Fail	e.style['grid-row'] = "4 / first 3 last" should not set the property value
-Fail	e.style['grid-row'] = "first last / 3 span" should not set the property value
-Fail	e.style['grid-row'] = "4 / first last" should not set the property value
-Fail	e.style['grid-row'] = "span 4 4 / 3" should not set the property value
-Fail	e.style['grid-row'] = "5 span 4 / 3" should not set the property value
-Fail	e.style['grid-row'] = "span first last / 3" should not set the property value
-Fail	e.style['grid-row'] = "3 / span first last" should not set the property value
-Fail	e.style['grid-row'] = "span first last 7 / 3" should not set the property value
-Fail	e.style['grid-row'] = "3 / span first 5 last" should not set the property value
-Fail	e.style['grid-row'] = "1 span last 7 / 3" should not set the property value
-Fail	e.style['grid-row'] = "3 / 5 span first 5" should not set the property value
-Fail	e.style['grid-row'] = "-3 span / -4" should not set the property value
-Fail	e.style['grid-row'] = "-3 / span -4" should not set the property value
-Fail	e.style['grid-row'] = "span 0 / 0" should not set the property value
-Fail	e.style['grid-row'] = "0 / 0 span" should not set the property value
-Fail	e.style['grid-row'] = "last -2 span / 1 nav" should not set the property value
-Fail	e.style['grid-row'] = "2 span first / last" should not set the property value
-Fail	e.style['grid-row'] = "5 nav / last span 7" should not set the property value
-Fail	e.style['grid-row'] = "5 / 3 span 3" should not set the property value
+Pass	e.style['grid-row'] = "5 /" should not set the property value
+Pass	e.style['grid-row'] = "8 auto" should not set the property value
+Pass	e.style['grid-row'] = "8 / /" should not set the property value
+Pass	e.style['grid-row'] = "0 / 6" should not set the property value
+Pass	e.style['grid-row'] = "8 / 0" should not set the property value
+Pass	e.style['grid-row'] = "0" should not set the property value
+Pass	e.style['grid-row'] = "span" should not set the property value
+Pass	e.style['grid-row'] = "span / span" should not set the property value
+Pass	e.style['grid-row'] = "span span / span span" should not set the property value
+Pass	e.style['grid-row'] = "4 4 / 3 span" should not set the property value
+Pass	e.style['grid-row'] = "first 4 last / 3 span" should not set the property value
+Pass	e.style['grid-row'] = "4 / first 3 last" should not set the property value
+Pass	e.style['grid-row'] = "first last / 3 span" should not set the property value
+Pass	e.style['grid-row'] = "4 / first last" should not set the property value
+Pass	e.style['grid-row'] = "span 4 4 / 3" should not set the property value
+Pass	e.style['grid-row'] = "5 span 4 / 3" should not set the property value
+Pass	e.style['grid-row'] = "span first last / 3" should not set the property value
+Pass	e.style['grid-row'] = "3 / span first last" should not set the property value
+Pass	e.style['grid-row'] = "span first last 7 / 3" should not set the property value
+Pass	e.style['grid-row'] = "3 / span first 5 last" should not set the property value
+Pass	e.style['grid-row'] = "1 span last 7 / 3" should not set the property value
+Pass	e.style['grid-row'] = "3 / 5 span first 5" should not set the property value
+Pass	e.style['grid-row'] = "-3 span / -4" should not set the property value
+Pass	e.style['grid-row'] = "-3 / span -4" should not set the property value
+Pass	e.style['grid-row'] = "span 0 / 0" should not set the property value
+Pass	e.style['grid-row'] = "0 / 0 span" should not set the property value
+Pass	e.style['grid-row'] = "last -2 span / 1 nav" should not set the property value
+Pass	e.style['grid-row'] = "2 span first / last" should not set the property value
+Pass	e.style['grid-row'] = "5 nav / last span 7" should not set the property value
+Pass	e.style['grid-row'] = "5 / 3 span 3" should not set the property value


### PR DESCRIPTION
This PR ensures that invalid values for the `grid-row` and `grid-column` properties and their respective longhands are rejected.

This gives us +64 WPT subtest passes.