### PR TITLE
Everywhere: Remove references to the "chrome" process

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -148,7 +148,7 @@ If you wish to use clang from homebrew instead:
 brew install llvm@19
 ```
 
-If you also plan to use the Qt chrome on macOS:
+If you also plan to use the Qt UI on macOS:
 ```
 brew install qt
 ```
@@ -236,22 +236,22 @@ BUILD_PRESET=Debug ./Meta/ladybird.sh run ladybird
 
 Note that debug symbols are available in both Release and Debug builds.
 
-### The chromes
+### The User Interfaces
 
-Ladybird will be built with one of the following browser chromes (graphical frontends), depending on the platform:
-* [AppKit](https://developer.apple.com/documentation/appkit?language=objc) - The native chrome on macOS.
-* [Qt](https://doc.qt.io/qt-6/) - The chrome used on all other platforms.
-* [Android UI](https://developer.android.com/develop/ui) - The native chrome on Android.
+Ladybird will be built with one of the following browser frontends, depending on the platform:
+* [AppKit](https://developer.apple.com/documentation/appkit?language=objc) - The native UI on macOS.
+* [Qt](https://doc.qt.io/qt-6/) - The UI used on all other platforms.
+* [Android UI](https://developer.android.com/develop/ui) - The native UI on Android.
 
-The Qt chrome is available on platforms where it is not the default as well (except on Android). To build the
-Qt chrome, install the Qt dependencies for your platform, and enable the Qt chrome via CMake:
+The Qt UI is available on platforms where it is not the default as well (except on Android). To build the
+Qt UI, install the Qt dependencies for your platform, and enable the Qt UI via CMake:
 
 ```bash
 # From /path/to/ladybird
 cmake --preset default -DENABLE_QT=ON
 ```
 
-To re-disable the Qt chrome, run the above command with `-DENABLE_QT=OFF`.
+To re-disable the Qt UI, run the above command with `-DENABLE_QT=OFF`.
 
 ### Build error messages you may encounter
 

--- a/Documentation/Porting.md
+++ b/Documentation/Porting.md
@@ -7,15 +7,15 @@ be accepted into the mainline repository.
 
 There are two types of ports that can be made to Ladybird:
 
-- Chrome port: We define the "browser chrome" as the UI layer. This includes the browser window, tabs, address bar, etc.
+- UI port: We define the "browser frontend" as the UI layer. This includes the browser window, tabs, address bar, etc.
 - Platform port: This includes the underlying platform-specific code that interacts with the OS. This includes things like
   file I/O, networking, and process management.
 
-### Chrome Ports
+### UI Ports
 
-There are currently three supported chrome ports:
+There are currently three supported UI ports:
 
-- Qt6: The generic chrome port.
+- Qt6: The generic UI port.
 - AppKit/Cocoa: The macOS native port, which uses the AppKit framework.
 - Headless: A headless port that does not have a UI, used for testing.
 
@@ -38,15 +38,15 @@ There is currently one in progress platform port:
 
 ## Porting Steps
 
-### Chrome ports
+### UI ports
 
-Chrome ports mostly concern themselves with the UI layer. This means the main Ladybird process, using LibWebView.
+UI ports mostly concern themselves with the UI layer. This means the main Ladybird process, using LibWebView.
 
-To create a new Ladybird chrome, you will need to implement a new `WebView::ViewImplementation` subclass.
+To create a new Ladybird UI, you will need to implement a new `WebView::ViewImplementation` subclass.
 ViewImplementation is the main interface between the UI process and WebContent processes. It is expected that each tab
 of the browser will have its own WebContent process. This is all managed by the WebView layer.
 
-Each chrome must also subclass `WebView::Application` to add any chrome-specific command-line flags.
+Each UI port must also subclass `WebView::Application` to add any UI-specific command-line flags.
 
 TODO: Explain any more details that are necessary
 
@@ -56,7 +56,7 @@ Platform ports concern themselves with the underlying OS-specific code. In Ladyb
 the AK and LibCore libraries.
 
 AK is the standard template library for Ladybird. The first step of a new platform port is a new platform define in
-`AK/Platform.h`. This define will be used to conditionally compile platform-specific code. 
+`AK/Platform.h`. This define will be used to conditionally compile platform-specific code.
 In AK, the most likely class to need platform-specific code is `AK::StackInfo`.
 
 LibCore is an abstraction over POSIX. It contains classes to wrap lower level OS functionality into APIs that are

--- a/Documentation/Testing.md
+++ b/Documentation/Testing.md
@@ -87,13 +87,6 @@ CTEST_OUTPUT_ON_FAILURE=1 LADYBIRD_SOURCE_DIR=${PWD}/../.. ninja test
 The Web Platform Tests can be run with the `WPT.sh` script. This script can also be used to compare the results of two
 test runs.
 
-Enabling the Qt chrome is recommended when running the Web Platform Tests on MacOS. This can be done by running the
-following command:
-
-```sh
-cmake -GNinja Build/release -DENABLE_QT=ON
-```
-
 Example usage:
 
 ```sh
@@ -123,16 +116,16 @@ That is, you give `./Meta/WPT.sh import` the path part of any `http://wpt.live/`
 
 ## Writing tests
 
-Running `Tests/LibWeb/add_libweb_test.py your-new-test-name test_type` will create a new test HTML file in 
+Running `Tests/LibWeb/add_libweb_test.py your-new-test-name test_type` will create a new test HTML file in
 `Tests/LibWeb/test_type(/input)` (`/input` is appended for Text and Layout tests) with the correct boilerplate
 code for a `test_type` test — along with a corresponding expectations file in the appropriate directory, e.g.,
 `Tests/LibWeb/Text/expected/your-new-test-name.txt`, for a Text test, or
 `Tests/LibWeb/Ref/reference/your-new-test-name.txt` for a Ref test. The accepted `test_types` are "Text",
 "Ref", "Screenshot", and "Layout".
 
-If you make a new Text or Layout test, after you update/replace the generated boilerplate in your 
-`your-new-test-name.html` test file with your actual test, running 
-`./Meta/ladybird.sh run headless-browser --run-tests "./Tests/LibWeb" --rebaseline -f Text/input/foobar.html` 
+If you make a new Text or Layout test, after you update/replace the generated boilerplate in your
+`your-new-test-name.html` test file with your actual test, running
+`./Meta/ladybird.sh run headless-browser --run-tests "./Tests/LibWeb" --rebaseline -f Text/input/foobar.html`
 will regenerate the corresponding expectations file to match the actual output from your updated test.
 
 If you add a new Ref or Screenshot test, you'll need to supply the equivalently rendering HTML manually.

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -32,16 +32,20 @@ CipherString = DEFAULT@SECLEVEL=1
 Options = UnsafeLegacyRenegotiation
 ```
 
-### “Targets may link only to libraries. CMake is dropping the item” message (when building with the Qt chrome on macOS)
+### “Targets may link only to libraries. CMake is dropping the item” message (when building with the Qt UI on macOS)
 
-When building with the Qt chrome on macOS, you may encounter the following message:
+When building with the Qt UI on macOS, you may encounter the following message:
 
-> CMake Warning at /opt/homebrew/Cellar/qt/6.7.0_1/lib/cmake/Qt6/FindWrapOpenGL.cmake:48 (target_link_libraries):
-> Target "ladybird" requests linking to directory "/usr/X11R6/lib". Targets
-> may link only to libraries. CMake is dropping the item.
+```
+CMake Warning at /opt/homebrew/Cellar/qt/6.7.0_1/lib/cmake/Qt6/FindWrapOpenGL.cmake:48 (target_link_libraries):
+Target "ladybird" requests linking to directory "/usr/X11R6/lib". Targets
+may link only to libraries. CMake is dropping the item.
+```
 
 …followed by 14-line stack trace, the top of which is this:
 
-> Build/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
+```
+Build/vcpkg/scripts/buildsystems/vcpkg.cmake:859 (_find_package)
+```
 
-…and all of it shown in bright yellow, making you think it must be important and something must need to be fixed. But that’s not the case. Instead, despite that, you’ll be able to build successfully with the Qt chrome.
+…and all of it shown in bright yellow, making you think it must be important and something must need to be fixed. But that’s not the case. Instead, despite that, you’ll be able to build successfully with the Qt UI.

--- a/Libraries/LibWeb/Clipboard/Clipboard.cpp
+++ b/Libraries/LibWeb/Clipboard/Clipboard.cpp
@@ -42,7 +42,7 @@ void Clipboard::initialize(JS::Realm& realm)
 // https://w3c.github.io/clipboard-apis/#os-specific-well-known-format
 static StringView os_specific_well_known_format(StringView mime_type_string)
 {
-    // NOTE: Here we always takes the Linux case, and defer to the chrome layer to handle OS specific implementations.
+    // NOTE: Here we always takes the Linux case, and defer to the browser process to handle OS specific implementations.
     auto mime_type = MimeSniff::MimeType::parse(mime_type_string);
 
     // 1. Let wellKnownFormat be an empty string.

--- a/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -82,7 +82,7 @@ void HTMLAnchorElement::activation_behavior(Web::DOM::Event const& event)
         return;
 
     // AD-HOC: Do not activate the element for clicks with the ctrl/cmd modifier present. This lets
-    //         the chrome open the link in a new tab.
+    //         the browser process open the link in a new tab.
     if (is<UIEvents::MouseEvent>(event)) {
         auto const& mouse_event = static_cast<UIEvents::MouseEvent const&>(event);
         if (mouse_event.platform_ctrl_key())

--- a/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
+++ b/Libraries/LibWeb/Loader/GeneratedPagesLoader.cpp
@@ -16,14 +16,17 @@
 
 namespace Web {
 
-void set_chrome_process_command_line(StringView command_line)
+static String s_browser_process_command_line;
+static String s_browser_process_executable_path;
+
+void set_browser_process_command_line(StringView command_line)
 {
-    s_chrome_process_command_line = MUST(String::from_utf8(command_line));
+    s_browser_process_command_line = MUST(String::from_utf8(command_line));
 }
 
-void set_chrome_process_executable_path(StringView executable_path)
+void set_browser_process_executable_path(StringView executable_path)
 {
-    s_chrome_process_executable_path = MUST(String::from_utf8(executable_path));
+    s_browser_process_executable_path = MUST(String::from_utf8(executable_path));
 }
 
 ErrorOr<String> load_error_page(URL::URL const& url, StringView error_message)
@@ -92,8 +95,8 @@ ErrorOr<String> load_about_version_page()
     generator.set("arch_name", CPU_STRING);
     generator.set("os_name", OS_STRING);
     generator.set("user_agent", default_user_agent);
-    generator.set("command_line", s_chrome_process_command_line);
-    generator.set("executable_path", s_chrome_process_executable_path);
+    generator.set("command_line", s_browser_process_command_line);
+    generator.set("executable_path", s_browser_process_executable_path);
     generator.append(template_file->data());
     return TRY(String::from_utf8(generator.as_string_view()));
 }

--- a/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
+++ b/Libraries/LibWeb/Loader/GeneratedPagesLoader.h
@@ -11,11 +11,8 @@
 
 namespace Web {
 
-static String s_chrome_process_command_line {};
-static String s_chrome_process_executable_path {};
-
-void set_chrome_process_command_line(StringView command_line);
-void set_chrome_process_executable_path(StringView executable_path);
+void set_browser_process_command_line(StringView command_line);
+void set_browser_process_executable_path(StringView executable_path);
 
 ErrorOr<String> load_error_page(URL::URL const&, StringView error_message);
 

--- a/Libraries/LibWeb/Page/InputEvent.cpp
+++ b/Libraries/LibWeb/Page/InputEvent.cpp
@@ -10,17 +10,17 @@
 
 namespace Web {
 
-KeyEvent KeyEvent::clone_without_chrome_data() const
+KeyEvent KeyEvent::clone_without_browser_data() const
 {
     return { type, key, modifiers, code_point, repeat, nullptr };
 }
 
-MouseEvent MouseEvent::clone_without_chrome_data() const
+MouseEvent MouseEvent::clone_without_browser_data() const
 {
     return { type, position, screen_position, button, buttons, modifiers, wheel_delta_x, wheel_delta_y, nullptr };
 }
 
-DragEvent DragEvent::clone_without_chrome_data() const
+DragEvent DragEvent::clone_without_browser_data() const
 {
     return { type, position, screen_position, button, buttons, modifiers, {}, nullptr };
 }

--- a/Libraries/LibWeb/Page/InputEvent.h
+++ b/Libraries/LibWeb/Page/InputEvent.h
@@ -18,8 +18,8 @@
 
 namespace Web {
 
-struct ChromeInputData {
-    virtual ~ChromeInputData() = default;
+struct BrowserInputData {
+    virtual ~BrowserInputData() = default;
 };
 
 struct KeyEvent {
@@ -28,7 +28,7 @@ struct KeyEvent {
         KeyUp,
     };
 
-    KeyEvent clone_without_chrome_data() const;
+    KeyEvent clone_without_browser_data() const;
 
     Type type;
     UIEvents::KeyCode key { UIEvents::KeyCode::Key_Invalid };
@@ -36,7 +36,7 @@ struct KeyEvent {
     u32 code_point { 0 };
     bool repeat { false };
 
-    OwnPtr<ChromeInputData> chrome_data;
+    OwnPtr<BrowserInputData> browser_data;
 };
 
 struct MouseEvent {
@@ -48,7 +48,7 @@ struct MouseEvent {
         DoubleClick,
     };
 
-    MouseEvent clone_without_chrome_data() const;
+    MouseEvent clone_without_browser_data() const;
 
     Type type;
     Web::DevicePixelPoint position;
@@ -59,7 +59,7 @@ struct MouseEvent {
     int wheel_delta_x { 0 };
     int wheel_delta_y { 0 };
 
-    OwnPtr<ChromeInputData> chrome_data;
+    OwnPtr<BrowserInputData> browser_data;
 };
 
 struct DragEvent {
@@ -70,7 +70,7 @@ struct DragEvent {
         Drop,
     };
 
-    DragEvent clone_without_chrome_data() const;
+    DragEvent clone_without_browser_data() const;
 
     Type type;
     Web::DevicePixelPoint position;
@@ -80,7 +80,7 @@ struct DragEvent {
     UIEvents::KeyModifier modifiers { UIEvents::KeyModifier::Mod_None };
     Vector<HTML::SelectedFile> files;
 
-    OwnPtr<ChromeInputData> chrome_data;
+    OwnPtr<BrowserInputData> browser_data;
 };
 
 using InputEvent = Variant<KeyEvent, MouseEvent, DragEvent>;

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -94,7 +94,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     args_parser.add_positional_argument(raw_urls, "URLs to open", "url", Core::ArgsParser::Required::No);
     args_parser.add_option(certificates, "Path to a certificate file", "certificate", 'C', "certificate");
     args_parser.add_option(new_window, "Force opening in a new window", "new-window", 'n');
-    args_parser.add_option(force_new_process, "Force creation of new browser/chrome process", "force-new-process");
+    args_parser.add_option(force_new_process, "Force creation of a new browser process", "force-new-process");
     args_parser.add_option(allow_popups, "Disable popup blocking by default", "allow-popups");
     args_parser.add_option(disable_scripting, "Disable scripting by default", "disable-scripting");
     args_parser.add_option(disable_sql_database, "Disable SQL database", "disable-sql-database");

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -360,8 +360,8 @@ void Application::process_did_exit(Process&& process)
     case ProcessType::WebWorker:
         dbgln_if(WEBVIEW_PROCESS_DEBUG, "WebWorker {} died, not sure what to do.", process.pid());
         break;
-    case ProcessType::Chrome:
-        dbgln("Invalid process type to be dying: Chrome");
+    case ProcessType::Browser:
+        dbgln("Invalid process type to be dying: Browser");
         VERIFY_NOT_REACHED();
     }
 }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -149,7 +149,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     if (debug_process_type == ProcessType::WebContent)
         disable_site_isolation = true;
 
-    m_chrome_options = {
+    m_browser_options = {
         .urls = sanitize_urls(raw_urls, new_tab_page_url),
         .raw_urls = move(raw_urls),
         .new_tab_page_url = move(new_tab_page_url),
@@ -170,7 +170,7 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
     };
 
     if (webdriver_content_ipc_path.has_value())
-        m_chrome_options.webdriver_content_ipc_path = *webdriver_content_ipc_path;
+        m_browser_options.webdriver_content_ipc_path = *webdriver_content_ipc_path;
 
     m_web_content_options = {
         .command_line = MUST(String::join(' ', arguments.strings)),
@@ -188,9 +188,9 @@ void Application::initialize(Main::Arguments const& arguments, URL::URL new_tab_
         .paint_viewport_scrollbars = disable_scrollbar_painting ? PaintViewportScrollbars::No : PaintViewportScrollbars::Yes,
     };
 
-    create_platform_options(m_chrome_options, m_web_content_options);
+    create_platform_options(m_browser_options, m_web_content_options);
 
-    if (m_chrome_options.disable_sql_database == DisableSQLDatabase::No) {
+    if (m_browser_options.disable_sql_database == DisableSQLDatabase::No) {
         m_database = Database::create().release_value_but_fixme_should_propagate_errors();
         m_cookie_jar = CookieJar::create(*m_database).release_value_but_fixme_should_propagate_errors();
     } else {
@@ -225,7 +225,7 @@ ErrorOr<NonnullRefPtr<WebContentClient>> Application::launch_web_content_process
 void Application::launch_spare_web_content_process()
 {
     // Disable spare processes when debugging WebContent. Otherwise, it breaks running `gdb attach -p $(pidof WebContent)`.
-    if (chrome_options().debug_helper_process == ProcessType::WebContent)
+    if (browser_options().debug_helper_process == ProcessType::WebContent)
         return;
 
     if (m_has_queued_task_to_launch_spare_web_content_process)
@@ -293,7 +293,7 @@ ErrorOr<void> Application::launch_image_decoder_server()
 ErrorOr<void> Application::launch_devtools_server()
 {
     VERIFY(!m_devtools);
-    m_devtools = TRY(DevTools::DevToolsServer::create(*this, m_chrome_options.devtools_port));
+    m_devtools = TRY(DevTools::DevToolsServer::create(*this, m_browser_options.devtools_port));
     return {};
 }
 

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -35,7 +35,7 @@ public:
 
     static Application& the() { return *s_the; }
 
-    static ChromeOptions const& chrome_options() { return the().m_chrome_options; }
+    static BrowserOptions const& browser_options() { return the().m_browser_options; }
     static WebContentOptions& web_content_options() { return the().m_web_content_options; }
 
     static Requests::RequestClient& request_server_client() { return *the().m_request_server_client; }
@@ -84,7 +84,7 @@ protected:
     virtual void process_did_exit(Process&&);
 
     virtual void create_platform_arguments(Core::ArgsParser&) { }
-    virtual void create_platform_options(ChromeOptions&, WebContentOptions&) { }
+    virtual void create_platform_options(BrowserOptions&, WebContentOptions&) { }
 
     virtual Optional<ByteString> ask_user_for_download_folder() const { return {}; }
 
@@ -127,7 +127,7 @@ private:
 
     static Application* s_the;
 
-    ChromeOptions m_chrome_options;
+    BrowserOptions m_browser_options;
     WebContentOptions m_web_content_options;
 
     RefPtr<Requests::RequestClient> m_request_server_client;

--- a/Libraries/LibWebView/BrowserProcess.cpp
+++ b/Libraries/LibWebView/BrowserProcess.cpp
@@ -10,7 +10,7 @@
 #include <LibCore/System.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/ChromeProcess.h>
+#include <LibWebView/BrowserProcess.h>
 #include <LibWebView/URL.h>
 
 namespace WebView {
@@ -25,7 +25,7 @@ private:
     explicit UIProcessClient(IPC::Transport);
 };
 
-ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteString> const& raw_urls, NewWindow new_window)
+ErrorOr<BrowserProcess::ProcessDisposition> BrowserProcess::connect(Vector<ByteString> const& raw_urls, NewWindow new_window)
 {
     static constexpr auto process_name = "Ladybird"sv;
 
@@ -45,7 +45,7 @@ ErrorOr<ChromeProcess::ProcessDisposition> ChromeProcess::connect(Vector<ByteStr
     return ProcessDisposition::ContinueMainProcess;
 }
 
-ErrorOr<void> ChromeProcess::connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, NewWindow new_window)
+ErrorOr<void> BrowserProcess::connect_as_client(ByteString const& socket_path, Vector<ByteString> const& raw_urls, NewWindow new_window)
 {
     auto socket = TRY(Core::LocalSocket::connect(socket_path));
     static_assert(IsSame<IPC::Transport, IPC::TransportSocket>, "Need to handle other IPC transports here");
@@ -62,7 +62,7 @@ ErrorOr<void> ChromeProcess::connect_as_client(ByteString const& socket_path, Ve
     return {};
 }
 
-ErrorOr<void> ChromeProcess::connect_as_server(ByteString const& socket_path)
+ErrorOr<void> BrowserProcess::connect_as_server(ByteString const& socket_path)
 {
     static_assert(IsSame<IPC::Transport, IPC::TransportSocket>, "Need to handle other IPC transports here");
 
@@ -88,7 +88,7 @@ ErrorOr<void> ChromeProcess::connect_as_server(ByteString const& socket_path)
     return {};
 }
 
-ChromeProcess::~ChromeProcess()
+BrowserProcess::~BrowserProcess()
 {
     if (m_pid_file) {
         MUST(m_pid_file->truncate(0));

--- a/Libraries/LibWebView/BrowserProcess.h
+++ b/Libraries/LibWebView/BrowserProcess.h
@@ -38,9 +38,9 @@ private:
     virtual void create_new_window(Vector<ByteString> urls) override;
 };
 
-class ChromeProcess {
-    AK_MAKE_NONCOPYABLE(ChromeProcess);
-    AK_MAKE_DEFAULT_MOVABLE(ChromeProcess);
+class BrowserProcess {
+    AK_MAKE_NONCOPYABLE(BrowserProcess);
+    AK_MAKE_DEFAULT_MOVABLE(BrowserProcess);
 
 public:
     enum class ProcessDisposition : u8 {
@@ -48,8 +48,8 @@ public:
         ExitProcess,
     };
 
-    ChromeProcess() = default;
-    ~ChromeProcess();
+    BrowserProcess() = default;
+    ~BrowserProcess();
 
     ErrorOr<ProcessDisposition> connect(Vector<ByteString> const& raw_urls, NewWindow new_window);
 

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -3,7 +3,7 @@ include(fontconfig)
 set(SOURCES
     Application.cpp
     Attribute.cpp
-    ChromeProcess.cpp
+    BrowserProcess.cpp
     ConsoleOutput.cpp
     CookieJar.cpp
     Database.cpp

--- a/Libraries/LibWebView/ChromeProcess.cpp
+++ b/Libraries/LibWebView/ChromeProcess.cpp
@@ -118,13 +118,13 @@ void UIProcessConnectionFromClient::die()
 void UIProcessConnectionFromClient::create_new_tab(Vector<ByteString> urls)
 {
     if (on_new_tab)
-        on_new_tab(sanitize_urls(urls, Application::chrome_options().new_tab_page_url));
+        on_new_tab(sanitize_urls(urls, Application::browser_options().new_tab_page_url));
 }
 
 void UIProcessConnectionFromClient::create_new_window(Vector<ByteString> urls)
 {
     if (on_new_window)
-        on_new_window(sanitize_urls(urls, Application::chrome_options().new_tab_page_url));
+        on_new_window(sanitize_urls(urls, Application::browser_options().new_tab_page_url));
 }
 
 }

--- a/Libraries/LibWebView/Options.h
+++ b/Libraries/LibWebView/Options.h
@@ -59,7 +59,7 @@ using DNSSettings = Variant<SystemDNS, DNSOverTLS, DNSOverUDP>;
 
 constexpr inline u16 default_devtools_port = 6000;
 
-struct ChromeOptions {
+struct BrowserOptions {
     Vector<URL::URL> urls;
     Vector<ByteString> raw_urls;
     URL::URL new_tab_page_url;

--- a/Libraries/LibWebView/ProcessManager.cpp
+++ b/Libraries/LibWebView/ProcessManager.cpp
@@ -14,8 +14,8 @@ namespace WebView {
 
 ProcessType process_type_from_name(StringView name)
 {
-    if (name == "Chrome"sv)
-        return ProcessType::Chrome;
+    if (name == "Browser"sv)
+        return ProcessType::Browser;
     if (name == "WebContent"sv)
         return ProcessType::WebContent;
     if (name == "WebWorker"sv)
@@ -32,8 +32,8 @@ ProcessType process_type_from_name(StringView name)
 StringView process_name_from_type(ProcessType type)
 {
     switch (type) {
-    case ProcessType::Chrome:
-        return "Chrome"sv;
+    case ProcessType::Browser:
+        return "Browser"sv;
     case ProcessType::WebContent:
         return "WebContent"sv;
     case ProcessType::WebWorker:
@@ -61,7 +61,7 @@ ProcessManager::ProcessManager()
         }
     });
 
-    add_process(Process(WebView::ProcessType::Chrome, nullptr, Core::Process::current()));
+    add_process(Process(WebView::ProcessType::Browser, nullptr, Core::Process::current()));
 
 #ifdef AK_OS_MACH
     auto self_send_port = mach_task_self();

--- a/Libraries/LibWebView/ProcessType.h
+++ b/Libraries/LibWebView/ProcessType.h
@@ -11,7 +11,7 @@
 namespace WebView {
 
 enum class ProcessType : u8 {
-    Chrome,
+    Browser,
     WebContent,
     WebWorker,
     RequestServer,

--- a/Libraries/LibWebView/SourceHighlighter.cpp
+++ b/Libraries/LibWebView/SourceHighlighter.cpp
@@ -72,7 +72,7 @@ SourceHighlighterClient::SourceHighlighterClient(String const& source, Syntax::L
     : m_document(SourceDocument::create(source))
 {
     // HACK: Syntax highlighters require a palette, but we don't actually care about the output styling, only the type of token for each span.
-    //       Also, getting a palette from the chrome is nontrivial. So, create a dummy blank one and use that.
+    //       Also, getting a palette from the UI is nontrivial. So, create a dummy blank one and use that.
     auto buffer = MUST(Core::AnonymousBuffer::create_with_size(sizeof(Gfx::SystemTheme)));
     auto palette_impl = Gfx::PaletteImpl::create_with_anonymous_buffer(buffer);
     Gfx::Palette dummy_palette { palette_impl };

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -203,13 +203,13 @@ void ViewImplementation::enqueue_input_event(Web::InputEvent event)
 
     m_pending_input_events.tail().visit(
         [this](Web::KeyEvent const& event) {
-            client().async_key_event(m_client_state.page_index, event.clone_without_chrome_data());
+            client().async_key_event(m_client_state.page_index, event.clone_without_browser_data());
         },
         [this](Web::MouseEvent const& event) {
-            client().async_mouse_event(m_client_state.page_index, event.clone_without_chrome_data());
+            client().async_mouse_event(m_client_state.page_index, event.clone_without_browser_data());
         },
         [this](Web::DragEvent& event) {
-            auto cloned_event = event.clone_without_chrome_data();
+            auto cloned_event = event.clone_without_browser_data();
             cloned_event.files = move(event.files);
 
             client().async_drag_event(m_client_state.page_index, cloned_event);

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -604,10 +604,10 @@ void ViewImplementation::initialize_client(CreateNewClient create_new_client)
     client().async_set_device_pixels_per_css_pixel(m_client_state.page_index, m_device_pixel_ratio);
     client().async_set_system_visibility_state(m_client_state.page_index, m_system_visibility_state);
 
-    if (auto webdriver_content_ipc_path = Application::chrome_options().webdriver_content_ipc_path; webdriver_content_ipc_path.has_value())
+    if (auto webdriver_content_ipc_path = Application::browser_options().webdriver_content_ipc_path; webdriver_content_ipc_path.has_value())
         client().async_connect_to_webdriver(m_client_state.page_index, *webdriver_content_ipc_path);
 
-    if (Application::chrome_options().allow_popups == AllowPopups::Yes)
+    if (Application::browser_options().allow_popups == AllowPopups::Yes)
         client().async_debug_request(m_client_state.page_index, "block-pop-ups"sv, "off"sv);
 
     if (auto const& user_agent_preset = Application::web_content_options().user_agent_preset; user_agent_preset.has_value())

--- a/Meta/gn/secondary/Ladybird/enable_appkit.gni
+++ b/Meta/gn/secondary/Ladybird/enable_appkit.gni
@@ -1,4 +1,4 @@
 declare_args() {
-  # Build the Ladybird application using the AppKit chrome.
+  # Build the Ladybird application using the AppKit UI.
   enable_appkit = current_os == "mac"
 }

--- a/Meta/gn/secondary/Ladybird/enable_qt.gni
+++ b/Meta/gn/secondary/Ladybird/enable_qt.gni
@@ -1,4 +1,4 @@
 declare_args() {
-  # Build the Ladybird application using the Qt chrome.
+  # Build the Ladybird application using the Qt UI.
   enable_qt = current_os != "mac"
 }

--- a/Services/WebContent/main.cpp
+++ b/Services/WebContent/main.cpp
@@ -112,8 +112,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView echo_server_port_string_view {};
 
     Core::ArgsParser args_parser;
-    args_parser.add_option(command_line, "Chrome process command line", "command-line", 0, "command_line");
-    args_parser.add_option(executable_path, "Chrome process executable path", "executable-path", 0, "executable_path");
+    args_parser.add_option(command_line, "Browser process command line", "command-line", 0, "command_line");
+    args_parser.add_option(executable_path, "Browser process executable path", "executable-path", 0, "executable_path");
     args_parser.add_option(config_path, "Ladybird configuration path", "config-path", 0, "config_path");
     args_parser.add_option(request_server_socket, "File descriptor of the socket for the RequestServer connection", "request-server-socket", 'r', "request_server_socket");
     args_parser.add_option(image_decoder_socket, "File descriptor of the socket for the ImageDecoder connection", "image-decoder-socket", 'i', "image_decoder_socket");
@@ -151,8 +151,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         force_cpu_painting = true;
     }
 
-    Web::set_chrome_process_command_line(command_line);
-    Web::set_chrome_process_executable_path(executable_path);
+    Web::set_browser_process_command_line(command_line);
+    Web::set_browser_process_executable_path(executable_path);
 
     // Always use the CPU backend for layout tests, as the GPU backend is not deterministic
     WebContent::PageClient::set_use_skia_painter(force_cpu_painting ? WebContent::PageClient::UseSkiaPainter::CPUBackend : WebContent::PageClient::UseSkiaPainter::GPUBackendIfAvailable);

--- a/Services/WebWorker/ConnectionFromClient.cpp
+++ b/Services/WebWorker/ConnectionFromClient.cpp
@@ -30,7 +30,7 @@ void ConnectionFromClient::die()
 
 void ConnectionFromClient::request_file(Web::FileRequest request)
 {
-    // FIXME: Route this to FSAS or Brower chrome as appropriate instead of allowing
+    // FIXME: Route this to FSAS or browser process as appropriate instead of allowing
     //        the WebWorker process filesystem access
     auto path = request.path();
     auto request_id = ++last_id;

--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -286,7 +286,7 @@
         self.info_bar = [[InfoBar alloc] init];
     }
 
-    auto message = MUST(String::formatted("DevTools is enabled on port {}", WebView::Application::chrome_options().devtools_port));
+    auto message = MUST(String::formatted("DevTools is enabled on port {}", WebView::Application::browser_options().devtools_port));
 
     [self.info_bar showWithMessage:Ladybird::string_to_ns_string(message)
               dismissButtonTooltip:@"Disable DevTools"
@@ -814,7 +814,7 @@
 {
     Tab* tab = nil;
 
-    for (auto const& url : WebView::Application::chrome_options().urls) {
+    for (auto const& url : WebView::Application::browser_options().urls) {
         auto activate_tab = tab == nil ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No;
 
         auto* controller = [self createNewTab:url

--- a/UI/AppKit/Interface/Event.mm
+++ b/UI/AppKit/Interface/Event.mm
@@ -75,7 +75,7 @@ Web::MouseEvent ns_event_to_mouse_event(Web::MouseEvent::Type type, NSEvent* eve
     return { type, device_position, device_screen_position, button, button, modifiers, wheel_delta_x, wheel_delta_y, nullptr };
 }
 
-struct DragData : public Web::ChromeInputData {
+struct DragData : public Web::BrowserInputData {
     explicit DragData(Vector<URL::URL> urls)
         : urls(move(urls))
     {
@@ -96,7 +96,7 @@ Web::DragEvent ns_event_to_drag_event(Web::DragEvent::Type type, id<NSDraggingIn
     auto modifiers = ns_modifiers_to_key_modifiers([NSEvent modifierFlags], button);
 
     Vector<Web::HTML::SelectedFile> files;
-    OwnPtr<DragData> chrome_data;
+    OwnPtr<DragData> browser_data;
 
     auto for_each_file = [&](auto callback) {
         NSArray* file_list = [[event draggingPasteboard] readObjectsForClasses:@[ [NSURL class] ]
@@ -123,16 +123,16 @@ Web::DragEvent ns_event_to_drag_event(Web::DragEvent::Type type, id<NSDraggingIn
                 urls.append(move(url));
         });
 
-        chrome_data = make<DragData>(move(urls));
+        browser_data = make<DragData>(move(urls));
     }
 
-    return { type, device_position, device_screen_position, button, button, modifiers, move(files), move(chrome_data) };
+    return { type, device_position, device_screen_position, button, button, modifiers, move(files), move(browser_data) };
 }
 
 Vector<URL::URL> drag_event_url_list(Web::DragEvent const& event)
 {
-    auto& chrome_data = as<DragData>(*event.chrome_data);
-    return move(chrome_data.urls);
+    auto& browser_data = as<DragData>(*event.browser_data);
+    return move(browser_data.urls);
 }
 
 NSEvent* create_context_menu_mouse_event(NSView* view, Gfx::IntPoint position)
@@ -269,7 +269,7 @@ static Web::UIEvents::KeyCode ns_key_code_to_key_code(unsigned short key_code, W
     return Web::UIEvents::KeyCode::Key_Invalid;
 }
 
-class KeyData : public Web::ChromeInputData {
+class KeyData : public Web::BrowserInputData {
 public:
     explicit KeyData(NSEvent* event)
         : m_event(CFBridgingRetain(event))
@@ -322,8 +322,8 @@ Web::KeyEvent ns_event_to_key_event(Web::KeyEvent::Type type, NSEvent* event)
 
 NSEvent* key_event_to_ns_event(Web::KeyEvent const& event)
 {
-    auto& chrome_data = as<KeyData>(*event.chrome_data);
-    return chrome_data.take_event();
+    auto& browser_data = as<KeyData>(*event.browser_data);
+    return browser_data.take_event();
 }
 
 }

--- a/UI/AppKit/Interface/TabController.mm
+++ b/UI/AppKit/Interface/TabController.mm
@@ -100,8 +100,8 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
         m_page_index = 0;
 
         m_settings = {
-            .scripting_enabled = WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
-            .block_popups = WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
+            .scripting_enabled = WebView::Application::browser_options().disable_scripting == WebView::DisableScripting::Yes ? NO : YES,
+            .block_popups = WebView::Application::browser_options().allow_popups == WebView::AllowPopups::Yes ? NO : YES,
             .autoplay_enabled = WebView::Application::web_content_options().enable_autoplay == WebView::EnableAutoplay::Yes ? YES : NO,
         };
 
@@ -234,7 +234,7 @@ static NSString* const TOOLBAR_TAB_OVERVIEW_IDENTIFIER = @"ToolbarTabOverviewIde
 
     self.tab.titlebarAppearsTransparent = NO;
 
-    [delegate createNewTab:WebView::Application::chrome_options().new_tab_page_url
+    [delegate createNewTab:WebView::Application::browser_options().new_tab_page_url
                    fromTab:[self tab]
                activateTab:Web::HTML::ActivateTab::Yes];
 

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -9,7 +9,7 @@
 #include <LibMain/Main.h>
 #include <LibURL/Parser.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/ChromeProcess.h>
+#include <LibWebView/BrowserProcess.h>
 #include <LibWebView/EventLoop/EventLoopImplementationMacOS.h>
 #include <LibWebView/MachPortServer.h>
 #include <LibWebView/URL.h>
@@ -56,22 +56,22 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     WebView::platform_init();
 
-    WebView::ChromeProcess chrome_process;
+    WebView::BrowserProcess browser_process;
 
     if (auto const& browser_options = WebView::Application::browser_options(); browser_options.force_new_process == WebView::ForceNewProcess::No) {
-        auto disposition = TRY(chrome_process.connect(browser_options.raw_urls, browser_options.new_window));
+        auto disposition = TRY(browser_process.connect(browser_options.raw_urls, browser_options.new_window));
 
-        if (disposition == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
+        if (disposition == WebView::BrowserProcess::ProcessDisposition::ExitProcess) {
             outln("Opening in existing process");
             return 0;
         }
     }
 
-    chrome_process.on_new_tab = [&](auto const& raw_urls) {
+    browser_process.on_new_tab = [&](auto const& raw_urls) {
         open_urls_from_client(raw_urls, WebView::NewWindow::No);
     };
 
-    chrome_process.on_new_window = [&](auto const& raw_urls) {
+    browser_process.on_new_window = [&](auto const& raw_urls) {
         open_urls_from_client(raw_urls, WebView::NewWindow::Yes);
     };
 

--- a/UI/AppKit/main.mm
+++ b/UI/AppKit/main.mm
@@ -58,8 +58,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     WebView::ChromeProcess chrome_process;
 
-    if (auto const& chrome_options = WebView::Application::chrome_options(); chrome_options.force_new_process == WebView::ForceNewProcess::No) {
-        auto disposition = TRY(chrome_process.connect(chrome_options.raw_urls, chrome_options.new_window));
+    if (auto const& browser_options = WebView::Application::browser_options(); browser_options.force_new_process == WebView::ForceNewProcess::No) {
+        auto disposition = TRY(chrome_process.connect(browser_options.raw_urls, browser_options.new_window));
 
         if (disposition == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
             outln("Opening in existing process");

--- a/UI/Headless/Application.cpp
+++ b/UI/Headless/Application.cpp
@@ -64,7 +64,7 @@ void Application::create_platform_arguments(Core::ArgsParser& args_parser)
     });
 }
 
-void Application::create_platform_options(WebView::ChromeOptions& chrome_options, WebView::WebContentOptions& web_content_options)
+void Application::create_platform_options(WebView::BrowserOptions& browser_options, WebView::WebContentOptions& web_content_options)
 {
     if (!test_root_path.is_empty()) {
         // --run-tests implies --layout-test-mode.
@@ -73,7 +73,7 @@ void Application::create_platform_options(WebView::ChromeOptions& chrome_options
 
     if (is_layout_test_mode) {
         // Allow window.open() to succeed for tests.
-        chrome_options.allow_popups = WebView::AllowPopups::Yes;
+        browser_options.allow_popups = WebView::AllowPopups::Yes;
 
         // Ensure consistent font rendering between operating systems.
         web_content_options.force_fontconfig = WebView::ForceFontconfig::Yes;

--- a/UI/Headless/Application.h
+++ b/UI/Headless/Application.h
@@ -29,7 +29,7 @@ public:
     }
 
     virtual void create_platform_arguments(Core::ArgsParser&) override;
-    virtual void create_platform_options(WebView::ChromeOptions&, WebView::WebContentOptions&) override;
+    virtual void create_platform_options(WebView::BrowserOptions&, WebView::WebContentOptions&) override;
 
     ErrorOr<void> launch_test_fixtures();
 

--- a/UI/Headless/main.cpp
+++ b/UI/Headless/main.cpp
@@ -83,8 +83,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& view = app->create_web_view(move(theme), window_size);
 
-    VERIFY(!WebView::Application::chrome_options().urls.is_empty());
-    auto const& url = WebView::Application::chrome_options().urls.first();
+    VERIFY(!WebView::Application::browser_options().urls.is_empty());
+    auto const& url = WebView::Application::browser_options().urls.first();
     if (!url.is_valid()) {
         warnln("Invalid URL: \"{}\"", url);
         return Error::from_string_literal("Invalid URL");
@@ -99,7 +99,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     RefPtr<Core::Timer> timer;
-    if (!WebView::Application::chrome_options().webdriver_content_ipc_path.has_value())
+    if (!WebView::Application::browser_options().webdriver_content_ipc_path.has_value())
         timer = TRY(load_page_for_screenshot_and_exit(Core::EventLoop::current(), view, url, app->screenshot_timeout));
 
     return app->execute();

--- a/UI/Qt/Application.cpp
+++ b/UI/Qt/Application.cpp
@@ -21,7 +21,7 @@ Application::Application(Badge<WebView::Application>, Main::Arguments& arguments
 {
 }
 
-void Application::create_platform_options(WebView::ChromeOptions&, WebView::WebContentOptions& web_content_options)
+void Application::create_platform_options(WebView::BrowserOptions&, WebView::WebContentOptions& web_content_options)
 {
     web_content_options.config_path = Settings::the()->directory();
 }

--- a/UI/Qt/Application.h
+++ b/UI/Qt/Application.h
@@ -37,7 +37,7 @@ public:
     void set_active_window(BrowserWindow& w) { m_active_window = &w; }
 
 private:
-    virtual void create_platform_options(WebView::ChromeOptions&, WebView::WebContentOptions&) override;
+    virtual void create_platform_options(WebView::BrowserOptions&, WebView::WebContentOptions&) override;
 
     virtual Optional<ByteString> ask_user_for_download_folder() const override;
 

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -574,7 +574,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 
     m_enable_scripting_action = new QAction("Enable Scripting", this);
     m_enable_scripting_action->setCheckable(true);
-    m_enable_scripting_action->setChecked(WebView::Application::chrome_options().disable_scripting == WebView::DisableScripting::No);
+    m_enable_scripting_action->setChecked(WebView::Application::browser_options().disable_scripting == WebView::DisableScripting::No);
     debug_menu->addAction(m_enable_scripting_action);
     QObject::connect(m_enable_scripting_action, &QAction::triggered, this, [this] {
         bool state = m_enable_scripting_action->isChecked();
@@ -596,7 +596,7 @@ BrowserWindow::BrowserWindow(Vector<URL::URL> const& initial_urls, IsPopupWindow
 
     m_block_pop_ups_action = new QAction("Block Pop-ups", this);
     m_block_pop_ups_action->setCheckable(true);
-    m_block_pop_ups_action->setChecked(WebView::Application::chrome_options().allow_popups == WebView::AllowPopups::No);
+    m_block_pop_ups_action->setChecked(WebView::Application::browser_options().allow_popups == WebView::AllowPopups::No);
     debug_menu->addAction(m_block_pop_ups_action);
     QObject::connect(m_block_pop_ups_action, &QAction::triggered, this, [this] {
         bool state = m_block_pop_ups_action->isChecked();
@@ -738,7 +738,7 @@ void BrowserWindow::devtools_enabled()
     m_enable_devtools_action->setText("Disable &DevTools");
     statusBar()->addPermanentWidget(disable_button);
 
-    auto message = MUST(String::formatted("DevTools is enabled on port {}", WebView::Application::chrome_options().devtools_port));
+    auto message = MUST(String::formatted("DevTools is enabled on port {}", WebView::Application::browser_options().devtools_port));
     statusBar()->showMessage(qstring_from_ak_string(message));
 }
 

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -11,7 +11,7 @@
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibMain/Main.h>
 #include <LibWebView/Application.h>
-#include <LibWebView/ChromeProcess.h>
+#include <LibWebView/BrowserProcess.h>
 #include <LibWebView/EventLoop/EventLoopImplementationQt.h>
 #include <LibWebView/HelperProcess.h>
 #include <LibWebView/ProcessManager.h>
@@ -82,18 +82,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     WebView::platform_init();
 
-    WebView::ChromeProcess chrome_process;
+    WebView::BrowserProcess browser_process;
 
     if (app->browser_options().force_new_process == WebView::ForceNewProcess::No) {
-        auto disposition = TRY(chrome_process.connect(app->browser_options().raw_urls, app->browser_options().new_window));
+        auto disposition = TRY(browser_process.connect(app->browser_options().raw_urls, app->browser_options().new_window));
 
-        if (disposition == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
+        if (disposition == WebView::BrowserProcess::ProcessDisposition::ExitProcess) {
             outln("Opening in existing process");
             return 0;
         }
     }
 
-    chrome_process.on_new_tab = [&](auto const& urls) {
+    browser_process.on_new_tab = [&](auto const& urls) {
         auto& window = app->active_window();
         for (size_t i = 0; i < urls.size(); ++i) {
             window.new_tab_from_url(urls[i], (i == 0) ? Web::HTML::ActivateTab::Yes : Web::HTML::ActivateTab::No);
@@ -125,7 +125,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(app->launch_services());
 
-    chrome_process.on_new_window = [&](auto const& urls) {
+    browser_process.on_new_window = [&](auto const& urls) {
         app->new_window(urls);
     };
 

--- a/UI/Qt/main.cpp
+++ b/UI/Qt/main.cpp
@@ -84,8 +84,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     WebView::ChromeProcess chrome_process;
 
-    if (app->chrome_options().force_new_process == WebView::ForceNewProcess::No) {
-        auto disposition = TRY(chrome_process.connect(app->chrome_options().raw_urls, app->chrome_options().new_window));
+    if (app->browser_options().force_new_process == WebView::ForceNewProcess::No) {
+        auto disposition = TRY(chrome_process.connect(app->browser_options().raw_urls, app->browser_options().new_window));
 
         if (disposition == WebView::ChromeProcess::ProcessDisposition::ExitProcess) {
             outln("Opening in existing process");
@@ -129,7 +129,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         app->new_window(urls);
     };
 
-    auto& window = app->new_window(app->chrome_options().urls);
+    auto& window = app->new_window(app->browser_options().urls);
     window.setWindowTitle("Ladybird");
 
     if (Ladybird::Settings::the()->is_maximized()) {


### PR DESCRIPTION
While technically correct, referring to the browser/UI process as the chrome process has only ever caused confusion for people unfamiliar with this term, as seen on Discord. This will be especially true in user-facing strings, such as the task manager process list. This PR just replaces these references with browser process & UI throughout.