### PR TITLE
RequestServer: Don't assert for socket fd not being CURL_SOCKET_BAD

### DIFF
--- a/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Services/RequestServer/ConnectionFromClient.cpp
@@ -625,10 +625,12 @@ void ConnectionFromClient::check_active_requests()
         // FIXME: Come up with a unified way to track websockets and standard fetches instead of this nasty tagged pointer
         if (reinterpret_cast<uintptr_t>(application_private) & websocket_private_tag) {
             auto* websocket_impl = reinterpret_cast<WebSocketImplCurl*>(reinterpret_cast<uintptr_t>(application_private) & ~websocket_private_tag);
-            if (msg->data.result == CURLE_OK)
-                websocket_impl->did_connect();
-            else
+            if (msg->data.result == CURLE_OK) {
+                if (!websocket_impl->did_connect())
+                    websocket_impl->on_connection_error();
+            } else {
                 websocket_impl->on_connection_error();
+            }
             continue;
         }
 

--- a/Services/RequestServer/WebSocketImplCurl.cpp
+++ b/Services/RequestServer/WebSocketImplCurl.cpp
@@ -160,11 +160,12 @@ void WebSocketImplCurl::discard_connection()
     }
 }
 
-void WebSocketImplCurl::did_connect()
+bool WebSocketImplCurl::did_connect()
 {
     curl_socket_t socket_fd = CURL_SOCKET_BAD;
     auto res = curl_easy_getinfo(m_easy_handle, CURLINFO_ACTIVESOCKET, &socket_fd);
-    VERIFY(res == CURLE_OK && socket_fd != CURL_SOCKET_BAD);
+    if (res != CURLE_OK || socket_fd == CURL_SOCKET_BAD)
+        return false;
 
     m_read_notifier = Core::Notifier::construct(socket_fd, Core::Notifier::Type::Read);
     m_read_notifier->on_activation = [this] {
@@ -190,6 +191,7 @@ void WebSocketImplCurl::did_connect()
     };
 
     on_connected();
+    return true;
 }
 
 }

--- a/Services/RequestServer/WebSocketImplCurl.h
+++ b/Services/RequestServer/WebSocketImplCurl.h
@@ -29,7 +29,7 @@ public:
 
     virtual bool handshake_complete_when_connected() const override { return true; }
 
-    void did_connect();
+    bool did_connect();
 
 private:
     explicit WebSocketImplCurl(CURLM*);


### PR DESCRIPTION
The assertion in `WebSocketImplCurl::did_connect()` keeps failing for multiple websockets when loading `https://www.speedtest.net/` since commit 14ebcd4. This fixes that by checking and returning false if something went wrong and letting the caller function handle it.

Fixes: #3828