### PR TITLE
LibJS: A handful of Intl updates

### DIFF
--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -743,19 +743,19 @@ ErrorOr<void> print_intl_plural_rules(JS::PrintContext& print_context, JS::Intl:
 ErrorOr<void> print_intl_collator(JS::PrintContext& print_context, JS::Intl::Collator const& collator, HashTable<JS::Object*>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.Collator"sv));
-    out("\n  locale: ");
+    TRY(js_out(print_context, "\n  locale: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(collator.vm(), collator.locale()), seen_objects));
-    out("\n  usage: ");
+    TRY(js_out(print_context, "\n  usage: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(collator.vm(), collator.usage_string()), seen_objects));
-    out("\n  sensitivity: ");
+    TRY(js_out(print_context, "\n  sensitivity: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(collator.vm(), collator.sensitivity_string()), seen_objects));
-    out("\n  caseFirst: ");
+    TRY(js_out(print_context, "\n  caseFirst: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(collator.vm(), collator.case_first_string()), seen_objects));
-    out("\n  collation: ");
+    TRY(js_out(print_context, "\n  collation: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(collator.vm(), collator.collation()), seen_objects));
-    out("\n  ignorePunctuation: ");
+    TRY(js_out(print_context, "\n  ignorePunctuation: "));
     TRY(print_value(print_context, JS::Value(collator.ignore_punctuation()), seen_objects));
-    out("\n  numeric: ");
+    TRY(js_out(print_context, "\n  numeric: "));
     TRY(print_value(print_context, JS::Value(collator.numeric()), seen_objects));
     return {};
 }
@@ -763,9 +763,9 @@ ErrorOr<void> print_intl_collator(JS::PrintContext& print_context, JS::Intl::Col
 ErrorOr<void> print_intl_segmenter(JS::PrintContext& print_context, JS::Intl::Segmenter const& segmenter, HashTable<JS::Object*>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.Segmenter"sv));
-    out("\n  locale: ");
+    TRY(js_out(print_context, "\n  locale: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(segmenter.vm(), segmenter.locale()), seen_objects));
-    out("\n  granularity: ");
+    TRY(js_out(print_context, "\n  granularity: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(segmenter.vm(), segmenter.segmenter_granularity_string()), seen_objects));
     return {};
 }
@@ -775,7 +775,7 @@ ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Seg
     auto segments_string = JS::Utf16String::create(segments.segments_string());
 
     TRY(print_type(print_context, "Segments"sv));
-    out("\n  string: ");
+    TRY(js_out(print_context, "\n  string: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(segments.vm(), move(segments_string)), seen_objects));
     return {};
 }
@@ -783,54 +783,54 @@ ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Seg
 ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::Intl::DurationFormat const& duration_format, HashTable<JS::Object*>& seen_objects)
 {
     TRY(print_type(print_context, "Intl.DurationFormat"sv));
-    out("\n  locale: ");
+    TRY(js_out(print_context, "\n  locale: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.locale()), seen_objects));
-    out("\n  numberingSystem: ");
+    TRY(js_out(print_context, "\n  numberingSystem: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.numbering_system()), seen_objects));
-    out("\n  style: ");
+    TRY(js_out(print_context, "\n  style: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.style_string()), seen_objects));
-    out("\n  years: ");
+    TRY(js_out(print_context, "\n  years: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.years_style_string()), seen_objects));
-    out("\n  yearsDisplay: ");
+    TRY(js_out(print_context, "\n  yearsDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.years_display_string()), seen_objects));
-    out("\n  months: ");
+    TRY(js_out(print_context, "\n  months: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.months_style_string()), seen_objects));
-    out("\n  monthsDisplay: ");
+    TRY(js_out(print_context, "\n  monthsDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.months_display_string()), seen_objects));
-    out("\n  weeks: ");
+    TRY(js_out(print_context, "\n  weeks: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.weeks_style_string()), seen_objects));
-    out("\n  weeksDisplay: ");
+    TRY(js_out(print_context, "\n  weeksDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.weeks_display_string()), seen_objects));
-    out("\n  days: ");
+    TRY(js_out(print_context, "\n  days: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.days_style_string()), seen_objects));
-    out("\n  daysDisplay: ");
+    TRY(js_out(print_context, "\n  daysDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.days_display_string()), seen_objects));
-    out("\n  hours: ");
+    TRY(js_out(print_context, "\n  hours: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.hours_style_string()), seen_objects));
-    out("\n  hoursDisplay: ");
+    TRY(js_out(print_context, "\n  hoursDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.hours_display_string()), seen_objects));
-    out("\n  minutes: ");
+    TRY(js_out(print_context, "\n  minutes: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.minutes_style_string()), seen_objects));
-    out("\n  minutesDisplay: ");
+    TRY(js_out(print_context, "\n  minutesDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.minutes_display_string()), seen_objects));
-    out("\n  seconds: ");
+    TRY(js_out(print_context, "\n  seconds: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.seconds_style_string()), seen_objects));
-    out("\n  secondsDisplay: ");
+    TRY(js_out(print_context, "\n  secondsDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.seconds_display_string()), seen_objects));
-    out("\n  milliseconds: ");
+    TRY(js_out(print_context, "\n  milliseconds: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.milliseconds_style_string()), seen_objects));
-    out("\n  millisecondsDisplay: ");
+    TRY(js_out(print_context, "\n  millisecondsDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.milliseconds_display_string()), seen_objects));
-    out("\n  microseconds: ");
+    TRY(js_out(print_context, "\n  microseconds: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.microseconds_style_string()), seen_objects));
-    out("\n  microsecondsDisplay: ");
+    TRY(js_out(print_context, "\n  microsecondsDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.microseconds_display_string()), seen_objects));
-    out("\n  nanoseconds: ");
+    TRY(js_out(print_context, "\n  nanoseconds: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.nanoseconds_style_string()), seen_objects));
-    out("\n  nanosecondsDisplay: ");
+    TRY(js_out(print_context, "\n  nanosecondsDisplay: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.nanoseconds_display_string()), seen_objects));
     if (duration_format.has_fractional_digits()) {
-        out("\n  fractionalDigits: ");
+        TRY(js_out(print_context, "\n  fractionalDigits: "));
         TRY(print_value(print_context, JS::Value(duration_format.fractional_digits()), seen_objects));
     }
     return {};

--- a/Libraries/LibJS/Print.cpp
+++ b/Libraries/LibJS/Print.cpp
@@ -782,6 +782,19 @@ ErrorOr<void> print_intl_segments(JS::PrintContext& print_context, JS::Intl::Seg
 
 ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::Intl::DurationFormat const& duration_format, HashTable<JS::Object*>& seen_objects)
 {
+    auto print_style_and_display = [&](StringView style_name, StringView display_name, JS::Intl::DurationFormat::DurationUnitOptions options) -> ErrorOr<void> {
+        auto style = JS::Intl::DurationFormat::value_style_to_string(options.style);
+        auto display = JS::Intl::DurationFormat::display_to_string(options.display);
+
+        TRY(js_out(print_context, "\n  {}: ", style_name));
+        TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), style), seen_objects));
+
+        TRY(js_out(print_context, "\n  {}: ", display_name));
+        TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), display), seen_objects));
+
+        return {};
+    };
+
     TRY(print_type(print_context, "Intl.DurationFormat"sv));
     TRY(js_out(print_context, "\n  locale: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.locale()), seen_objects));
@@ -789,46 +802,18 @@ ErrorOr<void> print_intl_duration_format(JS::PrintContext& print_context, JS::In
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.numbering_system()), seen_objects));
     TRY(js_out(print_context, "\n  style: "));
     TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  years: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.years_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  yearsDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.years_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  months: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.months_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  monthsDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.months_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  weeks: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.weeks_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  weeksDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.weeks_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  days: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.days_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  daysDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.days_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  hours: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.hours_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  hoursDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.hours_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  minutes: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.minutes_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  minutesDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.minutes_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  seconds: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.seconds_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  secondsDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.seconds_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  milliseconds: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.milliseconds_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  millisecondsDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.milliseconds_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  microseconds: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.microseconds_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  microsecondsDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.microseconds_display_string()), seen_objects));
-    TRY(js_out(print_context, "\n  nanoseconds: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.nanoseconds_style_string()), seen_objects));
-    TRY(js_out(print_context, "\n  nanosecondsDisplay: "));
-    TRY(print_value(print_context, JS::PrimitiveString::create(duration_format.vm(), duration_format.nanoseconds_display_string()), seen_objects));
+
+    TRY(print_style_and_display("years"sv, "yearsDisplay"sv, duration_format.years_options()));
+    TRY(print_style_and_display("months"sv, "monthsDisplay"sv, duration_format.months_options()));
+    TRY(print_style_and_display("weeks"sv, "weeksDisplay"sv, duration_format.weeks_options()));
+    TRY(print_style_and_display("days"sv, "daysDisplay"sv, duration_format.days_options()));
+    TRY(print_style_and_display("hours"sv, "hoursDisplay"sv, duration_format.hours_options()));
+    TRY(print_style_and_display("minutes"sv, "minutesDisplay"sv, duration_format.minutes_options()));
+    TRY(print_style_and_display("seconds"sv, "secondsDisplay"sv, duration_format.seconds_options()));
+    TRY(print_style_and_display("milliseconds"sv, "millisecondsDisplay"sv, duration_format.milliseconds_options()));
+    TRY(print_style_and_display("microseconds"sv, "microsecondsDisplay"sv, duration_format.microseconds_options()));
+    TRY(print_style_and_display("nanoseconds"sv, "nanosecondsDisplay"sv, duration_format.nanoseconds_options()));
+
     if (duration_format.has_fractional_digits()) {
         TRY(js_out(print_context, "\n  fractionalDigits: "));
         TRY(print_value(print_context, JS::Value(duration_format.fractional_digits()), seen_objects));

--- a/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -38,6 +38,7 @@ struct MatchedLocale {
 
 struct ResolvedLocale {
     String locale;
+    String icu_locale;
     LocaleKey ca; // [[Calendar]]
     LocaleKey co; // [[Collation]]
     LocaleKey hc; // [[HourCycle]]

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -47,32 +47,32 @@ static Optional<Unicode::DateTimeFormat const&> get_or_create_formatter(StringVi
 
 Optional<Unicode::DateTimeFormat const&> DateTimeFormat::temporal_plain_date_formatter()
 {
-    return get_or_create_formatter(m_locale, m_temporal_time_zone, m_temporal_plain_date_formatter, m_temporal_plain_date_format);
+    return get_or_create_formatter(m_icu_locale, m_temporal_time_zone, m_temporal_plain_date_formatter, m_temporal_plain_date_format);
 }
 
 Optional<Unicode::DateTimeFormat const&> DateTimeFormat::temporal_plain_year_month_formatter()
 {
-    return get_or_create_formatter(m_locale, m_temporal_time_zone, m_temporal_plain_year_month_formatter, m_temporal_plain_year_month_format);
+    return get_or_create_formatter(m_icu_locale, m_temporal_time_zone, m_temporal_plain_year_month_formatter, m_temporal_plain_year_month_format);
 }
 
 Optional<Unicode::DateTimeFormat const&> DateTimeFormat::temporal_plain_month_day_formatter()
 {
-    return get_or_create_formatter(m_locale, m_temporal_time_zone, m_temporal_plain_month_day_formatter, m_temporal_plain_month_day_format);
+    return get_or_create_formatter(m_icu_locale, m_temporal_time_zone, m_temporal_plain_month_day_formatter, m_temporal_plain_month_day_format);
 }
 
 Optional<Unicode::DateTimeFormat const&> DateTimeFormat::temporal_plain_time_formatter()
 {
-    return get_or_create_formatter(m_locale, m_temporal_time_zone, m_temporal_plain_time_formatter, m_temporal_plain_time_format);
+    return get_or_create_formatter(m_icu_locale, m_temporal_time_zone, m_temporal_plain_time_formatter, m_temporal_plain_time_format);
 }
 
 Optional<Unicode::DateTimeFormat const&> DateTimeFormat::temporal_plain_date_time_formatter()
 {
-    return get_or_create_formatter(m_locale, m_temporal_time_zone, m_temporal_plain_date_time_formatter, m_temporal_plain_date_time_format);
+    return get_or_create_formatter(m_icu_locale, m_temporal_time_zone, m_temporal_plain_date_time_formatter, m_temporal_plain_date_time_format);
 }
 
 Optional<Unicode::DateTimeFormat const&> DateTimeFormat::temporal_instant_formatter()
 {
-    return get_or_create_formatter(m_locale, m_temporal_time_zone, m_temporal_instant_formatter, m_temporal_instant_format);
+    return get_or_create_formatter(m_icu_locale, m_temporal_time_zone, m_temporal_instant_formatter, m_temporal_instant_format);
 }
 
 // 11.5.5 FormatDateTimePattern ( dateTimeFormat, patternParts, x, rangeFormatOptions ), https://tc39.es/ecma402/#sec-formatdatetimepattern

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -38,6 +38,9 @@ public:
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
+    String const& icu_locale() const { return m_icu_locale; }
+    void set_icu_locale(String icu_locale) { m_icu_locale = move(icu_locale); }
+
     String const& calendar() const { return m_calendar; }
     void set_calendar(String calendar) { m_calendar = move(calendar); }
 
@@ -107,6 +110,7 @@ private:
     GC::Ptr<NativeFunction> m_bound_format;                                // [[BoundFormat]]
 
     // Non-standard. Stores the ICU date-time formatters for the Intl object's formatting options.
+    String m_icu_locale;
     OwnPtr<Unicode::DateTimeFormat> m_formatter;
     OwnPtr<Unicode::DateTimeFormat> m_temporal_plain_date_formatter;
     OwnPtr<Unicode::DateTimeFormat> m_temporal_plain_year_month_formatter;

--- a/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -149,6 +149,7 @@ ThrowCompletionOr<GC::Ref<DateTimeFormat>> create_date_time_format(VM& vm, Funct
 
     // 18. Set dateTimeFormat.[[Locale]] to r.[[Locale]].
     date_time_format->set_locale(move(result.locale));
+    date_time_format->set_icu_locale(move(result.icu_locale));
 
     // 19. Let resolvedCalendar be r.[[ca]].
     // 20. Set dateTimeFormat.[[Calendar]] to resolvedCalendar.
@@ -355,7 +356,7 @@ ThrowCompletionOr<GC::Ref<DateTimeFormat>> create_date_time_format(VM& vm, Funct
         // d. Let styles be resolvedLocaleData.[[styles]].[[<resolvedCalendar>]].
         // e. Let bestFormat be DateTimeStyleFormat(dateStyle, timeStyle, styles).
         formatter = Unicode::DateTimeFormat::create_for_date_and_time_style(
-            date_time_format->locale(),
+            date_time_format->icu_locale(),
             time_zone,
             format_options.hour_cycle,
             format_options.hour12,
@@ -443,7 +444,7 @@ ThrowCompletionOr<GC::Ref<DateTimeFormat>> create_date_time_format(VM& vm, Funct
         }
 
         formatter = Unicode::DateTimeFormat::create_for_pattern_options(
-            date_time_format->locale(),
+            date_time_format->icu_locale(),
             time_zone,
             best_format);
     }

--- a/Libraries/LibJS/Runtime/Intl/DurationFormat.h
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormat.h
@@ -66,6 +66,12 @@ public:
         Nanoseconds,
     };
 
+    // 13.5.6.1 Duration Unit Options Records, https://tc39.es/ecma402/#sec-durationformat-unit-options-record
+    struct DurationUnitOptions {
+        ValueStyle style { ValueStyle::Long };
+        Display display { Display::Auto };
+    };
+
     static constexpr auto relevant_extension_keys()
     {
         // 13.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.DurationFormat-internal-slots
@@ -91,85 +97,35 @@ public:
     Style style() const { return m_style; }
     StringView style_string() const { return style_to_string(m_style); }
 
-    void set_years_style(ValueStyle years_style) { m_years_style = years_style; }
-    ValueStyle years_style() const { return m_years_style; }
-    StringView years_style_string() const { return value_style_to_string(m_years_style); }
+    void set_years_options(DurationUnitOptions years_options) { m_years_options = years_options; }
+    DurationUnitOptions years_options() const { return m_years_options; }
 
-    void set_years_display(Display years_display) { m_years_display = years_display; }
-    Display years_display() const { return m_years_display; }
-    StringView years_display_string() const { return display_to_string(m_years_display); }
+    void set_months_options(DurationUnitOptions months_options) { m_months_options = months_options; }
+    DurationUnitOptions months_options() const { return m_months_options; }
 
-    void set_months_style(ValueStyle months_style) { m_months_style = months_style; }
-    ValueStyle months_style() const { return m_months_style; }
-    StringView months_style_string() const { return value_style_to_string(m_months_style); }
+    void set_weeks_options(DurationUnitOptions weeks_options) { m_weeks_options = weeks_options; }
+    DurationUnitOptions weeks_options() const { return m_weeks_options; }
 
-    void set_months_display(Display months_display) { m_months_display = months_display; }
-    Display months_display() const { return m_months_display; }
-    StringView months_display_string() const { return display_to_string(m_months_display); }
+    void set_days_options(DurationUnitOptions days_options) { m_days_options = days_options; }
+    DurationUnitOptions days_options() const { return m_days_options; }
 
-    void set_weeks_style(ValueStyle weeks_style) { m_weeks_style = weeks_style; }
-    ValueStyle weeks_style() const { return m_weeks_style; }
-    StringView weeks_style_string() const { return value_style_to_string(m_weeks_style); }
+    void set_hours_options(DurationUnitOptions hours_options) { m_hours_options = hours_options; }
+    DurationUnitOptions hours_options() const { return m_hours_options; }
 
-    void set_weeks_display(Display weeks_display) { m_weeks_display = weeks_display; }
-    Display weeks_display() const { return m_weeks_display; }
-    StringView weeks_display_string() const { return display_to_string(m_weeks_display); }
+    void set_minutes_options(DurationUnitOptions minutes_options) { m_minutes_options = minutes_options; }
+    DurationUnitOptions minutes_options() const { return m_minutes_options; }
 
-    void set_days_style(ValueStyle days_style) { m_days_style = days_style; }
-    ValueStyle days_style() const { return m_days_style; }
-    StringView days_style_string() const { return value_style_to_string(m_days_style); }
+    void set_seconds_options(DurationUnitOptions seconds_options) { m_seconds_options = seconds_options; }
+    DurationUnitOptions seconds_options() const { return m_seconds_options; }
 
-    void set_days_display(Display days_display) { m_days_display = days_display; }
-    Display days_display() const { return m_days_display; }
-    StringView days_display_string() const { return display_to_string(m_days_display); }
+    void set_milliseconds_options(DurationUnitOptions milliseconds_options) { m_milliseconds_options = milliseconds_options; }
+    DurationUnitOptions milliseconds_options() const { return m_milliseconds_options; }
 
-    void set_hours_style(ValueStyle hours_style) { m_hours_style = hours_style; }
-    ValueStyle hours_style() const { return m_hours_style; }
-    StringView hours_style_string() const { return value_style_to_string(m_hours_style); }
+    void set_microseconds_options(DurationUnitOptions microseconds_options) { m_microseconds_options = microseconds_options; }
+    DurationUnitOptions microseconds_options() const { return m_microseconds_options; }
 
-    void set_hours_display(Display hours_display) { m_hours_display = hours_display; }
-    Display hours_display() const { return m_hours_display; }
-    StringView hours_display_string() const { return display_to_string(m_hours_display); }
-
-    void set_minutes_style(ValueStyle minutes_style) { m_minutes_style = minutes_style; }
-    ValueStyle minutes_style() const { return m_minutes_style; }
-    StringView minutes_style_string() const { return value_style_to_string(m_minutes_style); }
-
-    void set_minutes_display(Display minutes_display) { m_minutes_display = minutes_display; }
-    Display minutes_display() const { return m_minutes_display; }
-    StringView minutes_display_string() const { return display_to_string(m_minutes_display); }
-
-    void set_seconds_style(ValueStyle seconds_style) { m_seconds_style = seconds_style; }
-    ValueStyle seconds_style() const { return m_seconds_style; }
-    StringView seconds_style_string() const { return value_style_to_string(m_seconds_style); }
-
-    void set_seconds_display(Display seconds_display) { m_seconds_display = seconds_display; }
-    Display seconds_display() const { return m_seconds_display; }
-    StringView seconds_display_string() const { return display_to_string(m_seconds_display); }
-
-    void set_milliseconds_style(ValueStyle milliseconds_style) { m_milliseconds_style = milliseconds_style; }
-    ValueStyle milliseconds_style() const { return m_milliseconds_style; }
-    StringView milliseconds_style_string() const { return value_style_to_string(m_milliseconds_style); }
-
-    void set_milliseconds_display(Display milliseconds_display) { m_milliseconds_display = milliseconds_display; }
-    Display milliseconds_display() const { return m_milliseconds_display; }
-    StringView milliseconds_display_string() const { return display_to_string(m_milliseconds_display); }
-
-    void set_microseconds_style(ValueStyle microseconds_style) { m_microseconds_style = microseconds_style; }
-    ValueStyle microseconds_style() const { return m_microseconds_style; }
-    StringView microseconds_style_string() const { return value_style_to_string(m_microseconds_style); }
-
-    void set_microseconds_display(Display microseconds_display) { m_microseconds_display = microseconds_display; }
-    Display microseconds_display() const { return m_microseconds_display; }
-    StringView microseconds_display_string() const { return display_to_string(m_microseconds_display); }
-
-    void set_nanoseconds_style(ValueStyle nanoseconds_style) { m_nanoseconds_style = nanoseconds_style; }
-    ValueStyle nanoseconds_style() const { return m_nanoseconds_style; }
-    StringView nanoseconds_style_string() const { return value_style_to_string(m_nanoseconds_style); }
-
-    void set_nanoseconds_display(Display nanoseconds_display) { m_nanoseconds_display = nanoseconds_display; }
-    Display nanoseconds_display() const { return m_nanoseconds_display; }
-    StringView nanoseconds_display_string() const { return display_to_string(m_nanoseconds_display); }
+    void set_nanoseconds_options(DurationUnitOptions nanoseconds_options) { m_nanoseconds_options = nanoseconds_options; }
+    DurationUnitOptions nanoseconds_options() const { return m_nanoseconds_options; }
 
     void set_fractional_digits(Optional<u8> fractional_digits) { m_fractional_digits = move(fractional_digits); }
     bool has_fractional_digits() const { return m_fractional_digits.has_value(); }
@@ -183,64 +139,47 @@ private:
     String m_hour_minute_separator;   // [[HourMinutesSeparator]]
     String m_minute_second_separator; // [[MinutesSecondsSeparator]]
 
-    Style m_style { Style::Long };                        // [[Style]]
-    ValueStyle m_years_style { ValueStyle::Long };        // [[YearsStyle]]
-    Display m_years_display { Display::Auto };            // [[YearsDisplay]]
-    ValueStyle m_months_style { ValueStyle::Long };       // [[MonthsStyle]]
-    Display m_months_display { Display::Auto };           // [[MonthsDisplay]]
-    ValueStyle m_weeks_style { ValueStyle::Long };        // [[WeeksStyle]]
-    Display m_weeks_display { Display::Auto };            // [[WeeksDisplay]]
-    ValueStyle m_days_style { ValueStyle::Long };         // [[DaysStyle]]
-    Display m_days_display { Display::Auto };             // [[DaysDisplay]]
-    ValueStyle m_hours_style { ValueStyle::Long };        // [[HoursStyle]]
-    Display m_hours_display { Display::Auto };            // [[HoursDisplay]]
-    ValueStyle m_minutes_style { ValueStyle::Long };      // [[MinutesStyle]]
-    Display m_minutes_display { Display::Auto };          // [[MinutesDisplay]]
-    ValueStyle m_seconds_style { ValueStyle::Long };      // [[SecondsStyle]]
-    Display m_seconds_display { Display::Auto };          // [[SecondsDisplay]]
-    ValueStyle m_milliseconds_style { ValueStyle::Long }; // [[MillisecondsStyle]]
-    Display m_milliseconds_display { Display::Auto };     // [[MillisecondsDisplay]]
-    ValueStyle m_microseconds_style { ValueStyle::Long }; // [[MicrosecondsStyle]]
-    Display m_microseconds_display { Display::Auto };     // [[MicrosecondsDisplay]]
-    ValueStyle m_nanoseconds_style { ValueStyle::Long };  // [[NanosecondsStyle]]
-    Display m_nanoseconds_display { Display::Auto };      // [[NanosecondsDisplay]]
-    Optional<u8> m_fractional_digits;                     // [[FractionalDigits]]
+    Style m_style { Style::Long };              // [[Style]]
+    DurationUnitOptions m_years_options;        // [[YearsOptions]]
+    DurationUnitOptions m_months_options;       // [[MonthsOptions]]
+    DurationUnitOptions m_weeks_options;        // [[WeeksOptions]]
+    DurationUnitOptions m_days_options;         // [[DaysOptions]]
+    DurationUnitOptions m_hours_options;        // [[HoursOptions]]
+    DurationUnitOptions m_minutes_options;      // [[MinutesOptions]]
+    DurationUnitOptions m_seconds_options;      // [[SecondsOptions]]
+    DurationUnitOptions m_milliseconds_options; // [[MillisecondsOptions]]
+    DurationUnitOptions m_microseconds_options; // [[MicrosecondsOptions]]
+    DurationUnitOptions m_nanoseconds_options;  // [[NanosecondsOptions]]
+    Optional<u8> m_fractional_digits;           // [[FractionalDigits]]
 };
 
 struct DurationInstanceComponent {
     double (Temporal::Duration::*value_slot)() const;
-    DurationFormat::ValueStyle (DurationFormat::*get_style_slot)() const;
-    void (DurationFormat::*set_style_slot)(DurationFormat::ValueStyle);
-    DurationFormat::Display (DurationFormat::*get_display_slot)() const;
-    void (DurationFormat::*set_display_slot)(DurationFormat::Display);
+    DurationFormat::DurationUnitOptions (DurationFormat::*get_internal_slot)() const;
+    void (DurationFormat::*set_internal_slot)(DurationFormat::DurationUnitOptions);
     DurationFormat::Unit unit;
-    ReadonlySpan<StringView> values;
+    ReadonlySpan<StringView> styles;
     DurationFormat::ValueStyle digital_default;
 };
 
 // Table 20: Internal slots and property names of DurationFormat instances relevant to Intl.DurationFormat constructor, https://tc39.es/ecma402/#table-durationformat
-// Table 23: DurationFormat instance internal slots and properties relevant to PartitionDurationFormatPattern, https://tc39.es/ecma402/#table-partition-duration-format-pattern
-static constexpr auto date_values = AK::Array { "long"sv, "short"sv, "narrow"sv };
-static constexpr auto time_values = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv, "2-digit"sv };
-static constexpr auto sub_second_values = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv };
+// Table 24: DurationFormat instance internal slots and properties relevant to PartitionDurationFormatPattern, https://tc39.es/ecma402/#table-partition-duration-format-pattern
+static constexpr auto date_styles = AK::Array { "long"sv, "short"sv, "narrow"sv };
+static constexpr auto time_styles = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv, "2-digit"sv };
+static constexpr auto sub_second_styles = AK::Array { "long"sv, "short"sv, "narrow"sv, "numeric"sv };
 
 static constexpr auto duration_instances_components = to_array<DurationInstanceComponent>({
-    { &Temporal::Duration::years, &DurationFormat::years_style, &DurationFormat::set_years_style, &DurationFormat::years_display, &DurationFormat::set_years_display, DurationFormat::Unit::Years, date_values, DurationFormat::ValueStyle::Short },
-    { &Temporal::Duration::months, &DurationFormat::months_style, &DurationFormat::set_months_style, &DurationFormat::months_display, &DurationFormat::set_months_display, DurationFormat::Unit::Months, date_values, DurationFormat::ValueStyle::Short },
-    { &Temporal::Duration::weeks, &DurationFormat::weeks_style, &DurationFormat::set_weeks_style, &DurationFormat::weeks_display, &DurationFormat::set_weeks_display, DurationFormat::Unit::Weeks, date_values, DurationFormat::ValueStyle::Short },
-    { &Temporal::Duration::days, &DurationFormat::days_style, &DurationFormat::set_days_style, &DurationFormat::days_display, &DurationFormat::set_days_display, DurationFormat::Unit::Days, date_values, DurationFormat::ValueStyle::Short },
-    { &Temporal::Duration::hours, &DurationFormat::hours_style, &DurationFormat::set_hours_style, &DurationFormat::hours_display, &DurationFormat::set_hours_display, DurationFormat::Unit::Hours, time_values, DurationFormat::ValueStyle::Numeric },
-    { &Temporal::Duration::minutes, &DurationFormat::minutes_style, &DurationFormat::set_minutes_style, &DurationFormat::minutes_display, &DurationFormat::set_minutes_display, DurationFormat::Unit::Minutes, time_values, DurationFormat::ValueStyle::Numeric },
-    { &Temporal::Duration::seconds, &DurationFormat::seconds_style, &DurationFormat::set_seconds_style, &DurationFormat::seconds_display, &DurationFormat::set_seconds_display, DurationFormat::Unit::Seconds, time_values, DurationFormat::ValueStyle::Numeric },
-    { &Temporal::Duration::milliseconds, &DurationFormat::milliseconds_style, &DurationFormat::set_milliseconds_style, &DurationFormat::milliseconds_display, &DurationFormat::set_milliseconds_display, DurationFormat::Unit::Milliseconds, sub_second_values, DurationFormat::ValueStyle::Numeric },
-    { &Temporal::Duration::microseconds, &DurationFormat::microseconds_style, &DurationFormat::set_microseconds_style, &DurationFormat::microseconds_display, &DurationFormat::set_microseconds_display, DurationFormat::Unit::Microseconds, sub_second_values, DurationFormat::ValueStyle::Numeric },
-    { &Temporal::Duration::nanoseconds, &DurationFormat::nanoseconds_style, &DurationFormat::set_nanoseconds_style, &DurationFormat::nanoseconds_display, &DurationFormat::set_nanoseconds_display, DurationFormat::Unit::Nanoseconds, sub_second_values, DurationFormat::ValueStyle::Numeric },
+    { &Temporal::Duration::years, &DurationFormat::years_options, &DurationFormat::set_years_options, DurationFormat::Unit::Years, date_styles, DurationFormat::ValueStyle::Short },
+    { &Temporal::Duration::months, &DurationFormat::months_options, &DurationFormat::set_months_options, DurationFormat::Unit::Months, date_styles, DurationFormat::ValueStyle::Short },
+    { &Temporal::Duration::weeks, &DurationFormat::weeks_options, &DurationFormat::set_weeks_options, DurationFormat::Unit::Weeks, date_styles, DurationFormat::ValueStyle::Short },
+    { &Temporal::Duration::days, &DurationFormat::days_options, &DurationFormat::set_days_options, DurationFormat::Unit::Days, date_styles, DurationFormat::ValueStyle::Short },
+    { &Temporal::Duration::hours, &DurationFormat::hours_options, &DurationFormat::set_hours_options, DurationFormat::Unit::Hours, time_styles, DurationFormat::ValueStyle::Numeric },
+    { &Temporal::Duration::minutes, &DurationFormat::minutes_options, &DurationFormat::set_minutes_options, DurationFormat::Unit::Minutes, time_styles, DurationFormat::ValueStyle::Numeric },
+    { &Temporal::Duration::seconds, &DurationFormat::seconds_options, &DurationFormat::set_seconds_options, DurationFormat::Unit::Seconds, time_styles, DurationFormat::ValueStyle::Numeric },
+    { &Temporal::Duration::milliseconds, &DurationFormat::milliseconds_options, &DurationFormat::set_milliseconds_options, DurationFormat::Unit::Milliseconds, sub_second_styles, DurationFormat::ValueStyle::Numeric },
+    { &Temporal::Duration::microseconds, &DurationFormat::microseconds_options, &DurationFormat::set_microseconds_options, DurationFormat::Unit::Microseconds, sub_second_styles, DurationFormat::ValueStyle::Numeric },
+    { &Temporal::Duration::nanoseconds, &DurationFormat::nanoseconds_options, &DurationFormat::set_nanoseconds_options, DurationFormat::Unit::Nanoseconds, sub_second_styles, DurationFormat::ValueStyle::Numeric },
 });
-
-struct DurationUnitOptions {
-    DurationFormat::ValueStyle style;
-    DurationFormat::Display display;
-};
 
 struct DurationFormatPart {
     StringView type;
@@ -248,13 +187,14 @@ struct DurationFormatPart {
     StringView unit;
 };
 
-ThrowCompletionOr<DurationUnitOptions> get_duration_unit_options(VM&, DurationFormat::Unit unit, Object const& options, DurationFormat::Style base_style, ReadonlySpan<StringView> styles_list, DurationFormat::ValueStyle digital_base, Optional<DurationFormat::ValueStyle> previous_style, bool two_digit_hours);
+ThrowCompletionOr<DurationFormat::DurationUnitOptions> get_duration_unit_options(VM&, DurationFormat::Unit unit, Object const& options, DurationFormat::Style base_style, ReadonlySpan<StringView> styles_list, DurationFormat::ValueStyle digital_base, Optional<DurationFormat::ValueStyle> previous_style, bool two_digit_hours);
 Crypto::BigFraction compute_fractional_digits(DurationFormat const&, Temporal::Duration const&);
 bool next_unit_fractional(DurationFormat const&, DurationFormat::Unit unit);
 Vector<DurationFormatPart> format_numeric_hours(VM&, DurationFormat const&, MathematicalValue const& hours_value, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_minutes(VM&, DurationFormat const&, MathematicalValue const& minutes_value, bool hours_displayed, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_seconds(VM&, DurationFormat const&, MathematicalValue const& seconds_value, bool minutes_displayed, bool sign_displayed);
 Vector<DurationFormatPart> format_numeric_units(VM&, DurationFormat const&, Temporal::Duration const&, DurationFormat::Unit first_numeric_unit, bool sign_displayed);
+bool is_fractional_second_unit_name(DurationFormat::Unit);
 Vector<DurationFormatPart> list_format_parts(VM&, DurationFormat const&, Vector<Vector<DurationFormatPart>>& partitioned_parts_list);
 Vector<DurationFormatPart> partition_duration_format_pattern(VM&, DurationFormat const&, Temporal::Duration const&);
 

--- a/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -53,7 +53,7 @@ ThrowCompletionOr<GC::Ref<Object>> DurationFormatConstructor::construct(Function
     auto locales = vm.argument(0);
     auto options_value = vm.argument(1);
 
-    // 2. Let durationFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%Intl.DurationFormatPrototype%", « [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsStyle]], [[YearsDisplay]], [[MonthsStyle]], [[MonthsDisplay]], [[WeeksStyle]], [[WeeksDisplay]], [[DaysStyle]], [[DaysDisplay]], [[HoursStyle]], [[HoursDisplay]], [[MinutesStyle]], [[MinutesDisplay]], [[SecondsStyle]], [[SecondsDisplay]], [[MillisecondsStyle]], [[MillisecondsDisplay]], [[MicrosecondsStyle]], [[MicrosecondsDisplay]], [[NanosecondsStyle]], [[NanosecondsDisplay]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] »).
+    // 2. Let durationFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%Intl.DurationFormatPrototype%", « [[InitializedDurationFormat]], [[Locale]], [[NumberingSystem]], [[Style]], [[YearsOptions]], [[MonthsOptions]], [[WeeksOptions]], [[DaysOptions]], [[HoursOptions]], [[MinutesOptions]], [[SecondsOptions]], [[MillisecondsOptions]], [[MicrosecondsOptions]], [[NanosecondsOptions]], [[HourMinuteSeparator]], [[MinuteSecondSeparator]], [[FractionalDigits]] »).
     auto duration_format = TRY(ordinary_create_from_constructor<DurationFormat>(vm, new_target, &Intrinsics::intl_duration_format_prototype));
 
     // 3. Let requestedLocales be ? CanonicalizeLocaleList(locales).
@@ -112,31 +112,25 @@ ThrowCompletionOr<GC::Ref<Object>> DurationFormatConstructor::construct(Function
 
     // 19. For each row of Table 20, except the header row, in table order, do
     for (auto const& duration_instances_component : duration_instances_components) {
-        // a. Let styleSlot be the Style Slot value of the current row.
-        auto style_slot = duration_instances_component.set_style_slot;
+        // a. Let slot be the Internal Slot value of the current row.
+        auto slot = duration_instances_component.set_internal_slot;
 
-        // b. Let displaySlot be the Display Slot value of the current row.
-        auto display_slot = duration_instances_component.set_display_slot;
-
-        // c. Let unit be the Unit value of the current row.
+        // b. Let unit be the Unit value of the current row.
         auto unit = duration_instances_component.unit;
 
-        // d. Let valueList be the Values value of the current row.
-        auto value_list = duration_instances_component.values;
+        // c. Let styles be the Styles value of the current row.
+        auto styles = duration_instances_component.styles;
 
-        // e. Let digitalBase be the Digital Default value of the current row.
+        // d. Let digitalBase be the Digital Default value of the current row.
         auto digital_base = duration_instances_component.digital_default;
 
-        // f. Let unitOptions be ? GetDurationUnitOptions(unit, options, style, valueList, digitalBase, prevStyle, digitalFormat.[[TwoDigitHours]]).
-        auto unit_options = TRY(get_duration_unit_options(vm, unit, *options, duration_format->style(), value_list, digital_base, previous_style, digital_format.uses_two_digit_hours));
+        // e. Let unitOptions be ? GetDurationUnitOptions(unit, options, style, styles, digitalBase, prevStyle, digitalFormat.[[TwoDigitHours]]).
+        auto unit_options = TRY(get_duration_unit_options(vm, unit, *options, duration_format->style(), styles, digital_base, previous_style, digital_format.uses_two_digit_hours));
 
-        // g. Set the value of the styleSlot slot of durationFormat to unitOptions.[[Style]].
-        (duration_format->*style_slot)(unit_options.style);
+        // f. Set the value of durationFormat's internal slot whose name is slot to unitOptions.
+        (duration_format->*slot)(unit_options);
 
-        // h. Set the value of the displaySlot slot of durationFormat to unitOptions.[[Display]].
-        (duration_format->*display_slot)(unit_options.display);
-
-        // i. If unit is one of "hours", "minutes", "seconds", "milliseconds", or "microseconds", then
+        // g. If unit is one of "hours", "minutes", "seconds", "milliseconds", or "microseconds", then
         if (first_is_one_of(unit, DurationFormat::Unit::Hours, DurationFormat::Unit::Minutes, DurationFormat::Unit::Seconds, DurationFormat::Unit::Milliseconds, DurationFormat::Unit::Microseconds)) {
             // i. Set prevStyle to unitOptions.[[Style]].
             previous_style = unit_options.style;

--- a/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/DurationFormatConstructor.cpp
@@ -89,7 +89,7 @@ ThrowCompletionOr<GC::Ref<Object>> DurationFormatConstructor::construct(Function
     // 11. Let resolvedLocaleData be r.[[LocaleData]].
 
     // 12. Let digitalFormat be resolvedLocaleData.[[DigitalFormat]].
-    auto digital_format = Unicode::digital_format(duration_format->locale());
+    auto digital_format = Unicode::digital_format(result.icu_locale);
 
     // 13. Set durationFormat.[[HourMinuteSeparator]] to digitalFormat.[[HourMinuteSeparator]].
     duration_format->set_hour_minute_separator(move(digital_format.hours_minutes_separator));

--- a/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -47,7 +47,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
     // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. For each row of Table 24, except the header row, in table order, do
+    // 4. For each row of Table 25, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of lf's internal slot whose name is the Internal Slot value of the current row.
     //     c. Assert: v is not undefined.

--- a/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -184,8 +184,7 @@ ThrowCompletionOr<GC::Ref<Object>> NumberFormatConstructor::construct(FunctionOb
 
     // Non-standard, create an ICU number formatter for this Intl object.
     auto formatter = Unicode::NumberFormat::create(
-        number_format->locale(),
-        number_format->numbering_system(),
+        result.icu_locale,
         number_format->display_options(),
         number_format->rounding_options());
     number_format->set_formatter(move(formatter));

--- a/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -63,13 +63,13 @@ ThrowCompletionOr<GC::Ref<Object>> NumberFormatConstructor::construct(FunctionOb
     // 5. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 6. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
+    // 6. Let matcher be ? GetOption(options, "localeMatcher", STRING, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 7. Set opt.[[localeMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 8. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
+    // 8. Let numberingSystem be ? GetOption(options, "numberingSystem", STRING, EMPTY, undefined).
     auto numbering_system = TRY(get_option(vm, *options, vm.names.numberingSystem, OptionType::String, {}, Empty {}));
 
     // 9. If numberingSystem is not undefined, then
@@ -138,7 +138,7 @@ ThrowCompletionOr<GC::Ref<Object>> NumberFormatConstructor::construct(FunctionOb
     // 21. Perform ? SetNumberFormatDigitOptions(numberFormat, options, mnfdDefault, mxfdDefault, notation).
     TRY(set_number_format_digit_options(vm, number_format, *options, default_min_fraction_digits, default_max_fraction_digits, number_format->notation()));
 
-    // 22. Let compactDisplay be ? GetOption(options, "compactDisplay", string, « "short", "long" », "short").
+    // 22. Let compactDisplay be ? GetOption(options, "compactDisplay", STRING, « "short", "long" », "short").
     auto compact_display = TRY(get_option(vm, *options, vm.names.compactDisplay, OptionType::String, { "short"sv, "long"sv }, "short"sv));
 
     // 23. Let defaultUseGrouping be "auto".
@@ -172,7 +172,7 @@ ThrowCompletionOr<GC::Ref<Object>> NumberFormatConstructor::construct(FunctionOb
     // 29. Set numberFormat.[[UseGrouping]] to useGrouping.
     number_format->set_use_grouping(use_grouping);
 
-    // 30. Let signDisplay be ? GetOption(options, "signDisplay", string, « "auto", "never", "always", "exceptZero", "negative" », "auto").
+    // 30. Let signDisplay be ? GetOption(options, "signDisplay", STRING, « "auto", "never", "always", "exceptZero", "negative" », "auto").
     auto sign_display = TRY(get_option(vm, *options, vm.names.signDisplay, OptionType::String, { "auto"sv, "never"sv, "always"sv, "exceptZero"sv, "negative"sv }, "auto"sv));
 
     // 31. Set numberFormat.[[SignDisplay]] to signDisplay.
@@ -224,14 +224,14 @@ ThrowCompletionOr<void> set_number_format_digit_options(VM& vm, NumberFormatBase
     if (!sanctioned_rounding_increments.span().contains_slow(*rounding_increment))
         return vm.throw_completion<RangeError>(ErrorType::IntlInvalidRoundingIncrement, *rounding_increment);
 
-    // 9. Let roundingMode be ? GetOption(options, "roundingMode", string, « "ceil", "floor", "expand", "trunc", "halfCeil", "halfFloor", "halfExpand", "halfTrunc", "halfEven" », "halfExpand").
+    // 9. Let roundingMode be ? GetOption(options, "roundingMode", STRING, « "ceil", "floor", "expand", "trunc", "halfCeil", "halfFloor", "halfExpand", "halfTrunc", "halfEven" », "halfExpand").
     auto rounding_mode = TRY(get_option(vm, options, vm.names.roundingMode, OptionType::String, { "ceil"sv, "floor"sv, "expand"sv, "trunc"sv, "halfCeil"sv, "halfFloor"sv, "halfExpand"sv, "halfTrunc"sv, "halfEven"sv }, "halfExpand"sv));
 
-    // 10. Let roundingPriority be ? GetOption(options, "roundingPriority", string, « "auto", "morePrecision", "lessPrecision" », "auto").
+    // 10. Let roundingPriority be ? GetOption(options, "roundingPriority", STRING, « "auto", "morePrecision", "lessPrecision" », "auto").
     auto rounding_priority_option = TRY(get_option(vm, options, vm.names.roundingPriority, OptionType::String, { "auto"sv, "morePrecision"sv, "lessPrecision"sv }, "auto"sv));
     auto rounding_priority = rounding_priority_option.as_string().utf8_string_view();
 
-    // 11. Let trailingZeroDisplay be ? GetOption(options, "trailingZeroDisplay", string, « "auto", "stripIfInteger" », "auto").
+    // 11. Let trailingZeroDisplay be ? GetOption(options, "trailingZeroDisplay", STRING, « "auto", "stripIfInteger" », "auto").
     auto trailing_zero_display = TRY(get_option(vm, options, vm.names.trailingZeroDisplay, OptionType::String, { "auto"sv, "stripIfInteger"sv }, "auto"sv));
 
     // 12. NOTE: All fields required by SetNumberFormatDigitOptions have now been read from options. The remainder of this AO interprets the options and may throw exceptions.
@@ -402,13 +402,13 @@ ThrowCompletionOr<void> set_number_format_digit_options(VM& vm, NumberFormatBase
 // 16.1.3 SetNumberFormatUnitOptions ( intlObj, options ), https://tc39.es/ecma402/#sec-setnumberformatunitoptions
 ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& intl_object, Object const& options)
 {
-    // 1. Let style be ? GetOption(options, "style", string, « "decimal", "percent", "currency", "unit" », "decimal").
+    // 1. Let style be ? GetOption(options, "style", STRING, « "decimal", "percent", "currency", "unit" », "decimal").
     auto style = TRY(get_option(vm, options, vm.names.style, OptionType::String, { "decimal"sv, "percent"sv, "currency"sv, "unit"sv }, "decimal"sv));
 
     // 2. Set intlObj.[[Style]] to style.
     intl_object.set_style(style.as_string().utf8_string_view());
 
-    // 3. Let currency be ? GetOption(options, "currency", string, empty, undefined).
+    // 3. Let currency be ? GetOption(options, "currency", STRING, EMPTY, undefined).
     auto currency = TRY(get_option(vm, options, vm.names.currency, OptionType::String, {}, Empty {}));
 
     // 4. If currency is undefined, then
@@ -423,13 +423,13 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, currency, "currency"sv);
     }
 
-    // 6. Let currencyDisplay be ? GetOption(options, "currencyDisplay", string, « "code", "symbol", "narrowSymbol", "name" », "symbol").
+    // 6. Let currencyDisplay be ? GetOption(options, "currencyDisplay", STRING, « "code", "symbol", "narrowSymbol", "name" », "symbol").
     auto currency_display = TRY(get_option(vm, options, vm.names.currencyDisplay, OptionType::String, { "code"sv, "symbol"sv, "narrowSymbol"sv, "name"sv }, "symbol"sv));
 
-    // 7. Let currencySign be ? GetOption(options, "currencySign", string, « "standard", "accounting" », "standard").
+    // 7. Let currencySign be ? GetOption(options, "currencySign", STRING, « "standard", "accounting" », "standard").
     auto currency_sign = TRY(get_option(vm, options, vm.names.currencySign, OptionType::String, { "standard"sv, "accounting"sv }, "standard"sv));
 
-    // 8. Let unit be ? GetOption(options, "unit", string, empty, undefined).
+    // 8. Let unit be ? GetOption(options, "unit", STRING, EMPTY, undefined).
     auto unit = TRY(get_option(vm, options, vm.names.unit, OptionType::String, {}, Empty {}));
 
     // 9. If unit is undefined, then
@@ -444,7 +444,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(VM& vm, NumberFormat& int
         return vm.throw_completion<RangeError>(ErrorType::OptionIsNotValidValue, unit, "unit"sv);
     }
 
-    // 11. Let unitDisplay be ? GetOption(options, "unitDisplay", string, « "short", "narrow", "long" », "short").
+    // 11. Let unitDisplay be ? GetOption(options, "unitDisplay", STRING, « "short", "narrow", "long" », "short").
     auto unit_display = TRY(get_option(vm, options, vm.names.unitDisplay, OptionType::String, { "short"sv, "narrow"sv, "long"sv }, "short"sv));
 
     // 12. If style is "currency", then

--- a/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -53,7 +53,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
     // 4. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 5. For each row of Table 25, except the header row, in table order, do
+    // 5. For each row of Table 26, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of nf's internal slot whose name is the Internal Slot value of the current row.
     //     c. If v is not undefined, then

--- a/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -87,8 +87,7 @@ ThrowCompletionOr<GC::Ref<Object>> PluralRulesConstructor::construct(FunctionObj
 
     // Non-standard, create an ICU number formatter for this Intl object.
     auto formatter = Unicode::NumberFormat::create(
-        plural_rules->locale(),
-        {},
+        result.icu_locale,
         {},
         plural_rules->rounding_options());
 

--- a/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -56,7 +56,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
         return PrimitiveString::create(vm, Unicode::plural_category_to_string(category));
     });
 
-    // 5. For each row of Table 29, except the header row, in table order, do
+    // 5. For each row of Table 30, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. If p is "pluralCategories", then
     //         i. Let v be CreateArrayFromList(pluralCategories).

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -112,7 +112,7 @@ ThrowCompletionOr<GC::Ref<Object>> RelativeTimeFormatConstructor::construct(Func
     // 20. Let relativeTimeFormat.[[NumberFormat]] be ! Construct(%Intl.NumberFormat%, « locale »).
     // 21. Let relativeTimeFormat.[[PluralRules]] be ! Construct(%Intl.PluralRules%, « locale »).
     auto formatter = Unicode::RelativeTimeFormat::create(
-        relative_time_format->locale(),
+        result.icu_locale,
         relative_time_format->style());
     relative_time_format->set_formatter(move(formatter));
 

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -63,13 +63,13 @@ ThrowCompletionOr<GC::Ref<Object>> RelativeTimeFormatConstructor::construct(Func
     // 5. Let opt be a new Record.
     LocaleOptions opt {};
 
-    // 6. Let matcher be ? GetOption(options, "localeMatcher", string, « "lookup", "best fit" », "best fit").
+    // 6. Let matcher be ? GetOption(options, "localeMatcher", STRING, « "lookup", "best fit" », "best fit").
     auto matcher = TRY(get_option(vm, *options, vm.names.localeMatcher, OptionType::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
 
     // 7. Set opt.[[LocaleMatcher]] to matcher.
     opt.locale_matcher = matcher;
 
-    // 8. Let numberingSystem be ? GetOption(options, "numberingSystem", string, empty, undefined).
+    // 8. Let numberingSystem be ? GetOption(options, "numberingSystem", STRING, EMPTY, undefined).
     auto numbering_system = TRY(get_option(vm, *options, vm.names.numberingSystem, OptionType::String, {}, Empty {}));
 
     // 9. If numberingSystem is not undefined, then
@@ -97,13 +97,13 @@ ThrowCompletionOr<GC::Ref<Object>> RelativeTimeFormatConstructor::construct(Func
     if (auto* resolved_numbering_system = result.nu.get_pointer<String>())
         relative_time_format->set_numbering_system(move(*resolved_numbering_system));
 
-    // 16. Let style be ? GetOption(options, "style", string, « "long", "short", "narrow" », "long").
+    // 16. Let style be ? GetOption(options, "style", STRING, « "long", "short", "narrow" », "long").
     auto style = TRY(get_option(vm, *options, vm.names.style, OptionType::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
 
     // 17. Set relativeTimeFormat.[[Style]] to style.
     relative_time_format->set_style(style.as_string().utf8_string_view());
 
-    // 18. Let numeric be ? GetOption(options, "numeric", string, « "always", "auto" », "always").
+    // 18. Let numeric be ? GetOption(options, "numeric", STRING, « "always", "auto" », "always").
     auto numeric = TRY(get_option(vm, *options, vm.names.numeric, OptionType::String, { "always"sv, "auto"sv }, "always"sv));
 
     // 19. Set relativeTimeFormat.[[Numeric]] to numeric.

--- a/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -46,7 +46,7 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::resolved_options)
     // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. For each row of Table 30, except the header row, in table order, do
+    // 4. For each row of Table 31, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of relativeTimeFormat's internal slot whose name is the Internal Slot value of the current row.
     //     c. Assert: v is not undefined.

--- a/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
+++ b/Libraries/LibJS/Runtime/Intl/SegmenterPrototype.cpp
@@ -45,7 +45,7 @@ JS_DEFINE_NATIVE_FUNCTION(SegmenterPrototype::resolved_options)
     // 3. Let options be OrdinaryObjectCreate(%Object.prototype%).
     auto options = Object::create(realm, realm.intrinsics().object_prototype());
 
-    // 4. For each row of Table 31, except the header row, in table order, do
+    // 4. For each row of Table 32, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of segmenter's internal slot whose name is the Internal Slot value of the current row.
     //     c. Assert: v is not undefined.

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -652,17 +652,17 @@ describe("Temporal objects", () => {
 
     test("Temporal.PlainDate", () => {
         const plainDate = new Temporal.PlainDate(1989, 1, 23);
-        expect(formatter.format(plainDate)).toBe("1/23/1989");
+        expect(formatter.format(plainDate)).toBe("1989-01-23");
     });
 
     test("Temporal.PlainYearMonth", () => {
         const plainYearMonth = new Temporal.PlainYearMonth(1989, 1);
-        expect(formatter.format(plainYearMonth)).toBe("1/1989");
+        expect(formatter.format(plainYearMonth)).toBe("1989-01");
     });
 
     test("Temporal.PlainMonthDay", () => {
         const plainMonthDay = new Temporal.PlainMonthDay(1, 23);
-        expect(formatter.format(plainMonthDay)).toBe("1/23");
+        expect(formatter.format(plainMonthDay)).toBe("01-23");
     });
 
     test("Temporal.PlainTime", () => {
@@ -672,6 +672,6 @@ describe("Temporal objects", () => {
 
     test("Temporal.Instant", () => {
         const instant = new Temporal.Instant(1732740069000000000n);
-        expect(formatter.format(instant)).toBe("11/27/2024, 8:41:09 PM");
+        expect(formatter.format(instant)).toBe("2024-11-27, 8:41:09 PM");
     });
 });

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
@@ -322,19 +322,19 @@ describe("Temporal objects", () => {
     test("Temporal.PlainDate", () => {
         const plainDate1 = new Temporal.PlainDate(1989, 1, 23);
         const plainDate2 = new Temporal.PlainDate(2024, 11, 27);
-        expect(formatter.formatRange(plainDate1, plainDate2)).toBe("1/23/1989 – 11/27/2024");
+        expect(formatter.formatRange(plainDate1, plainDate2)).toBe("1989-01-23 – 2024-11-27");
     });
 
     test("Temporal.PlainYearMonth", () => {
         const plainYearMonth1 = new Temporal.PlainYearMonth(1989, 1);
         const plainYearMonth2 = new Temporal.PlainYearMonth(2024, 11);
-        expect(formatter.formatRange(plainYearMonth1, plainYearMonth2)).toBe("1/1989 – 11/2024");
+        expect(formatter.formatRange(plainYearMonth1, plainYearMonth2)).toBe("1989-01 – 2024-11");
     });
 
     test("Temporal.PlainMonthDay", () => {
         const plainMonthDay1 = new Temporal.PlainMonthDay(1, 23);
         const plainMonthDay2 = new Temporal.PlainMonthDay(11, 27);
-        expect(formatter.formatRange(plainMonthDay1, plainMonthDay2)).toBe("1/23 – 11/27");
+        expect(formatter.formatRange(plainMonthDay1, plainMonthDay2)).toBe("01-23 – 11-27");
     });
 
     test("Temporal.PlainTime", () => {
@@ -347,7 +347,7 @@ describe("Temporal objects", () => {
         const instant1 = new Temporal.Instant(601546251000000000n);
         const instant2 = new Temporal.Instant(1732740069000000000n);
         expect(formatter.formatRange(instant1, instant2)).toBe(
-            "1/23/1989, 8:10:51 AM – 11/27/2024, 8:41:09 PM"
+            "1989-01-23, 8:10:51 AM – 2024-11-27, 8:41:09 PM"
         );
     });
 });

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
@@ -736,17 +736,17 @@ describe("Temporal objects", () => {
         const plainDate1 = new Temporal.PlainDate(1989, 1, 23);
         const plainDate2 = new Temporal.PlainDate(2024, 11, 27);
         expect(formatter.formatRangeToParts(plainDate1, plainDate2)).toEqual([
-            { type: "month", value: "1", source: "startRange" },
-            { type: "literal", value: "/", source: "startRange" },
-            { type: "day", value: "23", source: "startRange" },
-            { type: "literal", value: "/", source: "startRange" },
             { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "-", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
+            { type: "literal", value: "-", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
             { type: "literal", value: " – ", source: "shared" },
-            { type: "month", value: "11", source: "endRange" },
-            { type: "literal", value: "/", source: "endRange" },
-            { type: "day", value: "27", source: "endRange" },
-            { type: "literal", value: "/", source: "endRange" },
             { type: "year", value: "2024", source: "endRange" },
+            { type: "literal", value: "-", source: "endRange" },
+            { type: "month", value: "11", source: "endRange" },
+            { type: "literal", value: "-", source: "endRange" },
+            { type: "day", value: "27", source: "endRange" },
         ]);
     });
 
@@ -754,13 +754,13 @@ describe("Temporal objects", () => {
         const plainYearMonth1 = new Temporal.PlainYearMonth(1989, 1);
         const plainYearMonth2 = new Temporal.PlainYearMonth(2024, 11);
         expect(formatter.formatRangeToParts(plainYearMonth1, plainYearMonth2)).toEqual([
-            { type: "month", value: "1", source: "startRange" },
-            { type: "literal", value: "/", source: "startRange" },
             { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "-", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
             { type: "literal", value: " – ", source: "shared" },
-            { type: "month", value: "11", source: "endRange" },
-            { type: "literal", value: "/", source: "endRange" },
             { type: "year", value: "2024", source: "endRange" },
+            { type: "literal", value: "-", source: "endRange" },
+            { type: "month", value: "11", source: "endRange" },
         ]);
     });
 
@@ -768,12 +768,12 @@ describe("Temporal objects", () => {
         const plainMonthDay1 = new Temporal.PlainMonthDay(1, 23);
         const plainMonthDay2 = new Temporal.PlainMonthDay(11, 27);
         expect(formatter.formatRangeToParts(plainMonthDay1, plainMonthDay2)).toEqual([
-            { type: "month", value: "1", source: "startRange" },
-            { type: "literal", value: "/", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
+            { type: "literal", value: "-", source: "startRange" },
             { type: "day", value: "23", source: "startRange" },
             { type: "literal", value: " – ", source: "shared" },
             { type: "month", value: "11", source: "endRange" },
-            { type: "literal", value: "/", source: "endRange" },
+            { type: "literal", value: "-", source: "endRange" },
             { type: "day", value: "27", source: "endRange" },
         ]);
     });
@@ -804,11 +804,11 @@ describe("Temporal objects", () => {
         const instant1 = new Temporal.Instant(601546251000000000n);
         const instant2 = new Temporal.Instant(1732740069000000000n);
         expect(formatter.formatRangeToParts(instant1, instant2)).toEqual([
-            { type: "month", value: "1", source: "startRange" },
-            { type: "literal", value: "/", source: "startRange" },
-            { type: "day", value: "23", source: "startRange" },
-            { type: "literal", value: "/", source: "startRange" },
             { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "-", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
+            { type: "literal", value: "-", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
             { type: "literal", value: ", ", source: "startRange" },
             { type: "hour", value: "8", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -818,11 +818,11 @@ describe("Temporal objects", () => {
             { type: "literal", value: " ", source: "startRange" },
             { type: "dayPeriod", value: "AM", source: "startRange" },
             { type: "literal", value: " – ", source: "shared" },
-            { type: "month", value: "11", source: "endRange" },
-            { type: "literal", value: "/", source: "endRange" },
-            { type: "day", value: "27", source: "endRange" },
-            { type: "literal", value: "/", source: "endRange" },
             { type: "year", value: "2024", source: "endRange" },
+            { type: "literal", value: "-", source: "endRange" },
+            { type: "month", value: "11", source: "endRange" },
+            { type: "literal", value: "-", source: "endRange" },
+            { type: "day", value: "27", source: "endRange" },
             { type: "literal", value: ", ", source: "endRange" },
             { type: "hour", value: "8", source: "endRange" },
             { type: "literal", value: ":", source: "endRange" },

--- a/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
@@ -350,28 +350,28 @@ describe("Temporal objects", () => {
     test("Temporal.PlainDate", () => {
         const plainDate = new Temporal.PlainDate(1989, 1, 23);
         expect(formatter.formatToParts(plainDate)).toEqual([
-            { type: "month", value: "1" },
-            { type: "literal", value: "/" },
-            { type: "day", value: "23" },
-            { type: "literal", value: "/" },
             { type: "year", value: "1989" },
+            { type: "literal", value: "-" },
+            { type: "month", value: "01" },
+            { type: "literal", value: "-" },
+            { type: "day", value: "23" },
         ]);
     });
 
     test("Temporal.PlainYearMonth", () => {
         const plainYearMonth = new Temporal.PlainYearMonth(1989, 1);
         expect(formatter.formatToParts(plainYearMonth)).toEqual([
-            { type: "month", value: "1" },
-            { type: "literal", value: "/" },
             { type: "year", value: "1989" },
+            { type: "literal", value: "-" },
+            { type: "month", value: "01" },
         ]);
     });
 
     test("Temporal.PlainMonthDay", () => {
         const plainMonthDay = new Temporal.PlainMonthDay(1, 23);
         expect(formatter.formatToParts(plainMonthDay)).toEqual([
-            { type: "month", value: "1" },
-            { type: "literal", value: "/" },
+            { type: "month", value: "01" },
+            { type: "literal", value: "-" },
             { type: "day", value: "23" },
         ]);
     });
@@ -392,11 +392,11 @@ describe("Temporal objects", () => {
     test("Temporal.Instant", () => {
         const instant = new Temporal.Instant(1732740069000000000n);
         expect(formatter.formatToParts(instant)).toEqual([
-            { type: "month", value: "11" },
-            { type: "literal", value: "/" },
-            { type: "day", value: "27" },
-            { type: "literal", value: "/" },
             { type: "year", value: "2024" },
+            { type: "literal", value: "-" },
+            { type: "month", value: "11" },
+            { type: "literal", value: "-" },
+            { type: "day", value: "27" },
             { type: "literal", value: ", " },
             { type: "hour", value: "8" },
             { type: "literal", value: ":" },

--- a/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.resolvedOptions.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.resolvedOptions.js
@@ -95,6 +95,26 @@ describe("correct behavior", () => {
         expect(en2.resolvedOptions().maximumFractionDigits).toBe(2);
     });
 
+    test("currency digits are not used for non-standard notation", () => {
+        const en1 = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            notation: "engineering",
+        });
+        expect(en1.resolvedOptions().style).toBe("currency");
+        expect(en1.resolvedOptions().minimumFractionDigits).toBe(0);
+        expect(en1.resolvedOptions().maximumFractionDigits).toBe(3);
+
+        const en2 = new Intl.NumberFormat("en", {
+            style: "currency",
+            currency: "USD",
+            notation: "compact",
+        });
+        expect(en2.resolvedOptions().style).toBe("currency");
+        expect(en2.resolvedOptions().minimumFractionDigits).toBe(0);
+        expect(en2.resolvedOptions().maximumFractionDigits).toBe(0);
+    });
+
     test("other style options default to min fraction digits of 0 and max fraction digits of 0 or 3", () => {
         const en1 = new Intl.NumberFormat("en", { style: "decimal" });
         expect(en1.resolvedOptions().style).toBe("decimal");

--- a/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.prototype.format.js
+++ b/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.prototype.format.js
@@ -129,6 +129,11 @@ describe("second", () => {
 
         runTest("second", "narrow", "auto", en, ar, pl);
     });
+
+    test("numberingSystem set via locale options", () => {
+        const formatter = new Intl.RelativeTimeFormat("en", { numberingSystem: "arab" });
+        expect(formatter.format(1, "second")).toBe("in ١ second");
+    });
 });
 
 describe("minute", () => {

--- a/Libraries/LibUnicode/DurationFormat.cpp
+++ b/Libraries/LibUnicode/DurationFormat.cpp
@@ -38,7 +38,7 @@ DigitalFormat digital_format(StringView locale)
     rounding_options.min_significant_digits = 1;
     rounding_options.max_significant_digits = 2;
 
-    auto number_formatter = NumberFormat::create(locale, "latn"sv, {}, rounding_options);
+    auto number_formatter = NumberFormat::create(locale, {}, rounding_options);
 
     auto icu_locale = adopt_own(*locale_data->locale().clone());
     icu_locale->setUnicodeKeywordValue("nu", "latn", status);

--- a/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Libraries/LibUnicode/NumberFormat.cpp
@@ -866,23 +866,15 @@ private:
 
 NonnullOwnPtr<NumberFormat> NumberFormat::create(
     StringView locale,
-    StringView numbering_system,
     DisplayOptions const& display_options,
     RoundingOptions const& rounding_options)
 {
-    UErrorCode status = U_ZERO_ERROR;
-
     auto locale_data = LocaleData::for_locale(locale);
     VERIFY(locale_data.has_value());
 
     auto formatter = icu::number::NumberFormatter::withLocale(locale_data->locale());
     apply_display_options(formatter, display_options);
     apply_rounding_options(formatter, rounding_options);
-
-    if (!numbering_system.is_empty()) {
-        if (auto* symbols = icu::NumberingSystem::createInstanceByName(ByteString(numbering_system).characters(), status); symbols && icu_success(status))
-            formatter = formatter.adoptSymbols(symbols);
-    }
 
     bool is_unit = display_options.style == NumberFormatStyle::Unit;
     return adopt_own(*new NumberFormatImpl(locale_data->locale(), move(formatter), is_unit));

--- a/Libraries/LibUnicode/NumberFormat.h
+++ b/Libraries/LibUnicode/NumberFormat.h
@@ -142,7 +142,6 @@ class NumberFormat {
 public:
     static NonnullOwnPtr<NumberFormat> create(
         StringView locale,
-        StringView numbering_system,
         DisplayOptions const&,
         RoundingOptions const&);
 


### PR DESCRIPTION
test262 diff:
```
test/intl402/NumberFormat/currency-digits-nonstandard-notation.js ❌ -> ✅
```
(which brings us back to 100% `Intl.NumberFormat` passing)