### PR TITLE
LibJS: Fix integer overflow in `target_offset` of `TypedArray.set()`

### DIFF
--- a/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -1433,7 +1433,11 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(VM& vm, TypedArr
 
     // 16. If srcLength + targetOffset > targetLength, throw a RangeError exception.
     Checked<size_t> checked = source_length;
-    checked += static_cast<u32>(target_offset);
+
+    if (target_offset > static_cast<double>(NumericLimits<size_t>::max()))
+        return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "target offset");
+    checked += static_cast<size_t>(target_offset);
+
     if (checked.has_overflow() || checked.value() > target_length)
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "target length");
 
@@ -1539,7 +1543,11 @@ static ThrowCompletionOr<void> set_typed_array_from_array_like(VM& vm, TypedArra
 
     // 7. If srcLength + targetOffset > targetLength, throw a RangeError exception.
     Checked<size_t> checked = source_length;
-    checked += static_cast<u32>(target_offset);
+
+    if (target_offset > static_cast<double>(NumericLimits<size_t>::max()))
+        return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "target offset");
+    checked += static_cast<size_t>(target_offset);
+
     if (checked.has_overflow() || checked.value() > target_length)
         return vm.throw_completion<RangeError>(ErrorType::TypedArrayOverflowOrOutOfBounds, "target length");
 

--- a/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
+++ b/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
@@ -146,3 +146,19 @@ test("detached buffer", () => {
         expect(typedArray.length).toBe(0);
     });
 });
+
+test("very large targetOffset", () => {
+    TYPED_ARRAYS.forEach(({ array: T }) => {
+        let typedArray = new T();
+
+        expect(() => {
+            // set_typed_array_from_typed_array
+            typedArray.set(typedArray, 2 ** 128);
+        }).toThrowWithMessage(RangeError, "Overflow or out of bounds in target offset");
+
+        expect(() => {
+            // set_typed_array_from_array_like
+            typedArray.set([], 2 ** 128);
+        }).toThrowWithMessage(RangeError, "Overflow or out of bounds in target offset");
+    });
+});


### PR DESCRIPTION
This ones a bit sneaky, the overflow happens before the `checked +=`