### PR TITLE
LibWeb: Implement the LegacyUnforgeable attribute

### DIFF
--- a/Libraries/LibIDL/IDLParser.cpp
+++ b/Libraries/LibIDL/IDLParser.cpp
@@ -504,7 +504,7 @@ void Parser::parse_stringifier(HashMap<ByteString, ByteString>& extended_attribu
     interface.has_stringifier = true;
     if (lexer.next_is("attribute"sv) || lexer.next_is("inherit"sv) || lexer.next_is("readonly"sv)) {
         parse_attribute(extended_attributes, interface);
-        interface.stringifier_attribute = interface.attributes.last().name;
+        interface.stringifier_attribute = interface.attributes.last();
     } else {
         assert_specific(';');
     }

--- a/Libraries/LibIDL/Types.h
+++ b/Libraries/LibIDL/Types.h
@@ -280,7 +280,7 @@ public:
     Vector<Function> functions;
     Vector<Function> static_functions;
     bool has_stringifier { false };
-    Optional<ByteString> stringifier_attribute;
+    Optional<Attribute> stringifier_attribute;
     bool has_unscopable_member { false };
 
     Optional<NonnullRefPtr<Type const>> value_iterator_type;

--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -483,6 +483,7 @@ void Document::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Document);
+    Bindings::DocumentPrototype::define_unforgeable_attributes(realm, *this);
 
     m_selection = realm.create<Selection::Selection>(realm, *this);
 

--- a/Libraries/LibWeb/DOM/Event.cpp
+++ b/Libraries/LibWeb/DOM/Event.cpp
@@ -57,6 +57,7 @@ void Event::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Event);
+    Bindings::EventPrototype::define_unforgeable_attributes(realm, *this);
 }
 
 void Event::visit_edges(Visitor& visitor)

--- a/Libraries/LibWeb/HTML/Location.cpp
+++ b/Libraries/LibWeb/HTML/Location.cpp
@@ -43,6 +43,7 @@ void Location::initialize(JS::Realm& realm)
 {
     Base::initialize(realm);
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Location);
+    Bindings::LocationPrototype::define_unforgeable_attributes(realm, *this);
 
     auto& vm = this->vm();
 

--- a/Libraries/LibWeb/HTML/Window.cpp
+++ b/Libraries/LibWeb/HTML/Window.cpp
@@ -731,6 +731,7 @@ WebIDL::ExceptionOr<void> Window::initialize_web_interfaces(Badge<WindowEnvironm
     WEB_SET_PROTOTYPE_FOR_INTERFACE(Window);
 
     Bindings::WindowGlobalMixin::initialize(realm, *this);
+    Bindings::WindowGlobalMixin::define_unforgeable_attributes(realm, *this);
     WindowOrWorkerGlobalScopeMixin::initialize(realm);
 
     if (s_internals_object_exposed)

--- a/Tests/LibWeb/Text/expected/DOM/Document-has-unforgeable-properties.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Document-has-unforgeable-properties.txt
@@ -1,0 +1,36 @@
+location exists on document itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined
+location exists on document itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined
+location exists on document itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined
+location exists on document itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined
+location exists on document itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined
+location exists on document itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined

--- a/Tests/LibWeb/Text/expected/DOM/Event-has-unforgeable-properties.txt
+++ b/Tests/LibWeb/Text/expected/DOM/Event-has-unforgeable-properties.txt
@@ -1,0 +1,18 @@
+isTrusted exists on Event instance itself: true
+isTrusted does not exist on LocationPrototype: true
+isTrusted descriptor is not undefined: true
+isTrusted enumerable: true
+isTrusted configurable: false
+isTrusted writable: undefined
+isTrusted exists on UIEvent instance itself: true
+isTrusted does not exist on LocationPrototype: true
+isTrusted descriptor is not undefined: true
+isTrusted enumerable: true
+isTrusted configurable: false
+isTrusted writable: undefined
+isTrusted exists on CustomEvent instance itself: true
+isTrusted does not exist on LocationPrototype: true
+isTrusted descriptor is not undefined: true
+isTrusted enumerable: true
+isTrusted configurable: false
+isTrusted writable: undefined

--- a/Tests/LibWeb/Text/expected/HTML/Location-has-unforgeable-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Location-has-unforgeable-properties.txt
@@ -1,0 +1,156 @@
+href exists on location itself: true
+href does not exist on LocationPrototype: true
+href descriptor is not undefined: true
+href enumerable: true
+href configurable: true
+href writable: undefined
+origin exists on location itself: true
+origin does not exist on LocationPrototype: true
+origin descriptor is not undefined: true
+origin enumerable: true
+origin configurable: true
+origin writable: undefined
+protocol exists on location itself: true
+protocol does not exist on LocationPrototype: true
+protocol descriptor is not undefined: true
+protocol enumerable: true
+protocol configurable: true
+protocol writable: undefined
+host exists on location itself: true
+host does not exist on LocationPrototype: true
+host descriptor is not undefined: true
+host enumerable: true
+host configurable: true
+host writable: undefined
+hostname exists on location itself: true
+hostname does not exist on LocationPrototype: true
+hostname descriptor is not undefined: true
+hostname enumerable: true
+hostname configurable: true
+hostname writable: undefined
+port exists on location itself: true
+port does not exist on LocationPrototype: true
+port descriptor is not undefined: true
+port enumerable: true
+port configurable: true
+port writable: undefined
+pathname exists on location itself: true
+pathname does not exist on LocationPrototype: true
+pathname descriptor is not undefined: true
+pathname enumerable: true
+pathname configurable: true
+pathname writable: undefined
+search exists on location itself: true
+search does not exist on LocationPrototype: true
+search descriptor is not undefined: true
+search enumerable: true
+search configurable: true
+search writable: undefined
+hash exists on location itself: true
+hash does not exist on LocationPrototype: true
+hash descriptor is not undefined: true
+hash enumerable: true
+hash configurable: true
+hash writable: undefined
+assign exists on location itself: true
+assign does not exist on LocationPrototype: true
+assign descriptor is not undefined: true
+assign enumerable: true
+assign configurable: true
+assign writable: false
+replace exists on location itself: true
+replace does not exist on LocationPrototype: true
+replace descriptor is not undefined: true
+replace enumerable: true
+replace configurable: true
+replace writable: false
+reload exists on location itself: true
+reload does not exist on LocationPrototype: true
+reload descriptor is not undefined: true
+reload enumerable: true
+reload configurable: true
+reload writable: false
+toString exists on location itself: true
+toString does not exist on LocationPrototype: true
+toString descriptor is not undefined: true
+toString enumerable: true
+toString configurable: true
+toString writable: false
+href exists on document.location itself: true
+href does not exist on LocationPrototype: true
+href descriptor is not undefined: true
+href enumerable: true
+href configurable: true
+href writable: undefined
+origin exists on document.location itself: true
+origin does not exist on LocationPrototype: true
+origin descriptor is not undefined: true
+origin enumerable: true
+origin configurable: true
+origin writable: undefined
+protocol exists on document.location itself: true
+protocol does not exist on LocationPrototype: true
+protocol descriptor is not undefined: true
+protocol enumerable: true
+protocol configurable: true
+protocol writable: undefined
+host exists on document.location itself: true
+host does not exist on LocationPrototype: true
+host descriptor is not undefined: true
+host enumerable: true
+host configurable: true
+host writable: undefined
+hostname exists on document.location itself: true
+hostname does not exist on LocationPrototype: true
+hostname descriptor is not undefined: true
+hostname enumerable: true
+hostname configurable: true
+hostname writable: undefined
+port exists on document.location itself: true
+port does not exist on LocationPrototype: true
+port descriptor is not undefined: true
+port enumerable: true
+port configurable: true
+port writable: undefined
+pathname exists on document.location itself: true
+pathname does not exist on LocationPrototype: true
+pathname descriptor is not undefined: true
+pathname enumerable: true
+pathname configurable: true
+pathname writable: undefined
+search exists on document.location itself: true
+search does not exist on LocationPrototype: true
+search descriptor is not undefined: true
+search enumerable: true
+search configurable: true
+search writable: undefined
+hash exists on document.location itself: true
+hash does not exist on LocationPrototype: true
+hash descriptor is not undefined: true
+hash enumerable: true
+hash configurable: true
+hash writable: undefined
+assign exists on document.location itself: true
+assign does not exist on LocationPrototype: true
+assign descriptor is not undefined: true
+assign enumerable: true
+assign configurable: true
+assign writable: false
+replace exists on document.location itself: true
+replace does not exist on LocationPrototype: true
+replace descriptor is not undefined: true
+replace enumerable: true
+replace configurable: true
+replace writable: false
+reload exists on document.location itself: true
+reload does not exist on LocationPrototype: true
+reload descriptor is not undefined: true
+reload enumerable: true
+reload configurable: true
+reload writable: false
+toString exists on document.location itself: true
+toString does not exist on LocationPrototype: true
+toString descriptor is not undefined: true
+toString enumerable: true
+toString configurable: true
+toString writable: false

--- a/Tests/LibWeb/Text/expected/HTML/Window-has-unforgeable-properties.txt
+++ b/Tests/LibWeb/Text/expected/HTML/Window-has-unforgeable-properties.txt
@@ -1,0 +1,24 @@
+window exists on window itself: true
+window does not exist on LocationPrototype: true
+window descriptor is not undefined: true
+window enumerable: true
+window configurable: false
+window writable: undefined
+document exists on window itself: true
+document does not exist on LocationPrototype: true
+document descriptor is not undefined: true
+document enumerable: true
+document configurable: false
+document writable: undefined
+location exists on window itself: true
+location does not exist on LocationPrototype: true
+location descriptor is not undefined: true
+location enumerable: true
+location configurable: false
+location writable: undefined
+top exists on window itself: true
+top does not exist on LocationPrototype: true
+top descriptor is not undefined: true
+top enumerable: true
+top configurable: false
+top writable: undefined

--- a/Tests/LibWeb/Text/input/DOM/Document-has-unforgeable-properties.html
+++ b/Tests/LibWeb/Text/input/DOM/Document-has-unforgeable-properties.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const unforgeableProperties = [
+            "location",
+        ];
+
+        const documents = [
+            document,
+            new Document(),
+            document.implementation.createDocument("http://www.w3.org/1999/xhtml", null, null),
+            document.implementation.createDocument("http://www.w3.org/2000/svg", null, null),
+            document.implementation.createDocument(null, null, null),
+            document.implementation.createHTMLDocument(),
+        ];
+
+        for (const document of documents) {
+            const documentPrototype = Object.getPrototypeOf(document);
+
+            for (const property of unforgeableProperties) { 
+                println(`${property} exists on document itself: ${Object.hasOwn(document, property)}`);
+                println(`${property} does not exist on LocationPrototype: ${!Object.hasOwn(documentPrototype, property)}`);
+                
+                const propertyDescriptor = Object.getOwnPropertyDescriptor(document, property);
+                println(`${property} descriptor is not undefined: ${propertyDescriptor !== undefined}`);
+                println(`${property} enumerable: ${propertyDescriptor.enumerable}`);
+                println(`${property} configurable: ${propertyDescriptor.configurable}`);
+                println(`${property} writable: ${propertyDescriptor.writable}`);
+            }
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/DOM/Event-has-unforgeable-properties.html
+++ b/Tests/LibWeb/Text/input/DOM/Event-has-unforgeable-properties.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const unforgeableProperties = [
+            "isTrusted",
+        ];
+
+        for (const eventType of [Event, UIEvent, CustomEvent]) {
+            const event = new eventType("test");
+            const eventPrototype = Object.getPrototypeOf(event);
+
+            for (const property of unforgeableProperties) { 
+                println(`${property} exists on ${eventType.name} instance itself: ${Object.hasOwn(event, property)}`);
+                println(`${property} does not exist on LocationPrototype: ${!Object.hasOwn(eventPrototype, property)}`);
+                
+                const propertyDescriptor = Object.getOwnPropertyDescriptor(event, property);
+                println(`${property} descriptor is not undefined: ${propertyDescriptor !== undefined}`);
+                println(`${property} enumerable: ${propertyDescriptor.enumerable}`);
+                println(`${property} configurable: ${propertyDescriptor.configurable}`);
+                println(`${property} writable: ${propertyDescriptor.writable}`);
+            }
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/Location-has-unforgeable-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Location-has-unforgeable-properties.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        for (const { location, name } of [{ location: window.location, name: "location" }, { location: document.location, name: "document.location" }]) {
+            const unforgeableProperties = [
+                "href",
+                "origin",
+                "protocol",
+                "host",
+                "hostname",
+                "port",
+                "pathname",
+                "search",
+                "hash",
+                "assign",
+                "replace",
+                "reload",
+                // FIXME: "ancestorOrigins",
+                "toString",
+            ];
+
+            const locationPrototype = Object.getPrototypeOf(location);
+
+            for (const property of unforgeableProperties) {
+                println(`${property} exists on ${name} itself: ${Object.hasOwn(location, property)}`);
+                println(`${property} does not exist on LocationPrototype: ${!Object.hasOwn(locationPrototype, property)}`);
+                
+                const propertyDescriptor = Object.getOwnPropertyDescriptor(location, property);
+                println(`${property} descriptor is not undefined: ${propertyDescriptor !== undefined}`);
+                println(`${property} enumerable: ${propertyDescriptor.enumerable}`);
+                println(`${property} configurable: ${propertyDescriptor.configurable}`);
+                println(`${property} writable: ${propertyDescriptor.writable}`);
+            }
+        }
+    });
+</script>

--- a/Tests/LibWeb/Text/input/HTML/Window-has-unforgeable-properties.html
+++ b/Tests/LibWeb/Text/input/HTML/Window-has-unforgeable-properties.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<script>
+    test(() => {
+        const unforgeableProperties = [
+            "window",
+            "document",
+            "location",
+            "top",
+        ];
+
+        const windowPrototype = Object.getPrototypeOf(window);
+
+        for (const property of unforgeableProperties) { 
+            println(`${property} exists on window itself: ${Object.hasOwn(window, property)}`);
+            println(`${property} does not exist on LocationPrototype: ${!Object.hasOwn(windowPrototype, property)}`);
+            
+            const propertyDescriptor = Object.getOwnPropertyDescriptor(window, property);
+            println(`${property} descriptor is not undefined: ${propertyDescriptor !== undefined}`);
+            println(`${property} enumerable: ${propertyDescriptor.enumerable}`);
+            println(`${property} configurable: ${propertyDescriptor.configurable}`);
+            println(`${property} writable: ${propertyDescriptor.writable}`);
+        }
+    });
+</script>


### PR DESCRIPTION
Part 5 of splitting up https://github.com/LadybirdBrowser/ladybird/pull/2854

----

This fixes the frame-ancestors WPT tests from crashing when an iframe is blocked from loading. This is because it would get an undefined location.href from the cross-origin iframe, which causes a crash as it expects it to be there.