### PR TITLE
LibWeb: Invalidate style when `media` content attribute changes

### DIFF
--- a/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -52,6 +52,16 @@ void HTMLStyleElement::removed_from(Node* old_parent, Node& old_root)
     Base::removed_from(old_parent, old_root);
 }
 
+void HTMLStyleElement::attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_)
+{
+    Base::attribute_changed(name, old_value, value, namespace_);
+
+    if (name == HTML::AttributeNames::media) {
+        if (auto* sheet = m_style_element_utils.sheet())
+            sheet->set_media(value.value_or({}));
+    }
+}
+
 // https://html.spec.whatwg.org/multipage/semantics.html#dom-style-disabled
 bool HTMLStyleElement::disabled()
 {
@@ -77,18 +87,6 @@ void HTMLStyleElement::set_disabled(bool disabled)
     // 2. If the given value is true, set this's associated CSS style sheet's disabled flag.
     //    Otherwise, unset this's associated CSS style sheet's disabled flag.
     sheet()->set_disabled(disabled);
-}
-
-String HTMLStyleElement::media() const
-{
-    return attribute(HTML::AttributeNames::media).value_or(String {});
-}
-
-void HTMLStyleElement::set_media(String media)
-{
-    (void)set_attribute(HTML::AttributeNames::media, media);
-    if (auto sheet = m_style_element_utils.sheet())
-        sheet->set_media(media);
 }
 
 // https://www.w3.org/TR/cssom/#dom-linkstyle-sheet

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.h
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.h
@@ -22,12 +22,10 @@ public:
     virtual void children_changed(ChildrenChangedMetadata const*) override;
     virtual void inserted() override;
     virtual void removed_from(Node* old_parent, Node& old_root) override;
+    virtual void attribute_changed(FlyString const& name, Optional<String> const& old_value, Optional<String> const& value, Optional<FlyString> const& namespace_) override;
 
     bool disabled();
     void set_disabled(bool disabled);
-
-    [[nodiscard]] String media() const;
-    void set_media(String);
 
     CSS::CSSStyleSheet* sheet();
     CSS::CSSStyleSheet const* sheet() const;

--- a/Libraries/LibWeb/HTML/HTMLStyleElement.idl
+++ b/Libraries/LibWeb/HTML/HTMLStyleElement.idl
@@ -8,7 +8,7 @@ interface HTMLStyleElement : HTMLElement {
     [HTMLConstructor] constructor();
 
     attribute boolean disabled;
-    [CEReactions] attribute DOMString media;
+    [CEReactions, Reflect] attribute DOMString media;
     [FIXME, SameObject, PutForwards=value] readonly attribute DOMTokenList blocking;
 
     // Obsolete

--- a/Tests/LibWeb/Text/expected/wpt-import/html/semantics/document-metadata/the-style-element/style_media_change.txt
+++ b/Tests/LibWeb/Text/expected/wpt-import/html/semantics/document-metadata/the-style-element/style_media_change.txt
@@ -1,0 +1,7 @@
+Harness status: OK
+
+Found 2 tests
+
+2 Pass
+Pass	change media value dynamically
+Pass	removing media attribute

--- a/Tests/LibWeb/Text/input/wpt-import/html/semantics/document-metadata/the-style-element/style_media_change.html
+++ b/Tests/LibWeb/Text/input/wpt-import/html/semantics/document-metadata/the-style-element/style_media_change.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Dynamically changing HTMLStyleElement.media should change the rendering accordingly</title>
+    <script src="../../../../resources/testharness.js"></script>
+    <script src="../../../../resources/testharnessreport.js"></script>
+    <link rel="help" href="https://html.spec.whatwg.org/multipage/#the-style-element">
+    <style>
+      span {
+       color: red;
+      }
+    </style>
+    <style id="text-style" media="none">
+      span {
+       color: green;
+      }
+    </style>
+    <style id="body-style" media="aural">
+      body {
+       color: green;
+      }
+    </style>
+  </head>
+  <body>
+    <span>text</span>
+    <script>
+      test(function() {
+        var element = document.querySelector("span");
+        assert_equals(getComputedStyle(element).color, "rgb(255, 0, 0)");
+        document.getElementById("text-style").media = 'all';
+        assert_equals(getComputedStyle(element).color, "rgb(0, 128, 0)");
+      }, "change media value dynamically");
+
+      test(function() {
+        var style = document.getElementById("body-style");
+        assert_not_equals(getComputedStyle(document.querySelector("body")).color, "rgb(0, 128, 0)");
+        style.removeAttribute("media");
+        assert_equals(getComputedStyle(document.querySelector("body")).color, "rgb(0, 128, 0)");
+      }, "removing media attribute");
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Previously, we would only invalidate style when setting the `media` IDL attribute; changing the attribute via `setAttribute()` and `removeAttribute()` had no immediate effect.

I came across this while looking at: http://wpt.live/css/mediaqueries/test_media_queries.html. 
This change causes a regression of -70 subtests in this particular case :sob:. I believe this change makes things more correct though, as the media queries that this test dynamically generates weren't previously being evaluated.