### PR TITLE
LibWeb: Reject invalid CSS `background` property values

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1360,6 +1360,8 @@ RefPtr<CSSStyleValue> Parser::parse_single_background_position_x_or_y_value(Toke
                 transaction.commit();
                 return EdgeStyleValue::create(relative_edge, {});
             }
+            if (value->is_keyword())
+                return {};
         }
     }
 

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1813,6 +1813,10 @@ RefPtr<CSSStyleValue> Parser::parse_single_shadow_value(TokenStream<ComponentVal
             if (!maybe_blur_radius)
                 continue;
             blur_radius = maybe_blur_radius;
+            if (blur_radius->is_length() && blur_radius->as_length().length().raw_value() < 0)
+                return nullptr;
+            if (blur_radius->is_percentage() && blur_radius->as_percentage().value() < 0)
+                return nullptr;
             tokens.discard_a_token();
 
             // spread distance (optional)

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -1656,6 +1656,10 @@ RefPtr<CSSStyleValue> Parser::parse_border_radius_shorthand_value(TokenStream<Co
         auto maybe_dimension = parse_length_percentage(tokens);
         if (!maybe_dimension.has_value())
             return nullptr;
+        if (maybe_dimension->is_length() && !property_accepts_length(PropertyID::BorderRadius, maybe_dimension->length()))
+            return nullptr;
+        if (maybe_dimension->is_percentage() && !property_accepts_percentage(PropertyID::BorderRadius, maybe_dimension->percentage()))
+            return nullptr;
         if (reading_vertical) {
             vertical_radii.append(maybe_dimension.release_value());
         } else {

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -615,6 +615,10 @@
       "border-bottom-left-radius",
       "border-bottom-right-radius"
     ],
+    "valid-types": [
+      "length [0,∞]",
+      "percentage [0,∞]"
+    ],
     "percentages-resolve-to": "length"
   },
   "border-right": {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/background-image-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/background-image-invalid.txt
@@ -1,0 +1,17 @@
+Harness status: OK
+
+Found 12 tests
+
+12 Pass
+Pass	e.style['background-image'] = "none, auto" should not set the property value
+Pass	e.style['background-image'] = "radial-gradient(circle -10px at center, red, blue)" should not set the property value
+Pass	e.style['background-image'] = "repeating-radial-gradient(-10px at center, red, blue)" should not set the property value
+Pass	e.style['background-image'] = "radial-gradient(ellipse -20px 30px at center, red, blue)" should not set the property value
+Pass	e.style['background-image'] = "repeating-radial-gradient(-20% 30% at center, red, blue)" should not set the property value
+Pass	e.style['background-image'] = "radial-gradient(20px -30px at center, red, blue)" should not set the property value
+Pass	e.style['background-image'] = "repeating-radial-gradient(20px -30px ellipse at center, red, blue)" should not set the property value
+Pass	e.style['background-image'] = "cross-fade(auto blue, 50% red)" should not set the property value
+Pass	e.style['background-image'] = "cross-fade(1px red, green)" should not set the property value
+Pass	e.style['background-image'] = "cross-fade(calc(1% + 1px) red, green)" should not set the property value
+Pass	e.style['background-image'] = "cross-fade(-1% red, green)" should not set the property value
+Pass	e.style['background-image'] = "cross-fade(101% red, green)" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/background-position-x-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/background-position-x-invalid.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Pass
+Pass	e.style['background-position-x'] = "top" should not set the property value
+Pass	e.style['background-position-x'] = "bottom" should not set the property value
+Pass	e.style['background-position-x'] = "y-start" should not set the property value
+Pass	e.style['background-position-x'] = "y-end" should not set the property value
+Pass	e.style['background-position-x'] = "center 10px" should not set the property value
+Pass	e.style['background-position-x'] = "20% left" should not set the property value
+Pass	e.style['background-position-x'] = "right left" should not set the property value
+Pass	e.style['background-position-x'] = "x-start center" should not set the property value
+Pass	e.style['background-position-x'] = "left, center right" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/background-position-y-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/background-position-y-invalid.txt
@@ -1,0 +1,14 @@
+Harness status: OK
+
+Found 9 tests
+
+9 Pass
+Pass	e.style['background-position-y'] = "left" should not set the property value
+Pass	e.style['background-position-y'] = "right" should not set the property value
+Pass	e.style['background-position-y'] = "x-start" should not set the property value
+Pass	e.style['background-position-y'] = "x-end" should not set the property value
+Pass	e.style['background-position-y'] = "center 10px" should not set the property value
+Pass	e.style['background-position-y'] = "20% top" should not set the property value
+Pass	e.style['background-position-y'] = "bottom top" should not set the property value
+Pass	e.style['background-position-y'] = "y-start center" should not set the property value
+Pass	e.style['background-position-y'] = "top, center bottom" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/border-radius-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/border-radius-invalid.txt
@@ -1,0 +1,16 @@
+Harness status: OK
+
+Found 11 tests
+
+11 Pass
+Pass	e.style['border-radius'] = "auto" should not set the property value
+Pass	e.style['border-radius'] = "none" should not set the property value
+Pass	e.style['border-radius'] = "1px 2px 3px 4px 5px" should not set the property value
+Pass	e.style['border-radius'] = "-1px" should not set the property value
+Pass	e.style['border-radius'] = "1px -2px" should not set the property value
+Pass	e.style['border-radius'] = "1em /" should not set the property value
+Pass	e.style['border-radius'] = "1px / 2px / 3px" should not set the property value
+Pass	e.style['border-radius'] = "4 / 5" should not set the property value
+Pass	e.style['border-radius'] = "5em 1px 5em 2% 5em 3px 5em 4%" should not set the property value
+Pass	e.style['border-radius'] = "1px 5em 2% 5em 3px 5em 4% 5em" should not set the property value
+Pass	e.style['border-top-left-radius'] = "10px 20px 30px" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/box-shadow-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-backgrounds/parsing/box-shadow-invalid.txt
@@ -1,0 +1,45 @@
+Harness status: OK
+
+Found 40 tests
+
+40 Pass
+Pass	e.style['box-shadow'] = "auto" should not set the property value
+Pass	e.style['box-shadow'] = "1 2" should not set the property value
+Pass	e.style['box-shadow'] = "1% 2%" should not set the property value
+Pass	e.style['box-shadow'] = "1px calc(2px + 2%)" should not set the property value
+Pass	e.style['box-shadow'] = "1px" should not set the property value
+Pass	e.style['box-shadow'] = "1px 2px 3px 4px 5px" should not set the property value
+Pass	e.style['box-shadow'] = "red 1px 2px blue" should not set the property value
+Pass	e.style['box-shadow'] = "red" should not set the property value
+Pass	e.style['box-shadow'] = "4px red" should not set the property value
+Pass	e.style['box-shadow'] = "red 4px" should not set the property value
+Pass	e.style['box-shadow'] = "-4px red 4px" should not set the property value
+Pass	e.style['box-shadow'] = "red -4px 4px red" should not set the property value
+Pass	e.style['box-shadow'] = "-4px 4px red 0" should not set the property value
+Pass	e.style['box-shadow'] = "-4px 4px 0 red 0" should not set the property value
+Pass	e.style['box-shadow'] = "inset" should not set the property value
+Pass	e.style['box-shadow'] = "inset 4px" should not set the property value
+Pass	e.style['box-shadow'] = "4px inset" should not set the property value
+Pass	e.style['box-shadow'] = "4px inset -4px" should not set the property value
+Pass	e.style['box-shadow'] = "inset 4px -4px inset" should not set the property value
+Pass	e.style['box-shadow'] = "4px -4px inset 0" should not set the property value
+Pass	e.style['box-shadow'] = "4px -4px 0 inset 0" should not set the property value
+Pass	e.style['box-shadow'] = "red inset" should not set the property value
+Pass	e.style['box-shadow'] = "inset red" should not set the property value
+Pass	e.style['box-shadow'] = "4px red inset" should not set the property value
+Pass	e.style['box-shadow'] = "red inset 4px" should not set the property value
+Pass	e.style['box-shadow'] = "4px inset red" should not set the property value
+Pass	e.style['box-shadow'] = "inset red 4px" should not set the property value
+Pass	e.style['box-shadow'] = "4px red inset -4px" should not set the property value
+Pass	e.style['box-shadow'] = "4px inset red -4px" should not set the property value
+Pass	e.style['box-shadow'] = "inset 4px red -4px" should not set the property value
+Pass	e.style['box-shadow'] = "4px red 4px inset" should not set the property value
+Pass	e.style['box-shadow'] = "red 4px inset -4px" should not set the property value
+Pass	e.style['box-shadow'] = "4px inset -4px red" should not set the property value
+Pass	e.style['box-shadow'] = "4px -4px red inset 0" should not set the property value
+Pass	e.style['box-shadow'] = "4px -4px inset red 0" should not set the property value
+Pass	e.style['box-shadow'] = "inset 4px -4px red 0" should not set the property value
+Pass	e.style['box-shadow'] = "4px -4px red 0 inset" should not set the property value
+Pass	e.style['box-shadow'] = "red 4px -4px inset 0" should not set the property value
+Pass	e.style['box-shadow'] = "4px -4px inset 0 red" should not set the property value
+Pass	e.style['box-shadow'] = "1px 1px -1px" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/background-image-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/background-image-invalid.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: parsing background-image with invalid values</title>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#background-image">
+<link rel="help" href="https://drafts.csswg.org/css-images/#radial-gradients">
+<meta name="assert" content="background-image supports only the grammar '<bg-image>#'.">
+<meta name="assert" content="Negative radial-gradient radii are invalid.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("background-image", "none, auto");
+
+// Negative radii are invalid.
+test_invalid_value("background-image", "radial-gradient(circle -10px at center, red, blue)");
+test_invalid_value("background-image", "repeating-radial-gradient(-10px at center, red, blue)");
+test_invalid_value("background-image", "radial-gradient(ellipse -20px 30px at center, red, blue)");
+test_invalid_value("background-image", "repeating-radial-gradient(-20% 30% at center, red, blue)");
+test_invalid_value("background-image", "radial-gradient(20px -30px at center, red, blue)");
+test_invalid_value("background-image", "repeating-radial-gradient(20px -30px ellipse at center, red, blue)");
+
+test_invalid_value("background-image", "cross-fade(auto blue, 50% red)");
+test_invalid_value("background-image", "cross-fade(1px red, green)");
+test_invalid_value("background-image", "cross-fade(calc(1% + 1px) red, green)");
+test_invalid_value("background-image", "cross-fade(-1% red, green)");
+test_invalid_value("background-image", "cross-fade(101% red, green)");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/background-position-x-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/background-position-x-invalid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: parsing background-position-x with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-x">
+<meta name="assert" content="background-position-x supports only the grammar '[ center | [ left | right | x-start | x-end ]? <length-percentage>? ]#'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("background-position-x", "top");
+test_invalid_value("background-position-x", "bottom");
+test_invalid_value("background-position-x", "y-start");
+test_invalid_value("background-position-x", "y-end");
+test_invalid_value("background-position-x", "center 10px");
+test_invalid_value("background-position-x", "20% left");
+test_invalid_value("background-position-x", "right left");
+test_invalid_value("background-position-x", "x-start center");
+test_invalid_value("background-position-x", "left, center right");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/background-position-y-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/background-position-y-invalid.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 4: parsing background-position-y with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-4/#propdef-background-position-y">
+<meta name="assert" content="background-position-y supports only the grammar '[ center | [ top | bottom | y-start | y-end ]? <length-percentage>? ]#'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("background-position-y", "left");
+test_invalid_value("background-position-y", "right");
+test_invalid_value("background-position-y", "x-start");
+test_invalid_value("background-position-y", "x-end");
+test_invalid_value("background-position-y", "center 10px");
+test_invalid_value("background-position-y", "20% top");
+test_invalid_value("background-position-y", "bottom top");
+test_invalid_value("background-position-y", "y-start center");
+test_invalid_value("background-position-y", "top, center bottom");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/border-radius-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/border-radius-invalid.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: parsing border-radius with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius">
+<meta name="assert" content="border-radius supports only the grammar '<length-percentage>{1,4} [ / <length-percentage>{1,4} ]?'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("border-radius", "auto");
+test_invalid_value("border-radius", "none");
+test_invalid_value("border-radius", "1px 2px 3px 4px 5px");
+test_invalid_value("border-radius", "-1px");
+test_invalid_value("border-radius", "1px -2px");
+test_invalid_value("border-radius", "1em /");
+test_invalid_value("border-radius", "1px / 2px / 3px");
+test_invalid_value("border-radius", "4 / 5");
+
+test_invalid_value("border-radius", "5em 1px 5em 2% 5em 3px 5em 4%");
+test_invalid_value("border-radius", "1px 5em 2% 5em 3px 5em 4% 5em");
+
+test_invalid_value("border-top-left-radius", "10px 20px 30px");
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/box-shadow-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-backgrounds/parsing/box-shadow-invalid.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Backgrounds and Borders Module Level 3: parsing box-shadow with invalid values</title>
+<link rel="author" title="Elika J. Etemad" href="http://fantasai.inkedblade.net/contact"/>
+<link rel="author" title="Eric Willigers" href="mailto:ericwilligers@chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds/#box-shadow">
+<meta name="assert" content="box-shadow supports only the grammar 'none | <shadow>#'.">
+<meta name="assert" content="Lengths must stay adjacent." />
+<meta name="assert" content="<blur-radius> must be non-negative." />
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("box-shadow", "auto");
+test_invalid_value("box-shadow", "1 2");
+test_invalid_value("box-shadow", "1% 2%");
+test_invalid_value("box-shadow", "1px calc(2px + 2%)");
+
+test_invalid_value("box-shadow", "1px");
+
+test_invalid_value("box-shadow", "1px 2px 3px 4px 5px");
+test_invalid_value("box-shadow", "red 1px 2px blue");
+
+
+test_invalid_value("box-shadow", "red");
+test_invalid_value("box-shadow", "4px red");
+test_invalid_value("box-shadow", "red 4px");
+test_invalid_value("box-shadow", "-4px red 4px");
+test_invalid_value("box-shadow", "red -4px 4px red");
+test_invalid_value("box-shadow", "-4px 4px red 0");
+test_invalid_value("box-shadow", "-4px 4px 0 red 0");
+test_invalid_value("box-shadow", "inset");
+test_invalid_value("box-shadow", "inset 4px");
+test_invalid_value("box-shadow", "4px inset");
+test_invalid_value("box-shadow", "4px inset -4px");
+test_invalid_value("box-shadow", "inset 4px -4px inset");
+test_invalid_value("box-shadow", "4px -4px inset 0");
+test_invalid_value("box-shadow", "4px -4px 0 inset 0");
+test_invalid_value("box-shadow", "red inset");
+test_invalid_value("box-shadow", "inset red");
+test_invalid_value("box-shadow", "4px red inset");
+test_invalid_value("box-shadow", "red inset 4px");
+test_invalid_value("box-shadow", "4px inset red");
+test_invalid_value("box-shadow", "inset red 4px");
+test_invalid_value("box-shadow", "4px red inset -4px");
+test_invalid_value("box-shadow", "4px inset red -4px");
+test_invalid_value("box-shadow", "inset 4px red -4px");
+test_invalid_value("box-shadow", "4px red 4px inset");
+test_invalid_value("box-shadow", "red 4px inset -4px");
+test_invalid_value("box-shadow", "4px inset -4px red");
+test_invalid_value("box-shadow", "4px -4px red inset 0");
+test_invalid_value("box-shadow", "4px -4px inset red 0");
+test_invalid_value("box-shadow", "inset 4px -4px red 0");
+test_invalid_value("box-shadow", "4px -4px red 0 inset");
+test_invalid_value("box-shadow", "red 4px -4px inset 0");
+test_invalid_value("box-shadow", "4px -4px inset 0 red");
+
+// <blur-radius> must be non-negative
+test_invalid_value("box-shadow", "1px 1px -1px");
+</script>
+</body>
+</html>


### PR DESCRIPTION
Fixes 12 WPT subtests in the `css/css-backgrounds` directory.