### PR TITLE
LibWeb: Use shortest serialization for `grid-row` and `grid-column` values

### DIFF
--- a/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
+++ b/Libraries/LibWeb/CSS/GridTrackPlacement.cpp
@@ -22,8 +22,7 @@ String GridTrackPlacement::to_string() const
                 builder.appendff("{} {}", *area_or_line.line_number, *area_or_line.name);
             } else if (area_or_line.line_number.has_value()) {
                 builder.appendff("{}", *area_or_line.line_number);
-            }
-            if (area_or_line.name.has_value()) {
+            } else if (area_or_line.name.has_value()) {
                 builder.appendff("{}", *area_or_line.name);
             }
         },

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -307,7 +307,7 @@ String ShorthandStyleValue::to_string(SerializationMode mode) const
     case PropertyID::GridRow: {
         auto start = longhand(PropertyID::GridRowStart);
         auto end = longhand(PropertyID::GridRowEnd);
-        if (end->as_grid_track_placement().grid_track_placement().is_auto())
+        if (end->as_grid_track_placement().grid_track_placement().is_auto() || start == end)
             return start->to_string(mode);
         return MUST(String::formatted("{} / {}", start->to_string(mode), end->to_string(mode)));
     }

--- a/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
+++ b/Libraries/LibWeb/CSS/StyleValues/ShorthandStyleValue.cpp
@@ -300,7 +300,7 @@ String ShorthandStyleValue::to_string(SerializationMode mode) const
     case PropertyID::GridColumn: {
         auto start = longhand(PropertyID::GridColumnStart);
         auto end = longhand(PropertyID::GridColumnEnd);
-        if (end->as_grid_track_placement().grid_track_placement().is_auto())
+        if (end->as_grid_track_placement().grid_track_placement().is_auto() || start == end)
             return start->to_string(mode);
         return MUST(String::formatted("{} / {}", start->to_string(mode), end->to_string(mode)));
     }

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 30 tests
 
-12 Pass
-18 Fail
+13 Pass
+17 Fail
 Fail	Property grid-area value 'auto / auto / auto / auto'
 Pass	Property grid-row value 'auto / auto'
 Pass	Property grid-column-end value 'auto'
@@ -12,7 +12,7 @@ Pass	Property grid-row-start value 'AZ'
 Fail	Property grid-column-start value '-_π'
 Pass	Property grid-row-end value '_9'
 Fail	Property grid-area value '1 / 90 -a- / auto / auto'
-Fail	Property grid-row value '2 az / auto'
+Pass	Property grid-row value '2 az / auto'
 Pass	Property grid-column value '9 / -19 zA'
 Pass	Property grid-row-start value '-19'
 Fail	Property grid-row-start value '9 -Z_'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-computed.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 30 tests
 
-9 Pass
-21 Fail
+12 Pass
+18 Fail
 Fail	Property grid-area value 'auto / auto / auto / auto'
 Pass	Property grid-row value 'auto / auto'
 Pass	Property grid-column-end value 'auto'
@@ -13,12 +13,12 @@ Fail	Property grid-column-start value '-_π'
 Pass	Property grid-row-end value '_9'
 Fail	Property grid-area value '1 / 90 -a- / auto / auto'
 Fail	Property grid-row value '2 az / auto'
-Fail	Property grid-column value '9 / -19 zA'
+Pass	Property grid-column value '9 / -19 zA'
 Pass	Property grid-row-start value '-19'
 Fail	Property grid-row-start value '9 -Z_'
-Fail	Property grid-column-start value '-44 Z'
+Pass	Property grid-column-start value '-44 Z'
 Fail	Property grid-row-end value '1 -πA'
-Fail	Property grid-column-end value '5 π_'
+Pass	Property grid-column-end value '5 π_'
 Fail	Property grid-area value 'span 2 i / auto / auto / auto'
 Pass	Property grid-row value 'span 2 / auto'
 Fail	Property grid-column-start value 'span 1 i'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-shorthand.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 53 tests
 
-42 Pass
-11 Fail
+44 Pass
+9 Fail
 Pass	e.style['grid-area'] = "auto" should set grid-column-end
 Pass	e.style['grid-area'] = "auto" should set grid-column-start
 Pass	e.style['grid-area'] = "auto" should set grid-row-end
@@ -45,8 +45,8 @@ Pass	e.style['grid-row'] = "auto" should not set unrelated longhands
 Pass	e.style['grid-row'] = "one / 2" should set grid-row-end
 Pass	e.style['grid-row'] = "one / 2" should set grid-row-start
 Pass	e.style['grid-row'] = "one / 2" should not set unrelated longhands
-Fail	e.style['grid-row'] = "1 two / four 3" should set grid-row-end
-Fail	e.style['grid-row'] = "1 two / four 3" should set grid-row-start
+Pass	e.style['grid-row'] = "1 two / four 3" should set grid-row-end
+Pass	e.style['grid-row'] = "1 two / four 3" should set grid-row-start
 Pass	e.style['grid-row'] = "1 two / four 3" should not set unrelated longhands
 Pass	e.style['grid-column'] = "5 span" should set grid-column-end
 Pass	e.style['grid-column'] = "5 span" should set grid-column-start

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 57 tests
 
-18 Pass
-39 Fail
+19 Pass
+38 Fail
 Fail	e.style['grid-area'] = "auto" should set the property value
 Fail	e.style['grid-area'] = "auto / auto" should set the property value
 Fail	e.style['grid-area'] = "auto / auto / auto" should set the property value
@@ -23,7 +23,7 @@ Fail	e.style['grid-area'] = "1" should set the property value
 Fail	e.style['grid-area'] = "+90 -a-" should set the property value
 Pass	e.style['grid-row'] = "az 2" should set the property value
 Pass	e.style['grid-column'] = "9" should set the property value
-Fail	e.style['grid-column'] = "-19 zA" should set the property value
+Pass	e.style['grid-column'] = "-19 zA" should set the property value
 Fail	e.style['grid-column'] = "-A0 33" should set the property value
 Pass	e.style['grid-row-start'] = "-19" should set the property value
 Fail	e.style['grid-row-start'] = "9 -Z_" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 57 tests
 
-13 Pass
-44 Fail
+15 Pass
+42 Fail
 Fail	e.style['grid-area'] = "auto" should set the property value
 Fail	e.style['grid-area'] = "auto / auto" should set the property value
 Fail	e.style['grid-area'] = "auto / auto / auto" should set the property value
@@ -28,9 +28,9 @@ Fail	e.style['grid-column'] = "-A0 33" should set the property value
 Pass	e.style['grid-row-start'] = "-19" should set the property value
 Fail	e.style['grid-row-start'] = "9 -Z_" should set the property value
 Pass	e.style['grid-column-start'] = "+90" should set the property value
-Fail	e.style['grid-column-start'] = "Z -44" should set the property value
+Pass	e.style['grid-column-start'] = "Z -44" should set the property value
 Fail	e.style['grid-row-end'] = "1 -πA" should set the property value
-Fail	e.style['grid-column-end'] = "π_ +5" should set the property value
+Pass	e.style['grid-column-end'] = "π_ +5" should set the property value
 Fail	e.style['grid-area'] = "span 2 i" should set the property value
 Fail	e.style['grid-area'] = "i 2 SpAn" should set the property value
 Fail	e.style['grid-area'] = "span 1 i" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-area-valid.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 57 tests
 
-15 Pass
-42 Fail
+18 Pass
+39 Fail
 Fail	e.style['grid-area'] = "auto" should set the property value
 Fail	e.style['grid-area'] = "auto / auto" should set the property value
 Fail	e.style['grid-area'] = "auto / auto / auto" should set the property value
@@ -15,13 +15,13 @@ Pass	e.style['grid-column-end'] = "AuTo" should set the property value
 Fail	e.style['grid-area'] = "--a" should set the property value
 Fail	e.style['grid-row'] = "-zπ" should set the property value
 Fail	e.style['grid-row'] = "-zπ/-zπ" should set the property value
-Fail	e.style['grid-row'] = "i / i" should set the property value
+Pass	e.style['grid-row'] = "i / i" should set the property value
 Pass	e.style['grid-row-start'] = "AZ" should set the property value
 Fail	e.style['grid-column-start'] = "-_π" should set the property value
 Pass	e.style['grid-row-end'] = "_9" should set the property value
 Fail	e.style['grid-area'] = "1" should set the property value
 Fail	e.style['grid-area'] = "+90 -a-" should set the property value
-Fail	e.style['grid-row'] = "az 2" should set the property value
+Pass	e.style['grid-row'] = "az 2" should set the property value
 Pass	e.style['grid-column'] = "9" should set the property value
 Fail	e.style['grid-column'] = "-19 zA" should set the property value
 Fail	e.style['grid-column'] = "-A0 33" should set the property value
@@ -55,7 +55,7 @@ Fail	e.style['grid-area'] = "auto / i / 2 j" should set the property value
 Fail	e.style['grid-area'] = "auto / i / 2 j / span 3 k" should set the property value
 Pass	e.style['grid-row'] = "auto / i" should set the property value
 Fail	e.style['grid-row'] = "i / auto" should set the property value
-Fail	e.style['grid-row'] = "2 i / auto" should set the property value
+Pass	e.style['grid-row'] = "2 i / auto" should set the property value
 Pass	e.style['grid-row'] = "1 / auto" should set the property value
 Fail	e.style['grid-column'] = "2 j / span 3 k" should set the property value
 Fail	e.style['grid-column-end'] = "\\31st" should set the property value

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-column-shortest-serialization.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-column-shortest-serialization.txt
@@ -2,20 +2,20 @@ Harness status: OK
 
 Found 16 tests
 
-8 Pass
-8 Fail
+12 Pass
+4 Fail
 Pass	Property grid-column value 'auto / auto'
 Pass	Property grid-column value 'auto'
 Pass	Property grid-column value '10 / auto'
 Pass	Property grid-column value '10'
 Pass	Property grid-column value '-10 / auto'
 Pass	Property grid-column value '-10'
-Fail	Property grid-column value 'first / first'
-Fail	Property grid-column value 'first'
+Pass	Property grid-column value 'first / first'
+Pass	Property grid-column value 'first'
 Pass	Property grid-column value 'span 2 / auto'
 Pass	Property grid-column value 'span 2'
-Fail	Property grid-column value '2 first / auto'
-Fail	Property grid-column value '2 first'
+Pass	Property grid-column value '2 first / auto'
+Pass	Property grid-column value '2 first'
 Fail	Property grid-column value 'span first / auto'
 Fail	Property grid-column value 'span first'
 Fail	Property grid-column value 'span 2 first / auto'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-column-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-column-shorthand.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 48 tests
 
-36 Pass
-12 Fail
+38 Pass
+10 Fail
 Pass	e.style['grid-column'] = "auto / auto" should set grid-column-end
 Pass	e.style['grid-column'] = "auto / auto" should set grid-column-start
 Pass	e.style['grid-column'] = "auto / auto" should not set unrelated longhands
@@ -29,10 +29,10 @@ Pass	e.style['grid-column'] = "span 2" should set grid-column-end
 Pass	e.style['grid-column'] = "span 2" should set grid-column-start
 Pass	e.style['grid-column'] = "span 2" should not set unrelated longhands
 Pass	e.style['grid-column'] = "3 last / auto" should set grid-column-end
-Fail	e.style['grid-column'] = "3 last / auto" should set grid-column-start
+Pass	e.style['grid-column'] = "3 last / auto" should set grid-column-start
 Pass	e.style['grid-column'] = "3 last / auto" should not set unrelated longhands
 Fail	e.style['grid-column'] = "3 last" should set grid-column-end
-Fail	e.style['grid-column'] = "3 last" should set grid-column-start
+Pass	e.style['grid-column'] = "3 last" should set grid-column-start
 Pass	e.style['grid-column'] = "3 last" should not set unrelated longhands
 Fail	e.style['grid-column'] = "span first / auto" should set grid-column-end
 Fail	e.style['grid-column'] = "span first / auto" should set grid-column-start

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-row-shortest-serialization.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-row-shortest-serialization.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 15 tests
 
-8 Pass
-7 Fail
+11 Pass
+4 Fail
 Pass	Property grid-row value 'auto / auto'
 Pass	Property grid-row value 'auto'
 Pass	Property grid-row value '10 / auto'
@@ -12,10 +12,10 @@ Pass	Property grid-row value '-10 / auto'
 Pass	Property grid-row value '-10'
 Pass	Property grid-row value 'span 2 / auto'
 Pass	Property grid-row value 'span 2'
-Fail	Property grid-row value '3 last / auto'
-Fail	Property grid-row value '3 last'
+Pass	Property grid-row value '3 last / auto'
+Pass	Property grid-row value '3 last'
 Fail	Property grid-row value 'span first / auto'
 Fail	Property grid-row value 'span first'
 Fail	Property grid-row value 'span 2 first / auto'
 Fail	Property grid-row value 'span 2 first'
-Fail	Property grid-row value 'last / last'
+Pass	Property grid-row value 'last / last'

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-row-shorthand.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/parsing/grid-row-shorthand.txt
@@ -2,8 +2,8 @@ Harness status: OK
 
 Found 48 tests
 
-36 Pass
-12 Fail
+38 Pass
+10 Fail
 Pass	e.style['grid-row'] = "auto / auto" should set grid-row-end
 Pass	e.style['grid-row'] = "auto / auto" should set grid-row-start
 Pass	e.style['grid-row'] = "auto / auto" should not set unrelated longhands
@@ -29,10 +29,10 @@ Pass	e.style['grid-row'] = "span 2" should set grid-row-end
 Pass	e.style['grid-row'] = "span 2" should set grid-row-start
 Pass	e.style['grid-row'] = "span 2" should not set unrelated longhands
 Pass	e.style['grid-row'] = "3 last / auto" should set grid-row-end
-Fail	e.style['grid-row'] = "3 last / auto" should set grid-row-start
+Pass	e.style['grid-row'] = "3 last / auto" should set grid-row-start
 Pass	e.style['grid-row'] = "3 last / auto" should not set unrelated longhands
 Fail	e.style['grid-row'] = "3 last" should set grid-row-end
-Fail	e.style['grid-row'] = "3 last" should set grid-row-start
+Pass	e.style['grid-row'] = "3 last" should set grid-row-start
 Pass	e.style['grid-row'] = "3 last" should not set unrelated longhands
 Fail	e.style['grid-row'] = "span first / auto" should set grid-row-end
 Fail	e.style['grid-row'] = "span first / auto" should set grid-row-start


### PR DESCRIPTION
This fixes 30 WPT subtests in the `css/css-grid` directory.