### PR TITLE
AK: Support capturing Objective-C block closures in AK::Function

### DIFF
--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -265,6 +265,14 @@
 #    define LSAN_UNREGISTER_ROOT_REGION(base, size)
 #endif
 
+#if __has_feature(blocks)
+#    define AK_HAS_BLOCKS
+#endif
+
+#if __has_feature(objc_arc)
+#    define AK_HAS_OBJC_ARC
+#endif
+
 #ifndef AK_OS_SERENITY
 #    ifdef AK_OS_WINDOWS
 // FIXME: No idea where to get this, but it's 4096 anyway :^)

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -142,6 +142,27 @@ inline constexpr bool IsFunction<Ret(Args...) const volatile&&> = true;
 template<class Ret, class... Args>
 inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&&> = true;
 
+template<class>
+inline constexpr bool IsBlockClosure = false;
+#ifdef AK_HAS_BLOCKS
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^)(Args...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^)(Args..., ...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^const)(Args...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^const)(Args..., ...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^volatile)(Args...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^volatile)(Args..., ...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^const volatile)(Args...)> = true;
+template<class Ret, class... Args>
+inline constexpr bool IsBlockClosure<Ret (^const volatile)(Args..., ...)> = true;
+#endif
+
 template<class T>
 inline constexpr bool IsRvalueReference = false;
 template<class T>
@@ -641,6 +662,7 @@ using AK::Detail::InvokeResult;
 using AK::Detail::IsArithmetic;
 using AK::Detail::IsAssignable;
 using AK::Detail::IsBaseOf;
+using AK::Detail::IsBlockClosure;
 using AK::Detail::IsClass;
 using AK::Detail::IsConst;
 using AK::Detail::IsConstructible;

--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -73,10 +73,21 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>* as(InputType* input)
     return result;
 }
 
+template<typename OutputType, typename InputType>
+ALWAYS_INLINE CopyConst<InputType, OutputType>* bridge_cast(InputType input)
+{
+#ifdef AK_HAS_OBJC_ARC
+    return (__bridge CopyConst<InputType, OutputType>*)(input);
+#else
+    return static_cast<CopyConst<InputType, OutputType>*>(input);
+#endif
+}
+
 }
 
 #if USING_AK_GLOBALLY
 using AK::as;
 using AK::as_if;
+using AK::bridge_cast;
 using AK::is;
 #endif

--- a/Libraries/LibCore/CMakeLists.txt
+++ b/Libraries/LibCore/CMakeLists.txt
@@ -122,12 +122,20 @@ if (ENABLE_SWIFT)
     else()
         list(APPEND SWIFT_EXCLUDE_HEADERS "EventLoopImplementationWindows.h")
     endif()
+    if (NOT APPLE)
+        list(APPEND SWIFT_EXCLUDE_HEADERS
+            IOSurface.h
+            MachPort.h
+            MachMessageTypes.h
+            ProcessStatisticsMach.h
+        )
+    endif()
 
     generate_clang_module_map(LibCore EXCLUDE_FILES ${SWIFT_EXCLUDE_HEADERS})
     target_sources(LibCore PRIVATE
         EventSwift.mm
         EventLoopExecutor.swift)
-    set_source_files_properties(EventSwift.mm PRIVATE PROPERTIES COMPILE_FLAGS -fobjc-arc)
+    set_source_files_properties(EventSwift.mm PRIVATE PROPERTIES COMPILE_FLAGS -fblocks)
     target_link_libraries(LibCore PRIVATE AK)
     add_swift_target_properties(LibCore LAGOM_LIBRARIES AK)
 endif()

--- a/Libraries/LibCore/EventSwift.mm
+++ b/Libraries/LibCore/EventSwift.mm
@@ -7,16 +7,10 @@
 #include <LibCore/EventLoop.h>
 #include <LibCore/EventSwift.h>
 
-#if !__has_feature(objc_arc)
-#    error "This file requires ARC"
-#endif
-
 namespace Core {
 void deferred_invoke_block(EventLoop& event_loop, void (^invokee)(void))
 {
-    event_loop.deferred_invoke([invokee = move(invokee)] {
-        invokee();
-    });
+    event_loop.deferred_invoke(invokee);
 }
 
 }

--- a/Meta/CMake/FindBlocksRuntime.cmake
+++ b/Meta/CMake/FindBlocksRuntime.cmake
@@ -1,0 +1,19 @@
+# Finds the BlocksRuntime library
+# On Apple platforms, this does not exist and is folded into other System libraries
+
+find_library(BLOCKS_RUNTIME NAMES BlocksRuntime
+    PATHS ${SWIFT_LIBRARY_SEARCH_PATHS}
+)
+if (BLOCKS_RUNTIME)
+    if (NOT TARGET BlocksRuntime::BlocksRuntime)
+        add_library(BlocksRuntime::BlocksRuntime IMPORTED UNKNOWN)
+        message(STATUS "Found BlocksRuntime: ${BLOCKS_RUNTIME}")
+        cmake_path(GET BLOCKS_RUNTIME PARENT_PATH _BLOCKS_RUNTIME_DIR)
+        set_target_properties(BlocksRuntime::BlocksRuntime PROPERTIES
+                IMPORTED_LOCATION "${BLOCKS_RUNTIME}"
+                INTERFACE_LINK_DIRECTORIES "${_BLOCKS_RUNTIME_DIR}"
+                INTERFACE_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:C,CXX>:-fblocks>;SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xcc -fblocks>"
+        )
+    endif()
+    set(BlocksRuntime_FOUND TRUE)
+endif()

--- a/Meta/CMake/Swift/InitializeSwift.cmake
+++ b/Meta/CMake/Swift/InitializeSwift.cmake
@@ -104,6 +104,9 @@ function(_setup_swift_paths)
               NO_DEFAULT_PATH)
     add_link_options("$<$<LINK_LANGUAGE:Swift>:${SWIFT_SWIFTRT_FILE}>")
   endif()
+
+  # FIXME: Re-enable SIL verification after https://github.com/swiftlang/swift/issues/80065 is fixed
+  add_compile_options("SHELL:$<$<COMPILE_LANGUAGE:Swift>:-Xfrontend -sil-verify-none>")
 endfunction()
 
 _setup_swift_paths()

--- a/Meta/CMake/common_options.cmake
+++ b/Meta/CMake/common_options.cmake
@@ -45,3 +45,22 @@ serenity_option(ENABLE_STD_STACKTRACE OFF CACHE BOOL "Force use of std::stacktra
 if (ENABLE_SWIFT)
     include(${CMAKE_CURRENT_LIST_DIR}/Swift/swift-settings.cmake)
 endif()
+
+include(CheckCXXSourceCompiles)
+set(BLOCKS_REQUIRED_LIBRARIES "")
+if (NOT APPLE)
+    find_package(BlocksRuntime)
+    if (BlocksRuntime_FOUND)
+        set(BLOCKS_REQUIRED_LIBRARIES BlocksRuntime::BlocksRuntime)
+        set(CMAKE_REQUIRED_LIBRARIES BlocksRuntime::BlocksRuntime)
+    endif()
+endif()
+check_cxx_source_compiles([=[
+    int main() { __block int x = 0; auto b = ^{++x;}; b(); }
+]=] CXX_COMPILER_SUPPORTS_BLOCKS)
+
+set(CMAKE_REQUIRED_FLAGS "-fobjc-arc")
+check_cxx_source_compiles([=[
+    int main() { auto b = ^{}; auto __weak w = b; w(); }
+]=] CXX_COMPILER_SUPPORTS_OBJC_ARC)
+unset(CMAKE_REQUIRED_FLAGS)

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -281,9 +281,9 @@ function(lagom_utility name)
 endfunction()
 
 function(serenity_test test_src sub_dir)
-    cmake_parse_arguments(PARSE_ARGV 2 SERENITY_TEST "MAIN_ALREADY_DEFINED" "CUSTOM_MAIN" "LIBS")
+    cmake_parse_arguments(PARSE_ARGV 2 SERENITY_TEST "MAIN_ALREADY_DEFINED" "CUSTOM_MAIN;NAME" "LIBS")
     # FIXME: Pass MAIN_ALREADY_DEFINED and CUSTOM_MAIN to support tests that use them.
-    lagom_test(${test_src} LIBS ${SERENITY_TEST_LIBS} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+    lagom_test(${test_src} LIBS ${SERENITY_TEST_LIBS} WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} NAME ${SERENITY_TEST_NAME})
 endfunction()
 
 function(serenity_bin name)

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -88,6 +88,16 @@ foreach(source IN LISTS AK_TEST_SOURCES)
     serenity_test("${source}" AK)
 endforeach()
 
+if (CXX_COMPILER_SUPPORTS_BLOCKS)
+    serenity_test(TestFunction.mm AK NAME TestFunction)
+    target_link_libraries(TestFunction PRIVATE ${BLOCKS_REQUIRED_LIBRARIES})
+endif()
+if (CXX_COMPILER_SUPPORTS_OBJC_ARC)
+    serenity_test(TestFunction.mm AK NAME TestFunctionArc)
+    target_compile_options(TestFunctionArc PRIVATE -fobjc-arc)
+    target_link_libraries(TestFunction PRIVATE ${BLOCKS_REQUIRED_LIBRARIES})
+endif()
+
 target_link_libraries(TestString PRIVATE LibUnicode)
 
 if (ENABLE_SWIFT)

--- a/Tests/AK/TestFunction.mm
+++ b/Tests/AK/TestFunction.mm
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025, Andrew Kaster <andrew@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/ByteReader.h>
+#include <AK/Function.h>
+#include <AK/Platform.h>
+
+TEST_CASE(SimpleBlock)
+{
+    auto b = ^{ };
+
+    static_assert(IsBlockClosure<decltype(b)>);
+
+    auto f = Function<void()>(b);
+
+    f();
+}
+
+TEST_CASE(BlockCaptureInt)
+{
+    __block int x = 0;
+    auto b = ^{
+        x = 2;
+    };
+    auto f = Function<void()>(b);
+
+    f();
+
+    EXPECT_EQ(x, 2);
+}
+
+TEST_CASE(BlockCaptureString)
+{
+    __block String s = "hello"_string;
+    auto b = ^{
+        s = "world"_string;
+    };
+    auto f = Function<void()>(b);
+
+    f();
+
+    EXPECT_EQ(s, "world"_string);
+}
+
+TEST_CASE(BlockCaptureLongStringAndInt)
+{
+    __block String s = "hello, world, this is a long string to avoid small string optimization"_string;
+    __block int x = 0;
+    auto b = ^{
+        s = "world, hello, this is a long string to avoid small string optimization"_string;
+        x = 2;
+    };
+    auto f = Function<void()>(b);
+
+    f();
+
+    EXPECT_EQ(s, "world, hello, this is a long string to avoid small string optimization"_string);
+    EXPECT_EQ(x, 2);
+}
+
+// Struct definitions from llvm-project/compiler-rt/lib/BlocksRuntime/Block_private.h @ d0177670a0e59e9d9719386f85bb78de0929407c
+struct Block_descriptor {
+    unsigned long int reserved;
+    unsigned long int size;
+    void (*copy)(void* dst, void* src);
+    void (*dispose)(void*);
+};
+
+struct Block_layout {
+    void* isa;
+    int flags;
+    int reserved;
+    void (*invoke)(void*, ...);
+    struct Block_descriptor* descriptor;
+    /* Imported variables. */
+};
+// This check is super important for proper tracking of block closure captures
+static_assert(sizeof(Block_layout) == AK::Detail::block_layout_size);
+
+TEST_CASE(BlockPointerCaptures)
+{
+    int x = 0;
+    int* p = &x;
+
+    auto b = ^{
+        *p = 2;
+    };
+
+    auto f = Function<void()>(b);
+    auto span = f.raw_capture_range();
+
+    int* captured_p = ByteReader::load_pointer<int>(span.data());
+    EXPECT_EQ(captured_p, p);
+
+    f();
+
+    EXPECT_EQ(x, 2);
+}
+
+TEST_CASE(AssignBlock)
+{
+    auto b = ^{ };
+
+    auto f = Function<void()>(b);
+
+    auto b2 = ^{ };
+
+    f = b2;
+
+    f();
+
+    f = b;
+
+    f();
+}
+
+#ifdef AK_HAS_OBJC_ARC
+TEST_CASE(AssignWeakBlock)
+{
+    __block int count = 0;
+    Function<void()> f;
+
+    {
+        auto b = ^{ ++count; };
+        f = b;
+    }
+    f();
+    EXPECT_EQ(count, 1);
+
+    {
+        auto b = ^{ ++count; };
+        auto const __weak weak_b = b;
+        f = weak_b;
+        f();
+        EXPECT_EQ(count, 2);
+    }
+    f();
+    EXPECT_EQ(count, 3);
+}
+#endif


### PR DESCRIPTION
With a bit of gnarly preprocessor and if constexpr magic, we can get this to work the same way-ish that libc++'s std::function handles block closures.

cc @bugaevc , in case you have any objective-c wisdom :)