### PR TITLE
CI: Only run commit linter for pull requests, not pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,17 @@ jobs:
 
   lint_commits:
     name: 'Lint Commits'
+    if: ${{ github.event_name == 'pull_request' }}
     uses: ./.github/workflows/lint-commits.yml
 
   # CI matrix - runs the job in lagom-template.yml with different configurations.
   Lagom:
-    if: github.repository == 'LadybirdBrowser/ladybird'
     needs: [lint_code, lint_commits]
+    if: |
+      always()
+      && github.repository == 'LadybirdBrowser/ladybird'
+      && needs.lint_code.result == 'success'
+      && (needs.lint_commits.result == 'skipped' || needs.lint_commits.result == 'success')
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
This requires us to always run the CI job and check the individual jobs' results, since only having `needs:` will not work when `lint_commits` is potentially skipped.

Should fix the red CI on master.