### PR TITLE
LibWebView: Keep javascript URL navigations in the same process

### DIFF
--- a/Libraries/LibWebView/SiteIsolation.cpp
+++ b/Libraries/LibWebView/SiteIsolation.cpp
@@ -27,6 +27,10 @@ bool is_url_suitable_for_same_process_navigation(URL::URL const& current_url, UR
     if (Web::HTML::url_matches_about_blank(current_url))
         return true;
 
+    // Make sure JavaScript URLs run in the same process.
+    if (target_url.scheme() == "javascript"sv)
+        return true;
+
     // Allow cross-scheme non-HTTP(S) navigation. Disallow cross-scheme HTTP(s) navigation.
     auto current_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(current_url.scheme());
     auto target_url_is_http = Web::Fetch::Infrastructure::is_http_or_https_scheme(target_url.scheme());

--- a/Tests/LibWeb/Text/expected/HTML/javascript-navigation-stays-in-same-process.txt
+++ b/Tests/LibWeb/Text/expected/HTML/javascript-navigation-stays-in-same-process.txt
@@ -1,0 +1,1 @@
+Hello world, this was printed by a JavaScript navigation!

--- a/Tests/LibWeb/Text/input/HTML/javascript-navigation-stays-in-same-process.html
+++ b/Tests/LibWeb/Text/input/HTML/javascript-navigation-stays-in-same-process.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<div id="test">Hello world, this was printed by a JavaScript navigation!</div>
+<script>
+    asyncTest((done) => {
+        location.href = "javascript:void println(document.getElementById('test').innerText)";
+        setTimeout(() => {
+            done();
+        }, 0);
+    });
+</script>


### PR DESCRIPTION
JavaScript URLs run in the same document context the navigation was started in, so they're not eligible to be moved to a new WebContent process.

Fixes the "Login as demo user" link on https://demo.immich.app/