### PR TITLE
LibWeb/Layout: Improve grid item sizing for replaced boxes

### DIFF
--- a/Tests/LibWeb/Layout/expected/grid/replaced-item-2.txt
+++ b/Tests/LibWeb/Layout/expected/grid/replaced-item-2.txt
@@ -1,0 +1,11 @@
+Viewport <#document> at (0,0) content-size 800x600 children: not-inline
+  BlockContainer <html> at (0,0) content-size 800x116 [BFC] children: not-inline
+    BlockContainer <body> at (8,8) content-size 100x100 children: not-inline
+      Box <div.img-wrapper> at (8,8) content-size 100x100 [GFC] children: not-inline
+        ImageBox <img> at (8,8) content-size 10x10 children: not-inline
+
+ViewportPaintable (Viewport<#document>) [0,0 800x600]
+  PaintableWithLines (BlockContainer<HTML>) [0,0 800x116]
+    PaintableWithLines (BlockContainer<BODY>) [8,8 100x100]
+      PaintableBox (Box<DIV>.img-wrapper) [8,8 100x100]
+        ImagePaintable (ImageBox<IMG>) [8,8 10x10]

--- a/Tests/LibWeb/Layout/input/grid/replaced-item-2.html
+++ b/Tests/LibWeb/Layout/input/grid/replaced-item-2.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html><style>
+body {
+    width: 100px;
+    height: 100px;
+}
+.img-wrapper {
+    display: grid;
+    width: 100%;
+    height: 100%;
+    background-color: darkorchid;
+}
+</style><div class="img-wrapper"><img src="data:image/webp;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAIAAAACUFjqAAAADUlEQVR4nGNgGAWkAwABNgABVtF/yAAAAABJRU5ErkJggg=="></div>

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-013.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-013.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
+1 Pass
+1 Fail
 Fail	.before 1
-Fail	.after 2
+Pass	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-014.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-014.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
-Fail	.before 1
+1 Pass
+1 Fail
+Pass	.before 1
 Fail	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-015.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-015.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Pass	.before 1
-Fail	.after 2
+Pass	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-016.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-016.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
-Fail	.before 1
+2 Pass
+Pass	.before 1
 Pass	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-031.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-031.txt
@@ -2,6 +2,7 @@ Harness status: OK
 
 Found 2 tests
 
-2 Fail
+1 Pass
+1 Fail
 Fail	.before 1
-Fail	.after 2
+Pass	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-032.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-032.txt
@@ -4,5 +4,5 @@ Found 2 tests
 
 1 Pass
 1 Fail
-Fail	.before 1
-Pass	.after 2
+Pass	.before 1
+Fail	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-033.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-033.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
+2 Pass
 Pass	.before 1
-Fail	.after 2
+Pass	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-034.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-implies-size-change-034.txt
@@ -2,7 +2,6 @@ Harness status: OK
 
 Found 2 tests
 
-1 Pass
-1 Fail
-Fail	.before 1
+2 Pass
+Pass	.before 1
 Pass	.after 2

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-style-changes-005.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-style-changes-005.txt
@@ -2,11 +2,11 @@ Harness status: OK
 
 Found 6 tests
 
-1 Pass
-5 Fail
+3 Pass
+3 Fail
 Fail	.before 1
-Fail	.before 2
+Pass	.before 2
 Fail	.before 3
 Fail	.after 4
 Pass	.after 5
-Fail	.after 6
+Pass	.after 6

--- a/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-style-changes-006.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/css-grid/alignment/grid-alignment-style-changes-006.txt
@@ -2,11 +2,11 @@ Harness status: OK
 
 Found 6 tests
 
-1 Pass
-5 Fail
+3 Pass
+3 Fail
 Fail	.before 1
 Pass	.before 2
-Fail	.before 3
+Pass	.before 3
 Fail	.after 4
-Fail	.after 5
+Pass	.after 5
 Fail	.after 6


### PR DESCRIPTION
With this change we no longer stretch "width: auto" for replaced boxes and also use width calculation rules for block-level replaced elements, like suggested by the spec.