### PR TITLE
LibWeb: Create temporary layout node in GCS if the element has none

### DIFF
--- a/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -551,16 +551,9 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
     if (!layout_node) {
         auto style = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element), m_pseudo_element);
 
-        // FIXME: This is a stopgap until we implement shorthand -> longhand conversion.
-        auto const* value = style->maybe_null_property(property_id);
-        if (!value) {
-            dbgln("FIXME: ResolvedCSSStyleDeclaration::property(property_id={:#x}) No value for property ID in newly computed style case.", to_underlying(property_id));
-            return {};
-        }
-        return StyleProperty {
-            .property_id = property_id,
-            .value = *value,
-        };
+        // Create a temporary layout node for this style, so that we can still use `style_value_for_property` without a
+        // layout node on the element, allowing us to have consistent style value handling.
+        layout_node = realm().heap().allocate<Layout::NodeWithStyle>(m_element->document(), m_element, style);
     }
 
     auto value = style_value_for_property(*layout_node, property_id);

--- a/Tests/LibWeb/Text/expected/css/getComputedStyle-with-no-layout-node.txt
+++ b/Tests/LibWeb/Text/expected/css/getComputedStyle-with-no-layout-node.txt
@@ -1,0 +1,1 @@
+display of hidden node: none

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-display/animations/display-interpolation.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 42 tests
 
-31 Pass
-11 Fail
+28 Pass
+14 Fail
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (-0.3) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0) should be [flex]
 Pass	CSS Transitions with transition-behavior:allow-discrete: property <display> from [none] to [flex] at (0.3) should be [flex]
@@ -32,9 +32,9 @@ Pass	CSS Transitions with transition: all: property <display> from [none] to [fl
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (0.6) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (1) should be [flex]
 Pass	CSS Transitions with transition: all: property <display> from [none] to [flex] at (1.5) should be [flex]
-Pass	CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
-Pass	CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
-Pass	CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block]
+Fail	CSS Animations: property <display> from [none] to [flex] at (-0.3) should be [block]
+Fail	CSS Animations: property <display> from [none] to [flex] at (0) should be [block]
+Fail	CSS Animations: property <display> from [none] to [flex] at (0.3) should be [block]
 Fail	CSS Animations: property <display> from [none] to [flex] at (0.5) should be [block]
 Fail	CSS Animations: property <display> from [none] to [flex] at (0.6) should be [block]
 Fail	CSS Animations: property <display> from [none] to [flex] at (1) should be [block]

--- a/Tests/LibWeb/Text/input/css/getComputedStyle-with-no-layout-node.html
+++ b/Tests/LibWeb/Text/input/css/getComputedStyle-with-no-layout-node.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<script src="../include.js"></script>
+<style>
+    #element #element2 {
+        display: none;
+    }
+</style>
+<div id="element">
+    <div id="element2"></div>
+</div>
+<script>
+    test(() => {
+        const element2 = document.getElementById("element2");
+        const computedStyle = window.getComputedStyle(element2);
+
+        // Previously, this would be 'block' instead of 'none' when the element had no layout node.
+        println("display of hidden node: " + computedStyle.display);
+    });
+</script>


### PR DESCRIPTION
Creating a temporary layout node when the element doesn't have one allows us to use `style_value_for_property`, which gives us the same value handling as when the element does have one.

This corrects hidden elements reporting `block` for the display property instead of `none`. This could happen if this was applied with a descendant selector. This made jQuery's show() function think such elements were already showing and return, ultimately not showing the element.

This regresses the display interpolation WPT test, but actually to the exact same pass and failed tests as WebKit and Blink.