### PR TITLE
LibWeb/CSS: Reject invalid `transition` values

### DIFF
--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -3819,15 +3819,15 @@ RefPtr<CSSStyleValue> Parser::parse_transition_value(TokenStream<ComponentValue>
                 continue;
             }
 
-            if (tokens.next_token().is(Token::Type::Ident)) {
+            if (auto transition_property = parse_custom_ident_value(tokens, { { "none"sv } })) {
                 if (transition.property_name) {
                     dbgln_if(CSS_PARSER_DEBUG, "Transition property has multiple property identifiers");
                     return {};
                 }
 
-                auto ident = tokens.consume_a_token().token().ident();
-                if (auto property = property_id_from_string(ident); property.has_value())
-                    transition.property_name = CustomIdentStyleValue::create(ident);
+                auto custom_ident = transition_property->custom_ident();
+                if (auto property = property_id_from_string(custom_ident); property.has_value())
+                    transition.property_name = CustomIdentStyleValue::create(custom_ident);
 
                 continue;
             }

--- a/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
+++ b/Libraries/LibWeb/CSS/Parser/PropertyParsing.cpp
@@ -3788,13 +3788,18 @@ RefPtr<CSSStyleValue> Parser::parse_transition_value(TokenStream<ComponentValue>
         auto time_value_count = 0;
 
         while (tokens.has_next_token() && !tokens.next_token().is(Token::Type::Comma)) {
-            if (auto time = parse_time(tokens); time.has_value()) {
+            if (auto maybe_time = parse_time(tokens); maybe_time.has_value()) {
+                auto time = maybe_time.release_value();
                 switch (time_value_count) {
                 case 0:
-                    transition.duration = time.release_value();
+                    if (!time.is_calculated() && !property_accepts_time(PropertyID::TransitionDuration, time.value()))
+                        return nullptr;
+                    transition.duration = move(time);
                     break;
                 case 1:
-                    transition.delay = time.release_value();
+                    if (!time.is_calculated() && !property_accepts_time(PropertyID::TransitionDelay, time.value()))
+                        return nullptr;
+                    transition.delay = move(time);
                     break;
                 default:
                     dbgln_if(CSS_PARSER_DEBUG, "Transition property has more than two time values");

--- a/Libraries/LibWeb/CSS/Properties.json
+++ b/Libraries/LibWeb/CSS/Properties.json
@@ -2848,7 +2848,7 @@
     "inherited": false,
     "initial": "0s",
     "valid-types": [
-      "time"
+      "time [0,∞]"
     ]
   },
   "transition-property": {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/parsing/transition-duration-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/parsing/transition-duration-invalid.txt
@@ -1,0 +1,10 @@
+Harness status: OK
+
+Found 5 tests
+
+5 Pass
+Pass	e.style['transition-duration'] = "infinite" should not set the property value
+Pass	e.style['transition-duration'] = "-500ms" should not set the property value
+Pass	e.style['transition-duration'] = "1s 2s" should not set the property value
+Pass	e.style['transition-duration'] = "1s, initial" should not set the property value
+Pass	e.style['transition-duration'] = "initial, 1s" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/parsing/transition-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/parsing/transition-invalid.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-3 Pass
-2 Fail
+5 Pass
 Pass	e.style['transition'] = "1s 2s 3s" should not set the property value
 Pass	e.style['transition'] = "-1s -2s" should not set the property value
 Pass	e.style['transition'] = "steps(1) steps(2)" should not set the property value
-Fail	e.style['transition'] = "none top" should not set the property value
-Fail	e.style['transition'] = "initial 1s" should not set the property value
+Pass	e.style['transition'] = "none top" should not set the property value
+Pass	e.style['transition'] = "initial 1s" should not set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/parsing/transition-invalid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-transitions/parsing/transition-invalid.txt
@@ -1,0 +1,11 @@
+Harness status: OK
+
+Found 5 tests
+
+3 Pass
+2 Fail
+Pass	e.style['transition'] = "1s 2s 3s" should not set the property value
+Pass	e.style['transition'] = "-1s -2s" should not set the property value
+Pass	e.style['transition'] = "steps(1) steps(2)" should not set the property value
+Fail	e.style['transition'] = "none top" should not set the property value
+Fail	e.style['transition'] = "initial 1s" should not set the property value

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/parsing/transition-duration-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/parsing/transition-duration-invalid.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition-duration with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#propdef-transition-duration">
+<meta name="assert" content="transition-duration supports only the grammar '<time> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+test_invalid_value("transition-duration", 'infinite');
+test_invalid_value("transition-duration", '-500ms');
+test_invalid_value("transition-duration", '1s 2s');
+
+test_invalid_value("transition-duration", '1s, initial');
+test_invalid_value("transition-duration", 'initial, 1s');
+</script>
+</body>
+</html>

--- a/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/parsing/transition-invalid.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/css-transitions/parsing/transition-invalid.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Transitions: parsing transition with invalid values</title>
+<link rel="help" href="https://drafts.csswg.org/css-transitions/#transition-shorthand-property">
+<meta name="assert" content="transition supports only the grammar '<single-transition> #'.">
+<script src="../../../resources/testharness.js"></script>
+<script src="../../../resources/testharnessreport.js"></script>
+<script src="../../../css/support/parsing-testcommon.js"></script>
+</head>
+<body>
+<script>
+// <single-transition> = [ none | <single-transition-property> ] ||
+// <time> || <easing-function> || <time>
+test_invalid_value("transition", "1s 2s 3s");
+test_invalid_value("transition", "-1s -2s");
+
+test_invalid_value("transition", "steps(1) steps(2)");
+
+test_invalid_value("transition", "none top");
+
+test_invalid_value("transition", "initial 1s");
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
This fixes 6 WPT subtests in `css/css-transitions`.