### PR TITLE
LibWebView+WebContent+WebDriver: Disable site isolation for WebDriver

### DIFF
--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -79,6 +79,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     Optional<u16> dns_server_port;
     bool use_dns_over_tls = false;
     bool log_all_js_exceptions = false;
+    bool disable_site_isolation = false;
     bool enable_idl_tracing = false;
     bool enable_http_cache = false;
     bool enable_autoplay = false;
@@ -102,6 +103,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     args_parser.add_option(webdriver_content_ipc_path, "Path to WebDriver IPC for WebContent", "webdriver-content-path", 0, "path", Core::ArgsParser::OptionHideMode::CommandLineAndMarkdown);
     args_parser.add_option(devtools_port, "Set the Firefox DevTools port (EXPERIMENTAL)", "devtools", 0, "port");
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
+    args_parser.add_option(disable_site_isolation, "Disable site isolation", "disable-site-isolation");
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
     args_parser.add_option(enable_autoplay, "Enable multimedia autoplay", "enable-autoplay");
@@ -171,6 +173,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
         .executable_path = MUST(String::from_byte_string(MUST(Core::System::current_executable_path()))),
         .user_agent_preset = move(user_agent_preset),
         .log_all_js_exceptions = log_all_js_exceptions ? LogAllJSExceptions::Yes : LogAllJSExceptions::No,
+        .disable_site_isolation = disable_site_isolation ? DisableSiteIsolation::Yes : DisableSiteIsolation::No,
         .enable_idl_tracing = enable_idl_tracing ? EnableIDLTracing::Yes : EnableIDLTracing::No,
         .enable_http_cache = enable_http_cache ? EnableHTTPCache::Yes : EnableHTTPCache::No,
         .expose_internals_object = expose_internals_object ? ExposeInternalsObject::Yes : ExposeInternalsObject::No,

--- a/Libraries/LibWebView/HelperProcess.cpp
+++ b/Libraries/LibWebView/HelperProcess.cpp
@@ -105,6 +105,8 @@ static ErrorOr<NonnullRefPtr<WebView::WebContentClient>> launch_web_content_proc
         arguments.append("--layout-test-mode"sv);
     if (web_content_options.log_all_js_exceptions == WebView::LogAllJSExceptions::Yes)
         arguments.append("--log-all-js-exceptions"sv);
+    if (web_content_options.disable_site_isolation == WebView::DisableSiteIsolation::Yes)
+        arguments.append("--disable-site-isolation"sv);
     if (web_content_options.enable_idl_tracing == WebView::EnableIDLTracing::Yes)
         arguments.append("--enable-idl-tracing"sv);
     if (web_content_options.enable_http_cache == WebView::EnableHTTPCache::Yes)

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -94,6 +94,11 @@ enum class EnableHTTPCache {
     Yes,
 };
 
+enum class DisableSiteIsolation {
+    No,
+    Yes,
+};
+
 enum class ExposeInternalsObject {
     No,
     Yes,
@@ -131,6 +136,7 @@ struct WebContentOptions {
     Optional<StringView> user_agent_preset {};
     IsLayoutTestMode is_layout_test_mode { IsLayoutTestMode::No };
     LogAllJSExceptions log_all_js_exceptions { LogAllJSExceptions::No };
+    DisableSiteIsolation disable_site_isolation { DisableSiteIsolation::No };
     EnableIDLTracing enable_idl_tracing { EnableIDLTracing::No };
     EnableHTTPCache enable_http_cache { EnableHTTPCache::No };
     ExposeInternalsObject expose_internals_object { ExposeInternalsObject::No };

--- a/Libraries/LibWebView/SiteIsolation.cpp
+++ b/Libraries/LibWebView/SiteIsolation.cpp
@@ -11,8 +11,18 @@
 
 namespace WebView {
 
+static bool s_site_isolation_enabled = true;
+
+void disable_site_isolation()
+{
+    s_site_isolation_enabled = false;
+}
+
 bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url)
 {
+    if (!s_site_isolation_enabled)
+        return true;
+
     // Allow navigating from about:blank to any site.
     if (Web::HTML::url_matches_about_blank(current_url))
         return true;

--- a/Libraries/LibWebView/SiteIsolation.h
+++ b/Libraries/LibWebView/SiteIsolation.h
@@ -10,6 +10,7 @@
 
 namespace WebView {
 
+void disable_site_isolation();
 [[nodiscard]] bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, URL::URL const& target_url);
 
 }

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -30,6 +30,7 @@
 #include <LibWeb/Platform/EventLoopPluginSerenity.h>
 #include <LibWebView/Plugins/FontPlugin.h>
 #include <LibWebView/Plugins/ImageCodecPlugin.h>
+#include <LibWebView/SiteIsolation.h>
 #include <LibWebView/Utilities.h>
 #include <WebContent/ConnectionFromClient.h>
 #include <WebContent/PageClient.h>
@@ -100,6 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool expose_internals_object = false;
     bool wait_for_debugger = false;
     bool log_all_js_exceptions = false;
+    bool disable_site_isolation = false;
     bool enable_idl_tracing = false;
     bool enable_http_cache = false;
     bool force_cpu_painting = false;
@@ -122,6 +124,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(wait_for_debugger, "Wait for debugger", "wait-for-debugger");
     args_parser.add_option(mach_server_name, "Mach server name", "mach-server-name", 0, "mach_server_name");
     args_parser.add_option(log_all_js_exceptions, "Log all JavaScript exceptions", "log-all-js-exceptions");
+    args_parser.add_option(disable_site_isolation, "Disable site isolation", "disable-site-isolation");
     args_parser.add_option(enable_idl_tracing, "Enable IDL tracing", "enable-idl-tracing");
     args_parser.add_option(enable_http_cache, "Enable HTTP cache", "enable-http-cache");
     args_parser.add_option(force_cpu_painting, "Force CPU painting", "force-cpu-painting");
@@ -158,6 +161,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     WebContent::PageClient::set_is_headless(is_headless);
     WebContent::PageClient::set_devtools_enabled(devtools);
+
+    if (disable_site_isolation)
+        WebView::disable_site_isolation();
 
     if (enable_http_cache) {
         Web::Fetch::Fetching::g_http_cache_enabled = true;

--- a/Services/WebDriver/main.cpp
+++ b/Services/WebDriver/main.cpp
@@ -56,6 +56,9 @@ static Vector<ByteString> create_arguments(ByteString const& socket_path, bool f
     if (debug_process.has_value())
         arguments.append(ByteString::formatted("--debug-process={}", debug_process.value()));
 
+    // FIXME: WebDriver does not yet handle the WebContent process switch brought by site isolation.
+    arguments.append("--disable-site-isolation"sv);
+
     arguments.append("about:blank"sv);
     return arguments;
 }


### PR DESCRIPTION
We will need to update WebDriver to handle the switch of WebContent processes.