### PR TITLE
Tests: Disable `css/css-lists/list-style-type-string-004.html`

### DIFF
--- a/Tests/LibWeb/TestConfig.ini
+++ b/Tests/LibWeb/TestConfig.ini
@@ -12,6 +12,7 @@ Ref/input/unicode-range.html
 Text/input/Crypto/SubtleCrypto-exportKey.html
 Text/input/Crypto/SubtleCrypto-generateKey.html
 Text/input/wpt-import/css/css-flexbox/text-as-flexitem-size-001.html
+Ref/input/wpt-import/css/css-lists/list-style-type-string-004.html
 
 ; Animation tests are flaky
 Text/input/css/cubic-bezier-infinite-slope-crash.html


### PR DESCRIPTION
259d39cb was not enough to make this test pass reliably, so let's disable it back for now.