### PR TITLE
LibWeb/CSS: Don't allow negative values in filter functions

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/backdrop-filter-parsing-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/backdrop-filter-parsing-invalid.txt
@@ -1,0 +1,30 @@
+Harness status: OK
+
+Found 25 tests
+
+25 Pass
+Pass	e.style['backdrop-filter'] = "auto" should not set the property value
+Pass	e.style['backdrop-filter'] = "none hue-rotate(0deg)" should not set the property value
+Pass	e.style['backdrop-filter'] = "blur(10)" should not set the property value
+Pass	e.style['backdrop-filter'] = "blur(-100px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "brightness(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "brightness(30px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "contrast(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "contrast(30px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "drop-shadow(10 20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "drop-shadow(10% 20%)" should not set the property value
+Pass	e.style['backdrop-filter'] = "drop-shadow(1px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "drop-shadow(1px 2px 3px 4px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "drop-shadow(rgb(4, 5, 6))" should not set the property value
+Pass	e.style['backdrop-filter'] = "drop-shadow()" should not set the property value
+Pass	e.style['backdrop-filter'] = "grayscale(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "grayscale(30px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "hue-rotate(90)" should not set the property value
+Pass	e.style['backdrop-filter'] = "invert(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "invert(30px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "opacity(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "opacity(30px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "saturate(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "saturate(30px)" should not set the property value
+Pass	e.style['backdrop-filter'] = "sepia(-20)" should not set the property value
+Pass	e.style['backdrop-filter'] = "sepia(30px)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/filter-parsing-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/filter-effects/parsing/filter-parsing-invalid.txt
@@ -1,0 +1,30 @@
+Harness status: OK
+
+Found 25 tests
+
+25 Pass
+Pass	e.style['filter'] = "auto" should not set the property value
+Pass	e.style['filter'] = "none hue-rotate(0deg)" should not set the property value
+Pass	e.style['filter'] = "blur(10)" should not set the property value
+Pass	e.style['filter'] = "blur(-100px)" should not set the property value
+Pass	e.style['filter'] = "brightness(-20)" should not set the property value
+Pass	e.style['filter'] = "brightness(30px)" should not set the property value
+Pass	e.style['filter'] = "contrast(-20)" should not set the property value
+Pass	e.style['filter'] = "contrast(30px)" should not set the property value
+Pass	e.style['filter'] = "drop-shadow(10 20)" should not set the property value
+Pass	e.style['filter'] = "drop-shadow(10% 20%)" should not set the property value
+Pass	e.style['filter'] = "drop-shadow(1px)" should not set the property value
+Pass	e.style['filter'] = "drop-shadow(1px 2px 3px 4px)" should not set the property value
+Pass	e.style['filter'] = "drop-shadow(rgb(4, 5, 6))" should not set the property value
+Pass	e.style['filter'] = "drop-shadow()" should not set the property value
+Pass	e.style['filter'] = "grayscale(-20)" should not set the property value
+Pass	e.style['filter'] = "grayscale(30px)" should not set the property value
+Pass	e.style['filter'] = "hue-rotate(90)" should not set the property value
+Pass	e.style['filter'] = "invert(-20)" should not set the property value
+Pass	e.style['filter'] = "invert(30px)" should not set the property value
+Pass	e.style['filter'] = "opacity(-20)" should not set the property value
+Pass	e.style['filter'] = "opacity(30px)" should not set the property value
+Pass	e.style['filter'] = "saturate(-20)" should not set the property value
+Pass	e.style['filter'] = "saturate(30px)" should not set the property value
+Pass	e.style['filter'] = "sepia(-20)" should not set the property value
+Pass	e.style['filter'] = "sepia(30px)" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/backdrop-filter-parsing-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/backdrop-filter-parsing-invalid.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Filter Effects Module Level 2: parsing backdrop-filter with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
+<meta name="assert" content="backdrop-filter supports only the grammar 'none | <backdrop-filter-function-list>'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+// Edge fails: expected "" but got "none"
+
+test_invalid_value("backdrop-filter", "auto");
+test_invalid_value("backdrop-filter", "none hue-rotate(0deg)");
+
+test_invalid_value("backdrop-filter", "blur(10)");
+test_invalid_value("backdrop-filter", "blur(-100px)");
+
+test_invalid_value("backdrop-filter", "brightness(-20)");
+test_invalid_value("backdrop-filter", "brightness(30px)");
+
+test_invalid_value("backdrop-filter", "contrast(-20)");
+test_invalid_value("backdrop-filter", "contrast(30px)");
+
+test_invalid_value("backdrop-filter", "drop-shadow(10 20)");
+test_invalid_value("backdrop-filter", "drop-shadow(10% 20%)");
+test_invalid_value("backdrop-filter", "drop-shadow(1px)");
+test_invalid_value("backdrop-filter", "drop-shadow(1px 2px 3px 4px)");
+test_invalid_value("backdrop-filter", "drop-shadow(rgb(4, 5, 6))");
+test_invalid_value("backdrop-filter", "drop-shadow()");
+
+test_invalid_value("backdrop-filter", "grayscale(-20)");
+test_invalid_value("backdrop-filter", "grayscale(30px)");
+
+test_invalid_value("backdrop-filter", "hue-rotate(90)");
+
+test_invalid_value("backdrop-filter", "invert(-20)");
+test_invalid_value("backdrop-filter", "invert(30px)");
+
+test_invalid_value("backdrop-filter", "opacity(-20)");
+test_invalid_value("backdrop-filter", "opacity(30px)");
+
+test_invalid_value("backdrop-filter", "saturate(-20)");
+test_invalid_value("backdrop-filter", "saturate(30px)");
+
+test_invalid_value("backdrop-filter", "sepia(-20)");
+test_invalid_value("backdrop-filter", "sepia(30px)");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/filter-parsing-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/filter-effects/parsing/filter-parsing-invalid.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Filter Effects Module Level 1: parsing filter with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#FilterProperty">
+<meta name="assert" content="filter supports only the grammar 'none | <filter-function-list>'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+// Edge fails: expected "" but got "none"
+
+test_invalid_value("filter", "auto");
+test_invalid_value("filter", "none hue-rotate(0deg)");
+
+test_invalid_value("filter", "blur(10)");
+test_invalid_value("filter", "blur(-100px)");
+
+test_invalid_value("filter", "brightness(-20)"); // crbug.com/776208 Blink/WebKit accept negative brightness.
+test_invalid_value("filter", "brightness(30px)");
+
+test_invalid_value("filter", "contrast(-20)");
+test_invalid_value("filter", "contrast(30px)");
+
+test_invalid_value("filter", "drop-shadow(10 20)");
+test_invalid_value("filter", "drop-shadow(10% 20%)");
+test_invalid_value("filter", "drop-shadow(1px)");
+test_invalid_value("filter", "drop-shadow(1px 2px 3px 4px)");
+test_invalid_value("filter", "drop-shadow(rgb(4, 5, 6))");
+test_invalid_value("filter", "drop-shadow()");
+
+test_invalid_value("filter", "grayscale(-20)");
+test_invalid_value("filter", "grayscale(30px)");
+
+test_invalid_value("filter", "hue-rotate(90)");
+
+test_invalid_value("filter", "invert(-20)");
+test_invalid_value("filter", "invert(30px)");
+
+test_invalid_value("filter", "opacity(-20)");
+test_invalid_value("filter", "opacity(30px)");
+
+test_invalid_value("filter", "saturate(-20)");
+test_invalid_value("filter", "saturate(30px)");
+
+test_invalid_value("filter", "sepia(-20)");
+test_invalid_value("filter", "sepia(30px)");
+</script>
+</body>
+</html>


### PR DESCRIPTION
This fixes 16 WPT subtests in the `css/filter-effects` directory.