### PR TITLE
LibJS+LibCrypto: Use a bitwise approach for BigInt's as*IntN methods

### DIFF
--- a/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
+++ b/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
@@ -131,7 +131,7 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_xor_without_allocation(
 /**
  * Complexity: O(N) where N is the number of words
  */
-FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_one_based_index_without_allocation(
+FLATTEN ErrorOr<void> UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_one_based_index_without_allocation(
     UnsignedBigInteger const& right,
     size_t index,
     UnsignedBigInteger& output)
@@ -139,16 +139,16 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_one_based_index_w
     // If the value is invalid, the output value is invalid as well.
     if (right.is_invalid()) {
         output.invalidate();
-        return;
+        return {};
     }
 
     if (index == 0) {
         output.set_to_0();
-        return;
+        return {};
     }
     size_t size = (index + UnsignedBigInteger::BITS_IN_WORD - 1) / UnsignedBigInteger::BITS_IN_WORD;
 
-    output.m_words.resize_and_keep_capacity(size);
+    TRY(output.m_words.try_resize_and_keep_capacity(size));
     VERIFY(size > 0);
     for (size_t i = 0; i < size - 1; ++i)
         output.m_words[i] = ~(i < right.length() ? right.words()[i] : 0);
@@ -158,6 +158,8 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_one_based_index_w
     auto last_word = last_word_index < right.length() ? right.words()[last_word_index] : 0;
 
     output.m_words[last_word_index] = (NumericLimits<UnsignedBigInteger::Word>::max() >> (UnsignedBigInteger::BITS_IN_WORD - index)) & ~last_word;
+
+    return {};
 }
 
 FLATTEN void UnsignedBigIntegerAlgorithms::shift_left_without_allocation(

--- a/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
+++ b/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
@@ -20,13 +20,13 @@ public:
     static void bitwise_or_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
     static void bitwise_and_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
     static void bitwise_xor_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
-    static void bitwise_not_fill_to_one_based_index_without_allocation(UnsignedBigInteger const& left, size_t, UnsignedBigInteger& output);
     static void shift_left_without_allocation(UnsignedBigInteger const& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
     static void shift_right_without_allocation(UnsignedBigInteger const& number, size_t num_bits, UnsignedBigInteger& output);
     static void multiply_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& output);
     static void divide_without_allocation(UnsignedBigInteger const& numerator, UnsignedBigInteger const& denominator, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
     static void divide_u16_without_allocation(UnsignedBigInteger const& numerator, UnsignedBigInteger::Word denominator, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);
 
+    static ErrorOr<void> bitwise_not_fill_to_one_based_index_without_allocation(UnsignedBigInteger const& left, size_t, UnsignedBigInteger& output);
     static ErrorOr<void> try_shift_left_without_allocation(UnsignedBigInteger const& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
 
     static void extended_GCD_without_allocation(UnsignedBigInteger const& a, UnsignedBigInteger const& b, UnsignedBigInteger& x, UnsignedBigInteger& y, UnsignedBigInteger& gcd, UnsignedBigInteger& temp_quotient, UnsignedBigInteger& temp_1, UnsignedBigInteger& temp_2, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_r, UnsignedBigInteger& temp_s, UnsignedBigInteger& temp_t);

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -291,6 +291,17 @@ FLATTEN SignedBigInteger SignedBigInteger::shift_right(size_t num_bits) const
     return SignedBigInteger { m_unsigned_data.shift_right(num_bits), m_sign };
 }
 
+FLATTEN ErrorOr<SignedBigInteger> SignedBigInteger::mod_power_of_two(size_t power_of_two) const
+{
+    auto const lower_bits = m_unsigned_data.as_n_bits(power_of_two);
+
+    if (is_positive())
+        return SignedBigInteger(lower_bits);
+
+    // twos encode lower bits
+    return SignedBigInteger(TRY(lower_bits.try_bitwise_not_fill_to_one_based_index(power_of_two)).plus(1).as_n_bits(power_of_two));
+}
+
 FLATTEN SignedBigInteger SignedBigInteger::multiplied_by(SignedBigInteger const& other) const
 {
     bool result_sign = m_sign ^ other.m_sign;

--- a/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -120,6 +120,7 @@ public:
     [[nodiscard]] SignedBigInteger multiplied_by(SignedBigInteger const& other) const;
     [[nodiscard]] SignedDivisionResult divided_by(SignedBigInteger const& divisor) const;
 
+    [[nodiscard]] ErrorOr<SignedBigInteger> mod_power_of_two(size_t power_of_two) const;
     [[nodiscard]] ErrorOr<SignedBigInteger> try_shift_left(size_t num_bits) const;
 
     [[nodiscard]] SignedBigInteger plus(UnsignedBigInteger const& other) const;

--- a/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -117,9 +117,11 @@ public:
     [[nodiscard]] UnsignedBigInteger bitwise_not_fill_to_one_based_index(size_t) const;
     [[nodiscard]] UnsignedBigInteger shift_left(size_t num_bits) const;
     [[nodiscard]] UnsignedBigInteger shift_right(size_t num_bits) const;
+    [[nodiscard]] UnsignedBigInteger as_n_bits(size_t n) const;
     [[nodiscard]] UnsignedBigInteger multiplied_by(UnsignedBigInteger const& other) const;
     [[nodiscard]] UnsignedDivisionResult divided_by(UnsignedBigInteger const& divisor) const;
 
+    [[nodiscard]] ErrorOr<UnsignedBigInteger> try_bitwise_not_fill_to_one_based_index(size_t) const;
     [[nodiscard]] ErrorOr<UnsignedBigInteger> try_shift_left(size_t num_bits) const;
 
     [[nodiscard]] u32 hash() const;

--- a/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -77,7 +77,7 @@
     M(InvalidEnumerationValue, "Invalid value '{}' for enumeration type '{}'")                                                      \
     M(InvalidFractionDigits, "Fraction Digits must be an integer no less than 0, and no greater than 100")                          \
     M(InvalidHint, "Invalid hint: \"{}\"")                                                                                          \
-    M(InvalidIndex, "Index must be a positive integer")                                                                             \
+    M(InvalidIndex, "Index must be a positive integer no greater than 2^53-1")                                                      \
     M(InvalidLeftHandAssignment, "Invalid left-hand side in assignment")                                                            \
     M(InvalidLength, "Invalid {} length")                                                                                           \
     M(InvalidNormalizationForm, "The normalization form must be one of NFC, NFD, NFKC, NFKD. Got '{}'")                             \

--- a/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asIntN.js
+++ b/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asIntN.js
@@ -22,12 +22,6 @@ describe("errors", () => {
             BigInt.asIntN(1, "foo");
         }).toThrowWithMessage(SyntaxError, "Invalid value for BigInt: foo");
     });
-
-    test("large allocation", () => {
-        expect(() => {
-            BigInt.asIntN(0x4000000000000, 1n);
-        }).toThrowWithMessage(InternalError, "Out of memory");
-    });
 });
 
 describe("correct behavior", () => {
@@ -81,5 +75,24 @@ describe("correct behavior", () => {
         expect(BigInt.asIntN(4, -extremelyBigInt)).toBe(-5n);
         expect(BigInt.asIntN(128, -extremelyBigInt)).toBe(99061374399389259395070030194384019691n);
         expect(BigInt.asIntN(256, -extremelyBigInt)).toBe(-extremelyBigInt);
+    });
+
+    test("large bit values", () => {
+        expect(BigInt.asIntN(0x4000000000000, 1n)).toBe(1n);
+        expect(BigInt.asIntN(0x8ffffffffffff, 1n)).toBe(1n);
+        expect(BigInt.asIntN(2 ** 53 - 1, 2n)).toBe(2n);
+
+        // These incur large intermediate values that 00M. For now, ensure they don't crash
+        expect(() => {
+            BigInt.asIntN(0x4000000000000, -1n);
+        }).toThrowWithMessage(InternalError, "Out of memory");
+
+        expect(() => {
+            BigInt.asIntN(0x8ffffffffffff, -1n);
+        }).toThrowWithMessage(InternalError, "Out of memory");
+
+        expect(() => {
+            BigInt.asIntN(2 ** 53 - 1, -2n);
+        }).toThrowWithMessage(InternalError, "Out of memory");
     });
 });

--- a/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asUintN.js
+++ b/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asUintN.js
@@ -22,12 +22,6 @@ describe("errors", () => {
             BigInt.asUintN(1, "foo");
         }).toThrowWithMessage(SyntaxError, "Invalid value for BigInt: foo");
     });
-
-    test("large allocation", () => {
-        expect(() => {
-            BigInt.asUintN(0x4000000000000, 1n);
-        }).toThrowWithMessage(InternalError, "Out of memory");
-    });
 });
 
 describe("correct behavior", () => {
@@ -79,5 +73,21 @@ describe("correct behavior", () => {
         expect(BigInt.asUintN(256, -extremelyBigInt)).toBe(
             115792089237316195423570861551898784396480861208851440582668460551124006183147n
         );
+    });
+
+    test("large bit values", () => {
+        const INDEX_MAX = 2 ** 53 - 1;
+        const LAST_8_DIGITS = 10n ** 8n;
+
+        expect(BigInt.asUintN(0x400000000, 1n)).toBe(1n);
+        expect(BigInt.asUintN(0x4000, -1n) % LAST_8_DIGITS).toBe(64066815n);
+
+        expect(BigInt.asUintN(0x400000000, 2n)).toBe(2n);
+        expect(BigInt.asUintN(0x4000, -2n) % LAST_8_DIGITS).toBe(64066814n);
+
+        expect(BigInt.asUintN(INDEX_MAX, 2n)).toBe(2n);
+        expect(() => {
+            BigInt.asUintN(INDEX_MAX, -2n);
+        }).toThrowWithMessage(InternalError, "Out of memory");
     });
 });


### PR DESCRIPTION
This speeds up expressions such as `BigInt.asIntN(0x4000000000000, 1n)` (https://github.com/LadybirdBrowser/ladybird/pull/3615), and those involving very large bigints. Instead of `modulo()` we just cut off high bits.