### PR TITLE
Revert "CI: Only run builds after successful linting"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint_code:
-    name: 'Lint Code'
-    uses: ./.github/workflows/lint-code.yml
-
-  lint_commits:
-    name: 'Lint Commits'
-    if: ${{ github.event_name == 'pull_request' }}
-    uses: ./.github/workflows/lint-commits.yml
-
   # CI matrix - runs the job in lagom-template.yml with different configurations.
   Lagom:
-    needs: [lint_code, lint_commits]
-    if: |
-      always()
-      && github.repository == 'LadybirdBrowser/ladybird'
-      && needs.lint_code.result == 'success'
-      && (needs.lint_commits.result == 'skipped' || needs.lint_commits.result == 'success')
+    if: github.repository == 'LadybirdBrowser/ladybird'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -1,7 +1,6 @@
 name: Lint Code
 
-# Used by ci.yml
-on: [workflow_call]
+on: [ push, pull_request ]
 
 jobs:
   lint:

--- a/.github/workflows/lint-commits.yml
+++ b/.github/workflows/lint-commits.yml
@@ -1,7 +1,6 @@
 name: Lint Commit Messages
 
-# Used by ci.yml
-on: [workflow_call]
+on: [pull_request_target]
 
 # Make sure to update Meta/lint-commit.sh to match this script when adding new checks!
 # (… but don't accept overlong 'fixup!' commit descriptions.)


### PR DESCRIPTION
This reverts commits bf333eaea253ebf47c7d6192ff0c42e7a198d606 and 6f69a445bd3d2fd5bbd61b3b3cea47df18fa6242.

The commit linter needs to run on event `pull_request_target` to have access to its secret token, which means we cannot have a dependency on that job from another workflow that is run as a result of the `pull_request` event.

Additionally, the linters were no longer run for first-time contributors. This isn't a huge problem but it was nice that a preliminary check took place before running the full CI on their PRs.