### PR TITLE
Revert "LibRegex: Remove orphaned save points in nested LookAhead"

### DIFF
--- a/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Libraries/LibRegex/RegexByteCode.cpp
@@ -217,12 +217,6 @@ ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input,
     input.fail_counter += state.forks_since_last_save;
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
-ALWAYS_INLINE ExecutionResult OpCode_PopSaved::execute(MatchInput const& input, MatchState&) const
-{
-    input.saved_positions.take_last();
-    input.saved_code_unit_positions.take_last();
-    return ExecutionResult::Failed_ExecuteLowPrioForks;
-}
 
 ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(MatchInput const&, MatchState& state) const
 {

--- a/Libraries/LibRegex/RegexByteCode.h
+++ b/Libraries/LibRegex/RegexByteCode.h
@@ -31,7 +31,6 @@ using ByteCodeValueType = u64;
     __ENUMERATE_OPCODE(ForkReplaceJump)            \
     __ENUMERATE_OPCODE(ForkReplaceStay)            \
     __ENUMERATE_OPCODE(FailForks)                  \
-    __ENUMERATE_OPCODE(PopSaved)                   \
     __ENUMERATE_OPCODE(SaveLeftCaptureGroup)       \
     __ENUMERATE_OPCODE(SaveRightCaptureGroup)      \
     __ENUMERATE_OPCODE(SaveRightNamedCaptureGroup) \
@@ -267,15 +266,9 @@ public:
         switch (type) {
         case LookAroundType::LookAhead: {
             // SAVE
-            // FORKJUMP _BODY
-            // POPSAVED
-            // LABEL _BODY
             // REGEXP BODY
             // RESTORE
             empend((ByteCodeValueType)OpCodeId::Save);
-            empend((ByteCodeValueType)OpCodeId::ForkJump);
-            empend((ByteCodeValueType)1);
-            empend((ByteCodeValueType)OpCodeId::PopSaved);
             extend(move(lookaround_body));
             empend((ByteCodeValueType)OpCodeId::Restore);
             return;
@@ -616,14 +609,6 @@ class OpCode_FailForks final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
-    ByteString arguments_string() const override { return ByteString::empty(); }
-};
-
-class OpCode_PopSaved final : public OpCode {
-public:
-    ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::PopSaved; }
     ALWAYS_INLINE size_t size() const override { return 1; }
     ByteString arguments_string() const override { return ByteString::empty(); }
 };

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -738,8 +738,6 @@ TEST_CASE(ECMA262_match)
         // Optimizer bug, ignoring an enabled trailing 'invert' when comparing blocks, ladybird#3421.
         { "[^]*[^]"sv, "i"sv, true },
         { "xx|...|...."sv, "cd"sv, false },
-        // Tests nested lookahead with alternation - verifies proper save/restore stack cleanup
-        { "a(?=.(?=c)|b)b"sv, "ab"sv, true },
     };
 
     for (auto& test : tests) {


### PR DESCRIPTION
This reverts commit f2678bfcb836c0b4e3339878c7883ca7aef57699.

This caused a WPT regression seen in this run: https://wpt.fyi/results/?diff&filter=ADC&run_id=5085544315092992&run_id=5190898705235968