### PR TITLE
LibDevTools: Some post Inspector-removal cleanup

### DIFF
--- a/Libraries/LibDevTools/Actors/FrameActor.cpp
+++ b/Libraries/LibDevTools/Actors/FrameActor.cpp
@@ -66,6 +66,7 @@ void FrameActor::handle_message(Message const& message)
 
     if (message.type == "detach"sv) {
         if (auto tab = m_tab.strong_ref()) {
+            devtools().delegate().stop_listening_for_dom_properties(tab->description());
             devtools().delegate().stop_listening_for_dom_mutations(tab->description());
             devtools().delegate().stop_listening_for_console_messages(tab->description());
             devtools().delegate().stop_listening_for_style_sheet_sources(tab->description());

--- a/Libraries/LibDevTools/Actors/PageStyleActor.cpp
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.cpp
@@ -14,47 +14,47 @@
 
 namespace DevTools {
 
-static void received_layout(JsonObject& response, JsonObject const& computed_style, JsonObject const& node_box_sizing)
+static void received_layout(JsonObject& response, JsonObject const& node_box_sizing)
 {
     response.set("autoMargins"sv, JsonObject {});
 
-    auto pixel_value = [&](auto const& object, auto key) {
-        return object.get_double_with_precision_loss(key).value_or(0);
+    auto pixel_value = [&](auto key) {
+        return node_box_sizing.get_double_with_precision_loss(key).value_or(0);
     };
-    auto set_pixel_value_from = [&](auto const& object, auto object_key, auto message_key) {
-        response.set(message_key, MUST(String::formatted("{}px", pixel_value(object, object_key))));
+    auto set_pixel_value = [&](auto key) {
+        response.set(key, MUST(String::formatted("{}px", pixel_value(key))));
     };
-    auto set_computed_value_from = [&](auto const& object, auto key) {
-        response.set(key, object.get_string(key).value_or(String {}));
+    auto set_computed_value = [&](auto key) {
+        response.set(key, node_box_sizing.get_string(key).value_or(String {}));
     };
-
-    response.set("width"sv, pixel_value(node_box_sizing, "content_width"sv));
-    response.set("height"sv, pixel_value(node_box_sizing, "content_height"sv));
 
     // FIXME: This response should also contain "top", "right", "bottom", and "left", but our box model metrics in
     //        WebContent do not provide this information.
 
-    set_pixel_value_from(node_box_sizing, "border_top"sv, "border-top-width"sv);
-    set_pixel_value_from(node_box_sizing, "border_right"sv, "border-right-width"sv);
-    set_pixel_value_from(node_box_sizing, "border_bottom"sv, "border-bottom-width"sv);
-    set_pixel_value_from(node_box_sizing, "border_left"sv, "border-left-width"sv);
+    set_computed_value("width"sv);
+    set_computed_value("height"sv);
 
-    set_pixel_value_from(node_box_sizing, "margin_top"sv, "margin-top"sv);
-    set_pixel_value_from(node_box_sizing, "margin_right"sv, "margin-right"sv);
-    set_pixel_value_from(node_box_sizing, "margin_bottom"sv, "margin-bottom"sv);
-    set_pixel_value_from(node_box_sizing, "margin_left"sv, "margin-left"sv);
+    set_pixel_value("border-top-width"sv);
+    set_pixel_value("border-right-width"sv);
+    set_pixel_value("border-bottom-width"sv);
+    set_pixel_value("border-left-width"sv);
 
-    set_pixel_value_from(node_box_sizing, "padding_top"sv, "padding-top"sv);
-    set_pixel_value_from(node_box_sizing, "padding_right"sv, "padding-right"sv);
-    set_pixel_value_from(node_box_sizing, "padding_bottom"sv, "padding-bottom"sv);
-    set_pixel_value_from(node_box_sizing, "padding_left"sv, "padding-left"sv);
+    set_pixel_value("margin-top"sv);
+    set_pixel_value("margin-right"sv);
+    set_pixel_value("margin-bottom"sv);
+    set_pixel_value("margin-left"sv);
 
-    set_computed_value_from(computed_style, "box-sizing"sv);
-    set_computed_value_from(computed_style, "display"sv);
-    set_computed_value_from(computed_style, "float"sv);
-    set_computed_value_from(computed_style, "line-height"sv);
-    set_computed_value_from(computed_style, "position"sv);
-    set_computed_value_from(computed_style, "z-index"sv);
+    set_pixel_value("padding-top"sv);
+    set_pixel_value("padding-right"sv);
+    set_pixel_value("padding-bottom"sv);
+    set_pixel_value("padding-left"sv);
+
+    set_computed_value("box-sizing"sv);
+    set_computed_value("display"sv);
+    set_computed_value("float"sv);
+    set_computed_value("line-height"sv);
+    set_computed_value("position"sv);
+    set_computed_value("z-index"sv);
 }
 
 static void received_computed_style(JsonObject& response, JsonObject const& computed_style)
@@ -151,7 +151,7 @@ void PageStyleActor::handle_message(Message const& message)
             return;
 
         inspect_dom_node(message, *node, [](auto& response, auto const& properties) {
-            received_layout(response, properties.computed_style, properties.node_box_sizing);
+            received_layout(response, properties.node_box_sizing);
         });
 
         return;

--- a/Libraries/LibDevTools/Actors/PageStyleActor.h
+++ b/Libraries/LibDevTools/Actors/PageStyleActor.h
@@ -6,18 +6,11 @@
 
 #pragma once
 
-#include <AK/JsonArray.h>
-#include <AK/JsonObject.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibDevTools/Actor.h>
+#include <LibWebView/DOMNodeProperties.h>
 
 namespace DevTools {
-
-struct DOMNodeProperties {
-    JsonObject computed_style;
-    JsonObject node_box_sizing;
-    JsonArray fonts;
-};
 
 class PageStyleActor final : public Actor {
 public:
@@ -33,10 +26,12 @@ private:
 
     virtual void handle_message(Message const&) override;
 
-    template<typename Callback>
-    void inspect_dom_node(Message const&, StringView node_actor, Callback&&);
+    void inspect_dom_node(Message const&, WebView::DOMNodeProperties::Type);
+    void received_dom_node_properties(WebView::DOMNodeProperties const&);
 
     WeakPtr<InspectorActor> m_inspector;
+
+    Vector<Message, 1> m_pending_inspect_requests;
 };
 
 }

--- a/Libraries/LibDevTools/DevToolsDelegate.h
+++ b/Libraries/LibDevTools/DevToolsDelegate.h
@@ -17,6 +17,7 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleSheetIdentifier.h>
 #include <LibWeb/Forward.h>
+#include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
 
 namespace DevTools {
@@ -31,8 +32,10 @@ public:
     using OnTabInspectionComplete = Function<void(ErrorOr<JsonValue>)>;
     virtual void inspect_tab(TabDescription const&, OnTabInspectionComplete) const { }
 
-    using OnDOMNodeInspectionComplete = Function<void(ErrorOr<DOMNodeProperties>)>;
-    virtual void inspect_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>, OnDOMNodeInspectionComplete) const { }
+    using OnDOMNodePropertiesReceived = Function<void(WebView::DOMNodeProperties)>;
+    virtual void listen_for_dom_properties(TabDescription const&, OnDOMNodePropertiesReceived) const { }
+    virtual void stop_listening_for_dom_properties(TabDescription const&) const { }
+    virtual void inspect_dom_node(TabDescription const&, WebView::DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const { }
     virtual void clear_inspected_dom_node(TabDescription const&) const { }
 
     virtual void highlight_dom_node(TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const { }

--- a/Libraries/LibWebView/Application.cpp
+++ b/Libraries/LibWebView/Application.cpp
@@ -449,25 +449,31 @@ void Application::inspect_tab(DevTools::TabDescription const& description, OnTab
     view->inspect_dom_tree();
 }
 
-void Application::inspect_dom_node(DevTools::TabDescription const& description, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element, OnDOMNodeInspectionComplete on_complete) const
+void Application::listen_for_dom_properties(DevTools::TabDescription const& description, OnDOMNodePropertiesReceived on_dom_node_properties_received) const
 {
     auto view = ViewImplementation::find_view_by_id(description.id);
-    if (!view.has_value()) {
-        on_complete(Error::from_string_literal("Unable to locate tab"));
+    if (!view.has_value())
         return;
-    }
 
-    view->on_received_dom_node_properties = [&view = *view, on_complete = move(on_complete)](ViewImplementation::DOMNodeProperties properties) {
-        view.on_received_dom_node_properties = nullptr;
+    view->on_received_dom_node_properties = move(on_dom_node_properties_received);
+}
 
-        on_complete(DevTools::DOMNodeProperties {
-            .computed_style = move(properties.computed_style),
-            .node_box_sizing = move(properties.node_box_sizing),
-            .fonts = move(properties.fonts),
-        });
-    };
+void Application::stop_listening_for_dom_properties(DevTools::TabDescription const& description) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
 
-    view->inspect_dom_node(node_id, pseudo_element);
+    view->on_received_dom_node_properties = nullptr;
+}
+
+void Application::inspect_dom_node(DevTools::TabDescription const& description, DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) const
+{
+    auto view = ViewImplementation::find_view_by_id(description.id);
+    if (!view.has_value())
+        return;
+
+    view->inspect_dom_node(node_id, property_type, pseudo_element);
 }
 
 void Application::clear_inspected_dom_node(DevTools::TabDescription const& description) const

--- a/Libraries/LibWebView/Application.h
+++ b/Libraries/LibWebView/Application.h
@@ -97,7 +97,9 @@ private:
     virtual Vector<DevTools::TabDescription> tab_list() const override;
     virtual Vector<DevTools::CSSProperty> css_property_list() const override;
     virtual void inspect_tab(DevTools::TabDescription const&, OnTabInspectionComplete) const override;
-    virtual void inspect_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>, OnDOMNodeInspectionComplete) const override;
+    virtual void listen_for_dom_properties(DevTools::TabDescription const&, OnDOMNodePropertiesReceived) const override;
+    virtual void stop_listening_for_dom_properties(DevTools::TabDescription const&) const override;
+    virtual void inspect_dom_node(DevTools::TabDescription const&, DOMNodeProperties::Type, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const override;
     virtual void clear_inspected_dom_node(DevTools::TabDescription const&) const override;
     virtual void highlight_dom_node(DevTools::TabDescription const&, Web::UniqueNodeID, Optional<Web::CSS::Selector::PseudoElement::Type>) const override;
     virtual void clear_highlighted_dom_node(DevTools::TabDescription const&) const override;

--- a/Libraries/LibWebView/CMakeLists.txt
+++ b/Libraries/LibWebView/CMakeLists.txt
@@ -7,6 +7,7 @@ set(SOURCES
     ConsoleOutput.cpp
     CookieJar.cpp
     Database.cpp
+    DOMNodeProperties.cpp
     HelperProcess.cpp
     Mutation.cpp
     Plugins/FontPlugin.cpp

--- a/Libraries/LibWebView/DOMNodeProperties.cpp
+++ b/Libraries/LibWebView/DOMNodeProperties.cpp
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibIPC/Decoder.h>
+#include <LibIPC/Encoder.h>
+#include <LibWebView/DOMNodeProperties.h>
+
+template<>
+ErrorOr<void> IPC::encode(Encoder& encoder, WebView::DOMNodeProperties const& attribute)
+{
+    TRY(encoder.encode(attribute.type));
+    TRY(encoder.encode(attribute.properties));
+    return {};
+}
+
+template<>
+ErrorOr<WebView::DOMNodeProperties> IPC::decode(Decoder& decoder)
+{
+    auto type = TRY(decoder.decode<WebView::DOMNodeProperties::Type>());
+    auto properties = TRY(decoder.decode<JsonValue>());
+
+    return WebView::DOMNodeProperties { type, move(properties) };
+}

--- a/Libraries/LibWebView/DOMNodeProperties.h
+++ b/Libraries/LibWebView/DOMNodeProperties.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025, Tim Flynn <trflynn89@ladybird.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <LibIPC/Forward.h>
+
+namespace WebView {
+
+struct DOMNodeProperties {
+    enum class Type {
+        ComputedStyle,
+        Layout,
+        UsedFonts,
+    };
+
+    Type type { Type::ComputedStyle };
+    JsonValue properties;
+};
+
+}
+
+namespace IPC {
+
+template<>
+ErrorOr<void> encode(Encoder&, WebView::DOMNodeProperties const&);
+
+template<>
+ErrorOr<WebView::DOMNodeProperties> decode(Decoder&);
+
+}

--- a/Libraries/LibWebView/Forward.h
+++ b/Libraries/LibWebView/Forward.h
@@ -21,6 +21,7 @@ class WebContentClient;
 struct Attribute;
 struct ConsoleOutput;
 struct CookieStorageKey;
+struct DOMNodeProperties;
 struct Mutation;
 struct ProcessHandle;
 struct SearchEngine;

--- a/Libraries/LibWebView/ViewImplementation.cpp
+++ b/Libraries/LibWebView/ViewImplementation.cpp
@@ -329,14 +329,14 @@ void ViewImplementation::get_hovered_node_id()
     client().async_get_hovered_node_id(page_id());
 }
 
-void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element)
+void ViewImplementation::inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type property_type, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element)
 {
-    client().async_inspect_dom_node(page_id(), node_id, pseudo_element);
+    client().async_inspect_dom_node(page_id(), property_type, node_id, pseudo_element);
 }
 
 void ViewImplementation::clear_inspected_dom_node()
 {
-    inspect_dom_node(0, {});
+    client().async_clear_inspected_dom_node(page_id());
 }
 
 void ViewImplementation::highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element)

--- a/Libraries/LibWebView/ViewImplementation.h
+++ b/Libraries/LibWebView/ViewImplementation.h
@@ -9,7 +9,6 @@
 
 #include <AK/Forward.h>
 #include <AK/Function.h>
-#include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/LexicalPath.h>
 #include <AK/Queue.h>
@@ -26,6 +25,7 @@
 #include <LibWeb/HTML/SelectItem.h>
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
+#include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/WebContentClient.h>
@@ -35,15 +35,6 @@ namespace WebView {
 class ViewImplementation {
 public:
     virtual ~ViewImplementation();
-
-    struct DOMNodeProperties {
-        JsonObject computed_style;
-        JsonObject resolved_style;
-        JsonObject custom_properties;
-        JsonObject node_box_sizing;
-        JsonObject aria_properties_state;
-        JsonArray fonts;
-    };
 
     static void for_each_view(Function<IterationDecision(ViewImplementation&)>);
     static Optional<ViewImplementation&> find_view_by_id(u64);
@@ -108,7 +99,7 @@ public:
     void inspect_accessibility_tree();
     void get_hovered_node_id();
 
-    void inspect_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);
+    void inspect_dom_node(Web::UniqueNodeID node_id, DOMNodeProperties::Type, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);
     void clear_inspected_dom_node();
 
     void highlight_dom_node(Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element);

--- a/Libraries/LibWebView/WebContentClient.h
+++ b/Libraries/LibWebView/WebContentClient.h
@@ -77,7 +77,7 @@ private:
     virtual void did_request_media_context_menu(u64 page_id, Gfx::IntPoint, ByteString, unsigned, Web::Page::MediaContextMenu) override;
     virtual void did_get_source(u64 page_id, URL::URL, URL::URL, String) override;
     virtual void did_inspect_dom_tree(u64 page_id, String) override;
-    virtual void did_inspect_dom_node(u64 page_id, bool has_style, String computed_style, String resolved_style, String custom_properties, String node_box_sizing, String aria_properties_state, String fonts) override;
+    virtual void did_inspect_dom_node(u64 page_id, DOMNodeProperties) override;
     virtual void did_inspect_accessibility_tree(u64 page_id, String) override;
     virtual void did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) override;
     virtual void did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) override;

--- a/Services/WebContent/ConnectionFromClient.h
+++ b/Services/WebContent/ConnectionFromClient.h
@@ -22,6 +22,7 @@
 #include <LibWeb/Page/EventResult.h>
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/Platform/Timer.h>
+#include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Forward.h>
 #include <LibWebView/PageInfo.h>
 #include <WebContent/Forward.h>
@@ -75,7 +76,8 @@ private:
     virtual void debug_request(u64 page_id, ByteString, ByteString) override;
     virtual void get_source(u64 page_id) override;
     virtual void inspect_dom_tree(u64 page_id) override;
-    virtual void inspect_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) override;
+    virtual void inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) override;
+    virtual void clear_inspected_dom_node(u64 page_id) override;
     virtual void highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) override;
     virtual void inspect_accessibility_tree(u64 page_id) override;
     virtual void get_hovered_node_id(u64 page_id) override;

--- a/Services/WebContent/WebContentClient.ipc
+++ b/Services/WebContent/WebContentClient.ipc
@@ -17,6 +17,7 @@
 #include <LibWeb/Page/Page.h>
 #include <LibWebView/Attribute.h>
 #include <LibWebView/ConsoleOutput.h>
+#include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/Mutation.h>
 #include <LibWebView/PageInfo.h>
 #include <LibWebView/ProcessHandle.h>
@@ -52,7 +53,7 @@ endpoint WebContentClient
     did_get_source(u64 page_id, URL::URL url, URL::URL base_url, String source) =|
 
     did_inspect_dom_tree(u64 page_id, String dom_tree) =|
-    did_inspect_dom_node(u64 page_id, bool has_style, String computed_style,  String resolved_style,  String custom_properties, String node_box_sizing, String aria_properties_state, String fonts) =|
+    did_inspect_dom_node(u64 page_id, WebView::DOMNodeProperties properties) =|
     did_inspect_accessibility_tree(u64 page_id, String accessibility_tree) =|
     did_get_hovered_node_id(u64 page_id, Web::UniqueNodeID node_id) =|
     did_finish_editing_dom_node(u64 page_id, Optional<Web::UniqueNodeID> node_id) =|

--- a/Services/WebContent/WebContentServer.ipc
+++ b/Services/WebContent/WebContentServer.ipc
@@ -12,6 +12,7 @@
 #include <LibWeb/Page/InputEvent.h>
 #include <LibWeb/WebDriver/ExecuteScript.h>
 #include <LibWebView/Attribute.h>
+#include <LibWebView/DOMNodeProperties.h>
 #include <LibWebView/PageInfo.h>
 
 endpoint WebContentServer
@@ -44,7 +45,8 @@ endpoint WebContentServer
     debug_request(u64 page_id, ByteString request, ByteString argument) =|
     get_source(u64 page_id) =|
     inspect_dom_tree(u64 page_id) =|
-    inspect_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) =|
+    inspect_dom_node(u64 page_id, WebView::DOMNodeProperties::Type property_type, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) =|
+    clear_inspected_dom_node(u64 page_id) =|
     highlight_dom_node(u64 page_id, Web::UniqueNodeID node_id, Optional<Web::CSS::Selector::PseudoElement::Type> pseudo_element) =|
     inspect_accessibility_tree(u64 page_id) =|
     get_hovered_node_id(u64 page_id) =|


### PR DESCRIPTION
When we inspect a DOM node, we currently serialize many properties for that node, including its layout, computed style, used fonts, etc. Now that we aren't piggy-backing on the Inspector interface, we can instead only serialize the specific information required by DevTools.