### PR TITLE
LibWeb: Protect audio codec callbacks against its own destruction

### DIFF
--- a/Libraries/LibWeb/Platform/AudioCodecPlugin.h
+++ b/Libraries/LibWeb/Platform/AudioCodecPlugin.h
@@ -10,11 +10,12 @@
 #include <AK/Function.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Weakable.h>
 #include <LibMedia/Audio/Forward.h>
 
 namespace Web::Platform {
 
-class AudioCodecPlugin {
+class AudioCodecPlugin : public Weakable<AudioCodecPlugin> {
 public:
     using AudioCodecPluginCreator = Function<ErrorOr<NonnullOwnPtr<AudioCodecPlugin>>(NonnullRefPtr<Audio::Loader>)>;
 


### PR DESCRIPTION
The plugin may go out of scope before the callbacks we've queued have fired. It is undefined behavior for these callbacks to access the plugin data after that has occurred.

This patch protects these callbacks with weak pointers. Note that the plugin is not ref-counted, so we cannot use `strong_ref` here.

Fixes #3933