### PR TITLE
LibWeb: Calculate the correct resolved value for inset properties

### DIFF
--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-insets-absolute.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-insets-absolute.txt
@@ -1,0 +1,330 @@
+Harness status: OK
+
+Found 324 tests
+
+288 Pass
+36 Fail
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Pixels resolve as-is
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Pixels resolve as-is
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-lr ltr - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr ltr - Percentages are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr ltr - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-lr rtl - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr rtl - Percentages are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr rtl - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-rl ltr - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl ltr - Percentages are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl ltr - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-rl rtl - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl rtl - Percentages are absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl rtl - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Pixels resolve as-is
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Pixels resolve as-is
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-lr ltr - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr ltr - Percentages are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr ltr - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-lr rtl - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr rtl - Percentages are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr rtl - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-rl ltr - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl ltr - Percentages are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl ltr - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-rl rtl - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl rtl - Percentages are absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl rtl - Pixels resolve as-is when overconstrained
+Pass	horizontal-tb rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
+Pass	horizontal-tb rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	horizontal-tb rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-lr ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-lr ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-lr ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-lr ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr ltr - Percentages are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-lr ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr rtl - Percentages are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-lr ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl ltr - Percentages are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-lr ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl rtl - Percentages are absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-lr ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-lr rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-lr rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-lr rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-lr rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr ltr - Percentages are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-lr rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr rtl - Percentages are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-lr rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl ltr - Percentages are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-lr rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl rtl - Percentages are absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-lr rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-lr rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-lr rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-rl ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-rl ltr inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-rl ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-rl ltr inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr ltr - Percentages are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-rl ltr inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr rtl - Percentages are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-rl ltr inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl ltr - Percentages are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-rl ltr inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl rtl - Percentages are absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-rl ltr inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-rl rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-rl rtl inside horizontal-tb ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-rl rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-rl rtl inside horizontal-tb rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr ltr - Percentages are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-rl rtl inside vertical-lr ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr rtl - Percentages are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-rl rtl inside vertical-lr rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl ltr - Percentages are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl ltr - Pixels resolve as-is when overconstrained
+Pass	vertical-rl rtl inside vertical-rl ltr - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl rtl - Percentages are absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl rtl - Pixels resolve as-is when overconstrained
+Pass	vertical-rl rtl inside vertical-rl rtl - Percentages absolutize the computed value when overconstrained
+Pass	vertical-rl rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Fail	vertical-rl rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-insets-relative.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/cssom/getComputedStyle-insets-relative.txt
@@ -1,0 +1,258 @@
+Harness status: OK
+
+Found 252 tests
+
+180 Pass
+72 Fail
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Pixels resolve as-is
+Pass	horizontal-tb ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Fail	horizontal-tb ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
+Fail	horizontal-tb ltr inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Pixels resolve as-is
+Pass	horizontal-tb ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Fail	horizontal-tb ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
+Fail	horizontal-tb ltr inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-lr ltr - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-lr ltr - Percentages are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-lr rtl - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-lr rtl - Percentages are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-rl ltr - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-rl ltr - Percentages are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb ltr inside vertical-rl rtl - Pixels resolve as-is
+Pass	horizontal-tb ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-rl rtl - Percentages are absolutized into pixels
+Fail	horizontal-tb ltr inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	horizontal-tb ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Pixels resolve as-is
+Pass	horizontal-tb rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Fail	horizontal-tb rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
+Fail	horizontal-tb rtl inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Pixels resolve as-is
+Pass	horizontal-tb rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Fail	horizontal-tb rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
+Fail	horizontal-tb rtl inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-lr ltr - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-lr ltr - Percentages are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-lr rtl - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-lr rtl - Percentages are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-rl ltr - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-rl ltr - Percentages are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	horizontal-tb rtl inside vertical-rl rtl - Pixels resolve as-is
+Pass	horizontal-tb rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-rl rtl - Percentages are absolutized into pixels
+Fail	horizontal-tb rtl inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	horizontal-tb rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	horizontal-tb rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-lr ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Fail	vertical-lr ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
+Fail	vertical-lr ltr inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-lr ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Fail	vertical-lr ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
+Fail	vertical-lr ltr inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-lr ltr - Percentages are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-lr rtl - Percentages are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-rl ltr - Percentages are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr ltr inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-lr ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-rl rtl - Percentages are absolutized into pixels
+Fail	vertical-lr ltr inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-lr ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-lr rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Fail	vertical-lr rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
+Fail	vertical-lr rtl inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-lr rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Fail	vertical-lr rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
+Fail	vertical-lr rtl inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-lr ltr - Percentages are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-lr rtl - Percentages are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-rl ltr - Percentages are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-lr rtl inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-lr rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-rl rtl - Percentages are absolutized into pixels
+Fail	vertical-lr rtl inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-lr rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-lr rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-rl ltr inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Fail	vertical-rl ltr inside horizontal-tb ltr - Percentages are absolutized into pixels
+Fail	vertical-rl ltr inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-rl ltr inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Fail	vertical-rl ltr inside horizontal-tb rtl - Percentages are absolutized into pixels
+Fail	vertical-rl ltr inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-lr ltr - Percentages are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-lr rtl - Percentages are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-rl ltr - Percentages are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl ltr inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-rl ltr inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-rl rtl - Percentages are absolutized into pixels
+Fail	vertical-rl ltr inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-rl ltr inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl ltr inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside horizontal-tb ltr - Pixels resolve as-is
+Pass	vertical-rl rtl inside horizontal-tb ltr - Relative lengths are absolutized into pixels
+Fail	vertical-rl rtl inside horizontal-tb ltr - Percentages are absolutized into pixels
+Fail	vertical-rl rtl inside horizontal-tb ltr - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside horizontal-tb ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside horizontal-tb ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside horizontal-tb rtl - Pixels resolve as-is
+Pass	vertical-rl rtl inside horizontal-tb rtl - Relative lengths are absolutized into pixels
+Fail	vertical-rl rtl inside horizontal-tb rtl - Percentages are absolutized into pixels
+Fail	vertical-rl rtl inside horizontal-tb rtl - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside horizontal-tb rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside horizontal-tb rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside horizontal-tb rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-lr ltr - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-lr ltr - Relative lengths are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-lr ltr - Percentages are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-lr ltr - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-lr ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-lr ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-lr rtl - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-lr rtl - Relative lengths are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-lr rtl - Percentages are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-lr rtl - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-lr rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-lr rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-lr rtl - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-rl ltr - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-rl ltr - Relative lengths are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-rl ltr - Percentages are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-rl ltr - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl ltr - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-rl ltr - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-rl ltr - If opposite sides are 'auto', they resolve to used value
+Pass	vertical-rl rtl inside vertical-rl rtl - Pixels resolve as-is
+Pass	vertical-rl rtl inside vertical-rl rtl - Relative lengths are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-rl rtl - Percentages are absolutized into pixels
+Fail	vertical-rl rtl inside vertical-rl rtl - calc() is absolutized into pixels
+Pass	vertical-rl rtl inside vertical-rl rtl - If start side is 'auto' and end side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-rl rtl - If end side is 'auto' and start side is not, 'auto' resolves to used value
+Pass	vertical-rl rtl inside vertical-rl rtl - If opposite sides are 'auto', they resolve to used value

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/getComputedStyle-insets-absolute.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/getComputedStyle-insets-absolute.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSOM: resolved values of the inset properties for absolute positioning</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<script type="module">
+import {runTests, containerForAbspos} from "./support/getComputedStyle-insets.js";
+runTests({
+  style: "position: absolute",
+  containingBlockElement: containerForAbspos,
+  containingBlockArea: "padding",
+  preservesPercentages: false,
+  preservesAuto: false,
+  canStretchAutoSize: true,
+  staticPositionY: 1 + 2 + 4 + 8,
+  staticPositionX: 2 + 4 + 8 + 16,
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/getComputedStyle-insets-relative.html
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/getComputedStyle-insets-relative.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSOM: resolved values of the inset properties for relative positioning</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#resolved-value">
+<link rel="help" href="https://drafts.csswg.org/css-position/#pos-sch">
+<link rel="author" title="Oriol Brufau" href="mailto:obrufau@igalia.com">
+<script src=../../resources/testharness.js></script>
+<script src=../../resources/testharnessreport.js></script>
+<script type="module">
+import {runTests, containerForInflow} from "./support/getComputedStyle-insets.js";
+runTests({
+  style: "position: relative",
+  containingBlockElement: containerForInflow,
+  containingBlockArea: "content",
+  preservesPercentages: false,
+  preservesAuto: false,
+  canStretchAutoSize: false,
+});
+</script>

--- a/Tests/LibWeb/Text/input/wpt-import/css/cssom/support/getComputedStyle-insets.js
+++ b/Tests/LibWeb/Text/input/wpt-import/css/cssom/support/getComputedStyle-insets.js
@@ -1,0 +1,375 @@
+export const testEl = document.createElement("div");
+export const containerForInflow = document.createElement("div");
+export const containerForAbspos = document.createElement("div");
+export const containerForFixed = document.createElement("div");
+
+testEl.id = "test";
+containerForInflow.id = "container-for-inflow";
+containerForAbspos.id = "container-for-abspos";
+containerForFixed.id = "container-for-fixed";
+
+containerForInflow.appendChild(testEl);
+containerForAbspos.appendChild(containerForInflow);
+containerForFixed.appendChild(containerForAbspos);
+document.body.appendChild(containerForFixed);
+
+const stylesheet = document.createElement("style");
+stylesheet.textContent = `
+  #container-for-inflow {
+    /* Content area: 100px tall, 200px wide */
+    height: 100px;
+    width: 200px;
+    padding: 1px 2px;
+    border-width: 2px 4px;
+    margin: 4px 8px;
+  }
+  #container-for-abspos {
+    /* Padding area: 200px tall, 400px wide */
+    height: 184px;
+    width: 368px;
+    padding: 8px 16px;
+    border-width: 16px 32px;
+    margin: 32px 64px;
+    position: relative;
+  }
+  #container-for-fixed {
+    /* Padding area: 300px tall, 600px wide */
+    height: 172px;
+    width: 344px;
+    padding: 64px 128px;
+    border-width: 128px 256px;
+    margin: 256px 512px;
+    position: absolute;
+    transform: scale(1);
+    visibility: hidden;
+  }
+  [id ^= container] {
+    border-style: solid;
+  }
+`;
+document.head.prepend(stylesheet);
+
+function runTestsWithWM(data, testWM, cbWM) {
+  const {
+    style,
+    containingBlockElement,
+    containingBlockArea,
+    preservesPercentages,
+    preservesAuto,
+    canStretchAutoSize,
+    staticPositionX,
+    staticPositionY,
+  } = data;
+
+  let cbHeight = containingBlockElement ? containingBlockElement.clientHeight : NaN;
+  let cbWidth = containingBlockElement ? containingBlockElement.clientWidth : NaN;
+  if (containingBlockElement && containingBlockArea == "content") {
+    const cs = getComputedStyle(containingBlockElement);
+    cbHeight -= parseFloat(cs.paddingTop) + parseFloat(cs.paddingBottom);
+    cbWidth -= parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+  }
+
+  const staticPositionTop = cbWM.blockStart == "top" || cbWM.inlineStart == "top"
+    ? staticPositionY : cbHeight - staticPositionY;
+  const staticPositionLeft = cbWM.blockStart == "left" || cbWM.inlineStart == "left"
+    ? staticPositionX : cbWidth - staticPositionX;
+  const staticPositionBottom = cbWM.blockStart == "bottom" || cbWM.inlineStart == "bottom"
+    ? staticPositionY : cbHeight - staticPositionY;
+  const staticPositionRight = cbWM.blockStart == "right" || cbWM.inlineStart == "right"
+    ? staticPositionX : cbWidth - staticPositionX;
+
+  function serialize(declarations) {
+    return Object.entries(declarations).map(([p, v]) => `${p}: ${v}; `).join("");
+  }
+
+  function wmName(wm) {
+    return Object.values(wm.style).join(" ");
+  }
+
+  function checkStyle(declarations, expected, msg) {
+    test(function() {
+      testEl.style.cssText = style + "; " + serialize(Object.assign({}, declarations, testWM.style));
+      if (containingBlockElement) {
+        containingBlockElement.style.cssText = serialize(Object.assign({}, cbWM.style));
+      }
+      const cs = getComputedStyle(testEl);
+      for (let [prop, value] of Object.entries(expected)) {
+        assert_equals(cs[prop], value, `'${prop}'`);
+      }
+    }, `${wmName(testWM)} inside ${wmName(cbWM)} - ${msg}`);
+
+    testEl.style.cssText = "";
+    if (containingBlockElement) {
+      containingBlockElement.style.cssText = "";
+    }
+  }
+
+  checkStyle({
+    top: "1px",
+    left: "2px",
+    bottom: "3px",
+    right: "4px",
+  }, {
+    top: "1px",
+    left: "2px",
+    bottom: "3px",
+    right: "4px",
+  }, "Pixels resolve as-is");
+
+  checkStyle({
+    top: "1em",
+    left: "2em",
+    bottom: "3em",
+    right: "4em",
+    "font-size": "10px",
+  }, {
+    top: "10px",
+    left: "20px",
+    bottom: "30px",
+    right: "40px",
+  }, "Relative lengths are absolutized into pixels");
+
+  if (preservesPercentages) {
+    checkStyle({
+      top: "10%",
+      left: "25%",
+      bottom: "50%",
+      right: "75%",
+    }, {
+      top: "10%",
+      left: "25%",
+      bottom: "50%",
+      right: "75%",
+    }, "Percentages resolve as-is");
+  } else {
+    checkStyle({
+      top: "10%",
+      left: "25%",
+      bottom: "50%",
+      right: "75%",
+    }, {
+      top: cbHeight * 10 / 100 + "px",
+      left: cbWidth * 25 / 100 + "px",
+      bottom: cbHeight * 50 / 100 + "px",
+      right: cbWidth * 75 / 100 + "px",
+    }, "Percentages are absolutized into pixels");
+
+    checkStyle({
+      top: "calc(10% - 1px)",
+      left: "calc(25% - 2px)",
+      bottom: "calc(50% - 3px)",
+      right: "calc(75% - 4px)",
+    }, {
+      top: cbHeight * 10 / 100 - 1 + "px",
+      left: cbWidth * 25 / 100 - 2 + "px",
+      bottom: cbHeight * 50 / 100 - 3 + "px",
+      right: cbWidth * 75 / 100 - 4 + "px",
+    }, "calc() is absolutized into pixels");
+  }
+
+  if (canStretchAutoSize) {
+    // Force overconstraintment by setting size or with insets that would result in
+    // negative size. Then the resolved value should be the computed one according to
+    // https://drafts.csswg.org/cssom/#resolved-value-special-case-property-like-top
+
+    checkStyle({
+      top: "1px",
+      left: "2px",
+      bottom: "3px",
+      right: "4px",
+      height: "0px",
+      width: "0px",
+    }, {
+      top: "1px",
+      left: "2px",
+      bottom: "3px",
+      right: "4px",
+    }, "Pixels resolve as-is when overconstrained");
+
+    checkStyle({
+      top: "100%",
+      left: "100%",
+      bottom: "100%",
+      right: "100%",
+    }, {
+      top: cbHeight + "px",
+      left: cbWidth + "px",
+      bottom: cbHeight + "px",
+      right: cbWidth + "px",
+    }, "Percentages absolutize the computed value when overconstrained");
+  }
+
+  if (preservesAuto) {
+    checkStyle({
+      top: "auto",
+      left: "auto",
+      bottom: "3px",
+      right: "4px",
+    }, {
+      top: "auto",
+      left: "auto",
+      bottom: "3px",
+      right: "4px",
+    }, "If start side is 'auto' and end side is not, 'auto' resolves as-is");
+
+    checkStyle({
+      top: "1px",
+      left: "2px",
+      bottom: "auto",
+      right: "auto",
+    }, {
+      top: "1px",
+      left: "2px",
+      bottom: "auto",
+      right: "auto",
+    }, "If end side is 'auto' and start side is not, 'auto' resolves as-is");
+
+    checkStyle({
+      top: "auto",
+      left: "auto",
+      bottom: "auto",
+      right: "auto",
+    }, {
+      top: "auto",
+      left: "auto",
+      bottom: "auto",
+      right: "auto",
+    }, "If opposite sides are 'auto', they resolve as-is");
+  } else if (canStretchAutoSize) {
+    checkStyle({
+      top: "auto",
+      left: "auto",
+      bottom: "3px",
+      right: "4px",
+    }, {
+      top: cbHeight - 3 + "px",
+      left: cbWidth - 4 + "px",
+      bottom: "3px",
+      right: "4px",
+    }, "If start side is 'auto' and end side is not, 'auto' resolves to used value");
+
+    checkStyle({
+      top: "1px",
+      left: "2px",
+      bottom: "auto",
+      right: "auto",
+    }, {
+      top: "1px",
+      left: "2px",
+      bottom: cbHeight - 1 + "px",
+      right: cbWidth - 2 + "px",
+    }, "If end side is 'auto' and start side is not, 'auto' resolves to used value");
+
+    checkStyle({
+      top: "auto",
+      left: "auto",
+      bottom: "auto",
+      right: "auto",
+    }, {
+      top: staticPositionTop + "px",
+      left: staticPositionLeft + "px",
+      bottom: staticPositionBottom + "px",
+      right: staticPositionRight + "px",
+    }, "If opposite sides are 'auto', they resolve to used value");
+  } else {
+    checkStyle({
+      top: "auto",
+      left: "auto",
+      bottom: "3px",
+      right: "4px",
+    }, {
+      top: "-3px",
+      left: "-4px",
+      bottom: "3px",
+      right: "4px",
+    }, "If start side is 'auto' and end side is not, 'auto' resolves to used value");
+
+    checkStyle({
+      top: "1px",
+      left: "2px",
+      bottom: "auto",
+      right: "auto",
+    }, {
+      top: "1px",
+      left: "2px",
+      bottom: "-1px",
+      right: "-2px",
+    }, "If end side is 'auto' and start side is not, 'auto' resolves to used value");
+
+    checkStyle({
+      top: "auto",
+      left: "auto",
+      bottom: "auto",
+      right: "auto",
+    }, {
+      top: "0px",
+      left: "0px",
+      bottom: "0px",
+      right: "0px",
+    }, "If opposite sides are 'auto', they resolve to used value");
+  }
+}
+
+const writingModes = [{
+  style: {
+    "writing-mode": "horizontal-tb",
+    "direction": "ltr",
+  },
+  blockStart: "top",
+  blockEnd: "bottom",
+  inlineStart: "left",
+  inlineEnd: "right",
+}, {
+  style: {
+    "writing-mode": "horizontal-tb",
+    "direction": "rtl",
+  },
+  blockStart: "top",
+  blockEnd: "bottom",
+  inlineStart: "right",
+  inlineEnd: "left",
+}, {
+  style: {
+    "writing-mode": "vertical-lr",
+    "direction": "ltr",
+  },
+  blockStart: "left",
+  blockEnd: "right",
+  inlineStart: "top",
+  inlineEnd: "bottom",
+}, {
+  style: {
+    "writing-mode": "vertical-lr",
+    "direction": "rtl",
+  },
+  blockStart: "left",
+  blockEnd: "right",
+  inlineStart: "bottom",
+  inlineEnd: "top",
+}, {
+  style: {
+    "writing-mode": "vertical-rl",
+    "direction": "ltr",
+  },
+  blockStart: "right",
+  blockEnd: "left",
+  inlineStart: "top",
+  inlineEnd: "bottom",
+}, {
+  style: {
+    "writing-mode": "vertical-rl",
+    "direction": "rtl",
+  },
+  blockStart: "right",
+  blockEnd: "left",
+  inlineStart: "bottom",
+  inlineEnd: "top",
+}];
+
+export function runTests(data) {
+  for (let testWM of writingModes) {
+    for (let cbWM of writingModes) {
+      runTestsWithWM(data, testWM, cbWM);
+    }
+  }
+}


### PR DESCRIPTION
This improves the output of `getComputedStyle()` for the `top`, `bottom`, `left` and `right` properties, where the used value is now returned rather than the computed value, where applicable.

This fixes 290 WPT subtests in the `css/cssom` directory.