### PR TITLE
LibWeb/SVG: Work around no layout node in SVGCircleElement::get_path

### DIFF
--- a/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -61,6 +61,11 @@ void SVGCircleElement::apply_presentational_hints(GC::Ref<CSS::CascadedPropertie
 Gfx::Path SVGCircleElement::get_path(CSSPixelSize viewport_size)
 {
     auto node = layout_node();
+    if (!node) {
+        dbgln("FIXME: Null layout node in SVGCircleElement::get_path");
+        return {};
+    }
+
     auto cx = float(node->computed_values().cx().to_px(*node, viewport_size.width()));
     auto cy = float(node->computed_values().cy().to_px(*node, viewport_size.height()));
     // Percentages refer to the normalized diagonal of the current SVG viewport

--- a/Tests/LibWeb/Crash/Layout/svg-circle-element-crash-no-layout-node.html
+++ b/Tests/LibWeb/Crash/Layout/svg-circle-element-crash-no-layout-node.html
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<g mask="url(#excludedEndPoints)"></g>
+<mask id="excludedEndPoints">
+  <circle cx="50" cy="50" r="4" fill="black" stroke="black"/>
+</mask>
+</svg>


### PR DESCRIPTION
This is clearly not the correct fix, but instead of crashing let's log an error and bail.

Works around a crash seen on both:

 * https://reddit.com
 * https://www.w3.org/TR/web-animations-1 (#879)