### PR TITLE
LibWeb: Delete root pointer in LayoutState

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -9,7 +9,6 @@
 #include <AK/Debug.h>
 #include <LibWeb/DOM/ShadowRoot.h>
 #include <LibWeb/Layout/AvailableSpace.h>
-#include <LibWeb/Layout/BlockContainer.h>
 #include <LibWeb/Layout/InlineNode.h>
 #include <LibWeb/Layout/LayoutState.h>
 #include <LibWeb/Layout/Viewport.h>
@@ -21,7 +20,6 @@ namespace Web::Layout {
 
 LayoutState::LayoutState(LayoutState const* parent)
     : m_parent(parent)
-    , m_root(find_root())
 {
 }
 

--- a/Libraries/LibWeb/Layout/LayoutState.h
+++ b/Libraries/LibWeb/Layout/LayoutState.h
@@ -55,21 +55,10 @@ struct StaticPositionRect {
 };
 
 struct LayoutState {
-    LayoutState()
-        : m_root(*this)
-    {
-    }
+    LayoutState() = default;
 
     explicit LayoutState(LayoutState const* parent);
     ~LayoutState();
-
-    LayoutState const& find_root() const
-    {
-        LayoutState const* root = this;
-        for (auto* state = m_parent; state; state = state->m_parent)
-            root = state;
-        return *root;
-    }
 
     struct UsedValues {
         NodeWithStyle const& node() const { return *m_node; }
@@ -222,7 +211,6 @@ struct LayoutState {
     HashMap<GC::Ref<Layout::Node const>, NonnullOwnPtr<UsedValues>> used_values_per_layout_node;
 
     LayoutState const* m_parent { nullptr };
-    LayoutState const& m_root;
 
 private:
     void resolve_relative_positions();


### PR DESCRIPTION
It's no longer needed after we moved intrinsic sizes cache into layout nodes.