### PR TITLE
Tests: Skip the svg-inline-sizing/svg-inline.html WPT test for now

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -308,3 +308,6 @@ Crash/wpt-import/css/css-contain/contain-style-remove-element-crash.html
 Ref/input/wpt-import/css/css-contain/contain-layout-020.html
 Ref/input/wpt-import/css/css-contain/contain-paint-050.html
 Ref/input/wpt-import/css/css-contain/contain-paint-change-opacity.html
+
+; Timing out; https://github.com/LadybirdBrowser/ladybird/issues/3912
+Text/input/wpt-import/html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html


### PR DESCRIPTION
See https://github.com/LadybirdBrowser/ladybird/issues/3911. The `html/rendering/replaced-elements/svg-inline-sizing/svg-inline.html` WPT test is causing a hang/timeout that prevents being able to run the test suite to completion with Debug builds.
