### PR TITLE
Tests: Disable fDAT-inherits-cICP.html test that uses "reftest-wait"

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -158,11 +158,13 @@ Text/input/wpt-import/css/css-backgrounds/animations/discrete-no-interpolation.h
 Text/input/ShadowDOM/css-hover-shadow-dom.html
 
 ; WPT ref tests that are flaky, probably due to not supporting class="reftest-wait"
+; https://github.com/LadybirdBrowser/ladybird/issues/3984
 Ref/input/wpt-import/css/css-contain/contain-layout-020.html
 Ref/input/wpt-import/css/css-contain/contain-paint-050.html
 Ref/input/wpt-import/css/css-contain/contain-paint-change-opacity.html
 Ref/input/wpt-import/css/css-lists/list-style-type-string-004.html
 Ref/input/wpt-import/css/css-transforms/individual-transform/stacking-context-001.html
+Ref/input/wpt-import/png/apng/fDAT-inherits-cICP.html
 
 ; Test is flaky on CI, as navigationStart time is not set according to spec.
 Text/input/wpt-import/user-timing/measure_associated_with_navigation_timing.html


### PR DESCRIPTION
I just had this flake on me, and it's only been once, but given it uses a known-unimplemented mechanism it's bound to flake again in the future. IMO it's better to disable it.