### PR TITLE
UI: Show "Disable" title in DevTools disable button

### DIFF
--- a/UI/AppKit/Application/ApplicationDelegate.mm
+++ b/UI/AppKit/Application/ApplicationDelegate.mm
@@ -272,7 +272,7 @@
     auto message = MUST(String::formatted("DevTools is enabled on port {}", WebView::Application::browser_options().devtools_port));
 
     [self.info_bar showWithMessage:Ladybird::string_to_ns_string(message)
-              dismissButtonTooltip:@"Disable DevTools"
+                dismissButtonTitle:@"Disable"
               dismissButtonClicked:^{
                   MUST(WebView::Application::the().toggle_devtools_enabled());
                   [self devtoolsDisabled];

--- a/UI/AppKit/Interface/InfoBar.h
+++ b/UI/AppKit/Interface/InfoBar.h
@@ -15,7 +15,7 @@ using InfoBarDismissed = void (^)(void);
 @interface InfoBar : NSStackView
 
 - (void)showWithMessage:(NSString*)message
-    dismissButtonTooltip:(NSString*)tooltip
+      dismissButtonTitle:(NSString*)title
     dismissButtonClicked:(InfoBarDismissed)on_dimissed
                activeTab:(Tab*)tab;
 - (void)hide;

--- a/UI/AppKit/Interface/InfoBar.mm
+++ b/UI/AppKit/Interface/InfoBar.mm
@@ -28,7 +28,7 @@ static constexpr CGFloat const INFO_BAR_HEIGHT = 40;
     if (self = [super init]) {
         self.text_label = [NSTextField labelWithString:@""];
 
-        self.dismiss_button = [NSButton buttonWithImage:[NSImage imageNamed:NSImageNameStopProgressTemplate]
+        self.dismiss_button = [NSButton buttonWithTitle:@""
                                                  target:self
                                                  action:@selector(dismiss:)];
         [self.dismiss_button setBezelStyle:NSBezelStyleAccessoryBarAction];
@@ -46,13 +46,13 @@ static constexpr CGFloat const INFO_BAR_HEIGHT = 40;
 }
 
 - (void)showWithMessage:(NSString*)message
-    dismissButtonTooltip:(NSString*)tooltip
+      dismissButtonTitle:(NSString*)title
     dismissButtonClicked:(InfoBarDismissed)on_dimissed
                activeTab:(Tab*)tab
 {
     [self.text_label setStringValue:message];
 
-    [self.dismiss_button setToolTip:tooltip];
+    self.dismiss_button.title = title;
     self.on_dimissed = on_dimissed;
 
     if (tab) {

--- a/UI/Qt/BrowserWindow.cpp
+++ b/UI/Qt/BrowserWindow.cpp
@@ -726,8 +726,7 @@ void BrowserWindow::devtools_disabled()
 
 void BrowserWindow::devtools_enabled()
 {
-    auto* disable_button = new TabBarButton(create_tvg_icon_with_theme_colors("close", palette()), this);
-    disable_button->setToolTip("Disable DevTools");
+    auto* disable_button = new QPushButton("Disable", this);
 
     connect(disable_button, &QPushButton::clicked, this, [this]() {
         MUST(WebView::Application::the().toggle_devtools_enabled());


### PR DESCRIPTION
The "disable DevTools" button looked like a "close this notification" button to me, and although a tooltip was set, it only showed up immediately on the AppKit UI and not the Qt version.

This makes the behavior of clicking the disable button a lot clearer by showing a button with "Disable" as its title.


<img width="780" alt="image" src="https://github.com/user-attachments/assets/f21a7c9d-de57-41e7-bc4e-f83c67365047" />

![image](https://github.com/user-attachments/assets/99665cef-f730-410d-a87e-093285935613)

CC @trflynn89 