### PR TITLE
LibDevTools: Some small refactoring to reduce boilerplate

### DIFF
--- a/Libraries/LibDevTools/Actor.cpp
+++ b/Libraries/LibDevTools/Actor.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/JsonObject.h>
 #include <LibDevTools/Actor.h>
 #include <LibDevTools/Connection.h>
 #include <LibDevTools/DevToolsServer.h>

--- a/Libraries/LibDevTools/Actor.h
+++ b/Libraries/LibDevTools/Actor.h
@@ -42,7 +42,7 @@ public:
         WeakPtr<Actor> m_actor;
     };
 
-    void send_message(JsonValue, Optional<BlockToken> block_token = {});
+    void send_message(JsonObject, Optional<BlockToken> block_token = {});
     void send_missing_parameter_error(StringView parameter);
     void send_unrecognized_packet_type_error(StringView type);
     void send_unknown_actor_error(StringView actor);
@@ -59,7 +59,7 @@ private:
     DevToolsServer& m_devtools;
     String m_name;
 
-    Vector<JsonValue> m_blocked_responses;
+    Vector<JsonObject> m_blocked_responses;
     bool m_block_responses { false };
 };
 

--- a/Libraries/LibDevTools/Actors/CSSPropertiesActor.cpp
+++ b/Libraries/LibDevTools/Actors/CSSPropertiesActor.cpp
@@ -27,7 +27,6 @@ CSSPropertiesActor::~CSSPropertiesActor() = default;
 void CSSPropertiesActor::handle_message(StringView type, JsonObject const&)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getCSSDatabase"sv) {
         auto css_property_list = devtools().delegate().css_property_list();

--- a/Libraries/LibDevTools/Actors/ConsoleActor.cpp
+++ b/Libraries/LibDevTools/Actors/ConsoleActor.cpp
@@ -31,7 +31,6 @@ ConsoleActor::~ConsoleActor() = default;
 void ConsoleActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "autocomplete"sv) {
         response.set("matches"sv, JsonArray {});
@@ -81,7 +80,6 @@ void ConsoleActor::handle_message(StringView type, JsonObject const& message)
 void ConsoleActor::received_console_result(String result_id, String input, JsonValue result, BlockToken block_token)
 {
     JsonObject message;
-    message.set("from"sv, name());
     message.set("type"sv, "evaluationResult"_string);
     message.set("timestamp"sv, AK::UnixDateTime::now().milliseconds_since_epoch());
     message.set("resultID"sv, move(result_id));

--- a/Libraries/LibDevTools/Actors/ConsoleActor.cpp
+++ b/Libraries/LibDevTools/Actors/ConsoleActor.cpp
@@ -40,11 +40,9 @@ void ConsoleActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "evaluateJSAsync"sv) {
-        auto text = message.get_string("text"sv);
-        if (!text.has_value()) {
-            send_missing_parameter_error("text"sv);
+        auto text = get_required_parameter<String>(message, "text"sv);
+        if (!text.has_value())
             return;
-        }
 
         auto result_id = MUST(String::formatted("{}-{}", name(), m_execution_id++));
 

--- a/Libraries/LibDevTools/Actors/ConsoleActor.h
+++ b/Libraries/LibDevTools/Actors/ConsoleActor.h
@@ -23,8 +23,6 @@ public:
 private:
     ConsoleActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
-    void received_console_result(String result_id, String input, JsonValue result, BlockToken);
-
     WeakPtr<TabActor> m_tab;
 
     u64 m_execution_id { 0 };

--- a/Libraries/LibDevTools/Actors/DeviceActor.cpp
+++ b/Libraries/LibDevTools/Actors/DeviceActor.cpp
@@ -48,10 +48,9 @@ void DeviceActor::handle_message(StringView type, JsonObject const&)
         value.set("arch"sv, arch);
 
         JsonObject response;
-        response.set("from"sv, name());
         response.set("value"sv, move(value));
-
         send_message(move(response));
+
         return;
     }
 

--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -54,7 +54,6 @@ FrameActor::~FrameActor()
 void FrameActor::handle_message(StringView type, JsonObject const&)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "detach"sv) {
         if (auto tab = m_tab.strong_ref()) {
@@ -88,7 +87,6 @@ void FrameActor::send_frame_update_message()
     }
 
     JsonObject message;
-    message.set("from"sv, name());
     message.set("type"sv, "frameUpdate"sv);
     message.set("frames"sv, move(frames));
     send_message(move(message));
@@ -198,7 +196,6 @@ void FrameActor::console_messages_received(i32 start_index, Vector<WebView::Cons
     array.must_append(move(console_message));
 
     JsonObject message;
-    message.set("from"sv, name());
     message.set("type"sv, "resources-available-array"sv);
     message.set("array"sv, move(array));
     send_message(move(message));

--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -30,7 +30,6 @@ HighlighterActor::~HighlighterActor() = default;
 void HighlighterActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "show"sv) {
         auto node = message.get_string("node"sv);

--- a/Libraries/LibDevTools/Actors/HighlighterActor.cpp
+++ b/Libraries/LibDevTools/Actors/HighlighterActor.cpp
@@ -32,11 +32,9 @@ void HighlighterActor::handle_message(StringView type, JsonObject const& message
     JsonObject response;
 
     if (type == "show"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         response.set("value"sv, false);
 

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -43,11 +43,9 @@ void InspectorActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "getHighlighterByType"sv) {
-        auto type_name = message.get_string("typeName"sv);
-        if (!type_name.has_value()) {
-            send_missing_parameter_error("typeName"sv);
+        auto type_name = get_required_parameter<String>(message, "typeName"sv);
+        if (!type_name.has_value())
             return;
-        }
 
         auto highlighter = m_highlighters.ensure(*type_name, [&]() -> NonnullRefPtr<HighlighterActor> {
             return devtools().register_actor<HighlighterActor>(*this);

--- a/Libraries/LibDevTools/Actors/InspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/InspectorActor.cpp
@@ -32,7 +32,6 @@ InspectorActor::~InspectorActor() = default;
 void InspectorActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getPageStyle"sv) {
         if (!m_page_style)
@@ -101,7 +100,6 @@ void InspectorActor::received_dom_tree(JsonObject dom_tree, BlockToken block_tok
     walker.set("root"sv, walker_actor.serialize_root());
 
     JsonObject message;
-    message.set("from"sv, name());
     message.set("walker"sv, move(walker));
     send_message(move(message), move(block_token));
 }

--- a/Libraries/LibDevTools/Actors/InspectorActor.h
+++ b/Libraries/LibDevTools/Actors/InspectorActor.h
@@ -27,7 +27,7 @@ public:
 private:
     InspectorActor(DevToolsServer&, String name, WeakPtr<TabActor>);
 
-    void received_dom_tree(JsonObject, BlockToken);
+    void received_dom_tree(JsonObject& response, JsonObject dom_tree);
 
     WeakPtr<TabActor> m_tab;
     WeakPtr<WalkerActor> m_walker;

--- a/Libraries/LibDevTools/Actors/LayoutInspectorActor.cpp
+++ b/Libraries/LibDevTools/Actors/LayoutInspectorActor.cpp
@@ -25,7 +25,6 @@ LayoutInspectorActor::~LayoutInspectorActor() = default;
 void LayoutInspectorActor::handle_message(StringView type, JsonObject const&)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getCurrentFlexbox"sv) {
         response.set("flexbox"sv, JsonValue {});

--- a/Libraries/LibDevTools/Actors/NodeActor.cpp
+++ b/Libraries/LibDevTools/Actors/NodeActor.cpp
@@ -110,11 +110,9 @@ void NodeActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "modifyAttributes"sv) {
-        auto modifications = message.get_array("modifications"sv);
-        if (!modifications.has_value()) {
-            send_missing_parameter_error("modifications"sv);
+        auto modifications = get_required_parameter<JsonArray>(message, "modifications"sv);
+        if (!modifications.has_value())
             return;
-        }
 
         auto [attribute_to_replace, replacement_attributes] = parse_attribute_modification(*modifications);
         if (!attribute_to_replace.has_value() && replacement_attributes.is_empty())
@@ -148,11 +146,9 @@ void NodeActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "setNodeValue"sv) {
-        auto value = message.get_string("value"sv);
-        if (!value.has_value()) {
-            send_missing_parameter_error("value"sv);
+        auto value = get_required_parameter<String>(message, "value"sv);
+        if (!value.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(m_walker, name());
         if (!dom_node.has_value()) {

--- a/Libraries/LibDevTools/Actors/NodeActor.cpp
+++ b/Libraries/LibDevTools/Actors/NodeActor.cpp
@@ -96,7 +96,6 @@ NodeActor::~NodeActor() = default;
 void NodeActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getUniqueSelector"sv) {
         auto dom_node = WalkerActor::dom_node_for(m_walker, name());
@@ -136,7 +135,7 @@ void NodeActor::handle_message(StringView type, JsonObject const& message)
             }
 
             if (auto self = weak_self.strong_ref())
-                self->finished_editing_dom_node(move(block_token));
+                self->send_message({}, move(block_token));
         };
 
         if (attribute_to_replace.has_value()) {
@@ -172,20 +171,13 @@ void NodeActor::handle_message(StringView type, JsonObject const& message)
                 }
 
                 if (auto self = weak_self.strong_ref())
-                    self->finished_editing_dom_node(move(block_token));
+                    self->send_message({}, move(block_token));
             });
 
         return;
     }
 
     send_unrecognized_packet_type_error(type);
-}
-
-void NodeActor::finished_editing_dom_node(BlockToken block_token)
-{
-    JsonObject message;
-    message.set("from"sv, name());
-    send_message(move(message), move(block_token));
 }
 
 }

--- a/Libraries/LibDevTools/Actors/NodeActor.h
+++ b/Libraries/LibDevTools/Actors/NodeActor.h
@@ -36,8 +36,6 @@ public:
 private:
     NodeActor(DevToolsServer&, String name, NodeIdentifier, WeakPtr<WalkerActor>);
 
-    void finished_editing_dom_node(BlockToken);
-
     NodeIdentifier m_node_identifier;
 
     WeakPtr<WalkerActor> m_walker;

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -41,11 +41,9 @@ void PageStyleActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "getComputed"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         inspect_dom_node(*node, [](auto& self, auto const& properties, auto block_token) {
             self.received_computed_style(properties.computed_style, move(block_token));
@@ -55,11 +53,9 @@ void PageStyleActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "getLayout"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         inspect_dom_node(*node, [](auto& self, auto const& properties, auto block_token) {
             self.received_layout(properties.computed_style, properties.node_box_sizing, move(block_token));

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -96,8 +96,10 @@ template<typename Callback>
 void PageStyleActor::inspect_dom_node(StringView node_actor, Callback&& callback)
 {
     auto dom_node = WalkerActor::dom_node_for(InspectorActor::walker_for(m_inspector), node_actor);
-    if (!dom_node.has_value())
+    if (!dom_node.has_value()) {
+        send_unknown_actor_error(node_actor);
         return;
+    }
 
     auto block_token = block_responses();
 

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -31,7 +31,6 @@ PageStyleActor::~PageStyleActor() = default;
 void PageStyleActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getApplied"sv) {
         // FIXME: This provides information to the "styles" pane in the inspector tab, which allows toggling and editing
@@ -119,7 +118,6 @@ void PageStyleActor::inspect_dom_node(StringView node_actor, Callback&& callback
 void PageStyleActor::received_layout(JsonObject const& computed_style, JsonObject const& node_box_sizing, BlockToken block_token)
 {
     JsonObject message;
-    message.set("from"sv, name());
     message.set("autoMargins"sv, JsonObject {});
 
     auto pixel_value = [&](auto const& object, auto key) {
@@ -175,7 +173,6 @@ void PageStyleActor::received_computed_style(JsonObject const& computed_style, B
     });
 
     JsonObject message;
-    message.set("from"sv, name());
     message.set("computed"sv, move(computed));
     send_message(move(message), move(block_token));
 }

--- a/Libraries/LibDevTools/Actors/PageStyleActor.h
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.h
@@ -33,9 +33,6 @@ private:
     template<typename Callback>
     void inspect_dom_node(StringView node_actor, Callback&&);
 
-    void received_layout(JsonObject const& computed_style, JsonObject const& node_box_sizing, BlockToken);
-    void received_computed_style(JsonObject const& computed_style, BlockToken);
-
     WeakPtr<InspectorActor> m_inspector;
 };
 

--- a/Libraries/LibDevTools/Actors/PreferenceActor.cpp
+++ b/Libraries/LibDevTools/Actors/PreferenceActor.cpp
@@ -30,7 +30,6 @@ void PreferenceActor::handle_message(StringView type, JsonObject const&)
     //        We just blindly return `false` for these, but we will eventually want a real configuration manager.
     if (type == "getBoolPref"sv) {
         JsonObject response;
-        response.set("from"sv, name());
         response.set("value"sv, false);
         send_message(move(response));
         return;

--- a/Libraries/LibDevTools/Actors/RootActor.cpp
+++ b/Libraries/LibDevTools/Actors/RootActor.cpp
@@ -65,11 +65,9 @@ void RootActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "getProcess"sv) {
-        auto id = message.get_integer<u64>("id"sv);
-        if (!id.has_value()) {
-            send_missing_parameter_error("id"sv);
+        auto id = get_required_parameter<u64>(message, "id"sv);
+        if (!id.has_value())
             return;
-        }
 
         for (auto const& actor : devtools().actor_registry()) {
             auto const* process_actor = as_if<ProcessActor>(*actor.value);
@@ -87,11 +85,9 @@ void RootActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "getTab"sv) {
-        auto browser_id = message.get_integer<u64>("browserId"sv);
-        if (!browser_id.has_value()) {
-            send_missing_parameter_error("browserId"sv);
+        auto browser_id = get_required_parameter<u64>(message, "browserId"sv);
+        if (!browser_id.has_value())
             return;
-        }
 
         for (auto const& actor : devtools().actor_registry()) {
             auto const* tab_actor = as_if<TabActor>(*actor.value);

--- a/Libraries/LibDevTools/Actors/RootActor.cpp
+++ b/Libraries/LibDevTools/Actors/RootActor.cpp
@@ -27,7 +27,6 @@ NonnullRefPtr<RootActor> RootActor::create(DevToolsServer& devtools, String name
     traits.set("networkMonitor"sv, false);
 
     JsonObject message;
-    message.set("from"sv, actor->name());
     message.set("applicationType"sv, "browser"sv);
     message.set("traits"sv, move(traits));
     actor->send_message(move(message));
@@ -45,7 +44,6 @@ RootActor::~RootActor() = default;
 void RootActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "connect") {
         send_message(move(response));
@@ -165,7 +163,6 @@ void RootActor::send_tab_list_changed_message()
         return;
 
     JsonObject message;
-    message.set("from"sv, name());
     message.set("type"sv, "tabListChanged"sv);
     send_message(move(message));
 

--- a/Libraries/LibDevTools/Actors/TabActor.cpp
+++ b/Libraries/LibDevTools/Actors/TabActor.cpp
@@ -31,7 +31,6 @@ TabActor::~TabActor()
 void TabActor::handle_message(StringView type, JsonObject const&)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getFavicon"sv) {
         // FIXME: Firefox DevTools wants a favicon URL here, but supplying a URL seems to prevent this tab from being

--- a/Libraries/LibDevTools/Actors/TargetConfigurationActor.cpp
+++ b/Libraries/LibDevTools/Actors/TargetConfigurationActor.cpp
@@ -27,11 +27,9 @@ void TargetConfigurationActor::handle_message(StringView type, JsonObject const&
     JsonObject response;
 
     if (type == "updateConfiguration"sv) {
-        auto configuration = message.get_object("configuration"sv);
-        if (!configuration.has_value()) {
-            send_missing_parameter_error("configuration"sv);
+        auto configuration = get_required_parameter<JsonObject>(message, "configuration"sv);
+        if (!configuration.has_value())
             return;
-        }
 
         send_message(move(response));
         return;

--- a/Libraries/LibDevTools/Actors/TargetConfigurationActor.cpp
+++ b/Libraries/LibDevTools/Actors/TargetConfigurationActor.cpp
@@ -25,7 +25,6 @@ TargetConfigurationActor::~TargetConfigurationActor() = default;
 void TargetConfigurationActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "updateConfiguration"sv) {
         auto configuration = message.get_object("configuration"sv);

--- a/Libraries/LibDevTools/Actors/ThreadConfigurationActor.cpp
+++ b/Libraries/LibDevTools/Actors/ThreadConfigurationActor.cpp
@@ -27,11 +27,9 @@ void ThreadConfigurationActor::handle_message(StringView type, JsonObject const&
     JsonObject response;
 
     if (type == "updateConfiguration"sv) {
-        auto configuration = message.get_object("configuration"sv);
-        if (!configuration.has_value()) {
-            send_missing_parameter_error("configuration"sv);
+        auto configuration = get_required_parameter<JsonObject>(message, "configuration"sv);
+        if (!configuration.has_value())
             return;
-        }
 
         send_message(move(response));
         return;

--- a/Libraries/LibDevTools/Actors/ThreadConfigurationActor.cpp
+++ b/Libraries/LibDevTools/Actors/ThreadConfigurationActor.cpp
@@ -25,7 +25,6 @@ ThreadConfigurationActor::~ThreadConfigurationActor() = default;
 void ThreadConfigurationActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "updateConfiguration"sv) {
         auto configuration = message.get_object("configuration"sv);

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -46,7 +46,6 @@ WalkerActor::~WalkerActor()
 void WalkerActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "children"sv) {
         auto node = message.get_string("node"sv);
@@ -99,11 +98,8 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
                     return;
                 }
 
-                if (auto self = weak_self.strong_ref()) {
-                    JsonObject message;
-                    message.set("from"sv, self->name());
-                    self->send_message(move(message), move(block_token));
-                }
+                if (auto self = weak_self.strong_ref())
+                    self->send_message({}, move(block_token));
             });
 
         return;
@@ -138,11 +134,8 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
                     return;
                 }
 
-                if (auto self = weak_self.strong_ref()) {
-                    JsonObject message;
-                    message.set("from"sv, self->name());
-                    self->send_message(move(message), move(block_token));
-                }
+                if (auto self = weak_self.strong_ref())
+                    self->send_message({}, move(block_token));
             });
 
         return;
@@ -199,7 +192,6 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
 
                 if (auto self = weak_self.strong_ref()) {
                     JsonObject message;
-                    message.set("from"sv, self->name());
                     message.set("value"sv, html.release_value());
                     self->send_message(move(message), move(block_token));
                 }
@@ -243,7 +235,6 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
                     }
 
                     JsonObject message;
-                    message.set("from"sv, self->name());
                     message.set("newParents"sv, JsonArray {});
                     message.set("nodes"sv, move(nodes));
                     self->send_message(move(message), move(block_token));
@@ -299,11 +290,8 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
                     return;
                 }
 
-                if (auto self = weak_self.strong_ref()) {
-                    JsonObject message;
-                    message.set("from"sv, self->name());
-                    self->send_message(move(message), move(block_token));
-                }
+                if (auto self = weak_self.strong_ref())
+                    self->send_message({}, move(block_token));
             });
 
         return;
@@ -346,7 +334,6 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
 
                 if (auto self = weak_self.strong_ref()) {
                     JsonObject message;
-                    message.set("from"sv, self->name());
                     message.set("value"sv, html.release_value());
                     self->send_message(move(message), move(block_token));
                 }
@@ -445,7 +432,6 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
 
                 if (auto self = weak_self.strong_ref()) {
                     JsonObject message;
-                    message.set("from"sv, self->name());
                     message.set("nextSibling"sv, move(next_sibling));
                     self->send_message(move(message), move(block_token));
                 }
@@ -488,11 +474,8 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
                     return;
                 }
 
-                if (auto self = weak_self.strong_ref()) {
-                    JsonObject message;
-                    message.set("from"sv, self->name());
-                    self->send_message(move(message), move(block_token));
-                }
+                if (auto self = weak_self.strong_ref())
+                    self->send_message({}, move(block_token));
             });
 
         return;
@@ -503,10 +486,7 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
         response.set("node"sv, serialize_root());
         send_message(move(response));
 
-        JsonObject message;
-        message.set("from"sv, name());
-        send_message(move(message));
-
+        send_message({});
         return;
     }
 
@@ -772,7 +752,6 @@ void WalkerActor::new_dom_node_mutation(WebView::Mutation mutation)
         return;
 
     JsonObject message;
-    message.set("from"sv, name());
     message.set("type"sv, "newMutations"sv);
     send_message(move(message));
 

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -48,11 +48,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     JsonObject response;
 
     if (type == "children"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto ancestor_node = WalkerActor::dom_node_for(*this, *node);
         if (!ancestor_node.has_value()) {
@@ -76,11 +74,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "duplicateNode"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -106,17 +102,13 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "editTagName"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
-        auto tag_name = message.get_string("tagName"sv);
-        if (!tag_name.has_value()) {
-            send_missing_parameter_error("tagName"sv);
+        auto tag_name = get_required_parameter<String>(message, "tagName"sv);
+        if (!tag_name.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -168,11 +160,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "innerHTML"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -204,11 +194,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
         // FIXME: This message also contains `value` and `position` parameters, containing the HTML to insert and the
         //        location to insert it. For the "Create New Node" action, this is always "<div></div>" and "beforeEnd",
         //        which is exactly what our WebView implementation currently supports.
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -245,17 +233,13 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "insertBefore"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
-        auto parent = message.get_string("parent"sv);
-        if (!parent.has_value()) {
-            send_missing_parameter_error("parent"sv);
+        auto parent = get_required_parameter<String>(message, "parent"sv);
+        if (!parent.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -298,11 +282,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "isInDOMTree"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         response.set("attached"sv, m_actor_to_dom_node_map.contains(*node));
         send_message(move(response));
@@ -310,11 +292,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "outerHTML"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -343,11 +323,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "previousSibling"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -365,17 +343,13 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "querySelector"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
-        auto selector = message.get_string("selector"sv);
-        if (!selector.has_value()) {
-            send_missing_parameter_error("selector"sv);
+        auto selector = get_required_parameter<String>(message, "selector"sv);
+        if (!selector.has_value())
             return;
-        }
 
         auto ancestor_node = WalkerActor::dom_node_for(*this, *node);
         if (!ancestor_node.has_value()) {
@@ -400,11 +374,9 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "removeNode"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {
@@ -446,17 +418,13 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "setOuterHTML"sv) {
-        auto node = message.get_string("node"sv);
-        if (!node.has_value()) {
-            send_missing_parameter_error("node"sv);
+        auto node = get_required_parameter<String>(message, "node"sv);
+        if (!node.has_value())
             return;
-        }
 
-        auto value = message.get_string("value"sv);
-        if (!value.has_value()) {
-            send_missing_parameter_error("value"sv);
+        auto value = get_required_parameter<String>(message, "value"sv);
+        if (!value.has_value())
             return;
-        }
 
         auto dom_node = WalkerActor::dom_node_for(*this, *node);
         if (!dom_node.has_value()) {

--- a/Libraries/LibDevTools/Actors/WalkerActor.cpp
+++ b/Libraries/LibDevTools/Actors/WalkerActor.cpp
@@ -98,6 +98,8 @@ void WalkerActor::handle_message(StringView type, JsonObject const& message)
                     }
                 });
         }
+
+        return;
     }
 
     if (type == "editTagName"sv) {

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -36,7 +36,6 @@ WatcherActor::~WatcherActor() = default;
 void WatcherActor::handle_message(StringView type, JsonObject const& message)
 {
     JsonObject response;
-    response.set("from"sv, name());
 
     if (type == "getParentBrowsingContextID"sv) {
         auto browsing_context_id = message.get_integer<u64>("browsingContextID"sv);
@@ -110,10 +109,7 @@ void WatcherActor::handle_message(StringView type, JsonObject const& message)
 
             target.send_frame_update_message();
 
-            JsonObject message;
-            message.set("from"sv, name());
-            send_message(move(message));
-
+            send_message({});
             return;
         }
     }

--- a/Libraries/LibDevTools/Actors/WatcherActor.cpp
+++ b/Libraries/LibDevTools/Actors/WatcherActor.cpp
@@ -38,11 +38,9 @@ void WatcherActor::handle_message(StringView type, JsonObject const& message)
     JsonObject response;
 
     if (type == "getParentBrowsingContextID"sv) {
-        auto browsing_context_id = message.get_integer<u64>("browsingContextID"sv);
-        if (!browsing_context_id.has_value()) {
-            send_missing_parameter_error("browsingContextID"sv);
+        auto browsing_context_id = get_required_parameter<u64>(message, "browsingContextID"sv);
+        if (!browsing_context_id.has_value())
             return;
-        }
 
         response.set("browsingContextID"sv, *browsing_context_id);
         send_message(move(response));
@@ -68,11 +66,9 @@ void WatcherActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "watchResources"sv) {
-        auto resource_types = message.get_array("resourceTypes"sv);
-        if (!resource_types.has_value()) {
-            send_missing_parameter_error("resourceTypes"sv);
+        auto resource_types = get_required_parameter<JsonArray>(message, "resourceTypes"sv);
+        if (!resource_types.has_value())
             return;
-        }
 
         if constexpr (DEVTOOLS_DEBUG) {
             for (auto const& resource_type : resource_types->values()) {
@@ -88,11 +84,9 @@ void WatcherActor::handle_message(StringView type, JsonObject const& message)
     }
 
     if (type == "watchTargets"sv) {
-        auto target_type = message.get_string("targetType"sv);
-        if (!target_type.has_value()) {
-            send_missing_parameter_error("targetType"sv);
+        auto target_type = get_required_parameter<String>(message, "targetType"sv);
+        if (!target_type.has_value())
             return;
-        }
 
         if (target_type == "frame"sv) {
             auto& css_properties = devtools().register_actor<CSSPropertiesActor>();


### PR DESCRIPTION
Now that a good chunk of DevTools has been implemented, there's been some clear boilerplate forming for many request handlers. This PR is to reduce that.