### PR TITLE
LibMedia: Popagate errors if demuxer creation fails

### DIFF
--- a/Libraries/LibMedia/DecoderError.h
+++ b/Libraries/LibMedia/DecoderError.h
@@ -92,3 +92,15 @@ private:
 #define DECODER_TRY_ALLOC(expression) DECODER_TRY(DecoderErrorCategory::Memory, expression)
 
 }
+
+namespace AK {
+
+template<>
+struct Formatter<Media::DecoderError> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, Media::DecoderError const& decoder_error)
+    {
+        return Formatter<FormatString>::format(builder, "[DecoderError]: {}"sv, decoder_error.description());
+    }
+};
+
+}

--- a/Libraries/LibMedia/PlaybackManager.cpp
+++ b/Libraries/LibMedia/PlaybackManager.cpp
@@ -35,8 +35,10 @@ DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_data(Readon
 
 DecoderErrorOr<NonnullOwnPtr<PlaybackManager>> PlaybackManager::from_stream(NonnullOwnPtr<SeekableStream> stream)
 {
-    auto demuxer = MUST(FFmpeg::FFmpegDemuxer::create(move(stream)));
-    return create(move(demuxer));
+    auto demuxer_or_error = FFmpeg::FFmpegDemuxer::create(move(stream));
+    if (demuxer_or_error.is_error())
+        return DecoderError::format(DecoderErrorCategory::Unknown, "{}", demuxer_or_error.error());
+    return create(demuxer_or_error.release_value());
 }
 
 PlaybackManager::PlaybackManager(NonnullOwnPtr<Demuxer>& demuxer, Track video_track, NonnullOwnPtr<VideoDecoder>&& decoder, VideoFrameQueue&& frame_queue)


### PR DESCRIPTION
This fixes WPT regression in the `html/dom` directory seen in this run: https://wpt.fyi/results/html/dom?diff&filter=ADC&run_id=4819693758316544&run_id=5104664167317504.