### PR TITLE
LibWeb: Invalidate text-decoration-thickness as paint-only property

### DIFF
--- a/Libraries/LibWeb/Layout/LayoutState.cpp
+++ b/Libraries/LibWeb/Layout/LayoutState.cpp
@@ -363,17 +363,6 @@ void LayoutState::commit(Box& root)
 
     for (auto* text_node : text_nodes) {
         text_node->add_paintable(text_node->create_paintable());
-        auto* paintable = text_node->first_paintable();
-        auto const& font = text_node->first_available_font();
-        auto const glyph_height = CSSPixels::nearest_value_for(font.pixel_size());
-        auto const css_line_thickness = [&] {
-            auto computed_thickness = text_node->computed_values().text_decoration_thickness().resolved(*text_node, CSS::Length(1, CSS::Length::Type::Em).to_px(*text_node));
-            if (computed_thickness.is_auto())
-                return max(glyph_height.scaled(0.1), 1);
-            return computed_thickness.to_px(*text_node);
-        }();
-        auto& text_paintable = static_cast<Painting::TextPaintable&>(*paintable);
-        text_paintable.set_text_decoration_thickness(css_line_thickness);
     }
 
     build_paint_tree(root);

--- a/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -687,9 +687,7 @@ void paint_text_decoration(PaintContext& context, TextPaintable const& paintable
 
     auto line_color = paintable.computed_values().text_decoration_color();
     auto line_style = paintable.computed_values().text_decoration_style();
-    auto const& text_paintable = static_cast<TextPaintable const&>(fragment.paintable());
-    auto device_line_thickness = context.rounded_device_pixels(text_paintable.text_decoration_thickness());
-
+    auto device_line_thickness = context.rounded_device_pixels(fragment.text_decoration_thickness());
     auto text_decoration_lines = paintable.computed_values().text_decoration_line();
     for (auto line : text_decoration_lines) {
         DevicePixelPoint line_start_point {};
@@ -1364,10 +1362,24 @@ void PaintableWithLines::resolve_paint_properties()
     Base::resolve_paint_properties();
 
     auto const& layout_node = this->layout_node();
-    for (auto const& fragment : fragments()) {
-        auto const& text_shadow = fragment.m_layout_node->computed_values().text_shadow();
+    for (auto& fragment : fragments()) {
+        if (!fragment.m_layout_node->is_text_node())
+            continue;
+        auto const& text_node = static_cast<Layout::TextNode const&>(*fragment.m_layout_node);
+
+        auto const& font = fragment.m_layout_node->first_available_font();
+        auto const glyph_height = CSSPixels::nearest_value_for(font.pixel_size());
+        auto const css_line_thickness = [&] {
+            auto computed_thickness = text_node.computed_values().text_decoration_thickness().resolved(text_node, CSS::Length(1, CSS::Length::Type::Em).to_px(text_node));
+            if (computed_thickness.is_auto())
+                return max(glyph_height.scaled(0.1), 1);
+            return computed_thickness.to_px(*fragment.m_layout_node);
+        }();
+        fragment.set_text_decoration_thickness(css_line_thickness);
+
+        auto const& text_shadow = text_node.computed_values().text_shadow();
         if (!text_shadow.is_empty()) {
-            Vector<Painting::ShadowData> resolved_shadow_data;
+            Vector<ShadowData> resolved_shadow_data;
             resolved_shadow_data.ensure_capacity(text_shadow.size());
             for (auto const& layer : text_shadow) {
                 resolved_shadow_data.empend(
@@ -1376,9 +1388,9 @@ void PaintableWithLines::resolve_paint_properties()
                     layer.offset_y.to_px(layout_node),
                     layer.blur_radius.to_px(layout_node),
                     layer.spread_distance.to_px(layout_node),
-                    Painting::ShadowPlacement::Outer);
+                    ShadowPlacement::Outer);
             }
-            const_cast<Painting::PaintableFragment&>(fragment).set_shadows(move(resolved_shadow_data));
+            fragment.set_shadows(move(resolved_shadow_data));
         }
     }
 }

--- a/Libraries/LibWeb/Painting/PaintableFragment.h
+++ b/Libraries/LibWeb/Painting/PaintableFragment.h
@@ -48,6 +48,9 @@ public:
 
     StringView string_view() const;
 
+    CSSPixels text_decoration_thickness() const { return m_text_decoration_thickness; }
+    void set_text_decoration_thickness(CSSPixels thickness) { m_text_decoration_thickness = thickness; }
+
 private:
     GC::Ref<Layout::Node const> m_layout_node;
     CSSPixelPoint m_offset;
@@ -58,6 +61,7 @@ private:
     RefPtr<Gfx::GlyphRun> m_glyph_run;
     CSS::WritingMode m_writing_mode;
     Vector<ShadowData> m_shadows;
+    CSSPixels m_text_decoration_thickness { 0 };
 };
 
 }

--- a/Libraries/LibWeb/Painting/TextPaintable.h
+++ b/Libraries/LibWeb/Painting/TextPaintable.h
@@ -25,9 +25,6 @@ public:
     virtual DispatchEventOfSameName handle_mouseup(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
     virtual DispatchEventOfSameName handle_mousemove(Badge<EventHandler>, CSSPixelPoint, unsigned button, unsigned modifiers) override;
 
-    void set_text_decoration_thickness(CSSPixels thickness) { m_text_decoration_thickness = thickness; }
-    CSSPixels text_decoration_thickness() const { return m_text_decoration_thickness; }
-
     String const& text_for_rendering() const { return m_text_for_rendering; }
 
 private:
@@ -36,7 +33,6 @@ private:
     TextPaintable(Layout::TextNode const&, String const& text_for_rendering);
 
     String m_text_for_rendering;
-    CSSPixels m_text_decoration_thickness { 0 };
 };
 
 }


### PR DESCRIPTION
Fixes underinvalidation caused by resolving text-decoration-thickness during layout commit, while this property can be invalidated independently of layout.