### PR TITLE
docs: changed LICENSE to 2018-present

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 2-Clause License
 
-Copyright (c) 2018-2025, the Ladybird developers.
+Copyright (c) 2018-present, the Ladybird developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I changed the License agreement from 2018-2025 to 2018-present. If we want to got ahead with the changes outlined in #3515.

This fixes #3515

![Screenshot 2025-03-14 102232](https://github.com/user-attachments/assets/66bf6964-82af-40bf-93da-78921eec1e93)
