### PR TITLE
LibWeb: Implement the `HTMLLinkElement.sheet` attribute

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -138,6 +138,12 @@ String HTMLLinkElement::media() const
     return attribute(HTML::AttributeNames::media).value_or(String {});
 }
 
+// https://drafts.csswg.org/cssom/#dom-linkstyle-sheet
+GC::Ptr<CSS::CSSStyleSheet> HTMLLinkElement::sheet() const
+{
+    return m_loaded_style_sheet;
+}
+
 bool HTMLLinkElement::has_loaded_icon() const
 {
     return m_relationship & Relationship::Icon && resource() && resource()->is_loaded() && resource()->has_encoded_data();

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -48,6 +48,8 @@ public:
     void set_media(String);
     String media() const;
 
+    GC::Ptr<CSS::CSSStyleSheet> sheet() const;
+
 private:
     HTMLLinkElement(DOM::Document&, DOM::QualifiedName);
 

--- a/Libraries/LibWeb/HTML/HTMLLinkElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLLinkElement.idl
@@ -60,4 +60,4 @@ interface HTMLLinkElement : HTMLElement {
     [CEReactions, Reflect] attribute DOMString target;
 
 };
-// FIXME: HTMLLinkElement includes LinkStyle;
+HTMLLinkElement includes LinkStyle;

--- a/Tests/LibWeb/Text/expected/css/HTMLLinkElement-sheet.txt
+++ b/Tests/LibWeb/Text/expected/css/HTMLLinkElement-sheet.txt
@@ -1,0 +1,2 @@
+sheet property initial value: null
+Sheet property after stylesheet loaded: [object CSSStyleSheet]

--- a/Tests/LibWeb/Text/input/css/HTMLLinkElement-sheet.html
+++ b/Tests/LibWeb/Text/input/css/HTMLLinkElement-sheet.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    asyncTest(done => {
+        const link = document.createElement("link");
+        link.rel = "stylesheet";
+        document.head.appendChild(link);
+        println(`sheet property initial value: ${link.sheet}`);
+        link.href = "../valid.css";
+        link.onload = () => {
+            println(`Sheet property after stylesheet loaded: ${link.sheet}`);
+            done();
+        }
+    });
+</script>


### PR DESCRIPTION
This returns the link element's associated style sheet.