### PR TITLE
Meta: Fix incorrect Prettier package name in Nix configuration

### DIFF
--- a/Toolchain/Nix/shell.nix
+++ b/Toolchain/Nix/shell.nix
@@ -4,7 +4,7 @@
   ccache,
   clang-tools,
   pre-commit,
-  prettier,
+  prettierd,
   ladybird,
   ...
 }:
@@ -17,7 +17,7 @@ mkShell {
     ccache
     clang-tools
     pre-commit
-    prettier
+    prettierd
   ];
 
   # Fix for: https://github.com/LadybirdBrowser/ladybird/issues/371#issuecomment-2616415434


### PR DESCRIPTION
Meta: Fix incorrect Prettier package name in Nix configuration

It's prettierd in 24.11