### PR TITLE
LibWeb: Fix layout bug related to immediate top layer removal

### DIFF
--- a/Libraries/LibWeb/DOM/Document.cpp
+++ b/Libraries/LibWeb/DOM/Document.cpp
@@ -6028,6 +6028,8 @@ void Document::remove_an_element_from_the_top_layer_immediately(GC::Ref<Element>
     // FIXME: 3. Remove the UA !important overlay: auto rule targeting el, if it exists.
     element->set_rendered_in_top_layer(false);
     element->set_needs_style_update(true);
+
+    invalidate_layout_tree(InvalidateLayoutTreeReason::DocumentRemoveAnElementFromTheTopLayerImmediately);
 }
 
 // https://drafts.csswg.org/css-position-4/#process-top-layer-removals

--- a/Libraries/LibWeb/DOM/Document.h
+++ b/Libraries/LibWeb/DOM/Document.h
@@ -52,6 +52,10 @@ enum class QuirksMode {
 #define ENUMERATE_INVALIDATE_LAYOUT_TREE_REASONS(X)       \
     X(DocumentAddAnElementToTheTopLayer)                  \
     X(DocumentRequestAnElementToBeRemovedFromTheTopLayer) \
+    X(DocumentRemoveAnElementFromTheTopLayerImmediately)  \
+    X(HTMLInputElementSrcAttributeChange)                 \
+    X(HTMLObjectElement)                                  \
+    X(SVGGraphicsElementTransformAttributeChange)         \
     X(ShadowRootSetInnerHTML)
 
 enum class InvalidateLayoutTreeReason {


### PR DESCRIPTION
Work on Fullscreen API support is going on https://github.com/theIDinside/ladybird/tree/fullscreen-whatwg-api and while working on it, I noticed that when exiting out of fullscreen, the layout was entirely messed up (when attempting to exit out of a fullscreen that was a non-simple-fullscreen, when it was just 1 element, it was fine).

This fixes that issue, by checking if the top layer now became empty and if so, invalidate the layout.