### PR TITLE
LibWeb: Update Element::directionality() for bdi elements to match spec

### DIFF
--- a/Libraries/LibWeb/DOM/Element.cpp
+++ b/Libraries/LibWeb/DOM/Element.cpp
@@ -3275,10 +3275,18 @@ Element::Directionality Element::directionality() const
     // -> undefined
     VERIFY(!maybe_dir.has_value());
 
-    // FIXME: If element is a bdi element:
-    // FIXME:     1. Let result be the auto directionality of element.
-    // FIXME:     2. If result is null, then return 'ltr'.
-    // FIXME:     3. Return result.
+    // If element is a bdi element:
+    if (local_name() == HTML::TagNames::bdi) {
+        // 1. Let result be the auto directionality of element.
+        auto result = auto_directionality();
+
+        // 2. If result is null, then return 'ltr'.
+        if (!result.has_value())
+            return Directionality::Ltr;
+
+        // 3. Return result.
+        return result.release_value();
+    }
 
     // If element is an input element whose type attribute is in the Telephone state:
     if (is<HTML::HTMLInputElement>(this) && static_cast<HTML::HTMLInputElement const&>(*this).type_state() == HTML::HTMLInputElement::TypeAttributeState::Telephone) {

--- a/Tests/LibWeb/Text/expected/wpt-import/css/selectors/dir-pseudo-on-bdi-element.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/css/selectors/dir-pseudo-on-bdi-element.txt
@@ -2,10 +2,9 @@ Harness status: OK
 
 Found 5 tests
 
-3 Pass
-2 Fail
-Fail	bdi element without dir content attribute
-Fail	bdi element with invalid dir content attribute
+5 Pass
+Pass	bdi element without dir content attribute
+Pass	bdi element with invalid dir content attribute
 Pass	bdi element with dir=auto content attribute
 Pass	bdi element with dir=ltr content attribute
 Pass	bdi element with dir=rtl content attribute


### PR DESCRIPTION
This fixes three WPT test cases at html/dom/elements/global-attributes/dir-assorted.window.html