### PR TITLE
CI: Only run builds after successful linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint_code:
+    name: 'Lint Code'
+    uses: ./.github/workflows/lint-code.yml
+
+  lint_commits:
+    name: 'Lint Commits'
+    uses: ./.github/workflows/lint-commits.yml
+
   # CI matrix - runs the job in lagom-template.yml with different configurations.
   Lagom:
     if: github.repository == 'LadybirdBrowser/ladybird'
+    needs: [lint_code, lint_commits]
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -1,6 +1,7 @@
 name: Lint Code
 
-on: [ push, pull_request ]
+# Used by ci.yml
+on: [workflow_call]
 
 jobs:
   lint:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,6 +1,7 @@
 name: Lint Commit Messages
 
-on: [pull_request_target]
+# Used by ci.yml
+on: [workflow_call]
 
 # Make sure to update Meta/lint-commit.sh to match this script when adding new checks!
 # (… but don't accept overlong 'fixup!' commit descriptions.)


### PR DESCRIPTION
We can prevent running builds unnecessarily by requiring the linters to succeed first. If either the code or commit linter fails, it means the author of the PR needs to rework their branch and after pushing their changes, we need to do a full new CI run anyway.