### PR TITLE
Docs: Add a “cloning the repo” step to the build instructions

### DIFF
--- a/Documentation/BuildInstructionsLadybird.md
+++ b/Documentation/BuildInstructionsLadybird.md
@@ -208,6 +208,22 @@ Or, download a version of Gradle >= 8.0.0, and run the ``gradlew`` program in ``
 
 ## Build steps
 
+### Cloning the repo
+
+Before you can run the build script, you'll need to clone the repo and `cd` to the clone directory:
+
+```bash
+git clone https://github.com/LadybirdBrowser/ladybird.git
+cd ladybird
+```
+
+If you have your public SSH key set up with GitHub, you can replace the `https` URL above with the SSH URL:
+
+```bash
+git clone git@github.com:LadybirdBrowser/ladybird.git
+cd ladybird
+```
+
 ### Using ladybird.sh
 
 The simplest way to build and run ladybird is via the ladybird.sh script:


### PR DESCRIPTION
This came up at https://github.com/LadybirdBrowser/ladybird/issues/3950 and at least a couple times on Discord too.

This may be overkill, but I guess what happens is that some users just browse to the documentation from the GitHub site — that is, not reading the docs locally after having first cloned the repo.

And yeah, not sure what they’re expecting will occur if they try to invoke the build script without having checked out the sources, but… it seems to happen.
