### PR TITLE
UI/Qt: Prevent UAF while parsing autocomplete response data

### DIFF
--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -18,6 +18,12 @@ constexpr bool is_space(int ch)
     return ch == '\t' || ch == '\n' || ch == '\r' || ch == ' ';
 }
 
+ErrorOr<JsonValue> JsonParser::parse(StringView input)
+{
+    JsonParser parser(input);
+    return parser.parse_json();
+}
+
 // ECMA-404 9 String
 // Boils down to
 // STRING = "\"" *("[^\"\\]" | "\\" ("[\"\\bfnrt]" | "u[0-9A-Za-z]{4}")) "\""
@@ -335,7 +341,7 @@ ErrorOr<JsonValue> JsonParser::parse_helper()
     return Error::from_string_literal("JsonParser: Unexpected character");
 }
 
-ErrorOr<JsonValue> JsonParser::parse()
+ErrorOr<JsonValue> JsonParser::parse_json()
 {
     auto result = TRY(parse_helper());
     ignore_while(is_space);

--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -13,14 +13,15 @@ namespace AK {
 
 class JsonParser : private GenericLexer {
 public:
+    static ErrorOr<JsonValue> parse(StringView);
+
+private:
     explicit JsonParser(StringView input)
         : GenericLexer(input)
     {
     }
 
-    ErrorOr<JsonValue> parse();
-
-private:
+    ErrorOr<JsonValue> parse_json();
     ErrorOr<JsonValue> parse_helper();
 
     ErrorOr<ByteString> consume_and_unescape_string();

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -190,7 +190,7 @@ JsonValue::JsonValue(JsonArray&& value)
 
 ErrorOr<JsonValue> JsonValue::from_string(StringView input)
 {
-    return JsonParser(input).parse();
+    return JsonParser::parse(input);
 }
 
 String JsonValue::serialized() const

--- a/Libraries/LibWeb/WebDriver/Client.cpp
+++ b/Libraries/LibWeb/WebDriver/Client.cpp
@@ -12,7 +12,6 @@
 #include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/JsonObject.h>
-#include <AK/JsonParser.h>
 #include <AK/JsonValue.h>
 #include <AK/Span.h>
 #include <AK/StringBuilder.h>
@@ -258,8 +257,7 @@ ErrorOr<JsonValue, Client::WrappedError> Client::read_body_as_json(HTTP::HttpReq
     if (content_length == 0)
         return JsonValue {};
 
-    JsonParser json_parser(request.body());
-    return TRY(json_parser.parse());
+    return TRY(JsonValue::from_string(request.body()));
 }
 
 ErrorOr<void, Client::WrappedError> Client::handle_request(HTTP::HttpRequest const& request, JsonValue body)

--- a/Meta/Lagom/Fuzzers/FuzzJsonParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJsonParser.cpp
@@ -9,7 +9,6 @@
 extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
 {
     AK::set_debug_enabled(false);
-    JsonParser parser({ data, size });
-    (void)parser.parse();
+    (void)JsonParser::parse({ data, size });
     return 0;
 }

--- a/UI/Qt/AutoComplete.cpp
+++ b/UI/Qt/AutoComplete.cpp
@@ -69,7 +69,7 @@ ErrorOr<Vector<String>> AutoComplete::parse_duckduckgo_autocomplete(Vector<JsonV
         if (!suggestion.is_object())
             return Error::from_string_literal("Invalid JSON, expected value to be an object");
 
-        if (auto value = suggestion.as_object().get_string("phrase"sv); !value.has_value())
+        if (auto value = suggestion.as_object().get_string("phrase"sv); value.has_value())
             results.append(*value);
     }
 

--- a/UI/Qt/AutoComplete.cpp
+++ b/UI/Qt/AutoComplete.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
-#include <AK/JsonParser.h>
 #include <LibURL/URL.h>
 #include <UI/Qt/AutoComplete.h>
 #include <UI/Qt/Settings.h>
@@ -111,8 +110,8 @@ ErrorOr<void> AutoComplete::got_network_response(QNetworkReply* reply)
     if (reply->error() == QNetworkReply::NetworkError::OperationCanceledError)
         return {};
 
-    AK::JsonParser parser(ak_byte_string_from_qstring(reply->readAll()));
-    auto json = TRY(parser.parse());
+    auto reply_data = ak_string_from_qstring(reply->readAll());
+    auto json = TRY(JsonValue::from_string(reply_data));
 
     auto engine_name = Settings::the()->autocomplete_engine().name;
     Vector<String> results;

--- a/UI/Qt/AutoComplete.h
+++ b/UI/Qt/AutoComplete.h
@@ -79,9 +79,9 @@ private:
 
     ErrorOr<void> got_network_response(QNetworkReply* reply);
 
-    ErrorOr<Vector<String>> parse_google_autocomplete(Vector<JsonValue> const&);
-    ErrorOr<Vector<String>> parse_duckduckgo_autocomplete(Vector<JsonValue> const&);
-    ErrorOr<Vector<String>> parse_yahoo_autocomplete(JsonObject const&);
+    ErrorOr<Vector<String>> parse_google_autocomplete(JsonValue const&);
+    ErrorOr<Vector<String>> parse_duckduckgo_autocomplete(JsonValue const&);
+    ErrorOr<Vector<String>> parse_yahoo_autocomplete(JsonValue const&);
 
     QNetworkAccessManager* m_manager;
     AutoCompleteModel* m_auto_complete_model;


### PR DESCRIPTION
`JsonParser` only holds a view into the provided string, the caller must keep it alive. Though we can actually just use `JsonValue::from_string` here instead.

Fixes #4005