### PR TITLE
Tests: Disable css-contain/contain-style-remove-element-crash.html

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -308,3 +308,6 @@ Text/input/wpt-import/html/syntax/parsing/html5lib_tests9-write_single.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_tricky01-write_single.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_webkit01-write_single.html
 Text/input/wpt-import/html/syntax/parsing/html5lib_webkit02-write_single.html
+
+; Inconsistently crashes because we haven't figured invalidation for CSS containment
+Crash/wpt-import/css/css-contain/contain-style-remove-element-crash.html


### PR DESCRIPTION
Disabling this test because it very often crashes on CI https://github.com/LadybirdBrowser/ladybird/issues/3894